### PR TITLE
Fix SimpleObjectHydrator behavior when column not exists in fieldMappings, relationMappings and metaMappings

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -176,10 +176,13 @@ class SimpleObjectHydrator extends AbstractHydrator
                 // One solution is to load the association, but it might require extra efforts.
                 return array('name' => $column);
 
-            default:
+            case (isset($this->_rsm->metaMappings[$column])):
                 return array(
                     'name' => $this->_rsm->metaMappings[$column]
                 );
+
+            default:
+                return null;
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -34,4 +34,28 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $hydrator   = new \Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
+
+    public function testExtraFieldInResultSetShouldBeIgnore()
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('Doctrine\Tests\Models\CMS\CmsAddress', 'a');
+        $rsm->addFieldResult('a', 'a__id', 'id');
+        $rsm->addFieldResult('a', 'a__city', 'city');
+        $resultSet = array(
+            array(
+                'a__id'   => '1',
+                'a__city' => 'Cracow',
+                'doctrine_rownum' => '1'
+            ),
+        );
+
+        $expectedEntity = new \Doctrine\Tests\Models\CMS\CmsAddress();
+        $expectedEntity->id = 1;
+        $expectedEntity->city = 'Cracow';
+
+        $stmt       = new HydratorMockStatement($resultSet);
+        $hydrator   = new \Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator($this->_em);
+        $result = $hydrator->hydrateAll($stmt, $rsm);
+        $this->assertEquals($result[0], $expectedEntity);
+    }
 }


### PR DESCRIPTION
https://github.com/doctrine/dbal/commit/88c1975dda492f3dd93cddea71ebacb40ed7efa5 change seems to make unable to use `findOneBy()` method because of `doctrine_rownum` added to query.

`findOneBy()` throws:

> Notice: Undefined index: doctrine_rownum in 
>  ...\vendor\doctrine\orm\lib\Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator.php line 183
