### PR TITLE
Fixed the version check in the entity generator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -150,7 +150,7 @@ public function <methodName>()
 
     public function __construct()
     {
-        if (version_compare(\Doctrine\Common\Version::VERSION, '3.0.0-DEV', '>=')) {
+        if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             $this->_annotationsPrefix = 'ORM\\';
         }
     }


### PR DESCRIPTION
When the 3.0.x branch of Common has been merged to become the incoming 2.2 release, the change has been done in one place in the file but not in the other.
