### PR TITLE
Fix and test for DDC-2073

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -84,7 +84,7 @@ class BasicEntityPersister
      */
     static private $comparisonMap = array(
         Comparison::EQ  => '= %s',
-        Comparison::IS  => '= %s',
+        Comparison::IS  => 'IS %s',
         Comparison::NEQ => '!= %s',
         Comparison::GT  => '> %s',
         Comparison::GTE => '>= %s',

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -88,4 +88,13 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals('t0."simple-entity-id" AS simpleentityid1, t0."simple-entity-value" AS simpleentityvalue2', $method->invoke($persister));
     }
+
+    /**
+     * @group DDC-2073
+     */
+    public function testSelectConditionStatementIsNull()
+    {
+        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, array(), Comparison::IS);
+        $this->assertEquals('test IS ?', $statement);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Persisters\BasicEntityPersister;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomTypeFriend;
+use Doctrine\Common\Collections\Expr\Comparison;
 
 require_once __DIR__ . '/../../TestInit.php';
 


### PR DESCRIPTION
Fix and test for [DDC-2073](http://www.doctrine-project.org/jira/browse/DDC-2073).

Ticket extract:

> PersistentCollection::matching() always returns empty collection, when passed criteria's expression is created using ExpressionBuilder::isNull()
> This happens because expression created by ExpressionBuilder::isNull() is wrongly translated to SQL using '=' operator instead of 'IS NULL'.
> If the collection is already loaded, result is as expected.
