### PR TITLE
EntityManagerDecorator base class as an extension point for EntityManager

### DIFF
--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -1,0 +1,271 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Decorator;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Common\Persistence\ObjectManagerDecorator;
+
+/**
+ * Base class for EntityManager decorators
+ *
+ * @since   2.4
+ * @author  Lars Strojny <lars@strojny.net
+ */
+abstract class EntityManagerDecorator extends ObjectManagerDecorator implements EntityManagerInterface
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $wrapped;
+
+    /**
+     * @param EntityManagerInterface $wrapped
+     */
+    public function __construct(EntityManagerInterface $wrapped)
+    {
+        $this->wrapped = $wrapped;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConnection()
+    {
+        return $this->wrapped->getConnection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpressionBuilder()
+    {
+        return $this->wrapped->getExpressionBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beginTransaction()
+    {
+        return $this->wrapped->beginTransaction();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transactional($func)
+    {
+        return $this->wrapped->transactional($func);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return $this->wrapped->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rollback()
+    {
+        return $this->wrapped->rollback();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQuery($dql = '')
+    {
+        return $this->wrapped->createQuery($dql);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNamedQuery($name)
+    {
+        return $this->wrapped->createNamedQuery($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNativeQuery($sql, ResultSetMapping $rsm)
+    {
+        return $this->wrapped->createNativeQuery($sql, $rsm);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNamedNativeQuery($name)
+    {
+        return $this->wrapped->createNamedNativeQuery($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQueryBuilder()
+    {
+        return $this->wrapped->createQueryBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReference($entityName, $id)
+    {
+        return $this->wrapped->getReference($entityName, $id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPartialReference($entityName, $identifier)
+    {
+        return $this->wrapped->getPartialReference($entityName, $identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return $this->wrapped->close();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function copy($entity, $deep = false)
+    {
+        return $this->wrapped->copy($entity, $deep);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lock($entity, $lockMode, $lockVersion = null)
+    {
+        return $this->wrapped->lock($entity, $lockMode, $lockVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function find($entityName, $id, $lockMode = LockMode::NONE, $lockVersion = null)
+    {
+        return $this->wrapped->find($entityName, $id, $lockMode, $lockVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush($entity = null)
+    {
+        return $this->wrapped->flush($entity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEventManager()
+    {
+        return $this->wrapped->getEventManager();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return $this->wrapped->getConfiguration();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOpen()
+    {
+        return $this->wrapped->isOpen();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUnitOfWork()
+    {
+        return $this->wrapped->getUnitOfWork();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHydrator($hydrationMode)
+    {
+        return $this->wrapped->getHydrator($hydrationMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function newHydrator($hydrationMode)
+    {
+        return $this->wrapped->newHydrator($hydrationMode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProxyFactory()
+    {
+        return $this->wrapped->getProxyFactory();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return $this->wrapped->getFilters();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isFiltersStateClean()
+    {
+        return $this->wrapped->isFiltersStateClean();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasFilters()
+    {
+        return $this->wrapped->hasFilters();
+    }
+}

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -40,7 +40,7 @@ use Doctrine\Common\Util\ClassUtils;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class EntityManager implements ObjectManager
+/* final */class EntityManager implements EntityManagerInterface
 {
     /**
      * The used Configuration.
@@ -286,7 +286,7 @@ class EntityManager implements ObjectManager
      *
      * @return \Doctrine\ORM\Query
      */
-    public function createQuery($dql = "")
+    public function createQuery($dql = '')
     {
         $query = new Query($this);
 

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION); HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE); ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Query\ResultSetMapping;
+
+/**
+ * EntityManager interface
+ *
+ * @since   2.4
+ * @author  Lars Strojny <lars@strojny.net
+ */
+interface EntityManagerInterface extends ObjectManager
+{
+    public function getConnection();
+    public function getExpressionBuilder();
+    public function beginTransaction();
+    public function transactional($func);
+    public function commit();
+    public function rollback();
+    public function createQuery($dql = '');
+    public function createNamedQuery($name);
+    public function createNativeQuery($sql, ResultSetMapping $rsm);
+    public function createNamedNativeQuery($name);
+    public function createQueryBuilder();
+    public function getReference($entityName, $id);
+    public function getPartialReference($entityName, $identifier);
+    public function close();
+    public function copy($entity, $deep = false);
+    public function lock($entity, $lockMode, $lockVersion = null);
+    public function getEventManager();
+    public function getConfiguration();
+    public function isOpen();
+    public function getUnitOfWork();
+    public function getHydrator($hydrationMode);
+    public function newHydrator($hydrationMode);
+    public function getProxyFactory();
+    public function getFilters();
+    public function isFiltersStateClean();
+    public function hasFilters();
+}

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Decorator;
+
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\ResultSetMapping;
+
+class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    private $wrapped;
+    private $decorator;
+
+    public function setUp()
+    {
+        $this->wrapped = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->decorator = $this->getMockBuilder('Doctrine\ORM\Decorator\EntityManagerDecorator')
+            ->setConstructorArgs(array($this->wrapped))
+            ->setMethods(null)
+            ->getMock();
+    }
+
+    public function getMethodParameters()
+    {
+        $class = new \ReflectionClass('Doctrine\ORM\EntityManager');
+
+        $methods = array();
+        foreach ($class->getMethods() as $method) {
+            if ($method->isConstructor() || $method->isStatic() || !$method->isPublic()) {
+                continue;
+            }
+
+            /** Special case EntityManager::createNativeQuery() */
+            if ($method->getName() === 'createNativeQuery') {
+                $methods[] = array($method->getName(), array('name', new ResultSetMapping()));
+                continue;
+            }
+
+            if ($method->getNumberOfRequiredParameters() === 0) {
+                $methods[] = array($method->getName(), array());
+            } elseif ($method->getNumberOfRequiredParameters() > 0) {
+                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: array());
+            }
+            if ($method->getNumberOfParameters() != $method->getNumberOfRequiredParameters()) {
+                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: array());
+            }
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @dataProvider getMethodParameters
+     */
+    public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters)
+    {
+        $stub = $this->wrapped
+            ->expects($this->once())
+            ->method($method)
+            ->will($this->returnValue('INNER VALUE FROM ' . $method));
+
+        call_user_func_array(array($stub, 'with'), $parameters);
+
+        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array(array($this->decorator, $method), $parameters));
+    }
+}


### PR DESCRIPTION
As discussed on IRC. Open issues to be discussed:
- Should we better extend ObjectManagerDecorator (see https://github.com/doctrine/common/pull/229) and introduce an EntityManagerInterface?
- Should the abstract decorator have a constructor?
