### PR TITLE
Allow overriding getShortName() for discriminator map

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -277,7 +277,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      *
      * @return string
      */
-    private function getShortName($className)
+    protected function getShortName($className)
     {
         if (strpos($className, "\\") === false) {
             return strtolower($className);


### PR DESCRIPTION
This will allow the keys for entries in a generated discriminator map to be customised. E.g. to include namespace

For example, if I had more than one entity with the same name, but used for different purposes, I could customise `getShortName` to include the namespace (or indeed just return the class name with no modifications), which would allow them both to work. 
