### PR TITLE
The new configuration option: defaultQueryHints

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -168,6 +168,7 @@ abstract class AbstractQuery
     {
         $this->_em          = $em;
         $this->parameters   = new ArrayCollection();
+        $this->_hints       = $em->getConfiguration()->getDefaultQueryHints();
         $this->hasCache     = $this->_em->getConfiguration()->isSecondLevelCacheEnabled();
 
         if ($this->hasCache) {
@@ -300,7 +301,7 @@ abstract class AbstractQuery
     {
         $this->parameters = new ArrayCollection();
 
-        $this->_hints = array();
+        $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
     }
 
     /**
@@ -1090,6 +1091,7 @@ abstract class AbstractQuery
         $this->parameters = new ArrayCollection();
 
         $this->_hints = array();
+        $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
     }
 
     /**

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -900,7 +900,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
-     * Sets a query hint. If the hint name is not recognized, it is silently ignored.
+     * Sets a default query hint. If the hint name is not recognized, it is silently ignored.
      *
      * @since 2.5
      *

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -858,4 +858,57 @@ class Configuration extends \Doctrine\DBAL\Configuration
             ? $this->_attributes['secondLevelCacheConfiguration']
             : null;
     }
+
+    /**
+     * Returns query hints, which will be applied to every query in application
+     *
+     * @since 2.5
+     *
+     * @return array
+     */
+    public function getDefaultQueryHints()
+    {
+        return isset($this->_attributes['defaultQueryHints']) ? $this->_attributes['defaultQueryHints'] : array();
+    }
+
+    /**
+     * Sets array of query hints, which will be applied to every query in application
+     *
+     * @since 2.5
+     *
+     * @param array $defaultQueryHints
+     */
+    public function setDefaultQueryHints(array $defaultQueryHints)
+    {
+        $this->_attributes['defaultQueryHints'] = $defaultQueryHints;
+    }
+
+    /**
+     * Gets the value of a default query hint. If the hint name is not recognized, FALSE is returned.
+     *
+     * @since 2.5
+     *
+     * @param string $name The name of the hint.
+     *
+     * @return mixed The value of the hint or FALSE, if the hint name is not recognized.
+     */
+    public function getDefaultQueryHint($name)
+    {
+        return isset($this->_attributes['defaultQueryHints'][$name])
+            ? $this->_attributes['defaultQueryHints'][$name]
+            : false;
+    }
+
+    /**
+     * Sets a query hint. If the hint name is not recognized, it is silently ignored.
+     *
+     * @since 2.5
+     *
+     * @param string $name  The name of the hint.
+     * @param mixed  $value The value of the hint.
+     */
+    public function setDefaultQueryHint($name, $value)
+    {
+        $this->_attributes['defaultQueryHints'][$name] = $value;
+    }
 }

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -683,7 +683,7 @@ final class Query extends AbstractQuery
         ksort($this->_hints);
 
         return md5(
-            $this->getDql() . var_export($this->_hints, true) .
+            $this->getDql() . serialize($this->_hints) .
             ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
             '&firstResult=' . $this->_firstResult . '&maxResult=' . $this->_maxResults .
             '&hydrationMode='.$this->_hydrationMode.'DOCTRINE_QUERY_CACHE_SALT'

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -5,10 +5,12 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Collections\ArrayCollection;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Query\Parameter;
 
 class QueryTest extends \Doctrine\Tests\OrmTestCase
 {
+    /** @var EntityManager */
     protected $_em = null;
 
     protected function setUp()
@@ -176,5 +178,23 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
             'Doctrine\Tests\Models\CMS\CmsAddress',
             $query->processParameterValue($this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'))
         );
+    }
+
+    public function testDefaultQueryHints()
+    {
+        $config = $this->_em->getConfiguration();
+        $defaultHints = array(
+            'hint_name_1' => 'hint_value_1',
+            'hint_name_2' => 'hint_value_2',
+            'hint_name_3' => 'hint_value_3',
+        );
+
+        $config->setDefaultQueryHints($defaultHints);
+        $query = $this->_em->createQuery();
+        $this->assertSame($config->getDefaultQueryHints(), $query->getHints());
+        $this->_em->getConfiguration()->setDefaultQueryHint('hint_name_1', 'hint_another_value_1');
+        $this->assertNotSame($config->getDefaultQueryHints(), $query->getHints());
+        $q2 = clone $query;
+        $this->assertSame($config->getDefaultQueryHints(), $q2->getHints());
     }
 }


### PR DESCRIPTION
I propose the new configuration option: `defaultQueryHints`, where developer can set array of hints, which will be applied to every query, created by doctrine. This option will be useful to set global AST walker, for example.
