### PR TITLE
add public has() method to filter collection.

### DIFF
--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -141,6 +141,18 @@ class FilterCollection
 
         return $filter;
     }
+    
+    /**
+     * Checks whether filter with given name is defined.
+     * 
+     * @param string $name Name of the filter.
+     *
+     * @return boolean
+     */
+    public function has($name)
+    {
+        return null !== $this->config->getFilterClassName($name);
+    }
 
     /**
      * Get an enabled filter from the collection.


### PR DESCRIPTION
Sorry if there is any reason why this is not implemented already.
This is useful when some feature, for example `soft-deleteable` filter may be optional.
