### PR TITLE
Fix Mapping Database Driver

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -130,18 +130,22 @@ class DatabaseDriver implements Driver
                 $allForeignKeyColumns = array_merge($allForeignKeyColumns, $foreignKey->getLocalColumns());
             }
 
-            $pkColumns = $table->getPrimaryKey()->getColumns();
-            sort($pkColumns);
-            sort($allForeignKeyColumns);
+            $pk = $table->getPrimaryKey();
+            if($pk !== null) {
+                $pkColumns = $pk->getColumns();
+                $pkColumns = $table->getPrimaryKey()->getColumns();
+                sort($pkColumns);
+                sort($allForeignKeyColumns);
 
-            if ($pkColumns == $allForeignKeyColumns && count($foreignKeys) == 2) {
-                $this->manyToManyTables[$tableName] = $table;
-            } else {
-                // lower-casing is necessary because of Oracle Uppercase Tablenames,
-                // assumption is lower-case + underscore separated.
-                $className = $this->getClassNameForTable($tableName);
-                $this->tables[$tableName] = $table;
-                $this->classToTableNames[$className] = $tableName;
+                if ($pkColumns == $allForeignKeyColumns && count($foreignKeys) == 2) {
+                    $this->manyToManyTables[$tableName] = $table;
+                } else {
+                    // lower-casing is necessary because of Oracle Uppercase Tablenames,
+                    // assumption is lower-case + underscore separated.
+                    $className = $this->getClassNameForTable($tableName);
+                    $this->tables[$tableName] = $table;
+                    $this->classToTableNames[$className] = $tableName;
+                }
             }
         }
     }


### PR DESCRIPTION
If the table primary key can't be found the code was throwing an exception. The fix checks for the primary key existance.
