### PR TITLE
Fluent entity (master)

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -737,7 +737,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-          '<entity>'			=> $this->_getClassName($metadata)
+          '<entity>'            => $this->_getClassName($metadata)
         );
 
         $method = str_replace(

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -115,10 +115,12 @@ public function <methodName>()
  * <description>
  *
  * @param <variableType>$<variableName>
+ * @return <entity>
  */
 public function <methodName>(<methodTypeHint>$<variableName>)
 {
 <spaces>$this-><fieldName> = $<variableName>;
+<spaces>return $this;
 }';
 
     private static $_addMethodTemplate =
@@ -734,7 +736,8 @@ public function <methodName>()
           '<variableType>'      => $variableType,
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
-          '<fieldName>'         => $fieldName
+          '<fieldName>'         => $fieldName,
+		  '<entity>'			=> $this->_getClassName($metadata)
         );
 
         $method = str_replace(

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -737,7 +737,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-		  '<entity>'			=> $this->_getClassName($metadata)
+          '<entity>'			=> $this->_getClassName($metadata)
         );
 
         $method = str_replace(


### PR DESCRIPTION
This code add a "return $this" on generated set methods to get a fluent entity and allow to use 

``` php
$myEntity->setFoo(true)
                ->setBar(true);
```

This also add a @return <EntityName> on comment

same for master
