### PR TITLE
[DDC-1301] Fixed count() for fetch="EXTRA_LAZY" on OneToMany association

### DIFF
--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -124,24 +124,26 @@ class OneToManyPersister extends AbstractCollectionPersister
     public function count(PersistentCollection $coll)
     {
         $mapping = $coll->getMapping();
-        $class = $this->_em->getClassMetadata($mapping['targetEntity']);
+        $targetClass = $this->_em->getClassMetadata($mapping['targetEntity']);
+        $sourceClass = $this->_em->getClassMetadata($mapping['sourceEntity']);
+
         $params = array();
         $id = $this->_em->getUnitOfWork()->getEntityIdentifier($coll->getOwner());
 
         $where = '';
-        foreach ($class->associationMappings[$mapping['mappedBy']]['joinColumns'] AS $joinColumn) {
+        foreach ($targetClass->associationMappings[$mapping['mappedBy']]['joinColumns'] AS $joinColumn) {
             if ($where != '') {
                 $where .= ' AND ';
             }
             $where .= $joinColumn['name'] . " = ?";
-            if ($class->containsForeignIdentifier) {
-                $params[] = $id[$class->getFieldForColumn($joinColumn['referencedColumnName'])];
+            if ($targetClass->containsForeignIdentifier) {
+                $params[] = $id[$sourceClass->getFieldForColumn($joinColumn['referencedColumnName'])];
             } else {
-                $params[] = $id[$class->fieldNames[$joinColumn['referencedColumnName']]];
+                $params[] = $id[$sourceClass->fieldNames[$joinColumn['referencedColumnName']]];
             }
         }
 
-        $sql = "SELECT count(*) FROM " . $class->getQuotedTableName($this->_conn->getDatabasePlatform()) . " WHERE " . $where;
+        $sql = "SELECT count(*) FROM " . $targetClass->getQuotedTableName($this->_conn->getDatabasePlatform()) . " WHERE " . $where;
         return $this->_conn->fetchColumn($sql, $params);
     }
 

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
@@ -13,21 +13,21 @@ class LegacyArticle
      * @Column(name="iArticleId", type="integer")
      * @GeneratedValue(strategy="AUTO")
      */
-    public $id;
+    public $_id;
     /**
      * @Column(name="sTopic", type="string", length=255)
      */
-    public $topic;
+    public $_topic;
     /**
      * @Column(name="sText", type="text")
      */
-    public $text;
+    public $_text;
     /**
-     * @ManyToOne(targetEntity="LegacyUser", inversedBy="articles")
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="_articles")
      * @JoinColumn(name="iUserId", referencedColumnName="iUserId")
      */
-    public $user;
+    public $_user;
     public function setAuthor(LegacyUser $author) {
-        $this->user = $author;
+        $this->_user = $author;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\Legacy;
+
+/**
+ * @Entity
+ * @Table(name="legacy_articles")
+ */
+class LegacyArticle
+{
+    /**
+     * @Id
+     * @Column(name="iArticleId", type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+    /**
+     * @Column(name="sTopic", type="string", length=255)
+     */
+    public $topic;
+    /**
+     * @Column(name="sText", type="text")
+     */
+    public $text;
+    /**
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="articles")
+     * @JoinColumn(name="iUserId", referencedColumnName="iUserId")
+     */
+    public $user;
+    public function setAuthor(LegacyUser $author) {
+        $this->user = $author;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\Tests\Models\Legacy;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="legacy_cars")
+ */
+class LegacyCar
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(name="iCarId", type="integer", nullable=false)
+     */
+    public $id;
+    /**
+     * @ManyToMany(targetEntity="LegacyUser", mappedBy="cars")
+     */
+    public $users;
+
+    /**
+     * @Column(name="sDescription", type="string", length=255, unique=true)
+     */
+    public $description;
+
+    function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function addUser(LegacyUser $user) {
+        $this->users[] = $user;
+    }
+
+    public function getUsers() {
+        return $this->users;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
@@ -15,27 +15,27 @@ class LegacyCar
      * @GeneratedValue
      * @Column(name="iCarId", type="integer", nullable=false)
      */
-    public $id;
+    public $_id;
     /**
-     * @ManyToMany(targetEntity="LegacyUser", mappedBy="cars")
+     * @ManyToMany(targetEntity="LegacyUser", mappedBy="_cars")
      */
-    public $users;
+    public $_users;
 
     /**
      * @Column(name="sDescription", type="string", length=255, unique=true)
      */
-    public $description;
+    public $_description;
 
     function getDescription()
     {
-        return $this->description;
+        return $this->_description;
     }
 
     public function addUser(LegacyUser $user) {
-        $this->users[] = $user;
+        $this->_users[] = $user;
     }
 
     public function getUsers() {
-        return $this->users;
+        return $this->_users;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Doctrine\Tests\Models\Legacy;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="legacy_users")
+ */
+class LegacyUser
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(name="iUserId", type="integer", nullable=false)
+     */
+    public $id;
+    /**
+     * @Column(name="sUsername", type="string", length=255, unique=true)
+     */
+    public $username;
+    /**
+     * @Column(type="string", length=255)
+     */
+    public $name;
+    /**
+     * @OneToMany(targetEntity="LegacyArticle", mappedBy="user")
+     */
+    public $articles;
+    /**
+     * @OneToMany(targetEntity="LegacyUserReference", mappedBy="source", cascade={"remove"})
+     */
+    public $references;
+    /**
+     * @ManyToMany(targetEntity="LegacyCar", inversedBy="users", cascade={"persist", "merge"})
+     * @JoinTable(name="legace_users_cars",
+     *      joinColumns={@JoinColumn(name="iUserId", referencedColumnName="iUserId")},
+     *      inverseJoinColumns={@JoinColumn(name="iCarId", referencedColumnName="iCarId")}
+     *      )
+     */
+    public $cars;
+    public function __construct() {
+        $this->articles = new ArrayCollection;
+        $this->references = new ArrayCollection;
+        $this->cars = new ArrayCollection;
+    }
+
+    public function getId() {
+        return $this->id;
+    }
+
+    public function getUsername() {
+        return $this->username;
+    }
+
+    public function addArticle(LegacyArticle $article) {
+        $this->articles[] = $article;
+        $article->setAuthor($this);
+    }
+
+    public function addReference($reference)
+    {
+        $this->references[] = $reference;
+    }
+
+    public function references()
+    {
+        return $this->references;
+    }
+
+    public function addCar(LegacyCar $car) {
+        $this->cars[] = $car;
+        $car->addUser($this);
+    }
+
+    public function getCars() {
+        return $this->cars;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
@@ -15,66 +15,66 @@ class LegacyUser
      * @GeneratedValue
      * @Column(name="iUserId", type="integer", nullable=false)
      */
-    public $id;
+    public $_id;
     /**
      * @Column(name="sUsername", type="string", length=255, unique=true)
      */
-    public $username;
+    public $_username;
     /**
      * @Column(type="string", length=255)
      */
-    public $name;
+    public $_name;
     /**
-     * @OneToMany(targetEntity="LegacyArticle", mappedBy="user")
+     * @OneToMany(targetEntity="LegacyArticle", mappedBy="_user")
      */
-    public $articles;
+    public $_articles;
     /**
-     * @OneToMany(targetEntity="LegacyUserReference", mappedBy="source", cascade={"remove"})
+     * @OneToMany(targetEntity="LegacyUserReference", mappedBy="_source", cascade={"remove"})
      */
-    public $references;
+    public $_references;
     /**
-     * @ManyToMany(targetEntity="LegacyCar", inversedBy="users", cascade={"persist", "merge"})
+     * @ManyToMany(targetEntity="LegacyCar", inversedBy="_users", cascade={"persist", "merge"})
      * @JoinTable(name="legace_users_cars",
      *      joinColumns={@JoinColumn(name="iUserId", referencedColumnName="iUserId")},
      *      inverseJoinColumns={@JoinColumn(name="iCarId", referencedColumnName="iCarId")}
      *      )
      */
-    public $cars;
+    public $_cars;
     public function __construct() {
-        $this->articles = new ArrayCollection;
-        $this->references = new ArrayCollection;
-        $this->cars = new ArrayCollection;
+        $this->_articles = new ArrayCollection;
+        $this->_references = new ArrayCollection;
+        $this->_cars = new ArrayCollection;
     }
 
     public function getId() {
-        return $this->id;
+        return $this->_id;
     }
 
     public function getUsername() {
-        return $this->username;
+        return $this->_username;
     }
 
     public function addArticle(LegacyArticle $article) {
-        $this->articles[] = $article;
+        $this->_articles[] = $article;
         $article->setAuthor($this);
     }
 
     public function addReference($reference)
     {
-        $this->references[] = $reference;
+        $this->_references[] = $reference;
     }
 
     public function references()
     {
-        return $this->references;
+        return $this->_references;
     }
 
     public function addCar(LegacyCar $car) {
-        $this->cars[] = $car;
+        $this->_cars[] = $car;
         $car->addUser($this);
     }
 
     public function getCars() {
-        return $this->cars;
+        return $this->_cars;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
@@ -10,56 +10,56 @@ class LegacyUserReference
 {
     /**
      * @Id
-     * @ManyToOne(targetEntity="LegacyUser", inversedBy="references")
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="_references")
      * @JoinColumn(name="iUserIdSource", referencedColumnName="iUserId")
      */
-    private $source;
+    private $_source;
 
     /**
      * @Id
-     * @ManyToOne(targetEntity="LegacyUser", inversedBy="references")
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="_references")
      * @JoinColumn(name="iUserIdTarget", referencedColumnName="iUserId")
      */
-    private $target;
+    private $_target;
 
     /**
      * @column(type="string")
      */
-    private $description;
+    private $_description;
 
     /**
      * @column(type="datetime")
      */
-    private $created;
+    private $_created;
 
     public function __construct($source, $target, $description)
     {
         $source->addReference($this);
         $target->addReference($this);
 
-        $this->source = $source;
-        $this->target = $target;
-        $this->description = $description;
-        $this->created = new \DateTime("now");
+        $this->_source = $source;
+        $this->_target = $target;
+        $this->_description = $description;
+        $this->_created = new \DateTime("now");
     }
 
     public function source()
     {
-        return $this->source;
+        return $this->_source;
     }
 
     public function target()
     {
-        return $this->target;
+        return $this->_target;
     }
 
     public function setDescription($desc)
     {
-        $this->description = $desc;
+        $this->_description = $desc;
     }
 
     public function getDescription()
     {
-        return $this->description;
+        return $this->_description;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\Tests\Models\Legacy;
+
+/**
+ * @Entity
+ * @Table(name="legacy_users_reference")
+ */
+class LegacyUserReference
+{
+    /**
+     * @Id
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="references")
+     * @JoinColumn(name="iUserIdSource", referencedColumnName="iUserId")
+     */
+    private $source;
+
+    /**
+     * @Id
+     * @ManyToOne(targetEntity="LegacyUser", inversedBy="references")
+     * @JoinColumn(name="iUserIdTarget", referencedColumnName="iUserId")
+     */
+    private $target;
+
+    /**
+     * @column(type="string")
+     */
+    private $description;
+
+    /**
+     * @column(type="datetime")
+     */
+    private $created;
+
+    public function __construct($source, $target, $description)
+    {
+        $source->addReference($this);
+        $target->addReference($this);
+
+        $this->source = $source;
+        $this->target = $target;
+        $this->description = $description;
+        $this->created = new \DateTime("now");
+    }
+
+    public function source()
+    {
+        return $this->source;
+    }
+
+    public function target()
+    {
+        return $this->target;
+    }
+
+    public function setDescription($desc)
+    {
+        $this->description = $desc;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+/**
+ * @author asm89
+ */
+class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    private $userId;
+
+    public function setUp()
+    {
+        $this->useModelSet('legacy');
+        parent::setUp();
+
+        $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\Legacy\LegacyUser');
+        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['cars']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+
+        $this->loadFixture();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\Legacy\LegacyUser');
+        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['cars']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+    }
+
+    public function testCountNotInitializesLegacyCollection()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
+        $queryCount = $this->getCurrentQueryCount();
+
+        $this->assertFalse($user->articles->isInitialized());
+        $this->assertEquals(2, count($user->articles));
+        $this->assertFalse($user->articles->isInitialized());
+
+        foreach ($user->articles AS $article) { }
+
+        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
+    }
+
+    public function testCountNotInitializesLegacyCollectionWithForeignIdentifier()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
+        $queryCount = $this->getCurrentQueryCount();
+
+        $this->assertFalse($user->references->isInitialized());
+        $this->assertEquals(2, count($user->references));
+        $this->assertFalse($user->references->isInitialized());
+
+        foreach ($user->references AS $reference) { }
+
+        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
+    }
+
+    public function testCountNotInitializesLegacyManyToManyCollection()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
+        $queryCount = $this->getCurrentQueryCount();
+
+        $this->assertFalse($user->cars->isInitialized());
+        $this->assertEquals(3, count($user->cars));
+        $this->assertFalse($user->cars->isInitialized());
+
+        foreach ($user->cars AS $reference) { }
+
+        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
+    }
+
+    public function loadFixture()
+    {
+        $user1 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
+        $user1->username = "beberlei";
+        $user1->name = "Benjamin";
+        $user1->status = "active";
+
+        $user2 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
+        $user2->username = "jwage";
+        $user2->name = "Jonathan";
+        $user2->status = "active";
+
+        $user3 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
+        $user3->username = "romanb";
+        $user3->name = "Roman";
+        $user3->status = "active";
+
+        $this->_em->persist($user1);
+        $this->_em->persist($user2);
+        $this->_em->persist($user3);
+
+        $article1 = new \Doctrine\Tests\Models\Legacy\LegacyArticle();
+        $article1->topic = "Test";
+        $article1->text = "Test";
+        $article1->setAuthor($user1);
+
+        $article2 = new \Doctrine\Tests\Models\Legacy\LegacyArticle();
+        $article2->topic = "Test";
+        $article2->text = "Test";
+        $article2->setAuthor($user1);
+
+        $this->_em->persist($article1);
+        $this->_em->persist($article2);
+
+        $car1 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
+        $car1->description = "Test1";
+
+        $car2 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
+        $car2->description = "Test2";
+
+        $car3 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
+        $car3->description = "Test3";
+
+        $user1->addCar($car1);
+        $user1->addCar($car2);
+        $user1->addCar($car3);
+
+        $user2->addCar($car1);
+        $user3->addCar($car1);
+
+        $this->_em->persist($car1);
+        $this->_em->persist($car2);
+        $this->_em->persist($car3);
+
+        $this->_em->flush();
+
+        $detail1 = new \Doctrine\Tests\Models\Legacy\LegacyUserReference($user1, $user2, "foo");
+        $detail2 = new \Doctrine\Tests\Models\Legacy\LegacyUserReference($user1, $user3, "bar");
+
+        $this->_em->persist($detail1);
+        $this->_em->persist($detail2);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->userId = $user1->getId();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -19,9 +19,9 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\Legacy\LegacyUser');
-        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
-        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
-        $class->associationMappings['cars']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['_articles']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['_references']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
+        $class->associationMappings['_cars']['fetch'] = ClassMetadataInfo::FETCH_EXTRA_LAZY;
 
         $this->loadFixture();
     }
@@ -31,9 +31,9 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::tearDown();
 
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\Legacy\LegacyUser');
-        $class->associationMappings['articles']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['references']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
-        $class->associationMappings['cars']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['_articles']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['_references']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+        $class->associationMappings['_cars']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
     }
 
     public function testCountNotInitializesLegacyCollection()
@@ -41,11 +41,11 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        $this->assertFalse($user->articles->isInitialized());
-        $this->assertEquals(2, count($user->articles));
-        $this->assertFalse($user->articles->isInitialized());
+        $this->assertFalse($user->_articles->isInitialized());
+        $this->assertEquals(2, count($user->_articles));
+        $this->assertFalse($user->_articles->isInitialized());
 
-        foreach ($user->articles AS $article) { }
+        foreach ($user->_articles AS $article) { }
 
         $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -55,11 +55,11 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        $this->assertFalse($user->references->isInitialized());
-        $this->assertEquals(2, count($user->references));
-        $this->assertFalse($user->references->isInitialized());
+        $this->assertFalse($user->_references->isInitialized());
+        $this->assertEquals(2, count($user->_references));
+        $this->assertFalse($user->_references->isInitialized());
 
-        foreach ($user->references AS $reference) { }
+        foreach ($user->_references AS $reference) { }
 
         $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -69,11 +69,11 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\Legacy\LegacyUser', $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        $this->assertFalse($user->cars->isInitialized());
-        $this->assertEquals(3, count($user->cars));
-        $this->assertFalse($user->cars->isInitialized());
+        $this->assertFalse($user->_cars->isInitialized());
+        $this->assertEquals(3, count($user->_cars));
+        $this->assertFalse($user->_cars->isInitialized());
 
-        foreach ($user->cars AS $reference) { }
+        foreach ($user->_cars AS $reference) { }
 
         $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -81,45 +81,45 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function loadFixture()
     {
         $user1 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
-        $user1->username = "beberlei";
-        $user1->name = "Benjamin";
-        $user1->status = "active";
+        $user1->_username = "beberlei";
+        $user1->_name = "Benjamin";
+        $user1->_status = "active";
 
         $user2 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
-        $user2->username = "jwage";
-        $user2->name = "Jonathan";
-        $user2->status = "active";
+        $user2->_username = "jwage";
+        $user2->_name = "Jonathan";
+        $user2->_status = "active";
 
         $user3 = new \Doctrine\Tests\Models\Legacy\LegacyUser();
-        $user3->username = "romanb";
-        $user3->name = "Roman";
-        $user3->status = "active";
+        $user3->_username = "romanb";
+        $user3->_name = "Roman";
+        $user3->_status = "active";
 
         $this->_em->persist($user1);
         $this->_em->persist($user2);
         $this->_em->persist($user3);
 
         $article1 = new \Doctrine\Tests\Models\Legacy\LegacyArticle();
-        $article1->topic = "Test";
-        $article1->text = "Test";
+        $article1->_topic = "Test";
+        $article1->_text = "Test";
         $article1->setAuthor($user1);
 
         $article2 = new \Doctrine\Tests\Models\Legacy\LegacyArticle();
-        $article2->topic = "Test";
-        $article2->text = "Test";
+        $article2->_topic = "Test";
+        $article2->_text = "Test";
         $article2->setAuthor($user1);
 
         $this->_em->persist($article1);
         $this->_em->persist($article2);
 
         $car1 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
-        $car1->description = "Test1";
+        $car1->_description = "Test1";
 
         $car2 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
-        $car2->description = "Test2";
+        $car2->_description = "Test2";
 
         $car3 = new \Doctrine\Tests\Models\Legacy\LegacyCar();
-        $car3->description = "Test3";
+        $car3->_description = "Test3";
 
         $user1->addCar($car1);
         $user1->addCar($car2);

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -104,6 +104,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\StockExchange\Stock',
             'Doctrine\Tests\Models\StockExchange\Market',
         ),
+        'legacy' => array(
+            'Doctrine\Tests\Models\Legacy\LegacyUser',
+            'Doctrine\Tests\Models\Legacy\LegacyUserReference',
+            'Doctrine\Tests\Models\Legacy\LegacyArticle',
+            'Doctrine\Tests\Models\Legacy\LegacyCar',
+        ),
     );
 
     protected function useModelSet($setName)
@@ -201,6 +207,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM exchange_bonds');
             $conn->executeUpdate('DELETE FROM exchange_stocks');
             $conn->executeUpdate('DELETE FROM exchange_markets');
+        }
+        if (isset($this->_usedModelSets['legacy'])) {
+            $conn->executeUpdate('DELETE FROM legacy_articles');
+            $conn->executeUpdate('DELETE FROM legacy_cars');
+            $conn->executeUpdate('DELETE FROM legacy_users');
+            $conn->executeUpdate('DELETE FROM legacy_users_reference');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
Ticket: http://www.doctrine-project.org/jira/browse/DDC-1301

The first commit adds (failing) tests and a set of "legacy" models. The second commit fixes the issue.

I added the legacy models because it may be useful to use them to verify some other features too? The count() function was broken, but it didn't show up in the tests because all the Cms models that were used for testing map the column `id` on $id.
