### PR TITLE
Removed dependency on common as required by dbal anyway

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": ">=5.3.2",
         "ext-pdo": "*",
-        "doctrine/common": "dev-master",
         "doctrine/dbal": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Not sure if this is the way to resolve this problem or not but I just tried to install dev-master using composer, doctrine/dbal and doctrine/common are both required in the "dev-master" versions but doctrine/dbal requires doctrine/common: >=2.2.0,<=2.2.99 which causes a conflict. Removing the dependency on doctrine/common would allow doctrine/dbal to install the version it requires. If this is not an ok solution then is there an alternative one?
