### PR TITLE
Fix typo in one of the orderBy examples.

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -222,7 +222,7 @@ alternative syntax is available:
     $qb->select('u')
        ->from('User u')
        ->where('u.id = :identifier')
-       ->orderBy('u.name ASC');
+       ->orderBy('u.name', 'ASC');
        ->setParameter('identifier', 100); // Sets :identifier to 100, and thus we will fetch a user with u.id = 100
 
 Note that numeric placeholders start with a ? followed by a number


### PR DESCRIPTION
Fix typo in one of the orderBy examples.
