### PR TITLE
Update lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
@@ -37,6 +37,7 @@ class SimpleSelectExpression extends Node
 {
     public $expression;
     public $fieldIdentificationVariable;
+    public $hiddenAliasResultVariable;
 
     public function __construct($expression)
     {


### PR DESCRIPTION
A public property $hiddenAliasResultVariable was added to `SelectExpression` in ebe93381. It should also be added to SimpleSelectExpression to allow for more advanced custom query walking like here:
https://github.com/beberlei/DoctrineExtensions/blob/master/lib/DoctrineExtensions/Paginate/LimitSubqueryWalker.php#L71

Right now the missing property is causing a crash when using the Paginate extension of beberlei.
