### PR TITLE
[DDC-2196] Improved "extendability" of EntityManager

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -872,7 +872,7 @@ class EntityManager implements ObjectManager
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
[DDC-2196 EntityManager can't be extended easily](http://www.doctrine-project.org/jira/browse/DDC-2196)

EntityManager::create now uses "new static" instead of "new EntityManager"
