### PR TITLE
Fixed empty namespace in generated code when repository class do not have namespace

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -60,7 +60,7 @@ class <className> extends EntityRepository
         );
         return str_replace(array_keys($variables), array_values($variables), self::$_template);
     }
-    
+
     /**
      * Generate the namespace statement, if class do not have namespace, return empty string instead
      * 

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -35,7 +35,7 @@ class EntityRepositoryGenerator
     protected static $_template =
 '<?php
 
-namespace <namespace>;
+<namespace>
 
 use Doctrine\ORM\EntityRepository;
 
@@ -52,16 +52,28 @@ class <className> extends EntityRepository
 
     public function generateEntityRepositoryClass($fullClassName)
     {
-        $namespace = substr($fullClassName, 0, strrpos($fullClassName, '\\'));
         $className = substr($fullClassName, strrpos($fullClassName, '\\') + 1, strlen($fullClassName));
 
         $variables = array(
-            '<namespace>' => $namespace,
+            '<namespace>' => $this->generateEntityRepositoryNamespace($fullClassName),
             '<className>' => $className
         );
         return str_replace(array_keys($variables), array_values($variables), self::$_template);
     }
-
+    
+    /**
+     * Generate the namespace statement, if class do not have namespace, return empty string instead
+     * 
+     * @param string $fullClassName The full repository class name
+     * @return string $namespace
+     */
+    private function generateEntityRepositoryNamespace($fullClassName)
+    {
+        $namespace = substr($fullClassName, 0, strrpos($fullClassName, '\\'));
+        
+        return $namespace ? 'namespace ' . $namespace . ';' : '';
+    }
+    
     public function writeEntityRepositoryClass($fullClassName, $outputDirectory)
     {
         $code = $this->generateEntityRepositoryClass($fullClassName);


### PR DESCRIPTION
When we defined a class without namespace for entity repository, just like @Entity(repositoryClass="BugRepository"), EntityRepositoryGenerator will generate the code like blow, which has error statement in namespace definition. So this is mainly added a generateEntityRepositoryNamespace method to generate the correct namespace.Just like what EntityGenerator does
https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Tools/EntityGenerator.php#L492

**before**

``` php
<?php

namespace ; //caurse parse error: syntax error, unexpected ';', expecting T_STRING or T_NS_SEPARATOR or '{'

use Doctrine\ORM\EntityRepository;

/**
 * BugRepository
 *
 * This class was generated by the Doctrine ORM. Add your own custom
 * repository methods below.
 */
class BugRepository extends EntityRepository
{
}
```

**after**

``` php
<?php



use Doctrine\ORM\EntityRepository;

/**
 * BugRepository
 *
 * This class was generated by the Doctrine ORM. Add your own custom
 * repository methods below.
 */
class BugRepository extends EntityRepository
{
}
```
