### PR TITLE
Allow 'nullable' attribute to be used during XML export

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -180,6 +180,9 @@ class XmlExporter extends AbstractExporter
                 if (isset($field['columnDefinition'])) {
                     $fieldXml->addAttribute('column-definition', $field['columnDefinition']);
                 }
+                if (isset($field['nullable'])) {
+                    $fieldXml->addAttribute('nullable', $field['nullable'] ? 'true' : 'false');
+                }
             }
         }
         $orderMap = array(


### PR DESCRIPTION
Allows 'nullable' attribute to be used during XML export, something which already worked for me in YamlExport. This addition saved me a lot of time during development; one less difference to deal with between the YAML and XML approach.

Don't know why this was missing, maybe it's me who is missing something, so let me know ;)
