### PR TITLE
Ddc 875

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1465,7 +1465,10 @@ class UnitOfWork implements PropertyChangedListener
             if ($assoc['type'] & ClassMetadata::TO_ONE) {
                 $prevClass->reflFields[$assocField]->setValue($prevManagedCopy, $managedCopy);
             } else {
-                $prevClass->reflFields[$assocField]->getValue($prevManagedCopy)->add($managedCopy);
+				// Only add to the collection if the entity doesn't already exist in it
+				if (!$prevClass->reflFields[$assocField]->getValue($prevManagedCopy)->unwrap()->contains($managedCopy))
+					$prevClass->reflFields[$assocField]->getValue($prevManagedCopy)->add($managedCopy);
+
                 if ($assoc['type'] == ClassMetadata::ONE_TO_MANY) {
                     $class->reflFields[$assoc['mappedBy']]->setValue($managedCopy, $prevManagedCopy);
                 }


### PR DESCRIPTION
Merge can sometimes add the same entity twice into a collection.

As far as I can tell I am using unwrap() in order to check whether the element already exists in the array, but then calling >add() directly on the PersistentCollection rather than the ArrayCollection, triggering $this>changed().
