### PR TITLE
Add ProxyFactoryInterface to allow custom proxy factories

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -28,6 +28,7 @@ use Closure, Exception,
     Doctrine\ORM\Mapping\ClassMetadataFactory,
     Doctrine\ORM\Query\ResultSetMapping,
     Doctrine\ORM\Proxy\ProxyFactory,
+    Doctrine\ORM\Proxy\ProxyFactoryInterface,
     Doctrine\ORM\Query\FilterCollection;
 
 /**
@@ -93,7 +94,7 @@ class EntityManager implements ObjectManager
     /**
      * The proxy factory used to create dynamic proxies.
      *
-     * @var \Doctrine\ORM\Proxy\ProxyFactory
+     * @var \Doctrine\ORM\Proxy\ProxyFactoryInterface
      */
     private $proxyFactory;
 
@@ -743,11 +744,24 @@ class EntityManager implements ObjectManager
     /**
      * Gets the proxy factory used by the EntityManager to create entity proxies.
      *
-     * @return ProxyFactory
+     * @return ProxyFactoryInterface
      */
     public function getProxyFactory()
     {
         return $this->proxyFactory;
+    }
+
+
+    /**
+     * Changes the proxy factory used by the EntityManager to create entity proxies.
+     *
+     * @param \Doctrine\ORM\Proxy\ProxyFactoryInterface $proxy
+     * @return EntityManager
+     */
+    public function setProxyFactory(ProxyFactoryInterface $proxy)
+    {
+        $this->proxyFactory = $proxy;
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -30,7 +30,7 @@ use Doctrine\ORM\EntityManager,
  * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
  * @since 2.0
  */
-class ProxyFactory
+class ProxyFactory implements ProxyFactoryInterface
 {
     /** The EntityManager this factory is bound to. */
     private $_em;

--- a/lib/Doctrine/ORM/Proxy/ProxyFactoryInterface.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactoryInterface.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Proxy;
+
+/**
+ * This factory is used to create proxy objects for entities at runtime.
+ *
+ * @author Jan Dolecek <juzna.cz@gmail.com>
+ * @since 2.1
+ */
+interface ProxyFactoryInterface
+{
+    /**
+     * Gets a reference proxy instance for the entity of the given type and identified by
+     * the given identifier.
+     *
+     * @param string $className
+     * @param mixed $identifier
+     * @return object
+     */
+    function getProxy($className, $identifier);
+
+    /**
+     * Generates proxy classes for all given classes.
+     *
+     * @param array $classes The classes (ClassMetadata instances) for which to generate proxies.
+     * @param string $toDir The target directory of the proxy classes. If not specified, the
+     *                      directory configured on the Configuration of the EntityManager used
+     *                      by this factory is used.
+     */
+    function generateProxyClasses(array $classes, $toDir = null);
+}


### PR DESCRIPTION
I'd love to have my custom proxy factory used with ORM, which is not possible at the moment

(my experimental proxy https://github.com/juzna/doctrine2/commit/7822446036201b066e390b2e182cac1dc0c85430 and some comments about it http://blog.juzna.cz/2011/06/lazy-loading-in-php/)
