### PR TITLE
2.1.x

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -884,7 +884,8 @@ class ClassMetadataInfo implements ClassMetadata
             foreach ($mapping['joinColumns'] as $key => &$joinColumn) {
                 if ($mapping['type'] === self::ONE_TO_ONE) {
                     if (count($mapping['joinColumns']) == 1) {
-                        $joinColumn['unique'] = true;
+                        if(! isset($mapping['id']) || ! $mapping['id'])
+                            $joinColumn['unique'] = true;
                     } else {
                         $uniqueContraintColumns[] = $joinColumn['name'];
                     }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -884,8 +884,9 @@ class ClassMetadataInfo implements ClassMetadata
             foreach ($mapping['joinColumns'] as $key => &$joinColumn) {
                 if ($mapping['type'] === self::ONE_TO_ONE) {
                     if (count($mapping['joinColumns']) == 1) {
-                        if(! isset($mapping['id']) || ! $mapping['id'])
+                        if (! isset($mapping['id']) || ! $mapping['id']) {
                             $joinColumn['unique'] = true;
+                        }
                     } else {
                         $uniqueContraintColumns[] = $joinColumn['name'];
                     }

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -186,7 +186,6 @@ class DatabaseDriver implements Driver
         foreach ($columns as $column) {
             $fieldMapping = array();
             
-            
             if (in_array($column->getName(), $allForeignKeyColumns)) {
                 continue;
             } else if ($primaryKeyColumns && in_array($column->getName(), $primaryKeyColumns)) {
@@ -305,7 +304,7 @@ class DatabaseDriver implements Driver
             }
             
             //Here we need to check if $cols are the same as $primaryKeyColums
-            if(!array_diff($cols,$primaryKeyColumns)) {
+            if (!array_diff($cols,$primaryKeyColumns)) {
                 $metadata->mapOneToOne($associationMapping);
             }
             else {

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -293,10 +293,9 @@ class DatabaseDriver implements Driver
             $associationMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $localColumn, true);
             $associationMapping['targetEntity'] = $this->getClassNameForTable($foreignTable);
             
-            if ($primaryKeyColumns && in_array($localColumn, $primaryKeyColumns))
-                    {
-                         $associationMapping['id'] = true;
-                    }
+            if ($primaryKeyColumns && in_array($localColumn, $primaryKeyColumns)) {
+                $associationMapping['id'] = true;
+            }
 
             for ($i = 0; $i < count($cols); $i++) {
                 $associationMapping['joinColumns'][] = array(
@@ -305,15 +304,13 @@ class DatabaseDriver implements Driver
                 );
             }
             
-            
             //Here we need to check if $cols are the same as $primaryKeyColums
-            if(!array_diff($cols,$primaryKeyColumns))
+            if(!array_diff($cols,$primaryKeyColumns)) {
                 $metadata->mapOneToOne($associationMapping);
-            else
+            }
+            else {
                 $metadata->mapManyToOne($associationMapping);
-            
-
-
+            }
         }
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -291,7 +291,7 @@ class DatabaseDriver implements Driver
             $associationMapping = array();
             $associationMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $localColumn, true);
             $associationMapping['targetEntity'] = $this->getClassNameForTable($foreignTable);
-            
+
             if ($primaryKeyColumns && in_array($localColumn, $primaryKeyColumns)) {
                 $associationMapping['id'] = true;
             }
@@ -306,8 +306,7 @@ class DatabaseDriver implements Driver
             //Here we need to check if $cols are the same as $primaryKeyColums
             if (!array_diff($cols,$primaryKeyColumns)) {
                 $metadata->mapOneToOne($associationMapping);
-            }
-            else {
+            } else {
                 $metadata->mapManyToOne($associationMapping);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -185,12 +185,14 @@ class DatabaseDriver implements Driver
         $fieldMappings = array();
         foreach ($columns as $column) {
             $fieldMapping = array();
-            if ($primaryKeyColumns && in_array($column->getName(), $primaryKeyColumns)) {
-                $fieldMapping['id'] = true;
-            } else if (in_array($column->getName(), $allForeignKeyColumns)) {
+            
+            
+            if (in_array($column->getName(), $allForeignKeyColumns)) {
                 continue;
+            } else if ($primaryKeyColumns && in_array($column->getName(), $primaryKeyColumns)) {
+                $fieldMapping['id'] = true;
             }
-
+            
             $fieldMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $column->getName(), false);
             $fieldMapping['columnName'] = $column->getName();
             $fieldMapping['type'] = strtolower((string) $column->getType());
@@ -290,6 +292,11 @@ class DatabaseDriver implements Driver
             $associationMapping = array();
             $associationMapping['fieldName'] = $this->getFieldNameForColumn($tableName, $localColumn, true);
             $associationMapping['targetEntity'] = $this->getClassNameForTable($foreignTable);
+            
+            if ($primaryKeyColumns && in_array($localColumn, $primaryKeyColumns))
+                    {
+                         $associationMapping['id'] = true;
+                    }
 
             for ($i = 0; $i < count($cols); $i++) {
                 $associationMapping['joinColumns'][] = array(
@@ -297,7 +304,16 @@ class DatabaseDriver implements Driver
                     'referencedColumnName' => $fkCols[$i],
                 );
             }
-            $metadata->mapManyToOne($associationMapping);
+            
+            
+            //Here we need to check if $cols are the same as $primaryKeyColums
+            if(!array_diff($cols,$primaryKeyColumns))
+                $metadata->mapOneToOne($associationMapping);
+            else
+                $metadata->mapManyToOne($associationMapping);
+            
+
+
         }
     }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -812,10 +812,8 @@ public function <methodName>()
                 $lines[] = $this->_spaces . ' * @' . $this->_annotationsPrefix . 'Id';
             
                 if ($generatorType = $this->_getIdGeneratorTypeString($metadata->generatorType)) {
-                    $lines[] = $this->_spaces.' * @' . $this->_annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
+                    $lines[] = $this->_spaces . ' * @' . $this->_annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
                 }
-            
-
             }
 
             $type = null;

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -807,6 +807,16 @@ public function <methodName>()
 
         if ($this->_generateAnnotations) {
             $lines[] = $this->_spaces . ' *';
+            
+            if (isset($associationMapping['id']) && $associationMapping['id']) {
+                $lines[] = $this->_spaces . ' * @' . $this->_annotationsPrefix . 'Id';
+            
+                if ($generatorType = $this->_getIdGeneratorTypeString($metadata->generatorType)) {
+                    $lines[] = $this->_spaces.' * @' . $this->_annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
+                }
+            
+
+            }
 
             $type = null;
             switch ($associationMapping['type']) {


### PR DESCRIPTION
Make Reverse Engineering to support Primary Keys as Foreign Keys.

The origin of the problem:

While parsing database Doctrine2 creates 2 separate arrays - "field mappings" and "association mappings".
If the field is within table foreign keys, it goes to "association mappings", otherwise it goes to "field mappings".

With primary keys as foreign keys Doctrine2 behaves incorrectly - it adds it both to "field mappings" and "association mappings", creating a nasty MappingException::duplicateFieldMapping

Reworked the code so it adds it only to the "association mappings", creating a OneToOne mapping type.

I wonder why so few attention is payed to reverse engineering in the project.

When you introspect database it only creates unidirectional mappings, so you have to manually create an
inverse in other entities.

In Doctrine 1.x it was much-much better.
Reverse engineering is not evil. Is a thing really very important in many situations when you a have a huge existing database structure.
