### PR TITLE
Appending the Paginator tree walker hint

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -232,6 +232,12 @@ class Paginator implements \Countable, \IteratorAggregate
         return $this->useOutputWalkers;
     }
 
+    /**
+     * Appends a custom tree walker to the tree walkers hint.
+     *
+     * @param Query $query
+     * @param string $walkerClass
+     */
     private function appendTreeWalker(Query $query, $walkerClass)
     {
         $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -134,7 +134,7 @@ class Paginator implements \Countable, \IteratorAggregate
                 $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\CountOutputWalker');
                 $countQuery->setResultSetMapping($rsm);
             } else {
-                $countQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+                $this->appendTreeWalker($countQuery, 'Doctrine\ORM\Tools\Pagination\CountWalker');
             }
 
             $countQuery->setFirstResult(null)->setMaxResults(null);
@@ -165,7 +165,7 @@ class Paginator implements \Countable, \IteratorAggregate
             if ($this->useOutputWalker($subQuery)) {
                 $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
             } else {
-                $subQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+                $this->appendTreeWalker($subQuery, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker');
             }
 
             $subQuery->setFirstResult($offset)->setMaxResults($length);
@@ -230,5 +230,17 @@ class Paginator implements \Countable, \IteratorAggregate
         }
 
         return $this->useOutputWalkers;
+    }
+
+    private function appendTreeWalker(Query $query, $walkerClass)
+    {
+        $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
+
+        if ($hints === false) {
+            $hints = array();
+        }
+
+        $hints[] = $walkerClass;
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, $hints);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -139,6 +139,18 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertTrue($query->getParameters()->isEmpty());
     }
 
+    public function testQueryWalkerIsKept()
+    {
+        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $query = $this->_em->createQuery($dql);
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomTreeWalker'));
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+        $this->assertCount(1, $paginator->getIterator());
+        $this->assertEquals(1, $paginator->count());
+    }
+
     public function populate()
     {
         for ($i = 0; $i < 3; $i++) {
@@ -164,5 +176,24 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
             array(true),
             array(false),
         );
+    }
+}
+
+class CustomTreeWalker extends Query\TreeWalkerAdapter
+{
+    public function walkSelectStatement(Query\AST\SelectStatement $selectStatement)
+    {
+        $condition = new Query\AST\ConditionalPrimary();
+
+        $path = new Query\AST\PathExpression(Query\AST\PathExpression::TYPE_STATE_FIELD, 'u', 'name');
+        $path->type = Query\AST\PathExpression::TYPE_STATE_FIELD;
+
+        $condition->simpleConditionalExpression = new Query\AST\ComparisonExpression(
+            $path,
+            '=',
+            new Query\AST\Literal(Query\AST\Literal::STRING, 'Name1')
+        );
+
+        $selectStatement->whereClause = new Query\AST\WhereClause($condition);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -143,7 +143,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $query = $this->_em->createQuery($dql);
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomTreeWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomPaginationTestTreeWalker'));
 
         $paginator = new Paginator($query, true);
         $paginator->setUseOutputWalkers(false);
@@ -179,7 +179,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 }
 
-class CustomTreeWalker extends Query\TreeWalkerAdapter
+class CustomPaginationTestTreeWalker extends Query\TreeWalkerAdapter
 {
     public function walkSelectStatement(Query\AST\SelectStatement $selectStatement)
     {


### PR DESCRIPTION
Appends the Paginator tree walker query hint instead of appending it, thus keeping other query hints.
