### PR TITLE
Fixed a code block.

### DIFF
--- a/docs/en/cookbook/resolve-target-entity-listener.rst
+++ b/docs/en/cookbook/resolve-target-entity-listener.rst
@@ -119,8 +119,7 @@ the targetEntity resolution will occur reliably:
     $evm = new \Doctrine\Common\EventManager;
 
     $rtel = new \Doctrine\ORM\Tools\ResolveTargetEntityListener;
-    $rtel->addResolveTargetEntity('Acme\\InvoiceModule\\Model\\InvoiceSubjectInterface',
-        'Acme\\CustomerModule\\Entity\\Customer', array());
+    $rtel->addResolveTargetEntity('Acme\\InvoiceModule\\Model\\InvoiceSubjectInterface', 'Acme\\CustomerModule\\Entity\\Customer', array());
 
     // Add the ResolveTargetEntityListener
     $evm->addEventSubscriber($rtel);


### PR DESCRIPTION
Last code block in the [Keeping your Modules independent](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/resolve-target-entity-listener.html) cookbook is broken.

Sphinx does not like the way code was indented. Building the documentation raises the following error:

```
en/cookbook/resolve-target-entity-listener.rst:121: ERROR: Unexpected indentation.
```
