### PR TITLE
Extended TreeWalker interface with getQueryComponents() and setQueryComponent() which are used by the Parser class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,6 +33,12 @@ Also, related functions were affected:
 Internal changes were made to DQL and SQL generation. If you have implemented your own TreeWalker,
 you probably need to update it. The method walkJoinVariableDeclaration is now named walkJoin.
 
+## New methods in TreeWalker interface *BC break*
+
+Two methods getQueryComponents() and setQueryComponent() were added to the TreeWalker interface and all its implementations
+including TreeWalkerAdapter, TreeWalkerChain and SqlWalker. If you have your own implementation not inheriting from one of the
+above you must implement these new methods.
+
 ## Metadata Drivers
 
 Metadata drivers have been rewritten to reuse code from Doctrine\Common. Anyone who is using the

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -358,6 +358,7 @@ class Parser
                 default:
                     $treeWalkerChain->walkSelectStatement($AST);
             }
+            $this->queryComponents = $treeWalkerChain->getQueryComponents();
         }
 
         $outputWalkerClass = $this->customOutputWalker ?: __NAMESPACE__ . '\SqlWalker';

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -358,6 +358,7 @@ class Parser
                 default:
                     $treeWalkerChain->walkSelectStatement($AST);
             }
+
             $this->queryComponents = $treeWalkerChain->getQueryComponents();
         }
 
@@ -1751,7 +1752,7 @@ class Parser
      * NewObjectArg ::= ScalarExpression
      *
      * @TODO - Maybe you should support other expressions and nested "new" operator
-     * 
+     *
      * @return \Doctrine\ORM\Query\AST\SimpleSelectExpression
      */
     public function NewObjectArg()
@@ -2094,7 +2095,7 @@ class Parser
             case ($lookaheadType === Lexer::T_NEW):
                 $expression = $this->NewObjectExpression();
                 break;
-            
+
             default:
                 $this->syntaxError(
                     'IdentificationVariable | ScalarExpression | AggregateExpression | FunctionDeclaration | PartialObjectExpression | "(" Subselect ")" | CaseExpression',

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -140,7 +140,7 @@ class SqlWalker implements TreeWalker
 
     /**
      * The DQL alias of the root class of the currently traversed query.
-     * 
+     *
      * @var array
      */
     private $rootAliases = array();
@@ -224,12 +224,22 @@ class SqlWalker implements TreeWalker
     }
 
     /**
+     * Return internal queryComponents array
+     *
+     * @return array
+     */
+    public function getQueryComponents()
+    {
+        return $this->queryComponents;
+    }
+
+    /**
      * Set or override a query component for a given dql alias.
      *
      * @param string $dqlAlias The DQL alias.
      * @param array $queryComponent
      */
-    protected function setQueryComponent($dqlAlias, array $queryComponent)
+    public function setQueryComponent($dqlAlias, array $queryComponent)
     {
         $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
 
@@ -1986,7 +1996,7 @@ class SqlWalker implements TreeWalker
 
         $dqlAlias = $instanceOfExpr->identificationVariable;
         $discrClass = $class = $this->queryComponents[$dqlAlias]['metadata'];
-        
+
         if ($class->discriminatorColumn) {
             $discrClass = $this->em->getClassMetadata($class->rootEntityName);
         }

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -37,6 +37,21 @@ interface TreeWalker
     public function __construct($query, $parserResult, array $queryComponents);
 
     /**
+     * Return internal queryComponents array
+     *
+     * @return array
+     */
+    public function getQueryComponents();
+
+    /**
+     * Set or override a query component for a given dql alias.
+     *
+     * @param string $dqlAlias The DQL alias.
+     * @param array $queryComponent
+     */
+    public function setQueryComponent($dqlAlias, array $queryComponent);
+
+    /**
      * Walks down a SelectStatement AST node, thereby generating the appropriate SQL.
      *
      * @return string The SQL.

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -43,6 +43,33 @@ abstract class TreeWalkerAdapter implements TreeWalker
     }
 
     /**
+     * Return internal queryComponents array
+     *
+     * @return array:
+     */
+    public function getQueryComponents()
+    {
+        return $this->_queryComponents;
+    }
+
+    /**
+     * Set or override a query component for a given dql alias.
+     *
+     * @param string $dqlAlias The DQL alias.
+     * @param array $queryComponent
+     */
+    public function setQueryComponent($dqlAlias, array $queryComponent)
+    {
+        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+
+        if (array_diff($requiredKeys, array_keys($queryComponent))) {
+            throw QueryException::invalidQueryComponent($dqlAlias);
+        }
+
+        $this->_queryComponents[$dqlAlias] = $queryComponent;
+    }
+
+    /**
      * @return array
      */
     protected function _getQueryComponents()

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -39,6 +39,33 @@ class TreeWalkerChain implements TreeWalker
     private $_queryComponents;
 
     /**
+     * Return internal queryComponents array
+     *
+     * @return array
+     */
+    public function getQueryComponents()
+    {
+        return $this->_queryComponents;
+    }
+
+    /**
+     * Set or override a query component for a given dql alias.
+     *
+     * @param string $dqlAlias The DQL alias.
+     * @param array $queryComponent
+     */
+    public function setQueryComponent($dqlAlias, array $queryComponent)
+    {
+        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+
+        if (array_diff($requiredKeys, array_keys($queryComponent))) {
+            throw QueryException::invalidQueryComponent($dqlAlias);
+        }
+
+        $this->_queryComponents[$dqlAlias] = $queryComponent;
+    }
+
+    /**
      * @inheritdoc
      */
     public function __construct($query, $parserResult, array $queryComponents)
@@ -67,6 +94,7 @@ class TreeWalkerChain implements TreeWalker
     {
         foreach ($this->_walkers as $walker) {
             $walker->walkSelectStatement($AST);
+            $this->_queryComponents = $walker->getQueryComponents();
         }
     }
 

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -94,6 +94,7 @@ class TreeWalkerChain implements TreeWalker
     {
         foreach ($this->_walkers as $walker) {
             $walker->walkSelectStatement($AST);
+
             $this->_queryComponents = $walker->getQueryComponents();
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/CustomTreeWalkersJoinTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomTreeWalkersJoinTest.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Query;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+/**
+ * Test case for custom AST walking and adding new joins.
+ *
+ * @author      Lukasz Cybula <lukasz.cybula@fsi.pl>
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        http://www.doctrine-project.org
+ */
+class CustomTreeWalkersJoinTest extends \Doctrine\Tests\OrmTestCase
+{
+    private $_em;
+
+    protected function setUp()
+    {
+        $this->_em = $this->_getTestEntityManager();
+    }
+
+    public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed)
+    {
+        try {
+            $query = $this->_em->createQuery($dqlToBeTested);
+            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomTreeWalker2'))
+                  ->useQueryCache(false);
+
+            $this->assertEquals($sqlToBeConfirmed, $query->getSql());
+            $query->free();
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage() . ' at "' . $e->getFile() . '" on line ' . $e->getLine());
+
+        }
+    }
+
+    public function testAddsJoin()
+    {
+        $this->assertSqlGeneration(
+            'select u from Doctrine\Tests\Models\CMS\CmsUser u',
+            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c1_.country AS country5, c1_.zip AS zip6, c1_.city AS city7, c0_.email_id AS email_id8, c1_.user_id AS user_id9 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id"
+        );
+    }
+
+    public function testDoesNotAddJoin()
+    {
+        $this->assertSqlGeneration(
+            'select a from Doctrine\Tests\Models\CMS\CmsAddress a',
+            "SELECT c0_.id AS id0, c0_.country AS country1, c0_.zip AS zip2, c0_.city AS city3, c0_.user_id AS user_id4 FROM cms_addresses c0_"
+        );
+    }
+}
+
+class CustomTreeWalker2 extends Query\TreeWalkerAdapter
+{
+    public function walkSelectStatement(Query\AST\SelectStatement $selectStatement)
+    {
+        foreach ($selectStatement->fromClause->identificationVariableDeclarations as $identificationVariableDeclaration) {
+            if ($identificationVariableDeclaration->rangeVariableDeclaration->abstractSchemaName == 'Doctrine\Tests\Models\CMS\CmsUser') {
+                $identificationVariableDeclaration->joins[] = new Query\AST\Join(
+                    Query\AST\Join::JOIN_TYPE_LEFT,
+                    new Query\AST\JoinAssociationDeclaration(
+                        new Query\AST\JoinAssociationPathExpression(
+                            $identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable,
+                            'address'
+                        ),
+                        $identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable . 'a',
+                        null
+                    )
+                );
+                $selectStatement->selectClause->selectExpressions[] =
+                    new Query\AST\SelectExpression(
+                        $identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable . 'a',
+                        null,
+                        false
+                    );
+                $meta1 = $this->_getQuery()->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+                $meta = $this->_getQuery()->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
+                $this->setQueryComponent($identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable . 'a',
+                    array(
+                        'metadata' => $meta,
+                        'parent' => $identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable,
+                        'relation' => $meta1->getAssociationMapping('address'),
+                        'map' => null,
+                        'nestingLevel' => 0,
+                        'token' => null
+                    )
+                );
+            }
+        }
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
@@ -13,37 +13,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
+ * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\Tests\ORM\Functional;
+namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\ORM\Query;
-
-require_once __DIR__ . '/../../TestInit.php';
 
 /**
  * Test case for custom AST walking and adding new joins.
  *
  * @author      Lukasz Cybula <lukasz.cybula@fsi.pl>
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @license     MIT
  * @link        http://www.doctrine-project.org
  */
 class CustomTreeWalkersJoinTest extends \Doctrine\Tests\OrmTestCase
 {
-    private $_em;
+    private $em;
 
     protected function setUp()
     {
-        $this->_em = $this->_getTestEntityManager();
+        $this->em = $this->_getTestEntityManager();
     }
 
     public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed)
     {
         try {
-            $query = $this->_em->createQuery($dqlToBeTested);
-            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomTreeWalker2'))
+            $query = $this->em->createQuery($dqlToBeTested);
+            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Query\CustomTreeWalkerJoin'))
                   ->useQueryCache(false);
 
             $this->assertEquals($sqlToBeConfirmed, $query->getSql());
@@ -71,7 +69,7 @@ class CustomTreeWalkersJoinTest extends \Doctrine\Tests\OrmTestCase
     }
 }
 
-class CustomTreeWalker2 extends Query\TreeWalkerAdapter
+class CustomTreeWalkerJoin extends Query\TreeWalkerAdapter
 {
     public function walkSelectStatement(Query\AST\SelectStatement $selectStatement)
     {


### PR DESCRIPTION
Another proposed solution for http://www.doctrine-project.org/jira/browse/DDC-2052 . The one that @beberlei introduced did not solve the problem that modifying query in a custom tree walker throws an exception from SqlWalker.
