### PR TITLE
s/EntityManager/EntityManagerInterface/ in a few places

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -37,7 +37,7 @@ class EntityManagerHelper extends Helper
     /**
      * Doctrine ORM EntityManager.
      *
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $_em;
 
@@ -46,7 +46,7 @@ class EntityManagerHelper extends Helper
      *
      * @param \Doctrine\ORM\EntityManager $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->_em = $em;
     }

--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -19,8 +19,9 @@
 
 namespace Doctrine\ORM\Tools\Console\Helper;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Helper\Helper;
-use Doctrine\ORM\EntityManager;
+
 
 /**
  * Doctrine CLI Connection Helper.
@@ -35,7 +36,7 @@ use Doctrine\ORM\EntityManager;
 class EntityManagerHelper extends Helper
 {
     /**
-     * Doctrine ORM EntityManager.
+     * Doctrine ORM EntityManagerInterface.
      *
      * @var EntityManagerInterface
      */
@@ -44,7 +45,7 @@ class EntityManagerHelper extends Helper
     /**
      * Constructor.
      *
-     * @param \Doctrine\ORM\EntityManager $em
+     * @param EntityManagerInterface $em
      */
     public function __construct(EntityManagerInterface $em)
     {
@@ -54,7 +55,7 @@ class EntityManagerHelper extends Helper
     /**
      * Retrieves Doctrine ORM EntityManager.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -26,7 +26,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Internal\CommitOrderCalculator;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
@@ -47,7 +47,7 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 class SchemaTool
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
@@ -67,9 +67,9 @@ class SchemaTool
      * Initializes a new SchemaTool instance that uses the connection of the
      * provided EntityManager.
      *
-     * @param \Doctrine\ORM\EntityManager $em
+     * @param \Doctrine\ORM\EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em               = $em;
         $this->platform         = $em->getConnection()->getDatabasePlatform();

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Tools;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\DBAL\Types\Type;
 
@@ -37,14 +37,14 @@ use Doctrine\DBAL\Types\Type;
 class SchemaValidator
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @param EntityManager $em
+     * @param EntityManagerInterface $em
      */
-    public function __construct(EntityManager $em)
+    public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }


### PR DESCRIPTION
This PR makes the constructors to EntityManagerHelper, SchemaTool, and SchemaValidator accept EntityManagerInterface instead of EntityManager.  
