### PR TITLE
Prevented "Undefined index" notice when updating

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -982,7 +982,7 @@ class UnitOfWork implements PropertyChangedListener
                 );
             }
 
-            if ($this->entityChangeSets[$oid]) {
+            if (!empty($this->entityChangeSets[$oid])) {
                 $persister->update($entity);
             }
 


### PR DESCRIPTION
While executing updates on an entity scheduled for update without a change-set, an "Undefined index" notice is raised.

This issue will occur when you manually call `$em()->getUnitOfWork()->scheduleForUpdate()` on an entity that hasn't changed. The entity will be included in `UnitOfWork::$entityUpdates`, but because there are no changes, its oid will not be included in `UnitOfWork::$entityChangeSets`.

I know I'm misusing `scheduleForUpdate()` a bit in this case, but the notice can easily be prevented with a `!empty()`.
