### PR TITLE
Added abillity to use metacolumn as indexBy

### DIFF
--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -211,7 +211,7 @@ class ResultSetMapping
     {
         $found = false;
 
-        foreach ($this->fieldMappings as $columnName => $columnFieldName) {
+        foreach (array_merge($this->metaMappings, $this->fieldMappings) as $columnName => $columnFieldName) {
             if ( ! ($columnFieldName === $fieldName && $this->columnOwnerMap[$columnName] === $alias)) continue;
 
             $this->addIndexByColumn($alias, $columnName);

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
@@ -24,12 +24,12 @@ class DDC117Article
     private $details;
 
     /**
-     * @OneToMany(targetEntity="DDC117Translation", mappedBy="article", cascade={"persist", "remove"})
+     * @OneToMany(targetEntity="DDC117Translation", mappedBy="article", indexBy="language", cascade={"persist", "remove"})
      */
     private $translations;
 
     /**
-     * @OneToMany(targetEntity="DDC117Link", mappedBy="source")
+     * @OneToMany(targetEntity="DDC117Link", mappedBy="source", indexBy="target_id")
      */
     private $links;
 
@@ -75,6 +75,10 @@ class DDC117Article
         return $this->details;
     }
 
+    public function getLinks()
+    {
+        return $this->links;
+    }
     public function resetText()
     {
         $this->details = null;

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
@@ -29,7 +29,7 @@ class DDC117Article
     private $translations;
 
     /**
-     * @OneToMany(targetEntity="DDC117Link", mappedBy="source", indexBy="target_id")
+     * @OneToMany(targetEntity="DDC117Link", mappedBy="source", indexBy="target_id", cascade={"persist", "remove"})
      */
     private $links;
 

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
@@ -24,7 +24,7 @@ class DDC117Article
     private $details;
 
     /**
-     * @OneToMany(targetEntity="DDC117Translation", mappedBy="article", indexBy="language", cascade={"persist", "remove"})
+     * @OneToMany(targetEntity="DDC117Translation", mappedBy="article", cascade={"persist", "remove"})
      */
     private $translations;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -8,6 +8,7 @@ use Doctrine\Tests\Models\DDC117\DDC117Reference;
 use Doctrine\Tests\Models\DDC117\DDC117Translation;
 use Doctrine\Tests\Models\DDC117\DDC117ApproveChanges;
 use Doctrine\Tests\Models\DDC117\DDC117Editor;
+use Doctrine\Tests\Models\DDC117\DDC117Link;
 
 require_once __DIR__ . '/../../../TestInit.php';
 
@@ -30,6 +31,9 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($this->article2);
         $this->_em->flush();
 
+        $link = new DDC117Link($this->article1, $this->article2, "Link-Description");
+        $this->_em->persist($link);
+        
         $this->reference = new DDC117Reference($this->article1, $this->article2, "Test-Description");
         $this->_em->persist($this->reference);
 
@@ -478,5 +482,16 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $reference = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
 
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($reference));
+    }
+    /**
+     * @group DDC-117
+     */
+    public function testIndexByOnCompositeKeyField()
+    {   
+        $article = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Article", $this->article1->id());
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\DDC117\DDC117Article', $article);
+        $this->assertEquals(1, count($article->getLinks()));
+        $this->assertTrue($article->getLinks()->offsetExists($this->article2->id()));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -255,19 +255,18 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('status'));
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('username'));
     }
-
+    /**
+     * @group DDC-117
+     */
     public function testIndexByMetadataColumn()
     {
-        $rms = $this->_rsm;
-        $rms->addEntityResult('Doctrine\Tests\Models\Legacy\LegacyUser', 'u')
-            ->addJoinedEntityResult('Doctrine\Tests\Models\Legacy', 'lu', 'u', '_references')
-            ->addMetaResult('lu', '_source',  '_source', true)
-            ->addMetaResult('lu', '_target',  '_target', true)
-            ->addIndexBy('lu', '_source');
+        $this->_rsm->addEntityResult('Doctrine\Tests\Models\Legacy\LegacyUser', 'u');
+        $this->_rsm->addJoinedEntityResult('Doctrine\Tests\Models\Legacy', 'lu', 'u', '_references');
+        $this->_rsm->addMetaResult('lu', '_source',  '_source', true);
+        $this->_rsm->addMetaResult('lu', '_target',  '_target', true);
+        $this->_rsm->addIndexBy('lu', '_source');
 
-
-          $this->assertTrue($rms->hasIndexBy('lu'));
-
+        $this->assertTrue($this->_rsm->hasIndexBy('lu'));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -255,5 +255,18 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('status'));
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('username'));
     }
+    public function testIndexByMetadataColumn()
+    {
+        $rms = $this->_rsm;
+        $rms->addEntityResult('Doctrine\Tests\Models\Legacy\LegacyUser', 'u')
+            ->addJoinedEntityResult('Doctrine\Tests\Models\Legacy', 'lu', 'u', '_references')
+            ->addMetaResult('lu', '_source',  '_source', true)
+            ->addMetaResult('lu', '_target',  '_target', true)
+            ->addIndexBy('lu', '_source');
+
+
+          $this->assertTrue($rms->hasIndexBy('lu'));
+
+    }
 }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -255,6 +255,7 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('status'));
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $rsm->getDeclaringClass('username'));
     }
+
     public function testIndexByMetadataColumn()
     {
         $rms = $this->_rsm;


### PR DESCRIPTION
Added ability to use meta column as indexBy. Useful if association entities is widely used. 
Replace #204 PR
