### PR TITLE
YAML mapping documentation of uniqueConstraint

### DIFF
--- a/docs/en/reference/yaml-mapping.rst
+++ b/docs/en/reference/yaml-mapping.rst
@@ -114,4 +114,22 @@ of several common elements:
 Be aware that class-names specified in the YAML files should be
 fully qualified.
 
+Reference
+~~~~~~~~~~~~~~~~~~~~~~
+
+Unique Constraints
+------------------
+
+It is possible to define unique constraints by the following declaration:
+
+.. code-block:: yaml
+
+    # ECommerceProduct.orm.yml
+    ECommerceProduct:
+      type: entity
+      fields:
+        # definition of some fields
+      uniqueConstraints:
+        search_idx:
+          columns: [ name, email ]
 


### PR DESCRIPTION
I have provided an example of YAML mapping for unique constraints which is equivalent to the [annotation reference for unique constraints](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/annotations-reference.html#annref-uniqueconstraint).

It is really basic, but I think better than nothing. Because there are severall people who search for that.

See
- http://stackoverflow.com/questions/8893473/how-to-add-a-constraint-index-in-yaml-doctrine-2
- http://stackoverflow.com/questions/7347581/how-to-create-a-unique-constraints-in-yml-in-doctrine2
- http://www.ozonesolutions.com/programming/2011/08/symfony-with-doctrine-multiple-unique-columns/

I felt the need of that doc, too ;)
