### PR TITLE
Added fix for collection->contains with many-to-many extra lazy fetchMode

### DIFF
--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -254,7 +254,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $uow = $this->_em->getUnitOfWork();
 
         // shortcut for new entities
-        if ($uow->getEntityState($element, UnitOfWork::STATE_NEW) == UnitOfWork::STATE_NEW) {
+        $entityState = $uow->getEntityState($element, UnitOfWork::STATE_NEW);
+        if ($entityState == UnitOfWork::STATE_NEW || 
+            ($entityState == UnitOfWork::STATE_MANAGED && $uow->isScheduledForInsert($element))) {
             return false;
         }
 

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -255,8 +255,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         // shortcut for new entities
         $entityState = $uow->getEntityState($element, UnitOfWork::STATE_NEW);
-        if ($entityState == UnitOfWork::STATE_NEW || 
-            ($entityState == UnitOfWork::STATE_MANAGED && $uow->isScheduledForInsert($element))) {
+        if ($entityState === UnitOfWork::STATE_NEW || 
+            ($entityState === UnitOfWork::STATE_MANAGED && $uow->isScheduledForInsert($element))) {
             return false;
         }
 
@@ -277,7 +277,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $uow = $this->_em->getUnitOfWork();
 
         // shortcut for new entities
-        if ($uow->getEntityState($element, UnitOfWork::STATE_NEW) == UnitOfWork::STATE_NEW) {
+        if ($uow->getEntityState($element, UnitOfWork::STATE_NEW) === UnitOfWork::STATE_NEW) {
             return false;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyExtraLazyContainsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyExtraLazyContainsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+require_once __DIR__ . '/../../TestInit.php';
+
+/**
+ * 
+ */
+class ManyToManyExtraLazyContainsTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->useModelSet('company');
+        parent::setUp();
+    }
+
+    public function testManyToManyExtraLazyContainsAddedPendingInsertEntityIsTrue()
+    {
+        $contract = new \Doctrine\Tests\Models\Company\CompanyFlexContract();
+
+        $this->_em->persist($contract);
+        $this->_em->flush();
+        
+        $this->_em->clear();
+        $contract = $this->_em->find('Doctrine\Tests\Models\Company\CompanyFlexContract', $contract->getId());
+        
+        $pendingInsertManager = new \Doctrine\Tests\Models\Company\CompanyManager();
+        $this->_em->persist($pendingInsertManager);
+        $contract->getManagers()->add($pendingInsertManager);
+        
+        $result = $contract->getManagers()->contains($pendingInsertManager);
+
+        $this->assertTrue($result);
+    }
+
+    public function testManyToManyExtraLazyContainsNonAddedPendingInsertEntityIsFalse()
+    {
+        $contract = new \Doctrine\Tests\Models\Company\CompanyFlexContract();
+
+        $this->_em->persist($contract);
+        $this->_em->flush();
+        
+        $this->_em->clear();
+        $contract = $this->_em->find('Doctrine\Tests\Models\Company\CompanyFlexContract', $contract->getId());
+        
+        $pendingInsertManager = new \Doctrine\Tests\Models\Company\CompanyManager();
+        $this->_em->persist($pendingInsertManager);
+        
+        $result = $contract->getManagers()->contains($pendingInsertManager);
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
That case previously triggered a PHP error along the lines of:

Notice: Undefined index: 0000000062a3a7690000000033c91b26 in doctrine/lib/Doctrine/ORM/UnitOfWork.php line 2202
#0 doctrine/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php(267): Doctrine\ORM\UnitOfWork->getEntityIdentifier(Object(Item))
#1 doctrine/lib/Doctrine/ORM/PersistentCollection.php(411): Doctrine\ORM\Persisters\ManyToManyPersister->contains(Object(Doctrine\ORM\PersistentCollection), Object(Item))
#2 Test.php(71): Doctrine\ORM\PersistentCollection->contains(Object(Item))
