### PR TITLE
Replaced the hard coded classname into static in the Entity Manager, in order to allow EntityManager extension

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -863,7 +863,7 @@ class EntityManager implements ObjectManager
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
Changing the hard coded reference to the EntityManager class into static in the factory method to create an entity manager instance
(new EntityManager() --> new static()). In order to make it possible to extend the EntityManager class
