### PR TITLE
Add Path to Output of ORM\MappingException

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AbstractFileDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AbstractFileDriver.php
@@ -155,7 +155,7 @@ abstract class AbstractFileDriver implements Driver
         if ($this->_paths) {
             foreach ((array) $this->_paths as $path) {
                 if ( ! is_dir($path)) {
-                    throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath();
+                    throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
                 }
             
                 $iterator = new \RecursiveIteratorIterator(

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -435,7 +435,7 @@ class AnnotationDriver implements Driver
 
         foreach ($this->_paths as $path) {
             if ( ! is_dir($path)) {
-                throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath();
+                throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
             }
 
             $iterator = new \RecursiveIteratorIterator(

--- a/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
@@ -78,7 +78,7 @@ class StaticPHPDriver implements Driver
 
         foreach ($this->_paths as $path) {
             if ( ! is_dir($path)) {
-                throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath();
+                throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
             }
 
             $iterator = new \RecursiveIteratorIterator(

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -170,9 +170,16 @@ class MappingException extends \Doctrine\ORM\ORMException
         );
     }
 
-    public static function fileMappingDriversRequireConfiguredDirectoryPath()
+    public static function fileMappingDriversRequireConfiguredDirectoryPath($path = null)
     {
-        return new self('File mapping drivers must have a valid directory path, however the given path seems to be incorrect!');
+        if ( ! empty($path)) {
+            $path = '[' . $path . ']';
+        }
+        
+        return new self(
+            'File mapping drivers must have a valid directory path, ' .
+            'however the given path ' . $path . ' seems to be incorrect!'
+        );
     }
 
     /**

--- a/tools/sandbox/Entities/User.php
+++ b/tools/sandbox/Entities/User.php
@@ -13,7 +13,7 @@ class User
     /** @Column(type="string", length=50) */
     private $name;
     /**
-     * @OneToOne(targetEntity="Address")
+     * @OneToOne(targetEntity="Address", inversedBy="user")
      * @JoinColumn(name="address_id", referencedColumnName="id")
      */
     private $address;


### PR DESCRIPTION
If the given Path is no directory, the MappingException is thrown - but there is no information displayed _which_ path is incorrect. 
