### PR TITLE
Fix attempt to get column by class property name

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -179,7 +179,7 @@ class SchemaTool
                     $this->_gatherColumn($class, $idMapping, $table);
                     $columnName = $class->getQuotedColumnName($class->identifier[0], $this->_platform);
                     // TODO: This seems rather hackish, can we optimize it?
-                    $table->getColumn($class->identifier[0])->setAutoincrement(false);
+                    $table->getColumn($class->fieldMappings[$class->identifier[0]]['columnName'])->setAutoincrement(false);
 
                     $pkColumns[] = $columnName;
 


### PR DESCRIPTION
Hi,

After upgrading from a Doctrine 2.0 RC to final version, I noticed a failure when using doctrine orm:schema:create:

```
  [Doctrine\DBAL\Schema\SchemaException]                 
  There is no column with name '_id' on table 'subuser'.
```

Since this worked before the upgrade, I investigated and found a new line of code that was attempting to get a column using the class identifier property name (_id) rather than the mapped column name (user_id). Please see patch.
