### PR TITLE
Removed "minimum-stability" : "dev" from composer.json

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -92,8 +92,7 @@ the following contents:
         },
         "autoload": {
             "psr-0": {"": "src/"}
-        },
-        "minimum-stability" : "dev"
+        }
     }
 
 


### PR DESCRIPTION
Now that ORM 2.4 stable is available `"minimum-stability" : "dev"` can be removed from the tutorial.
