### PR TITLE
Removed LOCK_EX for writing Proxy class file

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -189,7 +189,7 @@ class ProxyFactory
             throw ProxyException::proxyDirectoryNotWritable();
         }
 
-        file_put_contents($fileName, $file, LOCK_EX);
+        file_put_contents($fileName, $file);
     }
 
     /**


### PR DESCRIPTION
LOCK_EX will not work on NFS and many other networked file systems.

Replaces #307
