### PR TITLE
Ability to use a defined Column as a DiscriminatorColumn

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -276,11 +276,14 @@ class SchemaTool
             $discrColumn['length'] = 255;
         }
 
-        $table->addColumn(
-            $discrColumn['name'],
-            $discrColumn['type'],
-            array('length' => $discrColumn['length'], 'notnull' => true)
-        );
+        // Allow discriminatorColumn for existing column
+        if (!$table->hasColumn($discrColumn['name'])) {
+            $table->addColumn(
+                $discrColumn['name'],
+                $discrColumn['type'],
+                array('length' => $discrColumn['length'], 'notnull' => true)
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
The purpose of this feature is to be able to access the DiscriminatorColumn and define it with the flexibility of Column.

Example:

``` php

<?php
/**
 * @Entity
 * @InheritanceType("SINGLE_TABLE")
 * @DiscriminatorColumn(name="section_id")
 * @DiscriminatorMap({
 *  "1" = "Entities\Article\Science",
 *  "2" = "Entities\Article\News"
 *  })
 */
class Article {
  /**
   * @ManyToOne(targetEntity="Entities\Section")
   */
  private $section;
}

```
