### PR TITLE
Improve DocBlock annotations of generated entities

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -672,7 +672,7 @@ public function __construct()
     {
         $lines = array();
         $lines[] = '/**';
-        $lines[] = ' * '.$metadata->name;
+        $lines[] = ' * ' . $this->getClassName($metadata);
 
         if ($this->generateAnnotations) {
             $lines[] = ' *';
@@ -1126,7 +1126,7 @@ public function __construct()
     {
         $lines = array();
         $lines[] = $this->spaces . '/**';
-        $lines[] = $this->spaces . ' * @var ' . $this->getType($fieldMapping['type']) . ' $' . $fieldMapping['fieldName'];
+        $lines[] = $this->spaces . ' * @var ' . $this->getType($fieldMapping['type']);
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';


### PR DESCRIPTION
Currently, the DocBlock annotations for member variables contain the variable name as description which is redundant and should be removed. Furthermore the class is annotated with the FQN instead of just the name. This makes automatically generated documentation quite ugly.

These changes will result in entities that as follows

```
/**
 * User
 *
 * @ORM\Table()
 * @ORM\Entity
 */
class User
{
    /**
     * @var string
     *
     * @ORM\Column(name="name", type="string", length=255)
     */
    private $name;
```

instead of this:

```
/**
 * Some\Completely\Random\Namespace\User    <--- FQN is not needed here
 *
 * @ORM\Table()
 * @ORM\Entity
 */
class User
{
    /**
     * @var string $name  <--- description is better left blank instead of using variable name
     *
     * @ORM\Column(name="name", type="string", length=255)
     */
    private $name;
```
