### PR TITLE
Update create to use LSB

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -829,7 +829,7 @@ use Doctrine\Common\Util\ClassUtils;
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
Updated the create method, to use static, instead of EntityManager, when creating the new instance. This allows users to easily extend EntityManager without having to rewrite the create method or do other tricks in order to get back an instance of their extended class.
