### PR TITLE
Accept custom Message/Code for NoResultException

### DIFF
--- a/lib/Doctrine/ORM/NoResultException.php
+++ b/lib/Doctrine/ORM/NoResultException.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM;
 
+use \Exception;
+
 /**
  * Exception thrown when an ORM query unexpectedly does not return any results.
  * 
@@ -27,8 +29,12 @@ namespace Doctrine\ORM;
  */
 class NoResultException extends ORMException
 {
-    public function __construct()
+    public function __construct($message = null, $code = 0, Exception $previous = null)
     {
-        parent::__construct('No result was found for query although at least one row was expected.');
+        parent::__construct(
+            $message ?: 'No result was found for query although at least one row was expected.',
+            $code,
+            $previous
+        );
     }
 }


### PR DESCRIPTION
While overwriting EntityManager#findOneBy (to achieve same behaviour then AbstractQuery#getSingleResult) i found it useful to be able to set a custom message/code for NoResultException, which uses the current text as fallback
