### PR TITLE
Moved isInitalized assignment to be after the persister load to prevent bad change set computations

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -273,11 +273,11 @@ class <proxyClassName> extends \<className> implements \Doctrine\ORM\Proxy\Proxy
     public function __load()
     {
         if (!$this->__isInitialized__ && $this->_entityPersister) {
-            $this->__isInitialized__ = true;
             if ($this->_entityPersister->load($this->_identifier, $this) === null) {
                 throw new \Doctrine\ORM\EntityNotFoundException();
             }
             unset($this->_entityPersister, $this->_identifier);
+            $this->__isInitialized__ = true;
         }
     }
     


### PR DESCRIPTION
Moved isInitalized assignment to be after the persister load. If set before, the entity isn't correctly entered into unitOfWork's originalData array due a failing if entity->**isInitalized** in createEntity. This causes the changeSet to be computed incorrectly during flush and in worse case scenarios can result in an additional bad insert of existing data. 
