### PR TITLE
Hotfix/pre flush event args params

### DIFF
--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\ORM\EntityManager;
+
 /**
  * Provides event arguments for the onClear event.
  *
@@ -46,7 +48,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
      * @param \Doctrine\ORM\EntityManager $em
      * @param string|null                 $entityClass Optional entity class.
      */
-    public function __construct($em, $entityClass = null)
+    public function __construct(EntityManager $em, $entityClass = null)
     {
         $this->em          = $em;
         $this->entityClass = $entityClass;

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\Common\EventArgs;
 use Doctrine\ORM\EntityManager;
 
 /**
@@ -30,7 +31,7 @@ use Doctrine\ORM\EntityManager;
  * @author      Roman Borschel <roman@code-factory.de>
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  */
-class OnFlushEventArgs extends \Doctrine\Common\EventArgs
+class OnFlushEventArgs extends EventArgs
 {
     /**
      * @var \Doctrine\ORM\EntityManager

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\ORM\Event;
 
+use Doctrine\Common\EventArgs;
+use Doctrine\ORM\EntityManager;
+
 /**
  * Provides event arguments for the preFlush event.
  *
@@ -28,21 +31,21 @@ namespace Doctrine\ORM\Event;
  * @author      Roman Borschel <roman@code-factory.de>
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  */
-class PreFlushEventArgs extends \Doctrine\Common\EventArgs
+class PreFlushEventArgs extends EventArgs
 {
     /**
      * @var \Doctrine\ORM\EntityManager
      */
-    private $_em;
+    private $em;
 
     /**
      * Constructor.
      *
      * @param \Doctrine\ORM\EntityManager $em
      */
-    public function __construct($em)
+    public function __construct(EntityManager $em)
     {
-        $this->_em = $em;
+        $this->em = $em;
     }
 
     /**
@@ -50,6 +53,6 @@ class PreFlushEventArgs extends \Doctrine\Common\EventArgs
      */
     public function getEntityManager()
     {
-        return $this->_em;
+        return $this->em;
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -524,7 +524,7 @@ class UnitOfWork implements PropertyChangedListener
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::preFlush);
 
         if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-            $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($entity, $this->em), $invoke);
+            $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em), $invoke);
         }
 
         $actualData = array();


### PR DESCRIPTION
As reported by a user on IRC, the `PreFlushEventArgs` object was built with incorrect parameters. this fix solves the problem by typehinting the constructor.

Tests aren't really necessary since a lot of functional tests were simply broken because of this additional typehint.
