### PR TITLE
[Paginator]Add hidden field ordering for postgresql

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -91,7 +91,25 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        $innerSql = parent::walkSelectStatement($AST);
+        if ($this->platform instanceof PostgreSqlPlatform) {
+            // Set every select expression as visible(hidden = false) to
+            // make $AST to have scalar mappings properly
+            $hiddens = array();
+            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+                $hiddens[$idx] = $expr->hiddenAliasResultVariable;
+                $expr->hiddenAliasResultVariable = false;
+            }
+            
+            $innerSql = parent::walkSelectStatement($AST);
+    
+            // Restore hiddens
+            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+                $expr->hiddenAliasResultVariable = $hiddens[$idx];
+            }
+        } else {
+            $innerSql = parent::walkSelectStatement($AST);
+        }
+
 
         // Find out the SQL alias of the identifier column of the root entity.
         // It may be possible to make this work with multiple root entities but that

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -91,25 +91,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform instanceof PostgreSqlPlatform) {
-            // Set every select expression as visible(hidden = false) to
-            // make $AST to have scalar mappings properly
-            $hiddens = array();
-            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
-                $hiddens[$idx] = $expr->hiddenAliasResultVariable;
-                $expr->hiddenAliasResultVariable = false;
-            }
-            
-            $innerSql = parent::walkSelectStatement($AST);
-    
-            // Restore hiddens
-            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
-                $expr->hiddenAliasResultVariable = $hiddens[$idx];
-            }
-        } else {
-            $innerSql = parent::walkSelectStatement($AST);
-        }
-
+        $innerSql = parent::walkSelectStatement($AST);
 
         // Find out the SQL alias of the identifier column of the root entity.
         // It may be possible to make this work with multiple root entities but that

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -74,6 +74,25 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $this->entityManager->getConnection()->setDatabasePlatform($odp);
     }
 
+    public function testLimitSubqueryWithHiddenScalarSortPg()
+    {
+        $odp = $this->entityManager->getConnection()->getDatabasePlatform();
+        $this->entityManager->getConnection()->setDatabasePlatform(new \Doctrine\DBAL\Platforms\PostgreSqlPlatform);
+
+        $query = $this->entityManager->createQuery(
+           'SELECT u, g, COUNT(g.id) AS hidden g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity, u.id DESC'
+        );
+        $limitQuery = clone $query;
+        $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            "SELECT DISTINCT id1, sclr0 FROM (SELECT COUNT(g0_.id) AS sclr0, u1_.id AS id1, g0_.id AS id2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id ORDER BY sclr0 ASC, u1_.id DESC) dctrn_result ORDER BY sclr0 ASC, id1 DESC",
+            $limitQuery->getSql()
+        );
+
+        $this->entityManager->getConnection()->setDatabasePlatform($odp);
+    }
+
     public function testLimitSubqueryPg()
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();


### PR DESCRIPTION
In postgresql environment, when some hidden fields are used in orderBy clause,
they're not property added because $rsm->scalarMappings don't have information about them.

This change fixes above.

I'm afraid I'm not sure which branch this will be merged, but anyway here's a patch.
