### PR TITLE
Improved exception when a type hint class can not be found

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyException.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyException.php
@@ -49,4 +49,13 @@ class ProxyException extends \Doctrine\ORM\ORMException {
         ));
     }
 
+    public static function typeHintClassReflectionFailure($paramName, $className, $methodName, $previousException)
+    {
+        return new self(sprintf(
+            "Can not get type hint class for parameter %s of %s::%s()",
+            $paramName,
+            $className,
+            $methodName
+        ), 0, $previousException);
+    }
 }

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -230,7 +230,19 @@ class ProxyFactory
                     }
 
                     // We need to pick the type hint class too
-                    if (($paramClass = $param->getClass()) !== null) {
+
+                    try {
+                        $paramClass = $param->getClass();
+                    } catch (\ReflectionException $e) {
+                        throw ProxyException::typeHintClassReflectionFailure(
+                            $param->getName(),
+                            $param->getDeclaringClass()->getName(),
+                            $param->getDeclaringFunction()->getName(),
+                            $e
+                        );
+                    }
+
+                    if ($paramClass !== null) {
                         $parameterString .= '\\' . $paramClass->getName() . ' ';
                     } else if ($param->isArray()) {
                         $parameterString .= 'array ';

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyClassGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyClassGeneratorTest.php
@@ -181,6 +181,20 @@ class ProxyClassGeneratorTest extends \Doctrine\Tests\OrmTestCase
         new ProxyFactory($this->_getTestEntityManager(), __DIR__ . '/generated', null);
     }
 
+    public function testWrongTypeHintClass_ThrowsException()
+    {
+        $this->setExpectedException(
+            'Doctrine\ORM\Proxy\ProxyException',
+            "Can not get type hint class for parameter param of Doctrine\Tests\ORM\Proxy\WrontTypeHintClass::test()"
+        );
+
+        $cm = new \Doctrine\ORM\Mapping\ClassMetadata(__NAMESPACE__ . '\\WrontTypeHintClass');
+        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $this->assertNotNull($cm->reflClass);
+
+        $this->_proxyFactory->generateProxyClasses(array($cm));
+    }
+
     protected function _getMockPersister()
     {
         $persister = $this->getMock('Doctrine\ORM\Persisters\BasicEntityPersister', array('load'), array(), '', false);
@@ -202,3 +216,11 @@ abstract class AbstractClass
 {
 
 }
+
+class WrontTypeHintClass
+{
+    public function test(\WrontTypeHint $param)
+    {
+    }
+}
+


### PR DESCRIPTION
This improves the exception message when a type hint class was not found during the generation of a proxy.

Example:

``` php
<?php
class Foo
{
    function test(\InvalidClass $param) 
    {
    }
}
```

When generating a proxy for this class `Foo`, if the type hint class `InvalidClass` cannot be found, a `ReflectionException` exception is thrown with the following message: `Class InvalidClass does not exist`. There is no hint on the real cause of the error (which class, method, ...).

This PR wraps this exception with a message making the cause of the exception more obvious.
