### PR TITLE
XCache cannot be flushed on the CLI -> for pretty much the same reason as APC

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the metadata cache of the various cache drivers.
@@ -87,6 +88,11 @@ EOT
         if ($cacheDriver instanceof ApcCache) {
             throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
+
+        if ($cacheDriver instanceof XcacheCache) {
+            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
+        }
+
 
         $output->writeln('Clearing ALL Metadata cache entries');
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the query cache of the various cache drivers.
@@ -87,7 +88,10 @@ EOT
         if ($cacheDriver instanceof ApcCache) {
             throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
-
+        if ($cacheDriver instanceof XcacheCache) {
+            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
+        }
+        
         $output->write('Clearing ALL Query cache entries' . PHP_EOL);
 
         $result  = $cacheDriver->deleteAll();

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the result cache of the various cache drivers.
@@ -88,6 +89,10 @@ EOT
             throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
 
+        if ($cacheDriver instanceof XcacheCache) {
+            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
+        }
+        
         $output->writeln('Clearing ALL Result cache entries');
 
         $result  = $cacheDriver->deleteAll();


### PR DESCRIPTION
Stumbled upon that when implementing Caching in our project using Symfony2. It's pretty useless in SF2 to e.g. execute the "doctrine:cache:clear-query" since it doesn't clear anything. There are workarounds for that BTW: https://github.com/ornicar/ApcBundle (but it's kinda ugly) + my initial question on stackoverflow: http://stackoverflow.com/questions/20241652/symfony2-flush-xcache-class-cache-on-multiple-instances-on-deployment
