### PR TITLE
Persistent and Called First ClassName

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -601,6 +601,11 @@ class ClassMetadataInfo implements ClassMetadata
         $this->name = $entityName;
         $this->rootEntityName = $entityName;
         $this->namingStrategy = $namingStrategy ?: new DefaultNamingStrategy();
+        /**
+         * Allow implementations to store the dynamic class name first in execution,
+         * after initialization
+         */
+        $this->namingStrategy->setClassName($this->name);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1358,7 +1358,7 @@ class ClassMetadataInfo implements ClassMetadata
                 // Apply default join column
                 $mapping['joinColumns'] = array(array(
                     'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
-                    'referencedColumnName' => $this->namingStrategy->referenceColumnName()
+                    'referencedColumnName' => $this->namingStrategy->referenceColumnName($this->name)
                 ));
             }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -601,11 +601,6 @@ class ClassMetadataInfo implements ClassMetadata
         $this->name = $entityName;
         $this->rootEntityName = $entityName;
         $this->namingStrategy = $namingStrategy ?: new DefaultNamingStrategy();
-        /**
-         * Allow implementations to store the dynamic class name first in execution,
-         * after initialization
-         */
-        $this->namingStrategy->setClassName($this->name);
     }
 
     /**
@@ -1185,7 +1180,7 @@ class ClassMetadataInfo implements ClassMetadata
 
         // Complete fieldName and columnName mapping
         if ( ! isset($mapping['columnName'])) {
-            $mapping['columnName'] = $this->namingStrategy->propertyToColumnName($mapping['fieldName']);
+            $mapping['columnName'] = $this->namingStrategy->propertyToColumnName($mapping['fieldName'], $this->name);
         } else {
             if ($mapping['columnName'][0] == '`') {
                 $mapping['columnName'] = trim($mapping['columnName'], '`');
@@ -1362,7 +1357,7 @@ class ClassMetadataInfo implements ClassMetadata
             if ( ! isset($mapping['joinColumns']) || ! $mapping['joinColumns']) {
                 // Apply default join column
                 $mapping['joinColumns'] = array(array(
-                    'name' => $this->namingStrategy->joinColumnName($mapping['fieldName']),
+                    'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                     'referencedColumnName' => $this->namingStrategy->referenceColumnName()
                 ));
             }
@@ -1379,10 +1374,10 @@ class ClassMetadataInfo implements ClassMetadata
                     }
                 }
                 if (empty($joinColumn['name'])) {
-                    $joinColumn['name'] = $this->namingStrategy->joinColumnName($mapping['fieldName']);
+                    $joinColumn['name'] = $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name);
                 }
                 if (empty($joinColumn['referencedColumnName'])) {
-                    $joinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName();
+                    $joinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName($this->name);
                 }
                 $mapping['sourceToTargetKeyColumns'][$joinColumn['name']] = $joinColumn['referencedColumnName'];
                 $mapping['joinColumnFieldNames'][$joinColumn['name']] = isset($joinColumn['fieldName'])
@@ -1445,27 +1440,27 @@ class ClassMetadataInfo implements ClassMetadata
         if ($mapping['isOwningSide']) {
             // owning side MUST have a join table
             if ( ! isset($mapping['joinTable']['name'])) {
-                $mapping['joinTable']['name'] = $this->namingStrategy->joinTableName($mapping['sourceEntity'], $mapping['targetEntity'], $mapping['fieldName']);
+                $mapping['joinTable']['name'] = $this->namingStrategy->joinTableName($mapping['sourceEntity'], $mapping['targetEntity'], $mapping['fieldName'], $this->name);
             }
             if ( ! isset($mapping['joinTable']['joinColumns'])) {
                 $mapping['joinTable']['joinColumns'] = array(array(
-                        'name' => $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity']),
-                        'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
+                        'name' => $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $this->name),
+                        'referencedColumnName' => $this->namingStrategy->referenceColumnName($this->name),
                         'onDelete' => 'CASCADE'));
             }
             if ( ! isset($mapping['joinTable']['inverseJoinColumns'])) {
                 $mapping['joinTable']['inverseJoinColumns'] = array(array(
-                        'name' => $this->namingStrategy->joinKeyColumnName($mapping['targetEntity']),
-                        'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
+                        'name' => $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $this->name),
+                        'referencedColumnName' => $this->namingStrategy->referenceColumnName($this->name),
                         'onDelete' => 'CASCADE'));
             }
 
             foreach ($mapping['joinTable']['joinColumns'] as &$joinColumn) {
                 if (empty($joinColumn['name'])) {
-                    $joinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $joinColumn['referencedColumnName']);
+                    $joinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $joinColumn['referencedColumnName'], $this->name);
                 }
                 if (empty($joinColumn['referencedColumnName'])) {
-                    $joinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName();
+                    $joinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName($this->name);
                 }
                 if (isset($joinColumn['onDelete']) && strtolower($joinColumn['onDelete']) == 'cascade') {
                     $mapping['isOnDeleteCascade'] = true;
@@ -1476,10 +1471,10 @@ class ClassMetadataInfo implements ClassMetadata
 
             foreach ($mapping['joinTable']['inverseJoinColumns'] as &$inverseJoinColumn) {
                 if (empty($inverseJoinColumn['name'])) {
-                    $inverseJoinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $inverseJoinColumn['referencedColumnName']);
+                    $inverseJoinColumn['name'] = $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $inverseJoinColumn['referencedColumnName'], $this->name);
                 }
                 if (empty($inverseJoinColumn['referencedColumnName'])) {
-                    $inverseJoinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName();
+                    $inverseJoinColumn['referencedColumnName'] = $this->namingStrategy->referenceColumnName($this->name);
                 }
                 if (isset($inverseJoinColumn['onDelete']) && strtolower($inverseJoinColumn['onDelete']) == 'cascade') {
                     $mapping['isOnDeleteCascade'] = true;

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -64,7 +64,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function joinColumnName($propertyName, $className = null)
     {
-        return $propertyName . '_' . $this->referenceColumnName();
+        return $propertyName . '_' . $this->referenceColumnName($className);
     }
 
     /**
@@ -82,6 +82,6 @@ class DefaultNamingStrategy implements NamingStrategy
     public function joinKeyColumnName($entityName, $referencedColumnName = null, $className = null)
     {
         return strtolower($this->classToTableName($entityName) . '_' .
-                ($referencedColumnName ?: $this->referenceColumnName()));
+                ($referencedColumnName ?: $this->referenceColumnName($className)));
     }
 }

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -30,13 +30,6 @@ namespace Doctrine\ORM\Mapping;
  */
 class DefaultNamingStrategy implements NamingStrategy
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function setClassName($className) 
-    {
-        
-    }
     
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -46,7 +46,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function propertyToColumnName($propertyName)
+    public function propertyToColumnName($propertyName, $className = null)
     {
         return $propertyName;
     }
@@ -54,7 +54,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function referenceColumnName()
+    public function referenceColumnName($className = null)
     {
         return 'id';
     }
@@ -62,7 +62,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinColumnName($propertyName)
+    public function joinColumnName($propertyName, $className = null)
     {
         return $propertyName . '_' . $this->referenceColumnName();
     }
@@ -70,7 +70,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
+    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null, $className = null)
     {
         return strtolower($this->classToTableName($sourceEntity) . '_' .
                 $this->classToTableName($targetEntity));
@@ -79,7 +79,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinKeyColumnName($entityName, $referencedColumnName = null)
+    public function joinKeyColumnName($entityName, $referencedColumnName = null, $className = null)
     {
         return strtolower($this->classToTableName($entityName) . '_' .
                 ($referencedColumnName ?: $this->referenceColumnName()));

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -33,6 +33,14 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
+    public function setClassName($className) 
+    {
+        
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function classToTableName($className)
     {
         if (strpos($className, '\\') !== false) {

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -62,7 +62,7 @@ interface NamingStrategy
      * @param string $className The fully-qualified class name
      * @return string A join column name
      */
-    function joinColumnName($propertyName, $className = null);
+    function joinColumnName($propertyName = null, $className = null);
 
     /**
      * Return a join table name

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -45,7 +45,7 @@ interface NamingStrategy
      * @param string $className The fully-qualified class name
      * @return string A column name
      */
-    function propertyToColumnName($propertyName = null, $className = null);
+    function propertyToColumnName($propertyName, $className = null);
 
     /**
      * Return the default reference column name
@@ -62,7 +62,7 @@ interface NamingStrategy
      * @param string $className The fully-qualified class name
      * @return string A join column name
      */
-    function joinColumnName($propertyName = null, $className = null);
+    function joinColumnName($propertyName, $className = null);
 
     /**
      * Return a join table name

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -31,6 +31,17 @@ namespace Doctrine\ORM\Mapping;
 interface NamingStrategy
 {
     /**
+     * Set the class name at any time, implementations can
+     * create more robust naming strategies:
+     * i.e. always add a table prefix (based on class name)
+     * to column names. See ClassMetadataInfo.php
+     *
+     * @param $className The fully-qualified class name
+     * @return null
+     */
+    function setClassName($className);
+
+    /**
      * Return a table name for an entity class
      *
      * @param string $className The fully-qualified class name

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -45,7 +45,7 @@ interface NamingStrategy
      * @param string $className The fully-qualified class name
      * @return string A column name
      */
-    function propertyToColumnName($propertyName, $className = null);
+    function propertyToColumnName($propertyName = null, $className = null);
 
     /**
      * Return the default reference column name

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -31,17 +31,6 @@ namespace Doctrine\ORM\Mapping;
 interface NamingStrategy
 {
     /**
-     * Set the class name at any time, implementations can
-     * create more robust naming strategies:
-     * i.e. always add a table prefix (based on class name)
-     * to column names. See ClassMetadataInfo.php
-     *
-     * @param $className The fully-qualified class name
-     * @return null
-     */
-    function setClassName($className);
-
-    /**
      * Return a table name for an entity class
      *
      * @param string $className The fully-qualified class name
@@ -53,24 +42,27 @@ interface NamingStrategy
      * Return a column name for a property
      *
      * @param string $propertyName A property
+     * @param string $className The fully-qualified class name
      * @return string A column name
      */
-    function propertyToColumnName($propertyName);
+    function propertyToColumnName($propertyName, $className = null);
 
     /**
      * Return the default reference column name
-     *
+     *     
+     * @param string $className The fully-qualified class name
      * @return string A column name
      */
-    function referenceColumnName();
+    function referenceColumnName($className = null);
 
     /**
      * Return a join column name for a property
      *
      * @param string $propertyName A property
+     * @param string $className The fully-qualified class name
      * @return string A join column name
      */
-    function joinColumnName($propertyName);
+    function joinColumnName($propertyName, $className = null);
 
     /**
      * Return a join table name
@@ -78,16 +70,18 @@ interface NamingStrategy
      * @param string $sourceEntity The source entity
      * @param string $targetEntity The target entity
      * @param string $propertyName A property
+     * @param string $className The fully-qualified class name
      * @return string A join table name
      */
-    function joinTableName($sourceEntity, $targetEntity, $propertyName = null);
+    function joinTableName($sourceEntity, $targetEntity, $propertyName = null, $className = null);
 
     /**
      * Return the foreign key column name for the given parameters
      *
      * @param string $entityName A entity
      * @param string $referencedColumnName A property
+     * @param string $className The fully-qualified class name
      * @return string A join column name
      */
-    function joinKeyColumnName($entityName, $referencedColumnName = null);
+    function joinKeyColumnName($entityName, $referencedColumnName = null, $className = null);
 }

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -35,14 +35,6 @@ class UnderscoreNamingStrategy implements NamingStrategy
      * @var integer
      */
     private $case;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setClassName($className) 
-    {
-        
-    }
     
     /**
      * Underscore naming strategy construct

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -80,7 +80,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function propertyToColumnName($propertyName)
+    public function propertyToColumnName($propertyName, $className = null)
     {
         return $this->underscore($propertyName);
     }
@@ -88,7 +88,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function referenceColumnName()
+    public function referenceColumnName($className = null)
     {
         return $this->case === CASE_UPPER ?  'ID' : 'id';
     }
@@ -96,7 +96,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinColumnName($propertyName)
+    public function joinColumnName($propertyName, $className = null)
     {
         return $this->underscore($propertyName) . '_' . $this->referenceColumnName();
     }
@@ -104,7 +104,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
+    public function joinTableName($sourceEntity, $targetEntity, $propertyName = null, $className = null)
     {
         return $this->classToTableName($sourceEntity) . '_' . $this->classToTableName($targetEntity);
     }
@@ -112,7 +112,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinKeyColumnName($entityName, $referencedColumnName = null)
+    public function joinKeyColumnName($entityName, $referencedColumnName = null, $className = null)
     {
         return $this->classToTableName($entityName) . '_' .
                 ($referencedColumnName ?: $this->referenceColumnName());

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -37,6 +37,14 @@ class UnderscoreNamingStrategy implements NamingStrategy
     private $case;
 
     /**
+     * {@inheritdoc}
+     */
+    public function setClassName($className) 
+    {
+        
+    }
+    
+    /**
      * Underscore naming strategy construct
      *
      * @param integer $case CASE_LOWER | CASE_UPPER


### PR DESCRIPTION
--Allow the use of the ClassName in Naming functions other than just setting the table name

I am using it to add a table name prefix to all of my columns within the table; 
as follows:

```
<?php
/**
* Author: Brian P Johnson
* Date: 5/24/12
* Time: 8:23 AM
*/
require_once('/usr/src/doctrine2-orm/lib/Doctrine/ORM/Mapping/NamingStrategy.php'); 
use Doctrine\ORM\Mapping\NamingStrategy;

class rateGeniusNamingStrategy implements NamingStrategy
{
    public $className = '';
    public $prefix = '';

    public function setClassName($className) {

        $this->className = $className;

        $className = 'AdverseActionNaming';
        $capString = preg_replace('/[^A-Z]/','',$className);
        if(strlen($capString) < 4)
        {
            $capString = substr($capString,0,1).substr($className,1,4-strlen($capString)).substr($capString,1,3);
        }

        $this->prefix = strtoupper($capString);
    }

public function classToTableName($className)
{
    $wordArray = preg_split('/(?=\p{Lu})/u', $className);
    $table_name_body = '';
    $count = 0;
    $word = "";
    foreach($wordArray as $word)
    {
        $table_name_body .= '_'.strtoupper($word);
        $count++;
    }
    return $this->prefix.$table_name_body;
}

public function propertyToColumnName($propertyName)
{
    $wordArray = preg_split('/(?=\p{Lu})/u', $propertyName);
    $column_name_body = '';
    foreach($wordArray as $word)
    {
        $column_name_body .= '_'.strtoupper($word);
    }
    return $this->prefix.$column_name_body;
}

public function referenceColumnName()
{
    return $this->prefix.'_ID';
}

public function joinColumnName($propertyName)
{
    $table_name_parts = preg_split('/_/',$this->joinTableName());
    return $this->prefix .'_' . $table_name_parts[0] . '_' . $this->referenceColumnName();
}

public function joinTableName($sourceEntity, $targetEntity, $propertyName = null)
{
    return strtoupper($this->classToTableName($sourceEntity) . '_' .
        $this->classToTableName($targetEntity));
}

public function joinKeyColumnName($entityName, $referencedColumnName = null)
{
    return strtoupper($this->classToTableName($entityName) . '_' .
        ($referencedColumnName ?: $this->referenceColumnName()));
}
```

}
