### PR TITLE
Add DBAL\TypeAwareObject type inference.

### DIFF
--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\TypeAwareObject;
 
 /**
  * Provides an enclosed support for parameter infering.
@@ -58,6 +59,10 @@ class ParameterTypeInferer
             return is_integer(current($value))
                 ? Connection::PARAM_INT_ARRAY
                 : Connection::PARAM_STR_ARRAY;
+        }
+
+        if ($value instanceof TypeAwareObject) {
+                return $value->getDBALType();
         }
 
         return \PDO::PARAM_STR;


### PR DESCRIPTION
DBAL allows you to define custom field types for your entities, and those are seamlessly converted from PHP to SQL value. However, you can't those custom types as parameters without type hinting it :

``` php
$qb->select('e')
   ->from('Entity', 'e')
   ->where('e.customField = :customFieldValue')
   ->setParameter('customFieldValue',$customFieldValue,$customFieldDBALType);
   //this third argument is for now compulsory
:
```

In my case, `$customFieldValue` is an object that won't work well if converted with the default string type. I added a new DBAL interface (see doctrine/dbal#193 ) and tweaked the parameter type inference so that custom values can advertise their DBAL type.

There is currently no way to dynamically override the parameter type inference logic, this is one design that allows it in some cases. 
