### PR TITLE
add first backslash at "<variableType>" template

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -725,10 +725,11 @@ public function <methodName>()
         $var = sprintf('_%sMethodTemplate', $type);
         $template = self::$$var;
 
-        $variableType = $typeHint ? $typeHint . ' ' : null;
-
         $types = \Doctrine\DBAL\Types\Type::getTypesMap();
         $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : null;
+        
+        $variableType = $typeHint ? $typeHint . ' ' : null;
+        $variableType = $typeHint && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : $variableType;
 
         $replacements = array(
           '<description>'       => ucfirst($type) . ' ' . $fieldName,


### PR DESCRIPTION
Make the EntityGenerator generate the Object Type name with the first backslash.
