### PR TITLE
2.1.x added support for nested AND/OR expressions

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -43,7 +43,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * @var EntityManager
      */
     private $em;
-    
+
     /**
      * @var AbstractPlatform
      */
@@ -73,7 +73,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * @var bool
      */
     private $initialized = false;
-    
+
     /**
      * @param EntityManager $$em
      */
@@ -101,16 +101,16 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     {
         return $this->cacheDriver;
     }
-    
+
     public function getLoadedMetadata()
     {
         return $this->loadedMetadata;
     }
-    
+
     /**
      * Forces the factory to load the metadata of all classes known to the underlying
      * mapping driver.
-     * 
+     *
      * @return array The ClassMetadata instances of all mapped classes.
      */
     public function getAllMetadata()
@@ -188,7 +188,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
 
     /**
      * Checks whether the factory has the metadata for a class loaded already.
-     * 
+     *
      * @param string $className
      * @return boolean TRUE if the metadata of the class in question is already loaded, FALSE otherwise.
      */
@@ -199,7 +199,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
 
     /**
      * Sets the metadata descriptor for a specific class.
-     * 
+     *
      * NOTE: This is only useful in very special cases, like when generating proxy classes.
      *
      * @param string $className
@@ -314,7 +314,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
             }
 
             $this->validateRuntimeMetadata($class, $parent);
-            
+
             $this->loadedMetadata[$className] = $class;
 
             $parent = $class;
@@ -340,7 +340,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     {
         // Verify & complete identifier mapping
         if ( ! $class->identifier && ! $class->isMappedSuperclass) {
-            throw MappingException::identifierRequired($className);
+            throw MappingException::identifierRequired($class->name);
         }
 
         // verify inheritance

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -39,5 +39,6 @@ class Andx extends Composite
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
         'Doctrine\ORM\Query\Expr\Orx',
+        'Doctrine\ORM\Query\Expr\Andx',
     );
 }

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -37,6 +37,7 @@ class Orx extends Composite
     protected $_separator = ' OR ';
     protected $_allowedClasses = array(
         'Doctrine\ORM\Query\Expr\Andx',
+        'Doctrine\ORM\Query\Expr\Orx',
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
     );

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -114,6 +114,17 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('1 = 1 AND 2 = 2', (string) $this->_expr->andx((string) $this->_expr->eq(1, 1), (string) $this->_expr->eq(2, 2)));
     }
 
+    public function testNestedAndExpr()
+    {
+        $this->assertEquals(
+        	'(1 = 1 AND 2 = 2) AND 3 = 3',
+        	(string) $this->_expr->andx(
+        		$this->_expr->andx($this->_expr->eq(1, 1), $this->_expr->eq(2, 2)),
+        		$this->_expr->eq(3, 3)
+        	)
+        );
+    }
+
     public function testIntelligentParenthesisPreventionAndExpr()
     {
         $this->assertEquals(
@@ -125,6 +136,17 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     public function testOrExpr()
     {
         $this->assertEquals('1 = 1 OR 2 = 2', (string) $this->_expr->orx((string) $this->_expr->eq(1, 1), (string) $this->_expr->eq(2, 2)));
+    }
+
+    public function testNestedOrExpr()
+    {
+    	$this->assertEquals(
+            '(1 = 1 OR 2 = 2) OR 3 = 3',
+    		(string) $this->_expr->orx(
+    			$this->_expr->orx($this->_expr->eq(1, 1), $this->_expr->eq(2, 2)),
+    			$this->_expr->eq(3, 3)
+    		)
+    	);
     }
 
     public function testAbsExpr()


### PR DESCRIPTION
The issue with nested expressions was fixed in 816ce41f638d28934c79a12ef27f954124b2639e, but only for the master branch. It should also be fixed for 2.1.x (and possibly 2.0.x). 
