### PR TITLE
user can set its own commands in the cli-config.php file

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -21,6 +21,7 @@
 $configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';
 
 $helperSet = null;
+$commands = array();
 if (file_exists($configFile)) {
     if ( ! is_readable($configFile)) {
         trigger_error(
@@ -40,4 +41,4 @@ if (file_exists($configFile)) {
 
 $helperSet = ($helperSet) ?: new \Symfony\Component\Console\Helper\HelperSet();
 
-\Doctrine\ORM\Tools\Console\ConsoleRunner::run($helperSet);
+\Doctrine\ORM\Tools\Console\ConsoleRunner::run($helperSet, $commands);


### PR DESCRIPTION
Today we need to edit source to add custom commands. With this minor change, we can add custom commands directly in the cli-config.php file :

```
require_once "app/bootstrap.php";
$helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
            'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($entityManager)
        ));

// example here
$commands = array(
    new Doctrine\ORM\Tools\Console\Command\LoadDataCommand
);
```
