### PR TITLE
[PreUpdateEventArgs] Allows to add a new value on the entity changeset

### DIFF
--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -117,6 +117,27 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     }
 
     /**
+     * Adds a new field value in the entity changeset.
+     *
+     * If the field already exists, it sets the new value.
+     *
+     * @param string $field
+     * @param mixed  $value
+     *
+     * @return void
+     */
+    public function addNewValue($field, $value)
+    {
+        $metadata = $this->getEntityManager()->getClassMetadata(get_class($this->getEntity()));
+
+        if ( ! $metadata->hasField($field)) {
+            $this->assertValidField($field);
+        }
+
+        $this->entityChangeSet[$field][1] = $value;
+    }
+
+    /**
      * Asserts the field exists in changeset.
      *
      * @param string $field


### PR DESCRIPTION
Hey!

I propose to add a `addNewValue` method on the `PreUpdateEventArgs`. This method allows to add a new value on the entity changeset when the entity changeset does not wrap the field.

In one of my app, I need to update a field if an entity is updated but the field is not updated at the beginning.
