### PR TITLE
Add table alias to column names

### DIFF
--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -231,7 +231,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         foreach ($joinColumns as $joinColumn) {
             $columnName     = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
             $referencedName = $joinColumn['referencedColumnName'];
-            $conditions[]   = $columnName . ' = ?';
+            $conditions[]   = 't.' . $columnName . ' = ?';
             $params[]       = ($class->containsForeignIdentifier)
                 ? $id[$class->getFieldForColumn($referencedName)]
                 : $id[$class->fieldNames[$referencedName]];
@@ -352,7 +352,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $params          = array();
 
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
-            $whereClauses[] = $joinTableColumn . ' = ?';
+            $whereClauses[] = ($addFilters ? 't.' : '') . $joinTableColumn . ' = ?';
 
             if (isset($mapping['relationToTargetKeyColumns'][$joinTableColumn])) {
                 $params[] = ($targetClass->containsForeignIdentifier)


### PR DESCRIPTION
`ManyToManyPersister` does not add table alias to column names in multi-table `SELECT` queries. This will cause SQL servers complain about condition columns in where clause are ambiguous.
