### PR TITLE
prevent backup file to be recognized as valid Entity file

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -183,7 +183,7 @@ public function <methodName>()
         }
 
         if ($this->_backupExisting && file_exists($path)) {
-            $backupPath = dirname($path) . DIRECTORY_SEPARATOR .  "~" . basename($path);
+            $backupPath = dirname($path) . DIRECTORY_SEPARATOR . basename($path) . "~";
             if (!copy($path, $backupPath)) {
                 throw new \RuntimeException("Attempt to backup overwritten entitiy file but copy operation failed.");
             }


### PR DESCRIPTION
when using symfony command "./app/console doctrine:generate:entities MyHelloBundle", backup file are detected as "running" Entities and I get "PHP Fatal error: Cannot redeclare class..."

When adding ~ at the end it is now fine (even for the IDE parser) and follow vim backup convention
