### PR TITLE
Added "readOnly: true" to YAML reference

### DIFF
--- a/docs/en/reference/yaml-mapping.rst
+++ b/docs/en/reference/yaml-mapping.rst
@@ -73,6 +73,7 @@ of several common elements:
     Doctrine\Tests\ORM\Mapping\User:
       type: entity
       table: cms_users
+      readOnly: true
       indexes:
         name_index:
           columns: [ name ]


### PR DESCRIPTION
The readOnly configuration is documented nowhere except in the annotations reference.

I added it to the example, for a lack of a better place. But at least it will be documented somewhere.

Can you also confirm that this is correct? I'm starting to use it, and I can't find a way to have doctrine validate it is really working. Even with the metadata validation tool, it won't raise an error if I put an invalid entry (`readOnlyFOOBAR: true`) or an invalid value (`readOnly: FOOBAR`), so I'm kind of blind here.
