### PR TITLE
Fixed fetch mapping in xsd

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -177,7 +177,7 @@
     <xs:restriction base="xs:token"> 
       <xs:enumeration value="EAGER"/> 
       <xs:enumeration value="LAZY"/>
-      <xs:enumeration value="EXTRALAZY"/>
+      <xs:enumeration value="EXTRA_LAZY"/>
     </xs:restriction> 
   </xs:simpleType>
 


### PR DESCRIPTION
It was 'EXTRALAZY' and the constant name in ClassMetadata is 'EXTRA_LAZY'.

It's really annoying that my IDE says it's a wrong attribute.
