### PR TITLE
Update lib/Doctrine/ORM/Query/Expr/Base.php

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -57,7 +57,7 @@ abstract class Base
 
     public function add($arg)
     {
-        if ( $arg !== null || ($arg instanceof self && $arg->count() > 0)) {
+        if ( $arg !== null ) {
             // If we decide to keep Expr\Base instances, we can use this check
             if ( ! is_string($arg)) {
                 $class = get_class($arg);


### PR DESCRIPTION
Why check if ( $args != null || stuff ( $args ) ).
If $args is different of null, so the other condition will never be use.

Also, juste 2 lines after, the args class's is check.
