### PR TITLE
EntityGenerator will typehint core fields where applicable (DateTime)

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -802,7 +802,15 @@ public function <methodName>()
         $variableType = $typeHint ? $typeHint . ' ' : null;
 
         $types = \Doctrine\DBAL\Types\Type::getTypesMap();
-        $methodTypeHint = $typeHint && ! isset($types[$typeHint]) ? '\\' . $typeHint . ' ' : null;
+        $typehints = \Doctrine\DBAL\Types\Type::getTypeHintsMap();
+
+        if ($typeHint && ! isset($types[$typeHint])) {
+            $methodTypeHint = '\\' . $typeHint . ' ';
+        } elseif ($typeHint && isset($typehints[$typeHint])) {
+            $methodTypeHint = '\\' . $typehints[$typeHint] . ' ';
+        } else {
+            $methodTypeHint = null;
+        }
 
         $replacements = array(
           '<description>'       => ucfirst($type) . ' ' . $fieldName,

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -97,6 +97,14 @@ class EntityGenerator
 
     private $_fieldVisibility = 'private';
 
+    /** Map of field types requiring a core php class as a type hint */
+    private $_phpTypes = array(
+        \Doctrine\DBAL\Types\Type::DATE => 'DateTime',
+        \Doctrine\DBAL\Types\Type::DATETIME => 'DateTime',
+        \Doctrine\DBAL\Types\Type::DATETIMETZ => 'DateTime',
+        \Doctrine\DBAL\Types\Type::TIME => 'DateTime',
+    );
+
     private static $_classTemplate =
 '<?php
 
@@ -802,12 +810,11 @@ public function <methodName>()
         $variableType = $typeHint ? $typeHint . ' ' : null;
 
         $types = \Doctrine\DBAL\Types\Type::getTypesMap();
-        $typehints = \Doctrine\DBAL\Types\Type::getTypeHintsMap();
 
         if ($typeHint && ! isset($types[$typeHint])) {
             $methodTypeHint = '\\' . $typeHint . ' ';
-        } elseif ($typeHint && isset($typehints[$typeHint])) {
-            $methodTypeHint = '\\' . $typehints[$typeHint] . ' ';
+        } elseif ($typeHint && isset($this->_phpTypes[$typeHint])) {
+            $methodTypeHint = '\\' . $this->_phpTypes[$typeHint] . ' ';
         } else {
             $methodTypeHint = null;
         }


### PR DESCRIPTION
As per other PR (on dbal) - EntityGenerator doesn't currently do this. This PR adds it.

It requires the matching PR on dbal as well for the mapping info.

https://github.com/doctrine/dbal/pull/135
