### PR TITLE
update document on Doctrine cache provider

### DIFF
--- a/docs/en/reference/caching.rst
+++ b/docs/en/reference/caching.rst
@@ -211,49 +211,6 @@ By Cache ID
     <?php
     $cacheDriver->delete('my_array');
 
-You can also pass wild cards to the ``delete()`` method and it will
-return an array of IDs that were matched and deleted.
-
-.. code-block:: php
-
-    <?php
-    $deleted = $cacheDriver->delete('users_*');
-
-By Regular Expression
-^^^^^^^^^^^^^^^^^^^^^
-
-If you need a little more control than wild cards you can use a PHP
-regular expression to delete cache entries.
-
-.. code-block:: php
-
-    <?php
-    $deleted = $cacheDriver->deleteByRegex('/users_.*/');
-
-By Prefix
-^^^^^^^^^
-
-Because regular expressions are kind of slow, if simply deleting by
-a prefix or suffix is sufficient, it is recommended that you do
-that instead of using a regular expression because it will be much
-faster if you have many cache entries.
-
-.. code-block:: php
-
-    <?php
-    $deleted = $cacheDriver->deleteByPrefix('users_');
-
-By Suffix
-^^^^^^^^^
-
-Just like we did above with the prefix you can do the same with a
-suffix.
-
-.. code-block:: php
-
-    <?php
-    $deleted = $cacheDriver->deleteBySuffix('_my_account');
-
 All
 ^^^
 
@@ -264,17 +221,6 @@ the ``deleteAll()`` method.
 
     <?php
     $deleted = $cacheDriver->deleteAll();
-
-Counting
-~~~~~~~~
-
-If you want to count how many entries are stored in the cache
-driver instance you can use the ``count()`` method.
-
-.. code-block:: php
-
-    <?php
-    echo $cacheDriver->count();
 
 Namespaces
 ~~~~~~~~~~


### PR DESCRIPTION
A number of methods have been deleted long time ago. But they still show up on the document page.

http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/caching.html#deleting

http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/caching.html#counting

I checked source code. Most of the methods don't exist. They are better to be removed from the doc. I tried to use those functions and was surprised that they didn't exist.
