### PR TITLE
Added addParameters() to Query and QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -255,7 +255,8 @@ abstract class AbstractQuery
             {
                 return $parameter->getName();
             }
-        )->toArray();
+        );
+        $currentNames = $currentNames->toArray();
 
         foreach ($parameters as $key => $value) {
             if ($value instanceof Query\Parameter) {

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -241,6 +241,47 @@ abstract class AbstractQuery
     }
 
     /**
+     * Adds a collection of query parameters, overriding any existing positions/names.
+     * Behaves like setParameters() before 2.3.
+     *
+     * @param \Doctrine\Common\Collections\ArrayCollection|array $parameters
+     *
+     * @return \Doctrine\ORM\AbstractQuery This query instance.
+     */
+    public function addParameters($parameters)
+    {
+        $currentNames = $this->parameters->map(
+            function ($parameter)
+            {
+                return $parameter->getName();
+            }
+        )->toArray();
+
+        foreach ($parameters as $key => $value) {
+            if ($value instanceof Query\Parameter) {
+                // $value is a Query\Parameter
+                $parameter = $value;
+
+                if (false !== ($index = array_search($parameter->getName(), $currentNames))) {
+                    $this->parameters[$index]->setValue( $parameter->getValue(), $parameter->getType() );
+                } else {
+                    $this->parameters->add( $parameter );
+                }
+
+            } else {
+                // $value is an actual value, $key is its position/name
+                if (false !== ($index = array_search($key, $currentNames))) {
+                    $this->parameters[$index]->setValue( $value );
+                } else {
+                    $this->parameters->add(new Query\Parameter($key, $value));
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Process an individual parameter value
      *
      * @param mixed $value

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -264,15 +264,15 @@ abstract class AbstractQuery
                 $parameter = $value;
 
                 if (false !== ($index = array_search($parameter->getName(), $currentNames))) {
-                    $this->parameters[$index]->setValue( $parameter->getValue(), $parameter->getType() );
+                    $this->parameters[$index]->setValue($parameter->getValue(), $parameter->getType());
                 } else {
-                    $this->parameters->add( $parameter );
+                    $this->parameters->add($parameter);
                 }
 
             } else {
                 // $value is an actual value, $key is its position/name
                 if (false !== ($index = array_search($key, $currentNames))) {
-                    $this->parameters[$index]->setValue( $value );
+                    $this->parameters[$index]->setValue($value);
                 } else {
                     $this->parameters->add(new Query\Parameter($key, $value));
                 }

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -455,15 +455,15 @@ class QueryBuilder
                 $parameter = $value;
 
                 if (false !== ($index = array_search($parameter->getName(), $currentNames))) {
-                    $this->parameters[$index]->setValue( $parameter->getValue(), $parameter->getType() );
+                    $this->parameters[$index]->setValue($parameter->getValue(), $parameter->getType());
                 } else {
-                    $this->parameters->add( $parameter );
+                    $this->parameters->add($parameter);
                 }
 
             } else {
                 // $value is an actual value, $key is its position/name
                 if (false !== ($index = array_search($key, $currentNames))) {
-                    $this->parameters[$index]->setValue( $value );
+                    $this->parameters[$index]->setValue($value);
                 } else {
                     $this->parameters->add(new Query\Parameter($key, $value));
                 }

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -417,6 +417,62 @@ class QueryBuilder
     }
 
     /**
+     * Adds a collection of query parameters, overriding any existing positions/names.
+     * Behaves like setParameters() before 2.3.
+     *
+     * <code>
+     *     $qb = $em->createQueryBuilder()
+     *         ->select('u')
+     *         ->from('User', 'u')
+     *         ->where('u.id = :user_id1 OR u.id = :user_id2 OR u.id = :user_id3' OR u.id = :user_id4)
+     *         ->addParameters(new ArrayCollection(array(
+     *             new Parameter('user_id1', 1),
+     *             new Parameter('user_id2', 2)
+     *         )))
+     *         ->addParameters(new ArrayCollection(array(
+     *             new Parameter('user_id3', 3),
+     *             new Parameter('user_id4', 4)
+     *         )));
+     * </code>
+     *
+     * @param \Doctrine\Common\Collections\ArrayCollection|array $parameters
+     *
+     * @return \Doctrine\ORM\QueryBuilder This QueryBuilder instance.
+     */
+    public function addParameters($parameters)
+    {
+        $currentNames = $this->parameters->map(
+            function ($parameter)
+            {
+                return $parameter->getName();
+            }
+        )->toArray();
+
+        foreach ($parameters as $key => $value) {
+            if ($value instanceof Query\Parameter) {
+                // $value is a Query\Parameter
+                $parameter = $value;
+
+                if (false !== ($index = array_search($parameter->getName(), $currentNames))) {
+                    $this->parameters[$index]->setValue( $parameter->getValue(), $parameter->getType() );
+                } else {
+                    $this->parameters->add( $parameter );
+                }
+
+            } else {
+                // $value is an actual value, $key is its position/name
+                if (false !== ($index = array_search($key, $currentNames))) {
+                    $this->parameters[$index]->setValue( $value );
+                } else {
+                    $this->parameters->add(new Query\Parameter($key, $value));
+                }
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Gets all defined query parameters for the query being constructed.
      *
      * @return \Doctrine\Common\Collections\ArrayCollection The currently defined query parameters.

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -446,7 +446,8 @@ class QueryBuilder
             {
                 return $parameter->getName();
             }
-        )->toArray();
+        );
+        $currentNames = $currentNames->toArray();
 
         foreach ($parameters as $key => $value) {
             if ($value instanceof Query\Parameter) {

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -7,6 +7,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 use Doctrine\ORM\Query\Parameter;
 
+require_once __DIR__ . '/../../TestInit.php';
+
 class QueryTest extends \Doctrine\Tests\OrmTestCase
 {
     protected $_em = null;
@@ -47,6 +49,49 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
         $query->setParameters($parameters);
 
         $this->assertEquals($parameters, $query->getParameters());
+    }
+
+    public function testAddParameters()
+    {
+        $query = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1");
+
+        // Add 2 initial parameters as ArrayCollection containing Parameter objects.
+        $parameters = new ArrayCollection();
+        $parameters->add(new Parameter(1, 'foo'));
+        $parameters->add(new Parameter(2, 'bar'));
+
+        $query->addParameters($parameters);
+
+        $this->assertEquals($parameters, $query->getParameters());
+
+        // Add 2 other parameters as array containing key/value pairs.
+        // The first parameter should override an existing one, the second parameter is new.
+        $query->addParameters(array(
+            1 => 'foobar',
+            3 => 'barfoo'
+        ));
+
+        $parameters = $query->getParameters();
+
+        $this->assertEquals(3, count($parameters));
+        $this->assertEquals('foobar', $parameters[0]->getValue());
+        $this->assertEquals('bar', $parameters[1]->getValue());
+        $this->assertEquals('barfoo', $parameters[2]->getValue());
+
+        // Add 2 more parameters as ArrayCollection containing Parameter objects.
+        // The first parameter should override an existing one, the second parameter is new.
+        $query->addParameters(new ArrayCollection(array(
+            new Parameter(2, 'foobarfoo'),
+            new Parameter(4, 'barfoobar')
+        )));
+
+        $parameters = $query->getParameters();
+
+        $this->assertEquals(4, count($parameters));
+        $this->assertEquals('foobar', $parameters[0]->getValue());
+        $this->assertEquals('foobarfoo', $parameters[1]->getValue());
+        $this->assertEquals('barfoo', $parameters[2]->getValue());
+        $this->assertEquals('barfoobar', $parameters[3]->getValue());
     }
 
     public function testFree()

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -7,8 +7,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 use Doctrine\ORM\Query\Parameter;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class QueryTest extends \Doctrine\Tests\OrmTestCase
 {
     protected $_em = null;

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -463,6 +463,52 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($parameters, $qb->getQuery()->getParameters());
     }
 
+    public function testAddParameters()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')
+           ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+           ->where($qb->expr()->orx('u.username = :username', 'u.username = :username2'));
+
+        // Add 2 initial parameters as ArrayCollection containing Parameter objects.
+        $parameters = new ArrayCollection();
+        $parameters->add(new Parameter('username', 'foo'));
+        $parameters->add(new Parameter('username2', 'bar'));
+
+        $qb->addParameters($parameters);
+
+        $this->assertEquals($parameters, $qb->getParameters());
+
+        // Add 2 other parameters as array containing key/value pairs.
+        // The first parameter should override an existing one, the second parameter is new.
+        $qb->addParameters(array(
+            'username' => 'foobar',
+            'username3' => 'barfoo'
+        ));
+
+        $parameters = $qb->getParameters();
+
+        $this->assertEquals(3, count($parameters));
+        $this->assertEquals('foobar', $parameters[0]->getValue());
+        $this->assertEquals('bar', $parameters[1]->getValue());
+        $this->assertEquals('barfoo', $parameters[2]->getValue());
+
+        // Add 2 more parameters as ArrayCollection containing Parameter objects.
+        // The first parameter should override an existing one, the second parameter is new.
+        $qb->addParameters(new ArrayCollection(array(
+            new Parameter('username2', 'foobarfoo'),
+            new Parameter('username4', 'barfoobar')
+        )));
+
+        $parameters = $qb->getParameters();
+
+        $this->assertEquals(4, count($parameters));
+        $this->assertEquals('foobar', $parameters[0]->getValue());
+        $this->assertEquals('foobarfoo', $parameters[1]->getValue());
+        $this->assertEquals('barfoo', $parameters[2]->getValue());
+        $this->assertEquals('barfoobar', $parameters[3]->getValue());
+    }
+
 
     public function testGetParameters()
     {


### PR DESCRIPTION
This method behaves like `setParameters()` before version 2.3:
It will add new parameters to the collection, and override any existing positions/names.

It can take a `Doctrine\Common\Collections\ArrayCollection` with `Doctrine\ORM\Query\Parameter` objects, as well as a plain `array` with key/value pairs, as argument.

This will greatly ease the upgrade to Doctrine 2.3, because you only need to perform a project-wide replace of `setParameters` with `addParameters`, in stead of going into your code and determine if calls to `setParameters` are ok or need refactoring.

I've also added unit-tests to maintain integrity.
