### PR TITLE
prevent the validator to stop with an "undefined array index"-error

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -152,16 +152,18 @@ class SchemaValidator
                 }
 
                 // Verify inverse side/owning side match each other
-                $targetAssoc = $targetMetadata->associationMappings[$assoc['inversedBy']];
-                if ($assoc['type'] == ClassMetadataInfo::ONE_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_ONE){
-                    $ce[] = "If association " . $class->name . "#" . $fieldName . " is one-to-one, then the inversed " .
-                            "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-one as well.";
-                } else if ($assoc['type'] == ClassMetadataInfo::MANY_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_MANY){
-                    $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-one, then the inversed " .
-                            "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-many.";
-                } else if ($assoc['type'] == ClassMetadataInfo::MANY_TO_MANY && $targetAssoc['type'] !== ClassMetadataInfo::MANY_TO_MANY){
-                    $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-many, then the inversed " .
-                            "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be many-to-many as well.";
+                if (array_key_exists($assoc['inversedBy'], $targetMetadata->associationMappings)) {
+                    $targetAssoc = $targetMetadata->associationMappings[$assoc['inversedBy']];
+                    if ($assoc['type'] == ClassMetadataInfo::ONE_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_ONE){
+                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is one-to-one, then the inversed " .
+                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-one as well.";
+                    } else if ($assoc['type'] == ClassMetadataInfo::MANY_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_MANY){
+                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-one, then the inversed " .
+                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-many.";
+                    } else if ($assoc['type'] == ClassMetadataInfo::MANY_TO_MANY && $targetAssoc['type'] !== ClassMetadataInfo::MANY_TO_MANY){
+                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-many, then the inversed " .
+                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be many-to-many as well.";
+                    }
                 }
             }
 


### PR DESCRIPTION
 while validating a wrong inversedBy Attribute.

The validation-error is caught correctly in the block above. Just the warning / notice stops the validator when using stricter error handling
