### PR TITLE
No unique join column fields for Single Table inheritance type.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1217,7 +1217,7 @@ class ClassMetadataInfo implements ClassMetadata
 
             $uniqueContraintColumns = array();
             foreach ($mapping['joinColumns'] as $key => &$joinColumn) {
-                if ($mapping['type'] === self::ONE_TO_ONE) {
+                if ($mapping['type'] === self::ONE_TO_ONE && ! $this->isInheritanceTypeSingleTable()) {
                     if (count($mapping['joinColumns']) == 1) {
                         $joinColumn['unique'] = true;
                     } else {


### PR DESCRIPTION
When we have a Single Table Inheritance, and therefore, several classes that share the same table, we dont need an unique constraint for the joincolumn field.
## Example:

[ Main class 'Operation' ] => [ Subclass 'Rent' ]  1 - 1     [ Class Home ]
                                     => [ Subclass 'Sale' ]  1 - 1     [ Class Home ]

[ Table 'Operations' ]
- id
- discr
- home_id   -> we need a not unique field.
- [ ... ]
