### PR TITLE
Fix typo in remove method template in entity generator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -143,7 +143,7 @@ public function <methodName>(<methodTypeHint>$<variableName>)
 '/**
  * <description>
  *
- * @param <variableType$<variableName>
+ * @param <variableType>$<variableName>
  */
 public function <methodName>(<methodTypeHint>$<variableName>)
 {


### PR DESCRIPTION
Single character change - fixes generated docblocks for removeXXX methods.

Before:

```
/**
 * Remove measurements
 *
 * @param <variableType$measurements
 */
 public function removeMeasurement(\My\Bundle\Entity\CalibrationMeasurement $measurements)
 {
     $this->measurements->removeElement($measurements);
 }
```

After:

```
/**
 * Remove measurements
 *
 * @param My\Bundle\Entity\Measurement $measurements
 */
 public function removeMeasurement(\My\Bundle\Entity\Measurement $measurements)
 {
     $this->measurements->removeElement($measurements);
 }
```
