### PR TITLE
Add possibility to cache annotations wih APC

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -60,8 +60,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
         $classAnnotations = $this->reader->getClassAnnotations($class);
 
-        if ($classAnnotations && is_numeric(key($classAnnotations))) {
-            foreach ($classAnnotations as $annot) {
+        if ($classAnnotations) {
+            foreach($classAnnotations as $key=>&$annot) {
+                if(!is_numeric($key)) continue;
                 $classAnnotations[get_class($annot)] = $annot;
             }
         }


### PR DESCRIPTION
APC has a bug - after apc_fetch is made, arrays loose their cursors. That is why is_numeric(key(...)) is not working
