### PR TITLE
fixes DDC-1471

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2292,6 +2292,18 @@ class UnitOfWork implements PropertyChangedListener
                     : $data[$fieldName];
             }
 
+            //convert objects to strings
+            foreach ($id as $fieldName => $value) {
+                if (is_object($value)) {
+                    if (method_exists($value, '__toString'))
+                         $id[$fieldName] = $value->__toString();
+                    else if ($value instanceof \DateTime)
+                        $id[$fieldName] = $value->getTimestamp();
+                    else
+                        throw new \Exception(get_class($value)." does not implement a __toString() method");
+                }
+            }
+
             $idHash = implode(' ', $id);
         } else {
             $idHash = isset($class->associationMappings[$class->identifier[0]])


### PR DESCRIPTION
This should fix a bug when a primary key is combined of a string/int field and a date field.
Now a DateTime object is converted to a timestamp value before imploding.

Should be possible to integrate in 2.1, too, but I´m not sure how to do that.
