### PR TITLE
JoinedSubclassPersister doesn't properly bind on some versions of php

### DIFF
--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -197,7 +197,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 }
 
                 foreach ($data as $columnName => $value) {
-                    if (!isset($id[$columnName])) {
+                    if (!is_array($id) || !isset($id[$columnName])) {
                         $stmt->bindValue($paramIndex++, $value, $this->columnTypes[$columnName]);
                     }
                 }


### PR DESCRIPTION
I ran into this bug after deploying an application to production:

```
 An exception occurred while executing 'INSERT INTO TextSprite (id, text, fontId) VALUES (?, ?, ?)' with params ["4"]:

    SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens
```

The parent table is being inserted properly (It's where the single param 4 comes from for the id), but the child table insert fails.

This was on a shared host with PHP version 5.3.24. On my development machine, everything works fine.

The issue is when the id is not a composite key, it's just a string (in this case), and for whatever reason !isset($id[$columnName]) fails to return a sane value on my production version of php.

By adding a check to see if the ID is an array we can determine if its a composite key, and not bother with the column checks if its not.

Not sure how to write unit tests for this one since it only affects certain versions of PHP (apparently). So advice on that is appreciated.
