### PR TITLE
Don't add empty Expr to another one

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -86,7 +86,7 @@ abstract class Base
      */
     public function add($arg)
     {
-        if ( $arg !== null || ($arg instanceof self && $arg->count() > 0) ) {
+        if ( $arg !== null && (!$arg instanceof self || $arg->count() > 0) ) {
             // If we decide to keep Expr\Base instances, we can use this check
             if ( ! is_string($arg)) {
                 $class = get_class($arg);

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -414,4 +414,18 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $select = new Expr\Select(array('foo', 'bar'));
         $this->assertEquals(array('foo', 'bar'), $select->getParts());
     }
+
+    public function testAddEmpty() {
+        $andExpr = $this->_expr->andx();
+        $andExpr->add($this->_expr->andx());
+        
+        $this->assertEquals(0, $andExpr->count());
+    }
+
+    public function testAddNull() {
+        $andExpr = $this->_expr->andx();
+        $andExpr->add(null);
+        
+        $this->assertEquals(0, $andExpr->count());
+    }
 }


### PR DESCRIPTION
Doctrine should not allow to add an empty Expr to another one. Current code allows that, which can lead to wrong DQL.
Example 1:

``` php
$andExpr = $this->_expr->andx();
$andExpr->add($this->_expr->andx());
$andExpr->add($this->_expr->eq(1, 1));
echo $andExpr;
```

will output:

``` sql
 AND 1 = 1
```

instead of:

``` sql
1 = 1
```

Example 2:

``` php
$andExpr = $this->_expr->andx();
$andExpr->add($this->_expr->andx());
$andExpr->add($this->_expr->andx());
$andExpr->add($this->_expr->andx());
echo $andExpr;
```

will output:

``` sql
 AND  AND 
```

instead of nothing.

IRC log of the discusion on #doctrine:

``` irc
[jeudi 7 mars 2013] [14:36:18] <Jean-Gui>       hi
[jeudi 7 mars 2013] [14:36:35] <Jean-Gui>       I have a question about Doctrine/ORM/Query/Expr/Base.php
[jeudi 7 mars 2013] [14:37:17] <Jean-Gui>       looking at the add function (https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Query/Expr/Base.php#L89), the first if seems wrong
[jeudi 7 mars 2013] [14:37:39] <Jean-Gui>       [[ if ( $arg !== null || ($arg instanceof self && $arg->count() > 0) ) ]]
[jeudi 7 mars 2013] [14:39:49] <Jean-Gui>       if $arg is not null, then it will get added even if $arg->count === 0
[jeudi 7 mars 2013] [14:41:03] <ocramius>       yes
[jeudi 7 mars 2013] [14:41:42] <Jean-Gui>       that doesn't seem right, does it?
[jeudi 7 mars 2013] [14:43:29] <ocramius>       why not?
[jeudi 7 mars 2013] [14:43:34] <ocramius>       can you elaborate?
[jeudi 7 mars 2013] [14:45:37] <Jean-Gui>       that "if" seems to be meaning that the function shouldn't add $arg if  $arg->count() equals 0
[jeudi 7 mars 2013] [14:45:45] <Ninj>   ocramius: i think Jean-Gui means that the right side of the OR will be called only if the left side is false, which means $arg is null. And if $arg is null it cannot be an object
[jeudi 7 mars 2013] [14:46:07] <Jean-Gui>       right
[jeudi 7 mars 2013] [14:46:30] <Ninj>   this condition is indeed bugged
[jeudi 7 mars 2013] [14:47:12] <alcuadradoatwork>       I see Jean-Gui's point too
[jeudi 7 mars 2013] [14:47:18] <ocramius>       write a test case then :)
[jeudi 7 mars 2013] [14:47:24] <alcuadradoatwork>       maybe it works right, but it's confusing
[jeudi 7 mars 2013] [14:48:07] <Ninj>   this condition will not throw any error because the "instanceof" will prevent the $arg::count function to be called on a null object, but it is still useless
[jeudi 7 mars 2013] [14:48:20] <Jean-Gui>       I think [[ if ( $arg !== null && (!($arg instanceof self) || ($arg instanceof self && $arg->count() > 0)) ) ]] would work better
[jeudi 7 mars 2013] [14:48:31]   * Jean-Gui will look into how to submit bug reports
[jeudi 7 mars 2013] [14:48:49] <alcuadradoatwork>       isn't this enough?  if ($arg instanceof self && $arg->count() > 0)
[jeudi 7 mars 2013] [14:49:18] <Ninj>   i think it is, alcuadradoatwork
[jeudi 7 mars 2013] [14:49:28] <Jean-Gui>       no, because if $arg is not an instance of self, I think we still want to add it
[jeudi 7 mars 2013] [14:49:45] <ocramius>       alcuadradoatwork: again... if it is a buggy condition, write a small test and open a PR :)
[jeudi 7 mars 2013] [14:50:03] <alcuadradoatwork>       ocramius, it depends on your definition of "buggy"
[jeudi 7 mars 2013] [14:50:32] <alcuadradoatwork>       it won't damage the behavior of the software, but it's quality its kind of pour
[jeudi 7 mars 2013] [14:51:19] <ocramius>       alcuadradoatwork: yes, still it needs coverage. I didn't say it needs a _FAILING_ test
[jeudi 7 mars 2013] [14:51:38] <alcuadradoatwork>       I see your point
[jeudi 7 mars 2013] [14:51:47] <Ninj>   if the logic is :  "add any non-null object, but if it's self so add it only if count>0" then it must be rewriten
[jeudi 7 mars 2013] [14:52:46] <Jean-Gui>       $args should be added if it's an instance of self or $_allowedClasses
[jeudi 7 mars 2013] [14:53:16] <Ninj>   hum
[jeudi 7 mars 2013] [14:53:37] <Ninj>   $args should be added if it's an instance of self with count > 0 or any other $_allowedClasse
[jeudi 7 mars 2013] [14:53:55] <Jean-Gui>       yes, Ninj
[jeudi 7 mars 2013] [14:55:01] <Jean-Gui>       thanks for your help guys, I'll submit a bug report with some test cases
[jeudi 7 mars 2013] [14:55:43] <Ninj>   your welcome Jean-Gui
```
