### PR TITLE
Add getReader to AnnotationDriver

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -98,6 +98,16 @@ class AnnotationDriver implements Driver
     }
 
     /**
+     * Retrieve the current annotation reader
+     * 
+     * @return AnnotationReader
+     */
+    public function getReader()
+    {
+        return $this->_reader;
+    }
+
+    /**
      * Get the file extension used to look for mapping files under
      *
      * @return void


### PR DESCRIPTION
Added method to retrieve currently used Reader. This allows projects that use Doctrine to recycle the reader to use with other annotation-driven packages, like DMS\Filter and Symfony\Validator
