### PR TITLE
Type fix in ORM\PersistentCollection

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -122,7 +122,7 @@ final class PersistentCollection implements Collection, Selectable
      */
     public function __construct(EntityManager $em, $class, $coll)
     {
-        $this->coll      = $coll;
+        $this->coll      = is_array($coll) ? new ArrayCollection($coll) : $coll;
         $this->em        = $em;
         $this->typeClass = $class;
     }


### PR DESCRIPTION
The `ORM\PersistentCollection` class accepts anything as 3rd argument to its constructor while it should be either array or `Collection` object. The `$this->coll` phpdoc says that it's a `Collection` while the constructor's phpdoc says it's an array.

The class assumes `Collection` but there isn't any type check at all. I have added conversion of array into `ArrayCollection` in the constructor as in some (very unclear) cases it likes to die with a fatal error:

`Fatal error: Call to a member function add() on a non-object in Doctrine/ORM/PersistentCollection.php on line 169`
