### PR TITLE
[bugfix] if BIGINT or SMALLINT version field was not incremented.

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -464,7 +464,9 @@ class BasicEntityPersister
             $params[]   = $this->class->reflFields[$versionField]->getValue($entity);
 
             switch ($versionFieldType) {
+                case Type::SMALLINT:
                 case Type::INTEGER:
+                case Type::BIGINT:
                     $set[] = $versionColumn . ' = ' . $versionColumn . ' + 1';
                     break;
 


### PR DESCRIPTION
Made version field accepted type coherent between ClassMetadataInfo and BasicEntityPersister
