### PR TITLE
[DDC-1134] Entity generator: Namespace parsing fix

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -200,6 +200,54 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($cm->idGenerator, $metadata->idGenerator);
         $this->assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
     }
+
+    /**
+     * @dataProvider getParseTokensInEntityFileData
+     */
+    public function testParseTokensInEntityFile($php, $classes)
+    {
+        $r = new \ReflectionObject($this->_generator);
+        $m = $r->getMethod('_parseTokensInEntityFile');
+        $m->setAccessible(true);
+
+        $p = $r->getProperty('_staticReflection');
+        $p->setAccessible(true);
+
+        $ret = $m->invoke($this->_generator, $php);
+        $this->assertEquals($classes, array_keys($p->getValue($this->_generator)));
+    }
+
+    public function getParseTokensInEntityFileData()
+    {
+        return array(
+            array(
+                '<?php namespace Foo\Bar; class Baz {}',
+                array('Foo\Bar\Baz'),
+            ),
+            array(
+                '<?php namespace Foo\Bar; use Foo; class Baz {}',
+                array('Foo\Bar\Baz'),
+            ),
+            array(
+                '<?php namespace /*Comment*/ Foo\Bar; /** Foo */class /* Comment */ Baz {}',
+                array('Foo\Bar\Baz'),
+            ),
+            array(
+                '
+<?php namespace
+/*Comment*/
+Foo\Bar
+;
+
+/** Foo */
+class
+/* Comment */
+ Baz {}
+     ',
+                array('Foo\Bar\Baz'),
+            ),
+        );
+    }
 }
 
 class EntityGeneratorAuthor {}


### PR DESCRIPTION
The entity generator is not able to parse the namespace/class of existing entities in many cases. This makes the parsing more robust (see unit tests).
