### PR TITLE
Transactional callback isn't returning false

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -234,7 +234,7 @@ use Doctrine\Common\Util\ClassUtils;
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
+            return is_null($return) ? true : $return;
         } catch (Exception $e) {
             $this->close();
             $this->conn->rollback();


### PR DESCRIPTION
Trying to fix any situation that if we've something callback with explicit FALSE return, like:

``` php
$rtn = $mgr->transactional(function() {...; return false;});
$rtn //true 
```

Should be the return value of the callback method, 
If the method is not returning any value (null), then.. we consider the callback was done, then return true.

Regards.
