### PR TITLE
QueryBuilder::addCriteria improvements

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1082,12 +1082,13 @@ class QueryBuilder
      * Overrides firstResult and maxResults if they're set.
      *
      * @param Criteria $criteria
+     * @param string|null $alias
      *
      * @return QueryBuilder
      */
-    public function addCriteria(Criteria $criteria)
+    public function addCriteria(Criteria $criteria, $alias = null)
     {
-        $visitor = new QueryExpressionVisitor();
+        $visitor = new QueryExpressionVisitor($alias);
 
         if ($whereExpression = $criteria->getWhereExpression()) {
             $this->andWhere($visitor->dispatch($whereExpression));
@@ -1096,9 +1097,9 @@ class QueryBuilder
             }
         }
 
-        if ($criteria->getOrderings()) {
-            foreach ($criteria->getOrderings() as $sort => $order) {
-                $this->addOrderBy($sort, $order);
+        if ($orderings = $criteria->getOrderings()) {
+            foreach ($visitor->dispatchOrderings($orderings) as $orderBy) {
+                $this->addOrderBy($orderBy);
             }
         }
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -392,10 +392,10 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $criteria = new Criteria();
         $criteria->where($criteria->expr()->eq('field', 'value'));
 
-        $qb->addCriteria($criteria);
+        $qb->addCriteria($criteria, 'u');
 
-        $this->assertEquals('field = :field', (string) $qb->getDQLPart('where'));
-        $this->assertNotNull($qb->getParameter('field'));
+        $this->assertEquals('u.field = :u_field_0', (string) $qb->getDQLPart('where'));
+        $this->assertNotNull($qb->getParameter('u_field_0'));
     }
 
     public function testAddCriteriaOrder()
@@ -404,10 +404,10 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $criteria = new Criteria();
         $criteria->orderBy(array('field' => Criteria::DESC));
 
-        $qb->addCriteria($criteria);
+        $qb->addCriteria($criteria, 'u');
 
         $this->assertCount(1, $orderBy = $qb->getDQLPart('orderBy'));
-        $this->assertEquals('field DESC', (string) $orderBy[0]);
+        $this->assertEquals('u.field DESC', (string) $orderBy[0]);
     }
 
     public function testAddCriteriaLimit()


### PR DESCRIPTION
1. Fix problem with different comparisons on the same field in QueryExpressonVisitor (now index value is added).
2. Add criteria field aliasing. Usually oject criteria has "filed = value" notation while DQL has "alias.field = value".
   First level fields are added with alias, second+ level fields (object.field, parent.object.field) are truncated to the second level (object.field) without alias. Alias map can be implemented in future.
