### PR TITLE
Adding multiple identical joins via query builder should produce a valid DQL

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -523,6 +523,23 @@ class QueryBuilder
             $dqlPart = $newDqlPart;
         }
 
+        //adding multiple identical joins should still produce vaild SQL
+        if ($dqlPartName == 'join' && $isMultiple) {
+            $key = key($dqlPart);
+            if (isset($this->_dqlParts[$dqlPartName][$key])) {
+                foreach ($this->_dqlParts[$dqlPartName][$key] as $part) {
+                    if (($part->getAlias() == $dqlPart[$key]->getAlias()) &&
+                        ($part->getJoin() == $dqlPart[$key]->getJoin()) &&
+                        ($part->getJoinType() == $dqlPart[$key]->getJoinType()) &&
+                        ($part->getConditionType() == $dqlPart[$key]->getConditionType()) &&
+                        ($part->getCondition() == $dqlPart[$key]->getCondition()) &&
+                        ($part->getIndexBy() == $dqlPart[$key]->getIndexBy())) {
+                        return $this;
+                    }
+                }
+            }
+        }
+
         if ($append && $isMultiple) {
             if (is_array($dqlPart)) {
                 $key = key($dqlPart);

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -196,6 +196,18 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidQueryBuilder($qb, 'SELECT u, g FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.groups g LEFT JOIN u.address ad, Doctrine\Tests\Models\CMS\CmsArticle a INNER JOIN a.comments c');
     }
 
+    public function testMultipleIdenticalJoins()
+    {
+        $qb = $this->_em->createQueryBuilder()
+            ->select('u', 'g')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->from('Doctrine\Tests\Models\CMS\CmsGroup', 'g')
+            ->innerJoin('u.articles', 'a', 'ON', 'u.id = a.author_id')
+            ->innerJoin('u.articles', 'a', 'ON', 'u.id = a.author_id');
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u, g FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id, Doctrine\Tests\Models\CMS\CmsGroup g');
+    }
+
     public function testWhere()
     {
         $qb = $this->_em->createQueryBuilder()


### PR DESCRIPTION
Rationale:
I'm building a webservice where the client can specify a simple filter on the field of the 1:n table.
Without this patch I have to keep a state of which joins I have added to the DQL, which doesn't make any sense as IMHO the DQL builder is meant just for the kind of usage I do.
