### PR TITLE
Fix DatabaseDriverTest on SQL Server

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 


### PR DESCRIPTION
A missing `use` statement causes `Doctrine\Tests\ORM\Functional\DatabaseDriverTest` to fail.
