### PR TITLE
Update UnitOfWork.php

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -634,7 +634,7 @@ class UnitOfWork implements PropertyChangedListener
                 $orgValue = $originalData[$propName];
 
                 // skip if value haven't changed
-                if ($orgValue === $actualValue) {
+                if ($orgValue == $actualValue) {
                     continue;
                 }
 


### PR DESCRIPTION
For datetime objects the comparison doesn't work ex:
 array (size=2)
      0 => 
        object(DateTime)[990]
          public 'date' => string '2007-10-25 00:00:00' (length=19)
          public 'timezone_type' => int 3
          public 'timezone' => string 'Europe/Luxembourg' (length=17)
      1 => 
        object(DateTime)[1876]
          public 'date' => string '2007-10-25 00:00:00' (length=19)
          public 'timezone_type' => int 3
          public 'timezone' => string 'Europe/Luxembourg' (length=17)

it's the same date but the scrict comparison make the original value is different of the actual value.
