### PR TITLE
Corrected PHP type for "decimal" mapping type

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -152,7 +152,7 @@ class EntityGenerator
         Type::SMALLINT      => 'integer',
         Type::TEXT          => 'string',
         Type::BLOB          => 'string',
-        Type::DECIMAL       => 'float',
+        Type::DECIMAL       => 'string',
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
     );

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -548,9 +548,9 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
             )),
             array(array(
                 'fieldName' => 'decimal',
-                'phpType' => 'float',
+                'phpType' => 'string',
                 'dbType' => 'decimal',
-                'value' => 33.33
+                'value' => '33.33'
             ),
         ));
     }

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -550,7 +550,7 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
                 'fieldName' => 'decimal',
                 'phpType' => 'string',
                 'dbType' => 'decimal',
-                'value' => '33.33'
+                'value' => '12.34'
             ),
         ));
     }


### PR DESCRIPTION
"Basic Mapping" documentation says:
"decimal: Type that maps a SQL DECIMAL to a PHP string."
