### PR TITLE
Namespace based command names

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -131,6 +131,20 @@ The following Commands are currently available:
    update the database schema of EntityManager Storage Connection or
    generate the SQL output.
 
+For these commands are also available aliases:
+
+
+-  ``orm:convert:d1-schema`` is alias for ``orm:convert-d1-schema``.
+-  ``orm:convert:mapping`` is alias for ``orm:convert-mapping``.
+-  ``orm:generate:entities`` is alias for ``orm:generate-entities``.
+-  ``orm:generate:proxies`` is alias for ``orm:generate-proxies``.
+-  ``orm:generate:repositories`` is alias for ``orm:generate-repositories``.
+
+.. note::
+
+    Console also supports auto completion, for example, instead of
+    ``orm:clear-cache:query`` you can use just ``o:c:q``.
+
 Database Schema Generation
 --------------------------
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -101,7 +101,8 @@ class ConvertDoctrine1SchemaCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:convert:d1-schema')
+        ->setName('orm:convert-d1-schema')
+        ->setAliases(array('orm:convert:d1-schema'))
         ->setDescription('Converts Doctrine 1.X schema into a Doctrine 2.X schema.')
         ->setDefinition(array(
             new InputArgument(

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -101,7 +101,7 @@ class ConvertDoctrine1SchemaCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:convert-d1-schema')
+        ->setName('orm:convert:d1-schema')
         ->setDescription('Converts Doctrine 1.X schema into a Doctrine 2.X schema.')
         ->setDefinition(array(
             new InputArgument(

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -48,7 +48,7 @@ class ConvertMappingCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:convert-mapping')
+        ->setName('orm:convert:mapping')
         ->setDescription('Convert mapping information between supported formats.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -48,7 +48,8 @@ class ConvertMappingCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:convert:mapping')
+        ->setName('orm:convert-mapping')
+        ->setAliases(array('orm:convert:mapping'))
         ->setDescription('Convert mapping information between supported formats.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -46,7 +46,8 @@ class GenerateEntitiesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate:entities')
+        ->setName('orm:generate-entities')
+        ->setAliases(array('orm:generate:entities'))
         ->setDescription('Generate entity classes and method stubs from your mapping information.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -46,7 +46,7 @@ class GenerateEntitiesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate-entities')
+        ->setName('orm:generate:entities')
         ->setDescription('Generate entity classes and method stubs from your mapping information.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -44,7 +44,8 @@ class GenerateProxiesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate:proxies')
+        ->setName('orm:generate-proxies')
+        ->setAliases(array('orm:generate:proxies'))
         ->setDescription('Generates proxy classes for entity classes.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -44,7 +44,7 @@ class GenerateProxiesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate-proxies')
+        ->setName('orm:generate:proxies')
         ->setDescription('Generates proxy classes for entity classes.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -45,7 +45,8 @@ class GenerateRepositoriesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate:repositories')
+        ->setName('orm:generate-repositories')
+        ->setAliases(array('orm:generate:repositories'))
         ->setDescription('Generate repository classes from your mapping information.')
         ->setDefinition(array(
             new InputOption(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -45,7 +45,7 @@ class GenerateRepositoriesCommand extends Command
     protected function configure()
     {
         $this
-        ->setName('orm:generate-repositories')
+        ->setName('orm:generate:repositories')
         ->setDescription('Generate repository classes from your mapping information.')
         ->setDefinition(array(
             new InputOption(


### PR DESCRIPTION
Symfony console supports auto completion:
`orm:generate:entities` could called `o:g:e`
