### PR TITLE
Allow extending EntityManager and use create method

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -942,7 +942,7 @@ class EntityManager implements ObjectManager
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
If you create your own entityManager by extending this one, you can't use ::create method because
it will create an instance of the last one and not our new entityManager
