### PR TITLE
Fix an insertion of a collection to collectionUpdates/collectionDeletions properties

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -549,10 +549,11 @@ class UnitOfWork implements PropertyChangedListener
     private function computeAssociationChanges($assoc, $value)
     {
         if ($value instanceof PersistentCollection && $value->isDirty()) {
+            $coid = spl_object_hash($value);
             if ($assoc['isOwningSide']) {
-                $this->collectionUpdates[] = $value;
+                $this->collectionUpdates[$coid] = $value;
             }
-            $this->visitedCollections[] = $value;
+            $this->visitedCollections[$coid] = $value;
         }
 
         // Look through the entities, and in any of their associations, for transient (new)
@@ -1858,12 +1859,12 @@ class UnitOfWork implements PropertyChangedListener
     {
         //TODO: if $coll is already scheduled for recreation ... what to do?
         // Just remove $coll from the scheduled recreations?
-        $this->collectionDeletions[] = $coll;
+        $this->collectionDeletions[spl_object_hash($coll)] = $coll;
     }
 
     public function isCollectionScheduledForDeletion(PersistentCollection $coll)
     {
-        return in_array($coll, $this->collectionsDeletions, true);
+        return isset($this->collectionsDeletions[spl_object_hash($coll)]);
     }
 
     /**


### PR DESCRIPTION
Method computeAssociationChanges doesn't use spl_object_hash to add collection only once to array. It can lead to an exception if computeChangeSets would be called twice.

Exactly changes were already made to entityChangeSets, entityUpdates and etc.
