### PR TITLE
Add Configuration::setDefaultMetadataDriverImpl() method for convenience.

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -117,6 +117,16 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
+     * Sets default cache driver for metadata caching.
+     *
+     * @param array $paths
+     */
+    public function setDefaultMetadataDriverImpl($paths = array())
+    {
+        $this->setMetadataDriverImpl($this->newDefaultAnnotationDriver($paths));
+    }
+
+    /**
      * Add a new default annotation driver with a correctly configured annotation reader.
      *
      * @param array $paths


### PR DESCRIPTION
Current logic to setup Doctrine2 is a bit cluttered, because there's a circular dependency between $config and $driverImpl, which makes it impossible to configure things in Dependency Injection container.

``` php
$driverImpl = $config->newDefaultAnnotationDriver('/path/to/lib/MyProject/Entities');
$config->setMetadataDriverImpl($driverImpl);
```

```
  doctrine.config:
    class: \Doctrine\ORM\Configuration
    calls:
      - [setMetadataCacheImpl, ['@doctrine.metadata_cache']]
      - [setMetadataDriverImpl, ['@doctrine.metadata_driver']]
      ...
```

Configuration is not fully initialized (and not added to service map) when setMetadataDriverImpl is called, but then setMetadataDriverImpl needs to call Configuration's newDefaultAnnotationDriver. Dependency deadlock.

I think that simpliest way to solve is to introduce  setDefaultMetadataDriverImpl() method like this:

``` php
$config->setDefaultMetadataDriverImpl('/path/to/lib/MyProject/Entities');
```

```
  doctrine.config:
    class: \Doctrine\ORM\Configuration
    calls:
      - [setMetadataCacheImpl, ['@doctrine.metadata_cache']]
      - [setDefaultMetadataDriverImpl, ['/path/to/lib/MyProject/Entities']]
      ...
```

If you use non-default driver, you need to define everything explicitly anyway. 

For default one, now you need to read annotations class and copy logic from newDefaultAnnotationDriver to DI container map on your own.
