### PR TITLE
Cache results for extra lazy get

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -252,6 +252,7 @@ final class PersistentCollection implements Collection, Selectable
             $this->isDirty = true;
         }
 
+        $this->indexByCache = array();
         $this->initialized = true;
     }
 

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -530,7 +530,7 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
-            if (isset($this->indexByCache[$key])) {
+            if (array_key_exists($key, $this->indexByCache)) {
                 return $this->indexByCache[$key];
             }
 

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -114,6 +114,13 @@ final class PersistentCollection implements Collection, Selectable
     private $coll;
 
     /**
+     * A cache of items loaded from an indexed extra lazy collection
+     *
+     * @var array
+     */
+    private $indexByCache = array();
+
+    /**
      * Creates a new persistent collection.
      *
      * @param EntityManager $em    The EntityManager the collection will be associated with.
@@ -522,8 +529,8 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
-            if ($this->coll->containsKey($key)) {
-                return $this->coll->get($key);
+            if (isset($this->indexByCache[$key])) {
+                return $this->indexByCache[$key];
             }
 
             if (!$this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
@@ -532,7 +539,7 @@ final class PersistentCollection implements Collection, Selectable
                 $value = $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
             }
 
-            $this->coll->set($key, $value);
+            $this->indexByCache[$key] = $value;
 
             return $value;
         }

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -522,11 +522,19 @@ final class PersistentCollection implements Collection, Selectable
             && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
             && isset($this->association['indexBy'])
         ) {
-            if (!$this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
-                return $this->em->find($this->typeClass->name, $key);
+            if ($this->coll->containsKey($key)) {
+                return $this->coll->get($key);
             }
 
-            return $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
+            if (!$this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
+                $value = $this->em->find($this->typeClass->name, $key);
+            } else {
+                $value = $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);
+            }
+
+            $this->coll->set($key, $value);
+
+            return $value;
         }
 
         $this->initialize();

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -572,7 +572,14 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testGetNonExistentIndexBy()
     {
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $queryCount = $this->getCurrentQueryCount();
+
         $this->assertNull($user->articles->get(-1));
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+
+        $user->articles->get(-1);
+
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
     }
 
     private function loadFixture()

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -555,13 +555,15 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $queryCount = $this->getCurrentQueryCount();
 
         $article = $user->articles->get($this->topic);
+        $expected = $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId);
 
         $this->assertFalse($user->articles->isInitialized());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
-        $this->assertSame($article, $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId));
+        $this->assertSame($expected, $article);
 
         $article = $user->articles->get($this->topic);
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
+        $this->assertSame($expected, $article);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -552,13 +552,16 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
         /* @var $user CmsUser */
 
-        $queryCount = $this->getCurrentQueryCount();
+        $queryCount = $this->getCurrentQueryCount() + 1;
 
         $article = $user->articles->get($this->topic);
 
         $this->assertFalse($user->articles->isInitialized());
-        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
         $this->assertSame($article, $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId));
+
+        $article = $user->articles->get($this->topic);
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -552,16 +552,16 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
         /* @var $user CmsUser */
 
-        $queryCount = $this->getCurrentQueryCount() + 1;
+        $queryCount = $this->getCurrentQueryCount();
 
         $article = $user->articles->get($this->topic);
 
         $this->assertFalse($user->articles->isInitialized());
-        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertSame($article, $this->_em->find('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId));
 
         $article = $user->articles->get($this->topic);
-        $this->assertEquals($queryCount, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Getting the same entity should not cause an extra query to be executed");
     }
 
     /**


### PR DESCRIPTION
Repeated getting of the same key on an extra lazy collection
should only issue a query for the first get, not for any
subsequent gets.
