### PR TITLE
2.1.x

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -76,7 +76,7 @@ abstract class AbstractQuery
     protected $_resultSetMapping;
 
     /**
-     * @var Doctrine\ORM\EntityManager The entity manager used by this query object.
+     * @var \Doctrine\ORM\EntityManager The entity manager used by this query object.
      */
     protected $_em;
 
@@ -122,7 +122,7 @@ abstract class AbstractQuery
     /**
      * Initializes a new instance of a class derived from <tt>AbstractQuery</tt>.
      *
-     * @param Doctrine\ORM\EntityManager $entityManager
+     * @param \Doctrine\ORM\EntityManager $entityManager
      */
     public function __construct(EntityManager $em)
     {
@@ -132,7 +132,7 @@ abstract class AbstractQuery
     /**
      * Retrieves the associated EntityManager of this Query instance.
      *
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {
@@ -212,7 +212,7 @@ abstract class AbstractQuery
      * @param string $type The parameter type. If specified, the given value will be run through
      *                     the type conversion of this type. This is usually not needed for
      *                     strings and numeric types.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setParameter($key, $value, $type = null)
     {
@@ -231,7 +231,7 @@ abstract class AbstractQuery
      *
      * @param array $params
      * @param array $types
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setParameters(array $params, array $types = array())
     {
@@ -249,7 +249,7 @@ abstract class AbstractQuery
      * Sets the ResultSetMapping that should be used for hydration.
      *
      * @param ResultSetMapping $rsm
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setResultSetMapping(Query\ResultSetMapping $rsm)
     {
@@ -260,8 +260,8 @@ abstract class AbstractQuery
     /**
      * Defines a cache driver to be used for caching result sets.
      *
-     * @param Doctrine\Common\Cache\Cache $driver Cache driver
-     * @return Doctrine\ORM\AbstractQuery
+     * @param \Doctrine\Common\Cache\Cache $driver Cache driver
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setResultCacheDriver($resultCacheDriver = null)
     {
@@ -278,7 +278,7 @@ abstract class AbstractQuery
     /**
      * Returns the cache driver used for caching result sets.
      *
-     * @return Doctrine\Common\Cache\Cache Cache driver
+     * @return \Doctrine\Common\Cache\Cache Cache driver
      */
     public function getResultCacheDriver()
     {
@@ -296,7 +296,7 @@ abstract class AbstractQuery
      * @param boolean $bool
      * @param integer $timeToLive
      * @param string $resultCacheId
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function useResultCache($bool, $timeToLive = null, $resultCacheId = null)
     {
@@ -314,7 +314,7 @@ abstract class AbstractQuery
      * Defines how long the result cache will be active before expire.
      *
      * @param integer $timeToLive How long the cache entry is valid.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setResultCacheLifetime($timeToLive)
     {
@@ -340,7 +340,7 @@ abstract class AbstractQuery
      * Defines if the result cache is active or not.
      *
      * @param boolean $expire Whether or not to force resultset cache expiration.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function expireResultCache($expire = true)
     {
@@ -383,7 +383,7 @@ abstract class AbstractQuery
      *
      * @param integer $hydrationMode Doctrine processing mode to be used during hydration process.
      *                               One of the Query::HYDRATE_* constants.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setHydrationMode($hydrationMode)
     {
@@ -511,7 +511,7 @@ abstract class AbstractQuery
      *
      * @param string $name The name of the hint.
      * @param mixed $value The value of the hint.
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setHint($name, $value)
     {
@@ -621,7 +621,7 @@ abstract class AbstractQuery
      * generated for you.
      *
      * @param string $id
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setResultCacheId($id)
     {
@@ -667,7 +667,7 @@ abstract class AbstractQuery
     /**
      * Executes the query and returns a the resulting Statement object.
      *
-     * @return Doctrine\DBAL\Driver\Statement The executed database statement that holds the results.
+     * @return \Doctrine\DBAL\Driver\Statement The executed database statement that holds the results.
      */
     abstract protected function _doExecute();
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -43,21 +43,21 @@ class EntityManager implements ObjectManager
     /**
      * The used Configuration.
      *
-     * @var Doctrine\ORM\Configuration
+     * @var \Doctrine\ORM\Configuration
      */
     private $config;
 
     /**
      * The database connection used by the EntityManager.
      *
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     private $conn;
 
     /**
      * The metadata factory, used to retrieve the ORM metadata of entity classes.
      *
-     * @var Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
     private $metadataFactory;
 
@@ -71,14 +71,14 @@ class EntityManager implements ObjectManager
     /**
      * The UnitOfWork used to coordinate object-level transactions.
      *
-     * @var Doctrine\ORM\UnitOfWork
+     * @var \Doctrine\ORM\UnitOfWork
      */
     private $unitOfWork;
 
     /**
      * The event manager that is the central point of the event system.
      *
-     * @var Doctrine\Common\EventManager
+     * @var \Doctrine\Common\EventManager
      */
     private $eventManager;
 
@@ -92,14 +92,14 @@ class EntityManager implements ObjectManager
     /**
      * The proxy factory used to create dynamic proxies.
      *
-     * @var Doctrine\ORM\Proxy\ProxyFactory
+     * @var \Doctrine\ORM\Proxy\ProxyFactory
      */
     private $proxyFactory;
 
     /**
      * The expression builder instance used to generate query expressions.
      *
-     * @var Doctrine\ORM\Query\Expr
+     * @var \Doctrine\ORM\Query\Expr
      */
     private $expressionBuilder;
 
@@ -114,9 +114,9 @@ class EntityManager implements ObjectManager
      * Creates a new EntityManager that operates on the given database connection
      * and uses the given Configuration and EventManager implementations.
      *
-     * @param Doctrine\DBAL\Connection $conn
-     * @param Doctrine\ORM\Configuration $config
-     * @param Doctrine\Common\EventManager $eventManager
+     * @param \Doctrine\DBAL\Connection $conn
+     * @param \Doctrine\ORM\Configuration $config
+     * @param \Doctrine\Common\EventManager $eventManager
      */
     protected function __construct(Connection $conn, Configuration $config, EventManager $eventManager)
     {
@@ -139,7 +139,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the database connection object used by the EntityManager.
      *
-     * @return Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection
      */
     public function getConnection()
     {
@@ -149,7 +149,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the metadata factory used to gather the metadata of classes.
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @return \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
     public function getMetadataFactory()
     {
@@ -168,7 +168,7 @@ class EntityManager implements ObjectManager
      *         ->where($expr->orX($expr->eq('u.id', 1), $expr->eq('u.id', 2)));
      * </code>
      *
-     * @return Doctrine\ORM\Query\Expr
+     * @return \Doctrine\ORM\Query\Expr
      */
     public function getExpressionBuilder()
     {
@@ -249,7 +249,7 @@ class EntityManager implements ObjectManager
      * MyProject\Domain\User
      * sales:PriceRequest
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      * @internal Performance-sensitive method.
      */
     public function getClassMetadata($className)
@@ -261,7 +261,7 @@ class EntityManager implements ObjectManager
      * Creates a new Query object.
      *
      * @param string  The DQL string.
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     public function createQuery($dql = "")
     {
@@ -276,7 +276,7 @@ class EntityManager implements ObjectManager
      * Creates a Query from a named query.
      *
      * @param string $name
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     public function createNamedQuery($name)
     {
@@ -302,7 +302,7 @@ class EntityManager implements ObjectManager
      * Creates a NativeQuery from a named native query.
      *
      * @param string $name
-     * @return Doctrine\ORM\NativeQuery
+     * @return \Doctrine\ORM\NativeQuery
      */
     public function createNamedNativeQuery($name)
     {
@@ -325,7 +325,7 @@ class EntityManager implements ObjectManager
      * This effectively synchronizes the in-memory state of managed objects with the
      * database.
      *
-     * @throws Doctrine\ORM\OptimisticLockException If a version check on an entity that
+     * @throws \Doctrine\ORM\OptimisticLockException If a version check on an entity that
      *         makes use of optimistic locking fails.
      */
     public function flush()
@@ -601,7 +601,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the EventManager used by the EntityManager.
      *
-     * @return Doctrine\Common\EventManager
+     * @return \Doctrine\Common\EventManager
      */
     public function getEventManager()
     {
@@ -611,7 +611,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the Configuration used by the EntityManager.
      *
-     * @return Doctrine\ORM\Configuration
+     * @return \Doctrine\ORM\Configuration
      */
     public function getConfiguration()
     {
@@ -643,7 +643,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the UnitOfWork used by the EntityManager to coordinate operations.
      *
-     * @return Doctrine\ORM\UnitOfWork
+     * @return \Doctrine\ORM\UnitOfWork
      */
     public function getUnitOfWork()
     {
@@ -657,7 +657,7 @@ class EntityManager implements ObjectManager
      * selectively iterate over the result.
      *
      * @param int $hydrationMode
-     * @return Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     public function getHydrator($hydrationMode)
     {
@@ -672,7 +672,7 @@ class EntityManager implements ObjectManager
      * Create a new instance for the given hydration mode.
      *
      * @param  int $hydrationMode
-     * @return Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     public function newHydrator($hydrationMode)
     {

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -48,7 +48,7 @@ class EntityRepository implements ObjectRepository
     protected $_em;
 
     /**
-     * @var Doctrine\ORM\Mapping\ClassMetadata
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
 

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -26,7 +26,7 @@ abstract class AbstractIdGenerator
     /**
      * Generates an identifier for an entity.
      *
-     * @param Doctrine\ORM\Entity $entity
+     * @param \Doctrine\ORM\Entity $entity
      * @return mixed
      */
     abstract public function generate(EntityManager $em, $entity);

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -37,7 +37,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     /**
      * Initializes a new sequence generator.
      *
-     * @param Doctrine\ORM\EntityManager $em The EntityManager to use.
+     * @param \Doctrine\ORM\EntityManager $em The EntityManager to use.
      * @param string $sequenceName The name of the sequence.
      * @param integer $allocationSize The allocation size of the sequence.
      */

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -58,7 +58,7 @@ abstract class AbstractHydrator
     /**
      * Initializes a new instance of a class derived from <tt>AbstractHydrator</tt>.
      *
-     * @param Doctrine\ORM\EntityManager $em The EntityManager to use.
+     * @param \Doctrine\ORM\EntityManager $em The EntityManager to use.
      */
     public function __construct(EntityManager $em)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -29,7 +29,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 class IterableResult implements \Iterator
 {
     /**
-     * @var Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @var \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     private $_hydrator;
 
@@ -49,7 +49,7 @@ class IterableResult implements \Iterator
     private $_current = null;
 
     /**
-     * @param Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator
+     * @param \Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator
      */
     public function __construct($hydrator)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -85,7 +85,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Sets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @param Doctrine\Common\Cache\Cache $cacheDriver
+     * @param \Doctrine\Common\Cache\Cache $cacheDriver
      */
     public function setCacheDriver($cacheDriver)
     {
@@ -95,7 +95,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Gets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @return Doctrine\Common\Cache\Cache
+     * @return \Doctrine\Common\Cache\Cache
      */
     public function getCacheDriver()
     {
@@ -143,7 +143,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     public function getMetadataFor($className)
     {
@@ -370,7 +370,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Creates a new ClassMetadata instance for the given class name.
      *
      * @param string $className
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected function newClassMetadataInstance($className)
     {
@@ -380,8 +380,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Adds inherited fields to the subclass mapping.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $subClass
-     * @param Doctrine\ORM\Mapping\ClassMetadata $parentClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $subClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $parentClass
      */
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
@@ -402,8 +402,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Adds inherited association mappings to the subclass mapping.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $subClass
-     * @param Doctrine\ORM\Mapping\ClassMetadata $parentClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $subClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $parentClass
      */
     private function addInheritedRelations(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
@@ -430,7 +430,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Completes the ID generator mapping. If "auto" is specified we choose the generator
      * most appropriate for the targeted database platform.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function completeIdGeneratorMapping(ClassMetadataInfo $class)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1238,7 +1238,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Gets the type of a field.
      *
      * @param string $fieldName
-     * @return Doctrine\DBAL\Types\Type
+     * @return \Doctrine\DBAL\Types\Type
      */
     public function getTypeOfField($fieldName)
     {
@@ -1249,7 +1249,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Gets the type of a column.
      *
-     * @return Doctrine\DBAL\Types\Type
+     * @return \Doctrine\DBAL\Types\Type
      */
     public function getTypeOfColumn($columnName)
     {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -66,7 +66,7 @@ final class PersistentCollection implements Collection
     /**
      * The EntityManager that manages the persistence of the collection.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -265,7 +265,7 @@ final class PersistentCollection implements Collection
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @return Doctrine\ORM\Mapping\AssociationMapping
+     * @return \Doctrine\ORM\Mapping\AssociationMapping
      */
     public function getMapping()
     {

--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -36,19 +36,19 @@ abstract class AbstractCollectionPersister
     protected $_em;
 
     /**
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     protected $_conn;
 
     /**
-     * @var Doctrine\ORM\UnitOfWork
+     * @var \Doctrine\ORM\UnitOfWork
      */
     protected $_uow;
 
     /**
      * Initializes a new instance of a class derived from AbstractCollectionPersister.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -78,28 +78,28 @@ class BasicEntityPersister
     /**
      * Metadata object that describes the mapping of the mapped entity class.
      *
-     * @var Doctrine\ORM\Mapping\ClassMetadata
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
 
     /**
      * The underlying DBAL Connection of the used EntityManager.
      *
-     * @var Doctrine\DBAL\Connection $conn
+     * @var \Doctrine\DBAL\Connection $conn
      */
     protected $_conn;
 
     /**
      * The database platform.
      *
-     * @var Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
     protected $_platform;
 
     /**
      * The EntityManager instance.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     protected $_em;
 
@@ -171,8 +171,8 @@ class BasicEntityPersister
      * Initializes a new <tt>BasicEntityPersister</tt> that uses the given EntityManager
      * and persists instances of the class described by the given ClassMetadata descriptor.
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     public function __construct(EntityManager $em, ClassMetadata $class)
     {
@@ -183,7 +183,7 @@ class BasicEntityPersister
     }
 
     /**
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     public function getClassMetadata()
     {
@@ -271,7 +271,7 @@ class BasicEntityPersister
     /**
      * Fetch the current version value of a versioned entity.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $versionedClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $versionedClass
      * @param mixed $id
      * @return mixed
      */
@@ -724,7 +724,7 @@ class BasicEntityPersister
      * Load an array of entities from a given dbal statement.
      *
      * @param array $assoc
-     * @param Doctrine\DBAL\Statement $stmt
+     * @param \Doctrine\DBAL\Statement $stmt
      * @return array
      */
     private function loadArrayFromStatement($assoc, $stmt)
@@ -746,7 +746,7 @@ class BasicEntityPersister
      * Hydrate a collection from a given dbal statement.
      *
      * @param array $assoc
-     * @param Doctrine\DBAL\Statement $stmt
+     * @param \Doctrine\DBAL\Statement $stmt
      * @param PersistentCollection $coll
      */
     private function loadCollectionFromStatement($assoc, $stmt, $coll)
@@ -1272,7 +1272,7 @@ class BasicEntityPersister
      * @param object $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
-     * @return Doctrine\DBAL\Statement
+     * @return \Doctrine\DBAL\Statement
      */
     private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {

--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -67,7 +67,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      * This function finds the ClassMetadata instance in an inheritance hierarchy
      * that is responsible for enabling versioning.
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     private function _getVersionedClassMetadata()
     {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -81,7 +81,7 @@ final class Query extends AbstractQuery
     const HINT_INCLUDE_META_COLUMNS = 'doctrine.includeMetaColumns';
 
     /**
-     * An array of class names that implement Doctrine\ORM\Query\TreeWalker and
+     * An array of class names that implement \Doctrine\ORM\Query\TreeWalker and
      * are iterated and executed after the DQL has been parsed into an AST.
      *
      * @var string
@@ -89,7 +89,7 @@ final class Query extends AbstractQuery
     const HINT_CUSTOM_TREE_WALKERS = 'doctrine.customTreeWalkers';
 
     /**
-     * A string with a class name that implements Doctrine\ORM\Query\TreeWalker
+     * A string with a class name that implements \Doctrine\ORM\Query\TreeWalker
      * and is used for generating the target SQL from any DQL AST tree.
      *
      * @var string
@@ -119,7 +119,7 @@ final class Query extends AbstractQuery
     private $_dql = null;
 
     /**
-     * @var Doctrine\ORM\Query\ParserResult  The parser result that holds DQL => SQL information.
+     * @var \Doctrine\ORM\Query\ParserResult  The parser result that holds DQL => SQL information.
      */
     private $_parserResult;
 
@@ -158,7 +158,7 @@ final class Query extends AbstractQuery
     /**
      * Initializes a new Query instance.
      *
-     * @param Doctrine\ORM\EntityManager $entityManager
+     * @param \Doctrine\ORM\EntityManager $entityManager
      */
     /*public function __construct(EntityManager $entityManager)
     {
@@ -179,9 +179,9 @@ final class Query extends AbstractQuery
     /**
      * Returns the corresponding AST for this DQL query.
      *
-     * @return Doctrine\ORM\Query\AST\SelectStatement |
-     *         Doctrine\ORM\Query\AST\UpdateStatement |
-     *         Doctrine\ORM\Query\AST\DeleteStatement
+     * @return \Doctrine\ORM\Query\AST\SelectStatement |
+     *         \Doctrine\ORM\Query\AST\UpdateStatement |
+     *         \Doctrine\ORM\Query\AST\DeleteStatement
      */
     public function getAST()
     {
@@ -194,7 +194,7 @@ final class Query extends AbstractQuery
      *
      * Note: Populates $this->_parserResult as a side-effect.
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     private function _parse()
     {
@@ -428,7 +428,7 @@ final class Query extends AbstractQuery
      * Sets a DQL query string.
      *
      * @param string $dqlQuery DQL Query
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setDQL($dqlQuery)
     {
@@ -558,7 +558,7 @@ final class Query extends AbstractQuery
     /**
      * Set the lock mode for this Query.
      *
-     * @see Doctrine\DBAL\LockMode
+     * @see \Doctrine\DBAL\LockMode
      * @param  int $lockMode
      * @return Query
      */

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -49,9 +49,9 @@ abstract class AbstractSqlExecutor
     /**
      * Executes all sql statements.
      *
-     * @param Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
+     * @param \Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
      * @param array $params  The parameters.
-     * @return Doctrine\DBAL\Driver\Statement
+     * @return \Doctrine\DBAL\Driver\Statement
      */
     abstract public function execute(Connection $conn, array $params, array $types);    
 }

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -104,7 +104,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
     /**
      * Executes all SQL statements.
      *
-     * @param Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
+     * @param \Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
      * @param array $params The parameters.
      * @override
      */

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -37,8 +37,8 @@ class ParameterTypeInferer
 {
     /**
      * Infer type of a given value, returning a compatible constant:
-     * - Type (Doctrine\DBAL\Types\Type::*) 
-     * - Connection (Doctrine\DBAL\Connection::PARAM_*)
+     * - Type (\Doctrine\DBAL\Types\Type::*)
+     * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
      * 
      * @param mixed $value Parameter value
      * 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -75,14 +75,14 @@ class Parser
     /**
      * The lexer.
      *
-     * @var Doctrine\ORM\Query\Lexer
+     * @var \Doctrine\ORM\Query\Lexer
      */
     private $_lexer;
 
     /**
      * The parser result.
      *
-     * @var Doctrine\ORM\Query\ParserResult
+     * @var \Doctrine\ORM\Query\ParserResult
      */
     private $_parserResult;
 
@@ -170,7 +170,7 @@ class Parser
     /**
      * Gets the lexer used by the parser.
      *
-     * @return Doctrine\ORM\Query\Lexer
+     * @return \Doctrine\ORM\Query\Lexer
      */
     public function getLexer()
     {
@@ -180,7 +180,7 @@ class Parser
     /**
      * Gets the ParserResult that is being filled with information during parsing.
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     public function getParserResult()
     {
@@ -1466,7 +1466,7 @@ class Parser
     /**
      * RangeVariableDeclaration ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
      *
-     * @return Doctrine\ORM\Query\AST\RangeVariableDeclaration
+     * @return \Doctrine\ORM\Query\AST\RangeVariableDeclaration
      */
     public function RangeVariableDeclaration()
     {
@@ -1537,7 +1537,7 @@ class Parser
      * Join ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" JoinAssociationPathExpression
      *          ["AS"] AliasIdentificationVariable ["WITH" ConditionalExpression]
      *
-     * @return Doctrine\ORM\Query\AST\Join
+     * @return \Doctrine\ORM\Query\AST\Join
      */
     public function Join()
     {
@@ -1607,7 +1607,7 @@ class Parser
     /**
      * IndexBy ::= "INDEX" "BY" StateFieldPathExpression
      *
-     * @return Doctrine\ORM\Query\AST\IndexBy
+     * @return \Doctrine\ORM\Query\AST\IndexBy
      */
     public function IndexBy()
     {
@@ -1698,7 +1698,7 @@ class Parser
     /**
      * CoalesceExpression ::= "COALESCE" "(" ScalarExpression {"," ScalarExpression}* ")"
      * 
-     * @return Doctrine\ORM\Query\AST\CoalesceExpression 
+     * @return \Doctrine\ORM\Query\AST\CoalesceExpression
      */
     public function CoalesceExpression()
     {
@@ -1722,7 +1722,7 @@ class Parser
     /**
      * NullIfExpression ::= "NULLIF" "(" ScalarExpression "," ScalarExpression ")"
      * 
-     * @return Doctrine\ORM\Query\AST\ExistsExpression 
+     * @return \Doctrine\ORM\Query\AST\ExistsExpression
      */
     public function NullIfExpression()
     {
@@ -1743,7 +1743,7 @@ class Parser
      *      IdentificationVariable | StateFieldPathExpression |
      *      (AggregateExpression | "(" Subselect ")" | ScalarExpression) [["AS"] AliasResultVariable]
      *
-     * @return Doctrine\ORM\Query\AST\SelectExpression
+     * @return \Doctrine\ORM\Query\AST\SelectExpression
      */
     public function SelectExpression()
     {
@@ -1967,7 +1967,7 @@ class Parser
     /**
      * ConditionalPrimary ::= SimpleConditionalExpression | "(" ConditionalExpression ")"
      *
-     * @return Doctrine\ORM\Query\AST\ConditionalPrimary
+     * @return \Doctrine\ORM\Query\AST\ConditionalPrimary
      */
     public function ConditionalPrimary()
     {

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -89,7 +89,7 @@ class QueryException extends \Doctrine\ORM\ORMException
     }
 
     /**
-     * @param Doctrine\ORM\Mapping\AssociationMapping $assoc
+     * @param \Doctrine\ORM\Mapping\AssociationMapping $assoc
      */
     public static function iterateWithFetchJoinCollectionNotAllowed($assoc)
     {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -57,7 +57,7 @@ class SqlWalker implements TreeWalker
     private $_em;
 
     /**
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     private $_conn;
 

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -55,7 +55,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieve Query Instance reponsible for the current walkers execution.
      *
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     protected function _getQuery()
     {
@@ -65,7 +65,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieve ParserResult
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     protected function _getParserResult()
     {

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -50,7 +50,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /* @var $entityManager Doctrine\ORM\EntityManager */
+        /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
         $entityClassNames = $entityManager->getConfiguration()

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -27,7 +27,7 @@ use Doctrine\ORM\Tools\Export\ExportException;
 
 /**
  * Abstract base class which is to be used for the Exporter drivers
- * which can be found in Doctrine\ORM\Tools\Export\Driver
+ * which can be found in \Doctrine\ORM\Tools\Export\Driver
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link    www.doctrine-project.org

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -56,7 +56,7 @@ class SchemaTool
      * Initializes a new SchemaTool instance that uses the connection of the
      * provided EntityManager.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -174,7 +174,7 @@ class SchemaTool
                     $discrColumnDef = $this->_getDiscriminatorColumnDefinition($class, $table);
                 } else {
                     // Add an ID FK column to child tables
-                    /* @var Doctrine\ORM\Mapping\ClassMetadata $class */
+                    /* @var \Doctrine\ORM\Mapping\ClassMetadata $class */
                     $idMapping = $class->fieldMappings[$class->identifier[0]];
                     $this->_gatherColumn($class, $idMapping, $table);
                     $columnName = $class->getQuotedColumnName($class->identifier[0], $this->_platform);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -176,7 +176,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * The EntityManager that "owns" this UnitOfWork instance.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -184,7 +184,7 @@ class UnitOfWork implements PropertyChangedListener
      * The calculator used to calculate the order in which changes to
      * entities need to be written to the database.
      *
-     * @var Doctrine\ORM\Internal\CommitOrderCalculator
+     * @var \Doctrine\ORM\Internal\CommitOrderCalculator
      */
     private $commitOrderCalculator;
 
@@ -233,7 +233,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Initializes a new UnitOfWork instance, bound to the given EntityManager.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -700,7 +700,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity insertions for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeInserts($class)
     {
@@ -753,7 +753,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity updates for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeUpdates($class)
     {
@@ -797,7 +797,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity deletions for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeDeletions($class)
     {
@@ -1823,7 +1823,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the CommitOrderCalculator used by the UnitOfWork to order commits.
      *
-     * @return Doctrine\ORM\Internal\CommitOrderCalculator
+     * @return \Doctrine\ORM\Internal\CommitOrderCalculator
      */
     public function getCommitOrderCalculator()
     {
@@ -2261,7 +2261,7 @@ class UnitOfWork implements PropertyChangedListener
      * Gets the EntityPersister for an Entity.
      *
      * @param string $entityName  The name of the Entity.
-     * @return Doctrine\ORM\Persisters\AbstractEntityPersister
+     * @return \Doctrine\ORM\Persisters\AbstractEntityPersister
      */
     public function getEntityPersister($entityName)
     {


### PR DESCRIPTION
A regex replace over phpdoc annotations to use absolute (i.e. \Doctrine) namespace references, described in issue DDC-1025 - http://www.doctrine-project.org/jira/browse/DDC-1025

This should fix code completion in multiple IDEs including PhpStorm.
