### PR TITLE
Missing join-tables added in example

### DIFF
--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -41,7 +41,7 @@ information about its type and if it's the owning or inverse side.
         /**
          * Bidirectional - Many users have Many favorite comments (OWNING SIDE)
          *
-         * @ManyToMany(targetEntity="Comment", inversedBy="userFavorites")   
+         * @ManyToMany(targetEntity="Comment", inversedBy="userFavorites")
          * @JoinTable(name="user_favorite_comments")
          */
         private $favorites;
@@ -49,7 +49,7 @@ information about its type and if it's the owning or inverse side.
         /**
          * Unidirectional - Many users have marked many comments as read
          *
-         * @ManyToMany(targetEntity="Comment")    
+         * @ManyToMany(targetEntity="Comment")
          * @JoinTable(name="user_read_comments")
          */
         private $commentsRead;

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -41,14 +41,16 @@ information about its type and if it's the owning or inverse side.
         /**
          * Bidirectional - Many users have Many favorite comments (OWNING SIDE)
          *
-         * @ManyToMany(targetEntity="Comment", inversedBy="userFavorites")
+         * @ManyToMany(targetEntity="Comment", inversedBy="userFavorites")   
+         * @JoinTable(name="user_favorite_comments")
          */
         private $favorites;
     
         /**
          * Unidirectional - Many users have marked many comments as read
          *
-         * @ManyToMany(targetEntity="Comment")
+         * @ManyToMany(targetEntity="Comment")    
+         * @JoinTable(name="user_read_comments")
          */
         private $commentsRead;
     


### PR DESCRIPTION
There are 2 many-to-may associations between the users and comments. Both use another join-table. The join-tables user_favorite_comments and user_read_comments must be specified. Otherwise the default "user_comment" is taken twice, resulting in an error. 

See https://groups.google.com/forum/#!topic/doctrine-user/Kti36_n6490 and https://groups.google.com/forum/#!topic/doctrine-user/TYwafhgYiSU
