### PR TITLE
Invalid paginator query cloning

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -208,7 +208,11 @@ class Paginator implements \Countable, \IteratorAggregate
     {
         /* @var $cloneQuery Query */
         $cloneQuery = clone $query;
-        $cloneQuery->setParameters($query->getParameters());
+
+        foreach ($query->getParameters() as $parameter) {
+            $cloneQuery->setParameter($parameter->getName(), $parameter->getValue(), $parameter->getType());
+        }
+
         foreach ($query->getHints() as $name => $value) {
             $cloneQuery->setHint($name, $value);
         }

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -209,9 +209,7 @@ class Paginator implements \Countable, \IteratorAggregate
         /* @var $cloneQuery Query */
         $cloneQuery = clone $query;
 
-        foreach ($query->getParameters() as $parameter) {
-            $cloneQuery->setParameter($parameter->getName(), $parameter->getValue(), $parameter->getType());
-        }
+        $cloneQuery->setParameters(clone $query->getParameters());
 
         foreach ($query->getHints() as $name => $value) {
             $cloneQuery->setHint($name, $value);

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -128,6 +128,17 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         count($paginator);
     }
 
+    public function testCloneQuery()
+    {
+        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $paginator->getIterator();
+
+        $this->assertTrue($query->getParameters()->isEmpty());
+    }
+
     public function populate()
     {
         for ($i = 0; $i < 3; $i++) {


### PR DESCRIPTION
Hey!

I'm currently using Symfony 2.1 + Doctrine master branch + Pager fanta master branch.

I'm facing a vicious issue. 

The doctrine paginator is able to clone a query with his `cloneQuery` method. This method will only clone the query without this parameters & hints. The issue is the parameters is setted with the `setParameters` method which will only affect the ArrayCollection reference to the new query and so, shared the reference between the two queries.

This PR will clone the ArrayCollection instead of simply affect it.

Let me know if you need more information. :)
