### PR TITLE
DDC-1933 - Fixing cloning of QueryBuilder and adding related tests

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -429,7 +429,7 @@ class QueryBuilder
      *
      * @param mixed $key The key (index or name) of the bound parameter.
      *
-     * @return mixed The value of the bound parameter.
+     * @return Query\Parameter|null The value of the bound parameter.
      */
     public function getParameter($key)
     {
@@ -1169,5 +1169,13 @@ class QueryBuilder
                 $this->_dqlParts[$part] = clone $elements;
             }
         }
+
+        $parameters = array();
+
+        foreach ($this->parameters as $parameter) {
+            $parameters[] = clone $parameter;
+        }
+
+        $this->parameters = new ArrayCollection($parameters);
     }
 }

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -664,6 +664,23 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(2, $expr->count(), "Modifying the second query should affect the first one.");
     }
 
+    /**
+     * @group DDC-1933
+     */
+    public function testParametersAreCloned()
+    {
+        $originalQb = new QueryBuilder($this->_em);
+
+        $originalQb->setParameter('parameter1', 'value1');
+
+        $copy = clone $originalQb;
+        $copy->setParameter('parameter2', 'value2');
+
+        $this->assertCount(1, $originalQb->getParameters());
+        $this->assertSame('value1', $copy->getParameter('parameter1')->getValue());
+        $this->assertSame('value2', $copy->getParameter('parameter2')->getValue());
+    }
+
     public function testGetRootAlias()
     {
         $qb = $this->_em->createQueryBuilder()


### PR DESCRIPTION
This PR fixes DDC-1933 and mimics the behaviour of `Doctrine\ORM\AbstractQuery` in `Doctrine\ORM\QueryBuilder` when dealing with assigned parameters and `__clone`.
