### PR TITLE
QueryBuilder::getQuery

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -210,7 +210,7 @@ class QueryBuilder
      *
      * @return Query
      */
-    public function getQuery()
+    public function createQuery()
     {
         return $this->_em->createQuery($this->getDQL())
                 ->setParameters($this->_params, $this->_paramTypes)


### PR DESCRIPTION
Hi there,
I'm wondering myself if the QueryBuilder::getQuery is a good method name.
Actually, a getMethodObject makes me think that I can use many times the getMethodObject and work with the same object.
e.g :

``` php
$qb->getQuery()->useResultCache (true);
$qb->getQuery()->execute();
```

In my code, the problem is that getQuery return a new instance of Query each time that I call getQuery.
Furthermore, the getQuery method invoke a createQuery method.

So, maybe the QueryBuiler::getQuery can store a reference to the created Query instance, and if the QueryBuilder::getQuery is call many times without any change return the stored instance.
If the QueryBuilder::getQuery have to generate a new Query, throw an exception or something like that.

Because of a change to QueryBuilder::createQuery is a major change, I don't think that It could be the solution, but it's a reflexion around this.

What do you think about that ?
