### PR TITLE
Access properties via static:: instead of self::.

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -390,7 +390,7 @@ public function __construct()
             $this->generateEntityBody($metadata)
         );
 
-        $code = str_replace($placeHolders, $replacements, self::$classTemplate);
+        $code = str_replace($placeHolders, $replacements, static::$classTemplate);
 
         return str_replace('<spaces>', $this->spaces, $code);
     }
@@ -474,7 +474,7 @@ public function __construct()
      */
     public function setFieldVisibility($visibility)
     {
-        if ($visibility !== self::FIELD_VISIBLE_PRIVATE && $visibility !== self::FIELD_VISIBLE_PROTECTED) {
+        if ($visibility !== static::FIELD_VISIBLE_PRIVATE && $visibility !== static::FIELD_VISIBLE_PROTECTED) {
             throw new \InvalidArgumentException('Invalid provided visibility (only private and protected are allowed): ' . $visibility);
         }
 
@@ -633,7 +633,7 @@ public function __construct()
         }
 
         if ($collections) {
-            return $this->prefixCodeWithSpaces(str_replace("<collections>", implode("\n".$this->spaces, $collections), self::$constructorMethodTemplate));
+            return $this->prefixCodeWithSpaces(str_replace("<collections>", implode("\n".$this->spaces, $collections), static::$constructorMethodTemplate));
         }
 
         return '';
@@ -1102,7 +1102,7 @@ public function __construct()
         $this->staticReflection[$metadata->name]['methods'][] = $methodName;
 
         $var = sprintf('%sMethodTemplate', $type);
-        $template = self::$$var;
+        $template = static::$$var;
 
         $methodTypeHint = null;
         $types          = Type::getTypesMap();
@@ -1155,7 +1155,7 @@ public function __construct()
         $method = str_replace(
             array_keys($replacements),
             array_values($replacements),
-            self::$lifecycleCallbackMethodTemplate
+            static::$lifecycleCallbackMethodTemplate
         );
 
         return $this->prefixCodeWithSpaces($method);
@@ -1463,11 +1463,11 @@ public function __construct()
      */
     protected function getInheritanceTypeString($type)
     {
-        if ( ! isset(self::$inheritanceTypeMap[$type])) {
+        if ( ! isset(static::$inheritanceTypeMap[$type])) {
             throw new \InvalidArgumentException(sprintf('Invalid provided InheritanceType: %s', $type));
         }
 
-        return self::$inheritanceTypeMap[$type];
+        return static::$inheritanceTypeMap[$type];
     }
 
     /**
@@ -1479,11 +1479,11 @@ public function __construct()
      */
     protected function getChangeTrackingPolicyString($type)
     {
-        if ( ! isset(self::$changeTrackingPolicyMap[$type])) {
+        if ( ! isset(static::$changeTrackingPolicyMap[$type])) {
             throw new \InvalidArgumentException(sprintf('Invalid provided ChangeTrackingPolicy: %s', $type));
         }
 
-        return self::$changeTrackingPolicyMap[$type];
+        return static::$changeTrackingPolicyMap[$type];
     }
 
     /**
@@ -1495,10 +1495,10 @@ public function __construct()
      */
     protected function getIdGeneratorTypeString($type)
     {
-        if ( ! isset(self::$generatorStrategyMap[$type])) {
+        if ( ! isset(static::$generatorStrategyMap[$type])) {
             throw new \InvalidArgumentException(sprintf('Invalid provided IdGeneratorType: %s', $type));
         }
 
-        return self::$generatorStrategyMap[$type];
+        return static::$generatorStrategyMap[$type];
     }
 }


### PR DESCRIPTION
The properties of `EntityGenerator` are now protected instead of private.
But this does not make sense until they are accessed with `static::`.
Otherwise the templates cannot be overwritten within a sub class.
