### PR TITLE
Enable saving native queries using ResultSetMappingBuilder.

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -345,9 +345,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @return void
      */
-    public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm)
+    public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm, $placeholder = null, $tableAliases = array())
     {
-        $this->_attributes['namedNativeQueries'][$name] = array($sql, $rsm);
+        $this->_attributes['namedNativeQueries'][$name] = array($sql, $rsm, $placeholder, $tableAliases);
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -24,6 +24,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\ORM\Query\FilterCollection;
 use Doctrine\Common\Util\ClassUtils;
@@ -349,7 +350,11 @@ use Doctrine\Common\Util\ClassUtils;
      */
     public function createNamedNativeQuery($name)
     {
-        list($sql, $rsm) = $this->config->getNamedNativeQuery($name);
+        list($sql, $rsm, $placeholder, $tableAliases) = $this->config->getNamedNativeQuery($name);
+        
+        if ($rsm instanceof ResultSetMappingBuilder && !empty($placeholder)) {
+            $sql = str_replace($placeholder, $rsm->generateSelectClause($tableAliases), $sql);
+        }
 
         return $this->createNativeQuery($sql, $rsm);
     }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -61,6 +61,18 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertSame('SELECT foo', $query->getSql());
     }
+    
+    public function testCreateNamedNativeQueryWithResultSetMappingBuilder()
+    {
+        $rsmb = new \Doctrine\ORM\Query\ResultSetMappingBuilder($this->_em);
+        $rsmb->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+        $this->_em->getConfiguration()->addNamedNativeQuery('foo', 'SELECT {SELECTCLAUSE}', $rsmb, '{SELECTCLAUSE}');
+        
+        $query = $this->_em->createNamedNativeQuery('foo');
+        
+        $selectClause = $rsmb->generateSelectClause();
+        $this->assertSame("SELECT {$selectClause}", $query->getSql());
+    }
 
     public function testCreateQueryBuilder()
     {


### PR DESCRIPTION
At present, a useful feature of ResultSetMappingBuilder, which creates the SELECT clause relevant to the built result set mapping, is unusable with named native queries.

This feature adds two additional, optional parameters to named native queries which stores an arbitrary string placeholder and an array of table aliases with the query.

Upon creation of the named native query, if the ResultSetMapping is a ResultSetMappingBuilder, and the placeholder is specified, the arbitrary string specified as the placeholder will be replaced with the output of ResultSetMappingBuilder::generateSelectClause(), passed the table aliases.

This allows native queries to be bootstrapped into an application as named queries, while also allowing the select clause to be automatically updated in the query as the metadata for the mapped entities changes.

Because native queries are not parsed in any way, a string placeholder is required to be able to interpolate the select clause into the query.
