### PR TITLE
DDC-1025 - Absolute Namespace Annotations

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -77,7 +77,7 @@ abstract class AbstractQuery
     protected $_resultSetMapping;
 
     /**
-     * @var Doctrine\ORM\EntityManager The entity manager used by this query object.
+     * @var \Doctrine\ORM\EntityManager The entity manager used by this query object.
      */
     protected $_em;
 
@@ -104,7 +104,7 @@ abstract class AbstractQuery
     /**
      * Initializes a new instance of a class derived from <tt>AbstractQuery</tt>.
      *
-     * @param Doctrine\ORM\EntityManager $entityManager
+     * @param \Doctrine\ORM\EntityManager $entityManager
      */
     public function __construct(EntityManager $em)
     {
@@ -114,7 +114,7 @@ abstract class AbstractQuery
     /**
      * Retrieves the associated EntityManager of this Query instance.
      *
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {
@@ -202,7 +202,7 @@ abstract class AbstractQuery
      * @param string $type The parameter type. If specified, the given value will be run through
      *                     the type conversion of this type. This is usually not needed for
      *                     strings and numeric types.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setParameter($key, $value, $type = null)
     {
@@ -223,7 +223,7 @@ abstract class AbstractQuery
      *
      * @param array $params
      * @param array $types
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setParameters(array $params, array $types = array())
     {
@@ -238,7 +238,7 @@ abstract class AbstractQuery
      * Sets the ResultSetMapping that should be used for hydration.
      *
      * @param ResultSetMapping $rsm
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setResultSetMapping(Query\ResultSetMapping $rsm)
     {
@@ -250,8 +250,8 @@ abstract class AbstractQuery
     /**
      * Defines a cache driver to be used for caching result sets and implictly enables caching.
      *
-     * @param Doctrine\Common\Cache\Cache $driver Cache driver
-     * @return Doctrine\ORM\AbstractQuery
+     * @param \Doctrine\Common\Cache\Cache $driver Cache driver
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setResultCacheDriver($resultCacheDriver = null)
     {
@@ -270,7 +270,7 @@ abstract class AbstractQuery
      * Returns the cache driver used for caching result sets.
      *
      * @deprecated
-     * @return Doctrine\Common\Cache\Cache Cache driver
+     * @return \Doctrine\Common\Cache\Cache Cache driver
      */
     public function getResultCacheDriver()
     {
@@ -288,7 +288,7 @@ abstract class AbstractQuery
      * @param boolean $bool
      * @param integer $lifetime
      * @param string $resultCacheId
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function useResultCache($bool, $lifetime = null, $resultCacheId = null)
     {
@@ -308,7 +308,7 @@ abstract class AbstractQuery
      * Defines how long the result cache will be active before expire.
      *
      * @param integer $lifetime How long the cache entry is valid.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setResultCacheLifetime($lifetime)
     {
@@ -336,7 +336,7 @@ abstract class AbstractQuery
      * Defines if the result cache is active or not.
      *
      * @param boolean $expire Whether or not to force resultset cache expiration.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function expireResultCache($expire = true)
     {
@@ -389,7 +389,7 @@ abstract class AbstractQuery
      *
      * @param integer $hydrationMode Doctrine processing mode to be used during hydration process.
      *                               One of the Query::HYDRATE_* constants.
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setHydrationMode($hydrationMode)
     {
@@ -520,7 +520,7 @@ abstract class AbstractQuery
      *
      * @param string $name The name of the hint.
      * @param mixed $value The value of the hint.
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setHint($name, $value)
     {
@@ -609,7 +609,7 @@ abstract class AbstractQuery
      * generated for you.
      *
      * @param string $id
-     * @return Doctrine\ORM\AbstractQuery This query instance.
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
      */
     public function setResultCacheId($id)
     {
@@ -634,7 +634,7 @@ abstract class AbstractQuery
     /**
      * Executes the query and returns a the resulting Statement object.
      *
-     * @return Doctrine\DBAL\Driver\Statement The executed database statement that holds the results.
+     * @return \Doctrine\DBAL\Driver\Statement The executed database statement that holds the results.
      */
     abstract protected function _doExecute();
 

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -501,7 +501,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * 
      * @since 2.2
      * @param string $className
-     * @throws ORMException If not is a Doctrine\ORM\EntityRepository
+     * @throws ORMException If not is a \Doctrine\ORM\EntityRepository
      */
     public function setDefaultRepositoryClassName($className)
     {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -43,21 +43,21 @@ class EntityManager implements ObjectManager
     /**
      * The used Configuration.
      *
-     * @var Doctrine\ORM\Configuration
+     * @var \Doctrine\ORM\Configuration
      */
     private $config;
 
     /**
      * The database connection used by the EntityManager.
      *
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     private $conn;
 
     /**
      * The metadata factory, used to retrieve the ORM metadata of entity classes.
      *
-     * @var Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
     private $metadataFactory;
 
@@ -71,14 +71,14 @@ class EntityManager implements ObjectManager
     /**
      * The UnitOfWork used to coordinate object-level transactions.
      *
-     * @var Doctrine\ORM\UnitOfWork
+     * @var \Doctrine\ORM\UnitOfWork
      */
     private $unitOfWork;
 
     /**
      * The event manager that is the central point of the event system.
      *
-     * @var Doctrine\Common\EventManager
+     * @var \Doctrine\Common\EventManager
      */
     private $eventManager;
 
@@ -92,14 +92,14 @@ class EntityManager implements ObjectManager
     /**
      * The proxy factory used to create dynamic proxies.
      *
-     * @var Doctrine\ORM\Proxy\ProxyFactory
+     * @var \Doctrine\ORM\Proxy\ProxyFactory
      */
     private $proxyFactory;
 
     /**
      * The expression builder instance used to generate query expressions.
      *
-     * @var Doctrine\ORM\Query\Expr
+     * @var \Doctrine\ORM\Query\Expr
      */
     private $expressionBuilder;
 
@@ -114,9 +114,9 @@ class EntityManager implements ObjectManager
      * Creates a new EntityManager that operates on the given database connection
      * and uses the given Configuration and EventManager implementations.
      *
-     * @param Doctrine\DBAL\Connection $conn
-     * @param Doctrine\ORM\Configuration $config
-     * @param Doctrine\Common\EventManager $eventManager
+     * @param \Doctrine\DBAL\Connection $conn
+     * @param \Doctrine\ORM\Configuration $config
+     * @param \Doctrine\Common\EventManager $eventManager
      */
     protected function __construct(Connection $conn, Configuration $config, EventManager $eventManager)
     {
@@ -141,7 +141,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the database connection object used by the EntityManager.
      *
-     * @return Doctrine\DBAL\Connection
+     * @return \Doctrine\DBAL\Connection
      */
     public function getConnection()
     {
@@ -151,7 +151,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the metadata factory used to gather the metadata of classes.
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @return \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
     public function getMetadataFactory()
     {
@@ -170,7 +170,7 @@ class EntityManager implements ObjectManager
      *         ->where($expr->orX($expr->eq('u.id', 1), $expr->eq('u.id', 2)));
      * </code>
      *
-     * @return Doctrine\ORM\Query\Expr
+     * @return \Doctrine\ORM\Query\Expr
      */
     public function getExpressionBuilder()
     {
@@ -253,7 +253,7 @@ class EntityManager implements ObjectManager
      * MyProject\Domain\User
      * sales:PriceRequest
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      * @internal Performance-sensitive method.
      */
     public function getClassMetadata($className)
@@ -265,7 +265,7 @@ class EntityManager implements ObjectManager
      * Creates a new Query object.
      *
      * @param string  The DQL string.
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     public function createQuery($dql = "")
     {
@@ -282,7 +282,7 @@ class EntityManager implements ObjectManager
      * Creates a Query from a named query.
      *
      * @param string $name
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     public function createNamedQuery($name)
     {
@@ -309,7 +309,7 @@ class EntityManager implements ObjectManager
      * Creates a NativeQuery from a named native query.
      *
      * @param string $name
-     * @return Doctrine\ORM\NativeQuery
+     * @return \Doctrine\ORM\NativeQuery
      */
     public function createNamedNativeQuery($name)
     {
@@ -337,7 +337,7 @@ class EntityManager implements ObjectManager
      * the cascade-persist semantics + scheduled inserts/removals are synchronized.
      *
      * @param object $entity
-     * @throws Doctrine\ORM\OptimisticLockException If a version check on an entity that
+     * @throws \Doctrine\ORM\OptimisticLockException If a version check on an entity that
      *         makes use of optimistic locking fails.
      */
     public function flush($entity = null)
@@ -632,7 +632,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the EventManager used by the EntityManager.
      *
-     * @return Doctrine\Common\EventManager
+     * @return \Doctrine\Common\EventManager
      */
     public function getEventManager()
     {
@@ -642,7 +642,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the Configuration used by the EntityManager.
      *
-     * @return Doctrine\ORM\Configuration
+     * @return \Doctrine\ORM\Configuration
      */
     public function getConfiguration()
     {
@@ -674,7 +674,7 @@ class EntityManager implements ObjectManager
     /**
      * Gets the UnitOfWork used by the EntityManager to coordinate operations.
      *
-     * @return Doctrine\ORM\UnitOfWork
+     * @return \Doctrine\ORM\UnitOfWork
      */
     public function getUnitOfWork()
     {
@@ -688,7 +688,7 @@ class EntityManager implements ObjectManager
      * selectively iterate over the result.
      *
      * @param int $hydrationMode
-     * @return Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     public function getHydrator($hydrationMode)
     {
@@ -703,7 +703,7 @@ class EntityManager implements ObjectManager
      * Create a new instance for the given hydration mode.
      *
      * @param  int $hydrationMode
-     * @return Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     public function newHydrator($hydrationMode)
     {

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -48,7 +48,7 @@ class EntityRepository implements ObjectRepository
     protected $_em;
 
     /**
-     * @var Doctrine\ORM\Mapping\ClassMetadata
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
 

--- a/lib/Doctrine/ORM/Event/EntityEventDelegator.php
+++ b/lib/Doctrine/ORM/Event/EntityEventDelegator.php
@@ -80,7 +80,7 @@ class EntityEventDelegator implements EventSubscriber
      * Adds an EventSubscriber. The subscriber is asked for all the events he is
      * interested in and added as a listener for these events.
      *
-     * @param Doctrine\Common\EventSubscriber $subscriber The subscriber.
+     * @param \Doctrine\Common\EventSubscriber $subscriber The subscriber.
      * @param array $entities
      */
     public function addEventSubscriber(EventSubscriber $subscriber, $entities)

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -34,7 +34,7 @@ use Doctrine\ORM\EntityManager;
 class LifecycleEventArgs extends EventArgs
 {
     /**
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -47,7 +47,7 @@ class LifecycleEventArgs extends EventArgs
      * Constructor
      * 
      * @param object $entity
-     * @param Doctrine\ORM\EntityManager $em 
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct($entity, EntityManager $em)
     {
@@ -68,7 +68,7 @@ class LifecycleEventArgs extends EventArgs
     /**
      * Retrieve associated EntityManager.
      * 
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -32,20 +32,20 @@ use Doctrine\ORM\EntityManager;
 class LoadClassMetadataEventArgs extends EventArgs
 {
     /**
-     * @var Doctrine\ORM\Mapping\ClassMetadata
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     private $classMetadata;
 
     /**
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
     /**
      * Constructor.
      * 
-     * @param Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadata
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadata
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(ClassMetadataInfo $classMetadata, EntityManager $em)
     {
@@ -56,7 +56,7 @@ class LoadClassMetadataEventArgs extends EventArgs
     /**
      * Retrieve associated ClassMetadata.
      *  
-     * @return Doctrine\ORM\Mapping\ClassMetadataInfo
+     * @return \Doctrine\ORM\Mapping\ClassMetadataInfo
      */
     public function getClassMetadata()
     {
@@ -66,7 +66,7 @@ class LoadClassMetadataEventArgs extends EventArgs
     /**
      * Retrieve associated EntityManager.
      * 
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -31,7 +31,7 @@ namespace Doctrine\ORM\Event;
 class OnClearEventArgs extends \Doctrine\Common\EventArgs
 {
     /**
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -43,7 +43,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     /**
      * Constructor.
      * 
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      * @param string $entityClass Optional entity class
      */
     public function __construct($em, $entityClass = null)
@@ -55,7 +55,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     /**
      * Retrieve associated EntityManager.
      * 
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -45,7 +45,7 @@ class OnFlushEventArgs extends \Doctrine\Common\EventArgs
     /**
      * Constructor.
      * 
-     * @param Doctrine\ORM\EntityManager $em 
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -55,7 +55,7 @@ class OnFlushEventArgs extends \Doctrine\Common\EventArgs
     /**
      * Retrieve associated EntityManager.
      * 
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -35,14 +35,14 @@ use Doctrine\Common\EventArgs;
 class PostFlushEventArgs extends EventArgs
 {
     /**
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
     /**
      * Constructor.
      * 
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -52,7 +52,7 @@ class PostFlushEventArgs extends EventArgs
     /**
      * Retrieve associated EntityManager.
      * 
-     * @return Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -43,7 +43,7 @@ class PreUpdateEventArgs extends LifecycleEventArgs
      * Constructor.
      * 
      * @param object $entity
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      * @param array $changeSet
      */
     public function __construct($entity, EntityManager $em, array &$changeSet)

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -26,7 +26,7 @@ abstract class AbstractIdGenerator
     /**
      * Generates an identifier for an entity.
      *
-     * @param Doctrine\ORM\Entity $entity
+     * @param \Doctrine\ORM\Entity $entity
      * @return mixed
      */
     abstract public function generate(EntityManager $em, $entity);

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -37,7 +37,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     /**
      * Initializes a new sequence generator.
      *
-     * @param Doctrine\ORM\EntityManager $em The EntityManager to use.
+     * @param \Doctrine\ORM\EntityManager $em The EntityManager to use.
      * @param string $sequenceName The name of the sequence.
      * @param integer $allocationSize The allocation size of the sequence.
      */

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -344,7 +344,7 @@ abstract class AbstractHydrator
     /**
      * Register entity as managed in UnitOfWork.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      * @param object $entity
      * @param array $data
      *

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -60,7 +60,7 @@ abstract class AbstractHydrator
     /**
      * Initializes a new instance of a class derived from <tt>AbstractHydrator</tt>.
      *
-     * @param Doctrine\ORM\EntityManager $em The EntityManager to use.
+     * @param \Doctrine\ORM\EntityManager $em The EntityManager to use.
      */
     public function __construct(EntityManager $em)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -276,7 +276,7 @@ class ArrayHydrator extends AbstractHydrator
      *
      * @param string $className
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     private function getClassMetadata($className)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -29,7 +29,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 class IterableResult implements \Iterator
 {
     /**
-     * @var Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @var \Doctrine\ORM\Internal\Hydration\AbstractHydrator
      */
     private $_hydrator;
 
@@ -49,7 +49,7 @@ class IterableResult implements \Iterator
     private $_current = null;
 
     /**
-     * @param Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator
+     * @param \Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator
      */
     public function __construct($hydrator)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -437,8 +437,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Adds inherited named queries to the subclass mapping.
      * 
      * @since 2.2
-     * @param Doctrine\ORM\Mapping\ClassMetadata $subClass
-     * @param Doctrine\ORM\Mapping\ClassMetadata $parentClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $subClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $parentClass
      */
     private function addInheritedNamedQueries(ClassMetadata $subClass, ClassMetadata $parentClass)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -85,7 +85,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Sets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @param Doctrine\Common\Cache\Cache $cacheDriver
+     * @param \Doctrine\Common\Cache\Cache $cacheDriver
      */
     public function setCacheDriver($cacheDriver)
     {
@@ -95,7 +95,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Gets the cache driver used by the factory to cache ClassMetadata instances.
      *
-     * @return Doctrine\Common\Cache\Cache
+     * @return \Doctrine\Common\Cache\Cache
      */
     public function getCacheDriver()
     {
@@ -143,7 +143,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Gets the class metadata descriptor for a class.
      *
      * @param string $className The name of the class.
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     public function getMetadataFor($className)
     {
@@ -377,7 +377,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Creates a new ClassMetadata instance for the given class name.
      *
      * @param string $className
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected function newClassMetadataInstance($className)
     {
@@ -387,8 +387,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Adds inherited fields to the subclass mapping.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $subClass
-     * @param Doctrine\ORM\Mapping\ClassMetadata $parentClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $subClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $parentClass
      */
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
@@ -409,8 +409,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     /**
      * Adds inherited association mappings to the subclass mapping.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $subClass
-     * @param Doctrine\ORM\Mapping\ClassMetadata $parentClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $subClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $parentClass
      */
     private function addInheritedRelations(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
@@ -456,7 +456,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      * Completes the ID generator mapping. If "auto" is specified we choose the generator
      * most appropriate for the targeted database platform.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function completeIdGeneratorMapping(ClassMetadataInfo $class)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1250,7 +1250,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Gets the type of a field.
      *
      * @param string $fieldName
-     * @return Doctrine\DBAL\Types\Type
+     * @return \Doctrine\DBAL\Types\Type
      */
     public function getTypeOfField($fieldName)
     {
@@ -1261,7 +1261,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Gets the type of a column.
      *
-     * @return Doctrine\DBAL\Types\Type
+     * @return \Doctrine\DBAL\Types\Type
      */
     public function getTypeOfColumn($columnName)
     {

--- a/lib/Doctrine/ORM/Mapping/JoinColumns.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumns.php
@@ -25,6 +25,6 @@ namespace Doctrine\ORM\Mapping;
  */
 final class JoinColumns implements Annotation
 {
-    /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
+    /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
     public $value;
 }

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -29,8 +29,8 @@ final class JoinTable implements Annotation
     public $name;
     /** @var string */
     public $schema;
-    /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
+    /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
     public $joinColumns = array();
-    /** @var array<Doctrine\ORM\Mapping\JoinColumn> */
+    /** @var array<\Doctrine\ORM\Mapping\JoinColumn> */
     public $inverseJoinColumns = array();
 }

--- a/lib/Doctrine/ORM/Mapping/NamedQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQueries.php
@@ -25,6 +25,6 @@ namespace Doctrine\ORM\Mapping;
  */
 final class NamedQueries implements Annotation
 {
-    /** @var array<Doctrine\ORM\Mapping\NamedQuery> */
+    /** @var array<\Doctrine\ORM\Mapping\NamedQuery> */
     public $value;
 }

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -29,8 +29,8 @@ final class Table implements Annotation
     public $name;
     /** @var string */
     public $schema;
-    /** @var array<Doctrine\ORM\Mapping\Index> */
+    /** @var array<\Doctrine\ORM\Mapping\Index> */
     public $indexes;
-    /** @var array<Doctrine\ORM\Mapping\UniqueConstraint> */
+    /** @var array<\Doctrine\ORM\Mapping\UniqueConstraint> */
     public $uniqueConstraints;
 }

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -67,7 +67,7 @@ final class PersistentCollection implements Collection
     /**
      * The EntityManager that manages the persistence of the collection.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -284,7 +284,7 @@ final class PersistentCollection implements Collection
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @return Doctrine\ORM\Mapping\AssociationMapping
+     * @return \Doctrine\ORM\Mapping\AssociationMapping
      */
     public function getMapping()
     {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -728,7 +728,7 @@ final class PersistentCollection implements Collection
     /**
      * Retrieves the wrapped Collection instance.
      *
-     * @return Doctrine\Common\Collections\Collection
+     * @return \Doctrine\Common\Collections\Collection
      */
     public function unwrap()
     {

--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -36,19 +36,19 @@ abstract class AbstractCollectionPersister
     protected $_em;
 
     /**
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     protected $_conn;
 
     /**
-     * @var Doctrine\ORM\UnitOfWork
+     * @var \Doctrine\ORM\UnitOfWork
      */
     protected $_uow;
 
     /**
      * Initializes a new instance of a class derived from AbstractCollectionPersister.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -79,28 +79,28 @@ class BasicEntityPersister
     /**
      * Metadata object that describes the mapping of the mapped entity class.
      *
-     * @var Doctrine\ORM\Mapping\ClassMetadata
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
 
     /**
      * The underlying DBAL Connection of the used EntityManager.
      *
-     * @var Doctrine\DBAL\Connection $conn
+     * @var \Doctrine\DBAL\Connection $conn
      */
     protected $_conn;
 
     /**
      * The database platform.
      *
-     * @var Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
      */
     protected $_platform;
 
     /**
      * The EntityManager instance.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     protected $_em;
 
@@ -172,8 +172,8 @@ class BasicEntityPersister
      * Initializes a new <tt>BasicEntityPersister</tt> that uses the given EntityManager
      * and persists instances of the class described by the given ClassMetadata descriptor.
      *
-     * @param Doctrine\ORM\EntityManager $em
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     public function __construct(EntityManager $em, ClassMetadata $class)
     {
@@ -184,7 +184,7 @@ class BasicEntityPersister
     }
 
     /**
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     public function getClassMetadata()
     {
@@ -272,7 +272,7 @@ class BasicEntityPersister
     /**
      * Fetch the current version value of a versioned entity.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $versionedClass
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $versionedClass
      * @param mixed $id
      * @return mixed
      */
@@ -750,7 +750,7 @@ class BasicEntityPersister
      * Load an array of entities from a given dbal statement.
      *
      * @param array $assoc
-     * @param Doctrine\DBAL\Statement $stmt
+     * @param \Doctrine\DBAL\Statement $stmt
      *
      * @return array
      */
@@ -774,7 +774,7 @@ class BasicEntityPersister
      * Hydrate a collection from a given dbal statement.
      *
      * @param array $assoc
-     * @param Doctrine\DBAL\Statement $stmt
+     * @param \Doctrine\DBAL\Statement $stmt
      * @param PersistentCollection $coll
      *
      * @return array
@@ -1368,7 +1368,7 @@ class BasicEntityPersister
      * @param object $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
-     * @return Doctrine\DBAL\Statement
+     * @return \Doctrine\DBAL\Statement
      */
     private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {

--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -67,7 +67,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      * This function finds the ClassMetadata instance in an inheritance hierarchy
      * that is responsible for enabling versioning.
      *
-     * @return Doctrine\ORM\Mapping\ClassMetadata
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
      */
     private function _getVersionedClassMetadata()
     {

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -279,7 +279,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
     }
     
     /**
-     * @param Doctrine\ORM\PersistentCollection $coll
+     * @param \Doctrine\ORM\PersistentCollection $coll
      * @param object $element
      * @return array
      */

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -81,7 +81,7 @@ final class Query extends AbstractQuery
     const HINT_INCLUDE_META_COLUMNS = 'doctrine.includeMetaColumns';
 
     /**
-     * An array of class names that implement Doctrine\ORM\Query\TreeWalker and
+     * An array of class names that implement \Doctrine\ORM\Query\TreeWalker and
      * are iterated and executed after the DQL has been parsed into an AST.
      *
      * @var string
@@ -89,7 +89,7 @@ final class Query extends AbstractQuery
     const HINT_CUSTOM_TREE_WALKERS = 'doctrine.customTreeWalkers';
 
     /**
-     * A string with a class name that implements Doctrine\ORM\Query\TreeWalker
+     * A string with a class name that implements \Doctrine\ORM\Query\TreeWalker
      * and is used for generating the target SQL from any DQL AST tree.
      *
      * @var string
@@ -119,7 +119,7 @@ final class Query extends AbstractQuery
     private $_dql = null;
 
     /**
-     * @var Doctrine\ORM\Query\ParserResult  The parser result that holds DQL => SQL information.
+     * @var \Doctrine\ORM\Query\ParserResult  The parser result that holds DQL => SQL information.
      */
     private $_parserResult;
 
@@ -158,7 +158,7 @@ final class Query extends AbstractQuery
     /**
      * Initializes a new Query instance.
      *
-     * @param Doctrine\ORM\EntityManager $entityManager
+     * @param \Doctrine\ORM\EntityManager $entityManager
      */
     /*public function __construct(EntityManager $entityManager)
     {
@@ -179,9 +179,9 @@ final class Query extends AbstractQuery
     /**
      * Returns the corresponding AST for this DQL query.
      *
-     * @return Doctrine\ORM\Query\AST\SelectStatement |
-     *         Doctrine\ORM\Query\AST\UpdateStatement |
-     *         Doctrine\ORM\Query\AST\DeleteStatement
+     * @return \Doctrine\ORM\Query\AST\SelectStatement |
+     *         \Doctrine\ORM\Query\AST\UpdateStatement |
+     *         \Doctrine\ORM\Query\AST\DeleteStatement
      */
     public function getAST()
     {
@@ -194,7 +194,7 @@ final class Query extends AbstractQuery
      *
      * Note: Populates $this->_parserResult as a side-effect.
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     private function _parse()
     {
@@ -441,7 +441,7 @@ final class Query extends AbstractQuery
      * Sets a DQL query string.
      *
      * @param string $dqlQuery DQL Query
-     * @return Doctrine\ORM\AbstractQuery
+     * @return \Doctrine\ORM\AbstractQuery
      */
     public function setDQL($dqlQuery)
     {
@@ -577,7 +577,7 @@ final class Query extends AbstractQuery
     /**
      * Set the lock mode for this Query.
      *
-     * @see Doctrine\DBAL\LockMode
+     * @see \Doctrine\DBAL\LockMode
      * @param  int $lockMode
      * @return Query
      */

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -61,10 +61,10 @@ abstract class AbstractSqlExecutor
     /**
      * Executes all sql statements.
      *
-     * @param Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
+     * @param \Doctrine\DBAL\Connection $conn The database connection that is used to execute the queries.
      * @param array $params  The parameters.
      * @param array $types The parameter types.
-     * @return Doctrine\DBAL\Driver\Statement
+     * @return \Doctrine\DBAL\Driver\Statement
      */
     abstract public function execute(Connection $conn, array $params, array $types);
 }

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -42,9 +42,9 @@ class Expr
      *     // (u.type = ?1) AND (u.role = ?2)
      *     $expr->andX($expr->eq('u.type', ':1'), $expr->eq('u.role', ':2'));
      *
-     * @param Doctrine\ORM\Query\Expr\Comparison | 
-     *          Doctrine\ORM\Query\Expr\Func |
-     *          Doctrine\ORM\Query\Expr\Orx 
+     * @param \Doctrine\ORM\Query\Expr\Comparison |
+     *          \Doctrine\ORM\Query\Expr\Func |
+     *          \Doctrine\ORM\Query\Expr\Orx
     *               $x Optional clause. Defaults = null, but requires at least one defined when converting to string.
      * @return Expr\Andx
      */

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -37,8 +37,8 @@ class ParameterTypeInferer
 {
     /**
      * Infer type of a given value, returning a compatible constant:
-     * - Type (Doctrine\DBAL\Types\Type::*) 
-     * - Connection (Doctrine\DBAL\Connection::PARAM_*)
+     * - Type (\Doctrine\DBAL\Types\Type::*)
+     * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
      * 
      * @param mixed $value Parameter value
      * 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -76,14 +76,14 @@ class Parser
     /**
      * The lexer.
      *
-     * @var Doctrine\ORM\Query\Lexer
+     * @var \Doctrine\ORM\Query\Lexer
      */
     private $_lexer;
 
     /**
      * The parser result.
      *
-     * @var Doctrine\ORM\Query\ParserResult
+     * @var \Doctrine\ORM\Query\ParserResult
      */
     private $_parserResult;
 
@@ -171,7 +171,7 @@ class Parser
     /**
      * Gets the lexer used by the parser.
      *
-     * @return Doctrine\ORM\Query\Lexer
+     * @return \Doctrine\ORM\Query\Lexer
      */
     public function getLexer()
     {
@@ -181,7 +181,7 @@ class Parser
     /**
      * Gets the ParserResult that is being filled with information during parsing.
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     public function getParserResult()
     {
@@ -1457,7 +1457,7 @@ class Parser
     /**
      * RangeVariableDeclaration ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
      *
-     * @return Doctrine\ORM\Query\AST\RangeVariableDeclaration
+     * @return \Doctrine\ORM\Query\AST\RangeVariableDeclaration
      */
     public function RangeVariableDeclaration()
     {
@@ -1531,7 +1531,7 @@ class Parser
      * Join ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" JoinAssociationPathExpression
      *          ["AS"] AliasIdentificationVariable ["WITH" ConditionalExpression]
      *
-     * @return Doctrine\ORM\Query\AST\Join
+     * @return \Doctrine\ORM\Query\AST\Join
      */
     public function Join()
     {
@@ -1611,7 +1611,7 @@ class Parser
     /**
      * IndexBy ::= "INDEX" "BY" StateFieldPathExpression
      *
-     * @return Doctrine\ORM\Query\AST\IndexBy
+     * @return \Doctrine\ORM\Query\AST\IndexBy
      */
     public function IndexBy()
     {
@@ -1737,7 +1737,7 @@ class Parser
     /**
      * CoalesceExpression ::= "COALESCE" "(" ScalarExpression {"," ScalarExpression}* ")"
      *
-     * @return Doctrine\ORM\Query\AST\CoalesceExpression
+     * @return \Doctrine\ORM\Query\AST\CoalesceExpression
      */
     public function CoalesceExpression()
     {
@@ -1762,7 +1762,7 @@ class Parser
     /**
      * NullIfExpression ::= "NULLIF" "(" ScalarExpression "," ScalarExpression ")"
      *
-     * @return Doctrine\ORM\Query\AST\NullIfExpression
+     * @return \Doctrine\ORM\Query\AST\NullIfExpression
      */
     public function NullIfExpression()
     {
@@ -1858,7 +1858,7 @@ class Parser
      *     PartialObjectExpression | "(" Subselect ")" | CaseExpression
      * ) [["AS"] ["HIDDEN"] AliasResultVariable]
      *
-     * @return Doctrine\ORM\Query\AST\SelectExpression
+     * @return \Doctrine\ORM\Query\AST\SelectExpression
      */
     public function SelectExpression()
     {
@@ -2133,7 +2133,7 @@ class Parser
     /**
      * ConditionalPrimary ::= SimpleConditionalExpression | "(" ConditionalExpression ")"
      *
-     * @return Doctrine\ORM\Query\AST\ConditionalPrimary
+     * @return \Doctrine\ORM\Query\AST\ConditionalPrimary
      */
     public function ConditionalPrimary()
     {

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1781,7 +1781,7 @@ class Parser
     /**
      * GeneralCaseExpression ::= "CASE" WhenClause {WhenClause}* "ELSE" ScalarExpression "END"
      *
-     * @return Doctrine\ORM\Query\AST\GeneralExpression
+     * @return \Doctrine\ORM\Query\AST\GeneralExpression
      */
     public function GeneralCaseExpression()
     {
@@ -1827,7 +1827,7 @@ class Parser
     /**
      * WhenClause ::= "WHEN" ConditionalExpression "THEN" ScalarExpression
      *
-     * @return Doctrine\ORM\Query\AST\WhenExpression
+     * @return \Doctrine\ORM\Query\AST\WhenExpression
      */
     public function WhenClause()
     {
@@ -1841,7 +1841,7 @@ class Parser
     /**
      * SimpleWhenClause ::= "WHEN" ScalarExpression "THEN" ScalarExpression
      *
-     * @return Doctrine\ORM\Query\AST\SimpleWhenExpression
+     * @return \Doctrine\ORM\Query\AST\SimpleWhenExpression
      */
     public function SimpleWhenClause()
     {

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -94,7 +94,7 @@ class QueryException extends \Doctrine\ORM\ORMException
     }
 
     /**
-     * @param Doctrine\ORM\Mapping\AssociationMapping $assoc
+     * @param \Doctrine\ORM\Mapping\AssociationMapping $assoc
      */
     public static function iterateWithFetchJoinCollectionNotAllowed($assoc)
     {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -60,7 +60,7 @@ class SqlWalker implements TreeWalker
     private $_em;
 
     /**
-     * @var Doctrine\DBAL\Connection
+     * @var \Doctrine\DBAL\Connection
      */
     private $_conn;
 

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -55,7 +55,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieve Query Instance reponsible for the current walkers execution.
      *
-     * @return Doctrine\ORM\Query
+     * @return \Doctrine\ORM\Query
      */
     protected function _getQuery()
     {
@@ -65,7 +65,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieve ParserResult
      *
-     * @return Doctrine\ORM\Query\ParserResult
+     * @return \Doctrine\ORM\Query\ParserResult
      */
     protected function _getParserResult()
     {

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -50,7 +50,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /* @var $entityManager Doctrine\ORM\EntityManager */
+        /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
         $entityClassNames = $entityManager->getConfiguration()

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -27,7 +27,7 @@ use Doctrine\ORM\Tools\Export\ExportException;
 
 /**
  * Abstract base class which is to be used for the Exporter drivers
- * which can be found in Doctrine\ORM\Tools\Export\Driver
+ * which can be found in \Doctrine\ORM\Tools\Export\Driver
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link    www.doctrine-project.org

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -56,7 +56,7 @@ class SchemaTool
      * Initializes a new SchemaTool instance that uses the connection of the
      * provided EntityManager.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -180,7 +180,7 @@ class SchemaTool
                     $this->addDiscriminatorColumnDefinition($class, $table);
                 } else {
                     // Add an ID FK column to child tables
-                    /* @var Doctrine\ORM\Mapping\ClassMetadata $class */
+                    /* @var \Doctrine\ORM\Mapping\ClassMetadata $class */
                     $idMapping = $class->fieldMappings[$class->identifier[0]];
                     $this->_gatherColumn($class, $idMapping, $table);
                     $columnName = $class->getQuotedColumnName($class->identifier[0], $this->_platform);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -177,7 +177,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * The EntityManager that "owns" this UnitOfWork instance.
      *
-     * @var Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em;
 
@@ -185,7 +185,7 @@ class UnitOfWork implements PropertyChangedListener
      * The calculator used to calculate the order in which changes to
      * entities need to be written to the database.
      *
-     * @var Doctrine\ORM\Internal\CommitOrderCalculator
+     * @var \Doctrine\ORM\Internal\CommitOrderCalculator
      */
     private $commitOrderCalculator;
 
@@ -234,7 +234,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Initializes a new UnitOfWork instance, bound to the given EntityManager.
      *
-     * @param Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManager $em
      */
     public function __construct(EntityManager $em)
     {
@@ -842,7 +842,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity insertions for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeInserts($class)
     {
@@ -899,7 +899,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity updates for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeUpdates($class)
     {
@@ -949,7 +949,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes all entity deletions for entities of the specified type.
      *
-     * @param Doctrine\ORM\Mapping\ClassMetadata $class
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      */
     private function executeDeletions($class)
     {
@@ -2140,7 +2140,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Gets the CommitOrderCalculator used by the UnitOfWork to order commits.
      *
-     * @return Doctrine\ORM\Internal\CommitOrderCalculator
+     * @return \Doctrine\ORM\Internal\CommitOrderCalculator
      */
     public function getCommitOrderCalculator()
     {
@@ -2652,7 +2652,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param string $entityName  The name of the Entity.
      *
-     * @return Doctrine\ORM\Persisters\BasicEntityPersister
+     * @return \Doctrine\ORM\Persisters\BasicEntityPersister
      */
     public function getEntityPersister($entityName)
     {


### PR DESCRIPTION
Request pull into master using proper procedure this time:
https://github.com/doctrine/doctrine2/pull/215

---

A regex replace over phpdoc annotations to use absolute (i.e. \Doctrine) namespace references, described in issue DDC-1025 - http://www.doctrine-project.org/jira/browse/DDC-1025

This should fix code completion in multiple IDEs including PhpStorm.
