### PR TITLE
Change attribute 'columns' of type 'index' to 'xs:string' 

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -212,7 +212,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
-    <xs:attribute name="columns" type="xs:NMTOKENS" use="required"/>
+    <xs:attribute name="columns" type="xs:string" use="required"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   


### PR DESCRIPTION
The `columns` attribute of the `index` type was `xs:NMTOKENS`, therefore not allowing a comma, which is needed when multiple columns need to be specified. (I've checked the XmlDriver code for this)
It should be the same as the `columns` attribute of the `unique-constraints` type, namely `xs:string`.
