### PR TITLE
Update SqlWalker.php fixed wrong GROUP BY clause on SQL Server platform

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1624,13 +1624,17 @@ class SqlWalker implements TreeWalker
 
         // ResultVariable
         if (isset($this->queryComponents[$groupByItem]['resultVariable'])) {
-            if ($this->queryComponents[$groupByItem]['resultVariable'] instanceof AST\PathExpression) {
-                return $this->walkPathExpression($this->queryComponents[$groupByItem]['resultVariable']);
-            } elseif (isset($this->queryComponents[$groupByItem]['resultVariable']->pathExpression)) {
-                return $this->walkPathExpression($this->queryComponents[$groupByItem]['resultVariable']->pathExpression);
-            } else {
-                return $this->walkResultVariable($groupByItem);
+            $resultVariable = $this->queryComponents[$groupByItem]['resultVariable'];
+
+            if ($resultVariable instanceof AST\PathExpression) {
+                return $this->walkPathExpression($resultVariable);
             }
+
+            if (isset($resultVariable->pathExpression)) {
+                return $this->walkPathExpression($resultVariable->pathExpression);
+            }
+
+            return $this->walkResultVariable($groupByItem);
         }
 
         // IdentificationVariable

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -21,7 +21,6 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\QueryException;
@@ -1625,7 +1624,9 @@ class SqlWalker implements TreeWalker
 
         // ResultVariable
         if (isset($this->queryComponents[$groupByItem]['resultVariable'])) {
-            if ($this->platform instanceof SQLServerPlatform) {
+            if ($this->queryComponents[$groupByItem]['resultVariable'] instanceof AST\PathExpression) {
+                return $this->walkPathExpression($this->queryComponents[$groupByItem]['resultVariable']);
+            } elseif (isset($this->queryComponents[$groupByItem]['resultVariable']->pathExpression)) {
                 return $this->walkPathExpression($this->queryComponents[$groupByItem]['resultVariable']->pathExpression);
             } else {
                 return $this->walkResultVariable($groupByItem);

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\QueryException;
@@ -1624,7 +1625,11 @@ class SqlWalker implements TreeWalker
 
         // ResultVariable
         if (isset($this->queryComponents[$groupByItem]['resultVariable'])) {
-            return $this->walkResultVariable($groupByItem);
+            if ($this->platform instanceof SQLServerPlatform) {
+                return $this->walkPathExpression($this->queryComponents[$groupByItem]['resultVariable']->pathExpression);
+            } else {
+                return $this->walkResultVariable($groupByItem);
+            }
         }
 
         // IdentificationVariable

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1573,7 +1573,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             'SELECT u, u.status AS st FROM Doctrine\Tests\Models\CMS\CmsUser u GROUP BY st',
-            'SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.status AS status4 FROM cms_users c0_ GROUP BY status4'
+            'SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.status AS status4 FROM cms_users c0_ GROUP BY c0_.status'
         );
     }
 
@@ -2257,4 +2257,3 @@ class DDC1474Entity
     }
 
 }
-


### PR DESCRIPTION
Without this patch a query would like like:

```
SELECT c0_.Country AS sclr0
FROM Continent c0_ WITH (NOLOCK)
WHERE c0_.Country = 38
GROUP BY sclr0
```

Using the column alias in the GROUP BY clause. However this is not allowed on SQL Server. References:
1. http://stackoverflow.com/a/3841804
2. http://technet.microsoft.com/en-us/library/ms189499.aspx (Logical Processing Order of the SELECT statement)

The correct query should be:

```
SELECT c0_.Country AS sclr0
FROM Continent c0_ WITH (NOLOCK)
WHERE c0_.Country = 38
GROUP BY c0_.Country
```
