### PR TITLE
2.1.x setDiscriminatorMap fix

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1642,7 +1642,7 @@ class ClassMetadataInfo implements ClassMetadata
                 if ( ! class_exists($className)) {
                     throw MappingException::invalidClassInDiscriminatorMap($className, $this->name);
                 }
-                if (is_subclass_of($className, $this->name)) {
+                if (is_subclass_of($className, $this->name) && ! in_array($className, $this->subClasses)) {
                     $this->subClasses[] = $className;
                 }
             }


### PR DESCRIPTION
Fixing a bug when calling setDiscriminatorMap from multiple sources (ie: from Events::loadClassMetadata and annotation).

http://www.doctrine-project.org/jira/browse/DDC-1763
