### PR TITLE
index-by is an attribute, not an element

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -432,8 +432,8 @@ class XmlDriver extends AbstractFileDriver
                     $mapping['orderBy'] = $orderBy;
                 }
 
-                if (isset($manyToManyElement->{'index-by'})) {
-                    $mapping['indexBy'] = (string)$manyToManyElement->{'index-by'};
+                if (isset($manyToManyElement['index-by'])) {
+                    $mapping['indexBy'] = (string)$manyToManyElement['index-by'];
                 }
 
                 $metadata->mapManyToMany($mapping);


### PR DESCRIPTION
XmlDriver wrong index-by mapping for many to many relations

Modified XmlDriver.php to enbrace documentation page
http://www.doctrine-project.org/docs/orm/2.1/en/tutorials/working-with-indexed-associations.html#mapping-indexed-assocations
