### PR TITLE
Fixes PersistentCollection::matching() when collection is not initialize...

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -42,6 +42,7 @@ use Closure;
  * @author    Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author    Roman Borschel <roman@code-factory.org>
  * @author    Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
+ * @author    Stefano Rodriguez <stefano.rodriguez@fubles.com>
  * @todo      Design for inheritance to allow custom implementations?
  */
 final class PersistentCollection implements Collection, Selectable
@@ -812,6 +813,13 @@ final class PersistentCollection implements Collection, Selectable
             throw new \RuntimeException("Matching Criteria on PersistentCollection only works on OneToMany assocations at the moment.");
         }
 
+        // If there are NEW objects we have to check if any of them matches the criteria
+        $newObjects = array();
+
+        if ($this->isDirty) {
+            $newObjects = $this->coll->matching($criteria)->toArray();
+        }
+
         $targetClass = $this->em->getClassMetadata(get_class($this->owner));
 
         $id              = $targetClass->getSingleIdReflectionProperty()->getValue($this->owner);
@@ -824,7 +832,7 @@ final class PersistentCollection implements Collection, Selectable
 
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->association['targetEntity']);
 
-        return new ArrayCollection($persister->loadCriteria($criteria));
+        return new ArrayCollection(array_merge($persister->loadCriteria($criteria), $newObjects));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -174,7 +174,7 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $this->assertEquals(2, count($results));
     }
 	
-	public function testMatchingBis()
+    public function testMatchingBis()
     {
         $this->_createFixture();
 
@@ -190,12 +190,12 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         ));
 
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results);
-        $this->assertEquals(1, count($results));
+        $this->assertCount(1, $results);
 
         $results = $features->matching(new Criteria());
 
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results);
-        $this->assertEquals(3, count($results));
+        $this->assertCount(3, $results);
     }
 
     private function _createFixture()

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -173,6 +173,30 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results);
         $this->assertEquals(2, count($results));
     }
+	
+	public function testMatchingBis()
+    {
+        $this->_createFixture();
+
+        $product  = $this->_em->find('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $this->product->getId());
+        $features = $product->getFeatures();
+        
+        $thirdFeature = new ECommerceFeature();
+        $thirdFeature->setDescription('Third feature');
+        $product->addFeature($thirdFeature);
+
+        $results = $features->matching(new Criteria(
+            Criteria::expr()->eq('description', 'Third feature')
+        ));
+
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results);
+        $this->assertEquals(1, count($results));
+
+        $results = $features->matching(new Criteria());
+
+        $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results);
+        $this->assertEquals(3, count($results));
+    }
 
     private function _createFixture()
     {


### PR DESCRIPTION
...d and there are NEW entities in the collection.

If you have a PersistentCollection not already initialized and you add something to it and if you call matching() on it, that method doesn't return the elements you have just added even if they match the criteria.

This fixes the behaviour checking for any matching element that is NEW and merging it in the returned ArrayCollection.
