### PR TITLE
Fixing docblocks in SchemaTool

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -648,9 +648,11 @@ class SchemaTool
 
     /**
      * Updates the database schema of the given classes by comparing the ClassMetadata
-     * ins$tableNametances to the current database schema that is inspected.
+     * instances to the current database schema that is inspected. If $saveMode is set
+     * to true the command is executed in the Database, else SQL is returned.
      *
      * @param array $classes
+     * @param boolean $saveMode
      * @return void
      */
     public function updateSchema(array $classes, $saveMode=false)
@@ -666,8 +668,11 @@ class SchemaTool
     /**
      * Gets the sequence of SQL statements that need to be performed in order
      * to bring the given class mappings in-synch with the relational schema.
+     * If $saveMode is set to true the command is executed in the Database, 
+     * else SQL is returned.
      *
      * @param array $classes The classes to consider.
+     * @param boolean $saveMode True for writing to DB, false for SQL string
      * @return array The sequence of SQL statements.
      */
     public function getUpdateSchemaSql(array $classes, $saveMode=false)


### PR DESCRIPTION
Updating a few docblocks I noticed were outdates without the `$saveMode` parameter.
