### PR TITLE
[WIP] DDC-1852 - Validating lifecycle callbacks in tools

### DIFF
--- a/UPGRADE_TO_2_3
+++ b/UPGRADE_TO_2_3
@@ -25,3 +25,11 @@ Also, related functions were affected:
 * setParameters($parameters) the argument $parameters can be either an key=>value array or an ArrayCollection instance
 * getParameters() now returns ArrayCollection instead of array
 * getParameter($key) now returns Parameter instance instead of parameter value
+
+# Lifecycle Callbacks
+
+The `@HasLifecycleCallbacks` has been deprecated: you can now put the lifecycle annotations on your entities' public
+methods without having to annotate the class itself. Also, the CLI tools can now detect invalid lifecycle callbacks.
+
+* Public method `Doctrine\ORM\Mapping\ClassMetadataInfo#validateLifecycleCallbacks` has been removed.
+* Public static method `Doctrine\ORM\Mapping\MappingException#lifecycleCallbackMethodNotFound` has been removed.

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -382,7 +382,6 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
 
         $class->validateIdentifier();
         $class->validateAssocations();
-        $class->validateLifecycleCallbacks($this->getReflectionService());
 
         // verify inheritance
         if (!$class->isMappedSuperclass && !$class->isInheritanceTypeNone()) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -902,23 +902,6 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
-     * Validate lifecycle callbacks
-     *
-     * @param ReflectionService $reflService
-     * @return void
-     */
-    public function validateLifecycleCallbacks($reflService)
-    {
-        foreach ($this->lifecycleCallbacks as $event => $callbacks) {
-            foreach ($callbacks as $callbackFuncName) {
-                if ( ! $reflService->hasPublicMethod($this->name, $callbackFuncName)) {
-                    throw MappingException::lifecycleCallbackMethodNotFound($this->name, $callbackFuncName);
-                }
-            }
-        }
-    }
-
-    /**
      * Gets the ReflectionClass instance of the mapped class.
      *
      * @return ReflectionClass
@@ -1831,7 +1814,7 @@ class ClassMetadataInfo implements ClassMetadata
         $mapping['sourceToTargetKeyColumns']    = null;
         $mapping['relationToSourceKeyColumns']  = null;
         $mapping['relationToTargetKeyColumns']  = null;
-        
+
         switch ($mapping['type']) {
             case self::ONE_TO_ONE:
                 $mapping = $this->_validateAndCompleteOneToOneMapping($mapping);

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -532,50 +532,47 @@ class AnnotationDriver implements Driver
             }
         }
 
-        // Evaluate @HasLifecycleCallbacks annotation
-        if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks'])) {
-            foreach ($class->getMethods() as $method) {
-                // filter for the declaring class only, callbacks from parents will already be registered.
-                if ($method->isPublic() && $method->getDeclaringClass()->getName() == $class->name) {
-                    $annotations = $this->_reader->getMethodAnnotations($method);
+        foreach ($class->getMethods() as $method) {
+            // filter for the declaring class only, callbacks from parents will already be registered.
+            if ($method->getDeclaringClass()->getName() == $class->name) {
+                $annotations = $this->_reader->getMethodAnnotations($method);
 
-                    if ($annotations && is_numeric(key($annotations))) {
-                        foreach ($annotations as $annot) {
-                            $annotations[get_class($annot)] = $annot;
-                        }
+                if ($annotations && is_numeric(key($annotations))) {
+                    foreach ($annotations as $annot) {
+                        $annotations[get_class($annot)] = $annot;
                     }
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PrePersist'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::prePersist);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PrePersist'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::prePersist);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PostPersist'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postPersist);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PostPersist'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postPersist);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PreUpdate'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preUpdate);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PreUpdate'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preUpdate);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PostUpdate'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postUpdate);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PostUpdate'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postUpdate);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PreRemove'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preRemove);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PreRemove'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preRemove);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PostRemove'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postRemove);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PostRemove'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postRemove);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PostLoad'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postLoad);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PostLoad'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::postLoad);
+                }
 
-                    if (isset($annotations['Doctrine\ORM\Mapping\PreFlush'])) {
-                        $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preFlush);
-                    }
+                if (isset($annotations['Doctrine\ORM\Mapping\PreFlush'])) {
+                    $metadata->addLifecycleCallback($method->getName(), \Doctrine\ORM\Events::preFlush);
                 }
             }
         }

--- a/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
+++ b/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ORM\Mapping;
 
 /**
+ * @deprecated This annotation is currently unused and will probably removed with future releases
  * @Annotation
  * @Target("CLASS")
  */

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -144,7 +144,7 @@ class MappingException extends \Doctrine\ORM\ORMException
     {
         return new self('Result set mapping named "'.$resultName.'" in "'.$entity.' requires a field name.');
     }
-    
+
     public static function nameIsMandatoryForSqlResultSetMapping($className)
     {
         return new self("Result set mapping name on entity class '$className' is not defined.");
@@ -411,11 +411,6 @@ class MappingException extends \Doctrine\ORM\ORMException
             "to be properly mapped in the inheritance hierachy. Alternatively you can make '".$className."' an abstract class " .
             "to avoid this exception from occuring."
         );
-    }
-
-    public static function lifecycleCallbackMethodNotFound($className, $methodName)
-    {
-        return new self("Entity '" . $className . "' has no method '" . $methodName . "' to be registered as lifecycle callback.");
     }
 
     public static function invalidFetchMode($className, $annotation)

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -37,7 +37,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo,
  *     $generator->setUpdateEntityIfExists(true);
  *     $generator->generate($classes, '/path/to/generate/entities');
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -679,10 +679,6 @@ public function <methodName>()
             if ($metadata->customRepositoryClassName) {
                 $lines[count($lines) - 1] .= '(repositoryClass="' . $metadata->customRepositoryClassName . '")';
             }
-
-            if (isset($metadata->lifecycleCallbacks) && $metadata->lifecycleCallbacks) {
-                $lines[] = ' * @' . $this->annotationsPrefix . 'HasLifecycleCallbacks';
-            }
         }
 
         $lines[] = ' */';
@@ -975,10 +971,10 @@ public function <methodName>()
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';
-            
+
             if (isset($associationMapping['id']) && $associationMapping['id']) {
                 $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'Id';
-            
+
                 if ($generatorType = $this->getIdGeneratorTypeString($metadata->generatorType)) {
                     $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
                 }

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -259,11 +259,8 @@ class SchemaValidator
 
                 $method = $class->reflClass->getMethod($callback);
                 if (!$method->isPublic()) {
-                    $ce[] = "A lifecycle callback for event '" . $name . "' is defined on "
-                        . ($method->isProtected() ? 'protected' : 'private')
-                        . " method '" . $class->name . "#" . $callback
-                        . "'. Only public methods can be used as callbacks.";
-                    continue;
+                    $ce[] = "A lifecycle callback for event '" . $name . "' is defined on " . ($method->isProtected() ? 'protected' : 'private')
+                        . " method '" . $class->name . "#" . $callback . "'. Only public methods can be used as callbacks.";
                 }
             }
         }

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -249,6 +249,25 @@ class SchemaValidator
             }
         }
 
+        foreach ($class->lifecycleCallbacks as $name => $callbacks) {
+            foreach ($callbacks as $callback) {
+                if (!$class->reflClass->hasMethod($callback)) {
+                    $ce[] = "A lifecycle callback for event '" . $name . "' is defined on non-existing method ".
+                        " '" . $class->name . "#" . $callback . "'.";
+                    continue;
+                }
+
+                $method = $class->reflClass->getMethod($callback);
+                if (!$method->isPublic()) {
+                    $ce[] = "A lifecycle callback for event '" . $name . "' is defined on "
+                        . ($method->isProtected() ? 'protected' : 'private')
+                        . " method '" . $class->name . "#" . $callback
+                        . "'. Only public methods can be used as callbacks.";
+                    continue;
+                }
+            }
+        }
+
         return $ce;
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -184,7 +184,7 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 }
 
-/** @Entity @HasLifecycleCallbacks */
+/** @Entity */
 class LifecycleCallbackTestUser {
     /** @Id @Column(type="integer") @GeneratedValue */
     private $id;
@@ -203,7 +203,6 @@ class LifecycleCallbackTestUser {
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  * @Table(name="lc_cb_test_entity")
  */
 class LifecycleCallbackTestEntity
@@ -288,7 +287,7 @@ class LifecycleCallbackCascader
     }
 }
 
-/** @MappedSuperclass @HasLifecycleCallbacks */
+/** @MappedSuperclass */
 class LifecycleCallbackParentEntity {
     /** @PrePersist */
     function doStuff() {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
@@ -89,7 +89,6 @@ class DDC1655Test extends \Doctrine\Tests\OrmFunctionalTestCase
  *    "foo" = "DDC1655Foo",
  *    "bar" = "DDC1655Bar"
  * })
- * @HasLifecycleCallbacks
  */
 class DDC1655Foo
 {
@@ -112,10 +111,7 @@ class DDC1655Foo
     }
 }
 
-/**
- * @Entity
- * @HasLifecycleCallbacks
- */
+/** @Entity */
 class DDC1655Bar extends DDC1655Foo
 {
     public $subLoaded;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -103,7 +103,6 @@ class DDC345Group
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  * @Table(name="ddc345_memberships", uniqueConstraints={
  *      @UniqueConstraint(name="ddc345_memship_fks", columns={"user_id","group_id"})
  * })

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
@@ -53,7 +53,6 @@ class DDC448MainTable
 /**
  * @Entity
  * @Table(name="connectedClass")
- * @HasLifecycleCallbacks
  */
 class DDC448ConnectedClass
 {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -481,7 +481,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
     {
 
         $factory = $this->createClassMetadataFactory();
-        
+
         $factory->getMetadataFor('Doctrine\Tests\Models\DDC889\DDC889Entity');
     }
 
@@ -490,7 +490,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testNamedNativeQuery()
     {
-        
+
         $class = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
 
         //named native query
@@ -519,7 +519,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertArrayHasKey('mapping-count', $class->sqlResultSetMappings);
         $this->assertArrayHasKey('mapping-find-all', $class->sqlResultSetMappings);
         $this->assertArrayHasKey('mapping-without-fields', $class->sqlResultSetMappings);
-        
+
         $findAllMapping = $class->getSqlResultSetMapping('mapping-find-all');
         $this->assertEquals('mapping-find-all', $findAllMapping['name']);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $findAllMapping['entities'][0]['entityClass']);
@@ -531,7 +531,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('mapping-without-fields', $withoutFieldsMapping['name']);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $withoutFieldsMapping['entities'][0]['entityClass']);
         $this->assertEquals(array(), $withoutFieldsMapping['entities'][0]['fields']);
-        
+
         $countMapping = $class->getSqlResultSetMapping('mapping-count');
         $this->assertEquals('mapping-count', $countMapping['name']);
         $this->assertEquals(array('name'=>'count'), $countMapping['columns'][0]);
@@ -619,7 +619,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $adminMetadata  = $factory->getMetadataFor('Doctrine\Tests\Models\DDC964\DDC964Admin');
         $guestMetadata  = $factory->getMetadataFor('Doctrine\Tests\Models\DDC964\DDC964Guest');
 
-        
+
         // assert groups association mappings
         $this->assertArrayHasKey('groups', $guestMetadata->associationMappings);
         $this->assertArrayHasKey('groups', $adminMetadata->associationMappings);
@@ -678,7 +678,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($guestAddress['isCascadeRefresh'], $adminAddress['isCascadeRefresh']);
         $this->assertEquals($guestAddress['isCascadeMerge'], $adminAddress['isCascadeMerge']);
         $this->assertEquals($guestAddress['isCascadeDetach'], $adminAddress['isCascadeDetach']);
-        
+
         // assert override
         $this->assertEquals('address_id', $guestAddress['joinColumns'][0]['name']);
         $this->assertEquals(array('address_id'=>'id'), $guestAddress['sourceToTargetKeyColumns']);
@@ -735,7 +735,6 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  * @Table(
  *  name="cms_users",
  *  uniqueConstraints={@UniqueConstraint(name="search_idx", columns={"name", "user_email"})},
@@ -1037,7 +1036,7 @@ class DDC807Entity
      * @GeneratedValue(strategy="NONE")
      **/
    public $id;
-   
+
    public static function loadMetadata(ClassMetadataInfo $metadata)
     {
          $metadata->mapField(array(

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -262,7 +262,6 @@ class MappedSuperClassInheritence
  * @Entity
  * @InheritanceType("JOINED")
  * @DiscriminatorMap({"parent" = "AnnotationParent", "child" = "AnnotationChild"})
- * @HasLifecycleCallbacks
  */
 class AnnotationParent
 {
@@ -288,10 +287,7 @@ class AnnotationParent
     }
 }
 
-/**
- * @Entity
- * @HasLifecycleCallbacks
- */
+/** @Entity */
 class AnnotationChild extends AnnotationParent
 {
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -340,7 +340,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser'
         ));
-        
+
         $this->assertEquals(array('USER_ID'=>'ID'), $oneToOneMetadata->associationMappings['user']['sourceToTargetKeyColumns']);
         $this->assertEquals(array('USER_ID'=>'USER_ID'), $oneToOneMetadata->associationMappings['user']['joinColumnFieldNames']);
         $this->assertEquals(array('ID'=>'USER_ID'), $oneToOneMetadata->associationMappings['user']['targetToSourceKeyColumns']);
@@ -348,7 +348,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('USER_ID', $oneToOneMetadata->associationMappings['user']['joinColumns'][0]['name']);
         $this->assertEquals('ID', $oneToOneMetadata->associationMappings['user']['joinColumns'][0]['referencedColumnName']);
 
-        
+
         $this->assertEquals('CMS_ADDRESS_CMS_USER', $manyToManyMetadata->associationMappings['user']['joinTable']['name']);
 
         $this->assertEquals(array('CMS_ADDRESS_ID','CMS_USER_ID'), $manyToManyMetadata->associationMappings['user']['joinTableColumns']);
@@ -770,7 +770,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        
+
         $cm->addSqlResultSetMapping(array(
             'name'      => 'find-all',
             'entities'  => array(
@@ -800,19 +800,6 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
 
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
-    }
-
-    /**
-     * @group DDC-659
-     */
-    public function testLifecycleCallbackNotFound()
-    {
-        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $cm->addLifecycleCallback('notfound', 'postLoad');
-
-        $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "Entity 'Doctrine\Tests\Models\CMS\CmsUser' has no method 'notfound' to be registered as lifecycle callback.");
-        $cm->validateLifecycleCallbacks(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\ORM\Tools\Export;
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  * @Table(name="cms_users")
  */
 class User

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -144,14 +144,7 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
     {
         $nonPublicCallbacks = $this->em->getClassMetadata(__NAMESPACE__ . '\DDC1852InvalidLifecycleCallbacks');
 
-        // annotation driver allows callbacks mapping public properties only. Mocking XML/YAML/PHP driver behavior here
-        $nonPublicCallbacks->lifecycleCallbacks = array(
-            \Doctrine\ORM\Events::prePersist => array(
-                'somePrivateMethod',
-                'someProtectedMethod',
-                'someNonExistingMethod',
-            ),
-        );
+        $nonPublicCallbacks->lifecycleCallbacks[\Doctrine\ORM\Events::prePersist][] = 'someNonExistingMethod';
         $ce = $this->validator->validateClass($nonPublicCallbacks);
 
         $this->assertEquals(
@@ -299,14 +292,16 @@ class DDC1649Three
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  */
 class DDC1852InvalidLifecycleCallbacks
 {
     /** @Id @Column */
     private $id;
 
+    /** @PrePersist */
     private function somePrivateMethod() {}
+
+    /** @PrePersist */
     protected function someProtectedMethod() {}
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../../TestInit.php';
 class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
 {
     /**
-     * @var EntityManager
+     * @var \Doctrine\ORM\EntityManager
      */
     private $em = null;
 
@@ -136,6 +136,38 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
             "The referenced column name 'id' has to be a primary key column on the target entity class 'Doctrine\Tests\ORM\Tools\DDC1649Two'."
         ), $ce);
     }
+
+    /**
+     * @group DDC-1852
+     */
+    public function testInvalidLifecycleCallbacks()
+    {
+        $nonPublicCallbacks = $this->em->getClassMetadata(__NAMESPACE__ . '\DDC1852InvalidLifecycleCallbacks');
+
+        // annotation driver allows callbacks mapping public properties only. Mocking XML/YAML/PHP driver behavior here
+        $nonPublicCallbacks->lifecycleCallbacks = array(
+            \Doctrine\ORM\Events::prePersist => array(
+                'somePrivateMethod',
+                'someProtectedMethod',
+                'someNonExistingMethod',
+            ),
+        );
+        $ce = $this->validator->validateClass($nonPublicCallbacks);
+
+        $this->assertEquals(
+            array(
+                "A lifecycle callback for event 'prePersist' is defined on private method '"
+                    . __NAMESPACE__ . "\DDC1852InvalidLifecycleCallbacks#somePrivateMethod'."
+                    . " Only public methods can be used as callbacks.",
+                "A lifecycle callback for event 'prePersist' is defined on protected method '"
+                    . __NAMESPACE__ . "\DDC1852InvalidLifecycleCallbacks#someProtectedMethod'."
+                    . " Only public methods can be used as callbacks.",
+                "A lifecycle callback for event 'prePersist' is defined on non-existing method  '"
+                    . __NAMESPACE__ . "\DDC1852InvalidLifecycleCallbacks#someNonExistingMethod'.",
+            ),
+            $ce
+        );
+    }
 }
 
 /**
@@ -204,7 +236,7 @@ class DDC1587ValidEntity1
     private $name;
 
     /**
-     * @var Identifier
+     * @var DDC1587ValidEntity2
      *
      * @OneToOne(targetEntity="DDC1587ValidEntity2", cascade={"all"}, mappedBy="agent")
      * @JoinColumn(name="pk", referencedColumnName="pk_agent")
@@ -263,5 +295,18 @@ class DDC1649Three
     /** @Id @ManyToOne(targetEntity="DDC1649Two") @JoinColumn(name="id",
      * referencedColumnName="id") */
     private $two;
+}
+
+/**
+ * @Entity
+ * @HasLifecycleCallbacks
+ */
+class DDC1852InvalidLifecycleCallbacks
+{
+    /** @Id @Column */
+    private $id;
+
+    private function somePrivateMethod() {}
+    protected function someProtectedMethod() {}
 }
 


### PR DESCRIPTION
This feature simply adds validation for lifecycle callbacks.

This PR introduces some BC Breaks:
1.  `Doctrine\ORM\Mapping\ClassMetadataInfo#validateLifecycleCallbacks()` has been dropped
2.  `Doctrine\ORM\Mapping\HasLifecycleCallbacks` has been deprecated as it is not checked anymore. This makes the `AnnotationDriver` slower at first run, but I think this is where caching solves the problem correctly
3.  Mappings have to be validated via tools, as runtime validation is incomplete anyway. Runtime validation of lifecycle callbacks is dropped.

[![Build Status](https://secure.travis-ci.org/Ocramius/doctrine2.png?branch=DDC-1852)](http://travis-ci.org/Ocramius/doctrine2)
