### PR TITLE
default discriminator map - full namespace

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -241,43 +241,28 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         $allClasses = $this->driver->getAllClassNames();
         $fqcn = $class->getName();
-        $map = array($this->getShortName($class->name) => $fqcn);
+        $map = array($this->getUniqueName($class->name) => $fqcn);
 
-        $duplicates = array();
         foreach ($allClasses as $subClassCandidate) {
             if (is_subclass_of($subClassCandidate, $fqcn)) {
-                $shortName = $this->getShortName($subClassCandidate);
-
-                if (isset($map[$shortName])) {
-                    $duplicates[] = $shortName;
-                }
+                $shortName = $this->getUniqueName($subClassCandidate);
 
                 $map[$shortName] = $subClassCandidate;
             }
-        }
-
-        if ($duplicates) {
-            throw MappingException::duplicateDiscriminatorEntry($class->name, $duplicates, $map);
         }
 
         $class->setDiscriminatorMap($map);
     }
 
     /**
-     * Gets the lower-case short name of a class.
+     * Get the lower-case unique name of a class.
      *
      * @param string $className
-     *
      * @return string
      */
-    private function getShortName($className)
+    private function getUniqueName($className)
     {
-        if (strpos($className, "\\") === false) {
-            return strtolower($className);
-        }
-
-        $parts = explode("\\", $className);
-        return strtolower(end($parts));
+        return strtolower(str_replace("\\", "_", $className));
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -464,24 +464,6 @@ class MappingException extends \Doctrine\ORM\ORMException
 
     /**
      * @param string $className
-     * @param array  $entries
-     * @param array  $map
-     *
-     * @return MappingException
-     */
-    public static function duplicateDiscriminatorEntry($className, array $entries, array $map)
-    {
-        return new self(
-            "The entries " . implode(', ',  $entries) . " in discriminator map of class '" . $className . "' is duplicated. " .
-            "If the discriminator map is automatically generated you have to convert it to an explicit discriminator map now. " .
-            "The entries of the current map are: @DiscriminatorMap({" . implode(', ', array_map(
-                function($a, $b) { return "'$a': '$b'"; }, array_keys($map), array_values($map)
-            )) . "})"
-        );
-    }
-
-    /**
-     * @param string $className
      *
      * @return MappingException
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -175,9 +175,9 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $childClassKey = array_search($childClass, $rootDiscriminatorMap);
         $anotherChildClassKey = array_search($anotherChildClass, $rootDiscriminatorMap);
 
-        $this->assertEquals('rootclass', $rootClassKey);
-        $this->assertEquals('childclass', $childClassKey);
-        $this->assertEquals('anotherchildclass', $anotherChildClassKey);
+        $this->assertEquals('doctrine_tests_models_joinedinheritancetype_rootclass', $rootClassKey);
+        $this->assertEquals('doctrine_tests_models_joinedinheritancetype_childclass', $childClassKey);
+        $this->assertEquals('doctrine_tests_models_joinedinheritancetype_anotherchildclass', $anotherChildClassKey);
 
         $this->assertEquals($childDiscriminatorMap, $rootDiscriminatorMap);
         $this->assertEquals($anotherChildDiscriminatorMap, $rootDiscriminatorMap);
@@ -284,7 +284,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('parent-id', $user['joinColumns'][0]['name']);
         $this->assertEquals('group-id', $user['joinColumns'][0]['referencedColumnName']);
 
-        
+
         // Address Class Metadata
         $this->assertTrue($addressMetadata->fieldMappings['id']['quoted']);
         $this->assertTrue($addressMetadata->fieldMappings['zip']['quoted']);
@@ -302,11 +302,11 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         // User Class Metadata
         $this->assertTrue($userMetadata->fieldMappings['id']['quoted']);
         $this->assertTrue($userMetadata->fieldMappings['name']['quoted']);
-        
+
         $this->assertEquals('user-id', $userMetadata->fieldMappings['id']['columnName']);
         $this->assertEquals('user-name', $userMetadata->fieldMappings['name']['columnName']);
 
-        
+
         $address = $userMetadata->associationMappings['address'];
         $this->assertTrue($address['joinColumns'][0]['quoted']);
         $this->assertEquals('address-id', $address['joinColumns'][0]['name']);


### PR DESCRIPTION
Using Symfony2, if you have two entities with the same name in different bundles, automatic discriminator map detection will trow MappingException.

If the namespace is included, there should be no more duplicate key issues.

(In this case, setting the map manually is not an option)
