### PR TITLE
Removed deprecated assertType

### DIFF
--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -26,32 +26,32 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     public function testGetConnection()
     {
-        $this->assertInstanceOf('\Doctrine\DBAL\Connection', $this->_em->getConnection());
+        $this->assertInstanceOf('Doctrine\DBAL\Connection', $this->_em->getConnection());
     }
 
     public function testGetMetadataFactory()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\Mapping\ClassMetadataFactory', $this->_em->getMetadataFactory());
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\ClassMetadataFactory', $this->_em->getMetadataFactory());
     }
 
     public function testGetConfiguration()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\Configuration', $this->_em->getConfiguration());
+        $this->assertInstanceOf('Doctrine\ORM\Configuration', $this->_em->getConfiguration());
     }
 
     public function testGetUnitOfWork()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\UnitOfWork', $this->_em->getUnitOfWork());
+        $this->assertInstanceOf('Doctrine\ORM\UnitOfWork', $this->_em->getUnitOfWork());
     }
 
     public function testGetProxyFactory()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\Proxy\ProxyFactory', $this->_em->getProxyFactory());
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\ProxyFactory', $this->_em->getProxyFactory());
     }
 
     public function testGetEventManager()
     {
-        $this->assertInstanceOf('\Doctrine\Common\EventManager', $this->_em->getEventManager());
+        $this->assertInstanceOf('Doctrine\Common\EventManager', $this->_em->getEventManager());
     }
 
     public function testCreateNativeQuery()
@@ -64,7 +64,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     public function testCreateQueryBuilder()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\QueryBuilder', $this->_em->createQueryBuilder());
+        $this->assertInstanceOf('Doctrine\ORM\QueryBuilder', $this->_em->createQueryBuilder());
     }
 
     public function testCreateQueryBuilderAliasValid()
@@ -83,7 +83,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     public function testCreateQuery_DqlIsOptional()
     {
-        $this->assertInstanceOf('\Doctrine\ORM\Query', $this->_em->createQuery());
+        $this->assertInstanceOf('Doctrine\ORM\Query', $this->_em->createQuery());
     }
 
     public function testGetPartialReference()
@@ -97,7 +97,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
     public function testCreateQuery()
     {
         $q = $this->_em->createQuery('SELECT 1');
-        $this->assertInstanceOf('\Doctrine\ORM\Query', $q);
+        $this->assertInstanceOf('Doctrine\ORM\Query', $q);
         $this->assertEquals('SELECT 1', $q->getDql());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -64,8 +64,8 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query = $this->_em->createQuery("SELECT p,t FROM Doctrine\Tests\ORM\Functional\Phrase p JOIN p.type t");
         $res = $query->getResult();
         $this->assertEquals(1, count($res));
-        $this->assertTrue($res[0]->getType() instanceof PhraseType);
-        $this->assertTrue($res[0]->getType()->getPhrases() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\PhraseType', $res[0]->getType());
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $res[0]->getType()->getPhrases());
         $this->assertFalse($res[0]->getType()->getPhrases()->isInitialized());
         
         $this->_em->clear();
@@ -74,8 +74,8 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query = $this->_em->createQuery("SELECT p,t,pp FROM Doctrine\Tests\ORM\Functional\Phrase p JOIN p.type t JOIN t.phrases pp");
         $res = $query->getResult();
         $this->assertEquals(1, count($res));
-        $this->assertTrue($res[0]->getType() instanceof PhraseType);
-        $this->assertTrue($res[0]->getType()->getPhrases() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\PhraseType', $res[0]->getType());
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $res[0]->getType()->getPhrases());
         $this->assertTrue($res[0]->getType()->getPhrases()->isInitialized());
         
         $this->_em->clear();
@@ -83,8 +83,8 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // test3 - lazy-loading one-to-many after find()
         $phrase3 = $this->_em->find('Doctrine\Tests\ORM\Functional\Phrase', $phrase->getId());
         $definitions = $phrase3->getDefinitions();
-        $this->assertTrue($definitions instanceof \Doctrine\ORM\PersistentCollection);
-        $this->assertTrue($definitions[0] instanceof Definition);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $definitions);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Definition', $definitions[0]);
         
         $this->_em->clear();
         
@@ -95,7 +95,7 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $this->assertEquals(1, count($res));
         
-        $this->assertTrue($definitions[0] instanceof Definition);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Definition', $definitions[0]);
         $this->assertEquals(2, $definitions->count());
     }
     
@@ -119,7 +119,7 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $res = $query->getResult();
         $types = $res[0]->getTypes();
         
-        $this->assertTrue($types[0] instanceof Type);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Type', $types[0]);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -46,7 +46,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->assertTrue($this->_em->contains($ph));
         $this->assertTrue($this->_em->contains($user));
-        //$this->assertTrue($user->phonenumbers instanceof \Doctrine\ORM\PersistentCollection);
+        //$this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $user->phonenumbers);
 
         // Update name
         $user->name = 'guilherme';
@@ -92,7 +92,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        //$this->assertTrue($user->phonenumbers instanceof \Doctrine\ORM\PersistentCollection);
+        //$this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $user->phonenumbers);
 
         // Remove the first element from the collection
         unset($user->phonenumbers[0]);

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -136,8 +136,8 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->getSingleResult();
         
         // Address has been eager-loaded because it cant be lazy
-        $this->assertTrue($user2->address instanceof CmsAddress);
-        $this->assertFalse($user2->address instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $user2->address);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $user2->address);
     }
     
     /**
@@ -276,7 +276,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals('Guilherme', $users[0]->name);
         $this->assertEquals('gblanco', $users[0]->username);
         $this->assertEquals('developer', $users[0]->status);
-        $this->assertTrue($users[0]->phonenumbers instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $users[0]->phonenumbers);
         $this->assertTrue($users[0]->phonenumbers->isInitialized());
         $this->assertEquals(0, $users[0]->phonenumbers->count());
         //$this->assertNull($users[0]->articles);
@@ -520,8 +520,8 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.address a where u.username='gblanco'");
         $gblanco = $query->getSingleResult();
 
-        $this->assertTrue($gblanco instanceof CmsUser);
-        $this->assertTrue($gblanco->getAddress() instanceof CmsAddress);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $gblanco);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $gblanco->getAddress());
         $this->assertEquals('Berlin', $gblanco->getAddress()->getCity());
         
     }
@@ -629,7 +629,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user2 = $query->getSingleResult();
 
         $this->assertEquals(1, count($user2->articles));
-        $this->assertTrue($user2->address instanceof CmsAddress);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $user2->address);
         
         $oldLogger = $this->_em->getConnection()->getConfiguration()->getSQLLogger();
         $debugStack = new \Doctrine\DBAL\Logging\DebugStack;
@@ -690,7 +690,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->setParameter('user', $userRef)
                 ->getSingleResult();
         
-        $this->assertTrue($address2->getUser() instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $address2->getUser());
         $this->assertTrue($userRef === $address2->getUser());
         $this->assertFalse($userRef->__isInitialized__);
         $this->assertEquals('Germany', $address2->country);
@@ -905,7 +905,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $user2 = $this->_em->find(get_class($managedUser), $userId);
-        $this->assertTrue($user2 instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $user2);
     }
 
     public function testMergeThrowsExceptionIfEntityWithGeneratedIdentifierDoesNotExist()

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -50,8 +50,8 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $entities = $query->getResult();
 
         $this->assertEquals(2, count($entities));
-        $this->assertTrue($entities[0] instanceof CompanyPerson);
-        $this->assertTrue($entities[1] instanceof CompanyEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyPerson', $entities[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $entities[1]);
         $this->assertTrue(is_numeric($entities[0]->getId()));
         $this->assertTrue(is_numeric($entities[1]->getId()));
         $this->assertEquals('Roman S. Borschel', $entities[0]->getName());
@@ -65,7 +65,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $entities = $query->getResult();
 
         $this->assertEquals(1, count($entities));
-        $this->assertTrue($entities[0] instanceof CompanyEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $entities[0]);
         $this->assertTrue(is_numeric($entities[0]->getId()));
         $this->assertEquals('Guilherme Blanco', $entities[0]->getName());
         $this->assertEquals(100000, $entities[0]->getSalary());
@@ -73,7 +73,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
         
         $guilherme = $this->_em->getRepository(get_class($employee))->findOneBy(array('name' => 'Guilherme Blanco'));
-        $this->assertTrue($guilherme instanceof CompanyEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $guilherme);
         $this->assertEquals('Guilherme Blanco', $guilherme->getName());
 
         $this->_em->clear();
@@ -110,7 +110,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $manager = $this->_em->find('Doctrine\Tests\Models\Company\CompanyManager', $manager->getId());
         
-        $this->assertTrue($manager instanceof CompanyManager);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyManager', $manager);
         $this->assertEquals('Roman B.', $manager->getName());
         $this->assertEquals(119000, $manager->getSalary());
         $this->assertEquals('CEO', $manager->getTitle());
@@ -130,12 +130,12 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $person = $this->_em->find('Doctrine\Tests\Models\Company\CompanyPerson', $manager->getId());
         
-        $this->assertTrue($person instanceof CompanyManager);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyManager', $person);
         $this->assertEquals('Roman S. Borschel', $person->getName());
         $this->assertEquals(100000, $person->getSalary());
         $this->assertEquals('CTO', $person->getTitle());
         $this->assertTrue(is_numeric($person->getId()));
-        //$this->assertTrue($person->getCar() instanceof CompanyCar);
+        //$this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyCar', $person->getCar());
     }
     
     public function testSelfReferencingOneToOne() {
@@ -167,9 +167,9 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $result = $query->getResult();
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof CompanyPerson);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyPerson', $result[0]);
         $this->assertEquals('Mary Smith', $result[0]->getName());
-        $this->assertTrue($result[0]->getSpouse() instanceof CompanyEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $result[0]->getSpouse());
         $this->assertEquals('John Smith', $result[0]->getSpouse()->getName());
         $this->assertSame($result[0], $result[0]->getSpouse()->getSpouse());
     }
@@ -229,20 +229,20 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $q->getResult();
         
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof CompanyOrganization);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyOrganization', $result[0]);
         $this->assertNull($result[0]->getMainEvent());
         
         $events = $result[0]->getEvents();
         
-        $this->assertTrue($events instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $events);
         $this->assertFalse($events->isInitialized());
         
         $this->assertEquals(2, count($events));
         if ($events[0] instanceof CompanyAuction) {
-            $this->assertTrue($events[1] instanceof CompanyRaffle);
+            $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyRaffle', $events[1]);
         } else {
-            $this->assertTrue($events[0] instanceof CompanyRaffle);
-            $this->assertTrue($events[1] instanceof CompanyAuction);
+            $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyRaffle', $events[0]);
+            $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyAuction', $events[1]);
         }
     }
 
@@ -263,7 +263,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $result = $q->getResult();
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof CompanyAuction, sprintf("Is of class %s",get_class($result[0])));
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyAuction', $result[0], sprintf("Is of class %s",get_class($result[0])));
 
         $this->_em->clear();
 
@@ -273,12 +273,12 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $q->getResult();
 
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof CompanyOrganization);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyOrganization', $result[0]);
 
         $mainEvent = $result[0]->getMainEvent();
         // mainEvent should have been loaded because it can't be lazy
-        $this->assertTrue($mainEvent instanceof CompanyAuction);
-        $this->assertFalse($mainEvent instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyAuction', $mainEvent);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $mainEvent);
     }
     
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
@@ -43,9 +43,9 @@ class ClassTableInheritanceTest2 extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $related2 = $this->_em->find('Doctrine\Tests\ORM\Functional\CTIRelated', $relatedId);
         
-        $this->assertTrue($related2 instanceof CTIRelated);
-        $this->assertTrue($related2->getCTIParent() instanceof CTIChild);
-        $this->assertFalse($related2->getCTIParent() instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\CTIRelated', $related2);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\CTIChild', $related2->getCTIParent());
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $related2->getCTIParent());
         $this->assertEquals('hello', $related2->getCTIParent()->getData());
         
         $this->assertSame($related2, $related2->getCTIParent()->getRelated());
@@ -69,7 +69,7 @@ class ClassTableInheritanceTest2 extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($mmrel2->getCTIChildren()->isInitialized());
         $this->assertEquals(1, count($mmrel2->getCTIChildren()));
         $this->assertTrue($mmrel2->getCTIChildren()->isInitialized());
-        $this->assertTrue($mmrel2->getCTIChildren()->get(0) instanceof CTIChild);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\CTIChild', $mmrel2->getCTIChildren()->get(0));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -45,7 +45,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
 
-        $this->assertType('Doctrine\Tests\Models\Navigation\NavPointOfInterest', $poi);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Navigation\NavPointOfInterest', $poi);
         $this->assertEquals(100, $poi->getLat());
         $this->assertEquals(200, $poi->getLong());
         $this->assertEquals('Brandenburger Tor', $poi->getName());

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -50,7 +50,7 @@ class DefaultValuesTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
         
         $a2 = $this->_em->find(get_class($a), $a->id);
-        $this->assertTrue($a2->getUser() instanceof DefaultValueUser);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\DefaultValueUser', $a2->getUser());
         $this->assertEquals($userId, $a2->getUser()->getId());
         $this->assertEquals('Poweruser', $a2->getUser()->type);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -137,14 +137,14 @@ class DetachedEntityTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $address2 = $this->_em->find(get_class($address), $address->id);
-        $this->assertTrue($address2->user instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $address2->user);
         $this->assertFalse($address2->user->__isInitialized__);
         $detachedAddress2 = unserialize(serialize($address2));
-        $this->assertTrue($detachedAddress2->user instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $detachedAddress2->user);
         $this->assertFalse($detachedAddress2->user->__isInitialized__);
 
         $managedAddress2 = $this->_em->merge($detachedAddress2);
-        $this->assertTrue($managedAddress2->user instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $managedAddress2->user);
         $this->assertFalse($managedAddress2->user === $detachedAddress2->user);
         $this->assertFalse($managedAddress2->user->__isInitialized__);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -47,7 +47,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
         $user = $repos->find($user1Id);
-        $this->assertTrue($user instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser',$user);
         $this->assertEquals('Roman', $user->name);
         $this->assertEquals('freak', $user->status);
     }
@@ -59,7 +59,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $users = $repos->findBy(array('status' => 'dev'));
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser',$users[0]);
         $this->assertEquals('Guilherme', $users[0]->name);
         $this->assertEquals('dev', $users[0]->status);
     }
@@ -72,7 +72,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $users = $repos->findByStatus('dev');
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser',$users[0]);
         $this->assertEquals('Guilherme', $users[0]->name);
         $this->assertEquals('dev', $users[0]->status);
     }
@@ -244,7 +244,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
         $address = $repos->findOneBy(array('user' => $userId));
 
-        $this->assertType('Doctrine\Tests\Models\CMS\CmsAddress', $address);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $address);
         $this->assertEquals($addressId, $address->id);
     }
 
@@ -285,7 +285,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
         $address = $repos->findOneByUser($userId);
 
-        $this->assertType('Doctrine\Tests\Models\CMS\CmsAddress', $address);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $address);
         $this->assertEquals($addressId, $address->id);
     }
 
@@ -295,7 +295,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $query = $repos->createNamedQuery('all');
 
-        $this->assertType('Doctrine\ORM\Query', $query);
+        $this->assertInstanceOf('Doctrine\ORM\Query', $query);
         $this->assertEquals('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u', $query->getDQL());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -47,7 +47,7 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         $result = $query->getResult();
 
         $this->assertEquals(2, $this->_em->getUnitOfWork()->size());
-        $this->assertTrue($result[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0]);
         $this->assertEquals('Guilherme', $result[0]->name);
         $this->assertEquals(1, $result[0]->getGroups()->count());
         $groups = $result[0]->getGroups();
@@ -56,8 +56,8 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($result[0]));
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($groups[0]));
 
-        $this->assertTrue($groups instanceof \Doctrine\ORM\PersistentCollection);
-        $this->assertTrue($groups[0]->getUsers() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $groups);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $groups[0]->getUsers());
 
         $groups[0]->getUsers()->clear();
         $groups->clear();

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -117,8 +117,8 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
         //$query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
         $result = $query->getResult();
         $this->assertEquals(2, count($result));
-        $this->assertTrue($result[0] instanceof ECommerceCategory);
-        $this->assertTrue($result[1] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $result[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $result[1]);
         $prods1 = $result[0]->getProducts();
         $prods2 = $result[1]->getProducts();
         $this->assertTrue($prods1->isInitialized());
@@ -157,10 +157,10 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
         $this->assertEquals(2, count($secondCategoryProducts)); // lazy-load
         $this->assertTrue($secondCategoryProducts->isInitialized());
 
-        $this->assertTrue($firstCategoryProducts[0] instanceof ECommerceProduct);
-        $this->assertTrue($firstCategoryProducts[1] instanceof ECommerceProduct);
-        $this->assertTrue($secondCategoryProducts[0] instanceof ECommerceProduct);
-        $this->assertTrue($secondCategoryProducts[1] instanceof ECommerceProduct);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $firstCategoryProducts[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $firstCategoryProducts[1]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $secondCategoryProducts[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $secondCategoryProducts[1]);
         
         $this->assertCollectionEquals($firstCategoryProducts, $secondCategoryProducts);
     }
@@ -192,10 +192,10 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
         $this->assertEquals(2, count($secondProductCategories)); // lazy-load
         $this->assertTrue($secondProductCategories->isInitialized());
 
-        $this->assertTrue($firstProductCategories[0] instanceof ECommerceCategory);
-        $this->assertTrue($firstProductCategories[1] instanceof ECommerceCategory);
-        $this->assertTrue($secondProductCategories[0] instanceof ECommerceCategory);
-        $this->assertTrue($secondProductCategories[1] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $firstProductCategories[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $firstProductCategories[1]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $secondProductCategories[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $secondProductCategories[1]);
         
         $this->assertCollectionEquals($firstProductCategories, $secondProductCategories);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
@@ -95,10 +95,10 @@ class ManyToManySelfReferentialAssociationTest extends AbstractManyToManyAssocia
         $this->assertEquals(2, count($firstRelatedBy));
         $this->assertEquals(2, count($secondRelatedBy));
 
-        $this->assertTrue($firstRelatedBy[0] instanceof ECommerceProduct);
-        $this->assertTrue($firstRelatedBy[1] instanceof ECommerceProduct);
-        $this->assertTrue($secondRelatedBy[0] instanceof ECommerceProduct);
-        $this->assertTrue($secondRelatedBy[1] instanceof ECommerceProduct);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $firstRelatedBy[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $firstRelatedBy[1]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $secondRelatedBy[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $secondRelatedBy[1]);
         
         $this->assertCollectionEquals($firstRelatedBy, $secondRelatedBy);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
@@ -69,8 +69,8 @@ class ManyToManyUnidirectionalAssociationTest extends AbstractManyToManyAssociat
         $products = $firstCart->getProducts();
         $secondCart = $result[1];
         
-        $this->assertTrue($products[0] instanceof ECommerceProduct);
-        $this->assertTrue($products[1] instanceof ECommerceProduct);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $products[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $products[1]);
         $this->assertCollectionEquals($products, $secondCart->getProducts());
         //$this->assertEquals("Doctrine 1.x Manual", $products[0]->getName());
         //$this->assertEquals("Doctrine 2.x Manual", $products[1]->getName());
@@ -88,8 +88,8 @@ class ManyToManyUnidirectionalAssociationTest extends AbstractManyToManyAssociat
         $products = $firstCart->getProducts();
         $secondCart = $result[1];
         
-        $this->assertTrue($products[0] instanceof ECommerceProduct);
-        $this->assertTrue($products[1] instanceof ECommerceProduct);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $products[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $products[1]);
         $this->assertCollectionEquals($products, $secondCart->getProducts());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
@@ -38,9 +38,9 @@ class MappedSuperclassTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $cleanFile = $this->_em->find(get_class($file), $file->getId());
 
-        $this->assertType('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent());
+        $this->assertInstanceOf('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent());
         $this->assertEquals($directory->getId(), $cleanFile->getParent()->getId());
-        $this->assertType('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent()->getParent());
+        $this->assertInstanceOf('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent()->getParent());
         $this->assertEquals($root->getId(), $cleanFile->getParent()->getParent()->getId());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -49,7 +49,7 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $query->getResult();
 
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals('Roman', $users[0]->name);
     }
     
@@ -83,9 +83,9 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals('Roman', $users[0]->name);
-        $this->assertTrue($users[0]->getPhonenumbers() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $users[0]->getPhonenumbers());
         $this->assertTrue($users[0]->getPhonenumbers()->isInitialized());
         $this->assertEquals(1, count($users[0]->getPhonenumbers()));
         $phones = $users[0]->getPhonenumbers();
@@ -132,11 +132,11 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $query->getResult();
         
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals('Roman', $users[0]->name);
-        $this->assertTrue($users[0]->getPhonenumbers() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $users[0]->getPhonenumbers());
         $this->assertFalse($users[0]->getPhonenumbers()->isInitialized());
-        $this->assertTrue($users[0]->getAddress() instanceof CmsAddress);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $users[0]->getAddress());
         $this->assertTrue($users[0]->getAddress()->getUser() == $users[0]);
         $this->assertEquals('germany', $users[0]->getAddress()->getCountry());
         $this->assertEquals(10827, $users[0]->getAddress()->getZipCode());
@@ -185,9 +185,9 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals('Roman', $users[0]->name);
-        $this->assertTrue($users[0]->getPhonenumbers() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $users[0]->getPhonenumbers());
         $this->assertTrue($users[0]->getPhonenumbers()->isInitialized());
         $this->assertEquals(1, count($users[0]->getPhonenumbers()));
         $phones = $users[0]->getPhonenumbers();
@@ -226,11 +226,11 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $query->getResult();
 
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals('Roman', $users[0]->name);
-        $this->assertTrue($users[0]->getPhonenumbers() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $users[0]->getPhonenumbers());
         $this->assertFalse($users[0]->getPhonenumbers()->isInitialized());
-        $this->assertTrue($users[0]->getAddress() instanceof CmsAddress);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $users[0]->getAddress());
         $this->assertTrue($users[0]->getAddress()->getUser() == $users[0]);
         $this->assertEquals('germany', $users[0]->getAddress()->getCountry());
         $this->assertEquals(10827, $users[0]->getAddress()->getZipCode());

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -77,13 +77,13 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         
         $features = $product->getFeatures();
         
-        $this->assertTrue($features[0] instanceof ECommerceFeature);
-        $this->assertFalse($features[0]->getProduct() instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $features[0]);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $features[0]->getProduct());
         $this->assertSame($product, $features[0]->getProduct());
         $this->assertEquals('Model writing tutorial', $features[0]->getDescription());
-        $this->assertTrue($features[1] instanceof ECommerceFeature);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $features[1]);
         $this->assertSame($product, $features[1]->getProduct());
-        $this->assertFalse($features[1]->getProduct() instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $features[1]->getProduct());
         $this->assertEquals('Annotations examples', $features[1]->getDescription());
     }
     
@@ -97,11 +97,11 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $features = $product->getFeatures();
         
         $this->assertFalse($features->isInitialized());
-        $this->assertTrue($features[0] instanceof ECommerceFeature);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $features[0]);
         $this->assertTrue($features->isInitialized());
         $this->assertSame($product, $features[0]->getProduct());
         $this->assertEquals('Model writing tutorial', $features[0]->getDescription());
-        $this->assertTrue($features[1] instanceof ECommerceFeature);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $features[1]);
         $this->assertSame($product, $features[1]->getProduct());
         $this->assertEquals('Annotations examples', $features[1]->getDescription());
     }
@@ -114,8 +114,8 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $features = $query->getResult();
         
         $product = $features[0]->getProduct();
-        $this->assertTrue($product instanceof \Doctrine\ORM\Proxy\Proxy);
-        $this->assertTrue($product instanceof ECommerceProduct);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $product);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $product);
         $this->assertFalse($product->__isInitialized__);
         $this->assertSame('Doctrine Cookbook', $product->getName());
         $this->assertTrue($product->__isInitialized__);
@@ -130,8 +130,8 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $features = $query->getResult();
         
         $product = $features[0]->getProduct();
-        $this->assertFalse($product instanceof \Doctrine\ORM\Proxy\Proxy);
-        $this->assertTrue($product instanceof ECommerceProduct);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $product);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $product);
         $this->assertSame('Doctrine Cookbook', $product->getName());
         
         $this->assertFalse($product->getFeatures()->isInitialized());

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -79,10 +79,10 @@ class OneToManySelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunctio
         $parent = $result[0];
         $children = $parent->getChildren();
         
-        $this->assertTrue($children[0] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $children[0]);
         $this->assertSame($parent, $children[0]->getParent());
         $this->assertEquals(' books', strstr($children[0]->getName(), ' books'));
-        $this->assertTrue($children[1] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $children[1]);
         $this->assertSame($parent, $children[1]->getParent());
         $this->assertEquals(' books', strstr($children[1]->getName(), ' books'));
     }
@@ -98,10 +98,10 @@ class OneToManySelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunctio
         $parent = $result[0];
         $children = $parent->getChildren();
         
-        $this->assertTrue($children[0] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $children[0]);
         $this->assertSame($parent, $children[0]->getParent());
         $this->assertEquals(' books', strstr($children[0]->getName(), ' books'));
-        $this->assertTrue($children[1] instanceof ECommerceCategory);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCategory', $children[1]);
         $this->assertSame($parent, $children[1]->getParent());
         $this->assertEquals(' books', strstr($children[1]->getName(), ' books'));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -62,7 +62,7 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         $result = $query->getResult();
         $customer = $result[0];
         
-        $this->assertTrue($customer->getCart() instanceof ECommerceCart);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCart', $customer->getCart());
         $this->assertEquals('paypal', $customer->getCart()->getPayment());
     }
     
@@ -75,7 +75,7 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         $result = $query->getResult();
         $cart = $result[0];
         
-        $this->assertTrue($cart->getCustomer() instanceof ECommerceCustomer);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCustomer', $cart->getCustomer());
         $this->assertEquals('Giorgio', $cart->getCustomer()->getName());
     }
 
@@ -90,8 +90,8 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         $customer = $result[0];
         
         $this->assertNull($customer->getMentor());
-        $this->assertTrue($customer->getCart() instanceof ECommerceCart);
-        $this->assertFalse($customer->getCart() instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOF('Doctrine\Tests\Models\ECommerce\ECommerceCart', $customer->getCart());
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $customer->getCart());
         $this->assertEquals('paypal', $customer->getCart()->getPayment());
     }
     
@@ -107,7 +107,7 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         $this->_em->flush();
         $this->_em->clear();
         
-        $this->assertTrue($cust->getCart() instanceof ECommerceCart);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCart', $cust->getCart());
         $this->assertEquals('Roman', $cust->getName());
         $this->assertSame($cust, $cart->getCustomer());
         
@@ -126,7 +126,7 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         
         $cart3 = $query2->getSingleResult();
         
-        $this->assertTrue($cart3->getCustomer() instanceof ECommerceCustomer);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCustomer', $cart3->getCustomer());
         $this->assertEquals('Roman', $cart3->getCustomer()->getName());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -104,8 +104,8 @@ class OneToOneSelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunction
         
         $entity2 = $this->_em->find(get_class($entity1), $entity1->getId());
         
-        $this->assertTrue($entity2->getOther1() instanceof MultiSelfReference);
-        $this->assertTrue($entity2->getOther2() instanceof MultiSelfReference);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\MultiSelfReference', $entity2->getOther1());
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\MultiSelfReference', $entity2->getOther2());
         $this->assertNull($entity2->getOther1()->getOther1());
         $this->assertNull($entity2->getOther1()->getOther2());
         $this->assertNull($entity2->getOther2()->getOther1());
@@ -114,7 +114,7 @@ class OneToOneSelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunction
 
     public function assertLoadingOfAssociation($customer)
     {
-        $this->assertTrue($customer->getMentor() instanceof ECommerceCustomer);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCustomer', $customer->getMentor());
         $this->assertEquals('Obi-wan Kenobi', $customer->getMentor()->getName());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -56,7 +56,7 @@ class OneToOneUnidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $result = $query->getResult();
         $product = $result[0];
         
-        $this->assertTrue($product->getShipping() instanceof ECommerceShipping);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceShipping', $product->getShipping());
         $this->assertEquals(1, $product->getShipping()->getDays());
     }
     
@@ -69,7 +69,7 @@ class OneToOneUnidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $result = $query->getResult();
         $product = $result[0];
         
-        $this->assertTrue($product->getShipping() instanceof ECommerceShipping);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceShipping', $product->getShipping());
         $this->assertEquals(1, $product->getShipping()->getDays());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -38,7 +38,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $query->getResult();
         
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0][0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0][0]);
         $this->assertEquals('Guilherme', $result[0][0]->name);
         $this->assertEquals('gblanco', $result[0][0]->username);
         $this->assertEquals('developer', $result[0][0]->status);
@@ -90,7 +90,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a");
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
-        $this->assertTrue($users[0] instanceof CmsUser);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);
         $this->assertEquals(2, count($users[0]->articles));
         $this->assertEquals('Doctrine 2', $users[0]->articles[0]->topic);
         $this->assertEquals('Symfony 2', $users[0]->articles[1]->topic);
@@ -361,9 +361,9 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $result = $q->getResult();
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof CmsArticle);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $result[0]);
         $this->assertEquals("dr. dolittle", $result[0]->topic);
-        $this->assertTrue($result[0]->user instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[0]->user);
         $this->assertFalse($result[0]->user->__isInitialized__);
     }
     

--- a/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
@@ -64,7 +64,7 @@ class StandardEntityPersisterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         
         $this->assertEquals(2, count($p->getFeatures()));
-        $this->assertTrue($p->getFeatures() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $p->getFeatures());
 
         $q = $this->_em->createQuery(
             'SELECT p, f
@@ -75,7 +75,7 @@ class StandardEntityPersisterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $res = $q->getResult();
         
         $this->assertEquals(2, count($p->getFeatures()));
-        $this->assertTrue($p->getFeatures() instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $p->getFeatures());
         
         // Check that the features are the same instances still
         foreach ($p->getFeatures() as $feature) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
@@ -58,7 +58,7 @@ class DDC168Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals("bar", $theEmployee->getDepartment());
         $this->assertEquals("Foo", $theEmployee->getName());
         $this->assertEquals(1000, $theEmployee->getSalary());
-        $this->assertTrue($theEmployee instanceof CompanyEmployee);
-        $this->assertTrue($theEmployee->getSpouse() instanceof CompanyEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $theEmployee);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $theEmployee->getSpouse());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
@@ -40,11 +40,11 @@ class DDC199Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $query->getResult();
         
         $this->assertEquals(1, count($result));
-        $this->assertTrue($result[0] instanceof DDC199ChildClass);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC199ParentClass', $result[0]);
         $this->assertTrue($result[0]->relatedEntities->isInitialized());
         $this->assertEquals(2, $result[0]->relatedEntities->count());
-        $this->assertTrue($result[0]->relatedEntities[0] instanceof DDC199RelatedClass);
-        $this->assertTrue($result[0]->relatedEntities[1] instanceof DDC199RelatedClass);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC199RelatedClass', $result[0]->relatedEntities[0]);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC199RelatedClass', $result[0]->relatedEntities[1]);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -45,7 +45,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $z2 = $this->_em->createQuery('select z,y from ' . get_class($z) . ' z join z.y y where z.id = ?1')
                 ->setParameter(1, $z->id)
                 ->getSingleResult();
-       $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $z2->y);
         $this->assertTrue($z2->y->__isInitialized__);
         $this->assertEquals('Y', $z2->y->data);
         $this->assertEquals($y->id, $z2->y->id);
@@ -56,7 +56,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertNotSame($x, $x2);
         $this->assertNotSame($z, $z2);
         $this->assertSame($z2->y, $x2->y);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $z2->y);
         
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -37,7 +37,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
         
         $x2 = $this->_em->find(get_class($x), $x->id); // proxy injected for Y
-        $this->assertTrue($x2->y instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
         $this->assertFalse($x2->y->__isInitialized__);
         
         // proxy for Y is in identity map
@@ -45,7 +45,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $z2 = $this->_em->createQuery('select z,y from ' . get_class($z) . ' z join z.y y where z.id = ?1')
                 ->setParameter(1, $z->id)
                 ->getSingleResult();
-        $this->assertTrue($z2->y instanceof \Doctrine\ORM\Proxy\Proxy);
+       $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
         $this->assertTrue($z2->y->__isInitialized__);
         $this->assertEquals('Y', $z2->y->data);
         $this->assertEquals($y->id, $z2->y->id);
@@ -56,7 +56,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertNotSame($x, $x2);
         $this->assertNotSame($z, $z2);
         $this->assertSame($z2->y, $x2->y);
-        $this->assertTrue($z2->y instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
         
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
@@ -44,7 +44,7 @@ class DDC258Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $e2 = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC258Super', $c2->id);
 
-        $this->assertType('Doctrine\Tests\ORM\Functional\Ticket\DDC258Class2', $e2);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC258Class2', $e2);
         $this->assertEquals('Bar', $e2->title);
         $this->assertEquals('Bar', $e2->description);
         $this->assertEquals('Bar', $e2->text);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -48,7 +48,7 @@ class DDC345Test extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $this->assertEquals(1, $membership->prePersistCallCount);
         $this->assertEquals(0, $membership->preUpdateCallCount);
-        $this->assertTrue($membership->updated instanceof \DateTime);
+        $this->assertInstanceOf('DateTime', $membership->updated);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -41,7 +41,7 @@ class DDC371Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->getResult();
                 
         $this->assertEquals(1, count($children));
-        $this->assertFalse($children[0]->parent instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $children[0]->parent);
         $this->assertFalse($children[0]->parent->children->isInitialized());
         $this->assertEquals(0, $children[0]->parent->children->unwrap()->count());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -28,7 +28,7 @@ class DDC422Test extends \Doctrine\Tests\OrmFunctionalTestCase
         
         $customer = $this->_em->find(get_class($customer), $customer->id);
         
-        $this->assertTrue($customer->contacts instanceof \Doctrine\ORM\PersistentCollection);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $customer->contacts);
         $this->assertFalse($customer->contacts->isInitialized());
         $contact = new DDC422Contact;
         $customer->contacts->add($contact);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -64,13 +64,13 @@ class DDC440Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // Test the first phone.  The assertion actually failed because original entity data is not set properly.
         // This was because it is also set as MainPhone and that one is created as a proxy, not the
         // original object when the find on Client is called. However loading proxies did not work correctly.
-        $this->assertType('Doctrine\Tests\ORM\Functional\Ticket\DDC440Phone', $p1);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC440Phone', $p1);
         $originalData = $uw->getOriginalEntityData($p1);
         $this->assertEquals($phone->getNumber(), $originalData['number']);
 
 
         //If you comment out previous test, this one should pass
-        $this->assertType('Doctrine\Tests\ORM\Functional\Ticket\DDC440Phone', $p2);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC440Phone', $p2);
         $originalData = $uw->getOriginalEntityData($p2);
         $this->assertEquals($phone2->getNumber(), $originalData['number']);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
@@ -50,7 +50,7 @@ class DDC501Test extends OrmFunctionalTestCase
 
         // freeze and unfreeze
         $userClone = unserialize(serialize($userReloaded));
-        $this->assertType('Doctrine\Tests\Models\CMS\CmsUser', $userClone);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $userClone);
 
         // detached user can't know about his phonenumbers
         $this->assertEquals(0, count($userClone->getPhonenumbers()));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
@@ -32,14 +32,14 @@ class DDC512Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $q->getResult();
 
         $this->assertEquals(2, count($result));
-        $this->assertTrue($result[0] instanceof DDC512Customer);
-        $this->assertTrue($result[1] instanceof DDC512Customer);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC512Customer', $result[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC512Customer', $result[1]);
         if ($result[0]->id == $customer1->id) {
-            $this->assertTrue($result[0]->item instanceof DDC512OfferItem);
+            $this->assertInstanceOf(__NAMESPACE__ . '\DDC512OfferItem', $result[0]->item);
             $this->assertEquals($item->id, $result[0]->item->id);
             $this->assertNull($result[1]->item);
         } else {
-            $this->assertTrue($result[1]->item instanceof DDC512OfferItem);
+            $this->assertInstanceOf(__NAMESPACE__ . '\DDC512OfferItem', $result[1]->item);
             $this->assertNull($result[0]->item);
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -48,9 +48,9 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $r = $this->_em->createQuery("select ca,c from ".get_class($cart)." ca join ca.customer c")
                 ->getResult();
         
-        $this->assertTrue($r[0] instanceof DDC522Cart);
-        $this->assertTrue($r[0]->customer instanceof DDC522Customer);
-        $this->assertFalse($r[0]->customer instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC522Cart', $r[0]);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC522Customer', $r[0]->customer);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $r[0]->customer);
         $this->assertEquals('name', $r[0]->customer->name);
 
         $fkt = new DDC522ForeignKeyTest();
@@ -62,7 +62,7 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $fkt2 = $this->_em->find(get_class($fkt), $fkt->id);
         $this->assertEquals($fkt->cart->id, $fkt2->cartId);
-        $this->assertTrue($fkt2->cart instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $fkt2->cart);
         $this->assertFalse($fkt2->cart->__isInitialized__);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -29,8 +29,8 @@ class DDC531Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $item3 = $this->_em->find(__NAMESPACE__ . '\DDC531Item', $item2->id); // Load child item first (id 2)
         // parent will already be loaded, cannot be lazy because it has mapped subclasses and we would not
         // know which proxy type to put in.
-        $this->assertTrue($item3->parent instanceof DDC531Item);
-        $this->assertFalse($item3->parent instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC531Item', $item3->parent);
+        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $item3->parent);
         $item4 = $this->_em->find(__NAMESPACE__ . '\DDC531Item', $item1->id); // Load parent item (id 1)
         $this->assertNull($item4->parent);
         $this->assertNotNull($item4->getChildren());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -66,7 +66,7 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $appointments = $this->_em->createQuery("SELECT a FROM " . __NAMESPACE__ . "\DDC633Appointment a")->getResult();
         
         foreach ($appointments AS $eagerAppointment) {
-            $this->assertType('Doctrine\ORM\Proxy\Proxy', $eagerAppointment->patient);
+            $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $eagerAppointment->patient);
             $this->assertTrue($eagerAppointment->patient->__isInitialized__, "Proxy should already be initialized due to eager loading!");
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
@@ -36,11 +36,11 @@ class DDC729Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $a = new DDC729A();
         $a->id = $aId;
 
-        $this->assertType('Doctrine\Common\Collections\ArrayCollection', $a->related);
+        $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $a->related);
         
         $a = $this->_em->merge($a);
 
-        $this->assertType('Doctrine\ORM\PersistentCollection', $a->related);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $a->related);
 
         $this->assertFalse($a->related->isInitialized(), "Collection should not be marked initialized.");
         $this->assertFalse($a->related->isDirty(), "Collection should not be marked as dirty.");

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -72,7 +72,7 @@ class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         /* @var $cart2 Doctrine\Tests\Models\ECommerce\ECommerceCart */
         $cart2 = $result[0][0];
-        $this->assertType('Doctrine\ORM\Proxy\Proxy', $cart2->getCustomer());
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $cart2->getCustomer());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC748Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC748Test.php
@@ -33,10 +33,10 @@ class DDC748Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $this->assertType('Doctrine\Common\Collections\Collection', $user->articles);
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $user->articles);
         $this->_em->refresh($article);
         $this->assertTrue($article !== $user->articles, "The article should not be replaced on the inverse side of the relation.");
-        $this->assertType('Doctrine\Common\Collections\Collection', $user->articles);
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $user->articles);
     }
 
     public function testRefreshOneToOne()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -52,20 +52,20 @@ class DDC837Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // Test Class1
         $e1 = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC837Super', $c1->id);
 
-        $this->assertType('Doctrine\Tests\ORM\Functional\Ticket\DDC837Class1', $e1);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC837Class1', $e1);
         $this->assertEquals('Foo', $e1->title);
         $this->assertEquals('Foo', $e1->description);
-        $this->assertType(__NAMESPACE__ . '\DDC837Aggregate', $e1->aggregate);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC837Aggregate', $e1->aggregate);
         $this->assertEquals('test1', $e1->aggregate->getSysname());
 
         // Test Class 2
         $e2 = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC837Super', $c2->id);
 
-        $this->assertType('Doctrine\Tests\ORM\Functional\Ticket\DDC837Class2', $e2);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\DDC837Class2', $e2);
         $this->assertEquals('Bar', $e2->title);
         $this->assertEquals('Bar', $e2->description);
         $this->assertEquals('Bar', $e2->text);
-        $this->assertType(__NAMESPACE__ . '\DDC837Aggregate', $e2->aggregate);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC837Aggregate', $e2->aggregate);
         $this->assertEquals('test2', $e2->aggregate->getSysname());
 
         $all = $this->_em->getRepository(__NAMESPACE__.'\DDC837Super')->findAll();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
@@ -34,10 +34,10 @@ class DDC949Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $true = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(array('booleanField' => true));
         $false = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(array('booleanField' => false));
 
-        $this->assertType('Doctrine\Tests\Models\Generic\BooleanModel', $true);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Generic\BooleanModel', $true);
         $this->assertTrue($true->booleanField, "True Boolean Model should be true.");
 
-        $this->assertType('Doctrine\Tests\Models\Generic\BooleanModel', $false);
+        $this->assertInstanceOf('Doctrine\Tests\Models\Generic\BooleanModel', $false);
         $this->assertFalse($false->booleanField, "False Boolean Model should be false.");
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -85,11 +85,11 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase {
         $lemma = $res[0];
 
         $this->assertEquals('foo', $lemma->getLemma());
-        $this->assertTrue($lemma instanceof Lemma);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\Lemma', $lemma);
         $relations = $lemma->getRelations();
 
         foreach($relations as $relation) {
-            $this->assertTrue($relation instanceof Relation);
+            $this->assertInstanceOf('Doctrine\Tests\ORM\Functional\Ticket\Relation', $relation);
             $this->assertTrue($relation->getType()->getType() != '');
         }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/CustomHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/CustomHydratorTest.php
@@ -15,7 +15,7 @@ class CustomHydratorTest extends HydrationTestCase
         $config->addCustomHydrationMode('CustomHydrator', 'Doctrine\Tests\ORM\Hydration\CustomHydrator');
 
         $hydrator = $em->newHydrator('CustomHydrator');
-        $this->assertTrue($hydrator instanceof \Doctrine\Tests\ORM\Hydration\CustomHydrator);
+        $this->assertInstanceOf('Doctrine\Tests\ORM\Hydration\CustomHydrator', $hydrator);
         $this->assertNull($config->getCustomHydrationMode('does not exist'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -16,7 +16,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         // Test initial state
         $this->assertTrue(count($cm->getReflectionProperties()) == 0);
-        $this->assertTrue($cm->reflClass instanceof \ReflectionClass);
+        $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->rootEntityName);
         $this->assertEquals(array(), $cm->subClasses);
@@ -40,7 +40,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         // Check state
         $this->assertTrue(count($cm->getReflectionProperties()) > 0);
         $this->assertEquals('Doctrine\Tests\Models\CMS', $cm->namespace);
-        $this->assertTrue($cm->reflClass instanceof \ReflectionClass);
+        $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
         $this->assertEquals('UserParent', $cm->rootEntityName);
         $this->assertEquals(array('Doctrine\Tests\Models\CMS\One', 'Doctrine\Tests\Models\CMS\Two', 'Doctrine\Tests\Models\CMS\Three'), $cm->subClasses);


### PR DESCRIPTION
Now PHPUnit doesn't show warning about deprecation of assertType.
Also some refractoring from assertTrue($a instanceof $b) to assertInstanceOf.
Leading \ in namespaces is not required so I removed it from few assertions.
