### PR TITLE
Entity manager persist and flush

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -455,6 +455,21 @@ class EntityManager
     }
 
     /**
+     * Tells the EntityManager to manage and persist an entity directly to the database.
+     *
+     * NOTE: this method is just a shortcut for the two operations but it's useful as 
+     * developers generally persist only one entity at a time and it avoids to write two 
+     * lines of code everytime.
+     *
+     * @param object $object The instance to make managed and persist immediatly.
+     */
+    public function persistAndFlush($entity)
+    {
+        $this->persist($entity);
+        $this->flush();
+    }
+
+    /**
      * Removes an entity instance.
      *
      * A removed entity will be removed from the database at or before transaction commit

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -461,7 +461,7 @@ class EntityManager
      * developers generally persist only one entity at a time and it avoids to write two 
      * lines of code everytime.
      *
-     * @param object $object The instance to make managed and persist immediatly.
+     * @param object $entity The entity to make managed and persisted immediatly
      */
     public function persistAndFlush($entity)
     {

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -105,6 +105,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
     {
         return array(
             array('persist'),
+            array('persistAndFlush'),
             array('remove'),
             array('merge'),
             array('refresh'),
@@ -126,6 +127,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
         return array(
             array('flush'),
             array('persist'),
+            array('persistAndFlush'),
             array('remove'),
             array('merge'),
             array('refresh'),


### PR DESCRIPTION
Hello,

I have added a shortcut method to the EntityManager class: persistAndFlush()

Generally, developers need to persist and flush one single entity at a time. That means, we need to write two lines of code in controllers. The goal is to reduce a bit the number of lines of code by calling one single line of code, which is responsible to persist and flush the entity immediatly.

I didn't manage to run the tests suite so I cannot guarantee tests pass. Please, run the tests suite before applying the patch if you are convinced of its added value to the API.

Hugo Hamon
Sensio Labs Trainings Manager.
