### PR TITLE
[WIP] DDC-2622 - SQLServer expects column names in the `OVER` clause to not contain any table alias

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
@@ -44,9 +44,9 @@ class CountOutputWalkerTest extends PaginationTestCase
 
     public function testCountQueryOrderBySqlServer()
     {
-        if ($this->entityManager->getConnection()->getDatabasePlatform()->getName() !== "mssql") {
-            $this->markTestSkipped('SQLServer only test.');
-        }
+        $originalPlatform = $this->entityManager->getConnection()->getDatabasePlatform();
+
+        $this->entityManager->getConnection()->setDatabasePlatform(new \Doctrine\DBAL\Platforms\SQLServer2008Platform());
 
         $query = $this->entityManager->createQuery(
             'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p ORDER BY p.id');
@@ -54,9 +54,11 @@ class CountOutputWalkerTest extends PaginationTestCase
         $query->setFirstResult(null)->setMaxResults(null);
 
         $this->assertEquals(
-            "SELECT COUNT(*) AS dctrn_count FROM (SELECT DISTINCT id0 FROM (SELECT b0_.id AS id0, b0_.author_id AS author_id1, b0_.category_id AS category_id2 FROM BlogPost b0_) dctrn_result) dctrn_table",
+            "SELECT COUNT(*) AS dctrn_count FROM (SELECT DISTINCT id0 FROM (SELECT b0_.id AS id0, b0_.author_id AS author_id1, b0_.category_id AS category_id2 FROM BlogPost b0_ WITH (NOLOCK)) dctrn_result) dctrn_table",
             $query->getSql()
         );
+
+        $this->entityManager->getConnection()->setDatabasePlatform($originalPlatform);
     }
 }
 


### PR DESCRIPTION
This PR contains the failing test case for [DDC-2622](http://www.doctrine-project.org/jira/browse/DDC-2622)

Strictly depends on doctrine/dbal#371
