### PR TITLE
DDC-1056 PHPStaticDriver was missing two instance variables.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
@@ -41,6 +41,18 @@ class StaticPHPDriver implements Driver
 {
     private $_paths = array();
 
+    /**
+     * The file extension of mapping documents.
+     *
+     * @var string
+     */
+    protected $_fileExtension = '.php';
+
+    /**
+     * @param array
+     */
+    protected $_classNames;
+
     public function __construct($paths)
     {
         $this->addPaths((array) $paths);


### PR DESCRIPTION
Fixes the related issue.
