### PR TITLE
Doctrine\ORM\EntityManager::transactional() - return original value returned by user's function

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -227,7 +227,7 @@ class EntityManager implements ObjectManager
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
+            return $return;
         } catch (Exception $e) {
             $this->close();
             $this->conn->rollback();


### PR DESCRIPTION
Current behaviour of Doctrine\ORM\EntityManager::transactional() causes some troubles when we want to return a value that is considered FALSE (e.g. 0, empty string or NULL). Also returning TRUE makes no sense if errors are reported using exceptions.
