### PR TITLE
Sequence generator fix

### DIFF
--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -78,7 +78,9 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
      */
     public function generate(EntityManager $em, $entity)
     {
-        $this->_sequenceName=$em->getClassMetadata(get_class($entity))->sequenceGeneratorDefinition['sequenceName'];
+        if ($entity){
+            $this->_sequenceName=$em->getClassMetadata(get_class($entity))->sequenceGeneratorDefinition['sequenceName'];
+        }
 
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -78,6 +78,8 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
      */
     public function generate(EntityManager $em, $entity)
     {
+        $this->_sequenceName=$em->getClassMetadata(get_class($entity))->sequenceGeneratorDefinition['sequenceName'];
+
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values
             $conn = $em->getConnection();


### PR DESCRIPTION
$this->_sequenceName=$em->getClassMetadata(get_class($entity))->sequenceGeneratorDefinition['sequenceName'];

The sequence generator does not read the class metadata, so if there is table remapping via event listeners, any new entity won't have the appropriate changes in table names.

This pull request adds a remap the Sequence Generator to read the class metadata to determine the sequence name if there is an entity passed to the generate function.

Tests: 1854, Assertions: 6224, Skipped: 96.
