### PR TITLE
Changed the naming conventions of temporary files to avoid that they are loaded by Doctrine later on

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -183,7 +183,7 @@ public function <methodName>()
         }
 
         if ($this->_backupExisting && file_exists($path)) {
-            $backupPath = dirname($path) . DIRECTORY_SEPARATOR .  "~" . basename($path);
+            $backupPath = dirname($path) . DIRECTORY_SEPARATOR . basename($path) . "~";
             if (!copy($path, $backupPath)) {
                 throw new \RuntimeException("Attempt to backup overwritten entitiy file but copy operation failed.");
             }


### PR DESCRIPTION
Whenever you run the generate entities command, Doctrine creates temp files. As they end with .php, they loaded by the Doctrine later on, and this gives you an error as the class is loaded twice. Moving the `~` as the end of the file fixes this issue.
