### PR TITLE
Fix getSQLTableAlias for postgre camelized table name

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -284,7 +284,9 @@ class SqlWalker implements TreeWalker
         $tableName .= ($dqlAlias) ? '@[' . $dqlAlias . ']' : '';
 
         if ( ! isset($this->tableAliasMap[$tableName])) {
-            $this->tableAliasMap[$tableName] = strtolower(substr($tableName, 0, 1)) . $this->tableAliasCounter++ . '_';
+            $prefix = (substr($tableName, 0, 1) != "\"") ? substr($tableName, 0, 1) : substr($tableName, 1, 1);
+
+            $this->tableAliasMap[$tableName] = $prefix . $this->tableAliasCounter++ . '_';
         }
 
         return $this->tableAliasMap[$tableName];

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -284,9 +284,9 @@ class SqlWalker implements TreeWalker
         $tableName .= ($dqlAlias) ? '@[' . $dqlAlias . ']' : '';
 
         if ( ! isset($this->tableAliasMap[$tableName])) {
-            $prefix = (substr($tableName, 0, 1) != "\"") ? substr($tableName, 0, 1) : substr($tableName, 1, 1);
+            $prefix = (substr($tableName, 0, 1) != '"') ? substr($tableName, 0, 1) : substr($tableName, 1, 1);
 
-            $this->tableAliasMap[$tableName] = $prefix . $this->tableAliasCounter++ . '_';
+            $this->tableAliasMap[$tableName] = strtolower($prefix) . $this->tableAliasCounter++ . '_';
         }
 
         return $this->tableAliasMap[$tableName];


### PR DESCRIPTION
In postgreSQL with old databases we can have camelized model names to query on we need to add quote around the table name like :

```
 * @ORM\Table(name="""someThing""")
```

But when query is built the alias taken will be `"` this fix will find the good alias to use enabling to query camelized tables
