### PR TITLE
Add travis build matrix for all built-in PostgreSQL versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,14 @@ php:
 
 env:
   - DB=mysql ENABLE_SECOND_LEVEL_CACHE=1
-  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.1
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.2
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.3
   - DB=sqlite ENABLE_SECOND_LEVEL_CACHE=1
   - DB=mysql ENABLE_SECOND_LEVEL_CACHE=0
-  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.1
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.2
+  - DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.3
   - DB=sqlite ENABLE_SECOND_LEVEL_CACHE=0
 
 before_script:
@@ -19,6 +23,7 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi"
+  - sh -c "if [ '$DB' = 'pgsql' ]; then sudo service postgresql stop; sudo service postgresql start $POSTGRESQL_VERSION; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
   - composer install --prefer-dist --dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,17 @@ matrix:
     - php: hhvm
   exclude:
     - php: hhvm
-      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0  # driver currently unsupported by HHVM
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.1  # driver currently unsupported by HHVM
     - php: hhvm
-      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 # driver currently unsupported by HHVM
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.1 # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.2  # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.2 # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0 POSTGRESQL_VERSION=9.3  # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 POSTGRESQL_VERSION=9.3 # driver currently unsupported by HHVM
     - php: hhvm
       env: DB=mysqli ENABLE_SECOND_LEVEL_CACHE=0  # driver currently unsupported by HHVM
     - php: hhvm


### PR DESCRIPTION
[Travis now ships with PostgreSQL version 9.1, 9.2 and 9.3 built-in](http://about.travis-ci.org/blog/2013-11-29-postgresql-92-93-now-available/). We should extend our build matrix to test on all versions.
