### PR TITLE
[BUG] Schema Manager had no way to define extra options

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -360,6 +360,12 @@ class SchemaTool
             $options['columnDefinition'] = $mapping['columnDefinition'];
         }
 
+        if (isset($mapping['options'])) {
+            foreach ($mapping['options'] as $key => $value) {
+                $options[$key] = $value;
+            }
+        }
+
         if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == array($mapping['fieldName'])) {
             $options['autoincrement'] = true;
         }


### PR DESCRIPTION
Schema Manager had no way to define extra options ("comment" option for example). It is possible to add these options via Annotations. After the fix adding `@ORM\Column(type="string", options={"comment" = "test"})` starts to work producing valid SQL schema with COMMENT output.
