### PR TITLE
added support to extend strategies for IdGenerators

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -398,7 +398,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * @param ClassMetadataInfo $class
      * @throws ORMException
      */
-    private function completeIdGeneratorMapping(ClassMetadataInfo $class)
+    protected function completeIdGeneratorMapping(ClassMetadataInfo $class)
     {
         $idGenType = $class->generatorType;
         if ($idGenType == ClassMetadata::GENERATOR_TYPE_AUTO) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -270,7 +270,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 }
 
                 if ($generatedValueAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\GeneratedValue')) {
-                    $metadata->setIdGeneratorType(constant('Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_' . $generatedValueAnnot->strategy));
+                    $metadataClassName = get_class($metadata);
+                    $metadata->setIdGeneratorType(constant($metadataClassName . '::GENERATOR_TYPE_' . $generatedValueAnnot->strategy));
                 }
 
                 if ($this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Version')) {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -272,7 +272,8 @@ class XmlDriver extends FileDriver
             if (isset($idElement->generator)) {
                 $strategy = isset($idElement->generator['strategy']) ?
                         (string)$idElement->generator['strategy'] : 'AUTO';
-                $metadata->setIdGeneratorType(constant('Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_'
+                $metadataClassName = get_class($metadata);
+                $metadata->setIdGeneratorType(constant($metadataClassName . '::GENERATOR_TYPE_'
                         . $strategy));
             }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -264,7 +264,8 @@ class YamlDriver extends FileDriver
                 $metadata->mapField($mapping);
 
                 if (isset($idElement['generator'])) {
-                    $metadata->setIdGeneratorType(constant('Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_'
+                    $metadataClassName = get_class($metadata);
+                    $metadata->setIdGeneratorType(constant($metadataClassName . '::GENERATOR_TYPE_'
                             . strtoupper($idElement['generator']['strategy'])));
                 }
                 // Check for SequenceGenerator/TableGenerator definition


### PR DESCRIPTION
Mapping drivers now use extended classmetadata class to find constants of generator types.
Method completeIdGeneratorMapping is now protected and can be extended
