### PR TITLE
Add support for paginating WHERE NOT ... queries

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -120,7 +120,9 @@ class WhereInWalker extends TreeWalkerAdapter
                         $conditionalPrimary
                     ))
                 ));
-            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression) {
+            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
+                || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
+            ) {
                 $tmpPrimary = new ConditionalPrimary;
                 $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
                 $AST->whereClause->conditionalExpression = new ConditionalTerm(array(

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -107,5 +107,19 @@ class WhereInWalkerTest extends PaginationTestCase
                 "SELECT u0_.id AS id0, g1_.id AS id1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (1 = 1 AND 2 = 2 OR 3 = 3) AND u0_.id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $whereInQuery->getSql()
         );
     }
+
+    public function testWhereInQuery_WhereNot()
+    {
+        $query = $this->entityManager->createQuery(
+                        'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE NOT 1 = 2'
+        );
+        $whereInQuery = clone $query;
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
+
+        $this->assertEquals(
+                "SELECT u0_.id AS id0, g1_.id AS id1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (NOT 1 = 2) AND u0_.id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $whereInQuery->getSql()
+        );
+    }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -111,14 +111,14 @@ class WhereInWalkerTest extends PaginationTestCase
     public function testWhereInQuery_WhereNot()
     {
         $query = $this->entityManager->createQuery(
-                        'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE NOT 1 = 2'
+            'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE NOT 1 = 2'
         );
         $whereInQuery = clone $query;
         $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-                "SELECT u0_.id AS id0, g1_.id AS id1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (NOT 1 = 2) AND u0_.id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id0, g1_.id AS id1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (NOT 1 = 2) AND u0_.id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", $whereInQuery->getSql()
         );
     }
 }


### PR DESCRIPTION
The Pagination tool throws an exception on a DQL query like:

SELECT u FROM User u WHERE NOT (u INSTANCE OF Person)

This is because Paginate does not know about the
Doctrine\ORM\Query\AST\ConditionalFactor which implements the NOT
operator. This patch adds support for that.

Ported from beberlei/DoctrineExtentions as requested by @beberlei in PR#52
