### PR TITLE
Implemented "contains" operator for Criteria expressions

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -154,6 +154,11 @@ class QueryExpressionVisitor extends ExpressionVisitor
                 $this->parameters[] = $parameter;
                 return $this->expr->neq($comparison->getField(), $placeholder);
 
+            case Comparison::CONTAINS:
+                $parameter->setValue('%' . $parameter->getValue() . '%', $parameter->getType());
+                $this->parameters[] = $parameter;
+                return $this->expr->like($comparison->getField(), $placeholder);
+
             default:
                 $operator = self::convertComparisonOperator($comparison->getOperator());
                 if ($operator) {

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -85,6 +85,8 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
             array($cb->in('field', array('value')), $qb->in('field', ':field'), new Parameter('field', array('value'))),
             array($cb->notIn('field', array('value')), $qb->notIn('field', ':field'), new Parameter('field', array('value'))),
 
+            array($cb->contains('field', 'value'), $qb->like('field', ':field'), new Parameter('field', '%value%')),
+
             // Test parameter conversion
             array($cb->eq('object.field', 'value'), $qb->eq('object.field', ':object_field'), new Parameter('object_field', 'value')),
         );


### PR DESCRIPTION
Criteria expressions support the contains operator, and it is implemented for the ArrayCollection. However, it wasn't implemented in the QueryExpressionVisitor, the ORM implementation.

This is the implementation and the test.

The only thing I'm wondering: is the `%` wildcard valid for all supported RDBMS for the `LIKE` operator? After a quick search, it seems like so, but you guys probably know for sure.

FYI it seems that someone created an issue for this, but it was closed: [DDC-2394](http://www.doctrine-project.org/jira/browse/DDC-2394)
