### PR TITLE
De-deprecate transaction handling methods

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -192,8 +192,6 @@ class EntityManager implements ObjectManager
 
     /**
      * Starts a transaction on the underlying database connection.
-     *
-     * @deprecated Use {@link getConnection}.beginTransaction().
      */
     public function beginTransaction()
     {
@@ -234,8 +232,6 @@ class EntityManager implements ObjectManager
 
     /**
      * Commits a transaction on the underlying database connection.
-     *
-     * @deprecated Use {@link getConnection}.commit().
      */
     public function commit()
     {
@@ -244,8 +240,6 @@ class EntityManager implements ObjectManager
 
     /**
      * Performs a rollback on the underlying database connection.
-     *
-     * @deprecated Use {@link getConnection}.rollback().
      */
     public function rollback()
     {


### PR DESCRIPTION
As discussed with @beberlei over IRC, deprecating transaction handling methods make the API cleaner but testing of Entity Manager dependent components much messier. Also suggesting to use `$em->getConnection()->beginTransaction()` feels like a violation of the law of demeter.

Therefore this pull request would remove the deprecation warnings from `EntityManager::beginTransaction()`, `EntityManager::commit()`, `EntityManager::rollback()`.
