### PR TITLE
accept more than 2 parameters in CONCAT function

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -22,7 +22,7 @@ namespace Doctrine\ORM\Query\AST\Functions;
 use Doctrine\ORM\Query\Lexer;
 
 /**
- * "CONCAT" "(" StringPrimary "," StringPrimary "," StringPrimary ",...)"
+ * "CONCAT" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"
  *
  *
  * @link    www.doctrine-project.org
@@ -45,8 +45,8 @@ class ConcatFunction extends FunctionNode
         
         $args = array();
         
-        foreach($this->concatExpressions as $e){
-            $args[] = $sqlWalker->walkStringPrimary($this->firstStringPrimary);
+        foreach ($this->concatExpressions as $expression) {
+            $args[] = $sqlWalker->walkStringPrimary($expression);
         }
         
         return $platform->getConcatExpression( $args );
@@ -61,9 +61,11 @@ class ConcatFunction extends FunctionNode
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         
         $this->concatExpressions[] = $parser->StringPrimary(); 
+        $parser->match(Lexer::T_COMMA);
+        $this->concatExpressions[] = $parser->StringPrimary();
         
         while ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-            $parser->match(Lexer::T_COMMA);
+        	$parser->match(Lexer::T_COMMA);
         	$this->concatExpressions[] = $parser->StringPrimary();
         }
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -34,6 +34,10 @@ use Doctrine\ORM\Query\Lexer;
  */
 class ConcatFunction extends FunctionNode
 {
+    public $firstStringPrimary;
+    
+    public $secondStringPrimary;
+    
     public $concatExpressions = array();
     
     /**
@@ -60,12 +64,16 @@ class ConcatFunction extends FunctionNode
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
         
-        $this->concatExpressions[] = $parser->StringPrimary(); 
+        $this->firstStringPrimary = $parser->StringPrimary();
+        $this->concatExpressions[] = $this->firstStringPrimary;
+        
         $parser->match(Lexer::T_COMMA);
-        $this->concatExpressions[] = $parser->StringPrimary();
+        
+        $this->secondStringPrimary = $parser->StringPrimary();
+        $this->concatExpressions[] = $this->secondStringPrimary;
         
         while ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
- 			$parser->match(Lexer::T_COMMA);
+ 		    $parser->match(Lexer::T_COMMA);
 	        $this->concatExpressions[] = $parser->StringPrimary();
         }
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -49,7 +49,7 @@ class ConcatFunction extends FunctionNode
             $args[] = $sqlWalker->walkStringPrimary($expression);
         }
         
-        return $platform->getConcatExpression( $args );
+        return $platform->getConcatExpression($args);
     }
 
     /**
@@ -65,8 +65,8 @@ class ConcatFunction extends FunctionNode
         $this->concatExpressions[] = $parser->StringPrimary();
         
         while ($parser->getLexer()->isNextToken(Lexer::T_COMMA)) {
-        	$parser->match(Lexer::T_COMMA);
-        	$this->concatExpressions[] = $parser->StringPrimary();
+ 			$parser->match(Lexer::T_COMMA);
+	        $this->concatExpressions[] = $parser->StringPrimary();
         }
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -49,7 +49,7 @@ class ConcatFunction extends FunctionNode
             $args[] = $sqlWalker->walkStringPrimary($expression);
         }
         
-        return $platform->getConcatExpression($args);
+        return call_user_func_array(array($platform,'getConcatExpression'), $args);
     }
 
     /**


### PR DESCRIPTION
The DBAL Platform supports more then 2 parameters but the ConcatFunction only validates 2 parameters to CONCAT. This commit allows to pass more than 2 parameters to CONCAT. Also this change would require that `getConcatExpression` accept array as a parameter. I have opened a pull request for that as well.

Here is the pull request : https://github.com/doctrine/dbal/pull/275

I also propose that the function `getConcatExpression` only accept array of string rather than multiple string arguments.
