### PR TITLE
Add a AddParameters method in the QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -438,6 +438,38 @@ class QueryBuilder
     }
 
     /**
+     * Add a collection of query parameters for the query being constructed
+     *
+     * <code>
+     *     // $qb is an existing QueryBuilder instance, and may contain already
+     *     // initialized parameters.
+     *
+     *     $qb = $qb->where('u.id = :user_id1 OR u.id = :user_id2')
+     *         ->addParameters(new ArrayCollection(array(
+     *             new Parameter('user_id1', 1),
+     *             new Parameter('user_id2', 2)
+     *        )));
+     * </code>
+     *
+     * @param \Doctrine\Common\Collections\ArrayCollection|array $parameters The query parameters to set.
+     *
+     * @return QueryBuilder This QueryBuilder instance.
+     */
+    public function addParameters($parameters)
+    {
+        foreach ($parameters as $key => $value) {
+            if ($value instanceof Query\Parameter) {
+                $key   = $value->getName();
+                $value = $value->getValue();
+            }
+
+            $this->setParameter($key, $value);
+        }
+
+        return $this;
+    }
+
+    /**
      * Gets all defined query parameters for the query being constructed.
      *
      * @return \Doctrine\Common\Collections\ArrayCollection The currently defined query parameters.

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -474,6 +474,29 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($parameters, $qb->getQuery()->getParameters());
     }
 
+    public function testAddParameters()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')
+           ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+           ->where($qb->expr()->orX('u.username = :username', 'u.username = :username2', 'u.username = :username3'));
+
+        $parameters = new ArrayCollection();
+        $parameters->add(new Parameter('username', 'jwage'));
+        $parameters->add(new Parameter('username2', 'jonwage'));
+
+        $qb->setParameters($parameters);
+
+        $addParameters = new ArrayCollection();
+        $addParameters->add(new Parameter('username2', 'jwage'));
+        $addParameters->add(new Parameter('username3', 'jonwage'));
+
+        $qb->addParameters($addParameters);
+
+        $this->assertEquals('jwage', $qb->getQuery()->getParameter('username2')->getValue());
+        $this->assertEquals('jonwage', $qb->getQuery()->getParameter('username3')->getValue());
+    }
+
 
     public function testGetParameters()
     {

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -495,6 +495,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals('jwage', $qb->getQuery()->getParameter('username2')->getValue());
         $this->assertEquals('jonwage', $qb->getQuery()->getParameter('username3')->getValue());
+        $this->assertCount(3, $qb->getQuery()->getParameters());
     }
 
 


### PR DESCRIPTION
Hi,

On doctrine 2.2, when we were calling the method `setParameters` to set a bunch of parameters on the QueryBuilder, each parameters were added or modified if they were already existing. 

That is not the case since doctrine 2.3 : each calls to `setParameters` will wipe out the other already setted parameters. I think it is logic, but still is a huge BC break, which is not really mentionned in the UPGRADE file (only the one regarding the use of an ArrayCollection is mentionned). 

With this PR, I added a `addParameters` which allows to add several parameters in several calls. Here is a use case :

``` php
<?php
// ... A repository
class UserRepository extends EntityRepository
{
     public function getUserWithSomething($criteriaA, $criteriaB, DateTime $since = null)
     {
         $qb = $this->createQueryBuilder('u');
         $qb->where($qb->expr()->andX($qb->expr()->eq('u.criteriaA', ':criteriaA'),
                                      $qb->expr()->eq('u.criteriaB', ':criteriaB')));

         // wanna search for objects since a specific date
         if (null !== $since) {
             $qb = $this->addSince($qb, $since);
         }

         $qb->addParameters(new ArrayCollection(['criteriaA' => $criteriaA, 
                                                 'criteriaB' => $criteriaB]));  

         return $qb->getQuery()->execute();
     }

     public function addSince(QueryBuilder $qb, DateTime $since)
     {
         $qb = $qb->andWhere($qb->expr()->gte('u.date', ':since'));

         return $qb->setParameter('since', $since);
     }
}
```

So, as I was saying, until 2.2, you could use `setParameters` in the main method (`getUserWithSomething`) which was calling (or not) the submethod `addSince`, which could set parameters before calling the `setParameters` method. Now, you can't do that anymore : either you need to make several calls to `setParameter` :

``` php
<?php
// ....
     $qb = $qb->setParameter('criteriaA', $criteriaA)
              ->setParameter('criteriaB', $criteriaB); 
//...
```

Either, I guess, you need to first retrieve all the parameters and then add them by hand : 

``` php
<?php
// ....
     $parameters = $qb->getParameters();
     $parameters->add(new Parameter('criteriaA', $criteriaA);
     $parameters->add(new Parameter('criteriaB', $criteriaB);

     $qb = $qb->setParameters($parameters);
//...
```

So that's why I propose this new method in the QueryBuilder. if I'm wrong anywhere, or need more information please feel free to comment. :)

Cheers.

**edit :** If I tried to use either a `ArrayCollection` or an `array` in the parameters, it's because I tried to keep in mind the BC breeaks for 2.2 and below branches, and if I am converting the `Parameter` into a simple array, it is to ease the use for `setParameter`.
