### PR TITLE
Add EntityRepository->countBy() method to complement findBy()

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -182,6 +182,24 @@ class EntityRepository implements ObjectRepository, Selectable
     }
 
     /**
+     * Counts objects that satisfy a set of criteria.
+     *
+     * An implementation may throw an UnexpectedValueException if certain values
+     * of the limiting details are not supported.
+     *
+     * @throws \UnexpectedValueException
+     * @param array $criteria
+     * @return int
+     */
+    public function countBy(array $criteria)
+    {
+        $persister = $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName);
+
+        return $persister->countAll($criteria);
+    }
+
+
+    /**
      * Finds a single entity by a set of criteria.
      *
      * @param array $criteria

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -402,6 +402,18 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(0, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findBy(array('id' => $this->groupId2)));
     }
 
+    public function testRepositoryCountBy()
+    {
+        $this->loadFixtureData();
+
+        $this->assertSame(1, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->countBy(array('id' => $this->groupId2)));
+
+        $this->useCMSGroupPrefixFilter();
+        $this->_em->clear();
+
+        $this->assertSame(0, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->countBy(array('id' => $this->groupId2)));
+    }
+
     public function testRepositoryFindByX()
     {
         $this->loadFixtureData();

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\Collections\Criteria;
 
+require_once __DIR__ . '/../../TestInit.php';
+
 class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     private $salesPerson;
@@ -332,6 +334,27 @@ class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repos = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFlexUltraContract");
         $contracts = $repos->findBy(array('salesPerson' => $this->salesPerson->getId()));
         $this->assertEquals(1, count($contracts), "There should be 1 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFlexUltraContract'");
+    }
+
+    public function testCountByAssociation()
+    {
+        $this->loadFullFixture();
+
+        $repos         = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyContract");
+        $contractCount = $repos->countBy(array('salesPerson' => $this->salesPerson->getId()));
+        $this->assertEquals(3, $contractCount, "There should be 3 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyContract'");
+
+        $repos         = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFixContract");
+        $contractCount = $repos->countBy(array('salesPerson' => $this->salesPerson->getId()));
+        $this->assertEquals(1, $contractCount, "There should be 1 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFixContract'");
+
+        $repos         = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFlexContract");
+        $contractCount = $repos->countBy(array('salesPerson' => $this->salesPerson->getId()));
+        $this->assertEquals(2, $contractCount, "There should be 2 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFlexContract'");
+
+        $repos         = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFlexUltraContract");
+        $contractCount = $repos->countBy(array('salesPerson' => $this->salesPerson->getId()));
+        $this->assertEquals(1, $contractCount, "There should be 1 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFlexUltraContract'");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -127,7 +127,9 @@ class TypeTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
 
         $articles = $this->_em->getRepository( 'Doctrine\Tests\Models\Generic\DateTimeModel' )->findBy( array( 'datetime' => new \DateTime( "now" ) ) );
-        $this->assertEquals( 0, count( $articles ) );
+        $this->assertEquals(0, count($articles));
+        $articleCount = $this->_em->getRepository('Doctrine\Tests\Models\Generic\DateTimeModel')->countBy(array('datetime' => new \DateTime("now")));
+        $this->assertEquals(0, $articleCount);
     }
 
     public function testDqlQueryBindDateTimeInstance()


### PR DESCRIPTION
It would be reasonable to add the method to ObjectRepository interface, but I might not be aware of all its implementations that will become broken
