### PR TITLE
Respect unsigned fields when tables get converted to entities.

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1430,7 +1430,11 @@ public function __construct()
             if (isset($fieldMapping['nullable'])) {
                 $column[] = 'nullable=' .  var_export($fieldMapping['nullable'], true);
             }
-
+            
+            if (isset($fieldMapping['unsigned']) && $fieldMapping['unsigned']) {
+                $column[] = 'options={"unsigned"=true}';
+            }
+            
             if (isset($fieldMapping['columnDefinition'])) {
                 $column[] = 'columnDefinition="' . $fieldMapping['columnDefinition'] . '"';
             }


### PR DESCRIPTION
This is working on our mysql setup, however i have no idea of the consequences of this change when using other RDBMSes.
