### PR TITLE
Unify Class loading & move DoctrineAnnotations.php to reflect namespace

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -126,15 +126,13 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             // Register the ORM Annotations in the AnnotationRegistry
-            AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
-
+            \Doctrine\ORM\Mapping\DoctrineAnnotations::INIT;
             $reader = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
             $reader->addNamespace('Doctrine\ORM\Mapping');
             $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new ArrayCache());
         } else if (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0-DEV', '>=')) {
             // Register the ORM Annotations in the AnnotationRegistry
-            AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
-
+            \Doctrine\ORM\Mapping\DoctrineAnnotations::INIT;
             $reader = new AnnotationReader();
             $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Mapping\\');
             $reader->setIgnoreNotImportedAnnotations(true);

--- a/lib/Doctrine/ORM/Mapping/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/DoctrineAnnotations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -19,377 +20,499 @@
 
 namespace Doctrine\ORM\Mapping;
 
-interface Annotation {}
+final class DoctrineAnnotations {
+    /**
+     * Dummy Class so __FILE__ is loaded by your choice of autoloader 
+     * rather than by include.
+     */
+    const INIT =1;
+}
 
+interface Annotation {
+    
+}
 
 /* Annotations */
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class Entity implements Annotation {
+
     /** @var string */
     public $repositoryClass;
+
     /** @var boolean */
     public $readOnly = false;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class MappedSuperclass implements Annotation {
+
     /** @var string */
     public $repositoryClass;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class InheritanceType implements Annotation {
+
     /** @var string */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class DiscriminatorColumn implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var string */
     public $type;
+
     /** @var integer */
     public $length;
+
     /** @var mixed */
     public $fieldName; // field name used in non-object hydration (array/scalar)
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class DiscriminatorMap implements Annotation {
+
     /** @var array<string> */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
-final class Id implements Annotation {}
+final class Id implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class GeneratedValue implements Annotation {
-     /** @var string */
+
+    /** @var string */
     public $strategy = 'AUTO';
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
-final class Version implements Annotation {}
+final class Version implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target({"PROPERTY","ANNOTATION"})
  */
 final class JoinColumn implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var string */
     public $referencedColumnName = 'id';
+
     /** @var boolean */
     public $unique = false;
+
     /** @var boolean */
     public $nullable = true;
+
     /** @var mixed */
     public $onDelete;
+
     /** @var string */
     public $columnDefinition;
+
     /** @var string */
     public $fieldName; // field name used in non-object hydration (array/scalar)
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class JoinColumns implements Annotation {
+
     /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class Column implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var mixed */
     public $type = 'string';
+
     /** @var integer */
     public $length;
+
     /** @var integer */
     public $precision = 0; // The precision for a decimal (exact numeric) column (Applies only for decimal column)
     /** @var integer */
     public $scale = 0; // The scale for a decimal (exact numeric) column (Applies only for decimal column)
     /** @var boolean */
     public $unique = false;
+
     /** @var boolean */
     public $nullable = false;
+
     /** @var array */
     public $options = array();
+
     /** @var string */
     public $columnDefinition;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class OneToOne implements Annotation {
+
     /** @var string */
     public $targetEntity;
+
     /** @var string */
     public $mappedBy;
+
     /** @var string */
     public $inversedBy;
+
     /** @var array<string> */
     public $cascade;
+
     /** @var string */
     public $fetch = 'LAZY';
+
     /** @var boolean */
     public $orphanRemoval = false;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class OneToMany implements Annotation {
+
     /** @var string */
     public $mappedBy;
+
     /** @var string */
     public $targetEntity;
+
     /** @var array<string> */
     public $cascade;
+
     /** @var string */
     public $fetch = 'LAZY';
+
     /** @var boolean */
     public $orphanRemoval = false;
+
     /** @var string */
     public $indexBy;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class ManyToOne implements Annotation {
+
     /** @var string */
     public $targetEntity;
+
     /** @var array<string> */
     public $cascade;
+
     /** @var string */
     public $fetch = 'LAZY';
+
     /** @var string */
     public $inversedBy;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class ManyToMany implements Annotation {
+
     /** @var string */
     public $targetEntity;
+
     /** @var string */
     public $mappedBy;
+
     /** @var string */
     public $inversedBy;
+
     /** @var array<string> */
     public $cascade;
+
     /** @var string */
     public $fetch = 'LAZY';
+
     /** @var string */
     public $indexBy;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("ALL")
  * @todo check available targets
  */
 final class ElementCollection implements Annotation {
+
     /** @var string */
     public $tableName;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class Table implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var string */
     public $schema;
+
     /** @var array<Doctrine\ORM\Mapping\Index> */
     public $indexes;
+
     /** @var array<Doctrine\ORM\Mapping\UniqueConstraint> */
     public $uniqueConstraints;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("ANNOTATION")
  */
 final class UniqueConstraint implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var array<string> */
     public $columns;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("ANNOTATION")
  */
 final class Index implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var array<string> */
     public $columns;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class JoinTable implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var string */
     public $schema;
+
     /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
     public $joinColumns = array();
+
     /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
     public $inverseJoinColumns = array();
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class SequenceGenerator implements Annotation {
+
     /** @var string */
     public $sequenceName;
+
     /** @var integer */
     public $allocationSize = 1;
+
     /** @var integer */
     public $initialValue = 1;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class ChangeTrackingPolicy implements Annotation {
+
     /** @var string */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("PROPERTY")
  */
 final class OrderBy implements Annotation {
+
     /** @var array<string> */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
 final class NamedQueries implements Annotation {
+
     /** @var array<Doctrine\ORM\Mapping\NamedQuery> */
     public $value;
+
 }
 
-/** 
+/**
  * @Annotation 
  * @Target("ANNOTATION")
  */
 final class NamedQuery implements Annotation {
+
     /** @var string */
     public $name;
+
     /** @var string */
     public $query;
+
 }
 
 /* Annotations for lifecycle callbacks */
 
-/** 
+/**
  * @Annotation 
  * @Target("CLASS")
  */
-final class HasLifecycleCallbacks implements Annotation {}
+final class HasLifecycleCallbacks implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PrePersist implements Annotation {}
+final class PrePersist implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PostPersist implements Annotation {}
+final class PostPersist implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PreUpdate implements Annotation {}
+final class PreUpdate implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PostUpdate implements Annotation {}
+final class PostUpdate implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PreRemove implements Annotation {}
+final class PreRemove implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PostRemove implements Annotation {}
+final class PostRemove implements Annotation {
+    
+}
 
-/** 
+/**
  * @Annotation 
  * @Target("METHOD")
  */
-final class PostLoad implements Annotation {}
+final class PostLoad implements Annotation {
+    
+}
 
 /**
  * @Annotation
  * @Target("METHOD")
  */
-final class PreFlush implements Annotation {}
+final class PreFlush implements Annotation {
+    
+}


### PR DESCRIPTION
Include file by referencing DoctrineAnnotations::INIT constant so that file is included via your autoloading strategy rather than require_once.
This not only unifies Class loading to whatever autoloader implementation you use , but enables the Packaging of Doctrine core Classes into 1 file.
Also move  DoctrineAnnotations.php to reflect namespace.
Apart from refrencing a Class constant cant think how else you can do this, a bit hacky but better than having 2 Class loading strategies i feel. ps hope the commit is correct as first time Git user.
