### PR TITLE
fix $isComposite semantic confusion

### DIFF
--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -107,36 +107,38 @@ class ManyToManyPersister extends AbstractCollectionPersister
     {
         $params      = array();
         $mapping     = $coll->getMapping();
-        $isComposite = count($mapping['joinTableColumns']) > 2;
 
         $identifier1 = $this->_uow->getEntityIdentifier($coll->getOwner());
         $identifier2 = $this->_uow->getEntityIdentifier($element);
 
-        if ($isComposite) {
-            $class1 = $this->_em->getClassMetadata(get_class($coll->getOwner()));
-            $class2 = $coll->getTypeClass();
-        }
-
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
             if (isset($mapping['relationToSourceKeyColumns'][$joinTableColumn])) {
-                if ($isComposite) {
+                if (1 === count($identifier1)) {
+                    $params[] = current($identifier1);
+                } else {
+                    if (!isset($class1)) {
+                        $class1 = $this->_em->getClassMetadata(get_class($coll->getOwner()));
+                    }
+
                     if ($class1->containsForeignIdentifier) {
                         $params[] = $identifier1[$class1->getFieldForColumn($mapping['relationToSourceKeyColumns'][$joinTableColumn])];
                     } else {
                         $params[] = $identifier1[$class1->fieldNames[$mapping['relationToSourceKeyColumns'][$joinTableColumn]]];
                     }
-                } else {
-                    $params[] = array_pop($identifier1);
                 }
             } else {
-                if ($isComposite) {
+                if (1 === count($identifier2)) {
+                    $params[] = current($identifier2);
+                } else {
+                    if (!isset($class2)) {
+                        $class2 = $coll->getTypeClass();
+                    }
+
                     if ($class2->containsForeignIdentifier) {
                         $params[] = $identifier2[$class2->getFieldForColumn($mapping['relationToTargetKeyColumns'][$joinTableColumn])];
                     } else {
                         $params[] = $identifier2[$class2->fieldNames[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]];
                     }
-                } else {
-                    $params[] = array_pop($identifier2);
                 }
             }
         }


### PR DESCRIPTION
Working on a many to many relationship, we found a semantic confusion resulting in a bug:

We have a table A, single PK(A_1) and table B, composite PK(B_1, B_2)
We define a many to many relationship involving A_1 and B_1 (not B_2).
We build the schema, everything is OK.

But when adding to the collection of B in a A entity (A->addToBCollection(...)), then the ManyToManyPersister is buggy, because what is currently named $isComposite has in fact nothing to do with composite primary keys. array_pop() is used as if $identifier1 (or 2) is a single element array, but that is not the case for us, leading to the "popping" of the last column of the composite PK, which is invalid.

This patch makes less assumptions and fixes the bug.
