### PR TITLE
Fix a wrong return type

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -254,7 +254,7 @@ class BasicEntityPersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return;
+            return array();
         }
 
         $postInsertIds  = array();


### PR DESCRIPTION
`BasicEntityPersister::executeInserts()` is documented as:

```
@return array An array of any generated post-insert IDs. This will be an empty array
if the entity class does not use the IDENTITY generation strategy.
```

This PR fixes an empty `return;` that contradicted the documented return type.
