### PR TITLE
Make yaml/xml configuration for  "AttributeOverride" and "AssociationOverride" more discoverable

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -260,6 +260,7 @@ or auto-increment details). Furthermore each child table has to
 have a foreign key pointing from the id column to the root table id
 column and cascading on delete.
 
+.. _inheritence_mapping_overrides:
 
 Overrides
 ---------

--- a/docs/en/tutorials/override-field-association-mappings-in-subclasses.rst
+++ b/docs/en/tutorials/override-field-association-mappings-in-subclasses.rst
@@ -87,4 +87,4 @@ The case for just extending a class would be just the same but:
         // ...
     }
 
-Overriding is also supported via XML and YAML.
+Overriding is also supported via XML and YAML (:ref:`examples <inheritence_mapping_overrides>`).


### PR DESCRIPTION
I was trying to find out how to configure `AttributeOverride` in yaml for one of my entities and all paths led me to the [Override Field Association Mappings In Subclasses](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/override-field-association-mappings-in-subclasses.html) tutorial.

It was a lot harder to find anything for xml/yaml. This pull request adds a link to the [Overrides section](https://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#overrides) of the inheritance mapping reference which provides the needed examples.

Alternatively yaml/xml examples could be provided in the tutorial but I am not familiar enough with sphinx/the docs to make those changes
