### PR TITLE
[DDC-1303] Added possibility of cast on EntityGenerator's setters

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -67,6 +67,10 @@ class GenerateEntitiesCommand extends Console\Command\Command
                 'Flag to define if generator should generate stub methods on entities.', true
             ),
             new InputOption(
+                'cast-setters', null, InputOption::VALUE_OPTIONAL,
+                'Flag to define if cast should be put on setters.', false
+            ),
+            new InputOption(
                 'regenerate-entities', null, InputOption::VALUE_OPTIONAL,
                 'Flag to define if generator should regenerate entity if it exists.', false
             ),
@@ -137,6 +141,7 @@ EOT
 
             $entityGenerator->setGenerateAnnotations($input->getOption('generate-annotations'));
             $entityGenerator->setGenerateStubMethods($input->getOption('generate-methods'));
+            $entityGenerator->setAddCastToSetters($input->getOption('cast-setters'));
             $entityGenerator->setRegenerateEntityIfExists($input->getOption('regenerate-entities'));
             $entityGenerator->setUpdateEntityIfExists($input->getOption('update-entities'));
             $entityGenerator->setNumSpaces($input->getOption('num-spaces'));

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -166,7 +166,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $book = $this->newInstance($metadata);
 
         $cm = new \Doctrine\ORM\Mapping\ClassMetadata($metadata->name);
-	$driver = $this->createAnnotationDriver();
+        $driver = $this->createAnnotationDriver();
         $driver->loadMetadataForClass($cm->name, $cm);
 
         $this->assertEquals($cm->columnNames, $metadata->columnNames);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -166,7 +166,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $book = $this->newInstance($metadata);
 
         $cm = new \Doctrine\ORM\Mapping\ClassMetadata($metadata->name);
-        $driver = $this->createAnnotationDriver();
+	$driver = $this->createAnnotationDriver();
         $driver->loadMetadataForClass($cm->name, $cm);
 
         $this->assertEquals($cm->columnNames, $metadata->columnNames);
@@ -175,6 +175,17 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($cm->identifier, $metadata->identifier);
         $this->assertEquals($cm->idGenerator, $metadata->idGenerator);
         $this->assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
+    }
+
+    public function testCastOnSetters()
+    {
+	$this->_generator->setAddCastToSetters(true);
+        $metadata = $this->generateBookEntityFixture();
+
+	$book = $this->newInstance($metadata);
+
+        $book->setName(1984);
+        $this->assertTrue(is_string($book->getName()), "Check for cast on setters");
     }
 
     public function testLoadPrefixedMetadata()


### PR DESCRIPTION
As explained (http://www.doctrine-project.org/jira/browse/DDC-1303), adding casts on EntityGenerator's setter could help in the computing of change sets and avoid hitting the database when updating some datas
