### PR TITLE
Hotfix for DDC-1787

### DIFF
--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -181,6 +181,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
             }
 
+            if ($this->class->isVersioned) {
+                $this->assignDefaultVersionValue($entity, $id);
+            }
+
             // Execute inserts on subtables.
             // The order doesn't matter because all child tables link to the root table via FK.
             foreach ($subTableStmts as $tableName => $stmt) {
@@ -210,10 +214,6 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         foreach ($subTableStmts as $stmt) {
             $stmt->closeCursor();
-        }
-
-        if ($this->class->isVersioned) {
-            $this->assignDefaultVersionValue($entity, $id);
         }
 
         $this->queuedInserts = array();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+/**
+ * @group DDC-1787
+ */
+class DDC1787Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1787Foo'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1787Bar'),
+        ));
+    }
+
+    public function testIssue()
+    {
+        $bar = new DDC1787Bar;
+        $bar2 = new DDC1787Bar;
+
+        $this->_em->persist($bar);
+        $this->_em->persist($bar2);
+        $this->_em->flush();
+
+        $this->assertSame(1, $bar->getVersion());
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"bar" = "DDC1787Bar"})
+ */
+class DDC1787Foo
+{
+    /**
+     * @Id @Column(type="integer") @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @Version @Column(type="integer")
+     */
+    private $version;
+
+    public function getVersion()
+    {
+        return $this->version;
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC1787Bar extends DDC1787Foo
+{
+}


### PR DESCRIPTION
Using joined table inheritance, when persisting multiple new entities
that are subclasses of a baseclass that has the @Version attribute set,
only the last persisted entity will have it's version set.
