### PR TITLE
Remove extra semicolon before ->setParameter() calls

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -208,7 +208,7 @@ allowed. Binding parameters can simply be achieved as follows:
     $qb->select('u')
        ->from('User u')
        ->where('u.id = ?1')
-       ->orderBy('u.name', 'ASC');
+       ->orderBy('u.name', 'ASC')
        ->setParameter(1, 100); // Sets ?1 to 100, and thus we will fetch a user with u.id = 100
 
 You are not forced to enumerate your placeholders as the
@@ -222,7 +222,7 @@ alternative syntax is available:
     $qb->select('u')
        ->from('User u')
        ->where('u.id = :identifier')
-       ->orderBy('u.name', 'ASC');
+       ->orderBy('u.name', 'ASC')
        ->setParameter('identifier', 100); // Sets :identifier to 100, and thus we will fetch a user with u.id = 100
 
 Note that numeric placeholders start with a ? followed by a number


### PR DESCRIPTION
Just noticed in the query builder documentation that there are a couple of extra semicolons before the calls to `->setParameter()`.
