### PR TITLE
Clarified tutorial context in section introducing `orm:scehma-tool:*` commands

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -198,10 +198,12 @@ Doctrine command-line tool:
     $ php vendor/bin/doctrine orm:schema-tool:create
 
 At this point no entitiy metadata exists in `src` so you will see a message like 
-"No Metadata Classes to process." — we'll add a Product entity and metadata soon.
+"No Metadata Classes to process." Don't worry, we'll create a Product entity and 
+corresponding metadata in the next section.
 
-You should be aware that during the development process you'll need to keep 
-the database schema in sync with changes to your Entities metadata. 
+You should be aware that during the development process you'll periodically want 
+to synchronize your database schema with your Entities metadata.
+
 You can easily recreate the database:
 
 ::

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -201,8 +201,8 @@ At this point no entitiy metadata exists in `src` so you will see a message like
 "No Metadata Classes to process." Don't worry, we'll create a Product entity and 
 corresponding metadata in the next section.
 
-You should be aware that during the development process you'll periodically want 
-to synchronize your database schema with your Entities metadata.
+You should be aware that during the development process you'll periodically need 
+to update your database schema to be in sync with your Entities metadata.
 
 You can easily recreate the database:
 

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -197,9 +197,12 @@ Doctrine command-line tool:
     $ cd project/
     $ php vendor/bin/doctrine orm:schema-tool:create
 
-During the development you probably need to re-create the database
-several times when changing the Entity metadata. You can then
-either re-create the database:
+At this point no entitiy metadata exists in `src` so you will see a message like 
+"No Metadata Classes to process." — we'll add a Product entity and metadata soon.
+
+You should be aware that during the development process you'll need to keep 
+the database schema in sync with changes to your Entities metadata. 
+You can easily recreate the database:
 
 ::
 


### PR DESCRIPTION
While doing the tutorial I was confused why it suggested running `vendor/bin/doctrine orm:schema-tool:create` when no entities/metadata had been created. I somewhat suspect n00bs are getting tripped up by this too, as evidenced by this S.O. question: http://stackoverflow.com/questions/17473225/doctrine2-no-metadata-classes-to-process
