### PR TITLE
One-to-one relations and field used as association key

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -213,7 +213,7 @@ class XmlDriver extends AbstractFileDriver
         $associationIds = array();
         foreach ($xmlRoot->id as $idElement) {
             if ((bool)$idElement['association-key'] == true) {
-                $associationIds[(string)$idElement['fieldName']] = true;
+                $associationIds[(string)$idElement['name']] = true;
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -655,18 +655,21 @@ class BasicEntityPersister
             
             // TRICKY: since the association is specular source and target are flipped
             foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
-                if ( ! isset($sourceClass->fieldNames[$sourceKeyColumn])) {
+                if( isset($sourceClass->fieldNames[$sourceKeyColumn])){ // classic field
+                    // unset the old value and set the new sql aliased value here. By definition
+                    // unset($identifier[$targetKeyColumn] works here with how UnitOfWork::createEntity() calls this method.
+                    $ref = $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]];
+                    $identifier[$this->_getSQLTableAlias($targetClass->name) . "." . $targetKeyColumn] = $ref->getValue($sourceEntity);
+                    unset($identifier[$targetKeyColumn]);
+                } elseif(isset($sourceClass->associationMappings[$sourceClass->getFieldForColumn($sourceKeyColumn)]['id'])) { //field used as association key
+                    $ids = $this->_em->getUnitOfWork()->getEntityIdentifier($sourceEntity);
+                    $identifier[$this->_getSQLTableAlias($targetClass->name) . "." . $targetKeyColumn] = $ids[$sourceClass->getFieldForColumn($sourceKeyColumn)];
+                    unset($identifier[$targetKeyColumn]);
+                }else{
                     throw MappingException::joinColumnMustPointToMappedField(
                         $sourceClass->name, $sourceKeyColumn
                     );
                 }
-                
-                // unset the old value and set the new sql aliased value here. By definition
-                // unset($identifier[$targetKeyColumn] works here with how UnitOfWork::createEntity() calls this method.
-                $identifier[$this->_getSQLTableAlias($targetClass->name) . "." . $targetKeyColumn] =
-                    $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
-                
-                unset($identifier[$targetKeyColumn]);
             }
 
             $targetEntity = $this->load($identifier, null, $assoc);


### PR DESCRIPTION
Right field population in one-to-one relations, if the field is used as association key.

If the associated entity has an  association key, we cant use fieldNames metadata, but we have to use associationMappings metadata to identify the needed object.
