### PR TITLE
Fixed typo in SQLFilter addFilterConstraint first param

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -125,5 +125,5 @@ abstract class SQLFilter
      *
      * @return string The constraint SQL if there is available, empty string otherwise.
      */
-    abstract public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias);
+    abstract public function addFilterConstraint(ClassMetaData $targetEntity, $targetTableAlias);
 }


### PR DESCRIPTION
Hi, 

Description in subj,
the use statement for ClassMetaData is 
use Doctrine\ORM\Mapping\ClassMetaData;

But in the abstract method the param named ClassMetadata ("d" char should be in uppercase)
