### PR TITLE
Fix documentation for Doctrine\ORM\Query\AST\Node::dispatch()

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -37,7 +37,9 @@ abstract class Node
      * Implementation is not mandatory for all nodes.
      *
      * @param $walker
+     *
      * @return string
+     *
      * @throws ASTException
      */
     public function dispatch($walker)

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -37,6 +37,8 @@ abstract class Node
      * Implementation is not mandatory for all nodes.
      *
      * @param $walker
+     * @return string
+     * @throws ASTException
      */
     public function dispatch($walker)
     {


### PR DESCRIPTION
Because Node::dispatch() is not documented as `@return string`, static code analysis returned the following error in our project:

> void method 'dispatch' result used

This fixes the documentation for this method.
