### PR TITLE
[DDC-725] Removed onUpdate property on join columns

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -244,7 +244,6 @@ class AnnotationDriver implements Driver
                     'unique' => $joinColumnAnnot->unique,
                     'nullable' => $joinColumnAnnot->nullable,
                     'onDelete' => $joinColumnAnnot->onDelete,
-                    'onUpdate' => $joinColumnAnnot->onUpdate,
                     'columnDefinition' => $joinColumnAnnot->columnDefinition,
                 );
             } else if ($joinColumnsAnnot = $this->_reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinColumns')) {
@@ -255,7 +254,6 @@ class AnnotationDriver implements Driver
                         'unique' => $joinColumn->unique,
                         'nullable' => $joinColumn->nullable,
                         'onDelete' => $joinColumn->onDelete,
-                        'onUpdate' => $joinColumn->onUpdate,
                         'columnDefinition' => $joinColumn->columnDefinition,
                     );
                 }
@@ -363,7 +361,6 @@ class AnnotationDriver implements Driver
                             'unique' => $joinColumn->unique,
                             'nullable' => $joinColumn->nullable,
                             'onDelete' => $joinColumn->onDelete,
-                            'onUpdate' => $joinColumn->onUpdate,
                             'columnDefinition' => $joinColumn->columnDefinition,
                         );
                     }
@@ -375,7 +372,6 @@ class AnnotationDriver implements Driver
                             'unique' => $joinColumn->unique,
                             'nullable' => $joinColumn->nullable,
                             'onDelete' => $joinColumn->onDelete,
-                            'onUpdate' => $joinColumn->onUpdate,
                             'columnDefinition' => $joinColumn->columnDefinition,
                         );
                     }

--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -48,7 +48,6 @@ final class JoinColumn extends Annotation {
     public $unique = false;
     public $nullable = true;
     public $onDelete;
-    public $onUpdate;
     public $columnDefinition;
 }
 final class JoinColumns extends Annotation {}

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -471,10 +471,6 @@ class XmlDriver extends AbstractFileDriver
             $joinColumn['onDelete'] = (string)$joinColumnElement['on-delete'];
         }
 
-        if (isset($joinColumnElement['on-update'])) {
-            $joinColumn['onUpdate'] = (string)$joinColumnElement['on-update'];
-        }
-
         if (isset($joinColumnElement['column-definition'])) {
             $joinColumn['columnDefinition'] = (string)$joinColumnElement['column-definition'];
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -490,10 +490,6 @@ class YamlDriver extends AbstractFileDriver
             $joinColumn['onDelete'] = $joinColumnElement['onDelete'];
         }
 
-        if (isset($joinColumnElement['onUpdate'])) {
-            $joinColumn['onUpdate'] = $joinColumnElement['onUpdate'];
-        }
-
         if (isset($joinColumnElement['columnDefinition'])) {
             $joinColumn['columnDefinition'] = $joinColumnElement['columnDefinition'];
         }

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -248,7 +248,6 @@ class ConvertDoctrine1Schema
                             'name' => $relation['local'],
                             'referencedColumnName' => $relation['foreign'],
                             'onDelete' => isset($relation['onDelete']) ? $relation['onDelete'] : null,
-                            'onUpdate' => isset($relation['onUpdate']) ? $relation['onUpdate'] : null,
                         )
                     );
                 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -762,10 +762,6 @@ public function <methodName>()
             $joinColumnAnnot[] = 'onDelete=' . ($joinColumn['onDelete'] ? 'true' : 'false');
         }
 
-        if (isset($joinColumn['onUpdate'])) {
-            $joinColumnAnnot[] = 'onUpdate=' . ($joinColumn['onUpdate'] ? 'true' : 'false');
-        }
-
         if (isset($joinColumn['columnDefinition'])) {
             $joinColumnAnnot[] = 'columnDefinition="' . $joinColumn['columnDefinition'] . '"';
         }

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -215,9 +215,6 @@ class XmlExporter extends AbstractExporter
                     if (isset($joinColumn['onDelete'])) {
                         $joinColumnXml->addAttribute('on-delete', $joinColumn['onDelete']);
                     }
-                    if (isset($joinColumn['onUpdate'])) {
-                        $joinColumnXml->addAttribute('on-update', $joinColumn['onUpdate']);
-                    }
                 }
                 $inverseJoinColumnsXml = $joinTableXml->addChild('inverse-join-columns');
                 foreach ($associationMapping['joinTable']['inverseJoinColumns'] as $inverseJoinColumn) {
@@ -226,9 +223,6 @@ class XmlExporter extends AbstractExporter
                     $inverseJoinColumnXml->addAttribute('referenced-column-name', $inverseJoinColumn['referencedColumnName']);
                     if (isset($inverseJoinColumn['onDelete'])) {
                         $inverseJoinColumnXml->addAttribute('on-delete', $inverseJoinColumn['onDelete']);
-                    }
-                    if (isset($inverseJoinColumn['onUpdate'])) {
-                        $inverseJoinColumnXml->addAttribute('on-update', $inverseJoinColumn['onUpdate']);
                     }
                     if (isset($inverseJoinColumn['columnDefinition'])) {
                         $inverseJoinColumnXml->addAttribute('column-definition', $inverseJoinColumn['columnDefinition']);
@@ -249,9 +243,6 @@ class XmlExporter extends AbstractExporter
                     $joinColumnXml->addAttribute('referenced-column-name', $joinColumn['referencedColumnName']);
                     if (isset($joinColumn['onDelete'])) {
                         $joinColumnXml->addAttribute('on-delete', $joinColumn['onDelete']);
-                    }
-                    if (isset($joinColumn['onUpdate'])) {
-                        $joinColumnXml->addAttribute('on-update', $joinColumn['onUpdate']);
                     }
                     if (isset($joinColumn['columnDefinition'])) {
                         $joinColumnXml->addAttribute('column-definition', $joinColumn['columnDefinition']);

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -154,9 +154,6 @@ class YamlExporter extends AbstractExporter
                     if (isset($joinColumn['onDelete'])) {
                         $newJoinColumns[$joinColumn['name']]['onDelete'] = $joinColumn['onDelete'];
                     }
-                    if (isset($joinColumn['onUpdate'])) {
-                        $newJoinColumns[$joinColumn['name']]['onUpdate'] = $joinColumn['onUpdate'];
-                    }
                 }
                 $oneToOneMappingArray = array(
                     'mappedBy'      => $associationMapping['mappedBy'],

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -523,10 +523,6 @@ class SchemaTool
                 $uniqueConstraints[] = array('columns' => array($columnName));
             }
 
-            if (isset($joinColumn['onUpdate'])) {
-                $fkOptions['onUpdate'] = $joinColumn['onUpdate'];
-            }
-
             if (isset($joinColumn['onDelete'])) {
                 $fkOptions['onDelete'] = $joinColumn['onDelete'];
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
@@ -42,7 +42,7 @@ class DDC448MainTable
 
     /**
      * @ManyToOne(targetEntity="DDC448ConnectedClass",  cascade={"all"}, fetch="EAGER")
-     * @JoinColumn(name="connectedClassId", referencedColumnName="id", onDelete="CASCADE", onUpdate="CASCADE", nullable=true)
+     * @JoinColumn(name="connectedClassId", referencedColumnName="id", onDelete="CASCADE", nullable=true)
      */
     private $connectedClassId;
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -267,10 +267,9 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
      * @depends testColumnDefinition
      * @param ClassMetadata $class
      */
-    public function testJoinColumnOnDeleteAndOnUpdate($class)
+    public function testJoinColumnOnDelete($class)
     {
         $this->assertEquals('CASCADE', $class->associationMappings['address']['joinColumns'][0]['onDelete']);
-        $this->assertEquals('CASCADE', $class->associationMappings['address']['joinColumns'][0]['onUpdate']);
 
         return $class;
     }
@@ -324,7 +323,7 @@ class User
 
     /**
      * @OneToOne(targetEntity="Address", cascade={"remove"}, inversedBy="user")
-     * @JoinColumn(onDelete="CASCADE", onUpdate="CASCADE")
+     * @JoinColumn(onDelete="CASCADE")
      */
     public $address;
 
@@ -412,7 +411,6 @@ class User
             'name' => 'address_id',
             'referencedColumnName' => 'id',
             'onDelete' => 'CASCADE',
-            'onUpdate' => 'CASCADE'
            ),
            ),
            'orphanRemoval' => false,

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -51,7 +51,6 @@ $metadata->mapOneToOne(array(
     'name' => 'address_id',
     'referencedColumnName' => 'id',
     'onDelete' => 'CASCADE',
-    'onUpdate' => 'CASCADE'
    ),
    ),
    'orphanRemoval' => false,

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
@@ -30,7 +30,6 @@ Doctrine\Tests\ORM\Mapping\User:
         name: address_id
         referencedColumnName: id
         onDelete: CASCADE
-        onUpdate: CASCADE
       cascade: [ remove ]
   oneToMany:
     phonenumbers:

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -217,7 +217,6 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         $this->assertEquals('address_id', $class->associationMappings['address']['joinColumns'][0]['name']);
         $this->assertEquals('id', $class->associationMappings['address']['joinColumns'][0]['referencedColumnName']);
         $this->assertEquals('CASCADE', $class->associationMappings['address']['joinColumns'][0]['onDelete']);
-        $this->assertEquals('CASCADE', $class->associationMappings['address']['joinColumns'][0]['onUpdate']);
 
         $this->assertTrue($class->associationMappings['address']['isCascadeRemove']);
         $this->assertFalse($class->associationMappings['address']['isCascadePersist']);

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -24,7 +24,7 @@ class User
 
     /**
      * @OneToOne(targetEntity="Doctrine\Tests\ORM\Tools\Export\Address", cascade={"remove"}, inversedBy="user")
-     * @JoinColumn(name="address_id", onDelete="CASCADE", onUpdate="CASCADE")
+     * @JoinColumn(name="address_id", onDelete="CASCADE")
      */
     public $address;
 

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -47,7 +47,6 @@ $metadata->mapOneToOne(array(
     'name' => 'address_id',
     'referencedColumnName' => 'id',
     'onDelete' => 'CASCADE',
-    'onUpdate' => 'CASCADE'
    ),
    ),
    'orphanRemoval' => false,

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -23,7 +23,6 @@ Doctrine\Tests\ORM\Tools\Export\User:
         name: address_id
         referencedColumnName: id
         onDelete: CASCADE
-        onUpdate: CASCADE
       cascade: [ remove ]
       inversedBy: user
   oneToMany:

--- a/tests/Doctrine/Tests/ORM/Tools/doctrine1schema/schema.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/doctrine1schema/schema.yml
@@ -24,6 +24,5 @@ Profile:
   relations:
     User:
       onDelete: CASCADE
-      onUpdate: CASCADE
       foreignType: one
       type: one


### PR DESCRIPTION
This removes the onUpdate property on join columns. This breaks BC for any metadata that has an onUpdate property.  The exception being thrown right now is:

BadMethodCallException: Unknown property 'onUpdate' on annotation 'Doctrine\ORM\Mapping\JoinColumn'
