### PR TITLE
Improved error messages in Paginator: LimitSubqueryOutputWalker

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -149,7 +149,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
             }
         }
 
-        if (count($rootIdentifier) != count($sqlIdentifier)) {
+        if (count($sqlIdentifier) === 0) {
+            throw new \RuntimeException('The Paginator does not support Queries which only yield ScalarResults.');
+        } elseif (count($rootIdentifier) != count($sqlIdentifier)) {
             throw new \RuntimeException(sprintf(
                 'Not all identifier properties can be found in the ResultSetMapping: %s',
                 implode(', ', array_diff($rootIdentifier, array_keys($sqlIdentifier)))

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -151,7 +151,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
         if (count($sqlIdentifier) === 0) {
             throw new \RuntimeException('The Paginator does not support Queries which only yield ScalarResults.');
-        } elseif (count($rootIdentifier) != count($sqlIdentifier)) {
+        }
+
+        if (count($rootIdentifier) != count($sqlIdentifier)) {
             throw new \RuntimeException(sprintf(
                 'Not all identifier properties can be found in the ResultSetMapping: %s',
                 implode(', ', array_diff($rootIdentifier, array_keys($sqlIdentifier)))


### PR DESCRIPTION
The already existing follow-up check throwing "Not all identifier properties can be found in the ResultSetMapping: %s" is a much more technical description.

If $sqlIdentifier is empty (count 0) it can be concluded that there are no mapped results. An alternative error message could thus be "The Paginator does not support queries without mapped results." (line 153).

Possibly '!=' on line 154 could be replaced by '>' because i think this is the only situation that can occur. But since i don't know this for sure, i left it like i found it.
