### PR TITLE
Proposal: Support for default attribute in yaml mappings.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -263,6 +263,9 @@ class YamlDriver extends AbstractFileDriver
                 if (isset($fieldMapping['columnDefinition'])) {
                     $mapping['columnDefinition'] = $fieldMapping['columnDefinition'];
                 }
+                if (isset($fieldMapping['default'])) {
+                    $mapping['default'] = $fieldMapping['default'];
+                }
 
                 $metadata->mapField($mapping);
             }


### PR DESCRIPTION
There's probably a very good reason you don't already do this... please let me know if there is!

The EntityGenerator supports writing a default value for a property/column when generating a class, but the yaml driver doesn't pick this up. This tiny change makes it work - you can do something like:

```
Acme\MyBundle\Entity\MyObject:
  type: entity
  table: my_object
  fields:
    active:
      type: boolean
      default: true
```

and you end up with..

```
/**
 * @var boolean $active
 */
private $active = true;
```

Similar change would also work for the other drivers I guess.
