### PR TITLE
preFlush event and lifecycle callback

### DIFF
--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -38,9 +38,6 @@ class PreFlushEventArgs extends \Doctrine\Common\EventArgs
      */
     private $_em;
 
-    //private $_entitiesToPersist = array();
-    //private $_entitiesToRemove = array();
-
     public function __construct($em)
     {
         $this->_em = $em;

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ *  $Id$
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\ORM\Event;
+
+/**
+ * Provides event arguments for the preFlush event.
+ *
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        www.doctrine-project.com
+ * @since       2.0
+ * @version     $Revision$
+ * @author      Roman Borschel <roman@code-factory.de>
+ * @author      Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class PreFlushEventArgs extends \Doctrine\Common\EventArgs
+{
+    /**
+     * @var EntityManager
+     */
+    private $_em;
+
+    //private $_entitiesToPersist = array();
+    //private $_entitiesToRemove = array();
+
+    public function __construct($em)
+    {
+        $this->_em = $em;
+    }
+
+    /**
+     * @return EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->_em;
+    }
+}

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -110,6 +110,13 @@ final class Events
     const loadClassMetadata = 'loadClassMetadata';
     
     /**
+     * The preFlush event occurs when the EntityManager#flush() operation is invoked,
+     * but before any changes to managed entites have been calculated. This event is
+     * always raised right after EntityManager#flush() call.
+     */
+    const preFlush = 'preFlush';
+
+    /**
      * The onFlush event occurs when the EntityManager#flush() operation is invoked,
      * after any changes to managed entities have been determined but before any
      * actual database operations are executed. The event is only raised if there is

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -446,6 +446,10 @@ class AnnotationDriver implements Driver
                     if (isset($annotations['Doctrine\ORM\Mapping\PostLoad'])) {
                         $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postLoad);
                     }
+
+                    if (isset($annotations['Doctrine\ORM\Mapping\PreFlush'])) {
+                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preFlush);
+                    }
                 }
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -387,3 +387,9 @@ final class PostRemove implements Annotation {}
  * @Target("METHOD")
  */
 final class PostLoad implements Annotation {}
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class PreFlush implements Annotation {}

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -259,6 +259,41 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function commit($entity = null)
     {
+        // Run preFlush lifecycle callback for new entities
+        foreach ($this->entityInsertions as $classEntity) {
+            $class = $this->em->getClassMetadata(get_class($classEntity));
+
+            // Skip class if instances are read-only
+            if ($class->isReadOnly) {
+                continue;
+            }
+
+            if (isset($class->lifecycleCallbacks[Events::preFlush])) {
+                $class->invokeLifecycleCallbacks(Events::preFlush, $classEntity);
+            }
+        }
+
+        // Run preFlush lifecycle callback for persisted entities
+        foreach ($this->identityMap as $className => $classEntities) {
+            $class = $this->em->getClassMetadata($className);
+
+            // Skip class if instances are read-only
+            if ($class->isReadOnly) {
+                continue;
+            }
+
+            if (isset($class->lifecycleCallbacks[Events::preFlush])) {
+                foreach ($classEntities as $classEntity) {
+                    $class->invokeLifecycleCallbacks(Events::preFlush, $classEntity);
+                }
+            }
+        }
+
+        // Raise preFlush
+        if ($this->evm->hasListeners(Events::preFlush)) {
+            $this->evm->dispatchEvent(Events::preFlush, new Event\PreFlushEventArgs($this->em));
+        }
+
         // Compute changes done since last commit.
         if ($entity === null) {
             $this->computeChangeSets();

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -43,6 +43,29 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals('changed from preUpdate callback!', $result[0]->value);
     }
     
+    public function testPreFlushCallbacksAreInvoked()
+    {
+        $entity = new LifecycleCallbackTestEntity;
+        $entity->value = 'hello';
+        $this->_em->persist($entity);
+
+        $this->_em->flush();
+
+        $this->assertTrue($entity->prePersistCallbackInvoked);
+        $this->assertTrue($entity->preFlushCallbackInvoked);
+
+        $entity->preFlushCallbackInvoked = false;
+        $this->_em->flush();
+
+        $this->assertTrue($entity->preFlushCallbackInvoked);
+
+        $entity->value = 'bye';
+        $entity->preFlushCallbackInvoked = false;
+        $this->_em->flush();
+
+        $this->assertTrue($entity->preFlushCallbackInvoked);
+    }
+
     public function testChangesDontGetLost()
     {
         $user = new LifecycleCallbackTestUser;
@@ -190,6 +213,8 @@ class LifecycleCallbackTestEntity
     public $postPersistCallbackInvoked = false;
     public $postLoadCallbackInvoked = false;
     
+    public $preFlushCallbackInvoked = false;
+
     /**
      * @Id @Column(type="integer")
      * @GeneratedValue(strategy="AUTO")
@@ -232,6 +257,11 @@ class LifecycleCallbackTestEntity
     /** @PreUpdate */
     public function doStuffOnPreUpdate() {
         $this->value = 'changed from preUpdate callback!';
+    }
+
+    /** @PreFlush */
+    public function doStuffOnPreFlush() {
+        $this->preFlushCallbackInvoked = true;
     }
 }
 


### PR DESCRIPTION
For now, we have `@PrePersist`, `@PreUpdate` and `@PreRemove` callbacks. But it's not enough, cuz in some cases we need to run some entity method just before **every** `EntityManager#flush()` call (examples - translatable behavior and file uploading routines).

I've added and tested new `@PreFlush` event, which occurs during the start of the `EntityManager#flush()`, before any changeset gets calculated. This gives users ability to hook into flush process and prepare their entities to save even if they were not changed.
