### PR TITLE
Changed commands to use command.name in the help

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputArgument,
 /**
  * Command to clear the metadata cache of the various cache drivers.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -52,20 +52,19 @@ class MetadataCommand extends Console\Command\Command
             )
         ));
 
-        $fullName = $this->getName();
         $this->setHelp(<<<EOT
-The <info>$fullName</info> command is meant to clear the metadata cache of associated Entity Manager.
+The <info>%command.name%</info> command is meant to clear the metadata cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.
 
 The execution type differ on how you execute the command.
 If you want to invalidate the entries (and not delete from cache instance), this command would do the work:
 
-<info>$fullName</info>
+<info>%command.name%</info>
 
 Alternatively, if you want to flush the cache provider using this command:
 
-<info>$fullName --flush</info>
+<info>%command.name% --flush</info>
 
 Finally, be aware that if <info>--flush</info> option is passed, not all cache providers are able to flush entries,
 because of a limitation of its execution nature.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputArgument,
 /**
  * Command to clear the query cache of the various cache drivers.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -52,20 +52,19 @@ class QueryCommand extends Console\Command\Command
             )
         ));
 
-        $fullName = $this->getName();
         $this->setHelp(<<<EOT
-The <info>$fullName</info> command is meant to clear the query cache of associated Entity Manager.
+The <info>%command.name%</info> command is meant to clear the query cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.
 
 The execution type differ on how you execute the command.
 If you want to invalidate the entries (and not delete from cache instance), this command would do the work:
 
-<info>$fullName</info>
+<info>%command.name%</info>
 
 Alternatively, if you want to flush the cache provider using this command:
 
-<info>$fullName --flush</info>
+<info>%command.name% --flush</info>
 
 Finally, be aware that if <info>--flush</info> option is passed, not all cache providers are able to flush entries,
 because of a limitation of its execution nature.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Input\InputArgument,
 /**
  * Command to clear the result cache of the various cache drivers.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -52,20 +52,19 @@ class ResultCommand extends Console\Command\Command
             )
         ));
 
-        $fullName = $this->getName();
         $this->setHelp(<<<EOT
-The <info>$fullName</info> command is meant to clear the result cache of associated Entity Manager.
+The <info>%command.name%</info> command is meant to clear the result cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.
 
 The execution type differ on how you execute the command.
 If you want to invalidate the entries (and not delete from cache instance), this command would do the work:
 
-<info>$fullName</info>
+<info>%command.name%</info>
 
 Alternatively, if you want to flush the cache provider using this command:
 
-<info>$fullName --flush</info>
+<info>%command.name% --flush</info>
 
 Finally, be aware that if <info>--flush</info> option is passed, not all cache providers are able to flush entries,
 because of a limitation of its execution nature.

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Command\Command;
 /**
  * Show information about mapped entities
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.1
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -40,7 +40,7 @@ class InfoCommand extends Command
             ->setName('orm:info')
             ->setDescription('Show basic information about all mapped entities')
             ->setHelp(<<<EOT
-The <info>doctrine:mapping:info</info> shows basic information about which
+The <info>%command.name%</info> shows basic information about which
 entities exist and possibly if their mapping information contains errors or
 not.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Input\InputArgument,
  * Command to generate the SQL needed to update the database schema to match
  * the current mapping information.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
@@ -68,20 +68,19 @@ class UpdateCommand extends AbstractCommand
             ),
         ));
 
-        $fullName = $this->getName();
         $this->setHelp(<<<EOT
-The <info>$fullName</info> command generates the SQL needed to
+The <info>%command.name%</info> command generates the SQL needed to
 synchronize the database schema with the current mapping metadata of the
 default entity manager.
 
 For example, if you add metadata for a new column to an entity, this command
 would generate and output the SQL needed to add the new column to the database:
 
-<info>$fullName --dump-sql</info>
+<info>%command.name% --dump-sql</info>
 
 Alternatively, you can execute the generated queries:
 
-<info>$fullName --force</info>
+<info>%command.name% --force</info>
 
 Finally, be aware that if the <info>--complete</info> option is passed, this
 task will drop all database assets (e.g. tables, etc) that are *not* described


### PR DESCRIPTION
The current code does not work for child classes: it gets the name too early as the child has not changed it yet at this point. using `%command;name%` replaces it only when the help needs to be displayed.

This is similar to doctrine/dbal#174
