### PR TITLE
Added some improvments for generated XML

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -221,8 +221,7 @@ class XmlExporter extends AbstractExporter
                 $associationMappingXml->addAttribute('index-by', $associationMapping['indexBy']);
             }
             if (isset($associationMapping['orphanRemoval']) && $associationMapping['orphanRemoval']!==false) {
-                // false is the xml default 
-                $associationMappingXml->addAttribute('orphan-removal', $associationMapping['orphanRemoval']);
+                $associationMappingXml->addAttribute('orphan-removal', 'true');
             }
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
                 $joinTableXml = $associationMappingXml->addChild('join-table');

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -217,7 +217,7 @@ class XmlExporter extends AbstractExporter
             if (isset($associationMapping['inversedBy'])) {
                 $associationMappingXml->addAttribute('inversed-by', $associationMapping['inversedBy']);
             }
-        	if (isset($associationMapping['indexBy'])) {
+            if (isset($associationMapping['indexBy'])) {
                 $associationMappingXml->addAttribute('index-by', $associationMapping['indexBy']);
             }
             if (isset($associationMapping['orphanRemoval']) && $associationMapping['orphanRemoval']!==false) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -95,7 +95,10 @@ class XmlExporter extends AbstractExporter
             }
         }
 
-        $root->addChild('change-tracking-policy', $this->_getChangeTrackingPolicyString($metadata->changeTrackingPolicy));
+        $trackingPolicy = $this->_getChangeTrackingPolicyString($metadata->changeTrackingPolicy);
+        if ( $trackingPolicy != 'DEFERRED_IMPLICIT') {
+            $root->addChild('change-tracking-policy', $trackingPolicy);
+        }
 
         if (isset($metadata->table['indexes'])) {
             $indexesXml = $root->addChild('indexes');
@@ -183,7 +186,17 @@ class XmlExporter extends AbstractExporter
                 }
             }
         }
-
+        $orderMap = array(
+            ClassMetadataInfo::ONE_TO_ONE,
+            ClassMetadataInfo::ONE_TO_MANY,
+            ClassMetadataInfo::MANY_TO_ONE,
+            ClassMetadataInfo::MANY_TO_MANY,
+        );
+        uasort($metadata->associationMappings, function($m1, $m2)use(&$orderMap){
+            $a1 = array_search($m1['type'],$orderMap);
+            $a2 = array_search($m2['type'],$orderMap);
+            return strcmp($a1, $a2);
+        });
         foreach ($metadata->associationMappings as $name => $associationMapping) {
             if ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_ONE) {
                 $associationMappingXml = $root->addChild('one-to-one');
@@ -204,7 +217,11 @@ class XmlExporter extends AbstractExporter
             if (isset($associationMapping['inversedBy'])) {
                 $associationMappingXml->addAttribute('inversed-by', $associationMapping['inversedBy']);
             }
-            if (isset($associationMapping['orphanRemoval'])) {
+        	if (isset($associationMapping['indexBy'])) {
+                $associationMappingXml->addAttribute('index-by', $associationMapping['indexBy']);
+            }
+            if (isset($associationMapping['orphanRemoval']) && $associationMapping['orphanRemoval']!==false) {
+                // false is the xml default 
                 $associationMappingXml->addAttribute('orphan-removal', $associationMapping['orphanRemoval']);
             }
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
@@ -287,7 +304,7 @@ class XmlExporter extends AbstractExporter
             }
         }
 
-        if (isset($metadata->lifecycleCallbacks)) {
+        if (isset($metadata->lifecycleCallbacks) && count($metadata->lifecycleCallbacks)>0) {
             $lifecycleCallbacksXml = $root->addChild('lifecycle-callbacks');
             foreach ($metadata->lifecycleCallbacks as $name => $methods) {
                 foreach ($methods as $method) {


### PR DESCRIPTION
Added some improvements that makes the generated xml compatible with 2.1 xsd.
- change-tracking-policy non generated for default value (DEFERRED_IMPLICIT)
- associationMappings order respect xsd definition
- orphan-removal can not be empty (false was generated as empty string)
- lifecycleCallbacks non generated when the count of callbacks is zero
