### PR TITLE
Wrong UnitOfWork::computeChangeSet()

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -598,7 +598,7 @@ class UnitOfWork implements PropertyChangedListener
                 $orgValue = $originalData[$propName];
 
                 // skip if value havent changed
-                if ($orgValue === $actualValue) {
+                if ($orgValue === $actualValue || $actualValue instanceof Proxy) {
                     continue;
                 }
 


### PR DESCRIPTION
Sometimes some fields are Proxy when compute "changeSet". If it is Proxy, some listeners - example Gedmo sortable listener - belive the value has changed and this leads to chaos.

I check the $actualValue, if it is Proxy, the value didn't change.
