### PR TITLE
UPDATE clause supports ORDER BY and LIMIT

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
@@ -41,6 +41,11 @@ class UpdateStatement extends Node
     public $whereClause;
 
     /**
+     * @var OrderByClause|null
+     */
+    public $orderByClause;
+
+    /**
      * @param UpdateClause $updateClause
      */
     public function __construct($updateClause)

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -876,7 +876,7 @@ class Parser
     }
 
     /**
-     * UpdateStatement ::= UpdateClause [WhereClause]
+     * UpdateStatement ::= UpdateClause [WhereClause] [OrderByClause]
      *
      * @return \Doctrine\ORM\Query\AST\UpdateStatement
      */
@@ -885,6 +885,7 @@ class Parser
         $updateStatement = new AST\UpdateStatement($this->UpdateClause());
 
         $updateStatement->whereClause = $this->lexer->isNextToken(Lexer::T_WHERE) ? $this->WhereClause() : null;
+        $updateStatement->orderByClause = $this->lexer->isNextToken(Lexer::T_ORDER) ? $this->OrderByClause() : null;
 
         return $updateStatement;
     }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -546,8 +546,18 @@ class SqlWalker implements TreeWalker
     {
         $this->useSqlTableAliases = false;
 
-        return $this->walkUpdateClause($AST->updateClause)
+        $sql = $this->walkUpdateClause($AST->updateClause)
              . $this->walkWhereClause($AST->whereClause);
+        
+        if($AST->orderByClause){
+            $sql .= $this->walkOrderByClause($AST->orderByClause);
+        }
+
+        $sql = $this->platform->modifyLimitQuery(
+            $sql, $this->query->getMaxResults(), $this->query->getFirstResult()
+        );
+
+        return $sql;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
@@ -184,6 +184,31 @@ class UpdateSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    public function testSupportsOrderByClause()
+    {
+        $this->assertSqlGeneration(
+            'UPDATE Doctrine\Tests\Models\CMS\CmsUser u SET u.name = ?1 ORDER BY u.status',
+            'UPDATE cms_users SET name = ? ORDER BY status ASC'
+        );
+    }
+
+    public function testSupportsOrderByClauseDesc()
+    {
+        $this->assertSqlGeneration(
+            'UPDATE Doctrine\Tests\Models\CMS\CmsUser u SET u.name = ?1 ORDER BY u.status DESC',
+            'UPDATE cms_users SET name = ? ORDER BY status DESC'
+        );
+    }
+
+    public function testSuportsLimitClause()
+    {
+        $q = $this->_em
+            ->createQuery('UPDATE Doctrine\Tests\Models\CMS\CmsUser u SET u.name = ?1')
+            ->setMaxResults(10);
+
+        $this->assertEquals('UPDATE cms_users SET name = ? LIMIT 10', $q->getSql());
+    }
+
     /**
      * @group DDC-980
      */


### PR DESCRIPTION
Hi there,

I wanted get some feedback on what you thought about supporting ORDER BY and LIMIT for UPDATE statements.

Is there a reason this has not already been implemented?

Thanks
