### PR TITLE
Allow to unset one-to-one relation with generated class

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -117,7 +117,7 @@ public function <methodName>()
  * @param <variableType>$<variableName>
  * @return <entity>
  */
-public function <methodName>(<methodTypeHint>$<variableName>)
+public function <methodName>(<methodTypeHint>$<variableName><variableDefault>)
 {
 <spaces>$this-><fieldName> = $<variableName>;
 <spaces>return $this;
@@ -634,7 +634,7 @@ public function <methodName>()
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
-                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
+                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], 'null')) {
                     $methods[] = $code;
                 }
                 if ($code = $this->_generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
@@ -707,7 +707,7 @@ public function <methodName>()
         return implode("\n", $lines);
     }
 
-    private function _generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null)
+    private function _generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null,  $defaultValue = null)
     {
         if ($type == "add") {
             $addMethod = explode("\\", $typeHint);
@@ -737,6 +737,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
+		  '<variableDefault>'   => ($defaultValue!==null?('='.$defaultValue):''),
           '<entity>'            => $this->_getClassName($metadata)
         );
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -634,8 +634,8 @@ public function <methodName>()
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
-                $nullable = $this->_isAssociationIsNullable($associationMapping);
-                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], ($nullable ? 'null' : null))) {
+                $nullable = $this->_isAssociationIsNullable($associationMapping) ? 'null' : null;
+                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], $nullable)) {
                     $methods[] = $code;
                 }
                 if ($code = $this->_generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
@@ -754,7 +754,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-          '<variableDefault>'   => (($defaultValue !== null ) ? ('='.$defaultValue) : ''),
+          '<variableDefault>'   => ($defaultValue !== null ) ? ('='.$defaultValue) : '',
           '<entity>'            => $this->_getClassName($metadata)
         );
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -806,7 +806,12 @@ public function <methodName>()
     {
         $lines = array();
         $lines[] = $this->_spaces . '/**';
-        $lines[] = $this->_spaces . ' * @var ' . $associationMapping['targetEntity'];
+        
+        if ($associationMapping['type'] & ClassMetadataInfo::TO_MANY) {
+            $lines[] = $this->_spaces . ' * @var \Doctrine\Common\Collections\ArrayCollection';
+        }else{
+            $lines[] = $this->_spaces . ' * @var ' . $associationMapping['targetEntity'];
+        }
 
         if ($this->_generateAnnotations) {
             $lines[] = $this->_spaces . ' *';

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -634,8 +634,8 @@ public function <methodName>()
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
-                $nullable = $this->_isAssociationIsNullable($associationMapping);
-                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], ($nullable ? 'null' : null))) {
+                $nullable = $this->_isAssociationIsNullable($associationMapping) ? 'null' : null;
+                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], $nullable)) {
                     $methods[] = $code;
                 }
                 if ($code = $this->_generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -634,7 +634,7 @@ public function <methodName>()
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
-                $nullable = $this->_associationIsNullable($associationMapping);
+                $nullable = $this->_isAssociationIsNullable($associationMapping);
                 if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], ($nullable?'null':null))) {
                     $methods[] = $code;
                 }
@@ -654,7 +654,7 @@ public function <methodName>()
         return implode("\n\n", $methods);
     }
 
-    private function _associationIsNullable($associationMapping)
+    private function _isAssociationIsNullable($associationMapping)
     {
         if(isset($associationMapping['joinColumns'])){
             $joinColumns = $associationMapping['joinColumns'];
@@ -665,7 +665,7 @@ public function <methodName>()
             $joinColumns = array();
         }
         foreach ($joinColumns as $joinColumn) {
-            if(!isset($joinColumn['nullable']) || !$joinColumn['nullable']){
+            if(isset($joinColumn['nullable']) && !$joinColumn['nullable']){
                 return false;
             }
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -406,7 +406,7 @@ public function <methodName>()
         }
         
         if ($collections) {
-            return $this->_prefixCodeWithSpaces(str_replace("<collections>", implode("\n", $collections), self::$_constructorMethodTemplate));
+            return $this->_prefixCodeWithSpaces(str_replace("<collections>", implode("\n".$this->_spaces, $collections), self::$_constructorMethodTemplate));
         }
         
         return '';

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -635,7 +635,7 @@ public function <methodName>()
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $nullable = $this->_isAssociationIsNullable($associationMapping);
-                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], ($nullable?'null':null))) {
+                if ($code = $this->_generateEntityStubMethod($metadata, 'set', $associationMapping['fieldName'], $associationMapping['targetEntity'], ($nullable ? 'null' : null))) {
                     $methods[] = $code;
                 }
                 if ($code = $this->_generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
@@ -656,16 +656,14 @@ public function <methodName>()
 
     private function _isAssociationIsNullable($associationMapping)
     {
-        if(isset($associationMapping['joinColumns'])){
+        if (isset($associationMapping['joinColumns'])) {
             $joinColumns = $associationMapping['joinColumns'];
-        }else{
+        } else {
             //@todo thereis no way to retreive targetEntity metadata
-            //$targetMetadata = $this->getClassMetadata($associationMapping['targetEntity']);
-            //$joinColumns = $targetMetadata->associationMappings[$associationMapping["mappedBy"]]['joinColumns'];
             $joinColumns = array();
         }
         foreach ($joinColumns as $joinColumn) {
-            if(isset($joinColumn['nullable']) && !$joinColumn['nullable']){
+            if(isset($joinColumn['nullable']) && !$joinColumn['nullable']) {
                 return false;
             }
         }
@@ -756,7 +754,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-          '<variableDefault>'   => ($defaultValue!==null?('='.$defaultValue):''),
+          '<variableDefault>'   => (($defaultValue !== null ) ? ('='.$defaultValue) : ''),
           '<entity>'            => $this->_getClassName($metadata)
         );
 
@@ -825,10 +823,10 @@ public function <methodName>()
     {
         $lines = array();
         $lines[] = $this->_spaces . '/**';
-        
+
         if ($associationMapping['type'] & ClassMetadataInfo::TO_MANY) {
             $lines[] = $this->_spaces . ' * @var \Doctrine\Common\Collections\ArrayCollection';
-        }else{
+        } else {
             $lines[] = $this->_spaces . ' * @var ' . $associationMapping['targetEntity'];
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -808,7 +808,7 @@ public function <methodName>()
         $lines[] = $this->_spaces . '/**';
         
         if ($associationMapping['type'] & ClassMetadataInfo::TO_MANY) {
-            $lines[] = $this->_spaces . ' * @var \Doctrine\Common\Collections\ArrayCollection';
+            $lines[] = $this->_spaces . ' * @var \Doctrine\Common\Collections\Collection';
         }else{
             $lines[] = $this->_spaces . ' * @var ' . $associationMapping['targetEntity'];
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -737,7 +737,7 @@ public function <methodName>()
           '<variableName>'      => Inflector::camelize($fieldName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
-		  '<variableDefault>'   => ($defaultValue!==null?('='.$defaultValue):''),
+          '<variableDefault>'   => ($defaultValue!==null?('='.$defaultValue):''),
           '<entity>'            => $this->_getClassName($metadata)
         );
 


### PR DESCRIPTION
Added <variableDefault> on generated class. 
This generate methods like:
```function setGroup(Group $group = null){
}

```

that allow to remove "Group" association if the relation is one-to-one.

Plus some indentation issue
```
