### PR TITLE
Cannot do findBy lookup by 'field' => null anymore

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1296,10 +1296,6 @@ class BasicEntityPersister
         $params = $types = array();
 
         foreach ($criteria AS $field => $value) {
-            if ($value === null) {
-                continue; // skip null values.
-            }
-
             $type = null;
             if (isset($this->_class->fieldMappings[$field])) {
                 $type = Type::getType($this->_class->fieldMappings[$field]['type'])->getBindingType();

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -309,19 +309,6 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 
     /**
-     * @group DDC-1087
-     */
-    public function testIsNullCriteria()
-    {
-        $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $users = $repos->findBy(array('status' => null, 'username' => 'romanb'));
-
-        $params = $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['params'];
-        $this->assertEquals(1, count($params), "Should only execute with one parameter.");
-        $this->assertEquals(array('romanb'), $params);
-    }
-
-    /**
      * @group DDC-1094
      */
     public function testFindByLimitOffset()


### PR DESCRIPTION
This block of code was added in 2.0.4 and removes the ability to perform a findBy(array('field' => NULL)); in order to find all records where that field is null. The commit it was attached to appears to be for a different problem and this appears to have been added in by mistake. This solution not only causes a new problem, but did not solve the original problem. There is an associated unit test that needs to be removed as well.

Problem commit: af5bcc148d7460de2843
The original commit message: [DDC-1087] Add missing resolution to IS NULL in EntityRepository when passing a null value as a criteria.

This commit did in fact add the code to fix the original problem but then added another block of code to make it just not work at all.
