### PR TITLE
Suppressed an "undefined variable" notice by adding initialization code

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -110,6 +110,8 @@ class DatabaseDriver implements Driver
             return;
         }
 
+        $tables = array();
+                
         foreach ($this->_sm->listTableNames() as $tableName) {
             $tables[$tableName] = $this->_sm->listTableDetails($tableName);
         }


### PR DESCRIPTION
Suppressed an "undefined variable" notice by adding initialization code to Doctrine\ORM\Mapping\Driver\DatabaseDriver::reverseEngineerMappingFromDatabase().

This silly edge case only occurs when the database the mapping information should be imported from is empty.

Only one line has been inserted ($tables = array()) before the loop statement.
