### PR TITLE
Fixed plural variable names to singular when generating add or remove methods for entities

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1124,8 +1124,11 @@ public function __construct()
     protected function generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null,  $defaultValue = null)
     {
         $methodName = $type . Inflector::classify($fieldName);
+        $variableName = $fieldName;
+
         if (in_array($type, array("add", "remove"))) {
             $methodName = Inflector::singularize($methodName);
+            $variableName = Inflector::singularize($variableName);
         }
 
         if ($this->hasMethod($methodName, $metadata)) {
@@ -1146,10 +1149,10 @@ public function __construct()
         }
 
         $replacements = array(
-          '<description>'       => ucfirst($type) . ' ' . $fieldName,
+          '<description>'       => ucfirst($type) . ' ' . $variableName,
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
-          '<variableName>'      => Inflector::camelize($fieldName),
+          '<variableName>'      => Inflector::camelize($variableName),
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
           '<variableDefault>'   => ($defaultValue !== null ) ? (' = '.$defaultValue) : '',

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -119,15 +119,35 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
 
         $book = $this->newInstance($metadata);
         $this->assertTrue(class_exists($metadata->name), "Class does not exist.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', '__construct'), "EntityGeneratorBook::__construct() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getId'), "EntityGeneratorBook::getId() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'setName'), "EntityGeneratorBook::setName() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getName'), "EntityGeneratorBook::getName() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'setAuthor'), "EntityGeneratorBook::setAuthor() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getAuthor'), "EntityGeneratorBook::getAuthor() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getComments'), "EntityGeneratorBook::getComments() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'addComment'), "EntityGeneratorBook::addComment() missing.");
-        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'removeComment'), "EntityGeneratorBook::removeComment() missing.");
+        $className = $metadata->namespace . '\EntityGeneratorBook';
+        $this->assertTrue(method_exists($className, '__construct'), "EntityGeneratorBook::__construct() missing.");
+        $this->assertTrue(method_exists($className, 'getId'), "EntityGeneratorBook::getId() missing.");
+        $this->assertTrue(method_exists($className, 'setName'), "EntityGeneratorBook::setName() missing.");
+        $this->assertTrue(method_exists($className, 'getName'), "EntityGeneratorBook::getName() missing.");
+        $this->assertTrue(method_exists($className, 'setAuthor'), "EntityGeneratorBook::setAuthor() missing.");
+        $this->assertTrue(method_exists($className, 'getAuthor'), "EntityGeneratorBook::getAuthor() missing.");
+        $this->assertTrue(method_exists($className, 'getComments'), "EntityGeneratorBook::getComments() missing.");
+        $this->assertTrue(method_exists($className, 'addComment'), "EntityGeneratorBook::addComment() missing.");
+        $this->assertTrue(method_exists($className, 'removeComment'), "EntityGeneratorBook::removeComment() missing.");
+
+        $reflectionClass = new \ReflectionClass($className);
+
+        $this->assertEmpty($reflectionClass->getMethod('getId')->getParameters());
+        $this->assertEmpty($reflectionClass->getMethod('getName')->getParameters());
+        $this->assertEmpty($reflectionClass->getMethod('getAuthor')->getParameters());
+        $this->assertEmpty($reflectionClass->getMethod('getComments')->getParameters());
+
+        $paramsSetName = $reflectionClass->getMethod('setName')->getParameters();
+        $this->assertEquals('name', $paramsSetName[0]->name);
+
+        $paramsSetAuthor = $reflectionClass->getMethod('setAuthor')->getParameters();
+        $this->assertEquals('author', $paramsSetAuthor[0]->name);
+
+        $paramsAddComment = $reflectionClass->getMethod('addComment')->getParameters();
+        $this->assertEquals('comment', $paramsAddComment[0]->name);
+
+        $paramsRemoveComment = $reflectionClass->getMethod('removeComment')->getParameters();
+        $this->assertEquals('comment', $paramsRemoveComment[0]->name);
 
         $this->assertEquals('published', $book->getStatus());
 


### PR DESCRIPTION
Changed generateEntityStubMethod so that variable names in add or remove methods are singular too

Edited tests for EntityGenerator so that variable names are checked too
