### PR TITLE
Fixed Parser problem for SELECT (((3))) as ....

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -489,7 +489,7 @@ class Parser
         $this->_lexer->resetPeek();
 
         // We deny the COUNT(SELECT * FROM User u) here. COUNT won't be considered a function
-        return ($lookaheadType === Lexer::T_IDENTIFIER && $peek['type'] === Lexer::T_OPEN_PARENTHESIS && $nextpeek['type'] !== Lexer::T_SELECT);
+        return ($lookaheadType >= Lexer::T_IDENTIFIER && $peek['type'] === Lexer::T_OPEN_PARENTHESIS && $nextpeek['type'] !== Lexer::T_SELECT);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -482,13 +482,14 @@ class Parser
      */
     private function _isFunction()
     {
+        $lookaheadType = $this->_lexer->lookahead['type'];
         $peek     = $this->_lexer->peek();
         $nextpeek = $this->_lexer->peek();
 
         $this->_lexer->resetPeek();
 
         // We deny the COUNT(SELECT * FROM User u) here. COUNT won't be considered a function
-        return ($peek['type'] === Lexer::T_OPEN_PARENTHESIS && $nextpeek['type'] !== Lexer::T_SELECT);
+        return ($lookaheadType === Lexer::T_IDENTIFIER && $peek['type'] === Lexer::T_OPEN_PARENTHESIS && $nextpeek['type'] !== Lexer::T_SELECT);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -100,6 +100,11 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidDQL('SELECT COUNT(u.id) FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
+    public function testMultipleParenthesisInSelect()
+    {
+        $this->assertValidDQL('SELECT (((u.id))) as v FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testDuplicatedAliasInAggregateFunction()
     {
         $this->assertInvalidDQL('SELECT COUNT(u.id) AS num, SUM(u.id) AS num FROM Doctrine\Tests\Models\CMS\CmsUser u');


### PR DESCRIPTION
where the ((( would be incorrectly treated as function
