### PR TITLE
ProxyFactory was redeclaring methods in some OSs

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -167,7 +167,7 @@ class ProxyFactory
 
         foreach ($class->reflClass->getMethods() as $method) {
             /* @var $method ReflectionMethod */
-            if ($method->isConstructor() || in_array(strtolower($method->getName()), array("__sleep", "__clone"))) {
+            if ($method->isConstructor() || in_array(strtolower($method->getName()), array("__sleep", "__clone")) || $class->reflClass->getName() != $method->class) {
                 continue;
             }
 


### PR DESCRIPTION
The ProxyFactory was redeclaring methods serialize and unserialize (in my case) on the cache file on some OSs.

Here is the full comment with some screenshots: https://github.com/symfony/symfony/issues/2501
