### PR TITLE
Added support for field options to FieldBuilder

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -163,9 +163,6 @@ class FieldBuilder
      */
     public function option($name, $value)
     {
-        if ( ! array_key_exists('options', $this->mapping)) {
-            $this->mapping['options'] = array();
-        }
         $this->mapping['options'][$name] = $value;
         return $this;
     }

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -168,18 +168,6 @@ class FieldBuilder
     }
 
     /**
-     * Sets unsigned option.
-     *
-     * @param bool $flag
-     *
-     * @return FieldBuilder
-     */
-    public function unsigned($flag = true)
-    {
-        return $this->option('unsigned', (bool)$flag);
-    }
-
-    /**
      * @param string $strategy
      *
      * @return FieldBuilder

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -163,7 +163,7 @@ class FieldBuilder
      */
     public function option($name, $value)
     {
-        if (!array_key_exists('options', $this->mapping)) {
+        if ( ! array_key_exists('options', $this->mapping)) {
             $this->mapping['options'] = array();
         }
         $this->mapping['options'][$name] = $value;

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -154,6 +154,35 @@ class FieldBuilder
     }
 
     /**
+     * Sets an option.
+     *
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return FieldBuilder
+     */
+    public function option($name, $value)
+    {
+        if (!array_key_exists('options', $this->mapping)) {
+            $this->mapping['options'] = array();
+        }
+        $this->mapping['options'][$name] = $value;
+        return $this;
+    }
+
+    /**
+     * Sets unsigned option.
+     *
+     * @param bool $flag
+     *
+     * @return FieldBuilder
+     */
+    public function unsigned($flag = true)
+    {
+        return $this->option('unsigned', (bool)$flag);
+    }
+
+    /**
      * @param string $strategy
      *
      * @return FieldBuilder

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -174,6 +174,13 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(array('columnName' => 'id', 'fieldName' => 'id', 'id' => true, 'type' => 'integer'), $this->cm->fieldMappings['id']);
     }
 
+    public function testCreateUnsignedOptionField()
+    {
+        $this->builder->createField('state', 'integer')->unsigned()->build();
+
+        $this->assertEquals(array('fieldName' => 'state', 'type' => 'integer', 'options' => array('unsigned' => true), 'columnName' => 'state'), $this->cm->fieldMappings['state']);
+    }
+
     public function testAddLifecycleEvent()
     {
         $this->builder->addLifecycleEvent('getStatus', 'postLoad');

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -176,7 +176,7 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
 
     public function testCreateUnsignedOptionField()
     {
-        $this->builder->createField('state', 'integer')->unsigned()->build();
+        $this->builder->createField('state', 'integer')->option('unsigned', true)->build();
 
         $this->assertEquals(array('fieldName' => 'state', 'type' => 'integer', 'options' => array('unsigned' => true), 'columnName' => 'state'), $this->cm->fieldMappings['state']);
     }


### PR DESCRIPTION
Currently, there is no way of cleanly adding options to mapped fields using the FieldBuilder. This makes it impossible to provide the "unsigned" option using the fluid API.

The current solution is to provide options directly to ClassMetadataInfo::mapField() but, for consistency in my project, I'd like to use the FieldBuilder.

This patch adds two new methods allowing arbitrary options to be mapped to a field, and a shorthand method for enabling the "unsigned" option.

Unit test included.
