### PR TITLE
Allow options attribute in @Column annotation and pass value to Schema\Column's platformOptions

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -340,6 +340,12 @@ class SchemaTool
         $options['platformOptions'] = array();
         $options['platformOptions']['version'] = $class->isVersioned && $class->versionField == $mapping['fieldName'] ? true : false;
 
+        if (isset($mapping['options'])) {
+            foreach ($mapping['options'] as $key => $value) {
+                $options['platformOptions'][$key] = $value;
+            }
+        }
+
         if(strtolower($columnType) == 'string' && $options['length'] === null) {
             $options['length'] = 255;
         }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -32,6 +32,21 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($schema->getTable('cms_users')->columnsAreIndexed(array('username')), "username column should be indexed.");
     }
 
+    public function testOptionsAnnotation()
+    {
+        $em = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $classes = array(
+            $em->getClassMetadata(__NAMESPACE__ . '\TestEntityWithOptionAnnotation'),
+        );
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        $expected = array('foo' => 'bar', 'baz' => array('key' => 'val'), 'version' => false);
+        $this->assertEquals($expected, $schema->getTable('TestEntityWithOptionAnnotation')->getColumn('test')->getPlatformOptions(), "options annotation are passed to the columns platformOptions");
+    }
+
     /**
      * @group DDC-200
      */
@@ -84,6 +99,20 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(count($classes), $listener->tableCalls);
         $this->assertTrue($listener->schemaCalled);
     }
+}
+
+/**
+ * @Entity
+ */
+class TestEntityWithOptionAnnotation
+{
+    /** @Id @Column */
+    private $id;
+
+    /**
+     * @Column(type="string", options={"foo": "bar", "baz": {"key": "val"}})
+     */
+    private $test;
 }
 
 class GenerateSchemaEventListener


### PR DESCRIPTION
This is similar to #217 but stores values in platformOptions instead of overwriting other attributes.

I know that the options attribute was intended to be removed, but @beberlei [raised hopes](https://github.com/doctrine/doctrine2/pull/217#issuecomment-3189039) that it could stay and be properly supported :-)
