### PR TITLE
Do not add trailing whitespace to blank lines

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1213,7 +1213,7 @@ public function __construct()
         $lines = explode("\n", $code);
 
         foreach ($lines as $key => $value) {
-            if (!empty($value)) {
+            if ( ! empty($value)) {
                 $lines[$key] = str_repeat($this->spaces, $num) . $lines[$key];
             }
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -363,7 +363,7 @@ public function __construct()
         $body = str_replace('<spaces>', $this->spaces, $body);
         $last = strrpos($currentCode, '}');
 
-        return substr($currentCode, 0, $last) . $body . (strlen($body) > 0 ? "\n" : ''). "}";
+        return substr($currentCode, 0, $last) . $body . (strlen($body) > 0 ? "\n" : ''). "}\n";
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1207,7 +1207,9 @@ public function __construct()
         $lines = explode("\n", $code);
 
         foreach ($lines as $key => $value) {
-            $lines[$key] = str_repeat($this->spaces, $num) . $lines[$key];
+            if (!empty($value)) {
+                $lines[$key] = str_repeat($this->spaces, $num) . $lines[$key];
+            }
         }
 
         return implode("\n", $lines);


### PR DESCRIPTION
This change prevents spaces from being added to blank lines so PHP Code Sniffer doesn't generate errors when using PSR2 standards.
