### PR TITLE
[ProxyFactory] Problem this autogenerate proxies

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -77,7 +77,7 @@ class ProxyFactory
         $proxyClassName = str_replace('\\', '', $className) . 'Proxy';
         $fqn = $this->_proxyNamespace . '\\' . $proxyClassName;
 
-        if (! class_exists($fqn, false)) {
+        if (! class_exists($fqn)) {
             $fileName = $this->_proxyDir . DIRECTORY_SEPARATOR . $proxyClassName . '.php';
             if ($this->_autoGenerate) {
                 $this->_generateProxyClass($this->_em->getClassMetadata($className), $proxyClassName, $fileName, self::$_proxyClassTemplate);


### PR DESCRIPTION
I generated proxies from CLI script and it's class exists. But this method every time try rewrite it.

I think this is not normal behavior. But I don't know why you used second argument in class_exists() call (to disable autoloading). Maybe you have a reason for this.
