### PR TITLE
Fix connection mock fetchColumn signature

### DIFF
--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -83,7 +83,7 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function fetchColumn($statement, array $params = array(), $colnum = 0)
+    public function fetchColumn($statement, array $params = array(), $colnum = 0, array $types = array())
     {
         return $this->_fetchOneResult;
     }


### PR DESCRIPTION
Fixes `Doctrine\Test\Mocks\ConnectionMock::fetchColumn` signature to be compatible with latest DBAL master branch of `Doctrine\DBAL\Connection` introduced in https://github.com/doctrine/dbal/pull/496
