### PR TITLE
[RC][WIP] Retry on MySql deadlock errors

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -805,4 +805,58 @@ class Configuration extends \Doctrine\DBAL\Configuration
             ? $this->_attributes['repositoryFactory']
             : new DefaultRepositoryFactory();
     }
+
+    /**
+     * Set the deadlock retry count value
+     *
+     * @since  2.4
+     * 
+     * @param int $retryCount
+     * 
+     * @return void
+     */
+    public function setDeadlockRetryCount($retryCount)
+    {
+        $this->_attributes['deadlockRetryCount'] = $retryCount;
+    }
+
+    /**
+     * Get the deadlock retry count value
+     *
+     * @since  2.4
+     * @return int
+     */
+    public function getDeadlockRetryCount()
+    {
+        return isset($this->_attributes['deadlockRetryCount'])
+            ? $this->_attributes['deadlockRetryCount']
+            : null;
+    }
+
+    /**
+     * Set the deadlock retry sleep time
+     *
+     * @since  2.4
+     * 
+     * @param float $retryCount
+     * 
+     * @return void
+     */
+    public function setDeadlockRetrySleepTime($sleepTime)
+    {
+        $this->_attributes['deadlockRetrySleepTime'] = $sleepTime;
+    }
+
+    /**
+     * Get the deadlock retry sleep time
+     *
+     * @since  2.4
+     * @return float
+     */
+    public function getDeadlockRetrySleepTime()
+    {
+        return isset($this->_attributes['deadlockRetrySleepTime'])
+            ? $this->_attributes['deadlockRetrySleepTime']
+            : null;
+    }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -328,8 +328,8 @@ class UnitOfWork implements PropertyChangedListener
 
         $conn = $this->em->getConnection();
 
-        $retryCount = $this->em->getConfiguration()->getDeadlockRetryCount() ? $this->em->getConfiguration()->getDeadlockRetryCount() : 1;
-        $retrySleepTime = $this->em->getConfiguration()->getDeadlockRetrySleepTime() ? $this->em->getConfiguration()->getDeadlockRetrySleepTime() : 0;
+        $retryCount = $this->em->getConfiguration()->getDeadlockRetryCount() ?: 1;
+        $retrySleepTime = $this->em->getConfiguration()->getDeadlockRetrySleepTime() ?: 0;
         $currentTryCount = 1;
 
         while ($currentTryCount <= $retryCount) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -327,48 +327,66 @@ class UnitOfWork implements PropertyChangedListener
         $commitOrder = $this->getCommitOrder();
 
         $conn = $this->em->getConnection();
-        $conn->beginTransaction();
 
-        try {
-            if ($this->entityInsertions) {
-                foreach ($commitOrder as $class) {
-                    $this->executeInserts($class);
+        $retryCount = $this->em->getConfiguration()->getDeadlockRetryCount() ? $this->em->getConfiguration()->getDeadlockRetryCount() : 1;
+        $retrySleepTime = $this->em->getConfiguration()->getDeadlockRetrySleepTime() ? $this->em->getConfiguration()->getDeadlockRetrySleepTime() : 0;
+        $currentTryCount = 1;
+
+        while ($currentTryCount <= $retryCount) {
+            $conn->beginTransaction();
+            try {
+                if ($this->entityInsertions) {
+                    foreach ($commitOrder as $class) {
+                        $this->executeInserts($class);
+                    }
                 }
-            }
 
-            if ($this->entityUpdates) {
-                foreach ($commitOrder as $class) {
-                    $this->executeUpdates($class);
+                if ($this->entityUpdates) {
+                    foreach ($commitOrder as $class) {
+                        $this->executeUpdates($class);
+                    }
                 }
-            }
 
-            // Extra updates that were requested by persisters.
-            if ($this->extraUpdates) {
-                $this->executeExtraUpdates();
-            }
-
-            // Collection deletions (deletions of complete collections)
-            foreach ($this->collectionDeletions as $collectionToDelete) {
-                $this->getCollectionPersister($collectionToDelete->getMapping())->delete($collectionToDelete);
-            }
-            // Collection updates (deleteRows, updateRows, insertRows)
-            foreach ($this->collectionUpdates as $collectionToUpdate) {
-                $this->getCollectionPersister($collectionToUpdate->getMapping())->update($collectionToUpdate);
-            }
-
-            // Entity deletions come last and need to be in reverse commit order
-            if ($this->entityDeletions) {
-                for ($count = count($commitOrder), $i = $count - 1; $i >= 0; --$i) {
-                    $this->executeDeletions($commitOrder[$i]);
+                // Extra updates that were requested by persisters.
+                if ($this->extraUpdates) {
+                    $this->executeExtraUpdates();
                 }
+
+                // Collection deletions (deletions of complete collections)
+                foreach ($this->collectionDeletions as $collectionToDelete) {
+                    $this->getCollectionPersister($collectionToDelete->getMapping())->delete($collectionToDelete);
+                }
+                // Collection updates (deleteRows, updateRows, insertRows)
+                foreach ($this->collectionUpdates as $collectionToUpdate) {
+                    $this->getCollectionPersister($collectionToUpdate->getMapping())->update($collectionToUpdate);
+                }
+
+                // Entity deletions come last and need to be in reverse commit order
+                if ($this->entityDeletions) {
+                    for ($count = count($commitOrder), $i = $count - 1; $i >= 0; --$i) {
+                        $this->executeDeletions($commitOrder[$i]);
+                    }
+                }
+
+                $conn->commit();
+
+                break;
+            } catch (Exception $e) {
+                if (strstr($e->getMessage(), '1213 Deadlock found when trying to get lock; try restarting transaction')) {
+                    $currentTryCount++;
+
+                    if ($currentTryCount <= $retryCount) {
+                        $conn->rollback();
+                        sleep($retrySleepTime);
+
+                        continue;
+                    }
+                }
+                $this->em->close();
+                $conn->rollback();
+
+                throw $e;
             }
-
-            $conn->commit();
-        } catch (Exception $e) {
-            $this->em->close();
-            $conn->rollback();
-
-            throw $e;
         }
 
         // Take new snapshots from visited collections


### PR DESCRIPTION
I've done an initial setup of a way to handle MySql deadlocks by retrying the transaction when using em->flush().
I've added 2 configuration variables, one to set how many times to retry and for how long to sleep between each try.

Let me know if this can be merged, is useless or need improvements.
