### PR TITLE
[DDC-2764] Prefix criteria orderBy with rootAlias

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -48,6 +48,11 @@ class QueryExpressionVisitor extends ExpressionVisitor
     );
 
     /**
+     * @var string
+     */
+    private $rootAlias;
+
+    /**
      * @var Expr
      */
     private $expr;
@@ -58,10 +63,13 @@ class QueryExpressionVisitor extends ExpressionVisitor
     private $parameters = array();
 
     /**
-     * Constructor with internal initialization.
+     * Constructor
+     *
+     * @param string $rootAlias
      */
-    public function __construct()
+    public function __construct($rootAlias)
     {
+        $this->rootAlias = $rootAlias;
         $this->expr = new Expr();
     }
 
@@ -133,38 +141,38 @@ class QueryExpressionVisitor extends ExpressionVisitor
         switch ($comparison->getOperator()) {
             case Comparison::IN:
                 $this->parameters[] = $parameter;
-                return $this->expr->in($comparison->getField(), $placeholder);
+                return $this->expr->in($this->rootAlias . '.' . $comparison->getField(), $placeholder);
 
             case Comparison::NIN:
                 $this->parameters[] = $parameter;
-                return $this->expr->notIn($comparison->getField(), $placeholder);
+                return $this->expr->notIn($this->rootAlias . '.' . $comparison->getField(), $placeholder);
 
             case Comparison::EQ:
             case Comparison::IS:
                 if ($this->walkValue($comparison->getValue()) === null) {
-                    return $this->expr->isNull($comparison->getField());
+                    return $this->expr->isNull($this->rootAlias . '.' . $comparison->getField());
                 }
                 $this->parameters[] = $parameter;
-                return $this->expr->eq($comparison->getField(), $placeholder);
+                return $this->expr->eq($this->rootAlias . '.' . $comparison->getField(), $placeholder);
 
             case Comparison::NEQ:
                 if ($this->walkValue($comparison->getValue()) === null) {
-                    return $this->expr->isNotNull($comparison->getField());
+                    return $this->expr->isNotNull($this->rootAlias . '.' . $comparison->getField());
                 }
                 $this->parameters[] = $parameter;
-                return $this->expr->neq($comparison->getField(), $placeholder);
+                return $this->expr->neq($this->rootAlias . '.' . $comparison->getField(), $placeholder);
 
             case Comparison::CONTAINS:
                 $parameter->setValue('%' . $parameter->getValue() . '%', $parameter->getType());
                 $this->parameters[] = $parameter;
-                return $this->expr->like($comparison->getField(), $placeholder);
+                return $this->expr->like($this->rootAlias . '.' . $comparison->getField(), $placeholder);
 
             default:
                 $operator = self::convertComparisonOperator($comparison->getOperator());
                 if ($operator) {
                     $this->parameters[] = $parameter;
                     return new Expr\Comparison(
-                        $comparison->getField(),
+                        $this->rootAlias . '.' . $comparison->getField(),
                         $operator,
                         $placeholder
                     );

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1096,9 +1096,10 @@ class QueryBuilder
             }
         }
 
+        $rootAlias = $this->getRootAlias();
         if ($criteria->getOrderings()) {
             foreach ($criteria->getOrderings() as $sort => $order) {
-                $this->addOrderBy($this->getRootAlias() . '.' . $sort, $order);
+                $this->addOrderBy($rootAlias . '.' . $sort, $order);
             }
         }
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1098,7 +1098,7 @@ class QueryBuilder
 
         if ($criteria->getOrderings()) {
             foreach ($criteria->getOrderings() as $sort => $order) {
-                $this->addOrderBy($sort, $order);
+                $this->addOrderBy($this->getRootAlias() . '.' . $sort, $order);
             }
         }
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1087,7 +1087,8 @@ class QueryBuilder
      */
     public function addCriteria(Criteria $criteria)
     {
-        $visitor = new QueryExpressionVisitor();
+        $rootAlias = $this->getRootAlias();
+        $visitor = new QueryExpressionVisitor($rootAlias);
 
         if ($whereExpression = $criteria->getWhereExpression()) {
             $this->andWhere($visitor->dispatch($whereExpression));
@@ -1096,7 +1097,6 @@ class QueryBuilder
             }
         }
 
-        $rootAlias = $this->getRootAlias();
         if ($criteria->getOrderings()) {
             foreach ($criteria->getOrderings() as $sort => $order) {
                 $this->addOrderBy($rootAlias . '.' . $sort, $order);

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -47,7 +47,7 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->visitor = new QueryExpressionVisitor();
+        $this->visitor = new QueryExpressionVisitor('o');
     }
 
     /**
@@ -71,24 +71,24 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $qb = new QueryBuilder();
 
         return array(
-            array($cb->eq('field', 'value'), $qb->eq('field', ':field'), new Parameter('field', 'value')),
-            array($cb->neq('field', 'value'), $qb->neq('field', ':field'), new Parameter('field', 'value')),
-            array($cb->eq('field', null), $qb->isNull('field')),
-            array($cb->neq('field', null), $qb->isNotNull('field')),
-            array($cb->isNull('field'), $qb->isNull('field')),
+            array($cb->eq('field', 'value'), $qb->eq('o.field', ':field'), new Parameter('field', 'value')),
+            array($cb->neq('field', 'value'), $qb->neq('o.field', ':field'), new Parameter('field', 'value')),
+            array($cb->eq('field', null), $qb->isNull('o.field')),
+            array($cb->neq('field', null), $qb->isNotNull('o.field')),
+            array($cb->isNull('field'), $qb->isNull('o.field')),
 
-            array($cb->gt('field', 'value'), $qb->gt('field', ':field'), new Parameter('field', 'value')),
-            array($cb->gte('field', 'value'), $qb->gte('field', ':field'), new Parameter('field', 'value')),
-            array($cb->lt('field', 'value'), $qb->lt('field', ':field'), new Parameter('field', 'value')),
-            array($cb->lte('field', 'value'), $qb->lte('field', ':field'), new Parameter('field', 'value')),
+            array($cb->gt('field', 'value'), $qb->gt('o.field', ':field'), new Parameter('field', 'value')),
+            array($cb->gte('field', 'value'), $qb->gte('o.field', ':field'), new Parameter('field', 'value')),
+            array($cb->lt('field', 'value'), $qb->lt('o.field', ':field'), new Parameter('field', 'value')),
+            array($cb->lte('field', 'value'), $qb->lte('o.field', ':field'), new Parameter('field', 'value')),
 
-            array($cb->in('field', array('value')), $qb->in('field', ':field'), new Parameter('field', array('value'))),
-            array($cb->notIn('field', array('value')), $qb->notIn('field', ':field'), new Parameter('field', array('value'))),
+            array($cb->in('field', array('value')), $qb->in('o.field', ':field'), new Parameter('field', array('value'))),
+            array($cb->notIn('field', array('value')), $qb->notIn('o.field', ':field'), new Parameter('field', array('value'))),
 
-            array($cb->contains('field', 'value'), $qb->like('field', ':field'), new Parameter('field', '%value%')),
+            array($cb->contains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')),
 
             // Test parameter conversion
-            array($cb->eq('object.field', 'value'), $qb->eq('object.field', ':object_field'), new Parameter('object_field', 'value')),
+            array($cb->eq('object.field', 'value'), $qb->eq('o.object.field', ':object_field'), new Parameter('object_field', 'value')),
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -414,13 +414,16 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testAddCriteriaOrder()
     {
         $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+
         $criteria = new Criteria();
         $criteria->orderBy(array('field' => Criteria::DESC));
 
         $qb->addCriteria($criteria);
 
         $this->assertCount(1, $orderBy = $qb->getDQLPart('orderBy'));
-        $this->assertEquals('field DESC', (string) $orderBy[0]);
+        $this->assertEquals('u.field DESC', (string) $orderBy[0]);
     }
 
     public function testAddCriteriaLimit()

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -410,7 +410,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
 
         $qb->addCriteria($criteria);
 
-        $this->assertEquals('field = :field', (string) $qb->getDQLPart('where'));
+        $this->assertEquals('u.field = :field', (string) $qb->getDQLPart('where'));
         $this->assertNotNull($qb->getParameter('field'));
     }
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -402,6 +402,9 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testAddCriteriaWhere()
     {
         $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+
         $criteria = new Criteria();
         $criteria->where($criteria->expr()->eq('field', 'value'));
 
@@ -429,6 +432,9 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testAddCriteriaLimit()
     {
         $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+
         $criteria = new Criteria();
         $criteria->setFirstResult(2);
         $criteria->setMaxResults(10);
@@ -442,7 +448,11 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testAddCriteriaUndefinedLimit()
     {
         $qb = $this->_em->createQueryBuilder();
-        $qb->setFirstResult(2)->setMaxResults(10);
+        $qb->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->setFirstResult(2)
+            ->setMaxResults(10);
+
         $criteria = new Criteria();
 
         $qb->addCriteria($criteria);


### PR DESCRIPTION
This fixes DDC-2764 by prefixing the QueryBuilder rootAlias to sortBy criteria.
