### PR TITLE
Fixed ClassMetadataInfo::isCollectionValuedAssociation()

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2666,7 +2666,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function isCollectionValuedAssociation($fieldName)
     {
         return isset($this->associationMappings[$fieldName]) &&
-                ! ($this->associationMappings[$fieldName]['type'] & self::TO_ONE);
+                ! ($this->associationMappings[$fieldName]['type'] & self::TO_MANY);
     }
 
     /**


### PR DESCRIPTION
The method was checking for TO_ONE instead of TO_MANY.
