### PR TITLE
enable set visibilty of class fields in EntityGenerator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -316,8 +316,7 @@ public function <methodName>()
      */
     public function setFieldVisibility($visibility)
     {
-        if($visibility != 'private' && $visibility != 'protected')
-        {
+        if ($visibility != 'private' && $visibility != 'protected') {
             throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -48,6 +48,15 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo,
 class EntityGenerator
 {
     /**
+     * Specifies class fields should be protected
+     */
+    const FIELD_VISIBLE_PROTECTED = 'protected';
+    /**
+     * Specifies class fields should be private
+     */
+    const FIELD_VISIBLE_PRIVATE = 'private';
+
+    /**
      * @var bool
      */
     private $_backupExisting = true;
@@ -86,8 +95,8 @@ class EntityGenerator
     /** Whether or not to re-generate entity class if it exists already */
     private $_regenerateEntityIfExists = false;
 
-	private $_fieldVisibility = 'private';
-	
+    private $_fieldVisibility = 'private';
+
     private static $_classTemplate =
 '<?php
 
@@ -150,7 +159,7 @@ public function <methodName>()
 {
 <spaces><collections>
 }
-';	
+';
 
     public function __construct()
     {
@@ -300,21 +309,21 @@ public function <methodName>()
     }
 
     /**
-     * Set whether or not to generate annotations for the entity
+     * Set the class fields visibility for the entity (can either be private or protected)
      *
      * @param bool $bool
      * @return void
      */
     public function setFieldVisibility($visibility)
     {
-		if($visibility != 'private' && $visibility != 'protected')
-		{
-			throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
-		}
-		
+        if($visibility != 'private' && $visibility != 'protected')
+        {
+            throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
+        }
+
         $this->_fieldVisibility = $visibility;
     }
-	
+
     /**
      * Set an annotation prefix.
      *

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -86,6 +86,8 @@ class EntityGenerator
     /** Whether or not to re-generate entity class if it exists already */
     private $_regenerateEntityIfExists = false;
 
+	private $_fieldVisibility = 'private';
+	
     private static $_classTemplate =
 '<?php
 
@@ -148,7 +150,7 @@ public function <methodName>()
 {
 <spaces><collections>
 }
-';
+';	
 
     public function __construct()
     {
@@ -297,6 +299,22 @@ public function <methodName>()
         $this->_generateAnnotations = $bool;
     }
 
+    /**
+     * Set whether or not to generate annotations for the entity
+     *
+     * @param bool $bool
+     * @return void
+     */
+    public function setFieldVisibility($visibility)
+    {
+		if($visibility != 'private' && $visibility != 'protected')
+		{
+			throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
+		}
+		
+        $this->_fieldVisibility = $visibility;
+    }
+	
     /**
      * Set an annotation prefix.
      *
@@ -699,7 +717,7 @@ public function <methodName>()
             }
 
             $lines[] = $this->_generateAssociationMappingPropertyDocBlock($associationMapping, $metadata);
-            $lines[] = $this->_spaces . 'private $' . $associationMapping['fieldName']
+            $lines[] = $this->_spaces . $this->_fieldVisibility . ' $' . $associationMapping['fieldName']
                      . ($associationMapping['type'] == 'manyToMany' ? ' = array()' : null) . ";\n";
         }
 
@@ -717,7 +735,7 @@ public function <methodName>()
             }
 
             $lines[] = $this->_generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
-            $lines[] = $this->_spaces . 'private $' . $fieldMapping['fieldName']
+            $lines[] = $this->_spaces . $this->_fieldVisibility . ' $' . $fieldMapping['fieldName']
                      . (isset($fieldMapping['default']) ? ' = ' . var_export($fieldMapping['default'], true) : null) . ";\n";
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -316,7 +316,7 @@ public function <methodName>()
      */
     public function setFieldVisibility($visibility)
     {
-        if ($visibility !== EntityGenerator::FIELD_VISIBLE_PRIVATE && $visibility !== EntityGenerator::FIELD_VISIBLE_PROTECTED) {
+        if ($visibility !== self::FIELD_VISIBLE_PRIVATE && $visibility !== self::FIELD_VISIBLE_PROTECTED) {
             throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -316,7 +316,7 @@ public function <methodName>()
      */
     public function setFieldVisibility($visibility)
     {
-        if ($visibility != 'private' && $visibility != 'protected') {
+        if ($visibility !== EntityGenerator::FIELD_VISIBLE_PRIVATE && $visibility !== EntityGenerator::FIELD_VISIBLE_PROTECTED) {
             throw new \InvalidArgumentException('Invalid provided visibilty (only private and protected are allowed): ' . $visibility);
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -26,6 +26,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
         $this->_generator->setUpdateEntityIfExists(true);
+		$this->_generator->setFieldVisibility('protected');
     }
 
     public function tearDown()
@@ -133,7 +134,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($reflClass->hasProperty('id'), "Regenerating keeps property 'id'.");
 
         $this->assertTrue($reflClass->hasProperty('test'), "Check for property test failed.");
-        $this->assertTrue($reflClass->getProperty('test')->isPrivate(), "Check for private property test failed.");
+        $this->assertTrue($reflClass->getProperty('test')->isProtected(), "Check for private property test failed.");
         $this->assertTrue($reflClass->hasMethod('getTest'), "Check for method 'getTest' failed.");
         $this->assertTrue($reflClass->getMethod('getTest')->isPublic(), "Check for public visibility of method 'getTest' failed.");
         $this->assertTrue($reflClass->hasMethod('setTest'), "Check for method 'getTest' failed.");

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -134,7 +134,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($reflClass->hasProperty('id'), "Regenerating keeps property 'id'.");
 
         $this->assertTrue($reflClass->hasProperty('test'), "Check for property test failed.");
-        $this->assertTrue($reflClass->getProperty('test')->isProtected(), "Check for private property test failed.");
+        $this->assertTrue($reflClass->getProperty('test')->isProtected(), "Check for protected property test failed.");
         $this->assertTrue($reflClass->hasMethod('getTest'), "Check for method 'getTest' failed.");
         $this->assertTrue($reflClass->getMethod('getTest')->isPublic(), "Check for public visibility of method 'getTest' failed.");
         $this->assertTrue($reflClass->hasMethod('setTest'), "Check for method 'getTest' failed.");

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -26,7 +26,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
         $this->_generator->setUpdateEntityIfExists(true);
-		$this->_generator->setFieldVisibility('protected');
+        $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
 
     public function tearDown()


### PR DESCRIPTION
This commit makes it possible to set the field visibility to private or protected of the generated entities (generated with EntityGenerator).
For example: One can then generate a "DefaultUser" class with protected fields, and subclass it. (Class User extends DefaultUser). That way you can regenerate the entities with Doctrine over and over again without interfering with additional developer code.

Also, some project codingstandards say "protected over private" so all entities should have protected fields so they can always be extended.

See: groups.google.com/group/doctrine-user/browse_thread/thread/77609f754ddea7de/051cfdbdf2cfaa03
