### PR TITLE
Check identifier is not empty before accessing first item

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -982,7 +982,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function isIdentifier($fieldName)
     {
-        if ( ! $this->isIdentifierComposite) {
+        if ( ! $this->isIdentifierComposite && $this->identifier) {
             return $fieldName === $this->identifier[0];
         }
         return in_array($fieldName, $this->identifier);


### PR DESCRIPTION
Cause Notice when using Gedmo\Sluggable in a mapped super class.
