### PR TITLE
Multiple invokation of listeners on PreFlush event

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -530,7 +530,7 @@ class UnitOfWork implements PropertyChangedListener
             $class = $this->em->getClassMetadata(get_class($entity));
         }
 
-        $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::preFlush);
+        $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::preFlush) & ~ListenersInvoker::INVOKE_MANAGER;
 
         if ($invoke !== ListenersInvoker::INVOKE_NONE) {
             $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em), $invoke);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @group
+ */
+class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setup()
+    {
+        parent::setup();
+
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2692Foo'),
+            ));
+        } catch(\Exception $e) {
+            return;
+        }
+        $this->_em->clear();
+    }
+
+    public function testListenerCalledOneOnPreFlush()
+    {
+        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\Listener', array('preFlush'));
+        $listener->expects($this->once())->method('preFlush');
+
+        $this->_em->getEventManager()->addEventSubscriber($listener);
+
+        $this->_em->persist(new DDC2692Foo);
+        $this->_em->persist(new DDC2692Foo);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}
+/**
+ * @Entity @Table(name="ddc_2692_foo")
+ */
+class DDC2692Foo
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+}
+
+class Listener implements EventSubscriber {
+
+    public function getSubscribedEvents() {
+        return array(\Doctrine\ORM\Events::preFlush);
+    }
+
+    public function preFlush(PreFlushEventArgs $args) {
+    }
+}
+
+

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -29,7 +29,7 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIsListenerCalledOnlyOnceOnPreFlush()
     {
-        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\Listener', array('preFlush'));
+        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\DDC2692Listener', array('preFlush'));
         $listener->expects($this->once())->method('preFlush');
 
         $this->_em->getEventManager()->addEventSubscriber($listener);
@@ -50,7 +50,7 @@ class DDC2692Foo
     public $id;
 }
 
-class Listener implements EventSubscriber {
+class DDC2692Listener implements EventSubscriber {
 
     public function getSubscribedEvents() {
         return array(\Doctrine\ORM\Events::preFlush);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -4,11 +4,9 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\PreFlushEventArgs;
-use Doctrine\ORM\Query\ResultSetMappingBuilder;
-use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @group
+ * @group DDC-2692
  */
 class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -29,7 +27,7 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public function testListenerCalledOneOnPreFlush()
+    public function testIsListenerCalledOnlyOnceOnPreFlush()
     {
         $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\Listener', array('preFlush'));
         $listener->expects($this->once())->method('preFlush');


### PR DESCRIPTION
Only lifecycle callbacks and entity listeners should be triggered here. The preFlush listener event is already triggered at the beginning of commit()
