### PR TITLE
HHVM compatibility: func_get_args

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -894,8 +894,8 @@ class QueryBuilder
      */
     public function andWhere($where)
     {
-        $where = $this->getDQLPart('where');
         $args  = func_get_args();
+        $where = $this->getDQLPart('where');
 
         if ($where instanceof Expr\Andx) {
             $where->addMultiple($args);
@@ -927,8 +927,8 @@ class QueryBuilder
      */
     public function orWhere($where)
     {
-        $where = $this->getDqlPart('where');
         $args  = func_get_args();
+        $where = $this->getDqlPart('where');
 
         if ($where instanceof Expr\Orx) {
             $where->addMultiple($args);
@@ -1007,8 +1007,8 @@ class QueryBuilder
      */
     public function andHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Andx) {
             $having->addMultiple($args);
@@ -1030,8 +1030,8 @@ class QueryBuilder
      */
     public function orHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Orx) {
             $having->addMultiple($args);


### PR DESCRIPTION
All func_get_args() calls have been moved to the top of the methods because HHVM doesn't keep a copy of the original args for performance reasons.

See facebook/hiphop-php#1027 for details.
