### PR TITLE
Add ODM embedded-like functionality

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -158,10 +158,12 @@ class SimpleObjectHydrator extends AbstractHydrator
                     return null;
                 }
 
+                $field = isset($class->mappedAssociationMappings[$this->_rsm->fieldMappings[$column]]) ? null : true;
+
                 return array(
                     'class' => $class,
                     'name'  => $this->_rsm->fieldMappings[$column],
-                    'field' => true,
+                    'field' => $field,
                 );
 
             case (isset($this->_rsm->relationMap[$column])):

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -374,6 +374,13 @@ class ClassMetadataInfo implements ClassMetadata
     public $columnNames = array();
 
     /**
+     * READ-ONLY: The mapped associations of the class.
+     *
+     * @var array
+     */
+    public $mappedAssociations = array();
+
+    /**
      * READ-ONLY: The discriminator value of this class.
      *
      * <b>This does only apply to the JOINED and SINGLE_TABLE inheritance mapping strategies

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2536,6 +2536,26 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
+     * Checks whether the class has any mapped associations.
+     *
+     * @return array
+     */
+    public function hasMappedAssociations()
+    {
+        return $this->mappedAssociations;
+    }
+
+    /**
+     * Return array of all mapped associations of the class.
+     *
+     * @return array
+     */
+    public function getMappedAssociations()
+    {
+        return $this->mappedAssociations;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function hasAssociation($fieldName)

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -823,6 +823,10 @@ class ClassMetadataInfo implements ClassMetadata
             $serialized[] = "customGeneratorDefinition";
         }
 
+        if ($this->mappedAssociations) {
+            $serialized[] = "mappedAssociations";
+        }
+
         return $serialized;
     }
 
@@ -860,6 +864,10 @@ class ClassMetadataInfo implements ClassMetadata
             $this->reflFields[$field] = isset($mapping['declared'])
                 ? $reflService->getAccessibleProperty($mapping['declared'], $field)
                 : $reflService->getAccessibleProperty($this->name, $field);
+        }
+
+        foreach ($this->mappedAssociations as $field => $mapping) {
+            $this->reflFields[$field] = $reflService->getAccessibleProperty($this->name, $field);
         }
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2102,8 +2102,8 @@ class ClassMetadataInfo implements ClassMetadata
      * Add a mapped association to the class
      *
      * @param array $mapping
+     *
      * @throws MappingException
-     * @return void
      */
     public function addMappedAssociation(array $mapping)
     {

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -42,7 +42,6 @@ class DefaultQuoteStrategy implements QuoteStrategy
 
     /**
      * {@inheritdoc}
-     * TODO MappedEntity: add to interface and remaining strategies
      */
     public function getMappedAssociationDescriminatorColumnName(array $assoc, ClassMetadata $class, AbstractPlatform $platform)
     {

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -42,6 +42,17 @@ class DefaultQuoteStrategy implements QuoteStrategy
 
     /**
      * {@inheritdoc}
+     * TODO MappedEntity: add to interface and remaining strategies
+     */
+    public function getMappedAssociationDescriminatorColumnName(array $assoc, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        return isset($assoc['fieldMapping']['quoted'])
+            ? $platform->quoteIdentifier($assoc['fieldMapping']['columnName'])
+            : $assoc['fieldMapping']['columnName'];
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function getTableName(ClassMetadata $class, AbstractPlatform $platform)
     {

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -56,7 +56,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
      */
     public function getTableName(ClassMetadata $class, AbstractPlatform $platform)
     {
-        return isset($class->table['quoted']) 
+        return isset($class->table['quoted'])
             ? $platform->quoteIdentifier($class->table['name'])
             : $class->table['name'];
     }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -400,6 +400,18 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 $metadata->mapManyToMany($mapping);
             }
+
+            // Evaluate MappedAssociation annotation
+            $mappedAssociation = array();
+            if ($mappedAssocAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\MappedAssociation')) {
+                $mappedAssociation['name'] = $property->getName();
+                $mappedAssociation['fieldMapping'] = array (
+                    'columnName' => $mappedAssocAnnot->discriminatorColumn,
+                    'length'     => $mappedAssocAnnot->length,
+                    'nullable'   => $mappedAssocAnnot->nullable,
+                );
+                $metadata->addMappedAssociation($mappedAssociation);
+            }
         }
 
         // Evaluate AssociationOverrides annotation

--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -64,3 +64,4 @@ require_once __DIR__.'/../AssociationOverride.php';
 require_once __DIR__.'/../AssociationOverrides.php';
 require_once __DIR__.'/../AttributeOverride.php';
 require_once __DIR__.'/../AttributeOverrides.php';
+require_once __DIR__.'/../MappedAssociation.php';

--- a/lib/Doctrine/ORM/Mapping/MappedAssociation.php
+++ b/lib/Doctrine/ORM/Mapping/MappedAssociation.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Mapping;
+
+/**
+ * @Annotation
+ * @Target("PROPERTY")
+ */
+final class MappedAssociation implements Annotation
+{
+    /** @var string */
+    public $discriminatorColumn;
+
+    /** @var integer */
+    public $length = 255;
+
+    /** @var boolean */
+    public $nullable = true;
+}

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -438,4 +438,12 @@ class MappingException extends \Doctrine\ORM\ORMException
             $cascades
         ));
     }
+
+    public static function associationRequiredForMappedAssociation($className, $field) {
+        return new self("One-to-one association required on '$className#$field' for mapped association.");
+    }
+
+    public static function unsupportedAssociationForMappedAssociation($className, $field) {
+        return new self("Invalid association type on '$className#$field' for mapped association. Only one-to-one associations are supported.");
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -439,11 +439,25 @@ class MappingException extends \Doctrine\ORM\ORMException
         ));
     }
 
-    public static function associationRequiredForMappedAssociation($className, $field) {
+    /**
+     * @param string $className
+     * @param string $field
+     *
+     * @return self
+     */
+    public static function associationRequiredForMappedAssociation($className, $field)
+    {
         return new self("One-to-one association required on '$className#$field' for mapped association.");
     }
 
-    public static function unsupportedAssociationForMappedAssociation($className, $field) {
+    /**
+     * @param string $className
+     * @param string $field
+     *
+     * @return self
+     */
+    public static function unsupportedAssociationForMappedAssociation($className, $field)
+    {
         return new self("Invalid association type on '$className#$field' for mapped association. Only one-to-one associations are supported.");
     }
 }

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -112,11 +112,11 @@ interface QuoteStrategy
     /**
      * Gets the (possibly quoted) mapped association descriminator column name
      *
-     * @param array $assoc
-     * @param ClassMetadata $class
+     * @param array            $assoc
+     * @param ClassMetadata    $class
      * @param AbstractPlatform $platform
-     * @return  string
      *
+     * @return string
      */
     function getMappedAssociationDescriminatorColumnName(array $assoc, ClassMetadata $class, AbstractPlatform $platform);
 

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -109,4 +109,15 @@ interface QuoteStrategy
      */
     function getColumnAlias($columnName, $counter, AbstractPlatform $platform, ClassMetadata $class = null);
 
+    /**
+     * Gets the (possibly quoted) mapped association descriminator column name
+     *
+     * @param array $assoc
+     * @param ClassMetadata $class
+     * @param AbstractPlatform $platform
+     * @return  string
+     *
+     */
+    function getMappedAssociationDescriminatorColumnName(array $assoc, ClassMetadata $class, AbstractPlatform $platform);
+
 }

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1351,6 +1351,26 @@ class BasicEntityPersister
     }
 
     /**
+     * Gets the SQL snippet of a qualified mapped association descriminator column name for the given
+     * mapped association field name.
+     *
+     * @param array $assoc The mapped association.
+     * @param ClassMetadata $class The class that declares this field. The table this class is
+     *                             mapped to must own the column for the given field.
+     * @param string $alias
+     */
+    protected function _getSelectMappedAssociationDescriminatorColumnSQL(array $assoc, ClassMetadata $class, $alias = 'r')
+    {
+        $sql = $this->_getSQLTableAlias($class->name, $alias == 'r' ? '' : $alias)
+            . '.' . $this->quoteStrategy->getMappedAssociationDescriminatorColumnName($assoc, $class, $this->_platform);
+        $columnAlias = $this->getSQLColumnAlias($assoc['fieldMapping']['columnName']);
+
+        $this->_rsm->addFieldResult($alias, $columnAlias, $assoc['fieldMapping']['columnName']);
+
+        return $sql . ' AS ' . $columnAlias;
+    }
+
+    /**
      * Gets the SQL table alias for the given class name.
      *
      * @param string $className

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -748,6 +748,10 @@ class BasicEntityPersister
                 unset($identifier[$targetKeyColumn]);
             }
 
+            if (isset($targetClass->mappedAssociations[$owningAssoc['fieldName']]) && $owningAssoc['isOwningSide']) {
+                $identifier[$this->_getSQLTableAlias($targetClass->name) . "." . $targetClass->mappedAssociations[$owningAssoc['fieldName']]['fieldMapping']['columnName']] = $sourceClass->name;
+            }
+
             $targetEntity = $this->load($identifier, null, $assoc);
 
             if ($targetEntity !== null) {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1337,7 +1337,7 @@ class BasicEntityPersister
                         $columns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->_class, $this->_platform);
                     }
                 }
-            } else if ($this->_class->generatorType != ClassMetadata::GENERATOR_TYPE_IDENTITY || $this->_class->identifier[0] != $name) {
+            } else if (($this->_class->generatorType != ClassMetadata::GENERATOR_TYPE_IDENTITY || $this->_class->identifier[0] != $name) && !isset($this->_class->mappedAssociations[$name])) {
                 $columns[] = $this->quoteStrategy->getColumnName($name, $this->_class, $this->_platform);
                 $this->_columnTypes[$name] = $this->_class->fieldMappings[$name]['type'];
             }

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1103,6 +1103,22 @@ class BasicEntityPersister
             $columnList .= $this->_getSelectColumnSQL($field, $this->_class);
         }
 
+        $skipMapped = array();
+
+        // Add mapped association descriminator columns to select list
+        foreach ($this->_class->mappedAssociations as $mappedAssoc => $assoc) {
+            if ($columnList) $columnList .= ', ';
+
+            $columnList .= $this->_getSelectMappedAssociationDescriminatorColumnSQL($assoc, $this->_class);
+
+            if (isset($this->_class->associationMappings[$mappedAssoc])) {
+                $targetMetadata = $this->_em->getClassMetadata($this->_class->associationMappings[$mappedAssoc]['targetEntity']);
+                if ($targetMetadata->isMappedSuperclass && !$this->_class->associationMappings[$mappedAssoc]['isOwningSide']) {
+                    $skipMapped[$mappedAssoc] = true;
+                }
+            }
+        }
+
         $this->_selectJoinSql = '';
         $eagerAliasCounter = 0;
 

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -563,6 +563,13 @@ class BasicEntityPersister
 
             $newVal = $change[1];
 
+            if (isset($this->_class->mappedAssociations[$field])) {
+                $fieldMapping = $this->_class->mappedAssociations[$field]['fieldMapping'];
+                $columnName = $fieldMapping['columnName'];
+                $this->_columnTypes[$columnName] = $fieldMapping['type'];
+                $result[$this->getOwningTable($field)][$columnName] = $newVal ? get_class($newVal) : $newVal;
+            }
+
             if (isset($this->_class->associationMappings[$field])) {
                 $assoc = $this->_class->associationMappings[$field];
 

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1107,7 +1107,9 @@ class BasicEntityPersister
 
         // Add mapped association descriminator columns to select list
         foreach ($this->_class->mappedAssociations as $mappedAssoc => $assoc) {
-            if ($columnList) $columnList .= ', ';
+            if ($columnList) {
+                $columnList .= ', ';
+            }
 
             $columnList .= $this->_getSelectMappedAssociationDescriminatorColumnSQL($assoc, $this->_class);
 
@@ -1379,10 +1381,11 @@ class BasicEntityPersister
      * Gets the SQL snippet of a qualified mapped association descriminator column name for the given
      * mapped association field name.
      *
-     * @param array $assoc The mapped association.
-     * @param ClassMetadata $class The class that declares this field. The table this class is
-     *                             mapped to must own the column for the given field.
-     * @param string $alias
+     * @param array         $assoc The mapped association.
+     * @param ClassMetadata $class The class that declares this field. The table this class is mapped to must own the column for the given field.
+     * @param string        $alias Table alias
+     *
+     * @return string
      */
     protected function _getSelectMappedAssociationDescriminatorColumnSQL(array $assoc, ClassMetadata $class, $alias = 'r')
     {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1330,6 +1330,11 @@ class BasicEntityPersister
                 continue;
             }
 
+            if (isset($this->_class->mappedAssociations[$name])) {
+                $columns[] = $columnName = $this->quoteStrategy->getMappedAssociationDescriminatorColumnName($this->_class->mappedAssociations[$name], $this->_class, $this->_platform);
+                $this->_columnTypes[$columnName] = $this->_class->mappedAssociations[$name]['fieldMapping']['type'];
+            }
+
             if (isset($this->_class->associationMappings[$name])) {
                 $assoc = $this->_class->associationMappings[$name];
                 if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -33,7 +33,7 @@ use Doctrine\ORM\ORMException,
  * The SchemaTool is a tool to create/drop/update database schemas based on
  * <tt>ClassMetadata</tt> class descriptors.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -457,6 +457,14 @@ class SchemaTool
                 foreach($uniqueConstraints as $indexName => $unique) {
                     $table->addUniqueIndex($unique['columns'], is_numeric($indexName) ? null : $indexName);
                 }
+
+                if (isset($class->mappedAssociations[$fieldName]) && $foreignClass->isMappedSuperclass) {
+                    foreach ($table->getForeignKeys() as $fkName => $mapping) {
+                        if ($this->quoteStrategy->getTableName($foreignClass, $this->platform) == $mapping->getForeignTableName()) {
+                            $table->removeForeignKey($fkName);
+                        }
+                    }
+                }
             } else if ($mapping['type'] == ClassMetadata::ONE_TO_MANY && $mapping['isOwningSide']) {
                 //... create join table, one-many through join table supported later
                 throw ORMException::notSupported();

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -316,7 +316,7 @@ class SchemaTool
      * discriminator columns of a class.
      *
      * @param ClassMetadata $class
-     * @param Table $table
+     * @param Table         $table
      */
     private function addMappedAssociationDiscriminatorColumnDefinitions($class, $table)
     {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -308,6 +308,25 @@ class SchemaTool
     }
 
     /**
+     * Get a portable column definition as required by the DBAL for the mapped association
+     * discriminator columns of a class.
+     *
+     * @param ClassMetadata $class
+     * @param Table $table
+     */
+    private function addMappedAssociationDiscriminatorColumnDefinitions($class, $table)
+    {
+        foreach ($class->getMappedAssociations() as $mappedAssociation) {
+            $fieldMapping = $mappedAssociation['fieldMapping'];
+            $options = array(
+                'length' => $fieldMapping['length'],
+                'notnull' => !$fieldMapping['nullable'],
+            );
+            $table->addColumn($fieldMapping['columnName'], $fieldMapping['type'], $options);
+        }
+    }
+
+    /**
      * Gathers the column definitions as required by the DBAL of all field mappings
      * found in the given class.
      *

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -198,7 +198,7 @@ class SchemaTool
                     $pkColumns[] = $columnName;
 
                     // Add a FK constraint on the ID column
-                    $table->addUnnamedForeignKeyConstraint(
+                    $table->addForeignKeyConstraint(
                         $this->quoteStrategy->getTableName($this->em->getClassMetadata($class->rootEntityName), $this->platform),
                         array($columnName), array($columnName), array('onDelete' => 'CASCADE')
                     );
@@ -588,7 +588,7 @@ class SchemaTool
             }
         }
 
-        $theJoinTable->addUnnamedForeignKeyConstraint(
+        $theJoinTable->addForeignKeyConstraint(
             $foreignTableName, $localColumns, $foreignColumns, $fkOptions
         );
     }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -213,6 +213,10 @@ class SchemaTool
                 $this->_gatherRelationsSql($class, $table, $schema);
             }
 
+            if ($class->hasMappedAssociations()) {
+                $this->addMappedAssociationDiscriminatorColumnDefinitions($class, $table);
+            }
+
             $pkColumns = array();
             foreach ($class->identifier as $identifierField) {
                 if (isset($class->fieldMappings[$identifierField])) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -539,7 +539,7 @@ class UnitOfWork implements PropertyChangedListener
             $changeSet = array();
 
             foreach ($actualData as $propName => $actualValue) {
-                if ( ! isset($class->associationMappings[$propName])) {
+                if ( ! isset($class->associationMappings[$propName]) || isset($class->mappedAssociations[$propName])) {
                     $changeSet[$propName] = array(null, $actualValue);
 
                     continue;
@@ -575,8 +575,8 @@ class UnitOfWork implements PropertyChangedListener
                     continue;
                 }
 
-                // if regular field
-                if ( ! isset($class->associationMappings[$propName])) {
+                // if regular field or mapped association
+                if ( ! isset($class->associationMappings[$propName]) || isset($class->mappedAssociations[$propName])) {
                     if ($isChangeTrackingNotify) {
                         continue;
                     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2483,7 +2483,7 @@ class UnitOfWork implements PropertyChangedListener
                         default:
                             switch (true) {
                                 // Populate mapped associations
-                                case ($class->mappedAssociations[$field]):
+                                case (isset($class->mappedAssociations[$field])):
                                     $newValue = $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity, $associatedId);
                                     break;
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2407,6 +2407,10 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
+            if (isset($class->mappedAssociations[$field]) && ($assoc['targetEntity'] = $data[$class->mappedAssociations[$field]['fieldMapping']['columnName']]) == null) {
+                continue;
+            }
+
             $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
             switch (true) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2482,6 +2482,11 @@ class UnitOfWork implements PropertyChangedListener
 
                         default:
                             switch (true) {
+                                // Populate mapped associations
+                                case ($class->mappedAssociations[$field]):
+                                    $newValue = $this->getEntityPersister($assoc['targetEntity'])->loadOneToOneEntity($assoc, $entity, $associatedId);
+                                    break;
+
                                 // We are negating the condition here. Other cases will assume it is valid!
                                 case ($hints['fetchMode'][$class->name][$field] !== ClassMetadata::FETCH_EAGER):
                                     $newValue = $this->em->getProxyFactory()->getProxy($assoc['targetEntity'], $associatedId);

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
@@ -23,6 +23,11 @@ class AbstractObject
      */
     private $description;
 
+    public function getId()
+    {
+        return $this->id;
+    }
+
     public function setDescription($description)
     {
         $this->description = $description;

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
@@ -10,39 +10,60 @@ class AbstractObject
      * @Id
      * @GeneratedValue
      * @Column(type="integer")
+     *
+     * @var int $id
      */
     private $id;
 
     /**
      * @OneToOne(targetEntity="Shelf", mappedBy="object")
+     *
+     * @var Shelf $shelf
      */
     private $shelf;
 
     /**
      * @Column(type="string", length=128)
+     *
+     * @var string $description
      */
     private $description;
 
+    /**
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $description
+     */
     public function setDescription($description)
     {
         $this->description = $description;
     }
 
+    /**
+     * @return string
+     */
     public function getDescription()
     {
         return $this->description;
     }
 
+    /**
+     * @return Shelf
+     */
     public function getShelf()
     {
         return $this->shelf;
     }
 
+    /**
+     * @param Shelf $shelf
+     */
     public function setShelf(Shelf $shelf)
     {
         $this->shelf = $shelf;

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/AbstractObject.php
@@ -1,0 +1,45 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
+
+/**
+ * @MappedSuperclass
+ */
+class AbstractObject
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @OneToOne(targetEntity="Shelf", mappedBy="object")
+     */
+    private $shelf;
+
+    /**
+     * @Column(type="string", length=128)
+     */
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getShelf()
+    {
+        return $this->shelf;
+    }
+
+    public function setShelf(Shelf $shelf)
+    {
+        $this->shelf = $shelf;
+    }
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Book.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Book.php
@@ -1,0 +1,11 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
+
+/**
+ * @Entity
+ * @Table(name="dp_book")
+ */
+class Book extends AbstractObject
+{
+
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
@@ -8,7 +8,7 @@ namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
  *      @NamedNativeQuery(
  *          name                = "get-class-by-id",
  *          resultSetMapping    = "get-class",
- *          query               = "SELECT objectClass from dp_shelf WHERE id = ?"
+ *          query               = "SELECT objectclass from dp_shelf WHERE id = ?"
  *      )
  * })
  *
@@ -17,7 +17,7 @@ namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
  *          name    = "get-class",
  *          columns = {
  *              @ColumnResult(
- *                  name = "objectClass"
+ *                  name = "objectclass"
  *              )
  *          }
  *      )

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
@@ -30,41 +30,62 @@ class Shelf
      * @Id
      * @GeneratedValue
      * @Column(type="integer")
+     *
+     * @var int $id
      */
     private $id;
 
     /**
      * @Column(type="string", length=128)
+     *
+     * @var string $bookcase
      */
     private $bookcase;
 
     /**
      * @OneToOne(targetEntity="AbstractObject", inversedBy="shelf", cascade={"all"})
      * @MappedAssociation
+     *
+     * @var AbstractObject $object
      */
     private $object;
 
+    /**
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $bookcase
+     */
     public function setBookcase($bookcase)
     {
         $this->bookcase = $bookcase;
     }
 
+    /**
+     * @return string
+     */
     public function getBookcase()
     {
         return $this->bookcase;
     }
 
+    /**
+     * @param AbstractObject $object
+     */
     public function setObject(AbstractObject $object)
     {
         $object->setShelf($this);
         $this->object = $object;
     }
 
+    /**
+     * @return AbstractObject
+     */
     public function getObject()
     {
         return $this->object;

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Shelf.php
@@ -1,0 +1,72 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
+
+/**
+ * @Entity
+ * @Table(name="dp_shelf")
+ * @NamedNativeQueries({
+ *      @NamedNativeQuery(
+ *          name                = "get-class-by-id",
+ *          resultSetMapping    = "get-class",
+ *          query               = "SELECT objectClass from dp_shelf WHERE id = ?"
+ *      )
+ * })
+ *
+ * @SqlResultSetMappings({
+ *      @SqlResultSetMapping(
+ *          name    = "get-class",
+ *          columns = {
+ *              @ColumnResult(
+ *                  name = "objectClass"
+ *              )
+ *          }
+ *      )
+ * })
+ *
+ */
+class Shelf
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Column(type="string", length=128)
+     */
+    private $bookcase;
+
+    /**
+     * @OneToOne(targetEntity="AbstractObject", inversedBy="shelf", cascade={"all"})
+     * @MappedAssociation
+     */
+    private $object;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setBookcase($bookcase)
+    {
+        $this->bookcase = $bookcase;
+    }
+
+    public function getBookcase()
+    {
+        return $this->bookcase;
+    }
+
+    public function setObject(AbstractObject $object)
+    {
+        $object->setShelf($this);
+        $this->object = $object;
+    }
+
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Video.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/DiscretePrimary/Video.php
@@ -1,0 +1,11 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\DiscretePrimary;
+
+/**
+ * @Entity
+ * @Table(name="dp_video")
+ */
+class Video extends AbstractObject
+{
+
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/AbstractContent.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/AbstractContent.php
@@ -1,0 +1,39 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
+
+/**
+ * @MappedSuperclass
+ */
+class AbstractContent
+{
+    /**
+     * @Id
+     * @OneToOne(targetEntity="FileFolder", inversedBy="content")
+     */
+    private $fileFolder;
+
+    /**
+     * @Column(type="string", length=128)
+     */
+    private $description;
+
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getFileFolder()
+    {
+        return $this->fileFolder;
+    }
+
+    public function setFileFolder(FileFolder $fileFolder)
+    {
+        $this->fileFolder = $fileFolder;
+    }
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/AbstractContent.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/AbstractContent.php
@@ -9,29 +9,45 @@ class AbstractContent
     /**
      * @Id
      * @OneToOne(targetEntity="FileFolder", inversedBy="content")
+     *
+     * @var FileFolder $fileFolder
      */
     private $fileFolder;
 
     /**
      * @Column(type="string", length=128)
+     *
+     * @var string $description
      */
     private $description;
 
+    /**
+     * @param string $description
+     */
     public function setDescription($description)
     {
         $this->description = $description;
     }
 
+    /**
+     * @return string
+     */
     public function getDescription()
     {
         return $this->description;
     }
 
+    /**
+     * @return FileFolder
+     */
     public function getFileFolder()
     {
         return $this->fileFolder;
     }
 
+    /**
+     * @param FileFolder $fileFolder
+     */
     public function setFileFolder(FileFolder $fileFolder)
     {
         $this->fileFolder = $fileFolder;

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
@@ -1,0 +1,72 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
+
+/**
+ * @Entity
+ * @Table(name="pif_filefolder")
+ * @NamedNativeQueries({
+ *      @NamedNativeQuery(
+ *          name                = "get-class-by-id",
+ *          resultSetMapping    = "get-class",
+ *          query               = "SELECT contentClass from pif_filefolder WHERE id = ?"
+ *      )
+ * })
+ *
+ * @SqlResultSetMappings({
+ *      @SqlResultSetMapping(
+ *          name    = "get-class",
+ *          columns = {
+ *              @ColumnResult(
+ *                  name = "contentClass"
+ *              )
+ *          }
+ *      )
+ * })
+ *
+ */
+class FileFolder
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Column(type="string", length=128)
+     */
+    private $title;
+
+    /**
+     * @OneToOne(targetEntity="AbstractContent", mappedBy="fileFolder", cascade={"all"}, orphanRemoval=true)
+     * @MappedAssociation
+     */
+    private $content;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    public function setContent(AbstractContent $content)
+    {
+        $content->setFileFolder($this);
+        $this->content = $content;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
@@ -8,7 +8,7 @@ namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
  *      @NamedNativeQuery(
  *          name                = "get-class-by-id",
  *          resultSetMapping    = "get-class",
- *          query               = "SELECT contentClass from pif_filefolder WHERE id = ?"
+ *          query               = "SELECT contentclass from pif_filefolder WHERE id = ?"
  *      )
  * })
  *
@@ -17,7 +17,7 @@ namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
  *          name    = "get-class",
  *          columns = {
  *              @ColumnResult(
- *                  name = "contentClass"
+ *                  name = "contentclass"
  *              )
  *          }
  *      )

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/FileFolder.php
@@ -30,41 +30,62 @@ class FileFolder
      * @Id
      * @GeneratedValue
      * @Column(type="integer")
+     *
+     * @var int $id
      */
     private $id;
 
     /**
      * @Column(type="string", length=128)
+     *
+     * @var string $title
      */
     private $title;
 
     /**
      * @OneToOne(targetEntity="AbstractContent", mappedBy="fileFolder", cascade={"all"}, orphanRemoval=true)
      * @MappedAssociation
+     *
+     * @var AbstractContent $content
      */
     private $content;
 
+    /**
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @param string $title
+     */
     public function setTitle($title)
     {
         $this->title = $title;
     }
 
+    /**
+     * @return string
+     */
     public function getTitle()
     {
         return $this->title;
     }
 
+    /**
+     * @param AbstractContent $content
+     */
     public function setContent(AbstractContent $content)
     {
         $content->setFileFolder($this);
         $this->content = $content;
     }
 
+    /**
+     * @return AbstractContent
+     */
     public function getContent()
     {
         return $this->content;

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/Paper.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/Paper.php
@@ -1,0 +1,11 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
+
+/**
+ * @Entity
+ * @Table(name="pif_paper")
+ */
+class Paper extends AbstractContent
+{
+
+}

--- a/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/Photo.php
+++ b/tests/Doctrine/Tests/Models/MappedAssociation/PrimaryIsForeign/Photo.php
@@ -1,0 +1,11 @@
+<?php
+namespace Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign;
+
+/**
+ * @Entity
+ * @Table(name="pif_photo")
+ */
+class Photo extends AbstractContent
+{
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\FileFolder;
 use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Paper;
 use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Photo;
@@ -14,6 +12,8 @@ use Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Video;
 require_once __DIR__ . '/../../TestInit.php';
 
 /**
+ * Mapped association tests
+ *
  * @group Doctrine.MappedAssociation
  */
 class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
@@ -31,6 +31,9 @@ class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
     }
 
+    /**
+     * Test mapped association with mapped entity having primary key as a foreign key.
+     */
     public function testSimplePrimaryIsForeignMappedAssociation()
     {
         /**
@@ -151,6 +154,9 @@ class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEmpty($results);
     }
 
+    /**
+     * Test mapped association with mapped entity have its own identifier and container owning side.
+     */
     public function testSimpleDiscretePrimaryMappedAssociation()
     {
         /**

--- a/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\FileFolder;
+use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Paper;
+use Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Photo;
+use Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Shelf;
+use Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Book;
+use Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Video;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+/**
+ * @group Doctrine.MappedAssociation
+ */
+class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    const FILEFOLDER         = 'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\FileFolder';
+    const PAPER              = 'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Paper';
+    const PHOTO              = 'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Photo';
+    const SHELF              = 'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Shelf';
+    const BOOK               = 'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Book';
+    const VIDEO              = 'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Video';
+
+    protected function setUp()
+    {
+        $this->useModelSet('mappedassociation');
+        parent::setUp();
+    }
+
+    public function testSimplePrimaryIsForeignMappedAssociation()
+    {
+        /**
+         * Create file folder 0
+         */
+        $fileFolder0 = new FileFolder();
+        $fileFolder0->setTitle('Folder 0');
+        $this->_em->persist($fileFolder0);
+        $this->_em->flush();
+        $id0 = $fileFolder0->getId();
+
+        /**
+         * Create file folder 1
+         */
+        $fileFolder1 = new FileFolder();
+        $fileFolder1->setTitle('Folder 1');
+        $this->_em->persist($fileFolder1);
+        $this->_em->flush();
+        $id1 = $fileFolder1->getId();
+
+        $content1 = new Paper;
+        $content1->setDescription('Expense report');
+        $fileFolder1->setContent($content1);
+        $this->_em->flush();
+
+        /**
+         * Create file folder 2
+         */
+        $fileFolder2 = new FileFolder();
+        $fileFolder2->setTitle('Folder 2');
+        $this->_em->persist($fileFolder2);
+        $this->_em->flush();
+        $id2 = $fileFolder2->getId();
+
+        $content2 = new Photo;
+        $content2->setDescription('Family photo');
+        $fileFolder2->setContent($content2);
+        $this->_em->flush();
+
+        /**
+         * Clear entity manager for tests
+         */
+        $this->_em->clear();
+
+        /**
+         * Check descriminator column was set properly
+         */
+        $fileFolderRepository = $this->_em->getRepository($this::FILEFOLDER);
+        $query = $fileFolderRepository->createNativeNamedQuery('get-class-by-id');
+
+        $results = $query->setParameter(1, $id0)
+            ->getResult();
+        $this->assertEquals($results[0]['contentClass'], null);
+
+        $results = $query->setParameter(1, $id1)
+            ->getResult();
+        $this->assertEquals($results[0]['contentClass'], get_class($content1));
+
+        $results = $query->setParameter(1, $id2)
+            ->getResult();
+        $this->assertEquals($results[0]['contentClass'], get_class($content2));
+
+        /**
+         * Check can get container from mapped association
+         */
+        $paperRepository = $this->_em->getRepository($this::PAPER);
+        $queryPaper1 = $paperRepository->find($id1);
+        $this->assertEquals($content1->getFileFolder()->getTitle(), $queryPaper1->getFileFolder()->getTitle());
+
+        $photoRepository = $this->_em->getRepository($this::PHOTO);
+        $queryPhoto2 = $photoRepository->find($id2);
+        $this->assertEquals($content2->getFileFolder()->getTitle(), $queryPhoto2->getFileFolder()->getTitle());
+
+        /**
+         * Clear the EM so we're not comparing proxies (or set join eager)
+         */
+        $this->_em->clear();
+
+        /**
+         * Check container entity retrieval
+         */
+        $queryFileFolder0 = $fileFolderRepository->find($id0);
+        $this->assertEquals($fileFolder0, $queryFileFolder0);
+
+        $queryFileFolder1 = $fileFolderRepository->find($id1);
+        $this->assertEquals($fileFolder1, $queryFileFolder1);
+
+        $queryFileFolder2 = $fileFolderRepository->find($id2);
+        $this->assertEquals($fileFolder2, $queryFileFolder2);
+
+        /**
+         * Remove container entities and clear EM
+         */
+        $this->_em->remove($queryFileFolder0);
+        $this->_em->remove($queryFileFolder1);
+        $this->_em->remove($queryFileFolder2);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /**
+         * Check containers and mapped associations removed
+         */
+        $queryFileFolder0 = $fileFolderRepository->find($id0);
+        $this->assertEquals(null, $queryFileFolder0);
+
+        $queryFileFolder1 = $fileFolderRepository->find($id1);
+        $this->assertEquals(null, $queryFileFolder1);
+
+        $queryFileFolder2 = $fileFolderRepository->find($id2);
+        $this->assertEquals(null, $queryFileFolder2);
+
+        $fileFolderRepository = $this->_em->getRepository($this::PAPER);
+        $results = $fileFolderRepository->findAll();
+        $this->assertEmpty($results);
+
+        $fileFolderRepository = $this->_em->getRepository($this::PHOTO);
+        $results = $fileFolderRepository->findAll();
+        $this->assertEmpty($results);
+    }
+
+    public function testSimpleDiscretePrimaryMappedAssociation()
+    {
+        /**
+         * Create shelf 0
+         */
+        $shelf0 = new Shelf();
+        $shelf0->setBookcase('Basement');
+        $this->_em->persist($shelf0);
+        $this->_em->flush();
+        $id0 = $shelf0->getId();
+
+        /**
+         * Create shelf 1
+         */
+        $shelf1 = new Shelf();
+        $shelf1->setBookcase('Bedroom');
+
+        $object1 = new Book;
+        $object1->setDescription('To Kill a Mockingbird');
+        $shelf1->setObject($object1);
+        $this->_em->persist($shelf1);
+        $this->_em->flush();
+        $id1 = $shelf1->getId();
+        $ido1 = $object1->getId();
+
+        /**
+         * Create shelf 2
+         */
+        $shelf2 = new Shelf();
+        $shelf2->setBookcase('Theater');
+
+        $object2 = new Video;
+        $object2->setDescription('Die Hard');
+        $shelf2->setObject($object2);
+        $this->_em->persist($shelf2);
+        $this->_em->flush();
+        $id2 = $shelf2->getId();
+        $ido2 = $object2->getId();
+
+        /**
+         * Clear entity manager for tests
+         */
+        $this->_em->clear();
+
+        /**
+         * Check descriminator column was set properly
+         */
+        $repository = $this->_em->getRepository($this::SHELF);
+        $query = $repository->createNativeNamedQuery('get-class-by-id');
+
+        $query = $query->setParameter(1, $id0);
+        $results = $query->getResult();
+        $this->assertEquals($results[0]['objectClass'], null);
+
+        $query = $query->setParameter(1, $id1);
+        $results = $query->getResult();
+        $this->assertEquals($results[0]['objectClass'], get_class($object1));
+
+        $results = $query->setParameter(1, $id2)
+            ->getResult();
+        $this->assertEquals($results[0]['objectClass'], get_class($object2));
+
+        /**
+         * Check can get container from mapped association
+         */
+        $bookRepository = $this->_em->getRepository($this::BOOK);
+        $queryBook1 = $bookRepository->find($ido1);
+        $this->assertEquals($object1->getShelf()->getBookcase(), $queryBook1->getShelf()->getBookcase());
+
+        $videoRepository = $this->_em->getRepository($this::VIDEO);
+        $queryVideo2 = $videoRepository->find($ido2);
+        $this->assertEquals($object2->getShelf()->getBookcase(), $queryVideo2->getShelf()->getBookcase());
+
+        /**
+         * Check container entity retrieval
+         */
+        $queryShelf0 = $repository->find($id0);
+        $this->assertEquals($shelf0, $queryShelf0);
+
+        $queryShelf1 = $repository->find($id1);
+        $this->assertEquals($shelf1, $queryShelf1);
+
+        $queryShelf2 = $repository->find($id2);
+        $this->assertEquals($shelf2, $queryShelf2);
+
+        /**
+         * Remove container entities and clear EM
+         */
+        $this->_em->remove($queryShelf0);
+        $this->_em->remove($queryShelf1);
+        $this->_em->remove($queryShelf2);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /**
+         * Check containers and mapped associations removed
+         */
+        $queryShelf0 = $repository->find($id0);
+        $this->assertEquals(null, $queryShelf0);
+
+        $queryShelf1 = $repository->find($id1);
+        $this->assertEquals(null, $queryShelf1);
+
+        $queryShelf2 = $repository->find($id2);
+        $this->assertEquals(null, $queryShelf2);
+
+        $repository = $this->_em->getRepository($this::BOOK);
+        $results = $repository->findAll();
+        $this->assertEmpty($results);
+
+        $repository = $this->_em->getRepository($this::VIDEO);
+        $results = $repository->findAll();
+        $this->assertEmpty($results);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedAssociationTest.php
@@ -86,15 +86,15 @@ class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $results = $query->setParameter(1, $id0)
             ->getResult();
-        $this->assertEquals($results[0]['contentClass'], null);
+        $this->assertEquals($results[0]['contentclass'], null);
 
         $results = $query->setParameter(1, $id1)
             ->getResult();
-        $this->assertEquals($results[0]['contentClass'], get_class($content1));
+        $this->assertEquals($results[0]['contentclass'], get_class($content1));
 
         $results = $query->setParameter(1, $id2)
             ->getResult();
-        $this->assertEquals($results[0]['contentClass'], get_class($content2));
+        $this->assertEquals($results[0]['contentclass'], get_class($content2));
 
         /**
          * Check can get container from mapped association
@@ -209,15 +209,15 @@ class MappedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $query = $query->setParameter(1, $id0);
         $results = $query->getResult();
-        $this->assertEquals($results[0]['objectClass'], null);
+        $this->assertEquals($results[0]['objectclass'], null);
 
         $query = $query->setParameter(1, $id1);
         $results = $query->getResult();
-        $this->assertEquals($results[0]['objectClass'], get_class($object1));
+        $this->assertEquals($results[0]['objectclass'], get_class($object1));
 
         $results = $query->setParameter(1, $id2)
             ->getResult();
-        $this->assertEquals($results[0]['objectClass'], get_class($object2));
+        $this->assertEquals($results[0]['objectclass'], get_class($object2));
 
         /**
          * Check can get container from mapped association

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -124,6 +124,16 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\CustomType\CustomTypeParent',
             'Doctrine\Tests\Models\CustomType\CustomTypeUpperCase',
         ),
+        'mappedassociation' => array(
+            'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\FileFolder',
+            'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\AbstractContent',
+            'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Paper',
+            'Doctrine\Tests\Models\MappedAssociation\PrimaryIsForeign\Photo',
+            'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Shelf',
+            'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\AbstractObject',
+            'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Book',
+            'Doctrine\Tests\Models\MappedAssociation\DiscretePrimary\Video',
+        ),
     );
 
     protected function useModelSet($setName)
@@ -237,6 +247,15 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM customtype_parents');
             $conn->executeUpdate('DELETE FROM customtype_children');
             $conn->executeUpdate('DELETE FROM customtype_uppercases');
+        }
+
+        if (isset($this->_usedModelSets['customtype'])) {
+            $conn->executeUpdate('DELETE FROM pif_paper');
+            $conn->executeUpdate('DELETE FROM pif_photo');
+            $conn->executeUpdate('DELETE FROM pif_filefolder');
+            $conn->executeUpdate('DELETE FROM dp_shelf');
+            $conn->executeUpdate('DELETE FROM dp_book');
+            $conn->executeUpdate('DELETE FROM dp_video');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
This PR adds ODM embedded-like functionality to the ORM.

Including the new _@MappedAssociation_ annotation on a field having a one-to-one association adds a discriminator column to the table for storing the class name of a "mapped" entity.

This allows a class or mapped superclass with ID and association to be extended by additional entities without requiring any code changes (as is required when using inheritance).

I apologize if this is the incorrect way to submit a feature request. Currently just the annotation driver has been updated, I wanted to get feedback before continuing with the remaining drivers. Models and tests are included, and all the existing tests continue to pass (the ones that weren't skipped anyways).
