### PR TITLE
Allow running tests with composer

### DIFF
--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -6,11 +6,12 @@ namespace Doctrine\Tests;
 
 error_reporting(E_ALL | E_STRICT);
 
-require_once __DIR__ . '/../../../lib/vendor/doctrine-common/lib/Doctrine/Common/ClassLoader.php';
 
 if (isset($GLOBALS['DOCTRINE_COMMON_PATH'])) {
+    require_once $GLOBALS['DOCTRINE_COMMON_PATH'] . '/Doctrine/Common/ClassLoader.php';
     $classLoader = new \Doctrine\Common\ClassLoader('Doctrine\Common', $GLOBALS['DOCTRINE_COMMON_PATH']);
 } else {
+    require_once __DIR__ . '/../../../lib/vendor/doctrine-common/lib/Doctrine/Common/ClassLoader.php';
     $classLoader = new \Doctrine\Common\ClassLoader('Doctrine\Common', __DIR__ . '/../../../lib/vendor/doctrine-common/lib');
 }
 $classLoader->register();


### PR DESCRIPTION
To make it as easy as possible to run tests with a composer installed doctrine2, this PR changes the `TestInit.php` to load the ClassLoader from `$GLOBALS['DOCTRINE_COMMON_PATH']` if one is set.
