### PR TITLE
make merge copy non persisted properties too

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1522,7 +1522,9 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             // Merge state of $entity into existing (managed) entity
-            foreach ($class->reflFields as $name => $prop) {
+            foreach ($class->reflClass->getProperties() as $prop) {
+                $name = $prop->name;
+                $prop->setAccessible(true);
                 if ( ! isset($class->associationMappings[$name])) {
                     if ( ! $class->isIdentifier($name)) {
                         $prop->setValue($managedCopy, $prop->getValue($entity));

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -55,7 +55,11 @@ class CmsUser
      *      )
      */
     public $groups;
-    
+
+    public $nonPersistedProperty;
+
+    public $nonPersistedPropertyObject;
+
     public function __construct() {
         $this->phonenumbers = new ArrayCollection;
         $this->articles = new ArrayCollection;

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -907,6 +907,33 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $user2);
     }
 
+    public function testMergeNonPersistedProperties()
+    {
+        $user = new CmsUser();
+        $user->username = "beberlei";
+        $user->name = "Benjamin E.";
+        $user->status = 'active';
+        $user->nonPersistedProperty = 'test';
+        $user->nonPersistedPropertyObject = new CmsPhonenumber();
+
+        $managedUser = $this->_em->merge($user);
+        $this->assertEquals('test', $managedUser->nonPersistedProperty);
+        $this->assertSame($user->nonPersistedProperty, $managedUser->nonPersistedProperty);
+        $this->assertSame($user->nonPersistedPropertyObject, $managedUser->nonPersistedPropertyObject);
+
+        $this->assertTrue($user !== $managedUser);
+        $this->assertTrue($this->_em->contains($managedUser));
+
+        $this->_em->flush();
+        $userId = $managedUser->id;
+        $this->_em->clear();
+
+        $user2 = $this->_em->find(get_class($managedUser), $userId);
+        $this->assertNull($user2->nonPersistedProperty);
+        $this->assertNull($user2->nonPersistedPropertyObject);
+        $this->assertEquals('active', $user2->status);
+    }
+
     public function testMergeThrowsExceptionIfEntityWithGeneratedIdentifierDoesNotExist()
     {
         $user = new CmsUser();


### PR DESCRIPTION
The behavior of merging should be to return a managed object with _exactly_ the same values than the detached one.

The problem was that it only copies persistable properties.
