### PR TITLE
[DDC-2761] Fixed UnitOfWork::recomputeSingleEntityChangeSet exception with STATE_REMOVED entities

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -878,7 +878,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($entity);
 
-        if ( ! isset($this->entityStates[$oid]) || $this->entityStates[$oid] != self::STATE_MANAGED) {
+        if ( ! isset($this->entityStates[$oid]) || ($this->entityStates[$oid] != self::STATE_MANAGED && $this->entityStates[$oid] != self::STATE_REMOVED)) {
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -878,7 +878,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         $oid = spl_object_hash($entity);
 
-        if ( ! isset($this->entityStates[$oid]) || ($this->entityStates[$oid] != self::STATE_MANAGED && $this->entityStates[$oid] != self::STATE_REMOVED)) {
+        if ( ! isset($this->entityStates[$oid]) || ($this->entityStates[$oid] !== self::STATE_MANAGED && $this->entityStates[$oid] !== self::STATE_REMOVED)) {
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 


### PR DESCRIPTION
Hi!

I found a bug in UnitOfWork::recomputeSingleEntityChangeSet for the branch 2.4, which is also present in master. I didn't tested previous stable versions, but the bug may also apply.

The problem is that an exception is thrown on flush (at least when using a single entity flush), if an entity is in deleted state and also with pending modification and a preUpdate listener configured.

I've attached a patch and a unit tests (I've tweeked a previous preUpdate method used for testing, but everythings pass).

Anyway, this result in an UPDATE followed by a DELETE statement. An entity in STATE_REMOVED shouldn't need to be updated, and should be immediately deleted. If you agree, I could implement this behaviour myself (as long I manage not to break unit tests).

PS: sorry for the commit on the 2.4 branch :)
