### PR TITLE
Cast Doctrine\ORM\Query\Expr\Comparison::$_rightExpr to integer when false to fix DDC-1683

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Comparison.php
+++ b/lib/Doctrine/ORM/Query/Expr/Comparison.php
@@ -49,7 +49,7 @@ class Comparison
     {
         $this->_leftExpr  = $leftExpr;
         $this->_operator  = $operator;
-        $this->_rightExpr = $rightExpr === false ? (int) $rightExpr : $rightExpr;
+        $this->_rightExpr = $rightExpr === false ? 0 : $rightExpr;
     }
 
     public function __toString()

--- a/lib/Doctrine/ORM/Query/Expr/Comparison.php
+++ b/lib/Doctrine/ORM/Query/Expr/Comparison.php
@@ -49,7 +49,7 @@ class Comparison
     {
         $this->_leftExpr  = $leftExpr;
         $this->_operator  = $operator;
-        $this->_rightExpr = $rightExpr;
+        $this->_rightExpr = $rightExpr === false ? (int) $rightExpr : $rightExpr;
     }
 
     public function __toString()


### PR DESCRIPTION
Hi

I posted the following bug report http://www.doctrine-project.org/jira/browse/DDC-1683 related to casting false values to strings.

``` php
// Doctrine\ORM\Query\Expr\Comparison
public function __construct($leftExpr, $operator, $rightExpr)
{
    $this->_leftExpr  = $leftExpr;
    $this->_operator  = $operator;
    $this->_rightExpr = $rightExpr === false ? (int) $rightExpr : $rightExpr;
}
```
