### PR TITLE
Clear set of readOnlyObjects in UnitOfWork

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2192,6 +2192,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->collectionDeletions =
             $this->collectionUpdates =
             $this->extraUpdates =
+            $this->readOnlyObjects =
             $this->orphanRemovals = array();
 
             if ($this->commitOrderCalculator !== null) {


### PR DESCRIPTION
This fixes issues due to hash collisions, as spl_object_hash reuses hash values, when using clear interspersed within a bulk insert.
