### PR TITLE
Fixed typos in documentation.

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -909,7 +909,7 @@ Query Result Formats
 
 The format in which the result of a DQL SELECT query is returned
 can be influenced by a so-called ``hydration mode``. A hydration
-mode specifies a particular way in which an SQL result set is
+mode specifies a particular way in which a SQL result set is
 transformed. Each hydration mode has its own dedicated method on
 the Query class. Here they are:
 
@@ -1290,7 +1290,7 @@ userland:
 Query Cache (DQL Query Only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Parsing a DQL query and converting it into an SQL query against the
+Parsing a DQL query and converting it into a SQL query against the
 underlying database platform obviously has some overhead in
 contrast to directly executing Native SQL queries. That is why
 there is a dedicated Query Cache for caching the DQL parser

--- a/docs/en/reference/faq.rst
+++ b/docs/en/reference/faq.rst
@@ -147,7 +147,7 @@ Why does Doctrine not create proxy objects for my inheritance hierarchy?
 
 If you set a many-to-one or one-to-one association target-entity to any parent class of
 an inheritance hierarchy Doctrine does not know what PHP class the foreign is actually of.
-To find this out it has to execute an SQL query to look this information up in the database.
+To find this out it has to execute a SQL query to look this information up in the database.
 
 EntityGenerator
 ---------------

--- a/docs/en/reference/filters.rst
+++ b/docs/en/reference/filters.rst
@@ -7,7 +7,7 @@ Doctrine 2.2 features a filter system that allows the developer to add SQL to
 the conditional clauses of queries, regardless the place where the SQL is
 generated (e.g. from a DQL query, or by loading associated entities).
 
-The filter functionality works on SQL level. Whether an SQL query is generated
+The filter functionality works on SQL level. Whether a SQL query is generated
 in a Persister, during lazy loading, in extra lazy collections or from DQL.
 Each time the system iterates over all the enabled filters, adding a new SQL
 part as a filter returns.

--- a/docs/en/reference/native-sql.rst
+++ b/docs/en/reference/native-sql.rst
@@ -3,7 +3,7 @@ Native SQL
 
 A ``NativeQuery`` lets you execute native SELECT SQL statements, mapping the results
 according to your specifications. Such a specification that
-describes how an SQL result set is mapped to a Doctrine result is
+describes how a SQL result set is mapped to a Doctrine result is
 represented by a ``ResultSetMapping``. It describes how each column
 of the database result should be mapped by Doctrine in terms of the
 object graph. This allows you to map arbitrary SQL code to objects,
@@ -136,7 +136,7 @@ joined entity result.
 Field results
 ~~~~~~~~~~~~~
 
-A field result describes the mapping of a single column in an SQL
+A field result describes the mapping of a single column in a SQL
 result set to a field in an entity. As such, field results are
 inherently bound to entity results. You add a field result through
 ``ResultSetMapping#addFieldResult()``. Again, let's examine the
@@ -165,7 +165,7 @@ column should be set.
 Scalar results
 ~~~~~~~~~~~~~~
 
-A scalar result describes the mapping of a single column in an SQL
+A scalar result describes the mapping of a single column in a SQL
 result set to a scalar value in the Doctrine result. Scalar results
 are typically used for aggregate values but any column in the SQL
 result set can be mapped as a scalar value. To add a scalar result
@@ -190,7 +190,7 @@ of the column will be placed in the transformed Doctrine result.
 Meta results
 ~~~~~~~~~~~~
 
-A meta result describes a single column in an SQL result set that
+A meta result describes a single column in a SQL result set that
 is either a foreign key or a discriminator column. These columns
 are essential for Doctrine to properly construct objects out of SQL
 result sets. To add a column as a meta result use
@@ -546,12 +546,12 @@ it represents the name of a defined @SqlResultSetMapping.
 
 Things to note:
     - The resultset mapping declares the entities retrieved by this native query.
-    - Each field of the entity is bound to an SQL alias (or column name).
+    - Each field of the entity is bound to a SQL alias (or column name).
     - All fields of the entity including the ones of subclasses
       and the foreign key columns of related entities have to be present in the SQL query.
     - Field definitions are optional provided that they map to the same
       column name as the one declared on the class property.
-    - ``__CLASS__`` is a alias for the mapped class
+    - ``__CLASS__`` is an alias for the mapped class
 
 
 In the above example,

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -182,7 +182,7 @@ example we'll use an integer.
         // ...
     }
 
-Alternatively a datetime type can be used (which maps to an SQL
+Alternatively a datetime type can be used (which maps to a SQL
 timestamp or datetime):
 
 .. code-block:: php

--- a/docs/en/reference/unitofwork.rst
+++ b/docs/en/reference/unitofwork.rst
@@ -117,7 +117,7 @@ that consume new memory.
 Now whenever you call ``EntityManager#flush`` Doctrine will iterate over the
 Identity Map and for each object compares the original property and association
 values with the values that are currently set on the object. If changes are
-detected then the object is queued for an SQL UPDATE operation. Only the fields
+detected then the object is queued for a SQL UPDATE operation. Only the fields
 that actually changed are updated.
 
 This process has an obvious performance impact. The larger the size of the


### PR DESCRIPTION
Hello again everyone! I went ahead and fixed the rest of the instances in the documentation that used 'an SQL'. I also fixed an instance of 'a alias' to be 'an alias', which is proper since alias begins with a vowel. 
