### PR TITLE
[Documentation] Noted prePersist event only triggers on first persist

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -148,7 +148,8 @@ the life-time of their registered entities.
    delete operations. It is not called for a DQL DELETE statement.
 -  prePersist - The prePersist event occurs for a given entity
    before the respective EntityManager persist operation for that
-   entity is executed.
+   entity is executed. It should be noted that this event is only triggered on
+   *initial* persist of an entity
 -  postPersist - The postPersist event occurs for an entity after
    the entity has been made persistent. It will be invoked after the
    database insert operations. Generated primary key values are


### PR DESCRIPTION
While probably obvious to a core doctrine developer, a user of doctrine would not necessarily know this without doing some digging or [stack overflowing](http://stackoverflow.com/questions/7934555/doctrine-2-prepersist-doesnt-fire)
