### PR TITLE
DDC-2931 - one-to-one self-referencing association broken by DCOM-96

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -281,71 +281,6 @@ class ObjectHydrator extends AbstractHydrator
     }
 
     /**
-     * Gets an association entity instance.
-     *
-     * @param array $data
-     * @param string $dqlAlias
-     *
-     * @return object The associated entity.
-     *
-     * @throws HydrationException
-     */
-    private function getAssociatedEntity(array $data, $dqlAlias)
-    {
-        $className = $this->_rsm->aliasMap[$dqlAlias];
-
-        if (isset($this->_rsm->discriminatorColumns[$dqlAlias])) {
-            if ( ! isset($this->_rsm->metaMappings[$this->_rsm->discriminatorColumns[$dqlAlias]])) {
-                throw HydrationException::missingDiscriminatorMetaMappingColumn($className, $this->_rsm->discriminatorColumns[$dqlAlias], $dqlAlias);
-            }
-
-            $discrColumn = $this->_rsm->metaMappings[$this->_rsm->discriminatorColumns[$dqlAlias]];
-
-            if ( ! isset($data[$discrColumn])) {
-                throw HydrationException::missingDiscriminatorColumn($className, $discrColumn, $dqlAlias);
-            }
-
-            if ($data[$discrColumn] === '') {
-                throw HydrationException::emptyDiscriminatorValue($dqlAlias);
-            }
-
-            $className = $this->ce[$className]->discriminatorMap[$data[$discrColumn]];
-
-            unset($data[$discrColumn]);
-        }
-
-        if (isset($this->_hints[Query::HINT_REFRESH_ENTITY]) && isset($this->rootAliases[$dqlAlias])) {
-            $this->registerManaged($this->ce[$className], $this->_hints[Query::HINT_REFRESH_ENTITY], $data);
-        }
-
-        $refresh = $refreshEntity = null;
-
-        if (isset($this->_hints[Query::HINT_REFRESH_ENTITY])) {
-            $refreshEntity = $this->_hints[Query::HINT_REFRESH_ENTITY];
-        }
-
-        if (isset($this->_hints[Query::HINT_REFRESH])) {
-            $refresh = $this->_hints[Query::HINT_REFRESH];
-        }
-
-        unset($this->_hints[Query::HINT_REFRESH_ENTITY], $this->_hints[Query::HINT_REFRESH]);
-
-        $this->_hints['fetchAlias'] = $dqlAlias;
-
-        $entity = $this->_uow->createEntity($className, $data, $this->_hints);
-
-        if (isset($refreshEntity)) {
-            $this->_hints[Query::HINT_REFRESH_ENTITY] = $refreshEntity;
-        }
-
-        if (isset($refresh)) {
-            $this->_hints[Query::HINT_REFRESH] = $refresh;
-        }
-
-        return $entity;
-    }
-
-    /**
      * @param string $className
      * @param array  $data
      *
@@ -505,7 +440,7 @@ class ObjectHydrator extends AbstractHydrator
                                     unset($this->resultPointers[$dqlAlias]);
                                 }
                             } else {
-                                $element = $this->getAssociatedEntity($data, $dqlAlias);
+                                $element = $this->getEntity($data, $dqlAlias);
 
                                 if (isset($this->_rsm->indexByMap[$dqlAlias])) {
                                     $indexValue = $row[$this->_rsm->indexByMap[$dqlAlias]];
@@ -536,7 +471,7 @@ class ObjectHydrator extends AbstractHydrator
                         // we only need to take action if this value is null,
                         // we refresh the entity or its an unitialized proxy.
                         if (isset($nonemptyComponents[$dqlAlias])) {
-                            $element = $this->getAssociatedEntity($data, $dqlAlias);
+                            $element = $this->getEntity($data, $dqlAlias);
                             $reflField->setValue($parentObject, $element);
                             $this->_uow->setOriginalEntityProperty($oid, $relationField, $element);
                             $targetClass = $this->ce[$relation['targetEntity']];

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2514,14 +2514,14 @@ class UnitOfWork implements PropertyChangedListener
                 && isset($hints[Query::HINT_REFRESH_ENTITY])
                 && ($unmanagedProxy = $hints[Query::HINT_REFRESH_ENTITY]) !== $entity
                 && $unmanagedProxy instanceof Proxy
-                && (($unmanagedProxyClass = $this->em->getClassMetadata(get_class($unmanagedProxy))) === $class)
+                && $this->isIdentifierEquals($unmanagedProxy, $entity)
             ) {
                 // DDC-1238 - we have a managed instance, but it isn't the provided one.
                 // Therefore we clear its identifier. Also, we must re-fetch metadata since the
                 // refreshed object may be anything
 
-                foreach ($unmanagedProxyClass->identifier as $fieldName) {
-                    $unmanagedProxyClass->reflFields[$fieldName]->setValue($unmanagedProxy, null);
+                foreach ($class->identifier as $fieldName) {
+                    $class->reflFields[$fieldName]->setValue($unmanagedProxy, null);
                 }
 
                 return $unmanagedProxy;
@@ -3319,5 +3319,38 @@ class UnitOfWork implements PropertyChangedListener
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
         }
+    }
+
+    /**
+     * Verifies if two given entities actually are the same based on identifier comparison
+     *
+     * @param object $entity1
+     * @param object $entity2
+     *
+     * @return bool
+     */
+    private function isIdentifierEquals($entity1, $entity2)
+    {
+        if ($entity1 === $entity2) {
+            return true;
+        }
+
+        $class = $this->em->getClassMetadata(get_class($entity1));
+
+        if ($class !== $this->em->getClassMetadata(get_class($entity2))) {
+            return false;
+        }
+
+        $oid1 = spl_object_hash($entity1);
+        $oid2 = spl_object_hash($entity2);
+
+        $id1 = isset($this->entityIdentifiers[$oid1])
+            ? $this->entityIdentifiers[$oid1]
+            : $this->flattenIdentifier($class, $class->getIdentifierValues($entity1));
+        $id2 = isset($this->entityIdentifiers[$oid2])
+            ? $this->entityIdentifiers[$oid2]
+            : $this->flattenIdentifier($class, $class->getIdentifierValues($entity2));
+
+        return $id1 === $id2 || implode(' ', $id1) === implode(' ', $id2);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 require_once __DIR__ . '/../../../TestInit.php';
 
 /**
@@ -14,154 +12,59 @@ class DDC2931Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
+
         try {
             $this->_schemaTool->createSchema(array(
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2931User'),
             ));
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
+            // no action needed - schema seems to be already in place
         }
     }
 
     public function testIssue()
     {
- 		$first = new DDC2931User(null);
-		$this->_em->persist($first);
+        $first = new DDC2931User();
+        $second = new DDC2931User();
+        $third = new DDC2931User();
 
-		$second = new DDC2931User($first);
-		$this->_em->persist($second);
+        $second->parent = $first;
+        $third->parent  = $second;
 
-		$third = new DDC2931User($second);
-		$this->_em->persist($third);
-		
-		
-		$this->_em->flush();
-		$this->_em->clear();
+        $this->_em->persist($first);
+        $this->_em->persist($second);
+        $this->_em->persist($third);
 
-		// Load Entity in second order
-		$second = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC2931User', $second->getId());
-		// crash here with "Segmentation error" caused by infinite loop. This work correctly with doctrine 2.3 
-		$second->getRank();
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Load Entity in second order
+        $second = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC2931User', $second->id);
+        $this->assertSame(2, $second->getRank());
     }
 }
 
 
-/**
- * @Entity
- */
+/** @Entity */
 class DDC2931User
 {
 
-	/**
-	 * @Id
-	 * @Column(type="integer")
-	 * @GeneratedValue(strategy="AUTO")
-	 */
-	protected $id;
+    /** @Id @Column(type="integer") @GeneratedValue(strategy="AUTO") */
+    public $id;
 
-	/**
-	 *
-	 * @OneToOne(targetEntity="DDC2931User", inversedBy="child")
-	 * @JoinColumn(name="parent_id", referencedColumnName="id", nullable = true)
-	 **/
-	protected $parent;
+    /** @OneToOne(targetEntity="DDC2931User", inversedBy="child") */
+    public $parent;
 
-	/**
-	 * @OneToOne(targetEntity="DDC2931User", mappedBy="parent")
-	 **/
-	protected $child;
+    /** @OneToOne(targetEntity="DDC2931User", mappedBy="parent") */
+    public $child;
 
-
-	/**
-	 * Constructeur.
-	 */
-	public function __construct ($parent = null)
-	{
-		$this->parent = $parent;
-	}
-
-	/**
-	 * Return Rank recursively
-	 * My rank is 1 + rank of my parent
-	 * @return integer
-	 */
-	public function getRank()
-	{
-		if($this->parent == null)
-			return 1;
-		return 1 + $this->parent->getRank();
-	}
-
-	/**
-	 * @return the $id
-	 */
-	public function getId ()
-	{
-		return $this->id;
-	}
-
-	/**
-	 * @return the $parent
-	 */
-	public function getParent ()
-	{
-		return $this->parent;
-	}
-
-
-	/**
-	 * @param integer $id
-	 */
-	public function setId ($id)
-	{
-		$this->id = $id;
-	}
-
-	/**
-	 * @param DDC2931User $parent
-	 */
-	public function setParent ($parent)
-	{
-		$this->parent = $parent;
-	}
-
-
-	/**
-	 * @return the $child
-	 */
-	public function getChild ()
-	{
-		return $this->child;
-	}
-
-	/**
-	 * @param DDC2931User $child
-	 */
-	public function setChild ($child)
-	{
-		$this->child = $child;
-	}
-
-	/**
-	 * Magic getter to expose protected properties.
-	 *
-	 * @param string $property
-	 * @return mixed
-	 */
-	public function __get ($property)
-	{
-		return $this->$property;
-	}
-
-	/**
-	 * Magic setter to save protected properties.
-	 *
-	 * @param string $property
-	 * @param mixed $value
-	 */
-	public function __set ($property, $value)
-	{
-		$this->$property = $value;
-	}
-
+    /**
+     * Return Rank recursively
+     * My rank is 1 + rank of my parent
+     * @return integer
+     */
+    public function getRank()
+    {
+        return 1 + ($this->parent ? $this->parent->getRank() : 0);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -38,8 +38,18 @@ class DDC2931Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
+        // After some debugging, I found that the issue came from
+        // [`UnitOfWork#createEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/UnitOfWork.php#L2512-L2528) with #406 (DCOM-96).
+        // When initializing the proxy for `$first` (during the `DDC2931User#getRank()` call), the ORM attempts to fetch also `$second` again
+        // via [`ObjectHydrator#getEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L280)`,
+        // but the hint `doctrine.refresh.entity` contains the initialized proxy, while the identifier passed down
+        // is the identifier of `$second` (not a proxy).
+        // `UnitOfWork#createQuery` does some comparisons and detects that in fact, the two objects don't correspond,
+        // and therefore marks the entity as "to be detached"
+
         // Load Entity in second order
         $second = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC2931User', $second->id);
+
         $this->assertSame(2, $second->getRank());
     }
 }
@@ -65,6 +75,13 @@ class DDC2931User
      */
     public function getRank()
     {
+        //$id = $this->parent->id;
+        //$hash = spl_object_hash($this);
         return 1 + ($this->parent ? $this->parent->getRank() : 0);
+    }
+
+    public function __wakeup()
+    {
+        echo 'foo';
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -38,16 +38,6 @@ class DDC2931Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        // After some debugging, I found that the issue came from
-        // [`UnitOfWork#createEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/UnitOfWork.php#L2512-L2528) with #406 (DCOM-96).
-        // When initializing the proxy for `$first` (during the `DDC2931User#getRank()` call), the ORM attempts to fetch also `$second` again
-        // via [`ObjectHydrator#getEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L280)`,
-        // but the hint `doctrine.refresh.entity` contains the initialized proxy, while the identifier passed down
-        // is the identifier of `$second` (not a proxy).
-        // `UnitOfWork#createQuery` does some comparisons and detects that in fact, the two objects don't correspond,
-        // and therefore marks the entity as "to be detached"
-
-        // Load Entity in second order
         $second = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC2931User', $second->id);
 
         $this->assertSame(2, $second->getRank());
@@ -75,8 +65,6 @@ class DDC2931User
      */
     public function getRank()
     {
-        //$id = $this->parent->id;
-        //$hash = spl_object_hash($this);
         return 1 + ($this->parent ? $this->parent->getRank() : 0);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+/**
+ * @group DDC-2931
+ */
+class DDC2931Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2931User'),
+            ));
+        } catch(\Exception $e) {
+
+        }
+    }
+
+    public function testIssue()
+    {
+ 		$first = new DDC2931User(null);
+		$this->_em->persist($first);
+
+		$second = new DDC2931User($first);
+		$this->_em->persist($second);
+
+		$third = new DDC2931User($second);
+		$this->_em->persist($third);
+		
+		
+		$this->_em->flush();
+		$this->_em->clear();
+
+		// Load Entity in second order
+		$second = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC2931User', $second->getId());
+		// crash here with "Segmentation error" caused by infinite loop. This work correctly with doctrine 2.3 
+		$second->getRank();
+    }
+}
+
+
+/**
+ * @Entity
+ */
+class DDC2931User
+{
+
+	/**
+	 * @Id
+	 * @Column(type="integer")
+	 * @GeneratedValue(strategy="AUTO")
+	 */
+	protected $id;
+
+	/**
+	 *
+	 * @OneToOne(targetEntity="DDC2931User", inversedBy="child")
+	 * @JoinColumn(name="parent_id", referencedColumnName="id", nullable = true)
+	 **/
+	protected $parent;
+
+	/**
+	 * @OneToOne(targetEntity="DDC2931User", mappedBy="parent")
+	 **/
+	protected $child;
+
+
+	/**
+	 * Constructeur.
+	 */
+	public function __construct ($parent = null)
+	{
+		$this->parent = $parent;
+	}
+
+	/**
+	 * Return Rank recursively
+	 * My rank is 1 + rank of my parent
+	 * @return integer
+	 */
+	public function getRank()
+	{
+		if($this->parent == null)
+			return 1;
+		return 1 + $this->parent->getRank();
+	}
+
+	/**
+	 * @return the $id
+	 */
+	public function getId ()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return the $parent
+	 */
+	public function getParent ()
+	{
+		return $this->parent;
+	}
+
+
+	/**
+	 * @param integer $id
+	 */
+	public function setId ($id)
+	{
+		$this->id = $id;
+	}
+
+	/**
+	 * @param DDC2931User $parent
+	 */
+	public function setParent ($parent)
+	{
+		$this->parent = $parent;
+	}
+
+
+	/**
+	 * @return the $child
+	 */
+	public function getChild ()
+	{
+		return $this->child;
+	}
+
+	/**
+	 * @param DDC2931User $child
+	 */
+	public function setChild ($child)
+	{
+		$this->child = $child;
+	}
+
+	/**
+	 * Magic getter to expose protected properties.
+	 *
+	 * @param string $property
+	 * @return mixed
+	 */
+	public function __get ($property)
+	{
+		return $this->$property;
+	}
+
+	/**
+	 * Magic setter to save protected properties.
+	 *
+	 * @param string $property
+	 * @param mixed $value
+	 */
+	public function __set ($property, $value)
+	{
+		$this->$property = $value;
+	}
+
+}


### PR DESCRIPTION
This is a hotfix for DDC-2931 ( #916 )
### Background

> After some debugging, I found that the issue came from [`UnitOfWork#createEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/UnitOfWork.php#L2512-L2528) with #406 ([DCOM-96](http://www.doctrine-project.org/jira/browse/DCOM-96)).
> 
> When initializing the proxy for `$first` (during the `DDC2931User#getRank()` call), the ORM attempts to fetch also `$second` again via [`ObjectHydrator#getEntity`](https://github.com/doctrine/doctrine2/blob/bba5ec27fbbe35224be48878a0c92827ef2f9733/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L280), but the hint `doctrine.refresh.entity` contains the initialized proxy, while the identifier passed down is the identifier of `$second` (not a proxy).
> 
> `UnitOfWork#createQuery` does some comparisons and detects the fact that the two objects don't correspond, and therefore marks the entity as "to be detached" (since it thinks that the one in the "refresh" hint is the correct entity to load).
