### PR TITLE
Change UnitOfWork to no store at getIdentityMap id $idHash is empty.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1897,11 +1897,13 @@ class UnitOfWork implements PropertyChangedListener
             }
         } else {
             $entity = $class->newInstance();
+            if (!empty($idHash)) {
+                $this->identityMap[$class->rootEntityName][$idHash] = $entity;
+            }
             $oid = spl_object_hash($entity);
             $this->entityIdentifiers[$oid] = $id;
             $this->entityStates[$oid] = self::STATE_MANAGED;
             $this->originalEntityData[$oid] = $data;
-            $this->identityMap[$class->rootEntityName][$idHash] = $entity;
             if ($entity instanceof NotifyPropertyChanged) {
                 $entity->addPropertyChangedListener($this);
             }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -204,6 +204,27 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(UnitOfWork::STATE_DETACHED, $this->_unitOfWork->getEntityState($ph2));
         $this->assertFalse($persister->isExistsCalled());
     }
+
+    /**
+    * Test cenario that a entity is create with identifier set to null. Ex: Native Query for import entities from other schema 
+    */
+    public function testCreateANotIdentifiedEntitySholdNotStoreInstance()
+    {
+        $persister = new EntityPersisterMock($this->_emMock, $this->_emMock->getClassMetadata("Doctrine\Tests\Models\Generic\BooleanModel"));
+        $this->_unitOfWork->setEntityPersister('Doctrine\Tests\Models\Generic', $persister);
+        
+        $className = 'Doctrine\Tests\Models\Generic\BooleanModel';
+        $data = array('id'=>null,'booleanField'=>true);
+        
+        $entity = $this->_unitOfWork->createEntity($className,$data);
+        $this->assertInstanceOf($className, $entity);
+        $this->assertTrue($entity->booleanField);
+        $this->assertNull($entity->id);
+        
+        $identityMap = $this->_unitOfWork->getIdentityMap();
+        $this->assertEquals(0,count($identityMap));
+        
+    }
 }
 
 /**


### PR DESCRIPTION
- Change createEntity method that not store at unitOfWork->getIdentityMap $ifHash is not empty.
- Test cenario that a entity is create with identifier set to null. Ex: Native Query for import entities from other schema
