### PR TITLE
Moved dispatching of postLoad event to the point when entities are fully loaded and all associations initialized

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -186,13 +186,6 @@ the life-time of their registered entities.
 
 .. warning::
 
-    Note that the postLoad event occurs for an entity
-    before any associations have been initialized. Therefore it is not
-    safe to access associations in a postLoad callback or event
-    handler.
-
-.. warning::
-
     Note that the postRemove event or any events triggered after an entity removal
     can receive an uninitializable proxy in case you have configured an entity to
     cascade remove relations. In this case, you should load yourself the proxy in

--- a/lib/Doctrine/ORM/Event/PostLoadEventDispatcher.php
+++ b/lib/Doctrine/ORM/Event/PostLoadEventDispatcher.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Event;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Query;
+
+/**
+ * Dispatcher for postLoad event on entities used during object hydration.
+ *
+ * @author  Lukasz Cybula <lukasz@fsi.pl>
+ * @since   2.4
+ */
+class PostLoadEventDispatcher
+{
+    /**
+     * Entity Manager
+     *
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * Listeners Invoker
+     *
+     * @var \Doctrine\ORM\Event\ListenersInvoker
+     */
+    private $invoker;
+
+    /**
+     * Metadata Factory
+     *
+     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
+     */
+    private $metadataFactory;
+
+    /**
+     * The query hints
+     *
+     * @var array
+     */
+    private $hints = array();
+
+    /**
+     * Entities enqueued for postLoad dispatching
+     *
+     * @var array
+     */
+    private $entities = array();
+
+    /**
+     * Constructs a new dispatcher instance
+     *
+     * @param EntityManager $em
+     * @param array $hints
+     */
+    public function __construct(EntityManager $em, array $hints = array())
+    {
+        $this->entityManager = $em;
+        $this->metadataFactory = $em->getMetadataFactory();
+        $this->invoker = $this->entityManager->getUnitOfWork()->getListenersInvoker();
+        $this->hints = $hints;
+    }
+
+    /**
+     * Dispatches postLoad event for specified entity or enqueues it for later dispatching
+     *
+     * @param object $entity
+     */
+    public function dispatchPostLoad($entity)
+    {
+        $className = get_class($entity);
+        $meta = $this->metadataFactory->getMetadataFor($className);
+        $invoke = $this->invoker->getSubscribedSystems($meta, Events::postLoad);
+
+        if ($invoke === ListenersInvoker::INVOKE_NONE) {
+            return;
+        }
+
+        if (isset($this->hints[Query::HINT_INTERNAL_ITERATION])) {
+            $this->invoker->invoke($meta, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->entityManager), $invoke);
+        } else {
+            if ( ! isset($this->entities[$className])) {
+                $this->entities[$className] = array();
+            }
+
+            $this->entities[$className][] = $entity;
+        }
+    }
+
+    /**
+     * Dispatches all enqueued postLoad events
+     */
+    public function dispatchEnqueuedPostLoadEvents()
+    {
+        foreach ($this->entities as $class => $entities) {
+            $meta = $this->metadataFactory->getMetadataFor($class);
+            $invoke = $this->invoker->getSubscribedSystems($meta, Events::postLoad);
+
+            foreach ($entities as $entity) {
+                $this->invoker->invoke($meta, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->entityManager), $invoke);
+            }
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -24,6 +24,9 @@ use PDO;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostLoadEventDispatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Proxy\Proxy;
 
@@ -75,10 +78,17 @@ class ObjectHydrator extends AbstractHydrator
     private $existingCollections = array();
 
     /**
+     * @var \Doctrine\ORM\Event\PostLoadEventDispatcher
+     */
+    private $postLoadEventDispatcher;
+
+    /**
      * {@inheritdoc}
      */
     protected function prepare()
     {
+        $this->postLoadEventDispatcher = new PostLoadEventDispatcher($this->_em, $this->_hints);
+
         if ( ! isset($this->_hints[UnitOfWork::HINT_DEFEREAGERLOAD])) {
             $this->_hints[UnitOfWork::HINT_DEFEREAGERLOAD] = true;
         }
@@ -144,6 +154,8 @@ class ObjectHydrator extends AbstractHydrator
         $this->existingCollections =
         $this->resultPointers = array();
 
+        unset($this->postLoadEventDispatcher);
+
         if ($eagerLoad) {
             $this->_em->getUnitOfWork()->triggerEagerLoads();
         }
@@ -164,6 +176,8 @@ class ObjectHydrator extends AbstractHydrator
         foreach ($this->initializedCollections as $coll) {
             $coll->takeSnapshot();
         }
+
+        $this->postLoadEventDispatcher->dispatchEnqueuedPostLoadEvents();
 
         return $result;
     }
@@ -265,7 +279,13 @@ class ObjectHydrator extends AbstractHydrator
 
         $this->_hints['fetchAlias'] = $dqlAlias;
 
-        return $this->_uow->createEntity($className, $data, $this->_hints);
+        $created = false;
+        $entity = $this->_uow->createEntity($className, $data, $this->_hints, $created);
+        if ($created) {
+            $this->postLoadEventDispatcher->dispatchPostLoad($entity);
+        }
+
+        return $entity;
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2503,7 +2503,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @todo Rename: getOrCreateEntity
      */
-    public function createEntity($className, array $data, &$hints = array())
+    public function createEntity($className, array $data, &$hints = array(), &$created = null)
     {
         $class = $this->em->getClassMetadata($className);
         //$isReadOnly = isset($hints[Query::HINT_READ_ONLY]);
@@ -2789,12 +2789,8 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
-        if ($overrideLocalValues) {
-            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postLoad);
-
-            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
-            }
+        if (isset($created)) {
+            $created = $overrideLocalValues;
         }
 
         return $entity;
@@ -2861,6 +2857,16 @@ class UnitOfWork implements PropertyChangedListener
     public function getIdentityMap()
     {
         return $this->identityMap;
+    }
+
+    /**
+     * Gets the listeners invoker.
+     *
+     * @return \Doctrine\ORM\Event\ListenersInvoker
+     */
+    public function getListenersInvoker()
+    {
+        return $this->listenersInvoker;
     }
 
     /**


### PR DESCRIPTION
This is proposed solution for very old http://www.doctrine-project.org/jira/browse/DDC-54. I moved dispatching of `postLoad` from `UnitOfWork` to both object hydrators (`SimpleObjectHydrator` and `ObjectHydrator`). Now it's dispatched when entities are fully hydrated into objects with all associations.
