### PR TITLE
Error with Same Field, Multiple Values, Criteria and QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -127,6 +127,12 @@ class QueryExpressionVisitor extends ExpressionVisitor
     public function walkComparison(Comparison $comparison)
     {
         $parameterName = str_replace('.', '_', $comparison->getField());
+        foreach($this->parameters as $parameter) {
+            if($parameter->getName() === $parameterName) {
+                $parameterName .= '_' . count($this->parameters);
+                break;
+            }
+        }
         $parameter = new Parameter($parameterName, $this->walkValue($comparison->getValue()));
         $placeholder = ':' . $parameterName;
 

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -127,12 +127,14 @@ class QueryExpressionVisitor extends ExpressionVisitor
     public function walkComparison(Comparison $comparison)
     {
         $parameterName = str_replace('.', '_', $comparison->getField());
+
         foreach($this->parameters as $parameter) {
             if($parameter->getName() === $parameterName) {
                 $parameterName .= '_' . count($this->parameters);
                 break;
             }
         }
+
         $parameter = new Parameter($parameterName, $this->walkValue($comparison->getValue()));
         $placeholder = ':' . $parameterName;
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -141,7 +141,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a ON u.id = a.author_id'
         );
     }
-    
+
     public function testComplexInnerJoinWithIndexBy()
     {
         $qb = $this->_em->createQueryBuilder()
@@ -153,7 +153,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             $qb,
             'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a INDEX BY a.name ON u.id = a.author_id'
         );
-    }    
+    }
 
     public function testLeftJoin()
     {
@@ -409,6 +409,17 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals('field = :field', (string) $qb->getDQLPart('where'));
         $this->assertNotNull($qb->getParameter('field'));
+    }
+
+    public function testAddMultipleSameCriteriaWhere()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $criteria = new Criteria();
+        $criteria->where($criteria->expr()->andX($criteria->expr()->eq('field', 'value1'), $criteria->expr()->eq('field', 'value2')));
+        $qb->addCriteria($criteria);
+        $this->assertEquals('field = :field AND field = :field_1', (string) $qb->getDQLPart('where'));
+        $this->assertNotNull($qb->getParameter('field'));
+        $this->assertNotNull($qb->getParameter('field_1'));
     }
 
     public function testAddCriteriaOrder()


### PR DESCRIPTION
I just posted another quick patch for this, but after reviewing some of the tests, I realized I needed to change it slightly.  

The bug appeared when using same field for 2 different expression values within Criteria, then adding to QueryBuilder.

This makes sure the parameters are unique, avoiding the issue.

Example of issue:  
Criteria of Field1 = Value1 OR (Field1 = Value2 AND field2 = true) passed to QueryBuilder
In this case, the parameter :Field1 was duplicated, throwing an error on evaluation of DQL.
