### PR TITLE
Options not respected for ID Fields in XML Mapping Driver

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -350,6 +350,7 @@
       <xs:element name="generator" type="orm:generator" minOccurs="0" />
       <xs:element name="sequence-generator" type="orm:sequence-generator" minOccurs="0" maxOccurs="1" />
       <xs:element name="custom-id-generator" type="orm:custom-id-generator" minOccurs="0" maxOccurs="1" />
+      <xs:element name="options" type="orm:options" minOccurs="0" />
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -278,6 +278,10 @@ class XmlDriver extends FileDriver
                 $mapping['columnDefinition'] = (string)$idElement['column-definition'];
             }
 
+            if (isset($idElement->options)) {
+                $mapping['options'] = $this->_parseOptions($idElement->options->children());
+            }
+
             $metadata->mapField($mapping);
 
             if (isset($idElement->generator)) {


### PR DESCRIPTION
Same bug of the YAML driver, see: http://www.doctrine-project.org/jira/browse/DDC-2661
