### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
     },
     "autoload": {
-        "psr-0": { "Doctrine\\ORM": "lib/" }
+        "psr-0": { "Doctrine\\ORM\\": "lib/" }
     },
     "bin": ["bin/doctrine", "bin/doctrine.php"],
     "extra": {


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the number of stat calls made.
