### PR TITLE
Added missing return statement to AbstractCommand.

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -65,6 +65,7 @@ abstract class AbstractCommand extends Command
             return $this->executeSchemaCommand($input, $output, $tool, $metadatas);
         } else {
             $output->writeln('No Metadata Classes to process.');
+            return 0;
         }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -74,5 +74,7 @@ EOT
             $schemaTool->createSchema($metadatas);
             $output->writeln('Database schema created successfully!');
         }
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -116,5 +116,7 @@ EOT
         }
 
         $output->writeln('Nothing to drop. The database is empty!');
+
+        return 0;
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -110,7 +110,7 @@ EOT
         if (0 === count($sqls)) {
             $output->writeln('Nothing to update - your database is already in sync with the current entity metadata.');
 
-            return;
+            return 0;
         }
 
         $dumpSql = true === $input->getOption('dump-sql');


### PR DESCRIPTION
The `AbstractCommand::execute()` and `executeSchemaCommand()` method should return an `integer` or `null`.

Although in PHP, omitting the `return` statement is equivalent to returning `null`, it is recommended to put an explicit `return` to clearly differentiate it from `return void`.

I've added `return 0;` here, keeping the existent behavior.
