### PR TITLE
Update lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -43,6 +43,6 @@ class GeneralCaseExpression extends Node
 
     public function dispatch($sqlWalker)
     {
-        return $sqlWalker->walkGeneralCaseExpression($this);
+        return $sqlWalker->walkGeneralStringCaseExpression($this);
     }
 }


### PR DESCRIPTION
Changed to make the CASE EXPRESSION uses strings into DQL's. 

e.g.  

```
$source = $this->em->createQueryBuilder()
    ->select('m')
            ->addSelect("CASE WHEN (date >= newDate) THEN 'Active' ELSE 'Inactive' END status")
    ->from('sys:Mask', 'm')
    ->orderBy('status', 'ASC');
```
