### PR TITLE
[DDC-217] Cache SQL results before hydration (and not after).

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/CachedResultStatement.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/CachedResultStatement.php
@@ -1,0 +1,19 @@
+<?php
+namespace Doctrine\ORM\Internal\Hydration;
+
+class CachedResultStatement extends \ArrayIterator implements ResultStatementInterface {
+    
+    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    {
+        $value = $this->current();
+        $this->next();
+        return $value;
+    }
+  
+    public function closeCursor()
+    {
+        $this->rewind();
+        return true;
+    }
+  
+}

--- a/lib/Doctrine/ORM/Internal/Hydration/ResultStatementDecorator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ResultStatementDecorator.php
@@ -1,0 +1,38 @@
+<?php
+namespace Doctrine\ORM\Internal\Hydration;
+
+class ResultStatementDecorator implements ResultStatementInterface {
+  
+    /** @var Statement */
+    protected $_stmt;
+    
+    protected $result = array();
+  
+    public function __construct($stmt)
+    {
+        $this->_stmt = $stmt;
+    }
+  
+    public function fetch($fetchStyle = PDO::FETCH_BOTH)
+    {
+        $row = $this->_stmt->fetch($fetchStyle);
+        if ($row !== false) {
+            $this->result[] = $row;
+        }
+        return $row;
+    }
+  
+    public function closeCursor()
+    {
+        return $this->_stmt->closeCursor();
+    }
+    
+    public function __call($name, $args) {
+      return call_user_func_array(array($this->_stmt, $name), $args);
+    }
+    
+    public function getResult() {
+        return $this->result;
+    }
+  
+}

--- a/lib/Doctrine/ORM/Internal/Hydration/ResultStatementInterface.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ResultStatementInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Doctrine\ORM\Internal\Hydration;
+
+interface ResultStatementInterface
+{
+    
+    public function fetch($fetchStyle = PDO::FETCH_BOTH);
+    public function closeCursor();
+  
+}

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -55,6 +55,18 @@ final class NativeQuery extends AbstractQuery
     /**
      * {@inheritdoc}
      */
+    protected function _doPreExecute()
+    {
+        return array(
+            'executor' => null,
+            'params' => null,
+            'types' => null,
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function _doExecute()
     {
         $stmt = $this->_em->getConnection()->prepare($this->_sql);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -218,7 +218,7 @@ final class Query extends AbstractQuery
     /**
      * {@inheritdoc}
      */
-    protected function _doExecute()
+    protected function _doPreExecute()
     {
         $executor = $this->_parse()->getSqlExecutor();
 
@@ -271,7 +271,17 @@ final class Query extends AbstractQuery
             $this->_resultSetMapping = $this->_parserResult->getResultSetMapping();
         }
 
-        return $executor->execute($this->_em->getConnection(), $sqlParams, $types);
+        return array(
+            'executor' => $executor,
+            'params' => $sqlParams,
+            'types' => $types,
+        );
+    }
+
+    protected function _doExecute()
+    {
+        $analysis = $this->_doPreExecute();
+        return $analysis['executor']->execute($this->_em->getConnection(), $analysis['params'], $analysis['types']);
     }
 
     /**


### PR DESCRIPTION
I've made my own implementation for this:
https://github.com/sobstel/doctrine2/commit/f583625f791da22dec77dd7d6c83b813f0bcbdaa
There are no changes in specific hydrators and there is no fetchAll(). I've added 2 wrappers: one for cached result array, and one for uncached pdo statement. The former (CachedResultStatement) is actually ArrayIterator which just implements used methods (fetch & closeCursor => also specified in ResultStatementInterface). The latter is decorator for stmt, which just collects results on each call of fetch() (results are later available by calling getResult), and apart from this all calls are delegated to actual stmt object.

I've used (copied) following changes from Daniel https://github.com/dcousineau/doctrine2/commit/c23b5a902da79ffc472c0769b9258775baf3189e

Whole discussion: http://www.doctrine-project.org/jira/browse/DDC-217
