### PR TITLE
Allow to have non-distinct queries

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -702,6 +702,18 @@ abstract class AbstractQuery
     }
 
     /**
+     * Check if the query has a hint
+     *
+     * @param  string $name The name of the hint
+     *
+     * @return bool False if the query does not have any hint
+     */
+    public function hasHint($name)
+    {
+        return isset($this->_hints[$name]);
+    }
+
+    /**
      * Return the key value map of query hints that are currently set.
      *
      * @return array

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -121,7 +121,7 @@ class Paginator implements \Countable, \IteratorAggregate
             /* @var $countQuery Query */
             $countQuery = $this->cloneQuery($this->query);
 
-            if ( ! $countQuery->getHint(CountWalker::HINT_DISTINCT)) {
+            if ( ! $countQuery->hasHint(CountWalker::HINT_DISTINCT)) {
                 $countQuery->setHint(CountWalker::HINT_DISTINCT, true);
             }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -105,6 +105,8 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('bar', $q->getHint('foo'));
         $this->assertEquals('baz', $q->getHint('bar'));
         $this->assertEquals(array('foo' => 'bar', 'bar' => 'baz'), $q->getHints());
+        $this->assertTrue($q->hasHint('foo'));
+        $this->assertFalse($q->hasHint('barFooBaz'));
     }
 
     /**


### PR DESCRIPTION
The getHint method would return false if no hint was set for the given name. Therefore even if you set the CountWalker::HINT_DISTINCT to false, it would have been ignored and set to true by the paginator.
