### PR TITLE
DDC-1860 - Composer arbitrary for CLI and composer/autoload.php in different paths

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -17,11 +17,12 @@
  * <http://www.doctrine-project.org>.
  */
 
-if (!@include __DIR__ . '/../../../autoload.php') {
-   die(<<<'EOT'
-This command can only be run when Doctrine is installed through Composer.
-EOT
-   );
+$previousDir = null;
+$currentDir = __DIR__;
+
+while ($previousDir !== $currentDir && !@include_once($currentDir . '/vendor/autoload.php')) {
+    $previousDir = $currentDir;
+    $currentDir = dirname($currentDir);
 }
 
 $configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';

--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -17,14 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-$previousDir = null;
-$currentDir = __DIR__;
-
-while ($previousDir !== $currentDir && !@include_once($currentDir . '/vendor/autoload.php')) {
-    $previousDir = $currentDir;
-    $currentDir = dirname($currentDir);
-}
-
+(@include_once __DIR__ . '/../vendor/autoload.php') || @include_once __DIR__ . '/../../../autoload.php';
 $configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';
 
 $helperSet = null;


### PR DESCRIPTION
DDC-1860 - Composer became a requirement to run CLI some time ago. This patch:
1.  Makes composer optional if the user defines his own autoloaders in `cli-config.php`
2.  Makes the CLI look for `vendor/composer.php` in various parent paths of the `bin` directory.
