### PR TITLE
[DDC-2825] Fix persistence on a table with a schema on a platform without schema support

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1084,6 +1084,7 @@ Optional attributes:
 
 -  **indexes**: Array of @Index annotations
 -  **uniqueConstraints**: Array of @UniqueConstraint annotations.
+-  **schema**: (>= 2.5) Name of the schema the table lies in.
 
 Example:
 
@@ -1095,6 +1096,7 @@ Example:
      * @Table(name="user",
      *      uniqueConstraints={@UniqueConstraint(name="user_unique",columns={"username"})},
      *      indexes={@Index(name="user_idx", columns={"email"})}
+     *      schema="schema_name"
      * )
      */
     class User { }

--- a/docs/en/reference/php-mapping.rst
+++ b/docs/en/reference/php-mapping.rst
@@ -227,6 +227,7 @@ General Getters
 
 
 -  ``getTableName()``
+-  ``getSchemaName()``
 -  ``getTemporaryIdTableName()``
 
 Identifier Getters

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -187,7 +187,7 @@ specified as the ``<entity />`` element as a direct child of the
 .. code-block:: xml
 
     <doctrine-mapping>
-        <entity name="MyProject\User" table="cms_users" repository-class="MyProject\UserRepository">
+        <entity name="MyProject\User" table="cms_users" schema="schema_name" repository-class="MyProject\UserRepository">
             <!-- definition here -->
         </entity>
     </doctrine-mapping>
@@ -211,6 +211,7 @@ Optional attributes:
 -  **read-only** - (>= 2.1) Specifies that this entity is marked as read only and not
    considered for change-tracking. Entities of this type can be persisted
    and removed though.
+-  **schema** - (>= 2.5) The schema the table lies in, for platforms that support schemas
 
 Defining Fields
 ~~~~~~~~~~~~~~~

--- a/docs/en/reference/yaml-mapping.rst
+++ b/docs/en/reference/yaml-mapping.rst
@@ -74,6 +74,7 @@ of several common elements:
       type: entity
       repositoryClass: Doctrine\Tests\ORM\Mapping\UserRepository
       table: cms_users
+      schema: schema_name # The schema the table lies in, for platforms that support schemas (Optional, >= 2.5)
       readOnly: true
       indexes:
         name_index:

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -477,9 +477,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 // Platforms that do not have native IDENTITY support need a sequence to emulate this behaviour.
                 if ($this->targetPlatform->usesSequenceEmulatedIdentityColumns()) {
-                    $columnName   = $class->getSingleIdentifierColumnName();
-                    $quoted       = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
-                    $sequenceName = $this->targetPlatform->getIdentitySequenceName($class->getTableName(), $columnName);
+                    $columnName       = $class->getSingleIdentifierColumnName();
+                    $quoted           = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
+                    $sequencePrefix   = $class->getSequencePrefix($this->targetPlatform);
+
+                    $sequenceName = $this->targetPlatform->getIdentitySequenceName($sequencePrefix, $columnName);
                     $definition   = array(
                         'sequenceName' => $this->targetPlatform->fixSchemaElementName($sequenceName)
                     );
@@ -509,10 +511,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 if ( ! $definition) {
                     $fieldName      = $class->getSingleIdentifierFieldName();
-                    $columnName     = $class->getSingleIdentifierColumnName();
+                    $sequenceName   = $class->getSequenceName($this->targetPlatform);
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
-                    $sequenceName   = $class->getTableName() . '_' . $columnName . '_seq';
-                    $definition     = array(
+
+                    $definition = array(
                         'sequenceName'      => $this->targetPlatform->fixSchemaElementName($sequenceName),
                         'allocationSize'    => 1,
                         'initialValue'      => 1,

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -23,6 +23,7 @@ use BadMethodCallException;
 use InvalidArgumentException;
 use RuntimeException;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use ReflectionClass;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\ClassLoader;
@@ -1997,6 +1998,16 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
+     * Gets primary table's schema name.
+     *
+     * @return string|null
+     */
+    public function getSchemaName()
+    {
+        return isset($this->table['schema']) ? $this->table['schema'] : null;
+    }
+
+    /**
      * Gets the table name to use for temporary identifier tables of this class.
      *
      * @return string
@@ -2223,6 +2234,10 @@ class ClassMetadataInfo implements ClassMetadata
             }
 
             $this->table['name'] = $table['name'];
+        }
+
+        if (isset($table['schema'])) {
+            $this->table['schema'] = $table['schema'];
         }
 
         if (isset($table['indexes'])) {
@@ -3216,5 +3231,48 @@ class ClassMetadataInfo implements ClassMetadata
 
             throw MappingException::duplicateFieldMapping($this->name, $fieldName);
         }
+    }
+
+    /**
+     * Gets the sequence name based on class metadata.
+     *
+     * @param AbstractPlatform $platform
+     * @return string
+     *
+     * @todo Sequence names should be computed in DBAL depending on the platform
+     */
+    public function getSequenceName(AbstractPlatform $platform)
+    {
+        $sequencePrefix = $this->getSequencePrefix($platform);
+
+        $columnName   = $this->getSingleIdentifierColumnName();
+        $sequenceName = $sequencePrefix . '_' . $columnName . '_seq';
+
+        return $sequenceName;
+    }
+
+    /**
+     * Gets the sequence name prefix based on class metadata.
+     *
+     * @param AbstractPlatform $platform
+     * @return string
+     *
+     * @todo Sequence names should be computed in DBAL depending on the platform
+     */
+    public function getSequencePrefix(AbstractPlatform $platform)
+    {
+        $tableName      = $this->getTableName();
+        $sequencePrefix = $tableName;
+
+        // Prepend the schema name to the table name if there is one
+        if ($schemaName = $this->getSchemaName()) {
+            $sequencePrefix = $schemaName . '.' . $tableName;
+
+            if ( ! $platform->supportsSchemas() && $platform->canEmulateSchemas()) {
+                $sequencePrefix = $schemaName . '__' . $tableName;
+            }
+        }
+
+        return $sequencePrefix;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -41,12 +41,24 @@ class DefaultQuoteStrategy implements QuoteStrategy
 
     /**
      * {@inheritdoc}
+     *
+     * @todo Table names should be computed in DBAL depending on the platform
      */
     public function getTableName(ClassMetadata $class, AbstractPlatform $platform)
     {
-        return isset($class->table['quoted']) 
-            ? $platform->quoteIdentifier($class->table['name'])
-            : $class->table['name'];
+        $tableName = $class->table['name'];
+
+        if ( ! empty($class->table['schema'])) {
+            $tableName = $class->table['schema'] . '.' . $class->table['name'];
+
+            if ( ! $platform->supportsSchemas() && $platform->canEmulateSchemas()) {
+                $tableName = $class->table['schema'] . '__' . $class->table['name'];
+            }
+        }
+
+        return isset($class->table['quoted'])
+            ? $platform->quoteIdentifier($tableName)
+            : $tableName;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -94,9 +94,18 @@ class AnnotationDriver extends AbstractAnnotationDriver
         // Evaluate Table annotation
         if (isset($classAnnotations['Doctrine\ORM\Mapping\Table'])) {
             $tableAnnot = $classAnnotations['Doctrine\ORM\Mapping\Table'];
+
+            $tableName  = $tableAnnot->name;
+            $schemaName = $tableAnnot->schema;
+
+            // Split schema and table name from a table name like "myschema.mytable"
+            if (strpos($tableName, '.') !== false) {
+                list($schemaName, $tableName) = explode('.', $tableName);
+            }
+
             $primaryTable = array(
-                'name' => $tableAnnot->name,
-                'schema' => $tableAnnot->schema
+                'name'   => $tableName,
+                'schema' => $schemaName
             );
 
             if ($tableAnnot->indexes !== null) {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -77,8 +77,25 @@ class XmlDriver extends FileDriver
 
         // Evaluate <entity...> attributes
         $table = array();
+
+        $tableName  = null;
+        $schemaName = null;
+
         if (isset($xmlRoot['table'])) {
-            $table['name'] = (string)$xmlRoot['table'];
+            $tableName = (string)$xmlRoot['table'];
+
+            // Split schema and table name from a table name like "myschema.mytable"
+            if (strpos($tableName, '.') !== false) {
+                list($schemaName, $tableName) = explode('.', $tableName);
+            }
+        }
+
+        if (isset($xmlRoot['schema'])) {
+            $schemaName = (string)$xmlRoot['schema'];
+        }
+
+        if (null !== $tableName) {
+            $table['name'] = $tableName;
         }
 
         $metadata->setPrimaryTable($table);
@@ -149,11 +166,6 @@ class XmlDriver extends FileDriver
                 ));
             }
         }
-
-        /* not implemented specially anyway. use table = schema.table
-        if (isset($xmlRoot['schema'])) {
-            $metadata->table['schema'] = (string)$xmlRoot['schema'];
-        }*/
 
         if (isset($xmlRoot['inheritance-type'])) {
             $inheritanceType = (string)$xmlRoot['inheritance-type'];

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -75,8 +75,24 @@ class YamlDriver extends FileDriver
         // Evaluate root level properties
         $table = array();
 
+        $tableName  = null;
+        $schemaName = null;
+
         if (isset($element['table'])) {
-            $table['name'] = $element['table'];
+            $tableName = $element['table'];
+
+            // Split schema and table name from a table name like "myschema.mytable"
+            if (strpos($tableName, '.') !== false) {
+                list($schemaName, $tableName) = explode('.', $tableName);
+            }
+        }
+
+        if (isset($element['schema'])) {
+            $schemaName = $element['schema'];
+        }
+
+        if (null !== $tableName) {
+            $table['name'] = $tableName;
         }
 
         // Evaluate second level cache
@@ -162,11 +178,6 @@ class YamlDriver extends FileDriver
                 ));
             }
         }
-
-        /* not implemented specially anyway. use table = schema.table
-        if (isset($element['schema'])) {
-            $metadata->table['schema'] = $element['schema'];
-        }*/
 
         if (isset($element['inheritanceType'])) {
             $metadata->setInheritanceType(constant('Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_' . strtoupper($element['inheritanceType'])));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+
+/**
+ * This class makes tests on the correct use of a database schema when entities are stored
+ *
+ * @group DDC-2825
+ */
+class DDC2825Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setup()
+    {
+        parent::setup();
+
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+
+        if ( ! $platform->supportsSchemas() && ! $platform->canEmulateSchemas()) {
+            $this->markTestSkipped("This test is only useful for databases that support schemas or can emulate them.");
+        }
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaMyTable'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaMyTable2'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaOrder'),
+        ));
+    }
+
+    public function testIssue()
+    {
+        // Test with a table with a schema
+        $myEntity = new DDC2825MySchemaMyTable();
+
+        $this->_em->persist($myEntity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entities = $this->_em->createQuery('SELECT mt FROM ' . __NAMESPACE__ . '\\DDC2825MySchemaMyTable mt')->execute();
+        $this->assertEquals(count($entities), 1);
+
+        $classMetadata = $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaMyTable');
+        $this->checkClassMetadata($classMetadata, 'myschema', 'mytable');
+
+        // Test with schema defined directly as a table annotation property
+        $myEntity2 = new DDC2825MySchemaMyTable2();
+
+        $this->_em->persist($myEntity2);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entities = $this->_em->createQuery('SELECT mt2 FROM ' . __NAMESPACE__ . '\\DDC2825MySchemaMyTable2 mt2')->execute();
+        $this->assertEquals(count($entities), 1);
+
+        $classMetadata = $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaMyTable2');
+        $this->checkClassMetadata($classMetadata, 'myschema', 'mytable2');
+
+        // Test with a table named "order" (which is a reserved keyword) to make sure the table name is not
+        // incorrectly escaped when a schema is used and that the platform doesn't support schemas
+        $order = new DDC2825MySchemaOrder();
+
+        $this->_em->persist($order);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $classMetadata = $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2825MySchemaOrder');
+        $this->checkClassMetadata($classMetadata, 'myschema', 'order');
+
+        $entities = $this->_em->createQuery('SELECT mso FROM ' . __NAMESPACE__ . '\\DDC2825MySchemaOrder mso')->execute();
+        $this->assertEquals(count($entities), 1);
+    }
+
+    /**
+     * Checks that class metadata is correctly stored when a database schema is used and
+     * checks that the table name is correctly converted whether the platform supports database
+     * schemas or not
+     *
+     * @param  ClassMetadata $classMetadata Class metadata
+     * @param  string $expectedSchemaName   Expected schema name
+     * @param  string $expectedTableName    Expected table name
+     */
+    protected function checkClassMetadata($classMetadata, $expectedSchemaName, $expectedTableName)
+    {
+        $quoteStrategy   = $this->_em->getConfiguration()->getQuoteStrategy();
+        $platform        = $this->_em->getConnection()->getDatabasePlatform();
+        $quotedTableName = $quoteStrategy->getTableName($classMetadata, $platform);
+
+        // Check if table name and schema properties are defined in the class metadata
+        $this->assertEquals($classMetadata->table['name'], $expectedTableName);
+        $this->assertEquals($classMetadata->table['schema'], $expectedSchemaName);
+
+        if ($this->_em->getConnection()->getDatabasePlatform()->supportsSchemas()) {
+            $fullTableName = sprintf('%s.%s', $expectedSchemaName, $expectedTableName);
+        } else {
+            $fullTableName = sprintf('%s__%s', $expectedSchemaName, $expectedTableName);
+        }
+
+        $this->assertEquals($quotedTableName, $fullTableName);
+
+        // Checks sequence name validity
+        $expectedSchemaName = $fullTableName . '_' . $classMetadata->getSingleIdentifierColumnName() . '_seq';
+        $this->assertEquals($expectedSchemaName, $classMetadata->getSequenceName($platform));
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="myschema.mytable")
+ */
+class DDC2825MySchemaMyTable
+{
+    /**
+     * Test with a quoted column name to check that sequence names are
+     * correctly handled
+     *
+     * @Id @GeneratedValue
+     * @Column(name="`number`", type="integer")
+     *
+     * @var integer
+     */
+    public $id;
+}
+
+/**
+ * @Entity
+ * @Table(name="mytable2",schema="myschema")
+ */
+class DDC2825MySchemaMyTable2
+{
+    /**
+     * @Id @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var integer
+     */
+    public $id;
+}
+
+
+/**
+ * @Entity
+ * @Table(name="myschema.order")
+ */
+class DDC2825MySchemaOrder
+{
+    /**
+     * @Id @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var integer
+     */
+    public $id;
+}


### PR DESCRIPTION
This PR solves two related issues with the use of a database schema on platforms (such as SQLite) that don't support schemas.

I discovered the issues when I generated the schema from my Doctrine entities on SQLite (for unit test purposes of my application) whereas my main application uses PostgreSQL.

This is one of my first PR on Doctrine, so sorry if I made some things in the wrong way and I'm open to discussion.

**First problem: table names dots are not converted in the ORM**

On a platform like SQLite, DBAL converts table names with dots (ie. a schema is declared) to double underscores.
However, the ORM doesn't do it, and persisting leads to an exception.

Example:

```
MyNamespace\Mytable:
    type: entity
    table: myschema.mytable
    # ...
```

And then somewhere in the code:

```
$myTable = new MyNamespace\Mytable();
$entityManager->persist($myTable);
$entityManager->flush();
```

This doesn't work in the current version of Doctrine. The table is created as `myschema__mytable` but entities are unsuccessfully saved in `myschema.mytable`.

**Second problem: table names with reserved keywords in a database schema are not correctly escaped**

When a table name is declared as `myschema.order` (or any other reserved keyword), only the reserved keyword part is escaped when creating the table, leading to the creation of a table name like myschema__`order`, which is invalid and therefore fails.

**How this PR solves the problem**

The classmetadata now stores in 2 separated properties the name of the table and the name of the schema. The schema property was partially implemented but I now make a full use of it.

When metadata is read (from Annotations, YAML, ...), if the table name has a dot (`myschema.mytable`), it's splitted into 2 parts, and `myschema` is saved in the `schema` table property, and `mytable` is saved in the `name` table property, instead of storing the whole `myschema.mytable` in the `name` table property.

This allows to do specific things about schemas everywhere in Doctrine, and not splitting again parts everywhere it's needed.

By the way, the `schema` property can now fully be used.

For instance, these 2 YAML configurations are valid and do the same thing:

```
MyNamespace\Mytable:
    type: entity
    table: myschema.mytable
```

and:

```
MyNamespace\Mytable:
    type: entity
    table: mytable
    schema: myschema
```

This was something which was not finished to be implented since Doctrine 2.0.

The Default quote strategy now converts back the schema and table names to a unique table name, depending on the platform (e.g. `myschema.mytable` if the platform supports schemas, and `myschema__mytable` otherwise).

As a result, there is no problem anymore and entities can be persisted without getting any exception.
I added some unit tests for this (the same unit tests failed before of course).

There's however a slight tradeoff on performance, as the `getTableName` of the `DefaultQuoteStrategy` class adds some tests to return the correct table name.

This solved these Doctrine issues: [DDC-2825](http://www.doctrine-project.org/jira/browse/DDC-2825) and [DDC-2636](http://www.doctrine-project.org/jira/browse/DDC-2636).

Again, this is one of my first PRs on Doctrine, so if there's anything wrong or if you have any question, feel free to comment this PR.

@Ocramius This PR is about what we talked about in [DDC-2825](http://www.doctrine-project.org/jira/browse/DDC-2825)
