### PR TITLE
Fixed array flip breaking discriminator map SQL generation

### DIFF
--- a/lib/Doctrine/ORM/Persisters/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/SingleTablePersister.php
@@ -120,10 +120,10 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
             $values[] = $this->_conn->quote($this->_class->discriminatorValue);
         }
 
-        $discrValues = array_flip($this->_class->discriminatorMap);
+        $discrValues = array_keys($this->_class->discriminatorMap);
         
-        foreach ($this->_class->subClasses as $subclassName) {
-            $values[] = $this->_conn->quote($discrValues[$subclassName]);
+        foreach ($this->_class->subClasses as $i => $subclassName) {
+            $values[] = $this->_conn->quote($discrValues[$i]);
         }
         
         $conditionSql .= $this->_getSQLTableAlias($this->_class->name) . '.' . $this->_class->discriminatorColumn['name']


### PR DESCRIPTION
If you setup an entity discriminator map that maps multiple types to one class the SQL generation is broken. For example a mapping such as

@ORM\DiscriminatorMap({"developer" = "Employee", "salesperson" = "Employee", "manager" = "Employee", "ceo" = "FearlessLeader"})

The meta data is correctly loaded as 

Array
(
    [developer] => Employee
    [salesperson] => Employee
    [manager] => Employee
    [ceo] => FearlessLeader
)

However within SingleTablePersister::_getSelectConditionSQL() as part of the generation of the appropriate IN clause a call is made to array_flip() to retrieve the array keys by class, leading to an array structure of

Array
(
    [Employee] => manager
    [FearlessLeader] => ceo
)

This ultimately leads to an incorrect IN clause such as

IN ('manager', 'manager', 'manager', 'ceo')

This patch simply replaces the array_flip() with a call to array_keys() and retrieves them by index, leading to the correct statement

IN ('developer', 'salesperson', 'manager', 'ceo')
