### PR TITLE
SchemaTool ignoring 'fixed' option

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -395,7 +395,13 @@ class SchemaTool
 
                 unset($mapping['options']['unsigned']);
             }
-
+            
+            if (isset($mapping['options']['fixed'])) {
+                $options['fixed'] = $mapping['options']['fixed'];
+                
+                unset($mapping['options']['fixed']);
+            }
+            
             $options['customSchemaOptions'] = $mapping['options'];
         }
 


### PR DESCRIPTION
If the column is set to fixed string length like this:

``` php
<?php

/**
 * @ORM\Column(type="string", length=2, options={"fixed" = true})
 */
protected $foo;
```

The schema tool will not detect that 'fixed' option correctly when generating update SQL.

Fix attached.
