### PR TITLE
[DDC-1575] ClassMetadata should give the fully qualified class name to the naming strategy

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -68,7 +68,7 @@ class ClassMetadata extends ClassMetadataInfo implements IClassMetadata
         $namingStrategy  = $namingStrategy ?: new DefaultNamingStrategy();
         $this->reflClass = new ReflectionClass($entityName);
         $this->namespace = $this->reflClass->getNamespaceName();
-        $this->table['name'] = $namingStrategy->classToTableName($this->reflClass->getShortName());
+        $this->table['name'] = $namingStrategy->classToTableName($this->reflClass->getName());
         parent::__construct($this->reflClass->getName(),$namingStrategy); // do not use $entityName, possible case-problems
     }
 


### PR DESCRIPTION
http://www.doctrine-project.org/jira/browse/DDC-1575

Now the ClassMetadata passes the simple class name to the naming strategy, Would be better use the fqcn.
