### PR TITLE
Fixed Parser problem for SELECT (((3))) as ....

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -509,7 +509,6 @@ class Parser
     {
         $lookaheadType = $this->lexer->lookahead['type'];
         $peek          = $this->lexer->peek();
-        $nextpeek      = $this->lexer->peek();
 
         $this->lexer->resetPeek();
 

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -100,6 +100,11 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidDQL('SELECT COUNT(u.id) FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
+    public function testMultipleParenthesisInSelect()
+    {
+        $this->assertValidDQL('SELECT (((u.id))) as v FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testDuplicatedAliasInAggregateFunction()
     {
         $this->assertInvalidDQL('SELECT COUNT(u.id) AS num, SUM(u.id) AS num FROM Doctrine\Tests\Models\CMS\CmsUser u');


### PR DESCRIPTION
Hi this is the old PR https://github.com/doctrine/doctrine2/pull/438 ported to master.
I had to modify more than I expected to get it to work properly.

I had to apply some modifications to Parser::ScalarExpression and would like to discuss the desired coding style. After my modifications Parser::ScalarExpression looks a bit more like Parser::SelectExpression, but I don't know your preferred style.

I think there is some more cleanup we could apply to ScalarExpression, but I'd like to get some feedback first.

Stefan
