### PR TITLE
Added failing test case for querying and joining on an associated inheri...

### DIFF
--- a/tests/Doctrine/Tests/Models/Document/Document.php
+++ b/tests/Doctrine/Tests/Models/Document/Document.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\Tests\Models\Document;
+
+/**
+ * @Entity
+ * @Table(name="document")
+ */
+class Document
+{
+    /**
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    protected $dataClass = null;
+
+    /**
+     * @ORM\OneToOne(targetEntity="DocumentData", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=true, onDelete="cascade")
+     */
+    protected $data = null;
+
+    /**
+     * @Column(type="integer")
+     */
+    private $version;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+    
+    public function setData(DocumentData $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData()
+    {
+        if (null === $this->data && null !== ($dataClass = $this->dataClass) && class_exists($dataClass)) {
+            $this->setData(new $dataClass());
+        }
+
+        return $this->data;
+    }
+
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    public function setVersion($version)
+    {
+        $this->version = $version;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Document/DocumentData.php
+++ b/tests/Doctrine/Tests/Models/Document/DocumentData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\Document;
+
+/**
+ * @Entity
+ * @Table(name="document_data")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"document_data"="DocumentData", "image_document_data"="ImageDocumentData"})
+ */
+abstract class DocumentData
+{
+    /**
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Document/ImageDocument.php
+++ b/tests/Doctrine/Tests/Models/Document/ImageDocument.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\Document;
+
+/**
+ * @Entity
+ * @Table(name="image_document")
+ */
+class ImageDocument extends Document
+{
+    protected $dataClass = 'Doctrine\Tests\Models\Document\ImageDocumentData';
+
+    public function setUrl($url)
+    {
+        $this->getData()->setUrl($url);
+    }
+
+    public function getUrl()
+    {
+        return $this->getData()->getUrl();
+    }
+}

--- a/tests/Doctrine/Tests/Models/Document/ImageDocumentData.php
+++ b/tests/Doctrine/Tests/Models/Document/ImageDocumentData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\Document;
+
+/**
+ * @Entity
+ * @Table(name="image_document_data")
+ */
+class ImageDocumentData extends DocumentData
+{
+    /**
+     * @Column(name="url", type="string", length=255, nullable=false)
+     */
+    private $url;
+
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1571,6 +1571,14 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c1_.id AS id3, c1_.completed AS completed4, c1_.hoursWorked AS hoursWorked5, c1_.pricePerHour AS pricePerHour6, c1_.maxPrice AS maxPrice7, c0_.discr AS discr8, c1_.discr AS discr9 FROM company_contracts c0_, company_contracts c1_ WHERE (c0_.discr IN ('fix') AND c1_.discr IN ('flexible', 'flexultra'))"
         );
     }
+
+    public function testJoiningOnInheritedAssociation()
+    {
+        $this->assertSqlGeneration(
+            "SELECT id, idd FROM Doctrine\Tests\Models\Document\ImageDocument id JOIN id.data idd WHERE idd INSTANCE OF Doctrine\Tests\Models\Document\ImageDocumentData AND id.version = 55 ORDER BY idd.url DESC",
+            "TBD"
+        );
+    }
 }
 
 


### PR DESCRIPTION
...tance hierarchy

I have written this (partial) failing unit test. When running the test, you'll receive the Semantical Exception as follows:

```
[Semantical Error] line 0, col 81 near 'idd WHERE idd': Error: Class Doctrine\Tests\Models\Document\ImageDocument has no association named data
```

I expect that either:
1. This is expected behaviour. In which case, I'll update the test to expect the semantical exception.
2. This is a bug (I do hope it is!). In which case, any thoughts on a fix?

Either way, such a query would be great to have in the documentation (including the semantical error), so that when searching for the error, the Doctrine docs appear.

FYI, this has come up from my recent work on trying to find a solution for large inheritance hierarchies (and join limits) and solving the problem by using single table inheritance and associating a "data" class on the base class of the large hierarchy.

P.S. I hope that I do not have a flawed understanding of the ORM and that I'm trying to construct an impossible query/mapping. If so, apologies :)
