### PR TITLE
Bugfix for DateTimes and composite IDs.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2469,6 +2469,8 @@ class UnitOfWork implements PropertyChangedListener
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
                     ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
                     : $data[$fieldName];
+                    
+                if($id[$fieldName] instanceof \DateTime) $id[$fieldName] = $id[$fieldName]->format("Y-m-d H:i:s");
             }
 
             $idHash = implode(' ', $id);


### PR DESCRIPTION
The schema tool allows you to make DateTime fields part of composite IDs, but it causes DateTime conversion errors when you try to actually use them.

This can be fixed with the addition of one simple line that converts DateTimes to a string. I'm not able to find any negative effects of this change, and it makes DateTime composite IDs work perfectly.
