### PR TITLE
Exclude HHVM + PostgreSQL and HHVM + Mysqli from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,13 @@ after_script:
 matrix:
   allow_failures:
     - php: hhvm
+  exclude:
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=0  # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=pgsql ENABLE_SECOND_LEVEL_CACHE=1 # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=mysqli ENABLE_SECOND_LEVEL_CACHE=0  # driver currently unsupported by HHVM
+    - php: hhvm
+      env: DB=mysqli ENABLE_SECOND_LEVEL_CACHE=1 # driver currently unsupported by HHVM
+


### PR DESCRIPTION
HHVM currently does not support `pdo_pgsql` and `mysqli` drivers and therefore it is useless to test those combinations in the Travis build matrix.
