### PR TITLE
removed erroneous tip

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -1473,8 +1473,6 @@ the previously discussed query functionality in it:
         }
     }
 
-Don't forget to add a `require_once` call for this class to the bootstrap.php
-
 To be able to use this query logic through ``$this->getEntityManager()->getRepository('Bug')``
 we have to adjust the metadata slightly.
 


### PR DESCRIPTION
I'm working through the tutorial myself and got to this point.

**Don’t forget to add a require_once call for this class to the bootstrap.php**

This advice is wrong. The class is located in the src directory and so is autoloaded when required. No require statement is necessary.
