### PR TITLE
Singular form of generated methods should end with 'y' when property ends with 'ies'

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -930,7 +930,11 @@ public function __construct()
     {
         $methodName = $type . Inflector::classify($fieldName);
         if (in_array($type, array("add", "remove")) && substr($methodName, -1) == "s") {
-            $methodName = substr($methodName, 0, -1);
+            if (substr($methodName, -3) == "ies") {
+                $methodName = substr($methodName, 0, -3) . "y";
+            } else {
+                $methodName = substr($methodName, 0, -1);
+            }
         }
 
         if ($this->hasMethod($methodName, $metadata)) {


### PR DESCRIPTION
The singular form is not correctly detected if the property ends with 'ies' like 'entries' which should be transformed to 'entry'.
This change is related to http://www.doctrine-project.org/jira/browse/DDC-2184
