### PR TITLE
XmlDriver wrong index-by association implementation

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -322,8 +322,8 @@ class XmlDriver extends AbstractFileDriver
                     $mapping['orderBy'] = $orderBy;
                 }
 
-                if (isset($oneToManyElement->{'index-by'})) {
-                    $mapping['indexBy'] = (string)$oneToManyElement->{'index-by'};
+                if (isset($oneToManyElement['index-by'])) {
+                    $mapping['indexBy'] = (string)$oneToManyElement['index-by'];
                 }
 
                 $metadata->mapOneToMany($mapping);


### PR DESCRIPTION
Modified XmlDriver.php to enbrace documentation page
http://www.doctrine-project.org/docs/orm/2.1/en/tutorials/working-with-indexed-associations.html#mapping-indexed-assocations

Committer: Asmir Mustafic goetas@lignano.it
