### PR TITLE
Fix for entity generator discriminator column

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -953,7 +953,7 @@ public function __construct()
     protected function generateDiscriminatorColumnAnnotation($metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
-            $discrColumn = $metadata->discriminatorValue;
+            $discrColumn = $metadata->discriminatorColumn;
             $columnDefinition = 'name="' . $discrColumn['name']
                 . '", type="' . $discrColumn['type']
                 . '", length=' . $discrColumn['length'];


### PR DESCRIPTION
I was using the EntityGenerator to create class files from yaml when I realized php warnings like `PHP Warning:  Illegal string offset 'name'` on the console. Warnings have also been emitted for the `type` and `length` fields.

The generated php file also contained a wrong annotation for the discriminator column:

```
 * @ORM\DiscriminatorColumn(name="s", type="s", length=s)
```

The single change in this pull request resolves the problem, so even the warnings disappear and the generated file contains the proper annotation.

An example yaml:

```
Subscription:
  type: entity
  table: subscriptions
  id:
    id:
      type: integer
      generator:
        strategy: AUTO
  fields:
    created:
      type: datetime
    updated:
      type: datetime
  inheritanceType: SINGLE_TABLE
  discriminatorColumn:
    name: objectType
    type: string
    length: 255
  discriminatorMap:
  manyToOne:
    user:
      targetEntity: User
      joinColumn:
        name: user_id
        referencedColumnName: id
```
