### PR TITLE
Update UnitOfWork.php

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2905,11 +2905,15 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $entity
      *
-     * @return array The identifier values.
+     * @return array The identifier values, or an empty array if no identifiers were found
      */
     public function getEntityIdentifier($entity)
     {
-        return $this->entityIdentifiers[spl_object_hash($entity)];
+        $soh = spl_object_hash($entity);
+        if(!isset($this->entityIdentifiers[$soh])) {
+            return array();
+        }
+        return $this->entityIdentifiers[$soh];
     }
 
     /**


### PR DESCRIPTION
This function can fail to find any entityIdentifiers matching the given spl_object_hash, which causes an undefinedIndex exception. This update detects and prevents the problem, and testing this has caused no unexpected side-effects or problems.
This may occur only when using multiple Doctrine connectors simultaneously.
