### PR TITLE
[DDC-2074] Bugfix regarding clearing cloned PersistentCollections

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -655,7 +655,7 @@ final class PersistentCollection implements Collection, Selectable
 
         $this->initialized = true; // direct call, {@link initialize()} is too expensive
 
-        if ($this->association['isOwningSide']) {
+        if ($this->association['isOwningSide'] && $this->owner) {
             $this->changed();
 
             $uow->scheduleCollectionDeletion($this);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\Models\ECommerce\ECommerceCategory;
+use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
+
+/**
+ * @group DDC-2074
+ */
+class DDC2074Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function testShouldNotScheduleDeletionOnClonedInstances()
+    {
+        $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\ECommerce\ECommerceProduct');
+        $product = new ECommerceProduct();
+        $category = new ECommerceCategory();
+        $collection = new PersistentCollection($this->_em, $class, new ArrayCollection(array($category)));
+        $collection->setOwner($product, $class->associationMappings['categories']);
+
+        $uow = $this->_em->getUnitOfWork();
+        $clonedCollection = clone $collection;
+        $clonedCollection->clear();
+
+        $this->assertEquals(0, count($uow->getScheduledCollectionDeletions()));
+    }
+}


### PR DESCRIPTION
When calling clear on a PC that has no owner (e.g. because it was cloned), it can't be deleted as there is no metadata available (that's essentially the exception mentioned in the ticket). In these cases, I think it shouldn't be scheduled for deletion, but please have a look as my knowledge of the ORM internals is limited.
