### PR TITLE
Added support for string functions in OrderBy clause

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1460,6 +1460,10 @@ class Parser
 
         switch (true) {
 
+            case ($this->isFunction()):
+                $expr = $this->FunctionDeclaration();
+
+                break;
             case ($this->isMathOperator($peek)):
                 $expr = $this->SimpleArithmeticExpression();
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -241,6 +241,14 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    public function testSupportsStringFunctionInOrderBy()
+    {
+        $this->assertSqlGeneration(
+            'SELECT u FROM Doctrine\Tests\Models\Forum\ForumUser u ORDER BY LENGTH(u.username) DESC',
+            'SELECT f0_.id AS id0, f0_.username AS username1 FROM forum_users f0_ ORDER BY LENGTH(f0_.username) DESC'
+        );
+    }
+
     public function testSupportsSelectDistinct()
     {
         $this->assertSqlGeneration(


### PR DESCRIPTION
Extended the OrderBy parser to support string functions directly in the `Order By` clause so you can do things like:

`ORDER BY LENGTH(a.somefield)`

or a typical use case with the doctrineExtensions

`ORDER BY FIELD(a.somefield, 5, 10, 8, 12)`
