### PR TITLE
Fixes column name yaml mapping

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -176,7 +176,7 @@ default.
               length: 140
             postedAt:
               type: datetime
-              name: posted_at
+              column: posted_at
 
 When we don't explicitly specify a column name via the ``name`` option, Doctrine
 assumes the field name is also the column name. This means that:
@@ -391,7 +391,7 @@ besides specifying the sequence's name:
             </id>
           </entity>
         </doctrine-mapping>
- 
+
     .. code-block:: yaml
 
         Message:

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -665,6 +665,10 @@ class YamlDriver extends FileDriver
             }
         }
 
+        if (isset($column['name'])) {
+            $mapping['columnName'] = $column['name'];
+        }
+
         if (isset($column['column'])) {
             $mapping['columnName'] = $column['column'];
         }


### PR DESCRIPTION
Documentation about YAML field column name mapping is wrong:
- the doc says that `name` attribute defines column name;
- the code uses `column` as column name definition attribute.

This PR fixes documentation and adds `name` attribute supports to YAML field mapping.

Note that XML and annotations are using `name` attribute, then I think YAML should use it too. Feel free to tell me if I should remove one of these two commits.
