### PR TITLE
Fixed ObjectHydrator when namespace alias is given.

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -296,6 +296,7 @@ abstract class AbstractQuery
      */
     public function setResultSetMapping(Query\ResultSetMapping $rsm)
     {
+        $rsm->translateNamespaces($this->_em);
         $this->_resultSetMapping = $rsm;
 
         return $this;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -83,7 +83,7 @@ class ObjectHydrator extends AbstractHydrator
      */
     private $existingCollections = array();
 
-     /**
+    /**
      * {@inheritdoc}
      */
     protected function prepare()
@@ -101,6 +101,12 @@ class ObjectHydrator extends AbstractHydrator
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
             $this->identifierMap[$dqlAlias] = array();
             $this->idTemplate[$dqlAlias]    = '';
+
+            // Check for namespace alias.
+            if (strpos($className, ':') !== false) {
+                $metadata = $this->_em->getClassMetadata($className);
+                $className = $metadata->name;
+            }
 
             if ( ! isset($this->ce[$className])) {
                 $this->ce[$className] = $this->_em->getClassMetadata($className);
@@ -525,7 +531,7 @@ class ObjectHydrator extends AbstractHydrator
                 // check for existing result from the iterations before
                 if ( ! isset($this->identifierMap[$dqlAlias][$id[$dqlAlias]])) {
                     $element = $this->getEntity($rowData[$dqlAlias], $dqlAlias);
-   
+
                     if ($this->_rsm->isMixed) {
                         $element = array($entityKey => $element);
                     }
@@ -597,7 +603,7 @@ class ObjectHydrator extends AbstractHydrator
 
                 if ($count === 1) {
                     $result[$resultKey] = $obj;
-                    
+
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -102,12 +102,6 @@ class ObjectHydrator extends AbstractHydrator
             $this->identifierMap[$dqlAlias] = array();
             $this->idTemplate[$dqlAlias]    = '';
 
-            // Check for namespace alias.
-            if (strpos($className, ':') !== false) {
-                $metadata = $this->_em->getClassMetadata($className);
-                $className = $metadata->name;
-            }
-
             if ( ! isset($this->ce[$className])) {
                 $this->ce[$className] = $this->_em->getClassMetadata($className);
             }

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\EntityManager;
+
 /**
  * A ResultSetMapping describes how a result set of an SQL query maps to a Doctrine result.
  *
@@ -543,4 +545,33 @@ class ResultSetMapping
 
         return $this;
     }
+
+    /**
+     * Allows to translate entity namespaces to full qualified names.
+     *
+     * @param EntityManager $em
+     *
+     * @return void
+     */
+    public function translateNamespaces(EntityManager $em)
+    {
+        $fqcn = array();
+
+        $translate = function (&$alias) use ($em, $fqcn)
+        {
+            if (strpos($alias, ':') !== false && !isset($fqcn[$alias])) {
+                if ($metadata = $em->getClassMetadata($alias)) {
+                    $fqcn[$alias] = $metadata->name;
+                }
+            }
+
+            if (isset($fqcn[$alias])) {
+                $alias = $fqcn[$alias];
+            }
+        };
+
+        array_walk($this->aliasMap, $translate);
+        array_walk($this->declaringClasses, $translate);
+    }
 }
+

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -557,8 +557,7 @@ class ResultSetMapping
     {
         $fqcn = array();
 
-        $translate = function (&$alias) use ($em, $fqcn)
-        {
+        $translate = function (&$alias) use ($em, &$fqcn) {
             if ( ! isset($fqcn[$alias])) {
                 $fqcn[$alias] = $em->getClassMetadata($alias)->getName();
             }

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -559,15 +559,10 @@ class ResultSetMapping
 
         $translate = function (&$alias) use ($em, $fqcn)
         {
-            if (strpos($alias, ':') !== false && !isset($fqcn[$alias])) {
-                if ($metadata = $em->getClassMetadata($alias)) {
-                    $fqcn[$alias] = $metadata->name;
-                }
+            if ( ! isset($fqcn[$alias])) {
+                $fqcn[$alias] = $em->getClassMetadata($alias)->getName();
             }
-
-            if (isset($fqcn[$alias])) {
-                $alias = $fqcn[$alias];
-            }
+            $alias = $fqcn[$alias];
         };
 
         array_walk($this->aliasMap, $translate);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 require_once __DIR__ . '/../../../TestInit.php';
 
 use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
 
 /**
  * @group DDC-2256
@@ -34,18 +35,29 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->persist($group);
         $this->_em->flush();
+        $this->_em->clear();
 
+        $sql = 'SELECT u.id, u.name, g.id as group_id, g.name as group_name FROM ddc2256_users u LEFT JOIN ddc2256_groups g ON u.group_id = g.id';
+
+        // Test ResultSetMapping.
         $rsm = new ResultSetMapping();
 
-        $rsm->addEntityResult('MyNamespace:DDC2256Group', 'g');
-        $rsm->addFieldResult('g', 'id', 'id');
-        $rsm->addFieldResult('g', 'name', 'name');
+        $rsm->addEntityResult('MyNamespace:DDC2256User', 'u');
+        $rsm->addFieldResult('u', 'id', 'id');
+        $rsm->addFieldResult('u', 'name', 'name');
 
-        $rsm->addJoinedEntityResult('MyNamespace:DDC2256User', 'u', 'g', 'users');
-        $rsm->addFieldResult('u', 'user_id', 'id');
-        $rsm->addFieldResult('u', 'user_name', 'name');
+        $rsm->addJoinedEntityResult('MyNamespace:DDC2256Group', 'g', 'u', 'group');
+        $rsm->addFieldResult('g', 'group_id', 'id');
+        $rsm->addFieldResult('g', 'group_name', 'name');
 
-        $this->_em->createNativeQuery('SELECT g.id, g.name, u.id as user_id, u.name as user_name FROM ddc2256_groups g LEFT JOIN ddc2256_users u ON u.group_id = g.id', $rsm)->getResult();
+        $this->_em->createNativeQuery($sql, $rsm)->getResult();
+
+        // Test ResultSetMappingBuilder.
+        $rsm = new ResultSetMappingBuilder($this->_em);
+        $rsm->addRootEntityFromClassMetadata('MyNamespace:DDC2256User', 'u');
+        $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', array('id' => 'group_id', 'name' => 'group_name'));
+
+        $this->_em->createNativeQuery($sql, $rsm)->getResult();
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+use Doctrine\ORM\Query\ResultSetMapping;
+
+/**
+ * @group DDC-2256
+ */
+class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setup()
+    {
+        parent::setup();
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2256User'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2256Group')
+        ));
+    }
+
+    public function testIssue()
+    {
+        $config = $this->_em->getConfiguration();
+        $config->addEntityNamespace('MyNamespace', 'Doctrine\Tests\ORM\Functional\Ticket');
+
+        $user = new DDC2256User();
+        $user->name = 'user';
+        $group = new DDC2256Group();
+        $group->name = 'group';
+        $user->group = $group;
+
+        $this->_em->persist($user);
+        $this->_em->persist($group);
+        $this->_em->flush();
+
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult('MyNamespace:DDC2256Group', 'g');
+        $rsm->addFieldResult('g', 'id', 'id');
+        $rsm->addFieldResult('g', 'name', 'name');
+
+        $rsm->addJoinedEntityResult('MyNamespace:DDC2256User', 'u', 'g', 'users');
+        $rsm->addFieldResult('u', 'user_id', 'id');
+        $rsm->addFieldResult('u', 'user_name', 'name');
+
+        $this->_em->createNativeQuery('SELECT g.id, g.name, u.id as user_id, u.name as user_name FROM ddc2256_groups g LEFT JOIN ddc2256_users u ON u.group_id = g.id', $rsm)->getResult();
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="ddc2256_users")
+ */
+class DDC2256User
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @ManyToOne(targetEntity="DDC2256Group", inversedBy="users")A
+     * @JoinColumn(name="group_id")
+     */
+    public $group;
+}
+
+/**
+ * @Entity
+ * @Table(name="ddc2256_groups")
+ */
+class DDC2256Group
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @OneToMany(targetEntity="DDC2256User", mappedBy="group")
+     */
+    public $users;
+
+    public function __construct()
+    {
+        $this->users = new \Doctrine\Common\Collections\ArrayCollection();
+    }
+}
+


### PR DESCRIPTION
Fixes problem when executing native query:

``` php
$rsm = new ResultSetMapping();

$rsm->addEntityResult('DbBundle:Player', 'p');
$rsm->addFieldResult('p', 'id', 'id');
$rsm->addFieldResult('p', 'name', 'name');

$rsm->addJoinedEntityResult('DbBundle:User', 'u', 'p', 'user');
$rsm->addFieldResult('u', 'user_id', 'id');

$em->createNativeQuery('...', $rsm);
```

Hydrator couldn't find cached metadata, when "joined entity result" class name wasn't fully qualified name (as in the example above).
