### PR TITLE
Allow to not generate extra use

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -202,9 +202,7 @@ class EntityGenerator
 '<?php
 
 <namespace>
-
-use Doctrine\ORM\Mapping as ORM;
-
+<useStatement>
 <entityAnnotation>
 <entityClassName>
 {
@@ -380,6 +378,7 @@ public function __construct()
     {
         $placeHolders = array(
             '<namespace>',
+            '<useStatement>',
             '<entityAnnotation>',
             '<entityClassName>',
             '<entityBody>'
@@ -387,6 +386,7 @@ public function __construct()
 
         $replacements = array(
             $this->generateEntityNamespace($metadata),
+            $this->generateEntityUse(),
             $this->generateEntityDocBlock($metadata),
             $this->generateEntityClassName($metadata),
             $this->generateEntityBody($metadata)
@@ -566,6 +566,15 @@ public function __construct()
     {
         if ($this->hasNamespace($metadata)) {
             return 'namespace ' . $this->getNamespace($metadata) .';';
+        }
+    }
+    
+    protected function generateEntityUse()
+    {
+        if ($this->generateAnnotations) {
+            return "\n".'use Doctrine\ORM\Mapping as ORM;'."\n";
+        } else {
+            return "";
         }
     }
 


### PR DESCRIPTION
For case when we not generate annotation (by default at doctrine orm:generate-entities) allow to not generate extra use for it - 

``` php
use Doctrine\ORM\Mapping as ORM;
```

For example if generate entities for my project that use only dbal in pord but use orm for generate entities in dev mode.
