### PR TITLE
tests for DDC-2890

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -44,5 +44,21 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
             "SELECT DISTINCT a0_.id AS id0, sum(a0_.name) AS sclr1 FROM Author a0_", $limitQuery->getSql()
         );
     }
+    
+
+    /**
+     * @group DDC-2890
+     */
+    public function testLimitSubqueryWithSortOnAssociation()
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p ORDER BY p.author');
+        $limitQuery = clone $query;
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+
+        $this->assertEquals(
+            "SELECT DISTINCT m0_.id AS id0 FROM MyBlogPost m0_ ORDER BY m0_.author_id ASC", $limitQuery->getSql()
+        );
+    }
 }
 


### PR DESCRIPTION
First error is notice level so I added second test with notices ignored to show actual malformed SQL which will be executed on server ignoring notices.
