### PR TITLE
set metadata for interface to be able to fetch entites by interface name

### DIFF
--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -28,7 +28,7 @@ use Doctrine\ORM\EntityManager;
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @since  2.3
  */
-class PreLoadClassMetadataEventArgs extends EventArgs
+class OnClassMetadataNotFoundEventArgs extends EventArgs
 {
     /**
      * @var \Doctrine\ORM\Mapping\ClassMetadata

--- a/lib/Doctrine/ORM/Event/PreLoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreLoadClassMetadataEventArgs.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\ORM\EntityManager;
+
+/**
+ * Class that holds event arguments for a loadMetadata event.
+ *
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ * @since  2.3
+ */
+class PreLoadClassMetadataEventArgs extends EventArgs
+{
+    /**
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    private $className;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * Constructor.
+     *
+     * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadata
+     * @param \Doctrine\ORM\EntityManager $em
+     */
+    public function __construct($className, EntityManager $em)
+    {
+        $this->className = $className;
+        $this->em        = $em;
+    }
+
+    /**
+     * Retrieve associated ClassMetadata.
+     *
+     * @return \Doctrine\ORM\Mapping\ClassMetadataInfo
+     */
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
+    /**
+     * Retrieve associated EntityManager.
+     *
+     * @return \Doctrine\ORM\EntityManager
+     */
+    public function getEntityManager()
+    {
+        return $this->em;
+    }
+}
+

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -112,7 +112,7 @@ final class Events
      *
      * @var string
      */
-    const preLoadClassMetadata = 'preLoadClassMetadata';
+    const onClassMetadataNotFound = 'onClassMetadataNotFound';
 
     /**
      * The preFlush event occurs when the EntityManager#flush() operation is invoked,

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -106,6 +106,13 @@ final class Events
      * @var string
      */
     const loadClassMetadata = 'loadClassMetadata';
+    /**
+     * The preLoadClassMetadata event occurs before the mapping metadata for a
+     * class is loaded from a mapping source (annotations/xml/yaml).
+     *
+     * @var string
+     */
+    const preLoadClassMetadata = 'preLoadClassMetadata';
 
     /**
      * The preFlush event occurs when the EntityManager#flush() operation is invoked,

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -20,7 +20,10 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Event\PreLoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Events;
 
 /**
  * ResolveTargetEntityListener
@@ -31,13 +34,20 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @since 2.2
  */
-class ResolveTargetEntityListener
+class ResolveTargetEntityListener implements EventSubscriber
 {
     /**
      * @var array
      */
     private $resolveTargetEntities = array();
 
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::loadClassMetadata,
+            Events::preLoadClassMetadata
+        );
+    }
     /**
      * Add a target-entity class name to resolve to a new class name.
      *
@@ -50,6 +60,13 @@ class ResolveTargetEntityListener
     {
         $mapping['targetEntity'] = ltrim($newEntity, "\\");
         $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = $mapping;
+    }
+
+    public function preLoadClassMetadata(PreLoadClassMetadataEventArgs $args)
+    {
+        if (array_key_exists($args->getClassName(), $this->resolveTargetEntities)) {
+            $args->getEntityManager()->getClassMetadata($this->resolveTargetEntities[$args->getClassname()]['targetEntity']);
+        }
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -67,6 +67,12 @@ class ResolveTargetEntityListener
                 $this->remapAssociation($cm, $mapping);
             }
         }
+
+        foreach ($this->resolveTargetEntities as $interface => $data) {
+            if ($data['targetEntity'] == $cm->getName()) {
+                $args->getEntityManager()->getMetadataFactory()->setMetadataFor($interface, $cm);
+            }
+        }
     }
 
     private function remapAssociation($classMetadata, $mapping)

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -20,7 +20,7 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
-use Doctrine\ORM\Event\PreLoadClassMetadataEventArgs;
+use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
@@ -45,7 +45,7 @@ class ResolveTargetEntityListener implements EventSubscriber
     {
         return array(
             Events::loadClassMetadata,
-            Events::preLoadClassMetadata
+            Events::onClassMetadataNotFound
         );
     }
     /**
@@ -62,7 +62,7 @@ class ResolveTargetEntityListener implements EventSubscriber
         $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = $mapping;
     }
 
-    public function preLoadClassMetadata(PreLoadClassMetadataEventArgs $args)
+    public function onClassMetadataNotFound(OnClassMetadataNotFoundEventArgs $args)
     {
         if (array_key_exists($args->getClassName(), $this->resolveTargetEntities)) {
             $args->getEntityManager()->getClassMetadata($this->resolveTargetEntities[$args->getClassname()]['targetEntity']);

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Tools;
 
-use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 
@@ -32,7 +31,7 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->em = $this->_getTestEntityManager();
         $this->em->getConfiguration()->setMetadataDriverImpl($annotationDriver);
         $this->factory = $this->em->getMetadataFactory();
-        $this->listener = new ResolveTargetEntityListener;
+        $this->listener = new ResolveTargetEntityListener();
     }
 
     /**
@@ -51,7 +50,7 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
             'Doctrine\Tests\ORM\Tools\TargetEntity',
             array()
         );
-        $evm->addEventListener(Events::loadClassMetadata, $this->listener);
+        $evm->addEventSubscriber($this->listener);
 
         $this->assertNotNull($this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\ResolveTargetInterface'));
 

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -31,8 +31,7 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
 
         $this->em = $this->_getTestEntityManager();
         $this->em->getConfiguration()->setMetadataDriverImpl($annotationDriver);
-        $this->factory = new ClassMetadataFactory;
-        $this->factory->setEntityManager($this->em);
+        $this->factory = $this->em->getMetadataFactory();
         $this->listener = new ResolveTargetEntityListener;
     }
 
@@ -59,6 +58,8 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSame('Doctrine\Tests\ORM\Tools\ResolveTargetEntity', $meta['manyToOne']['targetEntity']);
         $this->assertSame('Doctrine\Tests\ORM\Tools\ResolveTargetEntity', $meta['oneToMany']['targetEntity']);
         $this->assertSame('Doctrine\Tests\ORM\Tools\TargetEntity', $meta['oneToOne']['targetEntity']);
+
+        $this->assertSame($cm, $this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\ResolveTargetInterface'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\ORM\Events;
 
 require_once __DIR__ . '/../../TestInit.php';
 

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -52,6 +52,9 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
             array()
         );
         $evm->addEventListener(Events::loadClassMetadata, $this->listener);
+
+        $this->assertNotNull($this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\ResolveTargetInterface'));
+
         $cm = $this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\ResolveTargetEntity');
         $meta = $cm->associationMappings;
         $this->assertSame('Doctrine\Tests\ORM\Tools\TargetEntity', $meta['manyToMany']['targetEntity']);


### PR DESCRIPTION
using the new ResolveTargetEntity functionality we noticed we needed another feature:

From the Symfony Bundle defining the interface, we'd like to be able to fetch entities by this very interface name, e.g.:

``` php
$em->find('Foo\BarBundle\Entity\PersonInterface', 1);
```

or

``` php
$em->getRepository('Foo\BarBundle\Entity\PersonInterface')->findAll();
```

This PR sets metadata for the interface when metadata for a class is loaded that the interface is configured for
