### PR TITLE
another attempt to allow parent methods in generated proxy classes to pass along all args

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -178,13 +178,14 @@ class ProxyFactory
                 }
                 $methods .= $method->getName() . '(';
                 $firstParam = true;
-                $parameterString = '';
+                $parameterString = $argumentString = '';
 
                 foreach ($method->getParameters() as $param) {
                     if ($firstParam) {
                         $firstParam = false;
                     } else {
                         $parameterString .= ', ';
+                        $argumentString  .= ', ';
                     }
 
                     // We need to pick the type hint class too
@@ -199,6 +200,7 @@ class ProxyFactory
                     }
 
                     $parameterString .= '$' . $param->getName();
+                    $argumentString  .= '$' . $param->getName();
 
                     if ($param->isDefaultValueAvailable()) {
                         $parameterString .= ' = ' . var_export($param->getDefaultValue(), true);
@@ -207,8 +209,16 @@ class ProxyFactory
 
                 $methods .= $parameterString . ')';
                 $methods .= PHP_EOL . '    {' . PHP_EOL;
-                $methods .= '        $this->__load();' . PHP_EOL;
-                $methods .= '        return call_user_func_array(array(\'parent\', \'' . $method->getName() . '\'), func_get_args());';
+                $methods .= '        $this->_load();' . PHP_EOL;
+                
+                // If we have no params we use call_user_func_array and pass along all args so it may be used in parent method 
+                if (empty($parameterString)) {
+                	$methods .= '        return call_user_func_array(array(\'parent\', \'' . $method->getName() . '\'), func_get_args());';
+                }
+                else {
+                    $methods .= '        return parent::' . $method->getName() . '(' . $argumentString . ');';
+                }
+                
                 $methods .= PHP_EOL . '    }' . PHP_EOL;
             }
         }

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -178,14 +178,13 @@ class ProxyFactory
                 }
                 $methods .= $method->getName() . '(';
                 $firstParam = true;
-                $parameterString = $argumentString = '';
+                $parameterString = '';
 
                 foreach ($method->getParameters() as $param) {
                     if ($firstParam) {
                         $firstParam = false;
                     } else {
                         $parameterString .= ', ';
-                        $argumentString  .= ', ';
                     }
 
                     // We need to pick the type hint class too
@@ -200,7 +199,6 @@ class ProxyFactory
                     }
 
                     $parameterString .= '$' . $param->getName();
-                    $argumentString  .= '$' . $param->getName();
 
                     if ($param->isDefaultValueAvailable()) {
                         $parameterString .= ' = ' . var_export($param->getDefaultValue(), true);
@@ -210,7 +208,7 @@ class ProxyFactory
                 $methods .= $parameterString . ')';
                 $methods .= PHP_EOL . '    {' . PHP_EOL;
                 $methods .= '        $this->__load();' . PHP_EOL;
-                $methods .= '        return parent::' . $method->getName() . '(' . $argumentString . ');';
+                $methods .= '        return call_user_func_array(array(\'parent\', \'' . $method->getName() . '\'), func_get_args());';
                 $methods .= PHP_EOL . '    }' . PHP_EOL;
             }
         }

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -213,7 +213,7 @@ class ProxyFactory
                 
                 // If we have no params we use call_user_func_array and pass along all args so it may be used in parent method 
                 if (empty($parameterString)) {
-                	$methods .= '        return call_user_func_array(array(\'parent\', \'' . $method->getName() . '\'), func_get_args());';
+                    $methods .= '        return call_user_func_array(array(\'parent\', \'' . $method->getName() . '\'), func_get_args());';
                 }
                 else {
                     $methods .= '        return parent::' . $method->getName() . '(' . $argumentString . ');';


### PR DESCRIPTION
After considering your feedback re performance I have made it only use the call_user_func_array approach in the case that there are no params to the arg which means it MAY be using func_get_args internally in the parent method. 
