### PR TITLE
Fix use of function in OrderBy

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1466,6 +1466,10 @@ class Parser
 
         switch (true) {
 
+            case ($this->isFunction($peek)):
+                $expr = $this->FunctionDeclaration();
+                break;
+
             case ($this->isMathOperator($peek)):
                 $expr = $this->SimpleArithmeticExpression();
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1838,6 +1838,14 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    public function testOrderByClauseSupportsFunction()
+    {
+        $this->assertSqlGeneration(
+            'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY CONCAT(u.username, u.name) ',
+            'SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3 FROM cms_users c0_ ORDER BY c0_.username || c0_.name ASC'
+        );
+    }
+
     /**
      * @group DDC-1719
      */


### PR DESCRIPTION
This commit adds support for functions (like CONCAT()) in OrderBy.
