### PR TITLE
fixed problems with joined inheritance and composite keys

### DIFF
--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -182,6 +182,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             // Execute inserts on subtables.
             // The order doesn't matter because all child tables link to the root table via FK.
             foreach ($subTableStmts as $tableName => $stmt) {
+                /** @var \Doctrine\DBAL\Statement $stmt */
                 $paramIndex = 1;
                 $data       = isset($insertData[$tableName])
                     ? $insertData[$tableName]
@@ -194,7 +195,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 }
 
                 foreach ($data as $columnName => $value) {
-                    $stmt->bindValue($paramIndex++, $value, $this->columnTypes[$columnName]);
+                    if (!isset($id[$columnName])) {
+                        $stmt->bindValue($paramIndex++, $value, $this->columnTypes[$columnName]);
+                    }
                 }
 
                 $stmt->execute();

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedChildClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedChildClass.php
@@ -1,0 +1,21 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyInheritance;
+
+/**
+ * @Entity
+ */
+class JoinedChildClass extends JoinedRootClass
+{
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $extension = 'ext';
+
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    private $additionalId = 'additional';
+}

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedRootClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedRootClass.php
@@ -1,0 +1,25 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyInheritance;
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"child" = "JoinedChildClass",})
+ */
+class JoinedRootClass
+{
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    protected $keyPart1 = 'part-1';
+
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    protected $keyPart2 = 'part-2';
+}

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleChildClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleChildClass.php
@@ -1,0 +1,21 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyInheritance;
+
+/**
+ * @Entity
+ */
+class SingleChildClass extends SingleRootClass
+{
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    public $extension = 'ext';
+
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    private $additionalId = 'additional';
+}

--- a/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleRootClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyInheritance/SingleRootClass.php
@@ -1,0 +1,25 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyInheritance;
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"child" = "SingleChildClass",})
+ */
+class SingleRootClass
+{
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    protected $keyPart1 = 'part-1';
+
+    /**
+     * @var string
+     * @Column(type="string")
+     * @Id
+     */
+    protected $keyPart2 = 'part-2';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass;
+
+class JoinedTableCompositeKeyTest extends OrmFunctionalTestCase
+{
+
+    public function setUp()
+    {
+        $this->useModelSet('compositekeyinheritance');
+        parent::setUp();
+
+    }
+
+    /**
+     *
+     */
+    public function testInsertWithCompositeKey()
+    {
+        $childEntity = new JoinedChildClass();
+        $this->_em->persist($childEntity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $entity = $this->findEntity();
+        $this->assertEquals($childEntity, $entity);
+    }
+
+    /**
+     *
+     */
+    public function testUpdateWithCompositeKey()
+    {
+        $childEntity = new JoinedChildClass();
+        $this->_em->persist($childEntity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $entity = $this->findEntity();
+        $entity->extension = 'ext-new';
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $persistedEntity = $this->findEntity();
+        $this->assertEquals($entity, $persistedEntity);
+    }
+
+    /**
+     * @return \Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass
+     */
+    private function findEntity()
+    {
+        return $this->_em->find(
+            'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass',
+            array('keyPart1' => 'part-1', 'keyPart2' => 'part-2')
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\Tests\Models\CompositeKeyInheritance\SingleChildClass;
+
+class SingleTableCompositeKeyTest extends OrmFunctionalTestCase
+{
+
+    public function setUp()
+    {
+        $this->useModelSet('compositekeyinheritance');
+        parent::setUp();
+
+    }
+
+    /**
+     *
+     */
+    public function testInsertWithCompositeKey()
+    {
+        $childEntity = new SingleChildClass();
+        $this->_em->persist($childEntity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $entity = $this->findEntity();
+        $this->assertEquals($childEntity, $entity);
+    }
+
+    /**
+     *
+     */
+    public function testUpdateWithCompositeKey()
+    {
+        $childEntity = new SingleChildClass();
+        $this->_em->persist($childEntity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $entity = $this->findEntity();
+        $entity->extension = 'ext-new';
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $persistedEntity = $this->findEntity();
+        $this->assertEquals($entity, $persistedEntity);
+    }
+
+    /**
+     * @return \Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass
+     */
+    private function findEntity()
+    {
+        return $this->_em->find(
+            'Doctrine\Tests\Models\CompositeKeyInheritance\SingleRootClass',
+            array('keyPart1' => 'part-1', 'keyPart2' => 'part-2')
+        );
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -124,6 +124,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\CustomType\CustomTypeParent',
             'Doctrine\Tests\Models\CustomType\CustomTypeUpperCase',
         ),
+        'compositekeyinheritance' => array(
+            'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass',
+            'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass',
+        )
     );
 
     protected function useModelSet($setName)
@@ -238,6 +242,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM customtype_children');
             $conn->executeUpdate('DELETE FROM customtype_uppercases');
         }
+
+        if (isset($this->_usedModelSets['compositekeyinheritance'])) {
+            $conn->executeUpdate('DELETE FROM JoinedChildClass');
+            $conn->executeUpdate('DELETE FROM JoinedRootClass');
+        }
+
 
         $this->_em->clear();
     }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -127,6 +127,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'compositekeyinheritance' => array(
             'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass',
             'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass',
+            'Doctrine\Tests\Models\CompositeKeyInheritance\SingleRootClass',
+            'Doctrine\Tests\Models\CompositeKeyInheritance\SingleChildClass',
         )
     );
 
@@ -246,6 +248,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['compositekeyinheritance'])) {
             $conn->executeUpdate('DELETE FROM JoinedChildClass');
             $conn->executeUpdate('DELETE FROM JoinedRootClass');
+            $conn->executeUpdate('DELETE FROM SingleRootClass');
         }
 
 


### PR DESCRIPTION
SchemaTool now creates all Id columns not just only the first one.
Insert statement for child entity now contains parameter for additional key columns only once.
