### PR TITLE
DDC-1893 - Updating configuration to reflect latest Doctrine Common changes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,11 +1,32 @@
 # Upgrade to 2.3
 
-## Configuration
+## Configuration *BC Break*
 
-`Doctrine\ORM\Configuration#newDefaultAnnotationDriver` has been changed to reflect latest changes in Doctrine\Common.
-If you use it to have an AnnotationDriver configured with a SimpleAnnotationReader in your projects, you should from now
-on call `newDefaultAnnotationDriver` with its second parameter set to `true`. Otherwise, the default consumed reader
-will be the AnnotationReader, which uses the `@Namespace\AnnotationName` syntax.
+The default annotation syntax has been changed from `@Entity` to `@ORM\Entity`. If you still want to use the simplified
+version, you should use `Doctrine\Common\Annotations\SimpleAnnotationReader` for your AnnotationDriver or call
+`Doctrine\ORM\Configuration#newDefaultAnnotationDriver` with its second parameter set to `true`.
+
+ *  before:
+    ```php
+    <?php
+
+    /** @Entity */
+    class MyEntity
+    {
+    }
+    ```
+
+ *  after:
+    ```php
+    <?php
+
+    use Doctrine\ORM\Mapping as ORM;
+
+    /** @ORM\Entity */
+    class MyEntity
+    {
+    }
+    ```
 
 ## EntityGenerator add*() method generation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,33 +1,5 @@
 # Upgrade to 2.3
 
-## Configuration *BC Break*
-
-The default annotation syntax has been changed from `@Entity` to `@ORM\Entity`. If you still want to use the simplified
-version, you should use `Doctrine\Common\Annotations\SimpleAnnotationReader` for your AnnotationDriver or call
-`Doctrine\ORM\Configuration#newDefaultAnnotationDriver` with its second parameter set to `true`.
-
- *  before:
-    ```php
-    <?php
-
-    /** @Entity */
-    class MyEntity
-    {
-    }
-    ```
-
- *  after:
-    ```php
-    <?php
-
-    use Doctrine\ORM\Mapping as ORM;
-
-    /** @ORM\Entity */
-    class MyEntity
-    {
-    }
-    ```
-
 ## EntityGenerator add*() method generation
 
 When generating an add*() method for a collection the EntityGenerator will now not

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade to 2.3
 
+## Configuration
+
+`Doctrine\ORM\Configuration#newDefaultAnnotationDriver` has been changed to reflect latest changes in Doctrine\Common.
+If you use it to have an AnnotationDriver configured with a SimpleAnnotationReader in your projects, you should from now
+on call `newDefaultAnnotationDriver` with its second parameter set to `true`. Otherwise, the default consumed reader
+will be the AnnotationReader, which uses the `@Namespace\AnnotationName` syntax.
+
 ## EntityGenerator add*() method generation
 
 When generating an add*() method for a collection the EntityGenerator will now not
@@ -315,7 +322,7 @@ the association. Example:
         private $user;
         //...
     }
-    
+
     // SINCE BETA1
     // User class DOES NOT CHANGE
     class Address
@@ -325,7 +332,7 @@ the association. Example:
         private $user;
         //...
     }
-    
+
 Thus, the inversedBy attribute is the counterpart to the mappedBy attribute. This change
 was necessary to enable some simplifications and further performance improvements. We
 apologize for the inconvenience.
@@ -344,7 +351,7 @@ had a DQL query like this:
 
     [sql]
     SELECT u.id, u.name FROM User u
-    
+
 Since BETA1, simple state field path expressions in the select clause are used to select
 object fields as plain scalar values (something that was not possible before).
 To achieve the same result as previously (that is, a partial object with only id and name populated)
@@ -427,7 +434,7 @@ With new required method AbstractTask::buildDocumentation, its implementation de
 # Upgrade from 2.0-ALPHA2 to 2.0-ALPHA3
 
 This section details the changes made to Doctrine 2.0-ALPHA3 to make it easier for you
-to upgrade your projects to use this version.  
+to upgrade your projects to use this version.
 
 ## CLI Changes
 

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -126,22 +126,23 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
-     * Add a new default annotation driver with a correctly configured annotation reader. If $useDefaultNamespace is
-     * to true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
+     * Add a new default annotation driver with a correctly configured annotation reader. If $useSimpleAnnotationReader
+     * is true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
      * @param array $paths
-     * @param bool $useDefaultNamespace
+     * @param bool $useSimpleAnnotationReader
      * @return AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array(), $useDefaultNamespace = false)
+    public function newDefaultAnnotationDriver($paths = array(), $useSimpleAnnotationReader = false)
     {
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
-        if ($useDefaultNamespace) {
+        if ($useSimpleAnnotationReader) {
             // Register the ORM Annotations in the AnnotationRegistry
             $reader = new SimpleAnnotationReader();
             $reader->addNamespace('Doctrine\ORM\Mapping');
             $cachedReader = new CachedReader($reader, new ArrayCache());
+
             return new AnnotationDriver($cachedReader, (array) $paths);
         }
 

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -28,7 +28,9 @@ use Doctrine\Common\Cache\Cache,
     Doctrine\ORM\Mapping\QuoteStrategy,
     Doctrine\ORM\Mapping\DefaultQuoteStrategy,
     Doctrine\ORM\Mapping\NamingStrategy,
-    Doctrine\ORM\Mapping\DefaultNamingStrategy;
+    Doctrine\ORM\Mapping\DefaultNamingStrategy,
+    Doctrine\Common\Annotations\SimpleAnnotationReader,
+    Doctrine\Common\Annotations\CachedReader;
 
 /**
  * Configuration container for all configuration options of Doctrine.
@@ -124,45 +126,29 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
-     * Add a new default annotation driver with a correctly configured annotation reader.
+     * Add a new default annotation driver with a correctly configured annotation reader. If $useDefaultNamespace is
+     * to true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
      * @param array $paths
-     * @return Mapping\Driver\AnnotationDriver
+     * @param bool $useDefaultNamespace
+     * @return AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array())
+    public function newDefaultAnnotationDriver($paths = array(), $useDefaultNamespace = false)
     {
-        switch (true) {
-            case (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')):
-                // Register the ORM Annotations in the AnnotationRegistry
-                AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
+        AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
-                $reader = new \Doctrine\Common\Annotations\SimpleAnnotationReader();
-                $reader->addNamespace('Doctrine\ORM\Mapping');
-
-                $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new ArrayCache());
-                break;
-
-            case (version_compare(\Doctrine\Common\Version::VERSION, '2.1.0-DEV', '>=')):
-                // Register the ORM Annotations in the AnnotationRegistry
-                AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
-
-                $reader = new AnnotationReader();
-                $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Mapping\\');
-                $reader->setIgnoreNotImportedAnnotations(true);
-                $reader->setEnableParsePhpImports(false);
-
-                $reader = new \Doctrine\Common\Annotations\CachedReader(
-                    new \Doctrine\Common\Annotations\IndexedReader($reader), new ArrayCache()
-                );
-                break;
-
-            default:
-                $reader = new AnnotationReader();
-                $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Mapping\\');
-                break;
+        if ($useDefaultNamespace) {
+            // Register the ORM Annotations in the AnnotationRegistry
+            $reader = new SimpleAnnotationReader();
+            $reader->addNamespace('Doctrine\ORM\Mapping');
+            $cachedReader = new CachedReader($reader, new ArrayCache());
+            return new AnnotationDriver($cachedReader, (array) $paths);
         }
 
-        return new AnnotationDriver($reader, (array) $paths);
+        return new AnnotationDriver(
+            new CachedReader(new AnnotationReader(), new ArrayCache()),
+            (array) $paths
+        );
     }
 
     /**
@@ -180,8 +166,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Resolves a registered namespace alias to the full namespace.
      *
      * @param string $entityNamespaceAlias
+     * @throws ORMException
      * @return string
-     * @throws MappingException
      */
     public function getEntityNamespace($entityNamespaceAlias)
     {
@@ -195,8 +181,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Set the entity alias map
      *
-     * @param array $entityAliasMap
-     * @return void
+     * @param array $entityNamespaces
      */
     public function setEntityNamespaces(array $entityNamespaces)
     {
@@ -307,6 +292,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Gets a previously registered named DQL query.
      *
      * @param string $name The name of the query.
+     * @throws ORMException
      * @return string The DQL query.
      */
     public function getNamedQuery($name)
@@ -321,9 +307,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Adds a named native query to the configuration.
      *
-     * @param string $name The name of the query.
-     * @param string $sql The native SQL query string.
-     * @param ResultSetMapping $rsm The ResultSetMapping used for the results of the SQL query.
+     * @param string                 $name The name of the query.
+     * @param string                 $sql  The native SQL query string.
+     * @param Query\ResultSetMapping $rsm  The ResultSetMapping used for the results of the SQL query.
      */
     public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm)
     {
@@ -333,9 +319,10 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Gets the components of a previously registered named native query.
      *
-     * @param string $name The name of the query.
-     * @return array A tuple with the first element being the SQL string and the second
-     *          element being the ResultSetMapping.
+     * @param  string $name  The name of the query.
+     * @throws ORMException
+     * @return array         A tuple with the first element being the SQL string and the second
+     *                       element being the ResultSetMapping.
      */
     public function getNamedNativeQuery($name)
     {
@@ -377,6 +364,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name
      * @param string $className
+     * @throws ORMException
      */
     public function addCustomStringFunction($name, $className)
     {
@@ -428,6 +416,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name
      * @param string $className
+     * @throws ORMException
      */
     public function addCustomNumericFunction($name, $className)
     {
@@ -479,6 +468,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name
      * @param string $className
+     * @throws ORMException
      */
     public function addCustomDatetimeFunction($name, $className)
     {
@@ -548,7 +538,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Set a class metadata factory.
      *
-     * @param string $cmf
+     * @param string $cmfName
      */
     public function setClassMetadataFactoryName($cmfName)
     {
@@ -646,7 +636,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
         if ( ! isset($this->_attributes['namingStrategy'])) {
             $this->_attributes['namingStrategy'] = new DefaultNamingStrategy();
         }
-        
+
         return $this->_attributes['namingStrategy'];
     }
 

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -133,7 +133,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param bool $useSimpleAnnotationReader
      * @return AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array(), $useSimpleAnnotationReader = false)
+    public function newDefaultAnnotationDriver($paths = array(), $useSimpleAnnotationReader = true)
     {
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -32,7 +32,17 @@ class ORMException extends Exception
     public static function missingMappingDriverImpl()
     {
         return new self("It's a requirement to specify a Metadata Driver and pass it ".
-            "to Doctrine\ORM\Configuration::setMetadataDriverImpl().");
+            "to Doctrine\\ORM\\Configuration::setMetadataDriverImpl().");
+    }
+
+    public static function namedQueryNotFound($queryName)
+    {
+        return new self('Could not find a named query by the name "' . $queryName . '"');
+    }
+
+    public static function namedNativeQueryNotFound($nativeQueryName)
+    {
+        return new self('Could not find a named native query by the name "' . $nativeQueryName . '"');
     }
 
     public static function entityMissingForeignAssignedId($entity, $relatedEntity)
@@ -54,6 +64,7 @@ class ORMException extends Exception
             "you need to adjust the metadata mapping accordingly."
         );
     }
+
     public static function unrecognizedField($field)
     {
         return new self("Unrecognized field: $field");
@@ -110,7 +121,7 @@ class ORMException extends Exception
     }
 
     public static function invalidResultCacheDriver() {
-        return new self("Invalid result cache driver; it must implement \Doctrine\Common\Cache\Cache.");
+        return new self("Invalid result cache driver; it must implement Doctrine\\Common\\Cache\\Cache.");
     }
 
     public static function notSupported() {
@@ -142,7 +153,7 @@ class ORMException extends Exception
     public static function invalidEntityRepository($className)
     {
         return new self("Invalid repository class '".$className."'. ".
-                "it must be a Doctrine\ORM\EntityRepository.");
+                "it must be a Doctrine\\ORM\\EntityRepository.");
     }
 
     public static function missingIdentifierField($className, $fieldName)

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -114,7 +114,7 @@ class Setup
      * @param bool $useSimpleAnnotationReader
      * @return Configuration
      */
-    static public function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null, $useSimpleAnnotationReader = false)
+    static public function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null, $useSimpleAnnotationReader = true)
     {
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths, $useSimpleAnnotationReader));

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -111,12 +111,13 @@ class Setup
      * @param boolean $isDevMode
      * @param string $proxyDir
      * @param Cache $cache
+     * @param bool $useSimpleAnnotationReader
      * @return Configuration
      */
-    static public function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null)
+    static public function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null, $useSimpleAnnotationReader = false)
     {
         $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths));
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths, $useSimpleAnnotationReader));
         return $config;
     }
 

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -78,7 +78,7 @@ class EntityManagerMock extends \Doctrine\ORM\EntityManager
             $config = new \Doctrine\ORM\Configuration();
             $config->setProxyDir(__DIR__ . '/../Proxies');
             $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver());
+            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
         }
         if (is_null($eventManager)) {
             $eventManager = new \Doctrine\Common\EventManager();

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -65,7 +65,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $paths = array(__DIR__);
         $reflectionClass = new ReflectionClass(__NAMESPACE__ . '\ConfigurationTestAnnotationReaderChecker');
 
-        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths);
+        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths, false);
         $reader = $annotationDriver->getReader();
         $annotation = $reader->getMethodAnnotation(
             $reflectionClass->getMethod('namespacedAnnotationMethod'),
@@ -73,7 +73,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         );
         $this->assertInstanceOf('Doctrine\ORM\Mapping\PrePersist', $annotation);
 
-        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths, true);
+        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths);
         $reader = $annotationDriver->getReader();
         $annotation = $reader->getMethodAnnotation(
             $reflectionClass->getMethod('simpleAnnotationMethod'),

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\ORM\Mapping as AnnotationNamespace;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\ORMException;
+use ReflectionClass;
+use PHPUnit_Framework_TestCase;
+
+require_once __DIR__ . '/../TestInit.php';
+
+/**
+ * Tests for the Configuration object
+ * @author Marco Pivetta <ocramius@gmail.com>
+ */
+class ConfigurationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->configuration = new Configuration();
+    }
+
+    public function testSetGetProxyDir()
+    {
+        $this->assertSame(null, $this->configuration->getProxyDir()); // defaults
+
+        $this->configuration->setProxyDir(__DIR__);
+        $this->assertSame(__DIR__, $this->configuration->getProxyDir());
+    }
+
+    public function testSetGetAutoGenerateProxyClasses()
+    {
+        $this->assertSame(true, $this->configuration->getAutoGenerateProxyClasses()); // defaults
+
+        $this->configuration->setAutoGenerateProxyClasses(false);
+        $this->assertSame(false, $this->configuration->getAutoGenerateProxyClasses());
+    }
+
+    public function testSetGetProxyNamespace()
+    {
+        $this->assertSame(null, $this->configuration->getProxyNamespace()); // defaults
+
+        $this->configuration->setProxyNamespace(__NAMESPACE__);
+        $this->assertSame(__NAMESPACE__, $this->configuration->getProxyNamespace());
+    }
+
+    public function testSetGetMetadataDriverImpl()
+    {
+        $this->assertSame(null, $this->configuration->getMetadataDriverImpl()); // defaults
+
+        $metadataDriver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $this->configuration->setMetadataDriverImpl($metadataDriver);
+        $this->assertSame($metadataDriver, $this->configuration->getMetadataDriverImpl());
+    }
+
+    public function testNewDefaultAnnotationDriver()
+    {
+        $paths = array(__DIR__);
+        $reflectionClass = new ReflectionClass(__NAMESPACE__ . '\ConfigurationTestAnnotationReaderChecker');
+
+        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths);
+        $reader = $annotationDriver->getReader();
+        $annotation = $reader->getMethodAnnotation(
+            $reflectionClass->getMethod('namespacedAnnotationMethod'),
+            'Doctrine\ORM\Mapping\PrePersist'
+        );
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\PrePersist', $annotation);
+
+        $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths, true);
+        $reader = $annotationDriver->getReader();
+        $annotation = $reader->getMethodAnnotation(
+            $reflectionClass->getMethod('simpleAnnotationMethod'),
+            'Doctrine\ORM\Mapping\PrePersist'
+        );
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\PrePersist', $annotation);
+    }
+
+    public function testSetGetEntityNamespace()
+    {
+        $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__);
+        $this->assertSame(__NAMESPACE__, $this->configuration->getEntityNamespace('TestNamespace'));
+        $namespaces = array('OtherNamespace' => __NAMESPACE__);
+        $this->configuration->setEntityNamespaces($namespaces);
+        $this->assertSame($namespaces, $this->configuration->getEntityNamespaces());
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->getEntityNamespace('NonExistingNamespace');
+    }
+
+    public function testSetGetQueryCacheImpl()
+    {
+        $this->assertSame(null, $this->configuration->getQueryCacheImpl()); // defaults
+        $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
+        $this->configuration->setQueryCacheImpl($queryCacheImpl);
+        $this->assertSame($queryCacheImpl, $this->configuration->getQueryCacheImpl());
+    }
+
+    public function testSetGetHydrationCacheImpl()
+    {
+        $this->assertSame(null, $this->configuration->getHydrationCacheImpl()); // defaults
+        $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
+        $this->configuration->setHydrationCacheImpl($queryCacheImpl);
+        $this->assertSame($queryCacheImpl, $this->configuration->getHydrationCacheImpl());
+    }
+
+    public function testSetGetMetadataCacheImpl()
+    {
+        $this->assertSame(null, $this->configuration->getMetadataCacheImpl()); // defaults
+        $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
+        $this->configuration->setMetadataCacheImpl($queryCacheImpl);
+        $this->assertSame($queryCacheImpl, $this->configuration->getMetadataCacheImpl());
+    }
+
+    public function testAddGetNamedQuery()
+    {
+        $dql = 'SELECT u FROM User u';
+        $this->configuration->addNamedQuery('QueryName', $dql);
+        $this->assertSame($dql, $this->configuration->getNamedQuery('QueryName'));
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->getNamedQuery('NonExistingQuery');
+    }
+
+    public function testAddGetNamedNativeQuery()
+    {
+        $sql = 'SELECT * FROM user';
+        $rsm = $this->getMock('Doctrine\ORM\Query\ResultSetMapping');
+        $this->configuration->addNamedNativeQuery('QueryName', $sql, $rsm);
+        $fetched = $this->configuration->getNamedNativeQuery('QueryName');
+        $this->assertSame($sql, $fetched[0]);
+        $this->assertSame($rsm, $fetched[1]);
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->getNamedQuery('NonExistingQuery');
+    }
+
+    public function ensureProductionSettings()
+    {
+        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $this->configuration->setAutoGenerateProxyClasses(true);
+
+        try {
+            $this->configuration->ensureProductionSettings();
+            $this->fail('Didn\'t check all production settings');
+        } catch (ORMException $e) {}
+
+        $this->configuration->setQueryCacheImpl($cache);
+
+        try {
+            $this->configuration->ensureProductionSettings();
+            $this->fail('Didn\'t check all production settings');
+        } catch (ORMException $e) {}
+
+        $this->configuration->setMetadataCacheImpl($cache);
+
+        try {
+            $this->configuration->ensureProductionSettings();
+            $this->fail('Didn\'t check all production settings');
+        } catch (ORMException $e) {}
+
+        $this->configuration->setAutoGenerateProxyClasses(false);
+        $this->configuration->ensureProductionSettings();
+    }
+
+    public function testAddGetCustomStringFunction()
+    {
+        $this->configuration->addCustomStringFunction('FunctionName', __CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('FunctionName'));
+        $this->assertSame(null, $this->configuration->getCustomStringFunction('NonExistingFunction'));
+        $this->configuration->setCustomStringFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('OtherFunctionName'));
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->addCustomStringFunction('concat', __CLASS__);
+    }
+
+    public function testAddGetCustomNumericFunction()
+    {
+        $this->configuration->addCustomNumericFunction('FunctionName', __CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('FunctionName'));
+        $this->assertSame(null, $this->configuration->getCustomNumericFunction('NonExistingFunction'));
+        $this->configuration->setCustomNumericFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('OtherFunctionName'));
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->addCustomNumericFunction('abs', __CLASS__);
+    }
+
+    public function testAddGetCustomDatetimeFunction()
+    {
+        $this->configuration->addCustomDatetimeFunction('FunctionName', __CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('FunctionName'));
+        $this->assertSame(null, $this->configuration->getCustomDatetimeFunction('NonExistingFunction'));
+        $this->configuration->setCustomDatetimeFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('OtherFunctionName'));
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->addCustomDatetimeFunction('date_add', __CLASS__);
+    }
+
+    public function testAddGetCustomHydrationMode()
+    {
+        $this->assertSame(null, $this->configuration->getCustomHydrationMode('NonExisting'));
+        $this->configuration->addCustomHydrationMode('HydrationModeName', __CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getCustomHydrationMode('HydrationModeName'));
+    }
+
+    public function testSetGetClassMetadataFactoryName()
+    {
+        $this->assertSame('Doctrine\ORM\Mapping\ClassMetadataFactory', $this->configuration->getClassMetadataFactoryName());
+        $this->configuration->setClassMetadataFactoryName(__CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getClassMetadataFactoryName());
+    }
+
+    public function testAddGetFilters()
+    {
+        $this->assertSame(null, $this->configuration->getFilterClassName('NonExistingFilter'));
+        $this->configuration->addFilter('FilterName', __CLASS__);
+        $this->assertSame(__CLASS__, $this->configuration->getFilterClassName('FilterName'));
+    }
+
+    public function setDefaultRepositoryClassName()
+    {
+        $this->assertSame('Doctrine\ORM\EntityRepository', $this->configuration->getDefaultRepositoryClassName());
+        $repositoryClass = 'Doctrine\Tests\Models\DDC753\DDC753CustomRepository';
+        $this->configuration->setDefaultRepositoryClassName($repositoryClass);
+        $this->assertSame($repositoryClass, $this->configuration->getDefaultRepositoryClassName());
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+        $this->configuration->setDefaultRepositoryClassName(__CLASS__);
+    }
+
+    public function testSetGetNamingStrategy()
+    {
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\NamingStrategy', $this->configuration->getNamingStrategy());
+        $namingStrategy = $this->getMock('Doctrine\ORM\Mapping\NamingStrategy');
+        $this->configuration->setNamingStrategy($namingStrategy);
+        $this->assertSame($namingStrategy, $this->configuration->getNamingStrategy());
+    }
+
+    public function testSetGetQuoteStrategy()
+    {
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\QuoteStrategy', $this->configuration->getQuoteStrategy());
+        $quoteStrategy = $this->getMock('Doctrine\ORM\Mapping\QuoteStrategy');
+        $this->configuration->setQuoteStrategy($quoteStrategy);
+        $this->assertSame($quoteStrategy, $this->configuration->getQuoteStrategy());
+    }
+}
+
+class ConfigurationTestAnnotationReaderChecker
+{
+    /** @PrePersist */
+    public function simpleAnnotationMethod()
+    {
+    }
+
+    /** @AnnotationNamespace\PrePersist */
+    public function namespacedAnnotationMethod()
+    {
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -95,7 +95,7 @@ class LockAgentWorker
         $config->setProxyNamespace('MyProject\Proxies');
         $config->setAutoGenerateProxyClasses(true);
 
-        $annotDriver = $config->newDefaultAnnotationDriver(array(__DIR__ . '/../../../Models/'));
+        $annotDriver = $config->newDefaultAnnotationDriver(array(__DIR__ . '/../../../Models/'), true);
         $config->setMetadataDriverImpl($annotDriver);
 
         $cache = new \Doctrine\Common\Cache\ArrayCache();

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -342,7 +342,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
 
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver());
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
 
         $conn = static::$_sharedConn;
         $conn->getConfiguration()->setSQLLogger($this->_sqlLoggerStack);

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -76,7 +76,7 @@ abstract class OrmTestCase extends DoctrineTestCase
         $config = new \Doctrine\ORM\Configuration();
 
         $config->setMetadataCacheImpl($metadataCache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver());
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
         $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');


### PR DESCRIPTION
This PR fixes DDC-1893 (http://www.doctrine-project.org/jira/browse/DDC-1893).

The `getDefaultAnnotationDriver` method was changes to stop supporting older incompatible Doctrine Common versions in favour of the newer logic.

Also, changing logic so that the SimpleAnnotationReader is no more the
default one. An additional parameter for the method will allow using it (this is a _BC break_!)

The CS fixes that were additionally implemented (along with other minor changes
that do not affect BC compatibility are caused by a CS sniff via IDE.
