### PR TITLE
Implemented tableName -> className and columnName -> fieldName mapping in DatabaseDriver.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -88,7 +88,7 @@ class DatabaseDriver implements Driver
     {
         $this->tables = $this->manyToManyTables = $this->classToTableNames = array();
         foreach ($entityTables AS $table) {
-            $className = $this->_getClassNameForTable($table->getName());
+            $className = $this->getClassNameForTable($table->getName());
             $this->classToTableNames[$className] = $table->getName();
             $this->tables[$table->getName()] = $table;
         }
@@ -130,7 +130,7 @@ class DatabaseDriver implements Driver
             } else {
                 // lower-casing is necessary because of Oracle Uppercase Tablenames,
                 // assumption is lower-case + underscore separated.
-                $className = $this->_getClassNameForTable($tableName);
+                $className = $this->getClassNameForTable($tableName);
                 $this->tables[$tableName] = $table;
                 $this->classToTableNames[$className] = $tableName;
             }
@@ -182,7 +182,7 @@ class DatabaseDriver implements Driver
                 continue;
             }
 
-            $fieldMapping['fieldName'] = $this->_getFieldNameForColumn($tableName, $column->getName(), false);
+            $fieldMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $column->getName(), false);
             $fieldMapping['columnName'] = $column->getName();
             $fieldMapping['type'] = strtolower((string) $column->getType());
 
@@ -236,10 +236,10 @@ class DatabaseDriver implements Driver
 
                     $localColumn = current($myFk->getColumns());
                     $associationMapping = array();
-                    $associationMapping['fieldName'] = $this->_getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
-                    $associationMapping['targetEntity'] = $this->_getClassNameForTable($otherFk->getForeignTableName());
+                    $associationMapping['fieldName'] = $this->getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
+                    $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
                     if (current($manyTable->getColumns())->getName() == $localColumn) {
-                        $associationMapping['inversedBy'] = $this->_getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
+                        $associationMapping['inversedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
                         $associationMapping['joinTable'] = array(
                             'name' => strtolower($manyTable->getName()),
                             'joinColumns' => array(),
@@ -264,7 +264,7 @@ class DatabaseDriver implements Driver
                             );
                         }
                     } else {
-                        $associationMapping['mappedBy'] = $this->_getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
+                        $associationMapping['mappedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
                     }
                     $metadata->mapManyToMany($associationMapping);
                     break;
@@ -279,8 +279,8 @@ class DatabaseDriver implements Driver
 
             $localColumn = current($cols);
             $associationMapping = array();
-            $associationMapping['fieldName'] = $this->_getFieldNameForColumn($tableName, $localColumn, true);
-            $associationMapping['targetEntity'] = $this->_getClassNameForTable($foreignTable);
+            $associationMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $localColumn, true);
+            $associationMapping['targetEntity'] = $this->getClassNameForTable($foreignTable);
 
             for ($i = 0; $i < count($cols); $i++) {
                 $associationMapping['joinColumns'][] = array(
@@ -345,7 +345,7 @@ class DatabaseDriver implements Driver
      * @param string $tableName
      * @return string
      */
-    private function _getClassNameForTable($tableName)
+    private function getClassNameForTable($tableName)
     {
         if (isset($this->classNamesForTables[$tableName])) {
             return $this->classNamesForTables[$tableName];
@@ -362,7 +362,7 @@ class DatabaseDriver implements Driver
      * @param boolean $fk Whether the column is a foreignkey or not.
      * @return string
      */
-    private function _getFieldNameForColumn($tableName, $columnName, $fk = false)
+    private function getFieldNameForColumn($tableName, $columnName, $fk = false)
     {
         if (isset($this->fieldNamesForColumns[$tableName]) && isset($this->fieldNamesForColumns[$tableName][$columnName])) {
             return $this->fieldNamesForColumns[$tableName][$columnName];

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -67,6 +67,13 @@ class DatabaseDriver implements Driver
     private $fieldNamesForColumns = array();
 
     /**
+     * The namespace for the generated entities.
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
      * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
      * docblock annotations.
      * 
@@ -348,10 +355,10 @@ class DatabaseDriver implements Driver
     private function getClassNameForTable($tableName)
     {
         if (isset($this->classNamesForTables[$tableName])) {
-            return $this->classNamesForTables[$tableName];
+            return $this->namespace . $this->classNamesForTables[$tableName];
         }
 
-        return Inflector::classify(strtolower($tableName));
+        return $this->namespace . Inflector::classify(strtolower($tableName));
     }
 
     /**
@@ -375,5 +382,16 @@ class DatabaseDriver implements Driver
             $columnName = str_replace('_id', '', $columnName);
         }
         return Inflector::camelize($columnName);
+    }
+
+    /**
+     * Set the namespace for the generated entities.
+     *
+     * @param string $namespace
+     * @return void
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -78,6 +78,10 @@ class ConvertMappingCommand extends Console\Command\Command
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
             ),
+            new InputOption(
+                'namespace', null, InputOption::VALUE_OPTIONAL,
+                'Defines a namespace for the generated entity classes, if converted from database.'
+            ),
         ))
         ->setHelp(<<<EOT
 Convert mapping information between supported formats.
@@ -107,11 +111,17 @@ EOT
         $em = $this->getHelper('em')->getEntityManager();
 
         if ($input->getOption('from-database') === true) {
-            $em->getConfiguration()->setMetadataDriverImpl(
-                new \Doctrine\ORM\Mapping\Driver\DatabaseDriver(
-                    $em->getConnection()->getSchemaManager()
-                )
+            $databaseDriver = new \Doctrine\ORM\Mapping\Driver\DatabaseDriver(
+                $em->getConnection()->getSchemaManager()
             );
+
+            $em->getConfiguration()->setMetadataDriverImpl(
+                $databaseDriver
+            );
+
+            if (($namespace = $input->getOption('namespace')) !== null) {
+                $databaseDriver->setNamespace($namespace);
+            }
         }
 
         $cmf = new DisconnectedClassMetadataFactory();


### PR DESCRIPTION
As discussed with beberlei on IRC. This enables custom naming of entities and fieldnames when re-engineering from the database. It can be used when the mapping is done with a script, not by the commandline (yet?).

``` php
<?php
// bootstrap
$db = new \Doctrine\ORM\Mapping\Driver\DatabaseDriver(
                    $em->getConnection()->getSchemaManager()
                );
$db->setClassNameForTable('tblArticles', 'Review');
$db->setFieldNameForColumn('tblArticles', 'iArticleId', 'id');
```
