### PR TITLE
Composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=5.3.2",
         "ext-pdo": "*",
-        "doctrine/common": ">=2.2.0,<2.2.99",
-        "doctrine/dbal": ">=2.2.1,<2.2.99"
+        "doctrine/common": "2.2.*",
+        "doctrine/dbal": "2.2.*"
     },
     "autoload": {
         "psr-0": { "Doctrine\\ORM": "lib/" }


### PR DESCRIPTION
The ORM should accept using the 2.2 branch of DBAL and Common too, not only the tags (preferring the stable release should be done using the stability flag in composer at the project level)
