### PR TITLE
[DDC-1104] Require statement in AnnotationDriver.php can cause PHP Fatal error

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Cache\ArrayCache,
     Doctrine\ORM\Mapping\ClassMetadataInfo,
     Doctrine\ORM\Mapping\MappingException;
 
-require __DIR__ . '/DoctrineAnnotations.php';
+require_once __DIR__ . '/DoctrineAnnotations.php';
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.


### PR DESCRIPTION
[DDC-1104] Require statement in AnnotationDriver.php can cause PHP Fatal error
