### PR TITLE
[DDC-2042] Added "targetEntity" to AssociationOverride

### DIFF
--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -50,4 +50,11 @@ final class AssociationOverride implements Annotation
      * @var \Doctrine\ORM\Mapping\JoinTable
      */
     public $joinTable;
+
+    /**
+     * The target entitiy that maps the relationship.
+     *
+     * @var string
+     */
+    public $targetEntity;
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1976,6 +1976,10 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['joinTable'] = $overrideMapping['joinTable'];
         }
 
+        if (isset($overrideMapping['targetEntity'])) {
+            $mapping['targetEntity'] = $overrideMapping['targetEntity'];
+        }
+
         $mapping['joinColumnFieldNames']        = null;
         $mapping['joinTableColumns']            = null;
         $mapping['sourceToTargetKeyColumns']    = null;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -403,6 +403,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     $override['joinTable'] = $joinTable;
                 }
 
+                if ($associationOverride->targetEntity) {
+                    $override['targetEntity'] = $associationOverride->targetEntity;
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -548,6 +548,10 @@ class XmlDriver extends FileDriver
                     $override['joinTable'] = $joinTable;
                 }
 
+                if ($overrideElement->targetEntity) {
+                    $override['targetEntity'] = $overrideElement->targetEntity;
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -553,6 +553,10 @@ class YamlDriver extends FileDriver
                     $override['joinTable'] = $joinTable;
                 }
 
+                if (isset($associationOverrideElement['targetEntity'])) {
+                    $override['targetEntity'] = $associationOverrideElement['targetEntity'];
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/tests/Doctrine/Tests/Models/DDC2042/DDC2042Bar.php
+++ b/tests/Doctrine/Tests/Models/DDC2042/DDC2042Bar.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC2042;
+
+/**
+* @Entity
+*/
+class DDC2042Bar
+{
+    /** @Id @Column(type="string") */
+    private $id;
+}

--- a/tests/Doctrine/Tests/Models/DDC2042/DDC2042Baz.php
+++ b/tests/Doctrine/Tests/Models/DDC2042/DDC2042Baz.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC2042;
+
+/**
+* @Entity
+*/
+class DDC2042Baz
+{
+    /** @Id @Column(type="string") */
+    private $id;
+}

--- a/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleEntityWithOverride.php
+++ b/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleEntityWithOverride.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC2042;
+
+/**
+ * @Entity
+ *
+ * @AssociationOverrides({
+ * @AssociationOverride(name="bar",
+ *          targetEntity="DDC2042Baz"
+ *      )
+ * })
+ */
+class DDC2042ExampleEntityWithOverride
+{
+    use DDC2042ExampleTrait;
+}

--- a/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleEntityWithoutOverride.php
+++ b/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleEntityWithoutOverride.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC2042;
+
+/**
+ * @Entity
+ */
+class DDC2042ExampleEntityWithoutOverride
+{
+    use DDC2042ExampleTrait;
+}

--- a/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleTrait.php
+++ b/tests/Doctrine/Tests/Models/DDC2042/DDC2042ExampleTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC2042;
+
+/**
+ * Trait class
+ */
+trait DDC2042ExampleTrait
+{
+    /** @Id @Column(type="string") */
+    private $id;
+
+    /**
+     * @Column(name="trait_foo", type="integer", length=100, nullable=true, unique=true)
+     */
+    protected $foo;
+
+    /**
+     * @OneToOne(targetEntity="DDC2042Bar", cascade={"persist", "merge"})
+     * @JoinColumn(name="example_trait_bar_id", referencedColumnName="id")
+     */
+    protected $bar;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -232,6 +232,24 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertArrayHasKey('example_trait_bar_id', $metadataWithoutOverride->associationMappings['bar']['joinColumnFieldNames']);
         $this->assertArrayHasKey('example_entity_overridden_bar_id', $metadataWithOverride->associationMappings['bar']['joinColumnFieldNames']);
     }
+
+    /**
+     * @group DDC-2042
+     */
+    public function testAttributeOverridesMappingWithTargetEntity()
+    {
+        if (!version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $this->markTestSkipped('This test is only for 5.4+.');
+        }
+
+        $factory = $this->createClassMetadataFactory();
+
+        $metadataWithoutOverride = $factory->getMetadataFor('Doctrine\Tests\Models\DDC2042\DDC2042ExampleEntityWithoutOverride');
+        $metadataWithOverride = $factory->getMetadataFor('Doctrine\Tests\Models\DDC2042\DDC2042ExampleEntityWithOverride');
+
+        $this->assertEquals('Doctrine\Tests\Models\DDC2042\DDC2042Bar', $metadataWithoutOverride->associationMappings['bar']['targetEntity']);
+        $this->assertEquals('Doctrine\Tests\Models\DDC2042\DDC2042Baz', $metadataWithOverride->associationMappings['bar']['targetEntity']);
+    }
 }
 
 /**


### PR DESCRIPTION
Hey,

I needed to override "targetEntity" so I forked Doctrine and applyed it myself. Just after that I found a Ticket [DDC-2042] in your Jira so I added a unit test to and would be more than happy to see this commit get merged in to the main master (at some point ;)).

Cheers, Alex

I will stick around in the #doctrine-dev on Freenode for any questions. My nick there is "fanta".

Keep up the good work.

/**
- @ORM\Entity
- @ORM\Table(name="customer")
- @ORM\AssociationOverrides({
-      @ORM\AssociationOverride(name="products",
-          targetEntity="MyNewProduct"
-      )
- })
  */
