### PR TITLE
Added the new DBAL 2.3 types in the EntityGenerator typehint map

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -154,6 +154,8 @@ class EntityGenerator
         Type::TEXT          => 'string',
         Type::BLOB          => 'string',
         Type::DECIMAL       => 'float',
+        Type::JSON_ARRAY    => 'array',
+        Type::SIMPLE_ARRAY  => 'array',
     );
 
     /**


### PR DESCRIPTION
This fixes the generated typehint for these new types.

@beberlei please backport it in 2.3 too
