### PR TITLE
Just an idea to avoid limitations in date intervals to days and months on more flexible DBMS ...

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -40,10 +40,9 @@ class DateAddFunction extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $unit = strtolower($this->unit);
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddDaysExpression(
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddExpression(
             $this->firstDateExpression->dispatch($sqlWalker),
-            $this->intervalExpression->dispatch($sqlWalker)
+            $this->intervalExpression->dispatch($sqlWalker),
             $this->unit->dispatch($sqlWalker)
         );
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -40,7 +40,7 @@ class DateAddFunction extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddExpression(
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddIntervalExpression(
             $this->firstDateExpression->dispatch($sqlWalker),
             $this->intervalExpression->dispatch($sqlWalker),
             $this->unit->dispatch($sqlWalker)

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -41,19 +41,11 @@ class DateAddFunction extends FunctionNode
     public function getSql(SqlWalker $sqlWalker)
     {
         $unit = strtolower($this->unit);
-        if ($unit == "day") {
-            return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddDaysExpression(
-                $this->firstDateExpression->dispatch($sqlWalker),
-                $this->intervalExpression->dispatch($sqlWalker)
-            );
-        } else if ($unit == "month") {
-            return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddMonthExpression(
-                $this->firstDateExpression->dispatch($sqlWalker),
-                $this->intervalExpression->dispatch($sqlWalker)
-            );
-        } else {
-            throw QueryException::semanticalError('DATE_ADD() only supports units of type day and month.');
-        }
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddDaysExpression(
+            $this->firstDateExpression->dispatch($sqlWalker),
+            $this->intervalExpression->dispatch($sqlWalker)
+            $this->unit->dispatch($sqlWalker)
+        );
     }
 
     public function parse(Parser $parser)

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
@@ -38,7 +38,7 @@ class DateDiffFunction extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateDiffExpression(
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateDiffIntervalExpression(
             $this->date1->dispatch($sqlWalker),
             $this->date2->dispatch($sqlWalker)
         );

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -41,18 +41,23 @@ class DateSubFunction extends DateAddFunction
     public function getSql(SqlWalker $sqlWalker)
     {
         $unit = strtolower($this->unit);
-        if ($unit == "day") {
-            return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubDaysExpression(
-                $this->firstDateExpression->dispatch($sqlWalker),
-                $this->intervalExpression->dispatch($sqlWalker)
-            );
-        } else if ($unit == "month") {
-            return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubMonthExpression(
-                $this->firstDateExpression->dispatch($sqlWalker),
-                $this->intervalExpression->dispatch($sqlWalker)
-            );
-        } else {
-            throw QueryException::semanticalError('DATE_SUB() only supports units of type day and month.');
-        }
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubExpression(
+            $this->firstDateExpression->dispatch($sqlWalker),
+            $this->intervalExpression->dispatch($sqlWalker),
+            $this->unit->dispatch($sqlWalker)
+        );
+    }
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->firstDateExpression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->intervalExpression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_COMMA);
+        $this->unit = $parser->StringPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -40,24 +40,10 @@ class DateSubFunction extends DateAddFunction
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $unit = strtolower($this->unit);
         return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubExpression(
             $this->firstDateExpression->dispatch($sqlWalker),
             $this->intervalExpression->dispatch($sqlWalker),
             $this->unit->dispatch($sqlWalker)
         );
-    }
-
-    public function parse(Parser $parser)
-    {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-
-        $this->firstDateExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->intervalExpression = $parser->ArithmeticPrimary();
-        $parser->match(Lexer::T_COMMA);
-        $this->unit = $parser->StringPrimary();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -40,7 +40,7 @@ class DateSubFunction extends DateAddFunction
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubExpression(
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubIntervalExpression(
             $this->firstDateExpression->dispatch($sqlWalker),
             $this->intervalExpression->dispatch($sqlWalker),
             $this->unit->dispatch($sqlWalker)


### PR DESCRIPTION
Different implementation of the date/time manipulation functions so that those are no more limited to days and months intervals in PostgreSQL without impacting over DBMS (and can be improved later by developers with sufficient skills on the other DBMS)

This pull request should be associated with the one i sent on the doctrine-dbal lib.
