### PR TITLE
ValidateSchemaCommand dont't call exit() in execute()

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -84,6 +84,6 @@ EOT
             $output->write('<info>[Database] OK - The database schema is in sync with the mapping files.</info>' . "\n");
         }
 
-        exit($exit);
+        return $exit;
     }
 }


### PR DESCRIPTION
calling exit() in the command itself is not needed. Symfony Application calls exit() with the return exit code.

changing this into return makes the validateSchemaCommand usable in other commands as a sub-command
