### PR TITLE
DDC-1430 - fix broken test on postgres

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -32,10 +32,11 @@ class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $query      = $builder->select('o.id, o.date, COUNT(p.id) AS p_count')
                         ->leftJoin('o.products', 'p')
                         ->groupBy('o.id, o.date')
+                        ->orderBy('o.id')
                         ->getQuery();
         
-        $this->assertEquals('SELECT o.id, o.date, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o.id, o.date', $query->getDQL());
-        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, COUNT(d1_.id) AS sclr2 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at', $query->getSQL());
+        $this->assertEquals('SELECT o.id, o.date, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o.id, o.date ORDER BY o.id ASC', $query->getDQL());
+        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, COUNT(d1_.id) AS sclr2 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at ORDER BY d0_.order_id ASC', $query->getSQL());
 
         
         $result = $query->getResult();
@@ -61,15 +62,16 @@ class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $builder    = $repository->createQueryBuilder('o');
         $query      = $builder->select('o, COUNT(p.id) AS p_count')
                         ->leftJoin('o.products', 'p')
-                        ->groupBy('o.id, o.date')
+                        ->groupBy('o.id, o.date, o.status')
+                        ->orderBy('o.id')
                         ->getQuery();
         
         
-        $this->assertEquals('SELECT o, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o.id, o.date', $query->getDQL());
-        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, d0_.order_status AS order_status2, COUNT(d1_.id) AS sclr3 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at', $query->getSQL());
+        $this->assertEquals('SELECT o, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o.id, o.date, o.status ORDER BY o.id ASC', $query->getDQL());
+        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, d0_.order_status AS order_status2, COUNT(d1_.id) AS sclr3 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at, d0_.order_status ORDER BY d0_.order_id ASC', $query->getSQL());
         
         $result = $query->getResult();
-
+        
         
         $this->assertEquals(2, sizeof($result));
         
@@ -90,11 +92,12 @@ class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $query      = $builder->select('o, COUNT(p.id) AS p_count')
                         ->leftJoin('o.products', 'p')
                         ->groupBy('o')
+                        ->orderBy('o.id')
                         ->getQuery();
         
         
-        $this->assertEquals('SELECT o, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o', $query->getDQL());
-        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, d0_.order_status AS order_status2, COUNT(d1_.id) AS sclr3 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at, d0_.order_status', $query->getSQL());
+        $this->assertEquals('SELECT o, COUNT(p.id) AS p_count FROM Doctrine\Tests\ORM\Functional\Ticket\DDC1430Order o LEFT JOIN o.products p GROUP BY o ORDER BY o.id ASC', $query->getDQL());
+        $this->assertEquals('SELECT d0_.order_id AS order_id0, d0_.created_at AS created_at1, d0_.order_status AS order_status2, COUNT(d1_.id) AS sclr3 FROM DDC1430Order d0_ LEFT JOIN DDC1430OrderProduct d1_ ON d0_.order_id = d1_.order_id GROUP BY d0_.order_id, d0_.created_at, d0_.order_status ORDER BY d0_.order_id ASC', $query->getSQL());
         
         
         $result = $query->getResult();


### PR DESCRIPTION
Hello all,

I think these changes fix the DDC-1430 test case  on PostgreSQL.

But I got the following error running test suite :

```

There was 1 error:

1) Doctrine\Tests\ORM\Functional\Ticket\DDC742Test::testIssue
Exception: [PHPUnit_Framework_Error_Notice] Undefined index: 0000000028077f55000000000c00b98f

With queries:
11. SQL: 'INSERT INTO comments (content) VALUES (?)' Params: 'baz'
10. SQL: 'INSERT INTO comments (content) VALUES (?)' Params: 'bar'
9. SQL: 'INSERT INTO comments (content) VALUES (?)' Params: 'foo'
8. SQL: 'ALTER TABLE user_comments ADD CONSTRAINT FK_BF13722AF8697D13 FOREIGN KEY (comment_id) REFERENCES comments (id) NOT DEFERRABLE INITIALLY IMMEDIATE' Params: 
7. SQL: 'ALTER TABLE user_comments ADD CONSTRAINT FK_BF13722AA76ED395 FOREIGN KEY (user_id) REFERENCES users (id) NOT DEFERRABLE INITIALLY IMMEDIATE' Params: 
6. SQL: 'CREATE TABLE comments (id SERIAL NOT NULL, content VARCHAR(100) NOT NULL, PRIMARY KEY(id))' Params: 
5. SQL: 'CREATE INDEX IDX_BF13722AF8697D13 ON user_comments (comment_id)' Params: 
4. SQL: 'CREATE INDEX IDX_BF13722AA76ED395 ON user_comments (user_id)' Params: 
3. SQL: 'CREATE TABLE user_comments (user_id INT NOT NULL, comment_id INT NOT NULL, PRIMARY KEY(user_id, comment_id))' Params: 
2. SQL: 'CREATE TABLE users (id SERIAL NOT NULL, title VARCHAR(100) NOT NULL, PRIMARY KEY(id))' Params: 

Trace:
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/UnitOfWork.php:2479
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php:113
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php:95
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php:130
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php:108
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/UnitOfWork.php:324
/Users/fabio/backup/workspace/php/doctrine2/lib/Doctrine/ORM/EntityManager.php:338
/Users/fabio/backup/workspace/php/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php:63


/Users/fabio/backup/workspace/php/doctrine2/tests/Doctrine/Tests/OrmFunctionalTestCase.php:359
```

Environment :

```
PostgreSQL 8.4.8 on i386-apple-darwin11.1.0, compiled by GCC i686-apple-darwin11-llvm-gcc-4.2 (GCC) 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00), 64-bit


PHP 5.3.8 (cli) (built: Sep 14 2011 10:17:25) 
Copyright (c) 1997-2011 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2011 Zend Technologies with Xdebug v2.1.1, Copyright (c) 2002-2011, by Derick Rethans
```
