### PR TITLE
Update lib/Doctrine/ORM/EntityRepository.php

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -75,14 +75,15 @@ class EntityRepository implements ObjectRepository, Selectable
      * Creates a new QueryBuilder instance that is prepopulated for this entity name.
      *
      * @param string $alias
-     *
+     * @param string $indexBy The index for the from.
+     * 
      * @return QueryBuilder
      */
-    public function createQueryBuilder($alias)
+    public function createQueryBuilder($alias, $indexBy = null)
     {
         return $this->_em->createQueryBuilder()
             ->select($alias)
-            ->from($this->_entityName, $alias);
+            ->from($this->_entityName, $alias, $indexBy);
     }
 
     /**


### PR DESCRIPTION
Add "indexby" missing parameter that permit an "index by" easily.

Ex : 
# Acme\AcmeBundle\Repository
# Before

public function findAllIndexById(){
    $qb = $this->_em->createQueryBuilder()
                              ->select('root')
                              ->from('Acme', 'root', 'root.id');
  /_..._/
}
# After

public function findAllIndexById(){
    $qb = $this->createQueryBuilder('root','root.id');
    /_..._/
}
