### PR TITLE
DDC-2390: Remove Query dependency in SqlWalker and Parser

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -193,7 +193,7 @@ final class Query extends AbstractQuery
      */
     public function getAST()
     {
-        $parser = new Parser($this);
+        $parser = new Parser($this->getDQL(), $this->metadata, $this->_em);
 
         return $parser->getAST();
     }
@@ -216,7 +216,7 @@ final class Query extends AbstractQuery
 
         // Check query cache.
         if ( ! ($this->_useQueryCache && ($queryCache = $this->getQueryCacheDriver()))) {
-            $parser = new Parser($this);
+            $parser = new Parser($this->getDQL(), $this->metadata, $this->_em);
 
             $this->_parserResult = $parser->parse();
 
@@ -234,7 +234,7 @@ final class Query extends AbstractQuery
         }
 
         // Cache miss.
-        $parser = new Parser($this);
+        $parser = new Parser($this->getDQL(), $this->metadata, $this->_em);
 
         $this->_parserResult = $parser->parse();
 

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -135,20 +135,6 @@ final class Query extends AbstractQuery
     private $_parserResult;
 
     /**
-     * The first result to return (the "offset").
-     *
-     * @var integer
-     */
-    private $_firstResult = null;
-
-    /**
-     * The maximum number of results to return (the "limit").
-     *
-     * @var integer
-     */
-    private $_maxResults = null;
-
-    /**
      * The cache driver used for caching queries.
      *
      * @var \Doctrine\Common\Cache\Cache|null
@@ -510,7 +496,7 @@ final class Query extends AbstractQuery
      */
     public function setFirstResult($firstResult)
     {
-        $this->_firstResult = $firstResult;
+        $this->metadata->setFirstResult($firstResult);
         $this->_state       = self::STATE_DIRTY;
 
         return $this;
@@ -524,7 +510,7 @@ final class Query extends AbstractQuery
      */
     public function getFirstResult()
     {
-        return $this->_firstResult;
+        return $this->metadata->getFirstResult();
     }
 
     /**
@@ -536,7 +522,7 @@ final class Query extends AbstractQuery
      */
     public function setMaxResults($maxResults)
     {
-        $this->_maxResults = $maxResults;
+        $this->metadata->setMaxResults($maxResults);
         $this->_state      = self::STATE_DIRTY;
 
         return $this;
@@ -550,7 +536,7 @@ final class Query extends AbstractQuery
      */
     public function getMaxResults()
     {
-        return $this->_maxResults;
+        return $this->metadata->getMaxResults();
     }
 
     /**
@@ -638,13 +624,10 @@ final class Query extends AbstractQuery
      */
     protected function _getQueryCacheId()
     {
-        ksort($this->_hints);
-
         return md5(
-            $this->getDql() . var_export($this->_hints, true) .
-            ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
-            '&firstResult=' . $this->_firstResult . '&maxResult=' . $this->_maxResults .
-            '&hydrationMode='.$this->_hydrationMode.'DOCTRINE_QUERY_CACHE_SALT'
+            $this->getDql() .
+            $this->metadata .
+            ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '')
         );
     }
 

--- a/lib/Doctrine/ORM/Query/MetadataBag.php
+++ b/lib/Doctrine/ORM/Query/MetadataBag.php
@@ -1,0 +1,166 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query;
+
+/**
+ * Bag for Query related Metadata such as Hints, First/Max Results Information.
+ *
+ * Data in this metadata bag affects the generation of SQL statements and as such
+ * should be part of a Query Cache mechanism.
+ *
+ * @since 2.4
+ */
+class MetadataBag
+{
+    /**
+     * Object Hydration
+     */
+    const HYDRATE_DEFAULT = 1;
+
+    /**
+     * The map of query hints.
+     *
+     * @var array
+     */
+    private $hints = array();
+
+    /**
+     * The maximum number of results to return (the "limit").
+     *
+     * @var integer
+     */
+    private $maxResults;
+
+    /**
+     * The first result to return (the "offset").
+     *
+     * @var integer
+     */
+    private $firstResult;
+
+    /**
+     * The hydration mode.
+     *
+     * @var integer
+     */
+    private $hydrationMode = self::HYDRATE_DEFAULT;
+
+    /**
+     * Return all query hints.
+     *
+     * @return array
+     */
+    public function getHints()
+    {
+        return $this->hints;
+    }
+
+    public function setFetchMode($class, $assocName, $fetchMode)
+    {
+        $this->hints['fetchMode'][$class][$assocName] = $fetchMode;
+    }
+
+    public function setHint($name, $value)
+    {
+        $this->hints[$name] = $value;
+    }
+
+    public function getHint($name)
+    {
+        return isset($this->hints[$name]) ? $this->hints[$name] : false;
+    }
+
+    public function setHydrationMode($hydrationMode)
+    {
+        $this->hydrationMode = $hydrationMode;
+    }
+
+    public function getHydrationMode()
+    {
+        return $this->hydrationMode;
+    }
+
+    /**
+     * Sets the position of the first result to retrieve (the "offset").
+     *
+     * @param integer $firstResult The first result to return.
+     *
+     * @return void
+     */
+    public function setFirstResult($firstResult)
+    {
+        $this->firstResult = $firstResult;
+    }
+
+    /**
+     * Gets the position of the first result the query object was set to retrieve (the "offset").
+     * Returns NULL if {@link setFirstResult} was not applied to this query.
+     *
+     * @return integer The position of the first result.
+     */
+    public function getFirstResult()
+    {
+        return $this->firstResult;
+    }
+
+    /**
+     * Sets the maximum number of results to retrieve (the "limit").
+     *
+     * @param integer $maxResults
+     *
+     * @return void
+     */
+    public function setMaxResults($maxResults)
+    {
+        $this->maxResults = $maxResults;
+    }
+
+    /**
+     * Gets the maximum number of results the query object was set to retrieve (the "limit").
+     * Returns NULL if {@link setMaxResults} was not applied to this query.
+     *
+     * @return integer Maximum number of results.
+     */
+    public function getMaxResults()
+    {
+        return $this->maxResults;
+    }
+
+    public function clearHints()
+    {
+        $this->hints = array();
+    }
+
+    /**
+     * Generate a string representation of that can be used as a cache key.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        ksort($this->hints);
+
+        return md5(
+            var_export($this->hints, true) .
+            '&firstResult=' . $this->firstResult . '&maxResult=' . $this->maxResults .
+            '&hydrationMode='.$this->hydrationMode.'DOCTRINE_QUERY_CACHE_SALT'
+        );
+    }
+}

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -170,13 +170,13 @@ class SqlWalker implements TreeWalker
     /**
      * {@inheritDoc}
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct($metadata, $entityManager, $parserResult, array $queryComponents)
     {
-        $this->query            = $query;
+        $this->query            = $metadata;
         $this->parserResult     = $parserResult;
         $this->queryComponents  = $queryComponents;
         $this->rsm              = $parserResult->getResultSetMapping();
-        $this->em               = $query->getEntityManager();
+        $this->em               = $entityManager;
         $this->conn             = $this->em->getConnection();
         $this->platform         = $this->conn->getDatabasePlatform();
         $this->quoteStrategy    = $this->em->getConfiguration()->getQuoteStrategy();

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -34,7 +34,7 @@ interface TreeWalker
      * @param \Doctrine\ORM\Query\ParserResult $parserResult    The result of the parsing process.
      * @param array                            $queryComponents The query components (symbol table).
      */
-    public function __construct($query, $parserResult, array $queryComponents);
+    public function __construct($query, $entityManager, $parserResult, array $queryComponents);
 
     /**
      * Returns internal queryComponents array.

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -50,13 +50,19 @@ abstract class TreeWalkerAdapter implements TreeWalker
     private $_queryComponents;
 
     /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $entityManager;
+
+    /**
      * {@inheritdoc}
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct($query, $entityManager, $parserResult, array $queryComponents)
     {
         $this->_query = $query;
         $this->_parserResult = $parserResult;
         $this->_queryComponents = $queryComponents;
+        $this->entityManager = $entityManager;
     }
 
     /**
@@ -107,6 +113,11 @@ abstract class TreeWalkerAdapter implements TreeWalker
     protected function _getParserResult()
     {
         return $this->_parserResult;
+    }
+
+    protected function getEntityManager()
+    {
+        return $this->entityManager;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -34,28 +34,28 @@ class TreeWalkerChain implements TreeWalker
      *
      * @var TreeWalker[]
      */
-    private $_walkers = array();
+    private $walkers = array();
 
     /**
      * The original Query.
      *
      * @var \Doctrine\ORM\AbstractQuery
      */
-    private $_query;
+    private $query;
 
     /**
      * The ParserResult of the original query that was produced by the Parser.
      *
      * @var \Doctrine\ORM\Query\ParserResult
      */
-    private $_parserResult;
+    private $parserResult;
 
     /**
      * The query components of the original query (the "symbol table") that was produced by the Parser.
      *
      * @var array
      */
-    private $_queryComponents;
+    private $queryComponents;
 
     /**
      * Returns the internal queryComponents array.
@@ -64,7 +64,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function getQueryComponents()
     {
-        return $this->_queryComponents;
+        return $this->queryComponents;
     }
 
     /**
@@ -78,17 +78,18 @@ class TreeWalkerChain implements TreeWalker
             throw QueryException::invalidQueryComponent($dqlAlias);
         }
 
-        $this->_queryComponents[$dqlAlias] = $queryComponent;
+        $this->queryComponents[$dqlAlias] = $queryComponent;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct($metadata, $entityManager, $parserResult, array $queryComponents)
     {
-        $this->_query = $query;
-        $this->_parserResult = $parserResult;
-        $this->_queryComponents = $queryComponents;
+        $this->metadata = $metadata;
+        $this->entityManager = $entityManager;
+        $this->parserResult = $parserResult;
+        $this->queryComponents = $queryComponents;
     }
 
     /**
@@ -100,7 +101,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function addTreeWalker($walkerClass)
     {
-        $this->_walkers[] = new $walkerClass($this->_query, $this->_parserResult, $this->_queryComponents);
+        $this->walkers[] = new $walkerClass($this->metadata, $this->entityManager, $this->parserResult, $this->queryComponents);
     }
 
     /**
@@ -108,10 +109,10 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectStatement(AST\SelectStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSelectStatement($AST);
 
-            $this->_queryComponents = $walker->getQueryComponents();
+            $this->queryComponents = $walker->getQueryComponents();
         }
     }
 
@@ -120,7 +121,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectClause($selectClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSelectClause($selectClause);
         }
     }
@@ -130,7 +131,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkFromClause($fromClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkFromClause($fromClause);
         }
     }
@@ -140,7 +141,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkFunction($function)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkFunction($function);
         }
     }
@@ -150,7 +151,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkOrderByClause($orderByClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkOrderByClause($orderByClause);
         }
     }
@@ -160,7 +161,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkOrderByItem($orderByItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkOrderByItem($orderByItem);
         }
     }
@@ -170,7 +171,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkHavingClause($havingClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkHavingClause($havingClause);
         }
     }
@@ -180,7 +181,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkJoin($join)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkJoin($join);
         }
     }
@@ -190,7 +191,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSelectExpression($selectExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSelectExpression($selectExpression);
         }
     }
@@ -200,7 +201,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkQuantifiedExpression($qExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkQuantifiedExpression($qExpr);
         }
     }
@@ -210,7 +211,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSubselect($subselect)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSubselect($subselect);
         }
     }
@@ -220,7 +221,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSubselectFromClause($subselectFromClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSubselectFromClause($subselectFromClause);
         }
     }
@@ -230,7 +231,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleSelectClause($simpleSelectClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSimpleSelectClause($simpleSelectClause);
         }
     }
@@ -240,7 +241,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleSelectExpression($simpleSelectExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSimpleSelectExpression($simpleSelectExpression);
         }
     }
@@ -250,7 +251,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkAggregateExpression($aggExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkAggregateExpression($aggExpression);
         }
     }
@@ -260,7 +261,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkGroupByClause($groupByClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkGroupByClause($groupByClause);
         }
     }
@@ -270,7 +271,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkGroupByItem($groupByItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkGroupByItem($groupByItem);
         }
     }
@@ -280,7 +281,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateStatement(AST\UpdateStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkUpdateStatement($AST);
         }
     }
@@ -290,7 +291,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkDeleteStatement(AST\DeleteStatement $AST)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkDeleteStatement($AST);
         }
     }
@@ -300,7 +301,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkDeleteClause(AST\DeleteClause $deleteClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkDeleteClause($deleteClause);
         }
     }
@@ -310,7 +311,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateClause($updateClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkUpdateClause($updateClause);
         }
     }
@@ -320,7 +321,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkUpdateItem($updateItem)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkUpdateItem($updateItem);
         }
     }
@@ -330,7 +331,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkWhereClause($whereClause)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkWhereClause($whereClause);
         }
     }
@@ -340,7 +341,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalExpression($condExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkConditionalExpression($condExpr);
         }
     }
@@ -350,7 +351,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalTerm($condTerm)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkConditionalTerm($condTerm);
         }
     }
@@ -360,7 +361,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalFactor($factor)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkConditionalFactor($factor);
         }
     }
@@ -370,7 +371,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkConditionalPrimary($condPrimary)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkConditionalPrimary($condPrimary);
         }
     }
@@ -380,7 +381,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkExistsExpression($existsExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkExistsExpression($existsExpr);
         }
     }
@@ -390,7 +391,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkCollectionMemberExpression($collMemberExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkCollectionMemberExpression($collMemberExpr);
         }
     }
@@ -400,7 +401,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkEmptyCollectionComparisonExpression($emptyCollCompExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkEmptyCollectionComparisonExpression($emptyCollCompExpr);
         }
     }
@@ -410,7 +411,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkNullComparisonExpression($nullCompExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkNullComparisonExpression($nullCompExpr);
         }
     }
@@ -420,7 +421,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkInExpression($inExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkInExpression($inExpr);
         }
     }
@@ -430,7 +431,7 @@ class TreeWalkerChain implements TreeWalker
      */
     function walkInstanceOfExpression($instanceOfExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkInstanceOfExpression($instanceOfExpr);
         }
     }
@@ -440,7 +441,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkLiteral($literal)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkLiteral($literal);
         }
     }
@@ -450,7 +451,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkBetweenExpression($betweenExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkBetweenExpression($betweenExpr);
         }
     }
@@ -460,7 +461,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkLikeExpression($likeExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkLikeExpression($likeExpr);
         }
     }
@@ -470,7 +471,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkStateFieldPathExpression($stateFieldPathExpression)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkStateFieldPathExpression($stateFieldPathExpression);
         }
     }
@@ -480,7 +481,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkComparisonExpression($compExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkComparisonExpression($compExpr);
         }
     }
@@ -490,7 +491,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkInputParameter($inputParam)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkInputParameter($inputParam);
         }
     }
@@ -500,7 +501,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticExpression($arithmeticExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkArithmeticExpression($arithmeticExpr);
         }
     }
@@ -510,7 +511,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticTerm($term)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkArithmeticTerm($term);
         }
     }
@@ -520,7 +521,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkStringPrimary($stringPrimary)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkStringPrimary($stringPrimary);
         }
     }
@@ -530,7 +531,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkArithmeticFactor($factor)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkArithmeticFactor($factor);
         }
     }
@@ -540,7 +541,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkSimpleArithmeticExpression($simpleArithmeticExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkSimpleArithmeticExpression($simpleArithmeticExpr);
         }
     }
@@ -550,7 +551,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkPathExpression($pathExpr)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkPathExpression($pathExpr);
         }
     }
@@ -560,7 +561,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function walkResultVariable($resultVariable)
     {
-        foreach ($this->_walkers as $walker) {
+        foreach ($this->walkers as $walker) {
             $walker->walkResultVariable($resultVariable);
         }
     }

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -55,13 +55,13 @@ class CountOutputWalker extends SqlWalker
      * @param \Doctrine\ORM\Query\ParserResult $parserResult
      * @param array                            $queryComponents
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct($query, $entityManager, $parserResult, array $queryComponents)
     {
-        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->platform = $entityManager->getConnection()->getDatabasePlatform();
         $this->rsm = $parserResult->getResultSetMapping();
         $this->queryComponents = $queryComponents;
 
-        parent::__construct($query, $parserResult, $queryComponents);
+        parent::__construct($query, $entityManager, $parserResult, $queryComponents);
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -66,18 +66,19 @@ class LimitSubqueryOutputWalker extends SqlWalker
      * @param \Doctrine\ORM\Query\ParserResult $parserResult
      * @param array                            $queryComponents
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct($query, $entityManager, $parserResult, array $queryComponents)
     {
-        $this->platform = $query->getEntityManager()->getConnection()->getDatabasePlatform();
+        $this->platform = $entityManager->getConnection()->getDatabasePlatform();
         $this->rsm = $parserResult->getResultSetMapping();
         $this->queryComponents = $queryComponents;
 
         // Reset limit and offset
         $this->firstResult = $query->getFirstResult();
         $this->maxResults = $query->getMaxResults();
-        $query->setFirstResult(null)->setMaxResults(null);
+        $query->setFirstResult(null);
+        $query->setMaxResults(null);
 
-        parent::__construct($query, $parserResult, $queryComponents);
+        parent::__construct($query, $entityManager, $parserResult, $queryComponents);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
@@ -92,8 +92,8 @@ class CustomTreeWalkerJoin extends Query\TreeWalkerAdapter
                         null,
                         false
                     );
-                $meta1 = $this->_getQuery()->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-                $meta = $this->_getQuery()->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
+                $meta1 = $this->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+                $meta = $this->getEntityManager()->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
                 $this->setQueryComponent($identificationVariableDeclaration->rangeVariableDeclaration->aliasIdentificationVariable . 'a',
                     array(
                         'metadata' => $meta,

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -44,15 +44,14 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
 
     public function parseDql($dql, $hints = array())
     {
-        $query = $this->_em->createQuery($dql);
-        $query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
-        $query->setDql($dql);
+        $metadata = new \Doctrine\ORM\Query\MetadataBag;
+        $metadata->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);
 
         foreach ($hints as $key => $value) {
-        	$query->setHint($key, $value);
+            $metadata->setHint($key, $value);
         }
 
-        $parser = new \Doctrine\ORM\Query\Parser($query);
+        $parser = new \Doctrine\ORM\Query\Parser($dql, $metadata, $this->_em);
 
         // We do NOT test SQL output here. That only unnecessarily slows down the tests!
         $parser->setCustomOutputTreeWalker('Doctrine\Tests\Mocks\MockTreeWalker');


### PR DESCRIPTION
To prevent future problems with illegal Query parameter access and also to decouple the namespaces by removing bidirectional dependency.
