### PR TITLE
add getManager

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -282,6 +282,14 @@ class EntityRepository implements ObjectRepository, Selectable
     }
 
     /**
+     * @return EntityManager
+     */
+    protected function getManager()
+    {
+        return $this->_em;
+    }
+
+    /**
      * @return Mapping\ClassMetadata
      */
     protected function getClassMetadata()


### PR DESCRIPTION
getEntityManager is deprecated in Symfony2 (and gone in 2.3). It would be nice if Doctrine followed this (or at least added the getManager call) ot make it consistent. https://github.com/sensiolabs/SensioGeneratorBundle/pull/123

What do you think? Was this already discussed?
