### PR TITLE
ClassMetadataInfo: use reflection for creating new instance (on PHP >=5.4)

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -862,7 +862,12 @@ class ClassMetadataInfo implements ClassMetadata
     public function newInstance()
     {
         if ($this->_prototype === null) {
-            $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+            if (PHP_VERSION_ID >= 50400) {
+                $refl = $this->reflClass ?: new ReflectionClass($this->name);
+                $this->_prototype = $refl->newInstanceWithoutConstructor();
+            } else {
+                $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
+            }
         }
 
         return clone $this->_prototype;


### PR DESCRIPTION
On PHP >=5.4, use proper way for instantiating classes without invoking constructor.

I think no test is necessary, since travis runs them on different PHP versions.
