### PR TITLE
[INVALID] [DDC-2452] DQL arbitrary joins between JTI entities produces invalid SQL

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1029,7 +1029,7 @@ class SqlWalker implements TreeWalker
         switch (true) {
             case ($joinDeclaration instanceof \Doctrine\ORM\Query\AST\RangeVariableDeclaration):
                 $class = $this->em->getClassMetadata($joinDeclaration->abstractSchemaName);
-                $condExprConjunction = $class->isInheritanceTypeJoined() && $joinType != AST\Join::JOIN_TYPE_LEFT && $joinType != AST\Join::JOIN_TYPE_LEFTOUTER
+                $condExprConjunction = $class->isInheritanceTypeJoined()
                     ? ' AND '
                     : ' ON ';
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2452Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2452Test.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+/**
+ * @group DDC-2452
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ */
+class DDC2452Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function testTicket()
+    {
+        if ($this->_em->getConnection()->getDatabasePlatform()->getName() != 'sqlite') {
+            // @todo set the abstract platform?
+            $this->markTestSkipped("This test is useful for all databases, but designed only for mysql.");
+        }
+
+        $dql = 'SELECT foo1 FROM '
+            . __NAMESPACE__ . '\DDC2452Foo foo1'
+            . ' LEFT JOIN '
+            . __NAMESPACE__ . '\DDC2452Foo foo2'
+            . ' WITH 1 = 1';
+
+        $sql = $this->_em->createQuery($dql)->getSQL();
+
+        $this->assertStringMatchesFormat(
+            'SELECT %s FROM %s LEFT JOIN %s ON %s LEFT JOIN %s LEFT JOIN %s ON %s = %s AND (1 = 1)',
+            $sql,
+            'The generated SQL adds conditions defined in `WITH` to the existing SQL joins produced by the inheritance'
+        );
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="foo")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"foo" = "DDC2452Foo", "bar" = "DDC2452Bar"})
+ */
+class DDC2452Foo
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+}
+
+/**
+ * @Entity
+ * @Table(name="bar")
+ */
+class DDC2452Bar extends DDC2452Foo
+{
+}

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -160,7 +160,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyManager m WITH e.id = m.id',
-            'SELECT c0_.id AS id0, c0_.name AS name1, c1_.salary AS salary2, c1_.department AS department3, c1_.startDate AS startDate4, c0_.discr AS discr5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ INNER JOIN company_employees c3_ ON c2_.id = c3_.id INNER JOIN company_persons c4_ ON c2_.id = c4_.id ON (c0_.id = c4_.id)'
+            'SELECT c0_.id AS id0, c0_.name AS name1, c1_.salary AS salary2, c1_.department AS department3, c1_.startDate AS startDate4, c0_.discr AS discr5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ INNER JOIN company_employees c3_ ON c2_.id = c3_.id INNER JOIN company_persons c4_ ON c2_.id = c4_.id AND (c0_.id = c4_.id)'
         );
     }
 


### PR DESCRIPTION
[DDC-2452](http://www.doctrine-project.org/jira/browse/DDC-2452) - DQL joins between JTI entities produce invalid SQL when additional conditions are inserted via WITH clause

Still working on a fix
