### PR TITLE
Fix QueryTest#testJoinQueries order

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -87,7 +87,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a ORDER BY a.id");
+        $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a ORDER BY a.topic");
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -87,7 +87,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a");
+        $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a ORDER BY a.id");
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[0]);


### PR DESCRIPTION
I don't know why, but sometimes postgres change the default order.

http://travis-ci.org/#!/doctrine/doctrine2/jobs/428335

I just add ORDER BY, I think that fix the problem. 
