### PR TITLE
Fixed Parser::match not matching token value (only type)

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -243,7 +243,8 @@ class Parser
         // short-circuit on first condition, usually types match
         if ($this->_lexer->lookahead['type'] !== $token &&
                 $token !== Lexer::T_IDENTIFIER &&
-                $this->_lexer->lookahead['type'] <= Lexer::T_IDENTIFIER
+                $this->_lexer->lookahead['type'] <= Lexer::T_IDENTIFIER &&
+                $this->_lexer->lookahead['value'] !== $token
          ) {
             $this->syntaxError($this->_lexer->getLiteral($token));
         }


### PR DESCRIPTION
According to the phpdoc for Parser::match(), the token provided can be either the token type or value. However, the method only checked type.

The method is now in accordance with the phpdoc.
