### PR TITLE
Improved test for DDC-1514 failing in some situations.

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -57,7 +57,11 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $dql = "SELECT a, b, ba, c FROM " . __NAMESPACE__ . "\DDC1514EntityA AS a LEFT JOIN a.entitiesB AS b LEFT JOIN b.entityATo AS ba LEFT JOIN a.entityC AS c";
         $results = $this->_em->createQuery($dql)->getResult();
 
-        $this->assertEquals($c->title, $results[1]->entityC->title);
+        $a2_db = array_filter($results, function($entity) use ($a2) {
+            if ($entity->id === $a2->id) return true;
+        })[0];
+
+        $this->assertEquals($c->title, $a2_db->entityC->title);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -61,7 +61,7 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
             return $entity->id === $a2FromDB->id;
         }));
 
-        $this->assertEquals($c->title, $a2_db->entityC->title);
+        $this->assertEquals($c->title, $a2FromDB->entityC->title);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -57,9 +57,9 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $dql = "SELECT a, b, ba, c FROM " . __NAMESPACE__ . "\DDC1514EntityA AS a LEFT JOIN a.entitiesB AS b LEFT JOIN b.entityATo AS ba LEFT JOIN a.entityC AS c";
         $results = $this->_em->createQuery($dql)->getResult();
 
-        $a2_db = array_filter($results, function($entity) use ($a2) {
-            if ($entity->id === $a2->id) return true;
-        })[0];
+        $a2FromDB = array_shift(array_filter($results, function($entity) use ($a2) {
+            return $entity->id === $a2FromDB->id;
+        }));
 
         $this->assertEquals($c->title, $a2_db->entityC->title);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -58,7 +58,7 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $results = $this->_em->createQuery($dql)->getResult();
 
         $a2FromDB = array_shift(array_filter($results, function($entity) use ($a2) {
-            return $entity->id === $a2FromDB->id;
+            return $entity->id === $a2->id;
         }));
 
         $this->assertEquals($c->title, $a2FromDB->entityC->title);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -61,7 +61,7 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
             if ($entity->id === $a2->id) {
                 $a2FromDB = $entity;
                 break;
-						}
+            }
         }
 
         $this->assertEquals($c->title, $a2FromDB->entityC->title);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -57,9 +57,12 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $dql = "SELECT a, b, ba, c FROM " . __NAMESPACE__ . "\DDC1514EntityA AS a LEFT JOIN a.entitiesB AS b LEFT JOIN b.entityATo AS ba LEFT JOIN a.entityC AS c";
         $results = $this->_em->createQuery($dql)->getResult();
 
-        $a2FromDB = array_shift(array_filter($results, function($entity) use ($a2) {
-            return $entity->id === $a2->id;
-        }));
+        foreach ($results as $entity) {
+            if ($entity->id === $a2->id) {
+                $a2FromDB = $entity;
+                break;
+						}
+        }
 
         $this->assertEquals($c->title, $a2FromDB->entityC->title);
     }


### PR DESCRIPTION
The problem is that the database will not guarantee entity a2 to be the second ([1]) in the results, because when not specifying an ORDER BY any order of results can not be guaranteed by the database.

This is a partial fix for bug http://www.doctrine-project.org/jira/browse/DDC-2689
