### PR TITLE
DDC-2161 Added failing test that moves a foreign key

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+class DDC2161Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    /**
+     * @group DDC-2161
+     */
+    public function testSchemaUpdateOnForeignKeyMove()
+    {
+        $classes = array(
+          $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2161_1')
+        );
+        $this->_schemaTool->createSchema($classes);
+
+        $classes = array(
+          $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2161_2'),
+          $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2161_3')
+        );
+        $this->_schemaTool->updateSchema($classes,true);
+
+        $sm = $this->_em->getConnection()->getSchemaManager();
+        $schema = $sm->createSchema();
+
+        $fk = $schema->getTable("DDC2161_1")->getForeignKeys();
+        $fk = array_shift($fk);
+
+        $this->assertEquals("DDC2161_3", $fk->getForeignTableName(), "Foreign key table should be DDC2161_3.");
+        ;
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC2161_1
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="DDC2161_1", mappedBy="parent")
+     */
+    private $children;
+
+    /**
+     * @ManyToOne(targetEntity="DDC2161_1", inversedBy="children")
+     */
+    private $parent;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    public function getChildren()
+    {
+        return $this->children;
+    }
+}
+
+/**
+ * @Table("DDC2161_1")
+ * @Entity
+ */
+class DDC2161_2
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ManyToOne(targetEntity="DDC2161_3", inversedBy="children")
+     */
+    private $parent;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC2161_3
+{
+    /**
+     * @Id @GeneratedValue @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="DDC2161_2", mappedBy="parent")
+     */
+    private $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getChildren()
+    {
+        return $this->children;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
@@ -32,7 +32,6 @@ class DDC2161Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $fk = array_shift($fk);
 
         $this->assertEquals("DDC2161_3", $fk->getForeignTableName(), "Foreign key table should be DDC2161_3.");
-        ;
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
@@ -54,26 +54,6 @@ class DDC2161_1
      * @ManyToOne(targetEntity="DDC2161_1", inversedBy="children")
      */
     private $parent;
-
-    public function __construct()
-    {
-        $this->children = new ArrayCollection();
-    }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getParent()
-    {
-        return $this->parent;
-    }
-
-    public function getChildren()
-    {
-        return $this->children;
-    }
 }
 
 /**
@@ -91,16 +71,6 @@ class DDC2161_2
      * @ManyToOne(targetEntity="DDC2161_3", inversedBy="children")
      */
     private $parent;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getParent()
-    {
-        return $this->parent;
-    }
 }
 
 /**
@@ -117,19 +87,4 @@ class DDC2161_3
      * @OneToMany(targetEntity="DDC2161_2", mappedBy="parent")
      */
     private $children;
-
-    public function __construct()
-    {
-        $this->children = new ArrayCollection();
-    }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getChildren()
-    {
-        return $this->children;
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DCC2161Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 require_once __DIR__ . '/../../../TestInit.php';
 
 class DDC2161Test extends \Doctrine\Tests\OrmFunctionalTestCase

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2161Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2161Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC2161Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
 


### PR DESCRIPTION
I'm including a test that should pass once the DCC-2161 is fixed.

As I'm stating in the bug, when you create an entity with a self-referencing bidirectional oneToMany, then you create another entity and move the oneToMany to that entity, changing the targetEntity in the ManyToOne, doing a schema:update doesn't move the foreign key reference inside the Mysql table.
