### PR TITLE
Fix for OptimisticLockingException

### DIFF
--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -73,8 +73,8 @@ class OptimisticLockException extends ORMException
      */
     public static function lockFailedVersionMismatch($entity, $expectedLockVersion, $actualLockVersion)
     {
-        $expectedLockVersion = (is_object($expectedLockVersion) && $expectedLockVersion instanceof \DateTime) ? $expectedLockVersion->getTimestamp() : $expectedLockVersion;
-        $actualLockVersion = (is_object($actualLockVersion) && $actualLockVersion instanceof \DateTime) ? $actualLockVersion->getTimestamp() : $actualLockVersion;
+        $expectedLockVersion = ($expectedLockVersion instanceof \DateTime) ? $expectedLockVersion->getTimestamp() : $expectedLockVersion;
+        $actualLockVersion = ($actualLockVersion instanceof \DateTime) ? $actualLockVersion->getTimestamp() : $actualLockVersion;
         return new self("The optimistic lock failed, version " . $expectedLockVersion . " was expected, but is actually ".$actualLockVersion, $entity);
     }
 

--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -73,6 +73,8 @@ class OptimisticLockException extends ORMException
      */
     public static function lockFailedVersionMismatch($entity, $expectedLockVersion, $actualLockVersion)
     {
+        $expectedLockVersion = (is_object($expectedLockVersion) && $expectedLockVersion instanceof \DateTime) ? $expectedLockVersion->getTimestamp() : $expectedLockVersion;
+        $actualLockVersion = (is_object($actualLockVersion) && $actualLockVersion instanceof \DateTime) ? $actualLockVersion->getTimestamp() : $actualLockVersion;
         return new self("The optimistic lock failed, version " . $expectedLockVersion . " was expected, but is actually ".$actualLockVersion, $entity);
     }
 


### PR DESCRIPTION
When using the $em->lock() method with an entity that uses a DateTime field for optimistic locking, and the optimistic locking fails, an OptimisticLockingException is generated Using the static method lockFailedVersionMismatch in OptimisticLockingException. In this case the parameters are of type DateTime. Therefore, the string for the exception message cannot be generated and you will get an error "Object of class DateTime could not be converted to string". I added a conversion to class to solve this problem.

I also changed the test OptimisticTest to actually test for this problem. If you run the tests without the changed OptimisticLockingException, you will see the error. I also modified the test to ensure that the Exception is actually thrown.
