### PR TITLE
Mention SQL Anywhere in basic mapping documentation

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -340,15 +340,16 @@ Here is the list of possible generation strategies:
 
 -  ``AUTO`` (default): Tells Doctrine to pick the strategy that is
    preferred by the used database platform. The preferred strategies
-   are IDENTITY for MySQL, SQLite and MsSQL and SEQUENCE for Oracle
-   and PostgreSQL. This strategy provides full portability.
+   are IDENTITY for MySQL, SQLite, MsSQL and SQL Anywhere and SEQUENCE
+   for Oracle and PostgreSQL. This strategy provides full portability.
 -  ``SEQUENCE``: Tells Doctrine to use a database sequence for ID
    generation. This strategy does currently not provide full
-   portability. Sequences are supported by Oracle and PostgreSql.
+   portability. Sequences are supported by Oracle, PostgreSql and
+   SQL Anywhere.
 -  ``IDENTITY``: Tells Doctrine to use special identity columns in
    the database that generate a value on insertion of a row. This
    strategy does currently not provide full portability and is
-   supported by the following platforms: MySQL/SQLite
+   supported by the following platforms: MySQL/SQLite/SQL Anywhere
    (AUTO\_INCREMENT), MSSQL (IDENTITY) and PostgreSQL (SERIAL).
 -  ``TABLE``: Tells Doctrine to use a separate table for ID
    generation. This strategy provides full portability.
@@ -391,7 +392,7 @@ besides specifying the sequence's name:
             </id>
           </entity>
         </doctrine-mapping>
- 
+
     .. code-block:: yaml
 
         Message:


### PR DESCRIPTION
Just for documentation completion of the new SQL Anywhere platform.
