### PR TITLE
Entity manager inheritance

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -728,6 +728,6 @@ class EntityManager
             throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 }


### PR DESCRIPTION
To be able to inherit from EntityManager, the `create()` method should be slightly changed to use `static` as the class name.
