### PR TITLE
Fix for wrong return types in documentation.

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -376,12 +376,12 @@ class EntityManager implements ObjectManager
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string  $entityName
-     * @param mixed   $id
-     * @param integer $lockMode
-     * @param integer $lockVersion
+     * @param string       $entityName
+     * @param mixed        $id
+     * @param integer      $lockMode
+     * @param integer|null $lockVersion
      *
-     * @return object
+     * @return object|null The entity instance or NULL if the entity can not be found.
      *
      * @throws OptimisticLockException
      * @throws ORMInvalidArgumentException

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -147,7 +147,7 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param int      $lockMode    The lock mode.
      * @param int|null $lockVersion The lock version.
      *
-     * @return object The entity.
+     * @return object|null The entity instance or NULL if the entity can not be found.
      */
     public function find($id, $lockMode = LockMode::NONE, $lockVersion = null)
     {
@@ -187,7 +187,7 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param array $criteria
      * @param array|null $orderBy
      *
-     * @return object
+     * @return object|null The entity instance or NULL if the entity can not be found.
      */
     public function findOneBy(array $criteria, array $orderBy = null)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1676,9 +1676,7 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
-     * Gets the mapped identifier field of this class.
-     *
-     * @return array|string
+     * {@inheritDoc}
      */
     public function getIdentifier()
     {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -714,7 +714,7 @@ class BasicEntityPersister
      * @param int|null    $limit    Limit number of results.
      * @param array|null  $orderBy  Criteria to order by.
      *
-     * @return object The loaded and managed entity instance or NULL if the entity can not be found.
+     * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
      *
      * @todo Check identity map? loadById method? Try to guess whether $criteria is the id?
      */


### PR DESCRIPTION
Several methods were declaring erroneous / incomplete return types.
This PR fixes them.
