### PR TITLE
fix relative path to doctrine/common

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -39,7 +39,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
 
     public function testDirectoryAutoload()
     {
-        Setup::registerAutoloadDirectory(__DIR__ . "/../../../../../lib/vendor/doctrine-common/lib");
+        Setup::registerAutoloadDirectory(__DIR__ . "/../../../../../vendor/doctrine/common/lib");
 
         $this->assertEquals($this->originalAutoloaderCount + 2, count(spl_autoload_functions()));
     }


### PR DESCRIPTION
While testing your framework on HHVM I found this test doesn't pass because the path doesn't find what composer was installing into
