### PR TITLE
Support for MySQL's MyISAM and other non-InnoDB engines in SchemaTool

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
@@ -62,7 +62,8 @@ class CompanySchemaTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $sql = $this->_schemaTool->getDropSchemaSQL(array(
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Company\CompanyManager'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\Company\CompanyCar')
         ));
-        $this->assertEquals(4, count($sql));
+        $this->assertEquals(5, count($sql));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -23,7 +23,7 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail'),
-            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber')
         );
 
         $tool = new SchemaTool($this->_em);
@@ -85,6 +85,18 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(0, count($sql));
     }
 
+    public function testGetCreateSchemaSql5()
+    {
+        $classes = array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\TableInnodb'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\TableMyisam')
+        );
+
+        $tool = new SchemaTool($this->_em);
+        $sql = $tool->getCreateSchemaSql($classes);
+
+        $this->assertEquals(3, count($sql));
+    }
 }
 
 /**
@@ -97,3 +109,25 @@ class MysqlSchemaNamespacedEntity
     public $id;
 }
 
+/**
+ * @Entity
+ */
+class TableInnodb
+{
+    /** @Column(type="integer") @Id @GeneratedValue */
+    public $id;
+    /** @OneToOne(targetEntity="TableInnodb") */
+    public $selfReferencing;
+}
+
+/**
+ * @Entity
+ * @Table(options={"engine"="MyISAM"})
+ */
+class TableMyisam
+{
+    /** @Column(type="integer") @Id @GeneratedValue */
+    public $id;
+    /** @ManyToOne(targetEntity="TableInnodb") */
+    public $tableInnodb;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -28,9 +28,11 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testGetCreateSchemaSql()
     {
         $classes = array(
-            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
-            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber')
         );
 
         $tool = new SchemaTool($this->_em);
@@ -91,9 +93,11 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testGetDropSchemaSql()
     {
         $classes = array(
-            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
-            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail'),
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber')
         );
 
         $tool = new SchemaTool($this->_em);

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -24,6 +24,7 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
+            $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail')
         );
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
@@ -94,6 +95,7 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
+            $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail')
         );
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);


### PR DESCRIPTION
MySQL allows foreign keys only between tables using the InnoDB engine (MyISAM, memory and other engines don't support foreign keys).
This PR delay foreign keys generation after the hydration of all `Table` objects. It enables DBAL to check tables engines before adding foreign keys.

This PR is related to https://github.com/doctrine/dbal/pull/437
