### PR TITLE
Allow entity name filtering by regexp in doctrine:mapping:import.

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -67,7 +67,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->_filter AS $filter) {
-            if (preg_match('/'.$filter.'/', $metadata->name)) {
+            if (preg_match('#'.$filter.'#', $metadata->name)) {
                 return true;
             }
         }

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -32,6 +32,7 @@ namespace Doctrine\ORM\Tools\Console;
  * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author      Jonathan Wage <jonwage@gmail.com>
  * @author      Roman Borschel <roman@code-factory.org>
+ * @author      Tomasz Kowalczyk <tomasz@kowalczyk.cc>
  */
 class MetadataFilter extends \FilterIterator implements \Countable
 {
@@ -66,7 +67,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->_filter AS $filter) {
-            if (strpos($metadata->name, $filter) !== false) {
+            if (preg_match('/'.$filter.'/', $metadata->name)) {
                 return true;
             }
         }


### PR DESCRIPTION
While working on a Symfony2 project I found it extremely useful to be able to filter entity names by regexp when importing entities to YAML metadata. This small commit makes it possible without any BC breaks or something. I've written about it on my blog: http://blog.kowalczyk.cc/2011/11/11/symfony2-importing-entity-mapping-data-using-regular-expression-filters/ .

Without this commit:

``` Bash
./app/console doctrine:mapping:import ThunderSampleBundle yml --force --filter="Category" --filter="User"
```

Imports everything that contains "Category" or "User" in its name. With my commit:

``` Bash
./app/console doctrine:mapping:import ThunderSampleBundle yml --force --filter="^Category" --filter="^User$"
```

Imports only wanted entities. And you can use both ways simultaneously, because `preg_match("/{name}/")` does the same as `strpos("{name}");`.
