### PR TITLE
Ensure <cascade/> elements preceed <join-columns/>

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -260,6 +260,39 @@ class XmlExporter extends AbstractExporter
             if (isset($associationMapping['orphanRemoval']) && $associationMapping['orphanRemoval'] !== false) {
                 $associationMappingXml->addAttribute('orphan-removal', 'true');
             }
+            
+            $cascade = array();
+            if ($associationMapping['isCascadeRemove']) {
+                $cascade[] = 'cascade-remove';
+            }
+
+            if ($associationMapping['isCascadePersist']) {
+                $cascade[] = 'cascade-persist';
+            }
+
+            if ($associationMapping['isCascadeRefresh']) {
+                $cascade[] = 'cascade-refresh';
+            }
+
+            if ($associationMapping['isCascadeMerge']) {
+                $cascade[] = 'cascade-merge';
+            }
+
+            if ($associationMapping['isCascadeDetach']) {
+                $cascade[] = 'cascade-detach';
+            }
+
+            if (count($cascade) === 5) {
+                $cascade  = array('cascade-all');
+            }
+
+            if ($cascade) {
+                $cascadeXml = $associationMappingXml->addChild('cascade');
+
+                foreach ($cascade as $type) {
+                    $cascadeXml->addChild($type);
+                }
+            }
 
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
                 $joinTableXml = $associationMappingXml->addChild('join-table');
@@ -328,39 +361,6 @@ class XmlExporter extends AbstractExporter
                     $orderByFieldXml = $orderByXml->addChild('order-by-field');
                     $orderByFieldXml->addAttribute('name', $name);
                     $orderByFieldXml->addAttribute('direction', $direction);
-                }
-            }
-            $cascade = array();
-
-            if ($associationMapping['isCascadeRemove']) {
-                $cascade[] = 'cascade-remove';
-            }
-
-            if ($associationMapping['isCascadePersist']) {
-                $cascade[] = 'cascade-persist';
-            }
-
-            if ($associationMapping['isCascadeRefresh']) {
-                $cascade[] = 'cascade-refresh';
-            }
-
-            if ($associationMapping['isCascadeMerge']) {
-                $cascade[] = 'cascade-merge';
-            }
-
-            if ($associationMapping['isCascadeDetach']) {
-                $cascade[] = 'cascade-detach';
-            }
-
-            if (count($cascade) === 5) {
-                $cascade  = array('cascade-all');
-            }
-
-            if ($cascade) {
-                $cascadeXml = $associationMappingXml->addChild('cascade');
-
-                foreach ($cascade as $type) {
-                    $cascadeXml->addChild($type);
                 }
             }
         }


### PR DESCRIPTION
When converting annotations based metadata to XML, the position of the `<cascade/>` elements in the generated files resulted in XSD validation errors caused by the definitions of the association ComplexTypes:
- https://github.com/doctrine/doctrine2/blob/master/doctrine-mapping.xsd#L463
- https://github.com/doctrine/doctrine2/blob/master/doctrine-mapping.xsd#L482
- https://github.com/doctrine/doctrine2/blob/master/doctrine-mapping.xsd#L495
- https://github.com/doctrine/doctrine2/blob/master/doctrine-mapping.xsd#L517

Since changing the XSD might result in validation problems in existing mappings, changing the XmlExporter seems a better approach.

Note that the `<cache/>` element is not yet generated by the XmlExporter, but according to the XML Schema, it should precede the `<cascade/>` element.
