### PR TITLE
Nullable assocations for entity generator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -707,6 +707,9 @@ public function <methodName>()
 
     private function _isAssociationIsNullable($associationMapping)
     {
+        if (isset($associationMapping['id']) && $associationMapping['id']) {
+            return false;
+        }
         if (isset($associationMapping['joinColumns'])) {
             $joinColumns = $associationMapping['joinColumns'];
         } else {


### PR DESCRIPTION
Hi all!
If an entity is identified thought another entity  (using @association-key), this entity can't be nullable
