### PR TITLE
eliminate duplicate placeholders in "walkComparison" function within Que...

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -126,7 +126,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function walkComparison(Comparison $comparison)
     {
-        $parameterName = str_replace('.', '_', $comparison->getField());
+        $parameterName = str_replace('.', '_', $comparison->getField()) . '_' . count($this->parameters);
         $parameter = new Parameter($parameterName, $this->walkValue($comparison->getValue()));
         $placeholder = ':' . $parameterName;
 


### PR DESCRIPTION
...ryExpressionVisitor

I've run into an issue when using Criteria with QueryBuilder when Criteria uses multiple checks on same variable in different context, example:
field1 = value OR (field1 in values AND field2 = true)... what happens is field 1 placeholder is duplicated, and an error occures in code complaining about invalid # of parameters.  The fix eliminates this issue, making sure parametername is unique.

I have not had time to check any other possible issues this may cause, but a review of the code doesn't appear to impact any other function.
