### PR TITLE
Allow 0 id for Entity

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -281,7 +281,7 @@ abstract class AbstractQuery
 
         $value = $values[$class->getSingleIdentifierFieldName()];
 
-        if ( ! $value) {
+        if ( ! isset($value)) {
             throw new \InvalidArgumentException(
                 "Binding entities to query parameters only allowed for entities that have an identifier."
             );

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -281,7 +281,7 @@ abstract class AbstractQuery
 
         $value = $values[$class->getSingleIdentifierFieldName()];
 
-        if ( ! isset($value)) {
+        if (null === $value) {
             throw new \InvalidArgumentException(
                 "Binding entities to query parameters only allowed for entities that have an identifier."
             );


### PR DESCRIPTION
When using a 0 id, it's throwing InvalidArgumentException (Binding entities to query parameters only allowed for entities that have an identifier.) 
