### PR TITLE
autoGenerate arg from bool to int

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -62,9 +62,9 @@ class ProxyFactory extends AbstractProxyFactory
      * @param \Doctrine\ORM\EntityManager $em           The EntityManager the new factory works for.
      * @param string                      $proxyDir     The directory to use for the proxy classes. It must exist.
      * @param string                      $proxyNs      The namespace to use for the proxy classes.
-     * @param boolean                     $autoGenerate Whether to automatically generate proxy classes.
+     * @param boolean|int                 $autoGenerate Whether to automatically generate proxy classes.
      */
-    public function __construct(EntityManager $em, $proxyDir, $proxyNs, $autoGenerate = false)
+    public function __construct(EntityManager $em, $proxyDir, $proxyNs, $autoGenerate = AbstractProxyFactory :: AUTOGENERATE_NEVER)
     {
         $proxyGenerator = new ProxyGenerator($proxyDir, $proxyNs);
 

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -64,7 +64,7 @@ class ProxyFactory extends AbstractProxyFactory
      * @param string                      $proxyNs      The namespace to use for the proxy classes.
      * @param boolean|int                 $autoGenerate Whether to automatically generate proxy classes.
      */
-    public function __construct(EntityManager $em, $proxyDir, $proxyNs, $autoGenerate = AbstractProxyFactory :: AUTOGENERATE_NEVER)
+    public function __construct(EntityManager $em, $proxyDir, $proxyNs, $autoGenerate = AbstractProxyFactory::AUTOGENERATE_NEVER)
     {
         $proxyGenerator = new ProxyGenerator($proxyDir, $proxyNs);
 

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -10,6 +10,7 @@ use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;
 use Doctrine\Tests\Mocks\DriverMock;
+use Doctrine\Common\Proxy\AbstractProxyFactory;
 
 /**
  * Test the proxy generator. Its work is generating on-the-fly subclasses of a given model, which implement the Proxy pattern.
@@ -47,7 +48,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->emMock = EntityManagerMock::create($this->connectionMock);
         $this->uowMock = new UnitOfWorkMock($this->emMock);
         $this->emMock->setUnitOfWork($this->uowMock);
-        $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', true);
+        $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', AbstractProxyFactory :: AUTOGENERATE_ALWAYS);
     }
 
     public function testReferenceProxyDelegatesLoadingToThePersister()

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -48,7 +48,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->emMock = EntityManagerMock::create($this->connectionMock);
         $this->uowMock = new UnitOfWorkMock($this->emMock);
         $this->emMock->setUnitOfWork($this->uowMock);
-        $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', AbstractProxyFactory :: AUTOGENERATE_ALWAYS);
+        $this->proxyFactory = new ProxyFactory($this->emMock, sys_get_temp_dir(), 'Proxies', AbstractProxyFactory::AUTOGENERATE_ALWAYS);
     }
 
     public function testReferenceProxyDelegatesLoadingToThePersister()


### PR DESCRIPTION
For using all four modes of proxies generation, change the 4th arg of
ProxyFactory's constructor to integer
