### PR TITLE
Added the postFlush event to the Event Manager for successful flushes; fi

### DIFF
--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -22,16 +22,17 @@
 namespace Doctrine\ORM\Event;
 
 /**
- * Provides event arguments for the onFlush event.
+ * Provides event arguments for the postFlush event.
  *
  * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link        www.doctrine-project.com
- * @since       2.0
+ * @since       2.1
  * @version     $Revision$
  * @author      Roman Borschel <roman@code-factory.de>
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
+ * @author      Christopher Hoult <choult@gmail.com>
  */
-class OnFlushEventArgs extends \Doctrine\Common\EventArgs
+class PostFlushEventArgs extends \Doctrine\Common\EventArgs
 {
     /**
      * @var EntityManager

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -35,55 +35,55 @@ final class Events
     /**
      * The preRemove event occurs for a given entity before the respective
      * EntityManager remove operation for that entity is executed.
-     * 
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const preRemove = 'preRemove';
     /**
-     * The postRemove event occurs for an entity after the entity has 
+     * The postRemove event occurs for an entity after the entity has
      * been deleted. It will be invoked after the database delete operations.
-     * 
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const postRemove = 'postRemove';
     /**
      * The prePersist event occurs for a given entity before the respective
      * EntityManager persist operation for that entity is executed.
-     * 
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const prePersist = 'prePersist';
     /**
-     * The postPersist event occurs for an entity after the entity has 
+     * The postPersist event occurs for an entity after the entity has
      * been made persistent. It will be invoked after the database insert operations.
      * Generated primary key values are available in the postPersist event.
-     * 
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const postPersist = 'postPersist';
     /**
-     * The preUpdate event occurs before the database update operations to 
-     * entity data. 
-     * 
+     * The preUpdate event occurs before the database update operations to
+     * entity data.
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const preUpdate = 'preUpdate';
     /**
-     * The postUpdate event occurs after the database update operations to 
-     * entity data. 
-     * 
+     * The postUpdate event occurs after the database update operations to
+     * entity data.
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const postUpdate = 'postUpdate';
@@ -91,34 +91,41 @@ final class Events
      * The postLoad event occurs for an entity after the entity has been loaded
      * into the current EntityManager from the database or after the refresh operation
      * has been applied to it.
-     * 
+     *
      * Note that the postLoad event occurs for an entity before any associations have been
      * initialized. Therefore it is not safe to access associations in a postLoad callback
      * or event handler.
-     * 
+     *
      * This is an entity lifecycle event.
-     * 
+     *
      * @var string
      */
     const postLoad = 'postLoad';
     /**
      * The loadClassMetadata event occurs after the mapping metadata for a class
      * has been loaded from a mapping source (annotations/xml/yaml).
-     * 
+     *
      * @var string
      */
     const loadClassMetadata = 'loadClassMetadata';
-    
+
     /**
      * The onFlush event occurs when the EntityManager#flush() operation is invoked,
      * after any changes to managed entities have been determined but before any
      * actual database operations are executed. The event is only raised if there is
      * actually something to do for the underlying UnitOfWork. If nothing needs to be done,
      * the onFlush event is not raised.
-     * 
+     *
      * @var string
      */
     const onFlush = 'onFlush';
+
+    /**
+     * The postFlush event occurs when the EntityManager#flush() operation has completed successfully.
+     *
+     * @var string
+     */
+    const postFlush = 'postFlush';
 
     /**
      * The onClear event occurs when the EntityManager#clear() operation is invoked,

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -116,7 +116,7 @@ class UnitOfWork implements PropertyChangedListener
      * Map of entities that are scheduled for dirty checking at commit time.
      * This is only used for entities with a change tracking policy of DEFERRED_EXPLICIT.
      * Keys are object ids (spl_object_hash).
-     * 
+     *
      * @var array
      * @todo rename: scheduledForSynchronization
      */
@@ -135,10 +135,10 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      */
     private $entityUpdates = array();
-    
+
     /**
      * Any pending extra updates that have been scheduled by persisters.
-     * 
+     *
      * @var array
      */
     private $extraUpdates = array();
@@ -201,26 +201,26 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      */
     private $collectionPersisters = array();
-    
+
     /**
      * The EventManager used for dispatching events.
-     * 
+     *
      * @var EventManager
      */
     private $evm;
-    
+
     /**
      * Orphaned entities that are scheduled for removal.
-     * 
+     *
      * @var array
      */
     private $orphanRemovals = array();
-    
+
     //private $_readOnlyObjects = array();
 
     /**
      * Map of Entity Class-Names and corresponding IDs that should eager loaded when requested.
-     * 
+     *
      * @var array
      */
     private $eagerLoadingEntities = array();
@@ -240,15 +240,15 @@ class UnitOfWork implements PropertyChangedListener
      * Commits the UnitOfWork, executing all operations that have been postponed
      * up to this point. The state of all managed entities will be synchronized with
      * the database.
-     * 
+     *
      * The operations are executed in the following order:
-     * 
+     *
      * 1) All entity insertions
      * 2) All entity updates
      * 3) All collection deletions
      * 4) All collection updates
      * 5) All entity deletions
-     * 
+     *
      */
     public function commit()
     {
@@ -269,12 +269,12 @@ class UnitOfWork implements PropertyChangedListener
                 $this->remove($orphan);
             }
         }
-        
+
         // Raise onFlush
         if ($this->evm->hasListeners(Events::onFlush)) {
             $this->evm->dispatchEvent(Events::onFlush, new Event\OnFlushEventArgs($this->em));
         }
-        
+
         // Now we need a commit order to maintain referential integrity
         $commitOrder = $this->getCommitOrder();
 
@@ -340,8 +340,13 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections =
         $this->scheduledForDirtyCheck =
         $this->orphanRemovals = array();
+
+        // Raise postFlush
+        if ($this->evm->hasListeners(Events::postFlush)) {
+            $this->evm->dispatchEvent(Events::postFlush, new Event\PostFlushEventArgs($this->em));
+        }
     }
-    
+
     /**
      * Executes any extra updates that have been scheduled.
      */
@@ -401,7 +406,7 @@ class UnitOfWork implements PropertyChangedListener
         if ( ! $class->isInheritanceTypeNone()) {
             $class = $this->em->getClassMetadata(get_class($entity));
         }
-        
+
         $oid = spl_object_hash($entity);
         $actualData = array();
         foreach ($class->reflFields as $name => $refProp) {
@@ -415,16 +420,16 @@ class UnitOfWork implements PropertyChangedListener
                 if ( ! $value instanceof Collection) {
                     $value = new ArrayCollection($value);
                 }
-                
+
                 $assoc = $class->associationMappings[$name];
-                
+
                 // Inject PersistentCollection
                 $coll = new PersistentCollection(
                     $this->em,
                     $this->em->getClassMetadata($assoc['targetEntity']),
                     $value
                 );
-                
+
                 $coll->setOwner($entity, $assoc);
                 $coll->setDirty( ! $coll->isEmpty());
                 $class->reflFields[$name]->setValue($entity, $coll);
@@ -620,16 +625,16 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->scheduleForInsert($entity);
     }
-    
+
     /**
      * INTERNAL:
      * Computes the changeset of an individual entity, independently of the
      * computeChangeSets() routine that is used at the beginning of a UnitOfWork#commit().
-     * 
+     *
      * The passed entity must be a managed entity. If the entity already has a change set
      * because this method is invoked during a commit cycle then the change sets are added.
      * whereby changes detected in this method prevail.
-     * 
+     *
      * @ignore
      * @param ClassMetadata $class The class descriptor of the entity.
      * @param object $entity The entity for which to (re)calculate the change set.
@@ -638,11 +643,11 @@ class UnitOfWork implements PropertyChangedListener
     public function recomputeSingleEntityChangeSet($class, $entity)
     {
         $oid = spl_object_hash($entity);
-        
+
         if ( ! isset($this->entityStates[$oid]) || $this->entityStates[$oid] != self::STATE_MANAGED) {
             throw new InvalidArgumentException('Entity must be managed.');
         }
-        
+
         /* TODO: Just return if changetracking policy is NOTIFY?
         if ($class->isChangeTrackingNotify()) {
             return;
@@ -688,13 +693,13 @@ class UnitOfWork implements PropertyChangedListener
     {
         $className = $class->name;
         $persister = $this->getEntityPersister($className);
-        
+
         $hasLifecycleCallbacks = isset($class->lifecycleCallbacks[Events::postPersist]);
         $hasListeners = $this->evm->hasListeners(Events::postPersist);
         if ($hasLifecycleCallbacks || $hasListeners) {
             $entities = array();
         }
-        
+
         foreach ($this->entityInsertions as $oid => $entity) {
             if (get_class($entity) === $className) {
                 $persister->addInsert($entity);
@@ -719,7 +724,7 @@ class UnitOfWork implements PropertyChangedListener
                 $this->addToIdentityMap($entity);
             }
         }
-        
+
         if ($hasLifecycleCallbacks || $hasListeners) {
             foreach ($entities as $entity) {
                 if ($hasLifecycleCallbacks) {
@@ -746,15 +751,15 @@ class UnitOfWork implements PropertyChangedListener
         $hasPreUpdateListeners = $this->evm->hasListeners(Events::preUpdate);
         $hasPostUpdateLifecycleCallbacks = isset($class->lifecycleCallbacks[Events::postUpdate]);
         $hasPostUpdateListeners = $this->evm->hasListeners(Events::postUpdate);
-        
+
         foreach ($this->entityUpdates as $oid => $entity) {
             if (get_class($entity) == $className || $entity instanceof Proxy && get_parent_class($entity) == $className) {
-                
+
                 if ($hasPreUpdateLifecycleCallbacks) {
                     $class->invokeLifecycleCallbacks(Events::preUpdate, $entity);
                     $this->recomputeSingleEntityChangeSet($class, $entity);
                 }
-                
+
                 if ($hasPreUpdateListeners) {
                     $this->evm->dispatchEvent(Events::preUpdate, new Event\PreUpdateEventArgs(
                         $entity, $this->em, $this->entityChangeSets[$oid])
@@ -765,7 +770,7 @@ class UnitOfWork implements PropertyChangedListener
                     $persister->update($entity);
                 }
                 unset($this->entityUpdates[$oid]);
-                
+
                 if ($hasPostUpdateLifecycleCallbacks) {
                     $class->invokeLifecycleCallbacks(Events::postUpdate, $entity);
                 }
@@ -785,10 +790,10 @@ class UnitOfWork implements PropertyChangedListener
     {
         $className = $class->name;
         $persister = $this->getEntityPersister($className);
-                
+
         $hasLifecycleCallbacks = isset($class->lifecycleCallbacks[Events::postRemove]);
         $hasListeners = $this->evm->hasListeners(Events::postRemove);
-        
+
         foreach ($this->entityDeletions as $oid => $entity) {
             if (get_class($entity) == $className || $entity instanceof Proxy && get_parent_class($entity) == $className) {
                 $persister->delete($entity);
@@ -829,14 +834,14 @@ class UnitOfWork implements PropertyChangedListener
                     $this->entityDeletions
                     );
         }
-        
+
         $calc = $this->getCommitOrderCalculator();
-        
+
         // See if there are any new classes in the changeset, that are not in the
         // commit order graph yet (dont have a node).
         $newNodes = array();
         foreach ($entityChangeSet as $oid => $entity) {
-            $className = get_class($entity);         
+            $className = get_class($entity);
             if ( ! $calc->hasClass($className)) {
                 $class = $this->em->getClassMetadata($className);
                 $calc->addClass($class);
@@ -928,14 +933,14 @@ class UnitOfWork implements PropertyChangedListener
             $this->entityUpdates[$oid] = $entity;
         }
     }
-    
+
     /**
      * INTERNAL:
      * Schedules an extra update that will be executed immediately after the
      * regular entity updates within the currently running commit cycle.
-     * 
+     *
      * Extra updates for entities are stored as (entity, changeset) tuples.
-     * 
+     *
      * @ignore
      * @param object $entity The entity for which to schedule an extra update.
      * @param array $changeset The changeset of the entity (what to update).
@@ -973,13 +978,13 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * INTERNAL:
      * Schedules an entity for deletion.
-     * 
+     *
      * @param object $entity
      */
     public function scheduleForDelete($entity)
     {
         $oid = spl_object_hash($entity);
-        
+
         if (isset($this->entityInsertions[$oid])) {
             if ($this->isInIdentityMap($entity)) {
                 $this->removeFromIdentityMap($entity);
@@ -1016,7 +1021,7 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Checks whether an entity is scheduled for insertion, update or deletion.
-     * 
+     *
      * @param $entity
      * @return boolean
      */
@@ -1185,7 +1190,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($idHash === '') {
             return false;
         }
-        
+
         return isset($this->identityMap[$classMetadata->rootEntityName][$idHash]);
     }
 
@@ -1216,7 +1221,7 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Persists an entity as part of the current unit of work.
-     * 
+     *
      * This method is internally called during persist() cascades as it tracks
      * the already visited entities to prevent infinite recursions.
      *
@@ -1294,8 +1299,8 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $visited[$oid] = $entity; // mark visited
-        
-        // Cascade first, because scheduleForDelete() removes the entity from the identity map, which 
+
+        // Cascade first, because scheduleForDelete() removes the entity from the identity map, which
         // can cause problems when a lazy proxy has to be initialized for the cascade operation.
         $this->cascadeRemove($entity, $visited);
 
@@ -1495,7 +1500,7 @@ class UnitOfWork implements PropertyChangedListener
 
         return $managedCopy;
     }
-    
+
     /**
      * Detaches an entity from the persistence management. It's persistence will
      * no longer be managed by Doctrine.
@@ -1507,10 +1512,10 @@ class UnitOfWork implements PropertyChangedListener
         $visited = array();
         $this->doDetach($entity, $visited);
     }
-    
+
     /**
      * Executes a detach operation on the given entity.
-     * 
+     *
      * @param object $entity
      * @param array $visited
      */
@@ -1522,7 +1527,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $visited[$oid] = $entity; // mark visited
-        
+
         switch ($this->getEntityState($entity, self::STATE_DETACHED)) {
             case self::STATE_MANAGED:
                 if ($this->isInIdentityMap($entity)) {
@@ -1536,14 +1541,14 @@ class UnitOfWork implements PropertyChangedListener
             case self::STATE_DETACHED:
                 return;
         }
-        
+
         $this->cascadeDetach($entity, $visited);
     }
-    
+
     /**
      * Refreshes the state of the given entity from the database, overwriting
      * any local, unpersisted changes.
-     * 
+     *
      * @param object $entity The entity to refresh.
      * @throws InvalidArgumentException If the entity is not MANAGED.
      */
@@ -1552,10 +1557,10 @@ class UnitOfWork implements PropertyChangedListener
         $visited = array();
         $this->doRefresh($entity, $visited);
     }
-    
+
     /**
      * Executes a refresh operation on an entity.
-     * 
+     *
      * @param object $entity The entity to refresh.
      * @param array $visited The already visited entities during cascades.
      * @throws InvalidArgumentException If the entity is not MANAGED.
@@ -1578,10 +1583,10 @@ class UnitOfWork implements PropertyChangedListener
         } else {
             throw new InvalidArgumentException("Entity is not MANAGED.");
         }
-        
+
         $this->cascadeRefresh($entity, $visited);
     }
-    
+
     /**
      * Cascades a refresh operation to associated entities.
      *
@@ -1609,7 +1614,7 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
     }
-    
+
     /**
      * Cascades a detach operation to associated entities.
      *
@@ -1681,7 +1686,7 @@ class UnitOfWork implements PropertyChangedListener
             if ( ! $assoc['isCascadePersist']) {
                 continue;
             }
-            
+
             $relatedEntities = $class->reflFields[$assoc['fieldName']]->getValue($entity);
             if (($relatedEntities instanceof Collection || is_array($relatedEntities))) {
                 if ($relatedEntities instanceof PersistentCollection) {
@@ -1710,11 +1715,11 @@ class UnitOfWork implements PropertyChangedListener
             if ( ! $assoc['isCascadeRemove']) {
                 continue;
             }
-            
+
             if ($entity instanceof Proxy && !$entity->__isInitialized__) {
                 $entity->__load();
             }
-            
+
             $relatedEntities = $class->reflFields[$assoc['fieldName']]->getValue($entity);
             if ($relatedEntities instanceof Collection || is_array($relatedEntities)) {
                 // If its a PersistentCollection initialization is intended! No unwrap!
@@ -1739,7 +1744,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($this->getEntityState($entity) != self::STATE_MANAGED) {
             throw new InvalidArgumentException("Entity is not MANAGED.");
         }
-        
+
         $entityName = get_class($entity);
         $class = $this->em->getClassMetadata($entityName);
 
@@ -1759,7 +1764,7 @@ class UnitOfWork implements PropertyChangedListener
             if (!$this->em->getConnection()->isTransactionActive()) {
                 throw TransactionRequiredException::transactionRequired();
             }
-            
+
             $oid = spl_object_hash($entity);
 
             $this->getEntityPersister($class->name)->lock(
@@ -1808,13 +1813,13 @@ class UnitOfWork implements PropertyChangedListener
             $this->evm->dispatchEvent(Events::onClear, new Event\OnClearEventArgs($this->em));
         }
     }
-    
+
     /**
      * INTERNAL:
      * Schedules an orphaned entity for removal. The remove() operation will be
      * invoked on that entity at the beginning of the next commit of this
      * UnitOfWork.
-     * 
+     *
      * @ignore
      * @param object $entity
      */
@@ -1822,7 +1827,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $this->orphanRemovals[spl_object_hash($entity)] = $entity;
     }
-    
+
     /**
      * INTERNAL:
      * Schedules a complete collection for removal when this UnitOfWork commits.
@@ -1851,7 +1856,7 @@ class UnitOfWork implements PropertyChangedListener
      * @param array $hints Any hints to account for during reconstitution/lookup of the entity.
      * @return object The managed entity instance.
      * @internal Highly performance-sensitive method.
-     * 
+     *
      * @todo Rename: getOrCreateEntity
      */
     public function createEntity($className, array $data, &$hints = array())
@@ -1877,8 +1882,8 @@ class UnitOfWork implements PropertyChangedListener
             }
             $id = array($class->identifier[0] => $idHash);
         }
-        
-        if (isset($this->identityMap[$class->rootEntityName][$idHash])) {            
+
+        if (isset($this->identityMap[$class->rootEntityName][$idHash])) {
             $entity = $this->identityMap[$class->rootEntityName][$idHash];
             $oid = spl_object_hash($entity);
             if ($entity instanceof Proxy && ! $entity->__isInitialized__) {
@@ -1913,7 +1918,7 @@ class UnitOfWork implements PropertyChangedListener
 
             // Loading the entity right here, if its in the eager loading map get rid of it there.
             unset($this->eagerLoadingEntities[$class->rootEntityName][$idHash]);
-            
+
             // Properly initialize any unfetched associations, if partial objects are not allowed.
             if ( ! isset($hints[Query::HINT_FORCE_PARTIAL_LOAD])) {
                 foreach ($class->associationMappings as $field => $assoc) {
@@ -1954,7 +1959,7 @@ class UnitOfWork implements PropertyChangedListener
                                 $relatedIdHash = implode(' ', $associatedId);
                                 if (isset($this->identityMap[$targetClass->rootEntityName][$relatedIdHash])) {
                                     $newValue = $this->identityMap[$targetClass->rootEntityName][$relatedIdHash];
-                                    
+
                                     // if this is an uninitialized proxy, we are deferring eager loads,
                                     // this association is marked as eager fetch, and its an uninitialized proxy (wtf!)
                                     // then we cann append this entity for eager loading!
@@ -1963,7 +1968,7 @@ class UnitOfWork implements PropertyChangedListener
                                         !$targetClass->isIdentifierComposite &&
                                         $newValue instanceof Proxy &&
                                         $newValue->__isInitialized__ === false) {
-                                        
+
                                         $this->eagerLoadingEntities[$targetClass->rootEntityName][$relatedIdHash] = current($associatedId);
                                     }
                                 } else {
@@ -1999,7 +2004,7 @@ class UnitOfWork implements PropertyChangedListener
                                 }
                                 $this->originalEntityData[$oid][$field] = $newValue;
                                 $class->reflFields[$field]->setValue($entity, $newValue);
-                                
+
                                 if ($assoc['inversedBy'] && $assoc['type'] & ClassMetadata::ONE_TO_ONE) {
                                     $inverseAssoc = $targetClass->associationMappings[$assoc['inversedBy']];
                                     $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($newValue, $entity);
@@ -2029,7 +2034,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
             }
         }
-        
+
         //TODO: These should be invoked later, after hydration, because associations may not yet be loaded here.
         if (isset($class->lifecycleCallbacks[Events::postLoad])) {
             $class->invokeLifecycleCallbacks(Events::postLoad, $entity);
@@ -2106,7 +2111,7 @@ class UnitOfWork implements PropertyChangedListener
         }
         return array();
     }
-    
+
     /**
      * @ignore
      */
@@ -2300,27 +2305,27 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Gets the currently scheduled entity insertions in this UnitOfWork.
-     * 
+     *
      * @return array
      */
     public function getScheduledEntityInsertions()
     {
         return $this->entityInsertions;
     }
-    
+
     /**
      * Gets the currently scheduled entity updates in this UnitOfWork.
-     * 
+     *
      * @return array
      */
     public function getScheduledEntityUpdates()
     {
         return $this->entityUpdates;
     }
-    
+
     /**
      * Gets the currently scheduled entity deletions in this UnitOfWork.
-     * 
+     *
      * @return array
      */
     public function getScheduledEntityDeletions()
@@ -2347,10 +2352,10 @@ class UnitOfWork implements PropertyChangedListener
     {
         return $this->collectionUpdates;
     }
-    
+
     /**
      * Helper method to initialize a lazy loading proxy or persistent collection.
-     * 
+     *
      * @param object
      * @return void
      */
@@ -2362,12 +2367,12 @@ class UnitOfWork implements PropertyChangedListener
             $obj->initialize();
         }
     }
-    
+
     /**
      * Helper method to show an object as string.
-     * 
+     *
      * @param  object $obj
-     * @return string 
+     * @return string
      */
     private static function objToStr($obj)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
 
 require_once __DIR__ . '/../../TestInit.php';
@@ -25,28 +26,47 @@ class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $this->_em->getEventManager()->addEventListener(Events::onFlush, new OnFlushListener);
-        
+
         $user = new CmsUser;
         $user->username = 'romanb';
         $user->name = 'Roman';
         $user->status = 'Dev';
-        
+
         $this->_em->persist($user);
-        
+
         $this->assertEquals(0, $user->phonenumbers->count());
-        
+
         $this->_em->flush();
-        
+
         $this->assertEquals(1, $user->phonenumbers->count());
         $this->assertTrue($this->_em->contains($user->phonenumbers->get(0)));
         $this->assertTrue($user->phonenumbers->get(0)->getUser() === $user);
-        
+
         $this->assertFalse($user->phonenumbers->isDirty());
-        
+
         // Can be used together with SQL Logging to check that a subsequent flush has
         // nothing to do. This proofs the correctness of the changes that happened in onFlush.
         //echo "SECOND FLUSH";
         //$this->_em->flush();
+    }
+
+    public function testPostFlush()
+    {
+        $postFlushListener = new PostFlushListener();
+        $this->_em->getEventManager()->addEventListener(Events::postFlush, $postFlushListener);
+
+        $user = new CmsUser;
+        $user->username = 'AnotherUser';
+        $user->name = 'AnotherName';
+        $user->status = 'AnotherStatus';
+
+        $this->_em->persist($user);
+
+        $this->assertFalse($postFlushListener->called);
+
+        $this->_em->flush();
+
+        $this->assertTrue($postFlushListener->called);
     }
 }
 
@@ -55,15 +75,15 @@ class OnFlushListener
     public function onFlush(OnFlushEventArgs $args)
     {
         //echo "---preFlush".PHP_EOL;
-        
+
         $em = $args->getEntityManager();
         $uow = $em->getUnitOfWork();
-        
+
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            
+
             if ($entity instanceof CmsUser) {
                 // Adds a phonenumber to every newly persisted CmsUser ...
-                
+
                 $phone = new CmsPhonenumber;
                 $phone->phonenumber = 12345;
                 // Update object model
@@ -73,22 +93,30 @@ class OnFlushListener
                 // Explicitly calculate the changeset since onFlush is raised
                 // after changeset calculation!
                 $uow->computeChangeSet($em->getClassMetadata(get_class($phone)), $phone);
-                
+
                 // Take a snapshot because the UoW wont do this for us, because
                 // the UoW did not visit this collection.
                 // Alternatively we could provide an ->addVisitedCollection() method
                 // on the UoW.
                 $entity->getPhonenumbers()->takeSnapshot();
             }
-            
+
             /*foreach ($uow->getEntityChangeSet($entity) as $field => $change) {
                 list ($old, $new) = $change;
 
                 var_dump($old);
             }*/
-            
+
         }
     }
 }
 
+class PostFlushListener
+{
+    public $called = false;
 
+    public function postFlush(PostFlushEventArgs $args)
+    {
+        $this->called = true;
+    }
+}


### PR DESCRIPTION
Added the postFlush event to the Event Manager for successful flushes; fixed a comment in OnFlushEventArgs

What this adds is the ability to detect when a successful flush has occurred for operations outside of Doctrine that depend on this - e.g. Doctrine event-driven SOLR indexing at persistence where we want our index to match our database
