### PR TITLE
Removed outdated methods in DatabasePlatformMock

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -25,20 +25,6 @@ class DatabasePlatformMock extends \Doctrine\DBAL\Platforms\AbstractPlatform
     /**
      * {@inheritdoc}
      */
-    public function getNativeDeclaration(array $field)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPortableDeclaration(array $field)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function prefersIdentityColumns()
     {
         return $this->_prefersIdentityColumns;


### PR DESCRIPTION
`DatabasePlatformMock::getNativeDeclaration()` and `getPortableDeclaration()` do not override an existing method in `AbstractPlatform`.
I guess they are leftovers of a previous version, and should be removed.
