### PR TITLE
DDC-1275: Added join columns to result set mapping

### DIFF
--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -67,6 +67,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             }
             $this->addFieldResult($alias, $platform->getSQLResultCasing($columnName), $propertyName);
         }
+        $this->addAssocationMappings($alias, $classMetadata->getAssociationMappings());
     }
 
     /**
@@ -95,6 +96,24 @@ class ResultSetMappingBuilder extends ResultSetMapping
                 throw new \InvalidArgumentException("The column '$columnName' conflicts with another column in the mapper.");
             }
             $this->addFieldResult($alias, $platform->getSQLResultCasing($columnName), $propertyName);
+        }
+        $this->addAssocationMappings($alias, $classMetadata->getAssociationMappings());
+    }
+
+    protected function addAssocationMappings($alias, $associationMappings)
+    {
+        $platform = $this->em->getConnection()->getDatabasePlatform();
+        foreach ($associationMappings AS $associationMapping) {
+            if (isset($associationMapping['joinColumns'])) {
+                foreach ($associationMapping['joinColumns'] AS $joinColumn) {
+                    $columnName = $joinColumn['name'];
+                    $renamedColumnName = isset($renamedColumns[$columnName]) ? $renamedColumns[$columnName] : $columnName;
+                    if (isset($this->metaMappings[$renamedColumnName])) {
+                        throw new \InvalidArgumentException("The column '$renamedColumnName' conflicts with another column in the mapper.");
+                    }
+                    $this->addMetaResult($alias, $platform->getSQLResultCasing($renamedColumnName), $platform->getSQLResultCasing($columnName));
+                }
+            }
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -244,9 +244,6 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query->setParameter(1, $phone->phonenumber);
         $phone = $query->getSingleResult();
 
-//        \Doctrine\Common\Util\Debug::dump($phone);
-//        die();
-
         $this->assertNotNull($phone->getUser());
         $this->assertEquals($user->name, $phone->getUser()->getName());
     }


### PR DESCRIPTION
I created some tests for the associations, and they did indeed fail in the expected way. This change adds the join columns to the result set mapping using addMetaResult()
