### PR TITLE
Added missing checks for associatation indexes

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -120,22 +120,30 @@ class PhpExporter extends AbstractExporter
                 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToOneMappingArray);
             } else if ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_MANY) {
-                $method = 'mapOneToMany';
-                $oneToManyMappingArray = array(
-                    'mappedBy'      => $associationMapping['mappedBy'],
-                    'orphanRemoval' => $associationMapping['orphanRemoval'],
-                    'orderBy' => $associationMapping['orderBy']
+                $method = 'mapOneToMany';                
+                $potentialAssociationMappingIndexes = array(
+                    'mappedBy',
+                    'orphanRemoval',
+                    'orderBy',
                 );
-                
+                foreach ($potentialAssociationMappingIndexes as $index) {
+                    if (isset($associationMapping[$index])) {
+                        $oneToManyMappingArray[$index] = $associationMapping[$index];
+                    }
+                }
                 $associationMappingArray = array_merge($associationMappingArray, $oneToManyMappingArray);
             } else if ($associationMapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
-                $method = 'mapManyToMany';
-                $manyToManyMappingArray = array(
-                    'mappedBy'  => $associationMapping['mappedBy'],
-                    'joinTable' => $associationMapping['joinTable'],
-                    'orderBy' => $associationMapping['orderBy']
+                $method = 'mapManyToMany';                
+                $potentialAssociationMappingIndexes = array(
+                    'mappedBy',
+                    'joinTable',
+                    'orderBy',
                 );
-                
+                foreach ($potentialAssociationMappingIndexes as $index) {
+                    if (isset($associationMapping[$index])) {
+                        $manyToManyMappingArray[$index] = $associationMapping[$index];
+                    }
+                }
                 $associationMappingArray = array_merge($associationMappingArray, $manyToManyMappingArray);
             }
             


### PR DESCRIPTION
I cam to that problem while running doctrine:mapping:import with 'php' mapping type.
I got in my database (MySQL) three tables (simplified):
categories(`id`), messages(`id`) and categories_messages(`categories_id`,`messages_id`).

Doctrine threw an exception while importing mappings in php, although in xml it was OK. 
The message was:
  [ErrorException]  
  Notice: Undefined index: orderBy in /var/project/vendor/doctrine/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php line 136

And there were no checks of the existence of indexes in an array so I added those checks and if they return true, copying a value takes place as previous.
