### PR TITLE
Can cache empty collections

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -508,7 +508,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
         $list = $this->persister->loadManyToManyCollection($assoc, $sourceEntity, $coll);
 
-        if ($hasCache && ! empty($list)) {
+        if ($hasCache) {
             $persister->storeCollectionCache($key, $list);
 
             if ($this->cacheLogger) {

--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -543,7 +543,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
         $list = $this->persister->loadOneToManyCollection($assoc, $sourceEntity, $coll);
 
-        if ($hasCache && ! empty($list)) {
+        if ($hasCache) {
             $persister->storeCollectionCache($key, $list);
 
             if ($this->cacheLogger) {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
@@ -121,7 +121,7 @@ abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
 
         $this->_em->flush();
     }
-    
+
     protected function loadFixturesTravelersWithProfile()
     {
         $t1   = new Traveler("Test traveler 1");
@@ -139,7 +139,7 @@ abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
 
         $this->travelersWithProfile[] = $t1;
         $this->travelersWithProfile[] = $t2;
-        
+
         $this->_em->flush();
     }
 
@@ -165,6 +165,7 @@ abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
     {
         $t1   = new Travel($this->travelers[0]);
         $t2   = new Travel($this->travelers[1]);
+        $t3   = new Travel($this->travelers[1]);
 
         $t1->addVisitedCity($this->cities[0]);
         $t1->addVisitedCity($this->cities[1]);
@@ -175,9 +176,11 @@ abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
 
         $this->_em->persist($t1);
         $this->_em->persist($t2);
+        $this->_em->persist($t3);
 
         $this->travels[] = $t1;
         $this->travels[] = $t2;
+        $this->travels[] = $t3;
 
         $this->_em->flush();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -214,4 +214,33 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         $this->_em->persist($travel);
         $this->_em->flush();
     }
+
+    public function testManyToManyWithEmptyRelation()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesTraveler();
+        $this->loadFixturesTravels();
+        $this->_em->clear();
+
+        $this->evictRegions();
+
+        $queryCount = $this->getCurrentQueryCount();
+
+        $entitiId   = $this->travels[2]->getId(); //empty travel
+        $entity     = $this->_em->find(Travel::CLASSNAME, $entitiId);
+
+        $this->assertEquals(0, $entity->getVisitedCities()->count());
+        $this->assertEquals($queryCount+2, $this->getCurrentQueryCount());
+
+        $this->_em->clear();
+
+        $entity     = $this->_em->find(Travel::CLASSNAME, $entitiId);
+
+        $queryCount = $this->getCurrentQueryCount();
+        $this->assertEquals(0, $entity->getVisitedCities()->count());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
+
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -171,7 +171,7 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->assertTrue($this->cache->containsEntity(Traveler::CLASSNAME, $travel->getId()));
+        $this->assertTrue($this->cache->containsEntity(Travel::CLASSNAME, $travel->getId()));
         $this->assertTrue($this->cache->containsEntity(Traveler::CLASSNAME, $traveler->getId()));
         $this->assertTrue($this->cache->containsEntity(City::CLASSNAME, $this->cities[0]->getId()));
         $this->assertTrue($this->cache->containsEntity(City::CLASSNAME, $this->cities[1]->getId()));


### PR DESCRIPTION
I should be able to cache an "empty" collection.

I have a some objects, where 90% of these have on-to-many relations with zero associated elements.
This causes doctrine to run a query each time, instead of cache it as empty relation.

(same thing should be applied to many-to-many collections)
