### PR TITLE
Fixed entities path

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -137,7 +137,7 @@ step:
 
     // Create a simple "default" Doctrine ORM configuration for Annotations
     $isDevMode = true;
-    $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/entities"), $isDevMode);
+    $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode);
     // or if you prefer yaml or XML
     //$config = Setup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
     //$config = Setup::createYAMLMetadataConfiguration(array(__DIR__."/config/yaml"), $isDevMode);


### PR DESCRIPTION
In the tutorial, the user is told to create a new file in the `/src` folder, and the `/entities` folder is never referenced. Updating the SQLite schema according to the tutorial fails with the 'No Metadata Classes to process.' message. Changing the folder to `/src` fixes this, ostensibly.
