### PR TITLE
@Target annotation

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -23,19 +23,31 @@ use Doctrine\Common\Annotations\Annotation;
 
 /* Annotations */
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class Entity extends Annotation {
     public $repositoryClass;
     public $readOnly = false;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class MappedSuperclass extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class InheritanceType extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class DiscriminatorColumn extends Annotation {
     public $name;
     public $fieldName; // field name used in non-object hydration (array/scalar)
@@ -43,21 +55,36 @@ final class DiscriminatorColumn extends Annotation {
     public $length;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class DiscriminatorMap extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class Id extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class GeneratedValue extends Annotation {
     public $strategy = 'AUTO';
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class Version extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target({"PROPERTY","ANNOTATION"})
+ */
 final class JoinColumn extends Annotation {
     public $name;
     public $fieldName; // field name used in non-object hydration (array/scalar)
@@ -68,10 +95,16 @@ final class JoinColumn extends Annotation {
     public $columnDefinition;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class JoinColumns extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class Column extends Annotation {
     public $type = 'string';
     public $length;
@@ -86,7 +119,10 @@ final class Column extends Annotation {
     public $columnDefinition;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class OneToOne extends Annotation {
     public $targetEntity;
     public $mappedBy;
@@ -96,7 +132,10 @@ final class OneToOne extends Annotation {
     public $orphanRemoval = false;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class OneToMany extends Annotation {
     public $mappedBy;
     public $targetEntity;
@@ -106,7 +145,10 @@ final class OneToMany extends Annotation {
     public $indexBy;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class ManyToOne extends Annotation {
     public $targetEntity;
     public $cascade;
@@ -114,7 +156,10 @@ final class ManyToOne extends Annotation {
     public $inversedBy;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class ManyToMany extends Annotation {
     public $targetEntity;
     public $mappedBy;
@@ -124,12 +169,19 @@ final class ManyToMany extends Annotation {
     public $indexBy;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("ALL")
+ * @todo check available targets
+ */
 final class ElementCollection extends Annotation {
     public $tableName;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class Table extends Annotation {
     public $name;
     public $schema;
@@ -137,19 +189,28 @@ final class Table extends Annotation {
     public $uniqueConstraints;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("ANNOTATION")
+ */
 final class UniqueConstraint extends Annotation {
     public $name;
     public $columns;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("ANNOTATION")
+ */
 final class Index extends Annotation {
     public $name;
     public $columns;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class JoinTable extends Annotation {
     public $name;
     public $schema;
@@ -157,49 +218,89 @@ final class JoinTable extends Annotation {
     public $inverseJoinColumns = array();
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class SequenceGenerator extends Annotation {
     public $sequenceName;
     public $allocationSize = 1;
     public $initialValue = 1;
 }
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class ChangeTrackingPolicy extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("PROPERTY")
+ */
 final class OrderBy extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class NamedQueries extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("ANNOTATION")
+ */
 final class NamedQuery extends Annotation {
     public $name;
     public $query;
 }
 
 /* Annotations for lifecycle callbacks */
-/** @Annotation */
+
+/** 
+ * @Annotation 
+ * @Target("CLASS")
+ */
 final class HasLifecycleCallbacks extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PrePersist extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PostPersist extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PreUpdate extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PostUpdate extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PreRemove extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PostRemove extends Annotation {}
 
-/** @Annotation */
+/** 
+ * @Annotation 
+ * @Target("METHOD")
+ */
 final class PostLoad extends Annotation {}

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -302,7 +302,7 @@ public function <methodName>()
      */
     public function setAnnotationPrefix($prefix)
     {
-        if (version_compare(\Doctrine\Common\Version::VERSION, '3.0.0-DEV', '>=')) {
+        if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             return;
         }
         $this->_annotationsPrefix = $prefix;

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -24,7 +24,14 @@ abstract class OrmTestCase extends DoctrineTestCase
             $reader = new \Doctrine\Common\Annotations\CachedReader(
                 new \Doctrine\Common\Annotations\AnnotationReader(), new ArrayCache()
             );
-        } else if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0-BETA3-DEV', '>=')) {
+        }
+        else if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
+            // Register the ORM Annotations in the AnnotationRegistry
+            $reader = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
+            $reader->addNamespace('Doctrine\ORM\Mapping');
+            $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new ArrayCache());
+        }
+        else if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0-BETA3-DEV', '>=')) {
             $reader = new \Doctrine\Common\Annotations\AnnotationReader();
             $reader->setIgnoreNotImportedAnnotations(true);
             $reader->setEnableParsePhpImports(false);


### PR DESCRIPTION
Hello all,

As referenced in http://www.doctrine-project.org/jira/browse/DDC-1325 by @schmittjoh
Now the parser has support for `@Target` annotation, that define the possible targets of a annotation.
This patch adds support for common 2.2 and `@Target` annotation.

all tests pass with these changes however i could not identify the targets of the annotation `@ElementCollection`.

Maybe someone can help me with this.

Best Regards,
Fabio B. SIlva
