### PR TITLE
Parser::match phpdoc fix

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -234,7 +234,7 @@ class Parser
      * If they match, updates the lookahead token; otherwise raises a syntax
      * error.
      *
-     * @param int|string token type or value
+     * @param int token type
      * @return void
      * @throws QueryException If the tokens dont match.
      */


### PR DESCRIPTION
Fixed phpdoc on Parser::match incorrectly stating that the token parameter can be a string value.
