### PR TITLE
Speling: "invidiual" -> "individual"

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1680,7 +1680,7 @@ class BasicEntityPersister
     }
 
     /**
-     * Retrieve an invidiual parameter value
+     * Retrieve an individual parameter value
      *
      * @param mixed $value
      * @return mixed


### PR DESCRIPTION
Just in a phpdoc comment, but should be corrected anyway.
