### PR TITLE
Lets make correct data structure

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -478,6 +478,13 @@ class ClassMetadataInfo implements ClassMetadata
     public $associationMappings = array();
 
     /**
+     * An array of quoted columns (to include all quoted columns of the Entity)
+     *
+     * @var array
+     */
+    public $quotedColumns = array();
+
+    /**
      * READ-ONLY: Flag indicating whether the identifier/primary key of the class is composite.
      *
      * @var boolean
@@ -1184,7 +1191,8 @@ class ClassMetadataInfo implements ClassMetadata
         } else {
             if ($mapping['columnName'][0] == '`') {
                 $mapping['columnName'] = trim($mapping['columnName'], '`');
-                $mapping['quoted'] = true;
+                //$mapping['quoted'] = true; //remove this atavizm
+                $this->quotedColumns[$mapping['columnName']] = true;
             }
         }
 
@@ -1349,6 +1357,13 @@ class ClassMetadataInfo implements ClassMetadata
 
         if (isset($mapping['joinColumns']) && $mapping['joinColumns']) {
             $mapping['isOwningSide'] = true;
+            foreach ($mapping['joinColumns'] as &$joinColumns)
+            {
+                if ($joinColumns['name'][0] == '`') {
+                    $joinColumns['name'] = trim($joinColumns['name'], '`');
+                    $this->quotedColumns[$joinColumns['name']] = true;
+                }
+            }
         }
 
         if ($mapping['isOwningSide']) {
@@ -2677,7 +2692,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getQuotedColumnName($field, $platform)
     {
-        return isset($this->fieldMappings[$field]['quoted'])
+        return isset($this->quotedColumns[$this->columnNames[$field]])
             ? $platform->quoteIdentifier($this->fieldMappings[$field]['columnName'])
             : $this->fieldMappings[$field]['columnName'];
     }


### PR DESCRIPTION
Dear all,

As you know Doctine2 supports explicit quoting of identifiers.

This is extremely useful for PostgreSQL where "TableName" and TableName(implicit lowercased) are 2 different things. That's why - please, do support explicit quoting with ` (back-ticks) in future.

Now a problem - you do not support quoting columns which are part of associations. Can you give me a reasonable answer why it should not be supported?

Now comes my first update - i think that keeping "quoted" property inside the fieldMapping array is globally wrong. "Quoted" is a property, related to a column, not field. For example, an association can consist of 2 joined columns, and 1 of them can be quoted (theoretically).

That's why a better choice to store "Quoted/Nonquoted"  properties in ClassMetadata level. I made an array quotedColumns for this and rewrote the function getQuotedColumnName to use it.

If you have time for short dispute, I may have a solution to make explicit quoting supported in join columns.

See related thread here:
http://www.doctrine-project.org/jira/browse/DDC-142

Last comment was
"After some discussion support for quoting join column names and discriminator column names has been dropped for the sake of simplicity.
Quoting table names and regular column names will continue to be supported.
The docs have been updated accordingly."

I can argue on this - my solution is even more simple.
