### PR TITLE
To avoid "SpacingAfterParams" error with PHPCS Symfony2 coding standard

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -234,6 +234,7 @@ public function <methodName>()
  * <description>
  *
  * @param <variableType>$<variableName>
+ *
  * @return <entity>
  */
 public function <methodName>(<methodTypeHint>$<variableName><variableDefault>)
@@ -251,6 +252,7 @@ public function <methodName>(<methodTypeHint>$<variableName><variableDefault>)
  * <description>
  *
  * @param <variableType>$<variableName>
+ *
  * @return <entity>
  */
 public function <methodName>(<methodTypeHint>$<variableName>)


### PR DESCRIPTION
Hello,
I added two blank lines in comments two avoid the following error with PHPCS Symfony2 coding standard :
Error Code: SpacingAfterParams
Error Description: Last parameter comment requires a blank new line after it.
