### PR TITLE
Generate-Entities-Console-Command: Adding an 'avoid backup' flag

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -82,7 +82,7 @@ class GenerateEntitiesCommand extends Command
                 'Defines the number of indentation spaces', 4
             ),
             new InputOption(
-                'nobackup', null, InputOption::VALUE_NONE,
+                'no-backup', null, InputOption::VALUE_NONE,
                 'Flag to define if generator should avoid backuping existing entity file if it exists.'
             )
         ))
@@ -145,7 +145,7 @@ EOT
             $entityGenerator->setRegenerateEntityIfExists($input->getOption('regenerate-entities'));
             $entityGenerator->setUpdateEntityIfExists($input->getOption('update-entities'));
             $entityGenerator->setNumSpaces($input->getOption('num-spaces'));
-            $entityGenerator->setBackupExisting(!$input->getOption('nobackup'));
+            $entityGenerator->setBackupExisting(!$input->getOption('no-backup'));
 
             if (($extend = $input->getOption('extend')) !== null) {
                 $entityGenerator->setClassToExtend($extend);

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -80,6 +80,10 @@ class GenerateEntitiesCommand extends Command
             new InputOption(
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
+            ),
+            new InputOption(
+                'nobackup', null, InputOption::VALUE_NONE,
+                'Flag to define if generator should avoid backuping existing entity file if it exists.'
             )
         ))
         ->setHelp(<<<EOT
@@ -141,6 +145,7 @@ EOT
             $entityGenerator->setRegenerateEntityIfExists($input->getOption('regenerate-entities'));
             $entityGenerator->setUpdateEntityIfExists($input->getOption('update-entities'));
             $entityGenerator->setNumSpaces($input->getOption('num-spaces'));
+            $entityGenerator->setBackupExisting(!$input->getOption('nobackup'));
 
             if (($extend = $input->getOption('extend')) !== null) {
                 $entityGenerator->setClassToExtend($extend);


### PR DESCRIPTION
Introducing a new "avoid creating backup files" flag in the existing command-line options list:

```
$ /console orm:generate-entities src/ --no-backup;
```

Scope: Allowing cli user to avoid the default backup file generation (new `~EntityName.php` file every time),
which is default behavior for now.

= adding only 5 lines to lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php.
