### PR TITLE
Preserve camelcase when mapping existing database

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -360,7 +360,7 @@ class DatabaseDriver implements Driver
             return $this->namespace . $this->classNamesForTables[$tableName];
         }
 
-        return $this->namespace . Inflector::classify(strtolower($tableName));
+        return $this->namespace . Inflector::classify($tableName);
     }
 
     /**
@@ -376,8 +376,6 @@ class DatabaseDriver implements Driver
         if (isset($this->fieldNamesForColumns[$tableName]) && isset($this->fieldNamesForColumns[$tableName][$columnName])) {
             return $this->fieldNamesForColumns[$tableName][$columnName];
         }
-
-        $columnName = strtolower($columnName);
 
         // Replace _id if it is a foreignkey column
         if ($fk) {


### PR DESCRIPTION
CamelCase is now preserved when importing entities from existing database using Symfony's command 

php app/console doctrine:mapping:convert xml ./src/Acme/BlogBundle/Resources/config/doctrine/metadata/orm --from-database --force
