### PR TITLE
Use cascade=all if all cascade options set

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1048,7 +1048,7 @@ public function __construct()
                 if (count($cascades) === 5) {
                     $cascades = array('"all"');
                 }
-                
+
                 $typeOptions[] = 'cascade={' . implode(',', $cascades) . '}';
             }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1045,6 +1045,10 @@ public function __construct()
                 if ($associationMapping['isCascadeMerge']) $cascades[] = '"merge"';
                 if ($associationMapping['isCascadeRefresh']) $cascades[] = '"refresh"';
 
+                if (count($cascades) === 5) {
+                    $cascades = array('"all"');
+                }
+                
                 $typeOptions[] = 'cascade={' . implode(',', $cascades) . '}';
             }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -99,6 +99,9 @@ class PhpExporter extends AbstractExporter
                     unset($cascade[$key]);
                 }
             }
+            if (count($cascade) === 5) {
+                $cascade = array('all');
+            }
             $associationMappingArray = array(
                 'fieldName'    => $associationMapping['fieldName'],
                 'targetEntity' => $associationMapping['targetEntity'],

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -99,9 +99,11 @@ class PhpExporter extends AbstractExporter
                     unset($cascade[$key]);
                 }
             }
+
             if (count($cascade) === 5) {
                 $cascade = array('all');
             }
+
             $associationMappingArray = array(
                 'fieldName'    => $associationMapping['fieldName'],
                 'targetEntity' => $associationMapping['targetEntity'],


### PR DESCRIPTION
The YAML and XML metadata exporters output cascade=all if all five cascade options are set. The php and annotation exporter do not, they output cascade=list of all 5 cascades instead. 

In order that all 4 exporters offer the same behavior, I updated the php and annotations exporters  so that they export cascade=all
