### PR TITLE
fix StatementMock bindParam parameters

### DIFF
--- a/tests/Doctrine/Tests/Mocks/StatementMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementMock.php
@@ -10,7 +10,7 @@ namespace Doctrine\Tests\Mocks;
 class StatementMock implements \IteratorAggregate, \Doctrine\DBAL\Driver\Statement
 {
     public function bindValue($param, $value, $type = null){}
-    public function bindParam($column, &$variable, $type = null){}
+    public function bindParam($column, &$variable, $type = null, $length = null){}
     public function errorCode(){}
     public function errorInfo(){}
     public function execute($params = null){}


### PR DESCRIPTION
Hi,

This patch fixes

PHP Fatal error:  Declaration of Doctrine\Tests\Mocks\StatementMock::bindParam() must be compatible with Doctrine\DBAL\Driver\Statement::bindParam($column, &$variable, $type = NULL, $length = NULL) in /home/michal/projekty/doctrine2/tests/Doctrine/Tests/Mocks/StatementMock.php on line 11

Best regards,
Michal
