### PR TITLE
ObjectHydrator: fix entity namespaces.

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -101,9 +101,10 @@ class ObjectHydrator extends AbstractHydrator
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
             $this->identifierMap[$dqlAlias] = array();
             $this->idTemplate[$dqlAlias]    = '';
+            $classMetadata = $this->_em->getClassMetadata($className);
 
-            if ( ! isset($this->ce[$className])) {
-                $this->ce[$className] = $this->_em->getClassMetadata($className);
+            if ( ! isset($this->ce[$classMetadata->name])) {
+                $this->ce[$classMetadata->name] = $this->_em->getClassMetadata($className);
             }
 
             // Remember which associations are "fetch joined", so that we know where to inject
@@ -135,7 +136,7 @@ class ObjectHydrator extends AbstractHydrator
 
             // handle fetch-joined owning side bi-directional one-to-one associations
             if ($assoc['inversedBy']) {
-                $class        = $this->ce[$className];
+                $class        = $this->ce[$classMetadata->name];
                 $inverseAssoc = $class->associationMappings[$assoc['inversedBy']];
 
                 if ( ! ($inverseAssoc['type'] & ClassMetadata::TO_ONE)) {
@@ -247,7 +248,9 @@ class ObjectHydrator extends AbstractHydrator
      */
     private function getEntity(array $data, $dqlAlias)
     {
-        $className = $this->_rsm->aliasMap[$dqlAlias];
+        $classAliasMap = $this->_rsm->aliasMap[$dqlAlias];
+        $classMetadata = $this->_em->getClassMetadata($classAliasMap);
+        $className = $classMetadata->name;
 
         if (isset($this->_rsm->discriminatorColumns[$dqlAlias])) {
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -104,7 +104,7 @@ class ObjectHydrator extends AbstractHydrator
             $classMetadata                  = $this->_em->getClassMetadata($className);
 
             if ( ! isset($this->ce[$classMetadata->name])) {
-                $this->ce[$classMetadata->name] = $this->_em->getClassMetadata($className);
+                $this->ce[$classMetadata->name] = $classMetadata;
             }
 
             // Remember which associations are "fetch joined", so that we know where to inject

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -101,7 +101,7 @@ class ObjectHydrator extends AbstractHydrator
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
             $this->identifierMap[$dqlAlias] = array();
             $this->idTemplate[$dqlAlias]    = '';
-            $classMetadata = $this->_em->getClassMetadata($className);
+            $classMetadata                  = $this->_em->getClassMetadata($className);
 
             if ( ! isset($this->ce[$classMetadata->name])) {
                 $this->ce[$classMetadata->name] = $this->_em->getClassMetadata($className);
@@ -250,7 +250,7 @@ class ObjectHydrator extends AbstractHydrator
     {
         $classAliasMap = $this->_rsm->aliasMap[$dqlAlias];
         $classMetadata = $this->_em->getClassMetadata($classAliasMap);
-        $className = $classMetadata->name;
+        $className     = $classMetadata->name;
 
         if (isset($this->_rsm->discriminatorColumns[$dqlAlias])) {
 

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -78,7 +78,7 @@ class HydratorMockStatement implements \IteratorAggregate, \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      */
-    public function bindParam($column, &$variable, $type = null)
+    public function bindParam($column, &$variable, $type = null, $length = null)
     {
     }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1928,4 +1928,130 @@ class ObjectHydratorTest extends HydrationTestCase
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
+
+    /**
+     * SELECT PARTIAL u.{id, status}, PARTIAL p.{phonenumber}, UPPER(u.name) nameUpper
+     *   FROM Doctrine\Tests\Models\CMS\CmsUser u
+     *   JOIN u.phonenumbers p
+     *
+     * @group EntityNamespaces
+     * @dataProvider provideDataForUserEntityResult
+     */
+    public function testMixedQueryNormalJoinWithEntityNamespaces($userEntityKey)
+    {
+        $this->_em->getConfiguration()->addEntityNamespace(
+            'DoctrineCmsModels', 'Doctrine\Tests\Models\CMS'
+        );
+
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('DoctrineCmsModels:CmsUser', 'u', $userEntityKey ?: null);
+        $rsm->addJoinedEntityResult(
+            'DoctrineCmsModels:CmsPhonenumber',
+            'p',
+            'u',
+            'phonenumbers'
+        );
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__status', 'status');
+        $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
+        $rsm->addScalarResult('sclr0', 'nameUpper');
+
+        // Faked result set
+        $resultSet = array(
+            //row1
+            array(
+                'u__id' => '1',
+                'u__status' => 'developer',
+                'p__phonenumber' => '42',
+                'sclr0' => 'ROMANB',
+            ),
+            array(
+                'u__id' => '1',
+                'u__status' => 'developer',
+                'p__phonenumber' => '43',
+                'sclr0' => 'ROMANB',
+            ),
+            array(
+                'u__id' => '2',
+                'u__status' => 'developer',
+                'p__phonenumber' => '91',
+                'sclr0' => 'JWAGE',
+            )
+        );
+
+        $stmt     = new HydratorMockStatement($resultSet);
+        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+
+        $this->assertEquals(2, count($result));
+
+        $this->assertInternalType('array', $result);
+        $this->assertInternalType('array', $result[0]);
+        $this->assertInternalType('array', $result[1]);
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0][$userEntityKey]);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $result[0][$userEntityKey]->phonenumbers);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsPhonenumber', $result[0][$userEntityKey]->phonenumbers[0]);
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[1][$userEntityKey]);
+        $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $result[1][$userEntityKey]->phonenumbers);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsPhonenumber', $result[0][$userEntityKey]->phonenumbers[1]);
+
+        // first user => 2 phonenumbers
+        $this->assertEquals(2, count($result[0][$userEntityKey]->phonenumbers));
+        $this->assertEquals('ROMANB', $result[0]['nameUpper']);
+
+        // second user => 1 phonenumber
+        $this->assertEquals(1, count($result[1][$userEntityKey]->phonenumbers));
+        $this->assertEquals('JWAGE', $result[1]['nameUpper']);
+
+        $this->assertEquals(42, $result[0][$userEntityKey]->phonenumbers[0]->phonenumber);
+        $this->assertEquals(43, $result[0][$userEntityKey]->phonenumbers[1]->phonenumber);
+        $this->assertEquals(91, $result[1][$userEntityKey]->phonenumbers[0]->phonenumber);
+    }
+
+    /**
+     * SELECT PARTIAL u.{id,name}
+     *   FROM Doctrine\Tests\Models\CMS\CmsUser u
+     *
+     * @group EntityNamespaces
+     */
+    public function testSimpleEntityQueryWithEntityNamespaces()
+    {
+        $this->_em->getConfiguration()->addEntityNamespace(
+            'DoctrineCmsModels', 'Doctrine\Tests\Models\CMS'
+        );
+
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('DoctrineCmsModels:CmsUser', 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__name', 'name');
+
+        // Faked result set
+        $resultSet = array(
+            array(
+                'u__id' => '1',
+                'u__name' => 'romanb'
+            ),
+            array(
+                'u__id' => '2',
+                'u__name' => 'jwage'
+            )
+        );
+
+        $stmt     = new HydratorMockStatement($resultSet);
+        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+
+        $this->assertEquals(2, count($result));
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0]);
+        $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[1]);
+
+        $this->assertEquals(1, $result[0]->id);
+        $this->assertEquals('romanb', $result[0]->name);
+
+        $this->assertEquals(2, $result[1]->id);
+        $this->assertEquals('jwage', $result[1]->name);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1939,9 +1939,7 @@ class ObjectHydratorTest extends HydrationTestCase
      */
     public function testMixedQueryNormalJoinWithEntityNamespaces($userEntityKey)
     {
-        $this->_em->getConfiguration()->addEntityNamespace(
-            'DoctrineCmsModels', 'Doctrine\Tests\Models\CMS'
-        );
+        $this->_em->getConfiguration()->addEntityNamespace('DoctrineCmsModels', 'Doctrine\Tests\Models\CMS');
 
         $rsm = new ResultSetMapping;
         $rsm->addEntityResult('DoctrineCmsModels:CmsUser', 'u', $userEntityKey ?: null);
@@ -2018,9 +2016,7 @@ class ObjectHydratorTest extends HydrationTestCase
      */
     public function testSimpleEntityQueryWithEntityNamespaces()
     {
-        $this->_em->getConfiguration()->addEntityNamespace(
-            'DoctrineCmsModels', 'Doctrine\Tests\Models\CMS'
-        );
+        $this->_em->getConfiguration()->addEntityNamespace('DoctrineCmsModels', 'Doctrine\Tests\Models\CMS');
 
         $rsm = new ResultSetMapping;
         $rsm->addEntityResult('DoctrineCmsModels:CmsUser', 'u');


### PR DESCRIPTION
# Object Hydrator: fix entity namespaces

If you are using Entity Namespace aliases, the ObjectHydrator will throw a notice for an undefined index of your entity namespace.
## Problem

The problem lies in the fact that the prepare() method uses the "className", used in the aliasMap (where you use the namespace alias) to store the local ClassMetadata cache. Though, in a later stage the actual namespace is being used to find this same item.
## Fix

I've changed the way this ClassMetadata cache is built. It now uses the full Entity namespace.
