### PR TITLE
findByXXX does not accept orderBy/limit/offset

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -212,7 +212,16 @@ class EntityRepository implements ObjectRepository
         $fieldName = lcfirst(\Doctrine\Common\Util\Inflector::classify($by));
 
         if ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName)) {
-            return $this->$method(array($fieldName => $arguments[0]));
+            $argumentSize = sizeof($arguments);
+            if ($argumentSize == 1) {
+                return $this->$method(array($fieldName => $arguments[0]));
+            } else if ($argumentSize == 2) {
+                return $this->$method(array($fieldName => $arguments[0]), $arguments[1]);
+            } else if ($argumentSize == 3) {
+                return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2]);
+            } else if ($argumentSize == 4) {
+                return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2], $arguments[3]);
+        	}
         } else {
             throw ORMException::invalidFindByCall($this->_entityName, $fieldName, $method.$by);
         }


### PR DESCRIPTION
Our modification to pass `findByXXX` functions `orderBy/limit/offset` params for entity repositories like one is used from normal findBy function.

We're using an if cascade in favor of the `call_user_function_array` since the latter is considered as slow.

PS: If i need to target this pull request to your master, I'll resubmit - it's just that we're building against a stable codebase.
