### PR TITLE
[DDC-1398] Extra-lazy get for indexed associations

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -521,8 +521,7 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
-            $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
-            return $persister->get($this, $key);
+            return $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
         }
 
         $this->initialize();

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -521,6 +521,12 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
+            $class = $this->em->getClassMetadata($this->association['targetEntity']);
+
+            if (!$class->isIdentifierComposite && $class->isIdentifier($this->association['indexBy'])) {
+                return $this->em->find($class->name, $key);
+            }
+
             return $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
         }
 

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -517,6 +517,14 @@ final class PersistentCollection implements Collection, Selectable
      */
     public function get($key)
     {
+        if ( ! $this->initialized
+            && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
+            && isset($this->association['indexBy'])
+        ) {
+            $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
+            return $persister->get($this, $key);
+        }
+
         $this->initialize();
 
         return $this->coll->get($key);

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -521,10 +521,8 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
-            $class = $this->em->getClassMetadata($this->association['targetEntity']);
-
-            if (!$class->isIdentifierComposite && $class->isIdentifier($this->association['indexBy'])) {
-                return $this->em->find($class->name, $key);
+            if (!$this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
+                return $this->em->find($this->typeClass->name, $key);
             }
 
             return $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -48,7 +48,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
         }
 
-        return current($persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1));
+        return $persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -38,6 +38,24 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @override
      */
+    public function get(PersistentCollection $coll, $index)
+    {
+        $mapping   = $coll->getMapping();
+        $uow       = $this->em->getUnitOfWork();
+        $persister = $uow->getEntityPersister($mapping['targetEntity']);
+
+        if (!isset($mapping['indexBy'])) {
+            throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
+        }
+
+        return current($persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @override
+     */
     protected function getDeleteRowSQL(PersistentCollection $coll)
     {
         $columns    = array();

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -33,6 +33,24 @@ use Doctrine\ORM\UnitOfWork;
 class OneToManyPersister extends AbstractCollectionPersister
 {
     /**
+     * {@inheritdoc}
+     *
+     * @override
+     */
+    public function get(PersistentCollection $coll, $index)
+    {
+        $mapping   = $coll->getMapping();
+        $uow       = $this->em->getUnitOfWork();
+        $persister = $uow->getEntityPersister($mapping['targetEntity']);
+
+        if (!isset($mapping['indexBy'])) {
+            throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
+        }
+
+        return current($persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1));
+    }
+
+    /**
      * Generates the SQL UPDATE that updates a particular row's foreign
      * key to null.
      *

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -47,7 +47,7 @@ class OneToManyPersister extends AbstractCollectionPersister
             throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
         }
 
-        return current($persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1));
+        return $persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -532,6 +532,9 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($user->articles->isInitialized());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertSame($article, $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId));
+
+        $article = $user->articles->get($this->articleId);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
     }
 
     /**
@@ -549,6 +552,9 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($user->groups->isInitialized());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertSame($group, $this->_em->find('Doctrine\Tests\Models\CMS\CmsGroup', $this->groupId));
+
+        $group = $user->groups->get($this->groupId);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -527,10 +527,11 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $queryCount = $this->getCurrentQueryCount();
 
-        $user->articles->get($this->articleId);
+        $article = $user->articles->get($this->articleId);
 
         $this->assertFalse($user->articles->isInitialized());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertSame($article, $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId));
     }
 
     /**
@@ -543,10 +544,11 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $queryCount = $this->getCurrentQueryCount();
 
-        $user->groups->get($this->groupId);
+        $group = $user->groups->get($this->groupId);
 
         $this->assertFalse($user->groups->isInitialized());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertSame($group, $this->_em->find('Doctrine\Tests\Models\CMS\CmsGroup', $this->groupId));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -549,6 +549,18 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
     }
 
+    /**
+     * @group DDC-1398
+     */
+    public function testGetNonExistentIndexBy()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        /* @var $user CmsUser */
+
+        $this->assertNull($user->articles->get(-1));
+        $this->assertNull($user->groups->get(-1));
+    }
+
     private function loadFixture()
     {
         $user1 = new \Doctrine\Tests\Models\CMS\CmsUser();


### PR DESCRIPTION
If an association is EXTRA_LAZY and has an indexBy, then
you can call get() without loading the entire collection.
