### PR TITLE
Validate embeddables do not contain other embeddables.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3162,6 +3162,10 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function mapEmbedded(array $mapping)
     {
+        if ($this->isEmbeddedClass) {
+            throw MappingException::noEmbeddablesInEmbeddable($this->name);
+        }
+
         $this->assertFieldNotMapped($mapping['fieldName']);
 
         $this->embeddedClasses[$mapping['fieldName']] = array(

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -781,4 +781,12 @@ class MappingException extends \Doctrine\ORM\ORMException
             sprintf('Missing "sequenceName" attribute for sequence id generator definition on class "%s".', $className)
         );
     }
+
+    public static function noEmbeddablesInEmbeddable($className)
+    {
+        return new self(sprintf(
+            "You embedded one or more embeddables in embeddable '%s', but this behavior is currently unsupported.",
+            $className
+        ));
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -162,6 +162,23 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $reloadedCar = $this->_em->find(__NAMESPACE__.'\\DDC93Car', $car->id);
         $this->assertEquals($car, $reloadedCar);
     }
+
+    public function testEmbeddableWithinEmbeddable()
+    {
+        $this->setExpectedException(
+            'Doctrine\ORM\Mapping\MappingException',
+            sprintf(
+                "You embedded one or more embeddables in embeddable '%s', but this behavior is currently unsupported.",
+                __NAMESPACE__ . '\DDC93ContactInfo'
+            )
+        );
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93Customer'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93ContactInfo'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93PhoneNumber')
+        ));
+    }
 }
 
 /**
@@ -263,3 +280,19 @@ class DDC93Address
     }
 }
 
+/** @Entity */
+class DDC93Customer
+{
+    /** @Id @GeneratedValue @Column(type="integer") */
+    private $id;
+
+    /** @Embedded(class = "DDC93ContactInfo", columnPrefix = "contact_info_") */
+    private $contactInfo;
+}
+
+/** @Embeddable */
+class DDC93ContactInfo
+{
+    /** @Embedded(class = "DDC93Address") */
+    private $address;
+}


### PR DESCRIPTION
Throw a `MappingException` during the metadata loading when it encounters an embeddable that contains other embeddables.
