### PR TITLE
When using a ManyToMany relationship no listener is notified about any change to the owning entity

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -620,6 +620,15 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($class->associationMappings as $field => $assoc) {
             if (($val = $class->reflFields[$field]->getValue($entity)) !== null) {
                 $this->computeAssociationChanges($assoc, $val);
+                if (!isset($this->entityChangeSets[$oid]) &&
+                    $assoc['isOwningSide'] &&
+                    $assoc['type'] == ClassMetadata::MANY_TO_MANY &&
+                    $val instanceof PersistentCollection &&
+                    $val->isDirty()) {
+                    $this->entityChangeSets[$oid]   = array();
+                    $this->originalEntityData[$oid] = $actualData;
+                    $this->entityUpdates[$oid]      = $entity;
+                }
             }
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\ORM\Events;
+require_once __DIR__ . '/../../TestInit.php';
+
+/**
+ * ManyToManyEventTest
+ *
+ * @author Francisco Facioni <fran6co@gmail.com>
+ */
+class ManyToManyEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    /**
+     * @var PostUpdateListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+        $this->listener = new PostUpdateListener();
+        $evm = $this->_em->getEventManager();
+        $evm->addEventListener(Events::postUpdate, $this->listener);
+    }
+
+    public function testListenerShouldBeNotifiedOnlyWhenUpdating()
+    {
+        $user = $this->createNewValidUser();
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->assertFalse($this->listener->wasNotified);
+
+        $group = new CmsGroup();
+        $group->name = "admins";
+        $user->addGroup($group);
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->assertTrue($this->listener->wasNotified);
+    }
+
+    /**
+     * @return CmsUser
+     */
+    private function createNewValidUser()
+    {
+        $user = new CmsUser();
+        $user->username = 'fran6co';
+        $user->name = 'Francisco Facioni';
+        $group = new CmsGroup();
+        $group->name = "users";
+        $user->addGroup($group);
+        return $user;
+    }
+}
+
+class PostUpdateListener
+{
+    /**
+     * @var bool
+     */
+    public $wasNotified = false;
+
+    /**
+     * @param $args
+     */
+    public function postUpdate($args)
+    {
+        $this->wasNotified = true;
+    }
+}
+
+


### PR DESCRIPTION
What I'm doing with this patch is marking the entity for update when there is a modification in the ManyToMany relationship so the listeners are notified about it.

The main reason for this is for hooking up services like Solr or other indexers to update the entities even for ManyToMany relationships.

This is the followup for #255
