### PR TITLE
Allow to add non existing maped class

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2426,10 +2426,7 @@ class ClassMetadataInfo implements ClassMetadata
         if ($this->name == $className) {
             $this->discriminatorValue = $name;
         } else {
-            if ( ! class_exists($className)) {
-                throw MappingException::invalidClassInDiscriminatorMap($className, $this->name);
-            }
-            if (is_subclass_of($className, $this->name) && ! in_array($className, $this->subClasses)) {
+            if (! in_array($className, $this->subClasses)) {
                 $this->subClasses[] = $className;
             }
         }


### PR DESCRIPTION
I've extended `Doctrine\ORM\Mapping\Driver\DatabaseDriver` with a more complicated schema conversion tool (that supports inheritance too).

i'm generating xml metadata starting from databse schema, then i generate entities starting from xml.

inside `DatabaseDriver::loadMetadataForClass()` i wanna call 
`$metadata->addDiscriminatorMapClass($discriminatorValue, $myClassName);`

`$myClassName` at this point, probably does not exists, so `addDiscriminatorMapClass` throws an exception. i've removed class existence check to allow this behaviour.
