### PR TITLE
Added support for ORDER BY NULLS (FIRST|LAST)

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/OrderByItem.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByItem.php
@@ -22,7 +22,7 @@
 namespace Doctrine\ORM\Query\AST;
 
 /**
- * OrderByItem ::= (ResultVariable | StateFieldPathExpression) ["ASC" | "DESC"]
+ * OrderByItem ::= (ResultVariable | StateFieldPathExpression) ["ASC" | "DESC"] ["NULLS (FIRST|LAST)"]
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link    www.doctrine-project.org
@@ -36,7 +36,7 @@ class OrderByItem extends Node
 {
     public $expression;
     public $type;
-    
+
     public function __construct($expression)
     {
         $this->expression = $expression;
@@ -44,12 +44,12 @@ class OrderByItem extends Node
 
     public function isAsc()
     {
-        return strtoupper($this->type) == 'ASC';
+        return 'ASC' === substr(strtoupper($this->type), 0, 3);
     }
 
     public function isDesc()
     {
-        return strtoupper($this->type) == 'DESC';
+        return 'DESC' === substr(strtoupper($this->type), 0, 4);
     }
 
     public function dispatch($sqlWalker)

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -49,7 +49,7 @@ class Lexer extends \Doctrine\Common\Lexer
     const T_PLUS                = 17;
     const T_OPEN_CURLY_BRACE    = 18;
     const T_CLOSE_CURLY_BRACE   = 19;
-    
+
     // All tokens that are also identifiers should be >= 100
     const T_IDENTIFIER          = 100;
     const T_ALL                 = 101;
@@ -106,7 +106,10 @@ class Lexer extends \Doctrine\Common\Lexer
     const T_WITH                = 153;
     const T_PARTIAL             = 154;
     const T_MOD                 = 155;
-   
+    const T_NULLS               = 156;
+    const T_FIRST               = 157;
+    const T_LAST                = 158;
+
     /**
      * Creates a new query scanner object.
      *
@@ -129,7 +132,7 @@ class Lexer extends \Doctrine\Common\Lexer
             '\?[0-9]*|:[a-z]{1}[a-z0-9_]{0,}'
         );
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -147,7 +150,7 @@ class Lexer extends \Doctrine\Common\Lexer
 
         // Recognizing numeric values
         if (is_numeric($value)) {
-            return (strpos($value, '.') !== false || stripos($value, 'e') !== false) 
+            return (strpos($value, '.') !== false || stripos($value, 'e') !== false)
                     ? self::T_FLOAT : self::T_INTEGER;
         }
 
@@ -160,7 +163,7 @@ class Lexer extends \Doctrine\Common\Lexer
 
             if (defined($name)) {
                 $type = constant($name);
-                
+
                 if ($type > 100) {
                     return $type;
                 }

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -323,7 +323,7 @@ class Parser
 
         return $this->_parserResult;
     }
-    
+
     private function assertSelectEntityRootAliasRequirement()
     {
         if ( count($this->_identVariableExpressions) > 0) {
@@ -333,20 +333,20 @@ class Parser
                     $foundRootEntity = true;
                 }
             }
-            
+
             if (!$foundRootEntity) {
                 $this->semanticalError('Cannot select entity through identification variables without choosing at least one root entity alias.');
             }
         }
     }
-    
+
     /**
      * Fix order of identification variables.
-     * 
+     *
      * They have to appear in the select clause in the same order as the
      * declarations (from ... x join ... y join ... z ...) appear in the query
      * as the hydration process relies on that order for proper operation.
-     * 
+     *
      * @param AST\SelectStatement|AST\DeleteStatement|AST\UpdateStatement $AST
      * @return void
      */
@@ -467,7 +467,7 @@ class Parser
 
             $token = $this->_lexer->peek();
         }
-        
+
         $this->_lexer->resetPeek();
 
         return $token;
@@ -661,7 +661,7 @@ class Parser
             if (($field = $pathExpression->field) === null) {
                 $field = $pathExpression->field = $class->identifier[0];
             }
-            
+
             // Check if field or association exists
             if ( ! isset($class->associationMappings[$field]) && ! isset($class->fieldMappings[$field])) {
                 $this->semanticalError(
@@ -716,7 +716,7 @@ class Parser
 
                 $this->semanticalError($semanticalError, $deferredItem['token']);
             }
-            
+
             // We need to force the type in PathExpression
             $pathExpression->type = $fieldType;
         }
@@ -967,7 +967,7 @@ class Parser
 
             $field = $this->_lexer->token['value'];
         }
-        
+
         // Creating AST node
         $pathExpr = new AST\PathExpression($expectedTypes, $identVariable, $field);
 
@@ -1342,7 +1342,7 @@ class Parser
     }
 
     /**
-     * OrderByItem ::= (ResultVariable | StateFieldPathExpression) ["ASC" | "DESC"]
+     * OrderByItem ::= (ResultVariable | StateFieldPathExpression) ["ASC" | "DESC"] ["NULLS (FIRST|LAST)"]
      *
      * @todo Post 2.0 release. Support general SingleValuedPathExpression instead
      * of only StateFieldPathExpression.
@@ -1370,6 +1370,18 @@ class Parser
         } else if ($this->_lexer->isNextToken(Lexer::T_DESC)) {
             $this->match(Lexer::T_DESC);
             $type = 'DESC';
+        }
+
+        if ($this->_lexer->isNextToken(Lexer::T_NULLS)) {
+            $this->match(Lexer::T_NULLS);
+            $type .= ' NULLS';
+            if ($this->_lexer->isNextToken(Lexer::T_FIRST)) {
+                $this->match(Lexer::T_FIRST);
+                $type .= ' FIRST';
+            } else if ($this->_lexer->isNextToken(Lexer::T_LAST)) {
+                $this->match(Lexer::T_LAST);
+                $type .= ' LAST';
+            }
         }
 
         $item->type = $type;
@@ -1518,7 +1530,7 @@ class Parser
             $this->match(Lexer::T_IDENTIFIER);
             $partialFieldSet[] = $this->_lexer->token['value'];
         }
-        
+
         $this->match(Lexer::T_CLOSE_CURLY_BRACE);
 
         $partialObjectExpression = new AST\PartialObjectExpression($identificationVariable, $partialFieldSet);
@@ -1645,7 +1657,7 @@ class Parser
         } else if ($lookahead == Lexer::T_INTEGER || $lookahead == Lexer::T_FLOAT) {
             return $this->SimpleArithmeticExpression();
         } else if ($lookahead == Lexer::T_CASE || $lookahead == Lexer::T_COALESCE || $lookahead == Lexer::T_NULLIF) {
-            // Since NULLIF and COALESCE can be identified as a function, 
+            // Since NULLIF and COALESCE can be identified as a function,
             // we need to check if before check for FunctionDeclaration
             return $this->CaseExpression();
         } else if ($this->_isFunction() || $this->_isAggregateFunction($this->_lexer->lookahead['type'])) {
@@ -1677,7 +1689,7 @@ class Parser
     public function CaseExpression()
     {
         $lookahead = $this->_lexer->lookahead['type'];
-        
+
         // if "CASE" "WHEN" => GeneralCaseExpression
         // else if "CASE" => SimpleCaseExpression
         // [DONE] else if "COALESCE" => CoalesceExpression
@@ -1685,26 +1697,26 @@ class Parser
         switch ($lookahead) {
             case Lexer::T_NULLIF:
                 return $this->NullIfExpression();
-                
+
             case Lexer::T_COALESCE:
                 return $this->CoalesceExpression();
-                
+
             default:
                 $this->semanticalError('CaseExpression not yet supported.');
                 return null;
         }
     }
-    
+
     /**
      * CoalesceExpression ::= "COALESCE" "(" ScalarExpression {"," ScalarExpression}* ")"
-     * 
-     * @return Doctrine\ORM\Query\AST\CoalesceExpression 
+     *
+     * @return Doctrine\ORM\Query\AST\CoalesceExpression
      */
     public function CoalesceExpression()
     {
         $this->match(Lexer::T_COALESCE);
         $this->match(Lexer::T_OPEN_PARENTHESIS);
-        
+
         // Process ScalarExpressions (1..N)
         $scalarExpressions = array();
         $scalarExpressions[] = $this->ScalarExpression();
@@ -1713,26 +1725,26 @@ class Parser
             $this->match(Lexer::T_COMMA);
             $scalarExpressions[] = $this->ScalarExpression();
         }
-        
+
         $this->match(Lexer::T_CLOSE_PARENTHESIS);
-        
+
         return new AST\CoalesceExpression($scalarExpressions);
     }
-    
+
     /**
      * NullIfExpression ::= "NULLIF" "(" ScalarExpression "," ScalarExpression ")"
-     * 
-     * @return Doctrine\ORM\Query\AST\ExistsExpression 
+     *
+     * @return Doctrine\ORM\Query\AST\ExistsExpression
      */
     public function NullIfExpression()
     {
         $this->match(Lexer::T_NULLIF);
         $this->match(Lexer::T_OPEN_PARENTHESIS);
-        
+
         $firstExpression = $this->ScalarExpression();
         $this->match(Lexer::T_COMMA);
         $secondExpression = $this->ScalarExpression();
-        
+
         $this->match(Lexer::T_CLOSE_PARENTHESIS);
 
         return new AST\NullIfExpression($firstExpression, $secondExpression);
@@ -1774,10 +1786,10 @@ class Parser
             }
         } else if ($this->_isFunction()) {
             $this->_lexer->peek(); // "("
-            
+
             $lookaheadType = $this->_lexer->lookahead['type'];
             $beyond        = $this->_peekBeyondClosingParenthesis();
-            
+
             if ($this->_isMathOperator($beyond)) {
                 $expression = $this->ScalarExpression();
             } else if ($this->_isAggregateFunction($this->_lexer->lookahead['type'])) {
@@ -1949,7 +1961,7 @@ class Parser
             $this->match(Lexer::T_NOT);
             $not = true;
         }
-        
+
         $conditionalPrimary = $this->ConditionalPrimary();
 
         // Phase 1 AST optimization: Prevent AST\ConditionalFactor
@@ -2275,7 +2287,7 @@ class Parser
             $this->match(($isPlus) ? Lexer::T_PLUS : Lexer::T_MINUS);
             $sign = $isPlus;
         }
-        
+
         $primary = $this->ArithmeticPrimary();
 
         // Phase 1 AST optimization: Prevent AST\ArithmeticFactor
@@ -2605,7 +2617,7 @@ class Parser
         }
 
         $instanceOfExpression->value = $exprValue;
-        
+
         return $instanceOfExpression;
     }
 


### PR DESCRIPTION
I was recently having troubles with ordering of values that may contain NULLs. For that, I added such support to Lexer and Parser. Yet, these (NULLS, FIRST and LAST) are Postgre/Oracle specific identifiers.

What are your thoughts on this?
