### PR TITLE
Add extension points into the xml schema

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -17,11 +17,18 @@
       <xs:sequence>
         <xs:element name="mapped-superclass" type="orm:mapped-superclass" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="entity" type="orm:entity" minOccurs="0" maxOccurs="unbounded" />
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:sequence>
+      <xs:anyAttribute namespace="##other"/>
     </xs:complexType>
   </xs:element>
   
-  <xs:complexType name="emptyType"/> 
+  <xs:complexType name="emptyType">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
+  </xs:complexType>
   
   <xs:complexType name="cascade-type">
     <xs:sequence>
@@ -30,7 +37,9 @@
       <xs:element name="cascade-merge" type="orm:emptyType" minOccurs="0"/> 
       <xs:element name="cascade-remove" type="orm:emptyType" minOccurs="0"/> 
       <xs:element name="cascade-refresh" type="orm:emptyType" minOccurs="0"/> 
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:simpleType name="lifecycle-callback-type">
@@ -46,24 +55,32 @@
   </xs:simpleType>
   
   <xs:complexType name="lifecycle-callback">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="type" type="orm:lifecycle-callback-type" use="required" />
     <xs:attribute name="method" type="xs:NMTOKEN" use="required" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="lifecycle-callbacks">
     <xs:sequence>
       <xs:element name="lifecycle-callback" type="orm:lifecycle-callback" minOccurs="1" maxOccurs="unbounded" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="named-query">
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="query" type="xs:string" use="required" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="named-queries">
     <xs:sequence>
       <xs:element name="named-query" type="orm:named-query" minOccurs="1" maxOccurs="unbounded" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -81,6 +98,7 @@
       <xs:element name="one-to-many" type="orm:one-to-many" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="many-to-one" type="orm:many-to-one" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="many-to-many" type="orm:many-to-many" minOccurs="0" maxOccurs="unbounded" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="table" type="xs:NMTOKEN" />
@@ -89,11 +107,17 @@
     <xs:attribute name="inheritance-type" type="orm:inheritance-type"/>
     <xs:attribute name="change-tracking-policy" type="orm:change-tracking-policy" />
     <xs:attribute name="read-only" type="xs:boolean" default="false" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="mapped-superclass" >
     <xs:complexContent>
-      <xs:extension base="orm:entity"/>
+      <xs:extension base="orm:entity">
+        <xs:sequence>
+          <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+        </xs:sequence>
+        <xs:anyAttribute namespace="##other"/>
+      </xs:extension>
     </xs:complexContent>
   </xs:complexType>
 
@@ -139,6 +163,9 @@
   </xs:simpleType>
 
   <xs:complexType name="field">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="type" type="xs:NMTOKEN" default="string" />
     <xs:attribute name="column" type="xs:NMTOKEN" />
@@ -149,76 +176,114 @@
     <xs:attribute name="column-definition" type="xs:string" />
     <xs:attribute name="precision" type="xs:integer" use="optional" />
     <xs:attribute name="scale" type="xs:integer" use="optional" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="discriminator-column">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="type" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="field-name" type="xs:NMTOKEN" />
     <xs:attribute name="length" type="xs:NMTOKEN" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="unique-constraint">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
     <xs:attribute name="columns" type="xs:string" use="required"/>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="unique-constraints">
     <xs:sequence>
       <xs:element name="unique-constraint" type="orm:unique-constraint" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="index">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
     <xs:attribute name="columns" type="xs:NMTOKENS" use="required"/>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="indexes">
     <xs:sequence>
       <xs:element name="index" type="orm:index" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="discriminator-mapping">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="value" type="xs:NMTOKEN" use="required"/>
     <xs:attribute name="class" type="xs:NMTOKEN" use="required"/>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="discriminator-map">
     <xs:sequence>
       <xs:element name="discriminator-mapping" type="orm:discriminator-mapping" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="generator">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="strategy" type="orm:generator-strategy" use="optional" default="AUTO" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="id">
     <xs:sequence>
       <xs:element name="generator" type="orm:generator" minOccurs="0" />
       <xs:element name="sequence-generator" type="orm:sequence-generator" minOccurs="0" maxOccurs="1" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="type" type="xs:NMTOKEN" />
     <xs:attribute name="column" type="xs:NMTOKEN" />
     <xs:attribute name="association-key" type="xs:boolean" default="false" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="sequence-generator">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
       <xs:attribute name="sequence-name" type="xs:NMTOKEN" use="required" />
       <xs:attribute name="allocation-size" type="xs:integer" use="optional" default="1" />
       <xs:attribute name="initial-value" type="xs:integer" use="optional" default="1" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="inverse-join-columns">
     <xs:sequence>
       <xs:element name="join-column" type="orm:join-column" minOccurs="1" maxOccurs="unbounded" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="join-column">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="referenced-column-name" type="xs:NMTOKEN" use="optional" default="id" />
     <xs:attribute name="unique" type="xs:boolean" default="false" />
@@ -226,32 +291,43 @@
     <xs:attribute name="on-delete" type="orm:fk-action" />
     <xs:attribute name="on-update" type="orm:fk-action" />
     <xs:attribute name="column-definition" type="xs:string" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="join-columns">
     <xs:sequence>
       <xs:element name="join-column" type="orm:join-column" minOccurs="1" maxOccurs="unbounded" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="join-table">
     <xs:sequence>
       <xs:element name="join-columns" type="orm:join-columns" />
       <xs:element name="inverse-join-columns" type="orm:join-columns" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="schema" type="xs:NMTOKEN" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="order-by">
       <xs:sequence>
           <xs:element name="order-by-field" type="orm:order-by-field" minOccurs="1" maxOccurs="unbounded" />
+          <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:sequence>
+      <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="order-by-field">
-      <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
-      <xs:attribute name="direction" type="orm:order-by-direction" default="ASC" />
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="direction" type="orm:order-by-direction" default="ASC" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:simpleType name="order-by-direction">
@@ -266,6 +342,7 @@
       <xs:element name="cascade" type="orm:cascade-type" minOccurs="0" />
       <xs:element name="join-table" type="orm:join-table" minOccurs="0" />
       <xs:element name="order-by" type="orm:order-by" minOccurs="0" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="target-entity" type="xs:string" use="required" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
@@ -273,12 +350,14 @@
     <xs:attribute name="index-by" type="xs:NMTOKEN" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
   <xs:complexType name="one-to-many">
     <xs:sequence>
       <xs:element name="cascade" type="orm:cascade-type" minOccurs="0" />
       <xs:element name="order-by" type="orm:order-by" minOccurs="0" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="target-entity" type="xs:string" use="required" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" use="required" />
@@ -286,6 +365,7 @@
     <xs:attribute name="index-by" type="xs:NMTOKEN" />
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="many-to-one">
@@ -294,13 +374,16 @@
       <xs:choice minOccurs="0" maxOccurs="1">
         <xs:element name="join-column" type="orm:join-column"/>
         <xs:element name="join-columns" type="orm:join-columns"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:choice>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="target-entity" type="xs:string" use="required" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   
   <xs:complexType name="one-to-one">
@@ -309,7 +392,9 @@
       <xs:choice minOccurs="0" maxOccurs="1">
         <xs:element name="join-column" type="orm:join-column"/>
         <xs:element name="join-columns" type="orm:join-columns"/>
+        <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
       </xs:choice>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="target-entity" type="xs:string" use="required" />
@@ -317,6 +402,7 @@
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
+    <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
Without this patch the final xml mapping cannot really be extended as xml won't be valid because doctrine xml schema doesn't allow for extension.
AFAIK, this is the only way to allow extending. 
Extending by importing the doctrine schema and extend it in another doesn't really work, as different vendors cannot really extend from one another.
