### PR TITLE
Parser returns string instead of Literal expression

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Query\AST\Literal;
 
 /**
  * "DATE_ADD(date1, interval, unit)"
@@ -40,7 +41,11 @@ class DateAddFunction extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $unit = strtolower($this->unit);
+        if(!$this->unit instanceof Literal) {
+           throw QueryException::semanticalError('DATE_ADD() only supports hardcoded units'); 
+        }
+        
+        $unit = strtolower($this->unit->value);
         if ($unit == "day") {
             return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddDaysExpression(
                 $this->firstDateExpression->dispatch($sqlWalker),

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Query\AST\Literal;
 
 /**
  * "DATE_ADD(date1, interval, unit)"
@@ -40,7 +41,11 @@ class DateSubFunction extends DateAddFunction
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        $unit = strtolower($this->unit);
+        if(!$this->unit instanceof Literal) {
+           throw QueryException::semanticalError('DATE_SUB() only supports hardcoded units'); 
+        }
+        
+        $unit = strtolower($this->unit->value);
         if ($unit == "day") {
             return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubDaysExpression(
                 $this->firstDateExpression->dispatch($sqlWalker),

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2561,7 +2561,7 @@ class Parser
             case Lexer::T_STRING:
                 $this->match(Lexer::T_STRING);
 
-                return $this->_lexer->token['value'];
+                return new AST\Literal(AST\Literal::STRING, $this->_lexer->token['value']);
 
             case Lexer::T_INPUT_PARAMETER:
                 return $this->InputParameter();

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1129,7 +1129,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id IN (SELECT CASE g2.name WHEN 'admin' THEN 1 ELSE 2 END FROM Doctrine\Tests\Models\CMS\CmsGroup g2)",
-            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id IN (SELECT CASE c1_.name WHEN admin THEN 1 ELSE 2 END AS sclr2 FROM cms_groups c1_)"
+            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id IN (SELECT CASE c1_.name WHEN 'admin' THEN 1 ELSE 2 END AS sclr2 FROM cms_groups c1_)"
         );
     }
 
@@ -1137,7 +1137,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id IN (SELECT CASE g2.name WHEN 'admin' THEN 1 WHEN 'moderator' THEN 2 ELSE 3 END FROM Doctrine\Tests\Models\CMS\CmsGroup g2)",
-            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id IN (SELECT CASE c1_.name WHEN admin THEN 1 WHEN moderator THEN 2 ELSE 3 END AS sclr2 FROM cms_groups c1_)"
+            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id IN (SELECT CASE c1_.name WHEN 'admin' THEN 1 WHEN 'moderator' THEN 2 ELSE 3 END AS sclr2 FROM cms_groups c1_)"
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1096,16 +1096,16 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSimpleCaseWithSingleWhenClause()
     {
         $this->assertSqlGeneration(
-            "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id = CASE g.name WHEN 'admin' THEN 1 ELSE 2 END",
-            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id = CASE c0_.name WHEN admin THEN 1 ELSE 2 END"
+            "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id = CASE g.name WHEN 'admin' THEN 1 ELSE 2 END", 
+            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id = CASE c0_.name WHEN 'admin' THEN 1 ELSE 2 END"
         );
     }
 
     public function testSimpleCaseWithMultipleWhenClause()
     {
         $this->assertSqlGeneration(
-            "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id = (CASE g.name WHEN 'admin' THEN 1 WHEN 'moderator' THEN 2 ELSE 3 END)",
-            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id = CASE c0_.name WHEN admin THEN 1 WHEN moderator THEN 2 ELSE 3 END"
+            "SELECT g FROM Doctrine\Tests\Models\CMS\CmsGroup g WHERE g.id = (CASE g.name WHEN 'admin' THEN 1 WHEN 'moderator' THEN 2 ELSE 3 END)", 
+            "SELECT c0_.id AS id0, c0_.name AS name1 FROM cms_groups c0_ WHERE c0_.id = CASE c0_.name WHEN 'admin' THEN 1 WHEN 'moderator' THEN 2 ELSE 3 END"
         );
     }
 


### PR DESCRIPTION
Hi, 
I have this patch lying here for some time now, and would like to propose it for the main development line.
The Problem is, that Parser::StringPrimary() returns a raw string instead of a Literal object of type String. This behaviour requires additional logic when adding custom DQL functions to doctrine.

The problem is, that this change can be considered a breaking change, for everyone relying on the current (inconsistent) behaviour.

One example to illustrate the Problem. Lets say we implement our custom MyToUpper function:

```
class MyToUpper extends FunctionNode
{
    public $content = null;

    public function parse(\Doctrine\ORM\Query\Parser $parser)
    {
        $parser->match(Lexer::T_IDENTIFIER); 
        $parser->match(Lexer::T_OPEN_PARENTHESIS); 
        $this->content = $parser->StringPrimary(); 
        $parser->match(Lexer::T_CLOSE_PARENTHESIS); 
    }

    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
    {
        //this will break for a string constant
        return 'NativeToUpper(' .$this->content->dispatch($sqlWalker) . ')'; 
    }
} 
```

This implementation works for MyToUpper(user.name) but crashes for MyToUpper('someConstant') 
