### PR TITLE
switched 2nd and 3rd argument for SelectExpression's constructor, making the 3rd one optional to keep its signature compatible to previous versions

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/SelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectExpression.php
@@ -36,14 +36,14 @@ namespace Doctrine\ORM\Query\AST;
 class SelectExpression extends Node
 {
     public $expression;
-    public $hiddenAliasResultVariable;
     public $fieldIdentificationVariable;
+    public $hiddenAliasResultVariable;
 
-    public function __construct($expression, $hiddenAliasResultVariable, $fieldIdentificationVariable)
+    public function __construct($expression, $fieldIdentificationVariable, $hiddenAliasResultVariable = false)
     {
         $this->expression = $expression;
-        $this->hiddenAliasResultVariable = $hiddenAliasResultVariable;
         $this->fieldIdentificationVariable = $fieldIdentificationVariable;
+        $this->hiddenAliasResultVariable = $hiddenAliasResultVariable;
     }    
     
     public function dispatch($sqlWalker)

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1921,7 +1921,7 @@ class Parser
             }
         }
 
-        $expr = new AST\SelectExpression($expression, $hiddenAliasResultVariable, $fieldAliasIdentificationVariable);
+        $expr = new AST\SelectExpression($expression, $fieldAliasIdentificationVariable, $hiddenAliasResultVariable);
         
         if ( ! $supportsAlias) {
             $this->_identVariableExpressions[$identVariable] = $expr;


### PR DESCRIPTION
switched 2nd and 3rd argument for SelectExpression's constructor, making the 3rd one optional to keep its signature compatible to previous versions
