### PR TITLE
Composite primary keys and datetime fields

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2394,7 +2394,7 @@ class UnitOfWork implements PropertyChangedListener
             foreach ($class->identifier as $fieldName) {
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
                     ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
-                    : $data[$fieldName];
+                    : $data[$fieldName] instanceof \DateTime ? $data[$fieldName]->format("d-m-Y-H-i-s") : $data[$fieldName];
             }
 
             $idHash = implode(' ', $id);


### PR DESCRIPTION
When using composite primary keys and fields with date or datetimes, the UnitOfWork throws an exception like "\DateTime object could not be converted to string".

This patch solves this issue by converting the datetime object into a simple timestamp.
