### PR TITLE
Update lib/Doctrine/ORM/UnitOfWork.php

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2455,6 +2455,10 @@ class UnitOfWork implements PropertyChangedListener
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
                     ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
                     : $data[$fieldName];
+                
+                if ($id[$fieldName] instanceof \DateTime) {
+                    $id[$fieldName] = $id[$fieldName]->getTimestamp();
+                }
             }
 
             $idHash = implode(' ', $id);


### PR DESCRIPTION
When the pk contains a DateTime object doctrine fail to create the index, because implode call __toString wich doesn't exists in \DateTime object
