### PR TITLE
[DDC-2113] Surround WHERE clause with parens if using SQLFilter

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1700,7 +1700,7 @@ class SqlWalker implements TreeWalker
 
             if (count($filterClauses)) {
                 if ($condSql) {
-                    $condSql .= ' AND ';
+                    $condSql = '(' . $condSql . ') AND ';
                 }
 
                 $condSql .= implode(' AND ', $filterClauses);

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -453,6 +453,22 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(1, count($query->getResult()));
     }
 
+    public function testWhereOrFilter()
+    {
+        $this->loadFixtureData();
+        $query = $this->_em->createQuery('select ug from Doctrine\Tests\Models\CMS\CmsGroup ug WHERE 1=1 OR 1=1');
+
+        // We get two users before enabling the filter
+        $this->assertEquals(2, count($query->getResult()));
+
+        $conf = $this->_em->getConfiguration();
+        $conf->addFilter("group_prefix", "\Doctrine\Tests\ORM\Functional\CMSGroupPrefixFilter");
+        $this->_em->getFilters()->enable("group_prefix")->setParameter("prefix", "bar_%", DBALType::STRING);
+
+        // We get one user after enabling the filter
+        $this->assertEquals(1, count($query->getResult()));
+    }
+
 
     private function loadLazyFixtureData()
     {


### PR DESCRIPTION
Patch to address DDC-2113, by surrounding the WHERE clause conditional with parens if there are any filterClauses
