### PR TITLE
Fix errors in JoinClassPathExpression and SqlWalker

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
@@ -40,6 +40,6 @@ class JoinClassPathExpression extends Node
 
     public function dispatch($walker)
     {
-        return $sqlWalker->walkJoinPathExpression($this);
+        return $walker->walkJoinPathExpression($this);
     }
 }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1172,7 +1172,7 @@ class SqlWalker implements TreeWalker
         switch (true) {
             case ($expr instanceof AST\PathExpression):
                 if ($expr->type !== AST\PathExpression::TYPE_STATE_FIELD) {
-                    throw QueryException::invalidPathExpression($expr->type);
+                    throw QueryException::invalidPathExpression($expr);
                 }
 
                 $fieldName = $expr->field;
@@ -1213,7 +1213,6 @@ class SqlWalker implements TreeWalker
             case ($expr instanceof AST\SimpleArithmeticExpression):
             case ($expr instanceof AST\ArithmeticTerm):
             case ($expr instanceof AST\ArithmeticFactor):
-            case ($expr instanceof AST\ArithmeticPrimary):
             case ($expr instanceof AST\Literal):
             case ($expr instanceof AST\NullIfExpression):
             case ($expr instanceof AST\CoalesceExpression):
@@ -1513,7 +1512,6 @@ class SqlWalker implements TreeWalker
             case ($expr instanceof AST\SimpleArithmeticExpression):
             case ($expr instanceof AST\ArithmeticTerm):
             case ($expr instanceof AST\ArithmeticFactor):
-            case ($expr instanceof AST\ArithmeticPrimary):
             case ($expr instanceof AST\Literal):
             case ($expr instanceof AST\NullIfExpression):
             case ($expr instanceof AST\CoalesceExpression):


### PR DESCRIPTION
- Fixes a typo in a variable name in JoinClassPathExpression::dispatch()
- Fixes an exception throw: QueryException::invalidPathExpression() expects a PathExpression, not a string
- Removes two references to an undefined class AST\ArithmeticPrimary
