### PR TITLE
Back ported changes of SimpleConditionalExpression

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -436,9 +436,10 @@ class Parser
     /**
      * Peek beyond the matched closing parenthesis and return the first token after that one.
      *
+     * @param boolean $resetPeek Reset peek after finding the closing parenthesis
      * @return array
      */
-    private function _peekBeyondClosingParenthesis()
+    private function _peekBeyondClosingParenthesis($resetPeek = true)
     {
         $token = $this->_lexer->peek();
         $numUnmatched = 1;
@@ -460,7 +461,9 @@ class Parser
             $token = $this->_lexer->peek();
         }
 
-        $this->_lexer->resetPeek();
+        if ($resetPeek) {
+            $this->_lexer->resetPeek();
+        }
 
         return $token;
     }
@@ -2190,7 +2193,13 @@ class Parser
             if ($peek['value'] == '(') {
                 // Peek beyond the matching closing paranthesis ')'
                 $this->_lexer->peek();
-                $token = $this->_peekBeyondClosingParenthesis();
+                $token = $this->_peekBeyondClosingParenthesis(false);
+
+                if ($token['type'] === Lexer::T_NOT) {
+                    $token = $this->_lexer->peek();
+                }
+
+                $this->_lexer->resetPeek();
             } else {
                 // Peek beyond the PathExpression (or InputParameter)
                 $peek = $this->_lexer->peek();


### PR DESCRIPTION
This following query fails.

```
SELECT I FROM Rollerworks\Bundle\RecordFilterBundle\Tests\Fixtures\BaseBundle\Entity\ECommerce\ECommerceInvoice I WHERE ((RECORD_FILTER_FIELD_CONVERSION('invoice_customer', I.customer) BETWEEN :invoice_customer_0 AND :invoice_customer_1) AND (RECORD_FILTER_FIELD_CONVERSION('invoice_customer', I.customer) NOT BETWEEN :invoice_customer_2 AND :invoice_customer_3))
```

With this message.

```
[Syntax Error] line 0, col 306: Error: Expected =, <, <=, <>, >, >=, !=, got 'NOT'
```

It only happens in version 2.2, 2.3 is working as expected.

I have traced the fix to one very simple change in SimpleConditionalExpression and only seem to happen when using an custom function NOT and having nested parenthesis.

As far as I can tell its BC.
