### PR TITLE
fix persistance for many-to-one association when using not primary key for referenced column

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -609,9 +609,10 @@ class BasicEntityPersister
                     }
                     // $newVal is not null
 
-                    // add the real column name ($targetColumn) and value, which is used for the assoc. to the array
-                    // otherwise this only works if $targetColumn is 'id' and nothing else
-                    $newValId[$targetColumn] = $targetClass->getFieldValue($newVal, $targetColumn);
+                    // add the real field name and value, which is used for the assoc.
+                    // otherwise this only works if $targetColumn is the primary key and nothing else
+                    $fieldName = $targetClass->getFieldName($targetColumn);
+                    $newValId[$fieldName] = $targetClass->getFieldValue($newVal, $fieldName);
                                         
                     if ($targetClass->containsForeignIdentifier) {
                         $result[$owningTable][$sourceColumn] = $newValId[$targetClass->getFieldForColumn($targetColumn)];

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -586,6 +586,9 @@ class BasicEntityPersister
                 }
 
                 if ($newVal !== null) {
+                    // is here the problem?!
+                    // this method returns only an array with the primary key of the entity
+                    // regardless of the assoc. foreign key is defined to a the primary key or another column
                     $newValId = $uow->getEntityIdentifier($newVal);
                 }
 
@@ -601,7 +604,17 @@ class BasicEntityPersister
 
                     if ($newVal === null) {
                         $result[$owningTable][$sourceColumn] = null;
-                    } else if ($targetClass->containsForeignIdentifier) {
+                        $this->_columnTypes[$sourceColumn] = $targetClass->getTypeOfColumn($targetColumn);
+                        return $result;
+                    }
+                    // $newVal is not null
+                    // create reflection class of the 
+                    $reflectionClass = new \ReflectionClass (get_class($newVal));
+                    // add the real column name ($targetColumn) and value, which is used for the assoc. to the array
+                    // otherwise this only works if $targetColumn is 'id' and nothing else
+                    $newValId[$targetColumn] = $reflectionClass->getProperty($targetColumn)->getValue($newVal);
+                    
+                    if ($targetClass->containsForeignIdentifier) {
                         $result[$owningTable][$sourceColumn] = $newValId[$targetClass->getFieldForColumn($targetColumn)];
                     } else {
                         $result[$owningTable][$sourceColumn] = $newValId[$targetClass->fieldNames[$targetColumn]];

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -608,12 +608,11 @@ class BasicEntityPersister
                         return $result;
                     }
                     // $newVal is not null
-                    // create reflection class of the 
-                    $reflectionClass = new \ReflectionClass (get_class($newVal));
+
                     // add the real column name ($targetColumn) and value, which is used for the assoc. to the array
                     // otherwise this only works if $targetColumn is 'id' and nothing else
-                    $newValId[$targetColumn] = $reflectionClass->getProperty($targetColumn)->getValue($newVal);
-                    
+                    $newValId[$targetColumn] = $targetClass->getFieldValue($newVal, $targetColumn);
+                                        
                     if ($targetClass->containsForeignIdentifier) {
                         $result[$owningTable][$sourceColumn] = $newValId[$targetClass->getFieldForColumn($targetColumn)];
                     } else {

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
@@ -24,7 +24,7 @@ class LegacyArticle
     public $_text;
     /**
      * @ManyToOne(targetEntity="LegacyUser", inversedBy="_articles")
-     * @JoinColumn(name="iUserId", referencedColumnName="iUserId")
+     * @JoinColumn(name="username", referencedColumnName="sUsername")
      */
     public $_user;
     public function setAuthor(LegacyUser $author) {


### PR DESCRIPTION
Bugfix for exception:
Undefined index: xyz in ...\doctrine\orm\lib\Doctrine\ORM\Persisters\BasicEntityPersister.php line 608
Problem occur, if you are using not the primary key for a many-to-one association.
For example if you using: @JoinColumn(name="address_no", referencedColumnName="a_no")
$newValId has only the primary key as element, but 
$newValId[$targetColumn] becomes in this case 
$newValId['a_no'] and this element does not exist -> exception
