### PR TITLE
Add an example to doc of YAML mapping

### DIFF
--- a/docs/en/reference/yaml-mapping.rst
+++ b/docs/en/reference/yaml-mapping.rst
@@ -87,6 +87,13 @@ of several common elements:
         name:
           type: string
           length: 50
+        email:
+          type: string
+          length: 32
+          column: user_email
+          unique: true
+          options:
+            fixed: true
       oneToOne:
         address:
           targetEntity: Address


### PR DESCRIPTION
YAML reference documentation is quite poor compared to XML, this PR is to improve a bit the example (based on the XML version).
