### PR TITLE
[DDC-2235] Fix for using a LEFT JOIN onto an entity with single table inheritance

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -807,7 +807,7 @@ class SqlWalker implements TreeWalker
      * Walks down a RangeVariableDeclaration AST node, thereby generating the appropriate SQL.
      *
      * @param AST\RangeVariableDeclaration $rangeVariableDeclaration
-     * @param boolean @rootAlias
+     * @param boolean $rootAlias
      *
      * @return string
      */

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -437,7 +437,7 @@ class SqlWalker implements TreeWalker
             }
 
             $sqlParts[] = (($this->useSqlTableAliases) ? $this->getSQLTableAlias($class->getTableName(), $dqlAlias) . '.' : '')
-                      . $class->discriminatorColumn['name'] . ' IN (' . implode(', ', $values) . ')';
+                        . $class->discriminatorColumn['name'] . ' IN (' . implode(', ', $values) . ')';
         }
 
         $sql = implode(' AND ', $sqlParts);
@@ -807,6 +807,7 @@ class SqlWalker implements TreeWalker
      * Walks down a RangeVariableDeclaration AST node, thereby generating the appropriate SQL.
      *
      * @param AST\RangeVariableDeclaration $rangeVariableDeclaration
+     * @param boolean @rootAlias
      *
      * @return string
      */

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1041,6 +1041,7 @@ class SqlWalker implements TreeWalker
                       . $condExprConjunction . '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
 
                 $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($joinAlias));
+
                 if ( ! empty($discrSql)) {
                     $sql .= ' AND (' . $discrSql . ')';
                 }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -146,7 +146,7 @@ class SqlWalker implements TreeWalker
     private $rootAliases = array();
 
     /**
-     * Any DQL alises used for left joins
+     * Any DQL aliases used for left joins
      *
      * @var array
      */

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -448,7 +448,7 @@ class SqlWalker implements TreeWalker
             $sql = $field . ' IN (' . implode(', ', $values) . ')';
 
             if (in_array($dqlAlias, $this->leftJoinAliases)) {
-                $sql = '(' . $sql . ' OR ' . $field . ' IS NULL )';
+                $sql = '(' . $sql . ' OR ' . $field . ' IS NULL)';
             }
 
             $sqlParts[] = $sql;

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1461,24 +1461,49 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     /**
      * @group DDC-2235
      */
-    public function testInheritanceTypeSingleTableInLeftJoinIncludesOrIsNull()
+    public function testInheritanceTypeSingleTableIncludesDiscriminatorInJoinOnClause()
     {
-        // Regression test for best-case
+        // Regression test for the bug
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyContract c WITH c.salesPerson = e.id',
-            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id LEFT JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) WHERE (c0_.discr IN ('fix', 'flexible', 'flexultra') OR c0_.discr IS NULL)"
+            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id LEFT JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) AND (c0_.discr IN ('fix', 'flexible', 'flexultra'))"
         );
 
         // Ensure other WHERE predicates are passed through to the main WHERE clause
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyContract c WITH c.salesPerson = e.id WHERE e.salary > 1000',
-            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id LEFT JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) WHERE (c1_.salary > 1000) AND (c0_.discr IN ('fix', 'flexible', 'flexultra') OR c0_.discr IS NULL)"
+            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id LEFT JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) AND (c0_.discr IN ('fix', 'flexible', 'flexultra')) WHERE c1_.salary > 1000"
         );
 
-        // Inner joins don't require the IS NULL
+        // Test inner joins too
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyEmployee e INNER JOIN Doctrine\Tests\Models\Company\CompanyContract c WITH c.salesPerson = e.id',
-            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id INNER JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) WHERE c0_.discr IN ('fix', 'flexible', 'flexultra')"
+            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id INNER JOIN company_contracts c0_ ON (c0_.salesPerson_id = c2_.id) AND (c0_.discr IN ('fix', 'flexible', 'flexultra'))"
+        );
+
+        // Test that the discriminator IN() predicate is still added into
+        // the where clause when not joining onto that table
+        $this->assertSqlGeneration(
+            'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c LEFT JOIN Doctrine\Tests\Models\Company\CompanyEmployee e WITH e.id = c.salesPerson WHERE c.completed = true',
+            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_contracts c0_ LEFT JOIN company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id ON (c2_.id = c0_.salesPerson_id) WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
+        );
+
+        // Test that the discriminator IN() predicate is still added
+        // into the where clause when not joining onto a single table inheritance entity
+        // via a join association
+        $this->assertSqlGeneration(
+            'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c JOIN c.salesPerson s WHERE c.completed = true',
+            "SELECT c0_.id AS id0, c0_.completed AS completed1, c0_.fixPrice AS fixPrice2, c0_.hoursWorked AS hoursWorked3, c0_.pricePerHour AS pricePerHour4, c0_.maxPrice AS maxPrice5, c0_.discr AS discr6 FROM company_contracts c0_ INNER JOIN company_employees c1_ ON c0_.salesPerson_id = c1_.id LEFT JOIN company_persons c2_ ON c1_.id = c2_.id WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
+        );
+
+        // Test that when joining onto an entity using single table inheritance via
+        // a join association that the discriminator IN() predicate is placed
+        // into the ON clause of the join
+        $this->assertSqlGeneration(
+            'SELECT e, COUNT(c) FROM Doctrine\Tests\Models\Company\CompanyEmployee e JOIN e.contracts c WHERE e.department = :department',
+            "SELECT c0_.id AS id0, c0_.name AS name1, c1_.salary AS salary2, c1_.department AS department3, c1_.startDate AS startDate4, COUNT(c2_.id) AS sclr5, c0_.discr AS discr6 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id INNER JOIN company_contract_employees c3_ ON c1_.id = c3_.employee_id INNER JOIN company_contracts c2_ ON c2_.id = c3_.contract_id AND c2_.discr IN ('fix', 'flexible', 'flexultra') WHERE c1_.department = ?",
+            array(),
+            array('department' => 'foobar')
         );
     }
 


### PR DESCRIPTION
Possible fix for the bug DDC-2235. I'd love to hear some opinions on whether this is the right way to go about this issue. I'm not particularly familiar with the internals of doctrine so there may be a better solution.

---

The issue is when using DQL to perform a left join on an entity using single table inheritance, doctrine tries to insert an `IN()` predicate into the `WHERE` clause for all of the discriminator values. That makes sense and is valid, so it would be wrong to remove that behaviour.

However when using a _left_ join having an `IN()` in the main where clause makes the `LEFT JOIN` pretty much useless, as it implicitly creates a `WHERE NOT NULL` clause. This commit attempts to fix that by including an `OR IS NULL` in the query if the join is a `LEFT JOIN`.

I've added some regression tests to ensure this bug never creeps back in. They fail on master (highlighting the bug) and pass after these commits have been applied. I've also included a couple of other queries as tests to be sure only this one case has been affected.
