### PR TITLE
joinTable error with DB to YML generator

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -181,7 +181,7 @@ class YamlExporter extends AbstractExporter
                 $manyToManyMappingArray = array(
                     'mappedBy'   => $associationMapping['mappedBy'],
                     'inversedBy' => $associationMapping['inversedBy'],
-                    'joinTable'  => $associationMapping['joinTable'],
+                    'joinTable'  => isset($associationMapping['joinTable']) ? $associationMapping['joinTable'] : null,
                     'orderBy'    => isset($associationMapping['orderBy']) ? $associationMapping['orderBy'] : null
                 );
 


### PR DESCRIPTION
joinTable can be undefined because ManyToMAny generation is bidirectional with inverse sides,
work better now but with curious "-" line :

 joinTable:
        name: service_relationships
        joinColumns:
          -
            name: sitter_id
            referencedColumnName: id
        inverseJoinColumns:
          -
            name: service_id
            referencedColumnName: id
