### PR TITLE
Makes children of AbstractQuery non-final.

### DIFF
--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -25,7 +25,7 @@ namespace Doctrine\ORM;
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
  */
-final class NativeQuery extends AbstractQuery
+class NativeQuery extends AbstractQuery
 {
     /**
      * @var string

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -37,7 +37,7 @@ use Doctrine\ORM\Query\ParameterTypeInferer;
  * @author  Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-final class Query extends AbstractQuery
+class Query extends AbstractQuery
 {
     /**
      * A query object is in CLEAN state when it has NO unparsed/unprocessed DQL parts.


### PR DESCRIPTION
b66d530540d18c60720e1843fc65ce7e0399a71c made these classes final, but there is no rationale for this change given in the commit log.  Leaving this as final makes it impossible to mock and makes testing some areas of code difficult (or impossible).
