### PR TITLE
Fix identifier generator strategy for composite identifier

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -114,8 +114,16 @@ class YamlExporter extends AbstractExporter
             $fieldMappings[$name] = $fieldMapping;
         }
 
+        $idFieldNames = $metadata->getIdentifierFieldNames();
+        if (count($idFieldNames)==1){
         if ($idGeneratorType = $this->_getIdGeneratorTypeString($metadata->generatorType)) {
-            $ids[$metadata->getSingleIdentifierFieldName()]['generator']['strategy'] = $idGeneratorType;
+                $ids[$idFieldNames[0]]['generator']['strategy'] = $idGeneratorType;
+            }
+        }
+        else {
+            foreach($idFieldNames as $idField){
+                $ids[$idField]['generator']['strategy'] = 'NONE';
+            }
         }
 
         if ($ids) {


### PR DESCRIPTION
When using the ConvertMappingCommand on a schema that contain a table with a composite key, we got the exception:

```
Single id is not allowed on composite primary key in entity CollectionFields
```

This can be fix by setting the identifier strategy to NONE for composite identifier fields
