### PR TITLE
Ddc 970

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -81,6 +81,10 @@ class GenerateEntitiesCommand extends Console\Command\Command
             new InputOption(
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
+            ),
+			new InputOption(
+                'attribute-visibility', null, InputOption::VALUE_OPTIONAL,
+                'Defines the visibility of generated attributes'
             )
         ))
         ->setHelp(<<<EOT
@@ -123,6 +127,10 @@ EOT
             $entityGenerator->setRegenerateEntityIfExists($input->getOption('regenerate-entities'));
             $entityGenerator->setUpdateEntityIfExists($input->getOption('update-entities'));
             $entityGenerator->setNumSpaces($input->getOption('num-spaces'));
+            
+			if (($attributeVisibility = $input->getOption('attribute-visibility')) !== null) {
+				$entityGenerator->setAttributeVisibility($attributeVisibility);
+			}
 
             if (($extend = $input->getOption('extend')) !== null) {
                 $entityGenerator->setClassToExtend($extend);

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -77,6 +77,9 @@ class EntityGenerator
     /** Whether or not to re-generate entity class if it exists already */
     private $_regenerateEntityIfExists = false;
 
+	/** The visibility to use when generating attributes */
+    private $_attributeVisibility = 'private';
+
     private static $_classTemplate =
 '<?php
 
@@ -297,6 +300,18 @@ public function <methodName>()
     {
         $this->_generateEntityStubMethods = $bool;
     }
+
+	/**
+	 * Set what visibility to use when generating attributes
+	 *
+	 * @param string $attributeVisibility
+	 */
+	public function setAttributeVisibility($attributeVisibility) {
+		if (!array_search($attributeVisibility, array("private", "protected", "public")))
+			throw new \InvalidArgumentException("$attributeVisibility is not a valid attribute visibility");
+
+		$this->_attributeVisibility = $attributeVisibility;
+	}
 
     private function _generateEntityNamespace(ClassMetadataInfo $metadata)
     {
@@ -550,7 +565,7 @@ public function <methodName>()
             }
 
             $lines[] = $this->_generateAssociationMappingPropertyDocBlock($associationMapping, $metadata);
-            $lines[] = $this->_spaces . 'private $' . $associationMapping['fieldName']
+            $lines[] = $this->_spaces . $this->_attributeVisibility . ' $' . $associationMapping['fieldName']
                      . ($associationMapping['type'] == 'manyToMany' ? ' = array()' : null) . ";\n";
         }
 
@@ -567,7 +582,7 @@ public function <methodName>()
             }
 
             $lines[] = $this->_generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
-            $lines[] = $this->_spaces . 'private $' . $fieldMapping['fieldName']
+            $lines[] = $this->_spaces . $this->_attributeVisibility . ' $' . $fieldMapping['fieldName']
                      . (isset($fieldMapping['default']) ? ' = ' . var_export($fieldMapping['default'], true) : null) . ";\n";
         }
 


### PR DESCRIPTION
orm:generate-entities should have an option to change the visibility of the attributes

The option is used like this:

doctrine orm:generate-entities --attribute-visibility=protected my_dir
doctrine orm:generate-entities --attribute-visibility=public my_dir

When the option is omitted attributes have private visibility as normal.
