### PR TITLE
SingleScalarHydrator reports ambiguous error.

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -43,8 +43,12 @@ class SingleScalarHydrator extends AbstractHydrator
             throw new NoResultException();
         }
 
-        if ($numRows > 1 || count($data[key($data)]) > 1) {
+        if ($numRows > 1) {
             throw new NonUniqueResultException('The query returned multiple rows. Change the query or use a different result function like getScalarResult().');
+        }
+
+        if (count($data[key($data)]) > 1) {
+            throw new NonUniqueResultException('The row contains multiple columns. Change the query or use a different result function like getScalarResult().');
         }
 
         $cache  = array();


### PR DESCRIPTION
In the previous situation there is a combined test (A or B) which result in the same error message. However the error message does not fit with condition B (see code).

Looking at the function description the function should return a **a single scalar value**.

On a side note:
1. it's weird that this method call is used gatherScalarRowData() as it seems to fetch an entire row.
2. there is no function to fetch a single row.
