### PR TITLE
Avoid PersistentCollection::isEmpty() to fully load the collection.

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -118,7 +118,7 @@ final class PersistentCollection implements Collection, Selectable
      *
      * @param EntityManager $em    The EntityManager the collection will be associated with.
      * @param ClassMetadata $class The class descriptor of the entity type of this collection.
-     * @param array         $coll  The collection elements.
+     * @param Collection    $coll  The collection elements.
      */
     public function __construct(EntityManager $em, $class, $coll)
     {
@@ -599,9 +599,7 @@ final class PersistentCollection implements Collection, Selectable
      */
     public function isEmpty()
     {
-        $this->initialize();
-
-        return $this->coll->isEmpty();
+        return $this->coll->isEmpty() && $this->count() === 0;
     }
 
     /**


### PR DESCRIPTION
This is a suggested simple performance improvement for `PersistentCollection`.

At the moment, `isEmpty()` always fully loads the collection. By changing the code to rely on `count()`, which makes advantage of extra lazy fetch when the collection is not loaded, this saves the overhead of loading the entire collection when one just wants to check whether the collection is empty.
