### PR TITLE
EntityManager::create for subclasses

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -727,7 +727,6 @@ class EntityManager implements ObjectManager
         } else {
             throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
-
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 }


### PR DESCRIPTION
This simple change allows EntityManager subclasses to be instantiated in standard way. Obvious.
