### PR TITLE
Register DoctrineAnnotations on call to OrmTestCase::createAnnotationDri...

### DIFF
--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -52,6 +52,8 @@ abstract class OrmTestCase extends DoctrineTestCase
                 $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Mapping\\');
             }
         }
+        \Doctrine\Common\Annotations\AnnotationRegistry::registerFile(
+            __DIR__ . "/../../../lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php");
         return new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($reader, (array)$paths);
     }
     


### PR DESCRIPTION
...ver()

Several tests were failing on reading annotations when executed alone. They passed in batch because on of earlier tests called Configuration::newDefaultAnnotationDriver() which automatically registers DoctrineAnnotations(). 
