### PR TITLE
Extra-lazy for containsKey on collections

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -471,6 +471,13 @@ final class PersistentCollection implements Collection, Selectable
      */
     public function containsKey($key)
     {
+
+        if (! $this->initialized && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY
+            && isset($this->association['indexBy'])) {
+            $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
+
+            return $this->coll->containsKey($key) || $persister->containsKey($this, $key);
+        }
         $this->initialize();
 
         return $this->coll->containsKey($key);
@@ -778,7 +785,7 @@ final class PersistentCollection implements Collection, Selectable
     public function next()
     {
         $this->initialize();
-        
+
         return $this->coll->next();
     }
 

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -349,9 +349,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $associationSourceClass = $this->em->getClassMetadata($mapping['targetEntity']);
             $mapping  = $associationSourceClass->associationMappings[$mapping['mappedBy']];
             $joinColumns = $mapping['joinTable']['joinColumns'];
+            $relationMode = 'relationToTargetKeyColumns';
         } else {
             $joinColumns = $mapping['joinTable']['inverseJoinColumns'];
             $associationSourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);
+            $relationMode = 'relationToSourceKeyColumns';
         }
 
         $quotedJoinTable = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform). ' t';
@@ -375,13 +377,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
-
-
-            if (isset($mapping['relationToTargetKeyColumns'][$joinTableColumn])) {
+            if (isset($mapping[$relationMode][$joinTableColumn])) {
                 $whereClauses[] = 't.' . $joinTableColumn . ' = ?';
                 $params[] = $targetEntity->containsForeignIdentifier
-                 ? $id[$targetEntity->getFieldForColumn($mapping['relationToTargetKeyColumns'][$joinTableColumn])]
-                 : $id[$targetEntity->fieldNames[$mapping['relationToTargetKeyColumns'][$joinTableColumn]]];
+                 ? $id[$targetEntity->getFieldForColumn($mapping[$relationMode][$joinTableColumn])]
+                 : $id[$targetEntity->fieldNames[$mapping[$relationMode][$joinTableColumn]]];
             } elseif (!$joinNeeded) {
                 $whereClauses[] = 't.' . $joinTableColumn . ' = ?';
                 $params[] = $key;

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -364,12 +364,12 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $joinConditions = array();
 
             foreach ($joinColumns as $joinTableColumn) {
-                $joinConditions[] = 't.'.$joinTableColumn['name'].' = tr.'.$joinTableColumn['referencedColumnName'];
+                $joinConditions[] = 't.' . $joinTableColumn['name'] . ' = tr.' . $joinTableColumn['referencedColumnName'];
             }
             $tableName = $this->quoteStrategy->getTableName($targetEntity, $this->platform);
-            $quotedJoinTable .= ' JOIN '. $tableName. ' tr ON '.implode(' AND ', $joinConditions);
+            $quotedJoinTable .= ' JOIN ' . $tableName . ' tr ON ' . implode(' AND ', $joinConditions);
 
-            $whereClauses[] = 'tr.'.$targetEntity->getColumnName($indexBy).' = ?';
+            $whereClauses[] = 'tr.' . $targetEntity->getColumnName($indexBy) . ' = ?';
             $params[] = $key;
 
         }

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -132,6 +132,45 @@ class OneToManyPersister extends AbstractCollectionPersister
      */
     public function count(PersistentCollection $coll)
     {
+        list($quotedJoinTable, $whereClauses, $params) = $this->getJoinTableRestrictions($coll, true);
+
+        $sql = 'SELECT count(*) FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
+
+        return $this->conn->fetchColumn($sql, $params);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function slice(PersistentCollection $coll, $offset, $length = null)
+    {
+        $mapping   = $coll->getMapping();
+        $uow       = $this->em->getUnitOfWork();
+        $persister = $uow->getEntityPersister($mapping['targetEntity']);
+
+        return $persister->getOneToManyCollection($mapping, $coll->getOwner(), $offset, $length);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function containsKey(PersistentCollection $coll, $key)
+    {
+        list($quotedJoinTable, $whereClauses, $params) = $this->getJoinTableRestrictions($coll, true);
+
+        $mapping     = $coll->getMapping();
+        $sourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);
+
+        $whereClauses[] = $sourceClass->getColumnName($mapping['indexBy']) . ' = ?';
+        $params[] = $key;
+
+        $sql = 'SELECT 1 FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
+
+        return (bool) $this->conn->fetchColumn($sql, $params);
+    }
+    
+    private function getJoinTableRestrictions(PersistentCollection $coll, $addFilters)
+    {
         $mapping     = $coll->getMapping();
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
         $sourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);
@@ -149,30 +188,18 @@ class OneToManyPersister extends AbstractCollectionPersister
                 : $id[$sourceClass->fieldNames[$joinColumn['referencedColumnName']]];
         }
 
-        $filterTargetClass = $this->em->getClassMetadata($targetClass->rootEntityName);
-        foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
-            if ($filterExpr = $filter->addFilterConstraint($filterTargetClass, 't')) {
-                $whereClauses[] = '(' . $filterExpr . ')';
+        if ($addFilters) {
+            $filterTargetClass = $this->em->getClassMetadata($targetClass->rootEntityName);
+            foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
+                if ($filterExpr = $filter->addFilterConstraint($filterTargetClass, 't')) {
+                    $whereClauses[] = '(' . $filterExpr . ')';
+                }
             }
         }
 
-        $sql = 'SELECT count(*)'
-             . ' FROM ' . $this->quoteStrategy->getTableName($targetClass, $this->platform) . ' t'
-             . ' WHERE ' . implode(' AND ', $whereClauses);
+        $quotedJoinTable = $this->quoteStrategy->getTableName($targetClass, $this->platform) . ' t';
 
-        return $this->conn->fetchColumn($sql, $params);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function slice(PersistentCollection $coll, $offset, $length = null)
-    {
-        $mapping   = $coll->getMapping();
-        $uow       = $this->em->getUnitOfWork();
-        $persister = $uow->getEntityPersister($mapping['targetEntity']);
-
-        return $persister->getOneToManyCollection($mapping, $coll->getOwner(), $offset, $length);
+        return array($quotedJoinTable, $whereClauses, $params);
     }
 
      /**
@@ -200,7 +227,7 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        $id = current( $uow->getEntityIdentifier($coll->getOwner()));
+        $id = current($uow->getEntityIdentifier($coll->getOwner()));
 
         return $persister->exists($element, array($mapping['mappedBy'] => $id));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/../../TestInit.php';
 class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     private $userId;
+    private $userId2;
     private $groupId;
     private $articleId;
 
@@ -592,7 +593,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testContainsKeyIndexByManyToMany()
     {
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId2);
 
         $group = $this->_em->find('Doctrine\Tests\Models\CMS\CmsGroup', $this->groupId);
 
@@ -606,7 +607,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
     public function testContainsKeyIndexByManyToManyNonOwning()
     {
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId2);
         $group = $this->_em->find('Doctrine\Tests\Models\CMS\CmsGroup', $this->groupId);
 
         $queryCount = $this->getCurrentQueryCount();
@@ -623,7 +624,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $class->associationMappings['groups']['indexBy'] = 'id';
 
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId2);
 
         $queryCount = $this->getCurrentQueryCount();
 
@@ -633,7 +634,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($user->groups->isInitialized(), "The collection must not be initialized");
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
     }
-    public function testContainsKeyIndexByWithPkManyToManyNonOwning()////
+    public function testContainsKeyIndexByWithPkManyToManyNonOwning()
     {
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup');
         $class->associationMappings['users']['indexBy'] = 'id';
@@ -642,7 +643,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $queryCount = $this->getCurrentQueryCount();
 
-        $contains = $group->users->containsKey($this->userId);
+        $contains = $group->users->containsKey($this->userId2);
 
         $this->assertTrue($contains, "The item is not into collection");
         $this->assertFalse($group->users->isInitialized(), "The collection must not be initialized");
@@ -651,7 +652,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testContainsKeyNonExistentIndexByOneToMany()
     {
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId2);
 
         $queryCount = $this->getCurrentQueryCount();
 
@@ -664,7 +665,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testContainsKeyNonExistentIndexByManyToMany()
     {
-        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId2);
 
 
         $queryCount = $this->getCurrentQueryCount();
@@ -753,6 +754,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->articleId = $article1->id;
         $this->userId = $user1->getId();
+        $this->userId2 = $user2->getId();
         $this->groupId = $group1->id;
 
         $this->topic = $article1->topic;

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -758,6 +758,5 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->topic = $article1->topic;
         $this->phonenumber = $phonenumber1->phonenumber;
 
-
     }
 }


### PR DESCRIPTION
If an association is EXTRA_LAZY and has an indexBy, then
you can call containsKey() without loading the entire collection.
