### PR TITLE
Support matching Criteria on PersistentCollection on ManyToMany associat...

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -865,7 +865,9 @@ final class PersistentCollection implements Collection, Selectable
         }
 
         if ($this->association['type'] !== ClassMetadata::ONE_TO_MANY) {
-            throw new \RuntimeException("Matching Criteria on PersistentCollection only works on OneToMany associations at the moment.");
+            $this->initialize();
+
+            return $this->coll->matching($criteria);
         }
 
         $builder         = Criteria::expr();


### PR DESCRIPTION
...ion

An unitialized (ManyToMany) PersistentCollection should be initialized instead of throwing \RuntimeException.
