### PR TITLE
DDC-1939 - Removing references to non-existing AssociationMapping class

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -294,7 +294,7 @@ final class PersistentCollection implements Collection, Selectable
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @return \Doctrine\ORM\Mapping\AssociationMapping
+     * @return array
      */
     public function getMapping()
     {

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -198,7 +198,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         // Composite identifier
-        $sourceClass = $this->_em->getClassMetadata(get_class($mapping->getOwner()));
+        $sourceClass = $this->_em->getClassMetadata(get_class($coll->getOwner()));
 
         foreach ($mapping['relationToSourceKeyColumns'] as $srcColumn) {
             $params[] = $identifier[$sourceClass->fieldNames[$srcColumn]];

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -21,7 +21,6 @@ namespace Doctrine\ORM\Proxy;
 
 use Doctrine\ORM\EntityManager,
     Doctrine\ORM\Mapping\ClassMetadata,
-    Doctrine\ORM\Mapping\AssociationMapping,
     Doctrine\Common\Util\ClassUtils;
 
 /**

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -96,7 +96,7 @@ class QueryException extends \Doctrine\ORM\ORMException
     }
 
     /**
-     * @param \Doctrine\ORM\Mapping\AssociationMapping $assoc
+     * @param array $assoc
      */
     public static function iterateWithFetchJoinCollectionNotAllowed($assoc)
     {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -20,7 +20,6 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo,
-    Doctrine\ORM\Mapping\AssociationMapping,
     Doctrine\Common\Util\Inflector,
     Doctrine\DBAL\Types\Type;
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
@@ -20,7 +20,6 @@
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo,
-    Doctrine\ORM\Mapping\AssociationMapping,
     Doctrine\ORM\Tools\EntityGenerator;
 
 /**


### PR DESCRIPTION
This fixes DDC-1939, which is caused by an overlooked usage of `Doctrine\ORM\Mapping\AssociationMapping`, which was removed.
