### PR TITLE
Fixes bug whereby orphan-removal value in XMLDriver is incorrectly parsed as true

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -334,7 +334,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($oneToOneElement['orphan-removal'])) {
-                    $mapping['orphanRemoval'] = (bool)$oneToOneElement['orphan-removal'];
+                    $mapping['orphanRemoval'] = (bool)(string)$oneToOneElement['orphan-removal'];
                 }
 
                 $metadata->mapOneToOne($mapping);
@@ -359,7 +359,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($oneToManyElement['orphan-removal'])) {
-                    $mapping['orphanRemoval'] = (bool)$oneToManyElement['orphan-removal'];
+                    $mapping['orphanRemoval'] = (bool)(string)$oneToManyElement['orphan-removal'];
                 }
 
                 if (isset($oneToManyElement->{'order-by'})) {
@@ -433,7 +433,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($manyToManyElement['orphan-removal'])) {
-                    $mapping['orphanRemoval'] = (bool)$manyToManyElement['orphan-removal'];
+                    $mapping['orphanRemoval'] = (bool)(string)$manyToManyElement['orphan-removal'];
                 }
 
                 if (isset($manyToManyElement['mapped-by'])) {


### PR DESCRIPTION
I realise this is very hand wavy and if you require some more information or test cases then I can see about that.

However, just to get the issue logged, as I just spent 3 hours reverse engineering the doctrine code to find this, and it may help someone else.

Basically when reading the XML mapping data from generated XML files the orphan-removal value was being incorrectly parse as 'true' when it was set to 'false' in the mapping file.

I think this is because the XML parser was parsing the attribute as an object and when it was casted a boolean this meant the value became true. To overcome this I first cast the value as a string, and then to a bool.

Let me know if you need more information.

Thanks.
