### PR TITLE
DQL Query: process ArrayCollection values to ease development

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
 use Doctrine\ORM\Query\Parameter;
@@ -403,6 +404,10 @@ abstract class AbstractQuery
     {
         if (is_scalar($value)) {
             return $value;
+        }
+
+        if ($value instanceof Collection) {
+            $value = $value->toArray();
         }
 
         if (is_array($value)) {
@@ -1089,7 +1094,7 @@ abstract class AbstractQuery
 
     /**
      * Generates a string of currently query to use for the cache second level cache.
-     * 
+     *
      * @return string
      */
     protected function getHash()


### PR DESCRIPTION
I added some code to ease "where in" parameter binding.

As you know, when a where condition is added, the object itself can be passed as a parameter and it's id is automatically retrieved:

``` php
$queryBuilder = $this
    ->where('model.category = :category')
    ->setParameter('category', $category)
;
```

Where `$category` is an object.

But it doesn't work for collections:

``` php
$queryBuilder = $this
    ->where('model.category IN (:categories)')
    ->setParameter('categories', $categories)
;
```

Where categories is an `ArrayCollection` object (retrieved from a many to one relation for instance).

This doesn't work in the current version of Doctrine, and my PR solves that.

~~Note that I didn't add any unit test for this feature. Can you explain me where I should add the test?~~

**This enhancement is now unit-tested in this same PR.**

So far, the only solution was to do the following, which is pretty borring:

``` php
$categoryIds = array();

foreach ($categories as $category) {
    $categoryIds[] = $category->getId();
}

$queryBuilder = $this
    ->where('model.category IN (:category_ids)')
    ->setParameter('category_ids', $categoryIds)
;
```
