### PR TITLE
Hotfix for DDC-2432

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -117,6 +117,9 @@ class ProxyFactory extends AbstractProxyFactory
     {
         if ($classMetadata->getReflectionClass()->hasMethod('__wakeup')) {
             return function (BaseProxy $proxy) use ($entityPersister, $classMetadata) {
+                $initializer = $proxy->__getInitializer();
+                $cloner      = $proxy->__getCloner();
+
                 $proxy->__setInitializer(null);
                 $proxy->__setCloner(null);
 
@@ -136,12 +139,19 @@ class ProxyFactory extends AbstractProxyFactory
                 $proxy->__wakeup();
 
                 if (null === $entityPersister->load($classMetadata->getIdentifierValues($proxy), $proxy)) {
+                    $proxy->__setInitializer($initializer);
+                    $proxy->__setCloner($cloner);
+                    $proxy->__setInitialized(false);
+
                     throw new EntityNotFoundException();
                 }
             };
         }
 
         return function (BaseProxy $proxy) use ($entityPersister, $classMetadata) {
+            $initializer = $proxy->__getInitializer();
+            $cloner      = $proxy->__getCloner();
+
             $proxy->__setInitializer(null);
             $proxy->__setCloner(null);
 
@@ -160,6 +170,10 @@ class ProxyFactory extends AbstractProxyFactory
             $proxy->__setInitialized(true);
 
             if (null === $entityPersister->load($classMetadata->getIdentifierValues($proxy), $proxy)) {
+                $proxy->__setInitializer($initializer);
+                $proxy->__setCloner($cloner);
+                $proxy->__setInitialized(false);
+
                 throw new EntityNotFoundException();
             }
         };


### PR DESCRIPTION
Attempt to fix DDC-2432 ( http://www.doctrine-project.org/jira/browse/DDC-2432 )

Loading proxies with invalid identifiers will currently mark them as initialized regardless of the failure
