### PR TITLE
Fixed wrong keyname

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -435,7 +435,7 @@ class YamlDriver extends AbstractFileDriver
                 }
 
                 if (isset($manyToManyElement['orphanRemoval'])) {
-                    $mapping['orphanRemoval'] = (bool)$manyToManyElement['orphan-removal'];
+                    $mapping['orphanRemoval'] = (bool)$manyToManyElement['orphanRemoval'];
                 }
 
                 if (isset($manyToManyElement['orderBy'])) {


### PR DESCRIPTION
the camelcased orphanRemoval is what should be used, this one place still has the orphan-removal key
