### PR TITLE
Fix for PHP entity default values generated by EntityGenerator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1116,7 +1116,7 @@ public function __construct()
 
             $lines[] = $this->generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
             $lines[] = $this->spaces . $this->fieldVisibility . ' $' . $fieldMapping['fieldName']
-                     . (isset($fieldMapping['default']) ? ' = ' . var_export($fieldMapping['default'], true) : null) . ";\n";
+                     . (isset($fieldMapping['options']['default']) ? ' = ' . var_export($fieldMapping['options']['default'], true) : null) . ";\n";
         }
 
         return implode("\n", $lines);


### PR DESCRIPTION
When specifying a default value for a column in the YAML, this value should be set in the entities that are generated by the EntityGenerator. The EntityGenerator looked for the default value in the wrong place of the field mapping and therefore defaults were never set. This issue has been fixed in this branch. 
