### PR TITLE
Now MetaDataFilter takess also regexp. For example whern you want to

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -51,7 +51,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
 
     public function __construct(\ArrayIterator $metadata, $filter)
     {
-        $this->filter = (array)$filter;
+        $this->filter = (array) $filter;
 
         parent::__construct($metadata);
     }
@@ -66,7 +66,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->filter as $filter) {
-            if (preg_match("/".preg_quote($filter)."/", $metadata->name)) {
+            if (preg_match("/" . preg_quote($filter) . "/", $metadata->name)) {
                 return true;
             }
         }

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -66,9 +66,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->filter as $filter) {
-            if (strpos($metadata->name, $filter) !== false) {
-                return true;
-            }
+            if(preg_match("#$filter#",$metadata->name,$m)) return true;
         }
 
         return false;

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -51,7 +51,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
 
     public function __construct(\ArrayIterator $metadata, $filter)
     {
-        $this->filter = (array) $filter;
+        $this->filter = (array)$filter;
 
         parent::__construct($metadata);
     }
@@ -66,7 +66,9 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->filter as $filter) {
-            if(preg_match("#$filter#",$metadata->name,$m)) return true;
+            if (preg_match("/$filter/", $metadata->name, $m)) {
+                return true;
+            }
         }
 
         return false;

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -66,7 +66,16 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->filter as $filter) {
-            if (preg_match("/" . preg_quote($filter) . "/", $metadata->name)) {
+            $pregResult = preg_match("/" . preg_quote($filter) . "/", $metadata->name);
+            if ($pregResult === false) {
+                return false;
+            }
+
+            if ($pregResult === 0) {
+                return false;
+            }
+
+            if ($pregResult) {
                 return true;
             }
         }

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -66,7 +66,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
         $metadata = $it->current();
 
         foreach ($this->filter as $filter) {
-            if (preg_match("/$filter/", $metadata->name, $m)) {
+            if (preg_match("/".preg_quote($filter)."/", $metadata->name)) {
                 return true;
             }
         }


### PR DESCRIPTION
extract metadata if you would filter like this: --filter="Article"
would extract also for "ArticleItems" (article_items table). Now you
can use --filter="Article$" if you want only that table (articl)
