### PR TITLE
Added function to return identifiers from proxy

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -383,6 +383,11 @@ class <proxyClassName> extends \<className> implements \Doctrine\ORM\Proxy\Proxy
         return $this->__isInitialized__;
     }
 
+    public function __getIdentifier()
+    {
+        return $this->_identifier;
+    }
+
     <methods>
 
     public function __sleep()


### PR DESCRIPTION
I needed a way to get the identfiers of a doctrine proxy immediately without going through the unit of work (not available)
or without actually waking up the entity. The proxy already has that information, I just added a public
getter.
