### PR TITLE
Fixes a Fatal Error when using a subexpression in parenthesis

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1581,6 +1581,10 @@ class SqlWalker implements TreeWalker
                 $sql .= $expr->dispatch($this) . ' AS ' . $columnAlias;
                 break;
 
+            case ($expr instanceof AST\ParenthesisExpression):
+                $sql .= $this->walkParenthesisExpression($expr);
+                break;
+
             default: // IdentificationVariable
                 $sql .= $this->walkEntityIdentificationVariable($expr);
                 break;

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1641,6 +1641,13 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    public function testSupportsParenthesisExpressionInSubSelect() {
+        $this->assertSqlGeneration(
+            'SELECT u.id, (SELECT (1000*SUM(subU.id)/SUM(subU.id)) FROM Doctrine\Tests\Models\CMS\CmsUser subU where subU.id = u.id) AS subSelect FROM Doctrine\Tests\Models\CMS\CmsUser u',
+            'SELECT c0_.id AS id0, (SELECT (1000 * SUM(c1_.id) / SUM(c1_.id)) FROM cms_users c1_ WHERE c1_.id = c0_.id) AS sclr1 FROM cms_users c0_'
+        );
+    }
+
     /**
      * @group DDC-1557
      */


### PR DESCRIPTION
When some dql contains a subselect with expression in parenthesis, the
expression of the $simpleSelectExpression parameter given to
walkSimpleSelectExpression is an instance of AST\ParenthesisExpression.
Before this commit, this case defaulted to
$this->walkEntityIdentificationVariable($expr) where $expr is supposed
to be a string. A fatal error was then yielded.
