### PR TITLE
DDC-1385

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -174,26 +174,24 @@ class ArrayHydrator extends AbstractHydrator
                 // Check for an existing element
                 if ($this->_isSimpleQuery || ! isset($this->_identifierMap[$dqlAlias][$id[$dqlAlias]])) {
                     $element = $rowData[$dqlAlias];
+                    if ($this->_rsm->isMixed) {
+                        $element = array(0 => $element);
+                    }
+
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {
                         $field = $this->_rsm->indexByMap[$dqlAlias];
-                        if ($this->_rsm->isMixed) {
-                            $result[] = array($element[$field] => $element);
-                            ++$this->_resultCounter;
-                        } else {
-                            $result[$element[$field]] = $element;
-                        }
+                        $resultKey = $rowData[$dqlAlias][$field];
+                        $result[$resultKey] = $element;
                     } else {
-                        if ($this->_rsm->isMixed) {
-                            $result[] = array($element);
-                            ++$this->_resultCounter;
-                        } else {
-                            $result[] = $element;
-                        }
+                        $resultKey = $this->_resultCounter;
+                        $result[] = $element;
+                        ++$this->_resultCounter;
                     }
-                    end($result);
-                    $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = key($result);
+
+                    $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $resultKey;
                 } else {
                     $index = $this->_identifierMap[$dqlAlias][$id[$dqlAlias]];
+                    $resultKey = $index;
                     /*if ($this->_rsm->isMixed) {
                         $result[] =& $result[$index];
                         ++$this->_resultCounter;
@@ -205,8 +203,12 @@ class ArrayHydrator extends AbstractHydrator
 
         // Append scalar values to mixed result sets
         if (isset($scalars)) {
+            if ( ! isset($resultKey) ) {
+                $resultKey = $this->_resultCounter - 1;
+            }
+
             foreach ($scalars as $name => $value) {
-                $result[$this->_resultCounter - 1][$name] = $value;
+                $result[$resultKey][$name] = $value;
             }
         }
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -430,19 +430,16 @@ class ObjectHydrator extends AbstractHydrator
                     $element = $this->_getEntity($rowData[$dqlAlias], $dqlAlias);
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {
                         $field = $this->_rsm->indexByMap[$dqlAlias];
-                        $key = $this->_ce[$entityName]->reflFields[$field]->getValue($element);
+                        $resultKey = $this->_ce[$entityName]->reflFields[$field]->getValue($element);
                         if ($this->_rsm->isMixed) {
-                            $element = array($key => $element);
-                            $result[] = $element;
-                            $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $this->_resultCounter;
-                            ++$this->_resultCounter;
-                        } else {
-                            $result[$key] = $element;
-                            $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $key;
+                            $element = array(0 => $element);
                         }
 
+                        $result[$resultKey] = $element;
+                        $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $resultKey;
+
                         if (isset($this->_hints['collection'])) {
-                            $this->_hints['collection']->hydrateSet($key, $element);
+                            $this->_hints['collection']->hydrateSet($resultKey, $element);
                         }
                     } else {
                         if ($this->_rsm->isMixed) {
@@ -464,6 +461,7 @@ class ObjectHydrator extends AbstractHydrator
                     // Update result pointer
                     $index = $this->_identifierMap[$dqlAlias][$id[$dqlAlias]];
                     $this->_resultPointers[$dqlAlias] = $result[$index];
+                    $resultKey = $index;
                     /*if ($this->_rsm->isMixed) {
                         $result[] = $result[$index];
                         ++$this->_resultCounter;
@@ -474,8 +472,12 @@ class ObjectHydrator extends AbstractHydrator
 
         // Append scalar values to mixed result sets
         if (isset($scalars)) {
+            if ( ! isset($resultKey) ) {
+                $resultKey = $this->_resultCounter - 1;
+            }
+
             foreach ($scalars as $name => $value) {
-                $result[$this->_resultCounter - 1][$name] = $value;
+                $result[$resultKey][$name] = $value;
             }
         }
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -428,31 +428,31 @@ class ObjectHydrator extends AbstractHydrator
                 // check for existing result from the iterations before
                 if ( ! isset($this->_identifierMap[$dqlAlias][$id[$dqlAlias]])) {
                     $element = $this->_getEntity($rowData[$dqlAlias], $dqlAlias);
+                    if ($this->_rsm->isMixed) {
+                        $element = array(0 => $element);
+                    }
+
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {
                         $field = $this->_rsm->indexByMap[$dqlAlias];
-                        $resultKey = $this->_ce[$entityName]->reflFields[$field]->getValue($element);
-                        if ($this->_rsm->isMixed) {
-                            $element = array(0 => $element);
-                        }
-
-                        $result[$resultKey] = $element;
-                        $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $resultKey;
+                        $resultKey = $rowData[$dqlAlias][$field];
 
                         if (isset($this->_hints['collection'])) {
                             $this->_hints['collection']->hydrateSet($resultKey, $element);
                         }
+
+                        $result[$resultKey] = $element;
                     } else {
-                        if ($this->_rsm->isMixed) {
-                            $element = array(0 => $element);
-                        }
-                        $result[] = $element;
-                        $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $this->_resultCounter;
+                        $resultKey = $this->_resultCounter;
                         ++$this->_resultCounter;
 
                         if (isset($this->_hints['collection'])) {
                             $this->_hints['collection']->hydrateAdd($element);
                         }
+
+                        $result[] = $element;
                     }
+
+                    $this->_identifierMap[$dqlAlias][$id[$dqlAlias]] = $resultKey;
 
                     // Update result pointer
                     $this->_resultPointers[$dqlAlias] = $element;

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -157,7 +157,41 @@ class ResultSetMapping
      */
     public function addIndexBy($alias, $fieldName)
     {
-        $this->indexByMap[$alias] = $fieldName;
+        $found = false;
+        foreach ($this->fieldMappings AS $columnName => $columnFieldName) {
+            if ($columnFieldName === $fieldName && $this->columnOwnerMap[$columnName] == $alias) {
+                $this->addIndexByColumn($alias, $columnName);
+                $found = true;
+                break;
+            }
+        }
+        if (!$found) {
+            throw new \LogicException("Cannot add index by for dql alias " . $alias . " and field " .
+                                      $fieldName . " without calling addFieldResult() for them before.");
+        }
+    }
+
+    /**
+     * Set to index by a scalar result column name
+     *
+     * @param $resultColumnName
+     * @return void
+     */
+    public function addIndexByScalar($resultColumnName)
+    {
+        $this->indexByMap['scalars'] = $resultColumnName;
+    }
+
+    /**
+     * Sets a column to use for indexing an entity or joined entity result by the given alias name.
+     *
+     * @param $alias
+     * @param $resultColumnName
+     * @return void
+     */
+    public function addIndexByColumn($alias, $resultColumnName)
+    {
+        $this->indexByMap[$alias] = $resultColumnName;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -256,20 +256,20 @@ class ArrayHydratorTest extends HydrationTestCase
 
         $this->assertEquals(2, count($result));
         $this->assertTrue(is_array($result));
-        $this->assertTrue(is_array($result[0]));
         $this->assertTrue(is_array($result[1]));
+        $this->assertTrue(is_array($result[2]));
 
         // test the scalar values
-        $this->assertEquals('ROMANB', $result[0]['nameUpper']);
-        $this->assertEquals('JWAGE', $result[1]['nameUpper']);
+        $this->assertEquals('ROMANB', $result[1]['nameUpper']);
+        $this->assertEquals('JWAGE', $result[2]['nameUpper']);
         // first user => 2 phonenumbers. notice the custom indexing by user id
-        $this->assertEquals(2, count($result[0]['1']['phonenumbers']));
+        $this->assertEquals(2, count($result[1][0]['phonenumbers']));
         // second user => 1 phonenumber. notice the custom indexing by user id
-        $this->assertEquals(1, count($result[1]['2']['phonenumbers']));
+        $this->assertEquals(1, count($result[2][0]['phonenumbers']));
         // test the custom indexing of the phonenumbers
-        $this->assertTrue(isset($result[0]['1']['phonenumbers']['42']));
-        $this->assertTrue(isset($result[0]['1']['phonenumbers']['43']));
-        $this->assertTrue(isset($result[1]['2']['phonenumbers']['91']));
+        $this->assertTrue(isset($result[1][0]['phonenumbers']['42']));
+        $this->assertTrue(isset($result[1][0]['phonenumbers']['43']));
+        $this->assertTrue(isset($result[2][0]['phonenumbers']['91']));
     }
 
     /**
@@ -816,5 +816,44 @@ class ArrayHydratorTest extends HydrationTestCase
         $this->assertNull($result[1][0]);
         $this->assertEquals(array('id' => 2, 'status' => 'developer'), $result[2][0]);
         $this->assertNull($result[3][0]);
+    }
+
+    /**
+     * @group DDC-1385
+     */
+    public function testIndexByAndMixedResult()
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__status', 'status');
+        $rsm->addScalarResult('sclr0', 'nameUpper');
+        $rsm->addIndexBy('u', 'id');
+
+        // Faked result set
+        $resultSet = array(
+            //row1
+            array(
+                'u__id' => '1',
+                'u__status' => 'developer',
+                'sclr0' => 'ROMANB',
+                ),
+            array(
+                'u__id' => '2',
+                'u__status' => 'developer',
+                'sclr0' => 'JWAGE',
+                ),
+            );
+
+        $stmt = new HydratorMockStatement($resultSet);
+        $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
+
+        $result = $hydrator->hydrateAll($stmt, $rsm);
+
+        $this->assertEquals(2, count($result));
+        $this->assertTrue(isset($result[1]));
+        $this->assertEquals(1, $result[1][0]['id']);
+        $this->assertTrue(isset($result[2]));
+        $this->assertEquals(2, $result[2][0]['id']);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -352,24 +352,24 @@ class ObjectHydratorTest extends HydrationTestCase
 
         $this->assertEquals(2, count($result));
         $this->assertTrue(is_array($result));
-        $this->assertTrue(is_array($result[0]));
         $this->assertTrue(is_array($result[1]));
+        $this->assertTrue(is_array($result[2]));
 
         // test the scalar values
-        $this->assertEquals('ROMANB', $result[0]['nameUpper']);
-        $this->assertEquals('JWAGE', $result[1]['nameUpper']);
+        $this->assertEquals('ROMANB', $result[1]['nameUpper']);
+        $this->assertEquals('JWAGE', $result[2]['nameUpper']);
 
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0]['1']);
-        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[1]['2']);
-        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $result[0]['1']->phonenumbers);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[1][0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[2][0]);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $result[1][0]->phonenumbers);
         // first user => 2 phonenumbers. notice the custom indexing by user id
-        $this->assertEquals(2, count($result[0]['1']->phonenumbers));
+        $this->assertEquals(2, count($result[1][0]->phonenumbers));
         // second user => 1 phonenumber. notice the custom indexing by user id
-        $this->assertEquals(1, count($result[1]['2']->phonenumbers));
+        $this->assertEquals(1, count($result[2][0]->phonenumbers));
         // test the custom indexing of the phonenumbers
-        $this->assertTrue(isset($result[0]['1']->phonenumbers['42']));
-        $this->assertTrue(isset($result[0]['1']->phonenumbers['43']));
-        $this->assertTrue(isset($result[1]['2']->phonenumbers['91']));
+        $this->assertTrue(isset($result[1][0]->phonenumbers['42']));
+        $this->assertTrue(isset($result[1][0]->phonenumbers['43']));
+        $this->assertTrue(isset($result[2][0]->phonenumbers['91']));
     }
 
     /**
@@ -1168,5 +1168,52 @@ class ObjectHydratorTest extends HydrationTestCase
         $this->assertEquals(2, count($result));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $result[0][0]->address);
         $this->assertNull($result[1][0]->address);
+    }
+
+    /**
+     * @group DDC-1385
+     */
+    public function testIndexByAndMixedResult()
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__status', 'status');
+        $rsm->addScalarResult('sclr0', 'nameUpper');
+        $rsm->addIndexBy('u', 'id');
+
+        // Faked result set
+        $resultSet = array(
+            //row1
+            array(
+                'u__id' => '1',
+                'u__status' => 'developer',
+                'sclr0' => 'ROMANB',
+                ),
+            array(
+                'u__id' => '2',
+                'u__status' => 'developer',
+                'sclr0' => 'JWAGE',
+                ),
+            );
+
+        $stmt = new HydratorMockStatement($resultSet);
+        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+
+        $result = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+
+        $this->assertEquals(2, count($result));
+        $this->assertTrue(isset($result[1]));
+        $this->assertEquals(1, $result[1][0]->id);
+        $this->assertTrue(isset($result[2]));
+        $this->assertEquals(2, $result[2][0]->id);
+    }
+
+    /**
+     * @group DDC-1385
+     */
+    public function testIndexByAndScalarResult()
+    {
+        $rsm = new ResultSetMapping;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1208,12 +1208,4 @@ class ObjectHydratorTest extends HydrationTestCase
         $this->assertTrue(isset($result[2]));
         $this->assertEquals(2, $result[2][0]->id);
     }
-
-    /**
-     * @group DDC-1385
-     */
-    public function testIndexByAndScalarResult()
-    {
-        $rsm = new ResultSetMapping;
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1208,4 +1208,32 @@ class ObjectHydratorTest extends HydrationTestCase
         $this->assertTrue(isset($result[2]));
         $this->assertEquals(2, $result[2][0]->id);
     }
+
+    /**
+     * @group DDC-1385
+     */
+    public function testIndexByScalarsOnly()
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addScalarResult('sclr0', 'nameUpper');
+        $rsm->addIndexByScalar('sclr0');
+
+                // Faked result set
+        $resultSet = array(
+            //row1
+            array(
+                'sclr0' => 'ROMANB',
+                ),
+            array(
+                'sclr0' => 'JWAGE',
+                ),
+            );
+
+        $stmt = new HydratorMockStatement($resultSet);
+        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+
+        $result = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+
+        $this->assertEquals(array('ROMANB' => array('nameUpper' => 'ROMANB'), 'JWAGE' => array('nameUpper' => 'JWAGE')), $result);
+    }
 }


### PR DESCRIPTION
This branch does multiple things:
1. Fix how INDEX BY works with mixed results. The index is now on the top level, not inside the mixed result.
2. Add support for INDEX BY in scalar only queries.
   
   ```
   SELECT u.id, u.name FROM User u INDEX BY u.id
   ```

The following BC Breaks had to be made:
1. The hydration format changed when using INDEX BY with either mixed or scalar only results.
2. ResultSetMapping::$indexByMap is now $dqlAlias => $columnName, not $dqlAlias => $fieldName anymore.

Todos:
1. Since Hydration uses 'scalars' internally, we should prevent that identification variable name from being used.
2. Array Hydration scalar only is missing.
3. Unit-tests for RSM changes, aswell as some more error conditions (Exceptions).
4. Scalar only array hydration for nested levels?

Please code review.
