### PR TITLE
Support NULL in EntityRepository's magic findBy and findOneBy methods

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -203,9 +203,8 @@ class EntityRepository implements ObjectRepository
                 "either findBy or findOneBy!"
             );
         }
-        
 
-        if (count($arguments) === 0) {
+        if (empty($arguments)) {
             throw ORMException::findByRequiresParameter($method.$by);
         }
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -203,6 +203,11 @@ class EntityRepository implements ObjectRepository
                 "either findBy or findOneBy!"
             );
         }
+        
+
+        if (count($arguments) === 0) {
+            throw ORMException::findByRequiresParameter($method.$by);
+        }
 
         $fieldName = lcfirst(\Doctrine\Common\Util\Inflector::classify($by));
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -204,11 +204,6 @@ class EntityRepository implements ObjectRepository
             );
         }
 
-        if ( !isset($arguments[0])) {
-            // we dont even want to allow null at this point, because we cannot (yet) transform it into IS NULL.
-            throw ORMException::findByRequiresParameter($method.$by);
-        }
-
         $fieldName = lcfirst(\Doctrine\Common\Util\Inflector::classify($by));
 
         if ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName)) {


### PR DESCRIPTION
The magic `findBy` and `findOneBy` methods don't support passing NULL as the value, because ["we cannot (yet) transform it into IS NULL"](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/EntityRepository.php#L207).

However, `BasicEntityPersister::_getSelectConditionSQL()` [does support that](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php#L1229). It seems like leftovers from when there was no support for it. I tried it locally (after applying this change) and it does seem to work well.
