### PR TITLE
fix ReflectionClass::getMethods bug

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -164,11 +164,14 @@ class ProxyFactory
     private function _generateMethods(ClassMetadata $class)
     {
         $methods = '';
+        $previousMethods = array();
 
         foreach ($class->reflClass->getMethods() as $method) {
             /* @var $method ReflectionMethod */
-            if ($method->isConstructor() || in_array(strtolower($method->getName()), array("__sleep", "__clone"))) {
+            if ($method->isConstructor() || strtolower($method->getName()) == "__sleep" || in_array($method->getName(), $previousMethods)) {
                 continue;
+            } else {
+                $previousMethods[] = $method->getName();
             }
 
             if ($method->isPublic() && ! $method->isFinal() && ! $method->isStatic()) {


### PR DESCRIPTION
There is a bug in some PHP versions in the method ReflectionClass::getMethods()

See: http://stackoverflow.com/questions/7437132/php-reflectionclassgetmethods-does-not-returns-the-right-number-of-methods

Not sure if it would be fix and if the implementation is good enough...
