### PR TITLE
Add DB-level onDelete CASCADE example

### DIFF
--- a/docs/en/reference/yaml-mapping.rst
+++ b/docs/en/reference/yaml-mapping.rst
@@ -100,6 +100,7 @@ of several common elements:
           joinColumn:
             name: address_id
             referencedColumnName: id
+            onDelete: CASCADE
       oneToMany:
         phonenumbers:
           targetEntity: Phonenumber


### PR DESCRIPTION
This adds `onDelete: CASCADE` to the `address` 1-1 relationship just to show how to map a db-level cascade delete.
