### PR TITLE
In some weird situation the SimpleXmlIterator used to iterate on the ``$...

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -166,6 +166,9 @@ class XmlDriver extends AbstractFileDriver
             $metadata->table['options'] = $this->_parseOptions($xmlRoot->options->children());
         }
 
+        // The mapping assignement is done in 2 times as a bug might occurs on some php/xml lib versions
+        // The internal SimpleXmlIterator get resetted, to this generate a duplicate field exception
+        $mappings = array();
         // Evaluate <field ...> mappings
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $fieldMapping) {
@@ -213,10 +216,14 @@ class XmlDriver extends AbstractFileDriver
                     $mapping['options'] = $this->_parseOptions($fieldMapping->options->children());
                 }
 
-                $metadata->mapField($mapping);
+                $mappings[] = $mapping;
             }
         }
 
+        foreach ($mappings as $mapping) {
+             $metadata->mapField($mapping);
+        }
+        
         // Evaluate <id ...> mappings
         $associationIds = array();
         foreach ($xmlRoot->id as $idElement) {


### PR DESCRIPTION
...xmlRoot->field`property just get resetted. This solution avoid this situation. This problem occurs when Symfony2 warms up cache with autogenerate proxy to`true``
