### PR TITLE
Update annotations-reference.rst

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -519,7 +519,7 @@ details of the database join table. If you do not specify
 @JoinTable on these relations reasonable mapping defaults apply
 using the affected table and the column names.
 
-Required attributes:
+Optional attributes:
 
 
 -  **name**: Database name of the join-table


### PR DESCRIPTION
@JoinTable because of mapping defaults does NOT have required attributes. Updated annotations reference to show them as optional.
