### PR TITLE
Teach orm:validate-schema to --skip-mapping and --skip-sync

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Tools\Console\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\ORM\Tools\SchemaValidator;
 
@@ -45,7 +46,20 @@ class ValidateSchemaCommand extends Command
         $this
         ->setName('orm:validate-schema')
         ->setDescription('Validate the mapping files.')
-        ->setHelp(<<<EOT
+        ->addOption(
+            'skip-mapping',
+            null,
+            InputOption::VALUE_NONE,
+            'Skip the mapping validation check'
+        )
+        ->addOption(
+            'skip-sync',
+            null,
+            InputOption::VALUE_NONE,
+            'Skip checking if the mapping is in sync with the database'
+        )
+        ->setHelp(
+            <<<EOT
 'Validate that the mapping files are correct and in sync with the database.'
 EOT
         );
@@ -57,12 +71,12 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
-
         $validator = new SchemaValidator($em);
-        $errors = $validator->validateMapping();
-
         $exit = 0;
-        if ($errors) {
+
+        if ($input->getOption('skip-mapping')) {
+            $output->writeln('<comment>[Mapping]  Skipped mapping check.</comment>');
+        } elseif ($errors = $validator->validateMapping()) {
             foreach ($errors as $className => $errorMessages) {
                 $output->writeln("<error>[Mapping]  FAIL - The entity-class '" . $className . "' mapping is invalid:</error>");
 
@@ -78,7 +92,9 @@ EOT
             $output->writeln('<info>[Mapping]  OK - The mapping files are correct.</info>');
         }
 
-        if (!$validator->schemaInSyncWithMetadata()) {
+        if ($input->getOption('skip-sync')) {
+            $output->writeln('<comment>[Database] SKIPPED - The database was not checked for synchronicity.</comment>');
+        } elseif (!$validator->schemaInSyncWithMetadata()) {
             $output->writeln('<error>[Database] FAIL - The database schema is not in sync with the current mapping file.</error>');
             $exit += 2;
         } else {


### PR DESCRIPTION
Use --skip-mapping to not check if the current mapping informaiton
is valid or not.

Use --skip-sync to not check if the database schema is in line with
the current schema mapping.
