### PR TITLE
short classname support for custom repository class

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1518,6 +1518,10 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function setCustomRepositoryClass($repositoryClassName)
     {
+        if ($repositoryClassName !== null && strpos($repositoryClassName, '\\') === false 
+                && strlen($this->namespace) > 0) {
+            $repositoryClassName = $this->namespace . '\\' . $repositoryClassName;
+        }
         $this->customRepositoryClassName = $repositoryClassName;
     }
 


### PR DESCRIPTION
Short classnames are suppported for `targetEntity`, so to be consistent they should be supported for `repositoryClass` too:

```
<?php
namespace Acme\Blog;

/*
 * @Entity(repositoryClass="PostRepository")
 **/
class Post 
{
    /** @ManyToOne(targetEntity="Author") */
    private $author;
```

Currently only `@Entity(repositoryClass="Acme\Blog\PostRepository")` works.
