### PR TITLE
Fix dependency for tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -20,6 +20,7 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('ecommerce');
+        $this->useModelSet('company');
         parent::setUp();
         $this->_factory = new ProxyFactory(
                 $this->_em,


### PR DESCRIPTION
If this test is run in isolation I get 

```
PDOException: SQLSTATE[HY000]: General error: 1 no such table: company_events
```

because the table isn't made yet. Running the whole suite works because some other test sets up the table.
