### PR TITLE
Fix extra lazy get

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -518,6 +518,7 @@ final class PersistentCollection implements Collection, Selectable
     public function get($key)
     {
         if ( ! $this->initialized
+            && $this->association['type'] === Mapping\ClassMetadataInfo::ONE_TO_MANY
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -38,24 +38,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @override
      */
-    public function get(PersistentCollection $coll, $index)
-    {
-        $mapping   = $coll->getMapping();
-        $uow       = $this->em->getUnitOfWork();
-        $persister = $uow->getEntityPersister($mapping['targetEntity']);
-
-        if (!isset($mapping['indexBy'])) {
-            throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
-        }
-
-        return $persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @override
-     */
     protected function getDeleteRowSQL(PersistentCollection $coll)
     {
         $columns    = array();

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -47,7 +47,7 @@ class OneToManyPersister extends AbstractCollectionPersister
             throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
         }
 
-        return $persister->load(array($mapping['indexBy'] => $index), null, null, array(), 0, 1);
+        return $persister->load(array($mapping['mappedBy'] => $coll->getOwner(), $mapping['indexBy'] => $index), null, null, array(), 0, 1);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -17,7 +17,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     private $groupId;
     private $articleId;
 
-    private $groupname;
     private $topic;
     private $phonenumber;
 
@@ -565,30 +564,10 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     /**
      * @group DDC-1398
      */
-    public function testGetIndexByManyToMany()
-    {
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
-        /* @var $user CmsUser */
-
-        $queryCount = $this->getCurrentQueryCount();
-
-        $group = $user->groups->get($this->groupname);
-
-        $this->assertFalse($user->groups->isInitialized());
-        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
-        $this->assertSame($group, $this->_em->find('Doctrine\Tests\Models\CMS\CmsGroup', $this->groupId));
-    }
-
-    /**
-     * @group DDC-1398
-     */
     public function testGetNonExistentIndexBy()
     {
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
-        /* @var $user CmsUser */
-
         $this->assertNull($user->articles->get(-1));
-        $this->assertNull($user->groups->get(-1));
     }
 
     private function loadFixture()
@@ -668,7 +647,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->userId = $user1->getId();
         $this->groupId = $group1->id;
 
-        $this->groupname = $group1->name;
         $this->topic = $article1->topic;
         $this->phonenumber = $phonenumber1->phonenumber;
     }


### PR DESCRIPTION
I made a big mistake in PR #706, my apologies. The get() function in the OneToManyPersister and ManyToManyPersister  did not add the collection owner to the load query. The unit tests failed to detect this because the first entity is always used (ID 1) was used to test with.

The first commit in this PR fixes this for the OneToMayPersister.

I could not find a way to fix this for the ManyToManyPersister. Problem is that you can only use conditions on the owning side of a ManyToMany relation, not on the inverse side. Code like `load(array($mapping['inversedBy'] => $coll->getOwner()), ...)` gave an ORMException.

Therefor, the second commit in this PR removes the extra-lazy-get for ManyToMany relations. If anyone has any ideas how to make this work for the ManyToMany side, please let me know.
