### PR TITLE
Make doctrine a Light-weight distribution package in Composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,9 +8,6 @@ build.properties export-ignore
 build.properties.dev export-ignore
 build.xml export-ignore
 CONTRIBUTING.md export-ignore
-doctrine-mapping.xsd export-ignore
-LICENSE export-ignore
 phpunit.xml.dist export-ignore
 README.markdown export-ignore
 run-all.sh export-ignore
-UPGRADE.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/tests export-ignore
+/tools export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+build.properties export-ignore
+build.properties.dev export-ignore
+build.xml export-ignore
+CONTRIBUTING.md export-ignore
+doctrine-mapping.xsd export-ignore
+LICENSE export-ignore
+phpunit.xml.dist export-ignore
+README.markdown export-ignore
+run-all.sh export-ignore
+UPGRADE.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 /tests export-ignore
 /tools export-ignore
-.gitattribues export-ignore
+.gitattributes export-ignore
 .gitignore export-ignore
 .gitmodules export-ignore
 .travis.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 /tests export-ignore
 /tools export-ignore
+.gitattribues export-ignore
 .gitignore export-ignore
+.gitmodules export-ignore
 .travis.yml export-ignore
 build.properties export-ignore
 build.properties.dev export-ignore


### PR DESCRIPTION
In order to save space and bandwidth when installing doctrine using Composer, I have added .gitattributes removing files and folders unnecessary when using doctrine as a dependecy.

(extracted from http://getcomposer.org/doc/02-libraries.md#light-weight-distribution-packages)

Including the tests and other useless information like .travis.yml in distributed packages is not a good idea.

The .gitattributes file is a git specific file like .gitignore also living at the root directory of your library. It overrides local and global configuration (.git/config and ~/.gitconfig respectively) when present and tracked by git.

Use .gitattributes to prevent unwanted files from bloating the zip distribution packages.

// .gitattributes
/Tests export-ignore
phpunit.xml.dist export-ignore
Resources/doc/ export-ignore
.travis.yml export-ignore
Test it by inspecting the zip file generated manually:

git archive branchName --format zip -o file.zip

Note: Files would be still tracked by git just not included in the distribution. This will only work for GitHub packages installed from dist (i.e. tagged releases) for now.
