### PR TITLE
Allow ExporterDrivers that implement the exportClassMetadata() function to return false

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -111,16 +111,18 @@ abstract class AbstractExporter
         }
 
         foreach ($this->_metadata as $metadata) {
-            $output = $this->exportClassMetadata($metadata);
-            $path = $this->_generateOutputPath($metadata);
-            $dir = dirname($path);
-            if ( ! is_dir($dir)) {
-                mkdir($dir, 0777, true);
+            //In case output is returned, write it to a file, skip otherwise
+            if($output = $this->exportClassMetadata($metadata)){
+                $path = $this->_generateOutputPath($metadata);
+                $dir = dirname($path);
+                if ( ! is_dir($dir)) {
+                    mkdir($dir, 0777, true);
+                }
+                if (file_exists($path) && !$this->_overwriteExistingFiles) {
+                    throw ExportException::attemptOverwriteExistingFile($path);
+                }
+                file_put_contents($path, $output);
             }
-            if (file_exists($path) && !$this->_overwriteExistingFiles) {
-                throw ExportException::attemptOverwriteExistingFile($path);
-            }
-            file_put_contents($path, $output);
         }
     }
 


### PR DESCRIPTION
Allow ExporterDrivers that implement the exportClassMetadata() function to return FALSE when no content is available/needs to be written to a file by the AbstractExporter, preventing empty files to be generated foreach processed ClassMetadataInfo instance.

I'm currently generating Data Transfer Object class for my Entities, but not all Entities require it. Based on an Annotation I determine which DTO's will be generated and return FALSE otherwise. Currently this 'negative' return is not respected and a lot of empty files are created.
