### PR TITLE
Fixed UnitOfWork::recomputeSingleEntityChangeSet exception with STATE_REMOVED entities

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -878,7 +878,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($entity);
 
-        if ( ! isset($this->entityStates[$oid]) || $this->entityStates[$oid] != self::STATE_MANAGED) {
+        if ( ! isset($this->entityStates[$oid]) || ($this->entityStates[$oid] != self::STATE_MANAGED && $this->entityStates[$oid] != self::STATE_REMOVED)) {
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -184,6 +184,29 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals('Bob', $bob->getName());
     }
 
+    public function testUpdateThenRemoveWithPreUpdateEvent()
+    {
+        $listener = new LifecycleListenerPreUpdate;
+        $this->_em->getEventManager()->addEventListener(array('preUpdate'), $listener);
+
+        $user = new LifecycleCallbackTestUser;
+        $user->setName('Giosh');
+        $user->setValue('value');
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $userId=$user->getId();
+
+        $user->setValue('YetAnotherValue');
+
+        $this->_em->remove($user);
+        $this->_em->flush($user);
+
+        $this->_em->getEventManager()->removeEventListener(array('preUpdate'), $listener);
+
+        $found = $this->_em->find(get_class($user), $userId);
+        $this->assertNull($found);
+    }
+
     /**
     * @group DDC-1955
     */
@@ -200,7 +223,7 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->_em->refresh($e);
-        
+
         $this->_em->remove($e);
         $this->_em->flush();
 
@@ -243,7 +266,7 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
             'Doctrine\ORM\Event\LifecycleEventArgs',
             $e->calls['postUpdateHandler']
         );
- 
+
         $this->assertInstanceOf(
             'Doctrine\ORM\Event\LifecycleEventArgs',
             $e->calls['preRemoveHandler']
@@ -378,7 +401,8 @@ class LifecycleListenerPreUpdate
 {
     public function preUpdate(PreUpdateEventArgs $eventArgs)
     {
-        $eventArgs->setNewValue('name', 'Bob');
+        if( $eventArgs->hasChangedField('name') )
+            $eventArgs->setNewValue('name', 'Bob');
     }
 }
 


### PR DESCRIPTION
Hi!

I found a bug in UnitOfWork::recomputeSingleEntityChangeSet for the branch 2.4. I didn't tested master and previous version, but the bug may also apply.

The problem is that an exception is thrown on flush (at least when using a single entity flush), if an entity is in deleted state and also with pending modification and a preUpdate listener configured.

I've attached a patch and a unit tests (I've tweeked a previous preUpdate method used for testing, but everythings pass).

Anyway, this result in an UPDATE followed by a DELETE statement. I think also that an entity in STATE_REMOVED don't need to be updated, and should be immediately deleted. If you agree, I could implement it myself (as long I manage not to break unit tests).
