### PR TITLE
Bugfix for crushing when git clone --recursive doctrine2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = git://github.com/symfony/Yaml.git
 [submodule "lib/vendor/doctrine-build-common"]
 	path = lib/vendor/doctrine-build-common
-	url = https://github.com/doctrine/doctrine-build-common.git
+	url = git://github.com/doctrine/doctrine-build-common.git


### PR DESCRIPTION
Bugfix for crushing when git clone --recursive doctrine2 without https-access users previlegies

Changed
https://github.com/doctrine/doctrine-build-common.git
to
git://github.com/doctrine/doctrine-build-common.git
with read-only access
