### PR TITLE
Identifier can be empty for MappedSuperclasses

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1031,6 +1031,9 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function isIdentifier($fieldName)
     {
+        if (0 == count($this->identifier)) {
+            return false;
+        }
         if ( ! $this->isIdentifierComposite) {
             return $fieldName === $this->identifier[0];
         }


### PR DESCRIPTION
When MappedSuperclass is inspected without identifier column been assigned, always return false. Solves "Undefined offset" notice.
