### PR TITLE
Recursive check for entity identifiers and hashes

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -257,15 +257,7 @@ class ObjectHydrator extends AbstractHydrator
 
         /* @var $class ClassMetadata */
         if ($class->isIdentifierComposite) {
-            $idHash = '';
-            foreach ($class->identifier as $fieldName) {
-                if (isset($class->associationMappings[$fieldName])) {
-                    $idHash .= $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']] . ' ';
-                } else {
-                    $idHash .= $data[$fieldName] . ' ';
-                }
-            }
-            return $this->_uow->tryGetByIdHash(rtrim($idHash), $class->rootEntityName);
+            return $this->_uow->tryGetById($class->identifier, $class->rootEntityName);
         } else if (isset($class->associationMappings[$class->identifier[0]])) {
             return $this->_uow->tryGetByIdHash($data[$class->associationMappings[$class->identifier[0]]['joinColumns'][0]['name']], $class->rootEntityName);
         } else {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1455,9 +1455,10 @@ class BasicEntityPersister
         }
         return $type;
     }
+
     /**
-     * Infer (recursivley) field type to be used by parameter type casting.
-     * Used by getType() method.
+     * Infer (recursively) field type to be used by parameter type casting.
+     * @see getType($field, $value)
      * 
      * @param string $field
      * @param mixed $value
@@ -1468,8 +1469,6 @@ class BasicEntityPersister
         switch (true) {
             case (isset($class->fieldMappings[$field])):
                 return $class->fieldMappings[$field]['type'];
-                break;
-
             case (isset($class->associationMappings[$field])):
                 $assoc = $class->associationMappings[$field];
 
@@ -1479,8 +1478,6 @@ class BasicEntityPersister
 
                 $targetClass  = $this->_em->getClassMetadata($assoc['targetEntity']);
                 return $this->getRecursiveType($targetClass->identifier[0], $targetClass);
-                break;
-
             default:
                return null;
         }   

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1305,9 +1305,11 @@ class UnitOfWork implements PropertyChangedListener
 
         if ( ! $id) {
             return self::STATE_NEW;
-        } elseif (count($id) && is_object(reset($id))) {
+        } 
+ 
+        if (count($id) && is_object(reset($id))) {
             $state = $this->getEntityState(reset($id));
-            if ($state===self::STATE_NEW) {
+            if ($state === self::STATE_NEW) {
                 return self::STATE_NEW;    
             }
         }
@@ -2612,10 +2614,10 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * Compute a hash for the given id. Acept also objects ( for association keys)
+     * Compute a hash for the given id. Accept also objects (for association keys)
      *
      * @param mixed $id The entity identifier to look for.
-     * @return strine Returns the computed hash.
+     * @return string Returns the computed hash.
      */
     private function getHashForEntityIdentifier(array $ids)
     {
@@ -2635,6 +2637,7 @@ class UnitOfWork implements PropertyChangedListener
         }
         return implode(' ', $strings);
     }
+
     /**
      * Tries to find an entity with the given identifier in the identity map of
      * this UnitOfWork.

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1253,7 +1253,7 @@ class UnitOfWork implements PropertyChangedListener
     public function addToIdentityMap($entity)
     {
         $classMetadata = $this->em->getClassMetadata(get_class($entity));
-        $idHash        = implode(' ', $this->entityIdentifiers[spl_object_hash($entity)]);
+        $idHash        = $this->getHashForEntityIdentifier($this->entityIdentifiers[spl_object_hash($entity)]);
 
         if ($idHash === '') {
             throw new InvalidArgumentException('The given entity has no identity.');
@@ -1305,6 +1305,11 @@ class UnitOfWork implements PropertyChangedListener
 
         if ( ! $id) {
             return self::STATE_NEW;
+        } elseif (count($id) && is_object(reset($id))) {
+            $state = $this->getEntityState(reset($id));
+            if ($state===self::STATE_NEW) {
+                return self::STATE_NEW;    
+            }
         }
 
         switch (true) {
@@ -1363,7 +1368,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid           = spl_object_hash($entity);
         $classMetadata = $this->em->getClassMetadata(get_class($entity));
-        $idHash        = implode(' ', $this->entityIdentifiers[$oid]);
+        $idHash        = $this->getHashForEntityIdentifier($this->entityIdentifiers[$oid]);
 
         if ($idHash === '') {
             throw new InvalidArgumentException('The given entity has no identity.');
@@ -1430,7 +1435,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $classMetadata = $this->em->getClassMetadata(get_class($entity));
-        $idHash        = implode(' ', $this->entityIdentifiers[$oid]);
+        $idHash        = $this->getHashForEntityIdentifier($this->entityIdentifiers[$oid]);
 
         if ($idHash === '') {
             return false;
@@ -2607,6 +2612,30 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * Compute a hash for the given id. Acept also objects ( for association keys)
+     *
+     * @param mixed $id The entity identifier to look for.
+     * @return strine Returns the computed hash.
+     */
+    private function getHashForEntityIdentifier(array $ids)
+    {
+        $strings = array();
+        foreach ($ids as $id){
+            if (is_object($id) && $this->em->getMetadataFactory()->hasMetadataFor(get_class($id))) {
+                $oid = spl_object_hash($id);
+                if (isset($this->entityIdentifiers[$oid])) {
+                    $strings[] = $this->getHashForEntityIdentifier($this->entityIdentifiers[$oid]);
+                } else {
+                    $value = $this->em->getClassMetadata(get_class($id))->getIdentifierValues($id);
+                    $strings[] = $this->getHashForEntityIdentifier($value);
+                }
+            } else {
+                $strings[] = $id;
+            }
+        }
+        return implode(' ', $strings);
+    }
+    /**
      * Tries to find an entity with the given identifier in the identity map of
      * this UnitOfWork.
      *
@@ -2617,13 +2646,8 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function tryGetById($id, $rootClassName)
     {
-        $idHash = implode(' ', (array) $id);
-
-        if (isset($this->identityMap[$rootClassName][$idHash])) {
-            return $this->identityMap[$rootClassName][$idHash];
-        }
-
-        return false;
+        $idHash = $this->getHashForEntityIdentifier((array)$id);
+        return $this->tryGetByIdHash($idHash, $rootClassName);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/AssociationKeysChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AssociationKeysChainTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+require_once __DIR__ . '/../../TestInit.php';
+/**
+ * Functional tests for the Single Table Inheritance mapping strategy.
+ *
+ * @author robo
+ */
+class AssociationKeysChainTest extends \Doctrine\Tests\OrmFunctionalTestCase{
+    public function setUp(){
+        parent::setUp();
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChain0'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChainA'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChainB'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChainC'),
+        ));
+    }
+    public function testIssue()
+    {
+
+        $root = new AssociationKeysChain0();
+        $this->_em->persist($root);
+        $this->_em->flush();
+
+        $a = new AssociationKeysChainA();
+        $a->aId = $root;
+        $this->_em->persist($a);
+        $this->_em->flush();
+
+        $b = new AssociationKeysChainB();
+        $b->bId = $a;
+        $this->_em->persist($b);
+        $this->_em->flush();
+
+
+        $c = new AssociationKeysChainC();
+        $c->cId = $b;
+        $this->_em->persist($c);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+
+        $root = new AssociationKeysChain0();
+        $a = new AssociationKeysChainA();
+        $a->aId = $root;
+        $b = new AssociationKeysChainB();
+        $b->bId = $a;
+      
+
+        $cNew = $this->_em->getRepository(__NAMESPACE__ . '\AssociationKeysChainC')->findOneBy(array(
+            'cId'=>$b
+        ));
+        $this->assertNull($cNew);
+        
+    }
+}
+
+/**
+ * @Entity
+ */
+class AssociationKeysChain0
+{
+    /**
+     * @Id @Column(type="integer") @GeneratedValue
+     */
+    public $id;
+}
+/**
+ * @Entity
+ */
+class AssociationKeysChainA
+{
+    /**
+     * @OneToOne(targetEntity="AssociationKeysChain0") @id
+     * @JoinColumn(name="a_id", referencedColumnName="id")
+     */
+    public $aId;
+}
+
+/**
+ * @Entity
+ */
+class AssociationKeysChainB
+{
+    /**
+     * @OneToOne(targetEntity="AssociationKeysChainA") @id
+     * @JoinColumn(name="b_id", referencedColumnName="a_id")
+     */
+    public $bId;
+}
+/**
+ * @Entity
+ */
+class AssociationKeysChainC
+{
+    /**
+     * @OneToOne(targetEntity="AssociationKeysChainB") @id
+     * @JoinColumn(name="c_id", referencedColumnName="b_id")
+     */
+    public $cId;
+}
+

--- a/tests/Doctrine/Tests/ORM/Functional/AssociationKeysChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AssociationKeysChainTest.php
@@ -8,8 +8,10 @@ require_once __DIR__ . '/../../TestInit.php';
  *
  * @author robo
  */
-class AssociationKeysChainTest extends \Doctrine\Tests\OrmFunctionalTestCase{
-    public function setUp(){
+class AssociationKeysChainTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
         parent::setUp();
         $this->_schemaTool->createSchema(array(
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChain0'),
@@ -18,6 +20,7 @@ class AssociationKeysChainTest extends \Doctrine\Tests\OrmFunctionalTestCase{
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\AssociationKeysChainC'),
         ));
     }
+
     public function testIssue()
     {
 


### PR DESCRIPTION
Hi all!
This PR will add a better support for entities with association keys.

getType will check recursively to find a type for the identifier.
getIndividualValue will search recursively to find the identifier value

trygetById improved, using a recursive function to find an id value instead of implode functions (that cause exceptions if the identifier is an object and do not implements __toString method).  
