### PR TITLE
Bug in UnitOfWork::executeDeletions when at least two entities have to b...

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1009,7 +1009,7 @@ class UnitOfWork implements PropertyChangedListener
         $hasLifecycleCallbacks = isset($class->lifecycleCallbacks[Events::postRemove]);
         $hasListeners = $this->evm->hasListeners(Events::postRemove);
 
-        foreach ($this->entityDeletions as $oid => $entity) {
+        foreach ($this->entityDeletions as $oid => &$entity) {
             if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
                 continue;
             }


### PR DESCRIPTION
Bug in UnitOfWork::executeDeletions.

There is a foreach on line 1012 and dispatchEvent on line 1038.
When at least two entities have to be deleted and a listener listening to postRemove event is attached to them and there is also EntityManager::flush in that listener.
- EntityManager::remove
- EntityManager::remove
- EntityManager::flush
  - UnitOfWork::commit
    - UnitOfWork::executeDeletions
      - BasicEntityPersister::delete // FOR THE FIRST REMOVED ENTITY
        ... 
      - EventManager::dispatchEvent
        - PostRemoveListener::postRemove
          - EntityManager::flush
            - UnitOfWork::commit
              - UnitOfWork::executeDeletions
                - BasicEntityPersister::delete // FOR THE SECOND REMOVED ENTITY 
      - BasicEntityPersister::delete // FOR THE SECOND REMOVED ENTITY AGAIN because that foreach operates with array "copies" and that unset on line 1020 in UnitOfWork doesnt affact to the array copy 
        - UnitOfWork::getEntityIdentifier // line 2735 - NOTICE, because the entity is already deleted from the array

Tests passed (those tests which are not skipped in my environment).

PHPUnit 3.7.9 by Sebastian Bergmann.

Configuration read from D:\Www\doctrine2\phpunit.xml.dist

.....................SSSSSS..................................   61 / 1783 (  3%)
.............................................................  122 / 1783 (  6%)
......S.....SSSS.............................................  183 / 1783 ( 10%)
......................................................SS.....  244 / 1783 ( 13%)
.............................................................  305 / 1783 ( 17%)
.............................................................  366 / 1783 ( 20%)
......S......................................................  427 / 1783 ( 23%)
.............................................................  488 / 1783 ( 27%)
....................SSSSSSSSSSSSS...........S................  549 / 1783 ( 30%)
...........S...S...........S............................S....  610 / 1783 ( 34%)
.............................................................  671 / 1783 ( 37%)
..............................................SS.............  732 / 1783 ( 41%)
....................S........................................  793 / 1783 ( 44%)
.............................................................  854 / 1783 ( 47%)
.............................................................  915 / 1783 ( 51%)
.............................................................  976 / 1783 ( 54%)
...........................................................S. 1037 / 1783 ( 58%)
........................................S.................... 1098 / 1783 ( 61%)
............................................................. 1159 / 1783 ( 65%)
............................................................. 1220 / 1783 ( 68%)
............................................................. 1281 / 1783 ( 71%)
............................................................. 1342 / 1783 ( 75%)
............................................................. 1403 / 1783 ( 78%)
............................................................. 1464 / 1783 ( 82%)
............................................................. 1525 / 1783 ( 85%)
............................................................. 1586 / 1783 ( 88%)
............................................................. 1647 / 1783 ( 92%)
................S.............S.............................. 1708 / 1783 ( 95%)
.....................................................

Time: 14 seconds, Memory: 97.75Mb

OK, but incomplete or skipped tests!
Tests: 1761, Assertions: 5932, Skipped: 39.
