### PR TITLE
Fix Lifecycle Callbacks

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2550,6 +2550,9 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function addLifecycleCallback($callback, $event)
     {
+        if(isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event]))
+            return;
+
         $this->lifecycleCallbacks[$event][] = $callback;
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2550,8 +2550,9 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function addLifecycleCallback($callback, $event)
     {
-        if(isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event]))
+        if(isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event])) {
             return;
+        }
 
         $this->lifecycleCallbacks[$event][] = $callback;
     }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -466,10 +466,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
         }
 
         // Evaluate @HasLifecycleCallbacks annotation
-        if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks']))
-        {
+        if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks'])) {
             /* @var $method \ReflectionMethod */
-            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method){
+            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
 
                 foreach ($this->getMethodCallbacks($method) as $value) {
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -469,10 +469,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks'])) {
             /* @var $method \ReflectionMethod */
             foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-                // filter for the declaring class only, callbacks from parents will already be registered.
-                if ($method->getDeclaringClass()->name !== $class->name) {
-                    continue;
-                }
 
                 foreach ($this->getMethodCallbacks($method) as $value) {
                     $metadata->addLifecycleCallback($value[0], $value[1]);

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -469,10 +469,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks']))
         {
             /* @var $method \ReflectionMethod */
-            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method)
-            {
-                foreach ($this->getMethodCallbacks($method) as $value)
-                {
+            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method){
+
+                foreach ($this->getMethodCallbacks($method) as $value) {
+
                     $metadata->addLifecycleCallback($value[0], $value[1]);
                 }
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -466,11 +466,13 @@ class AnnotationDriver extends AbstractAnnotationDriver
         }
 
         // Evaluate @HasLifecycleCallbacks annotation
-        if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks'])) {
+        if (isset($classAnnotations['Doctrine\ORM\Mapping\HasLifecycleCallbacks']))
+        {
             /* @var $method \ReflectionMethod */
-            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-
-                foreach ($this->getMethodCallbacks($method) as $value) {
+            foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method)
+            {
+                foreach ($this->getMethodCallbacks($method) as $value)
+                {
                     $metadata->addLifecycleCallback($value[0], $value[1]);
                 }
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -1,13 +1,12 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: gwagner
- * Date: 1/8/14
- * Time: 8:19 PM
- */
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+/**
+ * Class DDC2895Test
+ * @package Doctrine\Tests\ORM\Functional\Ticket
+ * @author http://github.com/gwagner
+ */
 class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gwagner
+ * Date: 1/8/14
+ * Time: 8:19 PM
+ */
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2895'),
+            ));
+        } catch(\Exception $e) {
+
+        }
+    }
+
+    public function testPostLoadOneToManyInheritance()
+    {
+        $cm = $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2895');
+
+        $this->assertEquals(
+            array(
+                "prePersist" => array("setLastModifiedPreUpdate"),
+                "preUpdate" => array("setLastModifiedPreUpdate"),
+            ),
+            $cm->lifecycleCallbacks
+        );
+
+        $ddc2895 = new DDC2895();
+
+        $this->_em->persist($ddc2895);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var DDC2895 $ddc2895 */
+        $ddc2895 = $this->_em->find(get_class($ddc2895), $ddc2895->id);
+
+        $this->assertNotNull($ddc2895->getLastModified());
+
+    }
+}
+
+/**
+ * @MappedSuperclass
+ * @HasLifecycleCallbacks
+ */
+abstract class AbstractDDC2895
+{
+    /**
+     * @Column(name="last_modified", type="datetimetz", nullable=false)
+     * @var \DateTime
+     */
+    protected $lastModified;
+
+    /**
+     * @PrePersist
+     * @PreUpdate
+     */
+    public function setLastModifiedPreUpdate()
+    {
+        $this->setLastModified(new \DateTime());
+    }
+
+    /**
+     * @param \DateTime $lastModified
+     */
+    public function setLastModified( $lastModified )
+    {
+        $this->lastModified = $lastModified;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getLastModified()
+    {
+        return $this->lastModified;
+    }
+}
+
+/**
+ * @Entity
+ * @HasLifecycleCallbacks
+ */
+class DDC2895 extends AbstractDDC2895
+{
+    /** @Id @GeneratedValue @Column(type="integer") */
+    public $id;
+
+    /**
+     * @param mixed $id
+     */
+    public function setId( $id )
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
Remove a bit of code that breaks lifecycle callbacks of parent MappedSuperclasses

Lets say we are working with this code:

``` php
/**
 * @MappedSuperclass
 */
abstract class BaseClass
{
    /**
     * @ORM\Column(name="last_modified", type="datetimetz", nullable=false)
     * @var \DateTime
     */
    protected $lastModified;

    /**
     * @ORM\PrePersist
     * @ORM\PreUpdate
     */
    public function setLastModifiedPreUpdate()
    {
        $this->setLastModified(new \DateTime());
    }

    /**
     * @param \DateTime $lastModified
     */
    public function setLastModified( $lastModified )
    {
        $this->lastModified = $lastModified;
    }

    /**
     * @return \DateTime
     */
    public function getLastModified()
    {
        return $this->lastModified;
    }
}

/**
 * Class MyClass
 *
 * @Entity
 * @HasLifecycleCallbacks
 */
class MyClass extends BaseClass
{
    // Whatever you want in here
}
```

And you want to save MyClass and have it call the Lifecycle callbacks for your BaseClass.  If you leave things they way they are programmed today, the BaseClass will never get its callbacks registered.

By removing the little bit of code there [Lines 472-475], you now get lifecycle callbacks through the entire stack, not just the top most class.
