### PR TITLE
Mismatch in method signature when compared to method calls.

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -160,7 +160,7 @@ class Setup
      * @param Cache $cache
      * @return Configuration 
      */
-    static public function createConfiguration($isDevMode = false, $proxyDir = null, Cache $cache = null)
+    static public function createConfiguration($isDevMode = false, Cache $cache = null, $proxyDir = null)
     {
         if ($isDevMode === false && $cache === null) {
             if (extension_loaded('apc')) {


### PR DESCRIPTION
Can either be changed here or in the method calls depending on your preference.
