### PR TITLE
DDC-2748 DQL expression "in" not working with Collection

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -447,6 +447,7 @@ class Expr
         if ($y instanceof Collection) {
             $y = $y->toArray();
         }
+
         if (is_array($y)) {
             foreach ($y as &$literal) {
                 if ( ! ($literal instanceof Expr\Literal)) {
@@ -454,6 +455,7 @@ class Expr
                 }
             }
         }
+
         return new Expr\Func($x . ' IN', (array) $y);
     }
 
@@ -470,6 +472,7 @@ class Expr
         if ($y instanceof Collection) {
             $y = $y->toArray();
         }
+
         if (is_array($y)) {
             foreach ($y as &$literal) {
                 if ( ! ($literal instanceof Expr\Literal)) {
@@ -477,6 +480,7 @@ class Expr
                 }
             }
         }
+
         return new Expr\Func($x . ' NOT IN', (array) $y);
     }
 

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\Common\Collections\Collection;
+
 /**
  * This class is used to generate DQL expressions via a set of PHP static functions.
 
@@ -442,6 +444,9 @@ class Expr
      */
     public function in($x, $y)
     {
+        if ($y instanceof Collection) {
+            $y = $y->toArray();
+        }
         if (is_array($y)) {
             foreach ($y as &$literal) {
                 if ( ! ($literal instanceof Expr\Literal)) {
@@ -462,6 +467,9 @@ class Expr
      */
     public function notIn($x, $y)
     {
+        if ($y instanceof Collection) {
+            $y = $y->toArray();
+        }
         if (is_array($y)) {
             foreach ($y as &$literal) {
                 if ( ! ($literal instanceof Expr\Literal)) {

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query;
 
@@ -281,6 +282,12 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals("u.type IN('foo', 'bar')", (string) $this->_expr->in('u.type', array('foo', 'bar')));
     }
 
+    public function testInExprWithCollection()
+    {
+        $collection = new ArrayCollection(array(1, 2, 3));
+        $this->assertEquals('u.id IN(1, 2, 3)', (string) $this->_expr->in('u.id', $collection));
+    }
+
     public function testNotInExpr()
     {
         $this->assertEquals('u.id NOT IN(1, 2, 3)', (string) $this->_expr->notIn('u.id', array(1, 2, 3)));
@@ -289,6 +296,12 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     public function testNotInLiteralExpr()
     {
         $this->assertEquals("u.type NOT IN('foo', 'bar')", (string) $this->_expr->notIn('u.type', array('foo', 'bar')));
+    }
+
+    public function testNotInExprWithCollection()
+    {
+        $collection = new ArrayCollection(array(1, 2, 3));
+        $this->assertEquals('u.id NOT IN(1, 2, 3)', (string) $this->_expr->notIn('u.id', $collection));
     }
 
     public function testAndxOrxExpr()


### PR DESCRIPTION
Fix + tests for [DDC-2748](http://www.doctrine-project.org/jira/browse/DDC-2748)

> DQL expression "in" not working with Collection
> Using $qb->expr()->in() with a Collection, will result in an empty array sent.
