### PR TITLE
Better error handling on missing assigned id

### DIFF
--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -53,14 +53,14 @@ class AssignedGenerator extends AbstractIdGenerator
                         if (!$em->getUnitOfWork()->isInIdentityMap($value)) {
                             throw ORMException::entityMissingForeignAssignedId($entity, $value);
                         }
-                        
+
                         // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
                         $identifier[$idField] = current($em->getUnitOfWork()->getEntityIdentifier($value));
                     } else {
                         $identifier[$idField] = $value;
                     }
                 } else {
-                    throw ORMException::entityMissingAssignedId($entity);
+                    throw ORMException::entityMissingAssignedIdForField($entity, $idField);
                 }
             }
         } else {
@@ -71,7 +71,7 @@ class AssignedGenerator extends AbstractIdGenerator
                     if (!$em->getUnitOfWork()->isInIdentityMap($value)) {
                         throw ORMException::entityMissingForeignAssignedId($entity, $value);
                     }
-                    
+
                     // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
                     $identifier[$idField] = current($em->getUnitOfWork()->getEntityIdentifier($value));
                 } else {
@@ -81,7 +81,7 @@ class AssignedGenerator extends AbstractIdGenerator
                 throw ORMException::entityMissingAssignedId($entity);
             }
         }
-        
+
         return $identifier;
     }
 }

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -34,7 +34,7 @@ class ORMException extends Exception
         return new self("It's a requirement to specify a Metadata Driver and pass it ".
             "to Doctrine\ORM\Configuration::setMetadataDriverImpl().");
     }
-    
+
     public static function entityMissingForeignAssignedId($entity, $relatedEntity)
     {
         return new self(
@@ -50,11 +50,18 @@ class ORMException extends Exception
     {
         return new self("Entity of type " . get_class($entity) . " is missing an assigned ID. " .
             "The identifier generation strategy for this entity requires the ID field to be populated before ".
-            "EntityManager#persist() is called. If you want automatically generated identifiers instead " . 
+            "EntityManager#persist() is called. If you want automatically generated identifiers instead " .
             "you need to adjust the metadata mapping accordingly."
         );
     }
-
+    public static function entityMissingAssignedIdForField($entity, $field)
+    {
+        return new self("Entity of type " . get_class($entity) . " is missing an assigned ID for field  '" . $field . "'. " .
+            "The identifier generation strategy for this entity requires the ID field to be populated before ".
+            "EntityManager#persist() is called. If you want automatically generated identifiers instead " .
+            "you need to adjust the metadata mapping accordingly."
+        );
+    }
     public static function unrecognizedField($field)
     {
         return new self("Unrecognized field: $field");
@@ -130,8 +137,8 @@ class ORMException extends Exception
             "Unknown Entity namespace alias '$entityNamespaceAlias'."
         );
     }
-    
-    public static function invalidEntityRepository($className) 
+
+    public static function invalidEntityRepository($className)
     {
         return new self("Invalid repository class '".$className."'. ".
                 "it must be a Doctrine\ORM\EntityRepository.");


### PR DESCRIPTION
If an entity has a primary key with two or more column, and the assigned generator cant find a valid ID for some column, throws a more accurate exception message.
