### PR TITLE
Changed the EntityManager::create() function to use late static binding

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -862,8 +862,8 @@ class EntityManager implements ObjectManager
             default:
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
-
-        return new EntityManager($conn, $config, $conn->getEventManager());
+	$class = get_called_class();
+        return new $class($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
This makes it possible to extend the EntityManager class and reuse the create
function, because now it will create an EntityManager of the type of the
extended class instead of always creating the non extended EntityManger type.
