### PR TITLE
Allow NamingStrategy Access to ClassMetadataInfo.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -627,7 +627,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->name = $entityName;
         $this->rootEntityName = $entityName;
-        $this->namingStrategy = $namingStrategy($this) ?: new DefaultNamingStrategy($this);
+        $this->namingStrategy = new $namingStrategy($this) ?: new DefaultNamingStrategy($this);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -627,7 +627,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->name = $entityName;
         $this->rootEntityName = $entityName;
-        $this->namingStrategy = $namingStrategy ?: new DefaultNamingStrategy();
+        $this->namingStrategy = $namingStrategy($this) ?: new DefaultNamingStrategy($this);
     }
 
     /**


### PR DESCRIPTION
NamingStrategy will power if it can use ClassMetadataInfo.
