### PR TITLE
Prepare to return StatementMock for nullifying DB write during testing

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -12,6 +12,7 @@ class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
      */
     public function prepare($prepareString)
     {
+        return new StatementMock;
     }
 
     /**


### PR DESCRIPTION
I'm attempting to mock the EntityManager so when I run unit tests on my Services, I don't want flush() to actually write to the DB.
I've narrowed down my issue to this file and this line not returning a StatementMock as a normal DriverConnection would return a Statement.
