### PR TITLE
Add a default lock mode to the EntityManager

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -924,4 +924,29 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         $this->_attributes['defaultQueryHints'][$name] = $value;
     }
+
+    /**
+     * Sets the default lock mode for all queries that do not specify one.
+     *
+     * Note that it does not make sense to use LockMode::OPTIMISTIC as a default, as it requires a lock version.
+     * Also note that native queries are not affected by this setting.
+     *
+     * @param integer|null $lockMode One of the Doctrine\DBAL\LockMode constants, or null to remove the default.
+     *
+     * @return void
+     */
+    public function setDefaultLockMode($lockMode)
+    {
+        $this->_attributes['defaultLockMode'] = $lockMode;
+    }
+
+    /**
+     * Returns the default lock mode for all queries that do not specify one.
+     *
+     * @return integer|null The lock mode, or null if no default is specified.
+     */
+    public function getDefaultLockMode()
+    {
+        return isset($this->_attributes['defaultLockMode']) ? $this->_attributes['defaultLockMode'] : null;
+    }
 }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1057,6 +1057,10 @@ class BasicEntityPersister implements EntityPersister
             ? $this->getSelectConditionCriteriaSQL($criteria)
             : $this->getSelectConditionSQL($criteria, $assoc);
 
+        if ($lockMode === null) {
+            $lockMode = $this->em->getConfiguration()->getDefaultLockMode();
+        }
+
         switch ($lockMode) {
             case LockMode::PESSIMISTIC_READ:
                 $lockSql = ' ' . $this->platform->getReadLockSql();

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -101,7 +101,7 @@ class SqlWalker implements TreeWalker
     private $conn;
 
     /**
-     * @var \Doctrine\ORM\AbstractQuery
+     * @var \Doctrine\ORM\Query
      */
     private $query;
 
@@ -175,7 +175,9 @@ class SqlWalker implements TreeWalker
     private $quoteStrategy;
 
     /**
-     * {@inheritDoc}
+     * @param \Doctrine\ORM\Query              $query           The parsed Query.
+     * @param \Doctrine\ORM\Query\ParserResult $parserResult    The result of the parsing process.
+     * @param array                            $queryComponents The query components (symbol table).
      */
     public function __construct($query, $parserResult, array $queryComponents)
     {
@@ -517,7 +519,7 @@ class SqlWalker implements TreeWalker
     {
         $limit    = $this->query->getMaxResults();
         $offset   = $this->query->getFirstResult();
-        $lockMode = $this->query->getHint(Query::HINT_LOCK_MODE);
+        $lockMode = $this->getQueryLockMode();
         $sql      = $this->walkSelectClause($AST->selectClause)
             . $this->walkFromClause($AST->fromClause)
             . $this->walkWhereClause($AST->whereClause);
@@ -881,7 +883,7 @@ class SqlWalker implements TreeWalker
         $sql = $this->platform->appendLockHint(
             $this->quoteStrategy->getTableName($class, $this->platform) . ' ' .
             $this->getSQLTableAlias($class->getTableName(), $dqlAlias),
-            $this->query->getHint(Query::HINT_LOCK_MODE)
+            $this->getQueryLockMode()
         );
 
         if ($class->isInheritanceTypeJoined()) {
@@ -2316,5 +2318,23 @@ class SqlWalker implements TreeWalker
         }
 
         return $resultAlias;
+    }
+
+    /**
+     * Returns the lock mode to use for the given query.
+     *
+     * If no lock mode is specified on the query, the default lock mode is returned instead.
+     *
+     * @return integer|null The lock mode, or null if not specified.
+     */
+    private function getQueryLockMode()
+    {
+        $lockMode = $this->query->getLockMode();
+
+        if ($lockMode === null) {
+            return $this->em->getConfiguration()->getDefaultLockMode();
+        }
+
+        return $lockMode;
     }
 }

--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -8,11 +8,18 @@ namespace Doctrine\Tests\Mocks;
 class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
 {
     /**
+     * @var string
+     */
+    private $lastPreparedStatementSql = '';
+
+    /**
      * {@inheritdoc}
      */
     public function prepare($prepareString)
     {
-        return new StatementMock();
+        $this->lastPreparedStatementSql = $prepareString;
+
+        return new StatementMock;
     }
 
     /**
@@ -77,5 +84,15 @@ class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
      */
     public function errorInfo()
     {
+    }
+
+    /* Mock API */
+
+    /**
+     * @return string
+     */
+    public function getLastPreparedStatementSql()
+    {
+        return $this->lastPreparedStatementSql;
     }
 }

--- a/tests/Doctrine/Tests/Models/Taxi/Car.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Car.php
@@ -44,4 +44,9 @@ class Car
     {
         $this->model = $model;
     }
+
+    public function getCarRides()
+    {
+        return $this->carRides;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/DefaultLockModeTest.php
+++ b/tests/Doctrine/Tests/ORM/DefaultLockModeTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\Tests\OrmTestCase;
+
+require_once __DIR__ . '/../TestInit.php';
+
+/**
+ * Tests that the default lock mode is correctly applied on all queries.
+ */
+class DefaultLockModeTest extends OrmTestCase
+{
+    const ENTITY_CLASS = 'Doctrine\Tests\Models\Taxi\Car';
+    const DQL_QUERY    = 'SELECT c FROM Doctrine\Tests\Models\Taxi\Car c WHERE c.brand = :brand';
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $em;
+
+    /**
+     * @var \Doctrine\ORM\Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var \Doctrine\Tests\Mocks\DriverConnectionMock
+     */
+    private $driverConnection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->em = $this->_getTestEntityManager();
+        $this->configuration = $this->em->getConfiguration();
+        $this->driverConnection = $this->em->getConnection()->getWrappedConnection();
+        $this->em->beginTransaction();
+    }
+
+    /**
+     * @param boolean     $hasLock Whether the SQL query should have a pessimistic lock.
+     * @param string|null $query   The SQL query, or null to use the last prepared statement SQL.
+     */
+    private function assertQueryHasLock($hasLock, $query = null)
+    {
+        if ($query === null) {
+            $query = $this->driverConnection->getLastPreparedStatementSql();
+        }
+
+        $this->assertStringEndsWith($hasLock ? ' FOR UPDATE' : ' = ?', $query);
+    }
+
+    public function testNewEntityManagerHasNoDefaultLockMode()
+    {
+        $this->assertNull($this->configuration->getDefaultLockMode());
+    }
+
+    public function testSetAndGetDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $this->assertSame(LockMode::PESSIMISTIC_WRITE, $this->configuration->getDefaultLockMode());
+    }
+
+    public function testEntityManagerFindUsesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $this->em->find(self::ENTITY_CLASS, '');
+        $this->assertQueryHasLock(true);
+    }
+
+    public function testEntityManagerFindWithLockModeOverridesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $this->em->find(self::ENTITY_CLASS, '', LockMode::NONE);
+        $this->assertQueryHasLock(false);
+    }
+
+    public function testEntityRepositoryFindByUsesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $this->em->getRepository(self::ENTITY_CLASS)->findBy(array('model' => 'model'));
+        $this->assertQueryHasLock(true);
+    }
+
+    public function testDqlQueryUsesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $query = $this->em->createQuery(self::DQL_QUERY);
+        $query->setParameter('brand', 'brand');
+        $this->assertQueryHasLock(true, $query->getSQL());
+    }
+
+    public function testDqlQueryWithLockModeOverridesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $query = $this->em->createQuery(self::DQL_QUERY);
+        $query->setParameter('brand', 'brand');
+        $query->setLockMode(LockMode::NONE);
+        $this->assertQueryHasLock(false, $query->getSQL());
+    }
+
+    public function testProxyUsesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $proxy = $this->em->getReference(self::ENTITY_CLASS, 1);
+        try {
+            $proxy->__load();
+        } catch (EntityNotFoundException $e) {
+            // The entity is expected not to be found.
+        }
+        $this->assertQueryHasLock(true);
+    }
+
+    public function testLazyLoadedCollectionUsesDefaultLockMode()
+    {
+        $this->configuration->setDefaultLockMode(LockMode::PESSIMISTIC_WRITE);
+        $entity = $this->em->getUnitOfWork()->createEntity(self::ENTITY_CLASS, array(
+            'brand' => 'brand',
+            'model' => 'model'
+        ));
+        $entity->getCarRides()->toArray();
+        $this->assertQueryHasLock(true);
+    }
+}


### PR DESCRIPTION
Following [this discussion](https://groups.google.com/forum/#!topic/doctrine-dev/xKGzQcDkilE) on the mailing list, this proposal introduces a default lock mode for all entities loaded through an EntityManager.

At the moment, there is no way to set a lock mode for the following use cases:
- Proxies obtained through `getReference()` and then initialized
- Entities lazy-loaded through traversal of associations

This proposal introduces the idea of a _default_ lock mode, which can be set at runtime when all reads in a transaction should be locking.

It works this way:

```
$transaction = $em->createTransaction()
    ->withDefaultLockMode(LockMode::PESSIMISTIC_WRITE)
    ->begin();

// load entities from EntityManager, Repositories or DQL, traverse associations, etc.
// all these entities will be loaded with the given lock mode

$transaction->commit();
```

I have successfully tested it with the following use cases:
- `EntityManager::find()`
- `EntityRepository::findBy()`
- DQL queries
- Proxies
- Lazy-loaded collections through OneToMany and ManyToMany associations

Happily waiting for your feedback!
