### PR TITLE
iteration risk note

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -94,6 +94,12 @@ with the batching strategy that was already used for bulk inserts:
     fetch-join a collection-valued association. The nature of such SQL
     result sets is not suitable for incremental hydration.
 
+.. note::
+
+    Results may be fully buffered by the database client/ connection allocating
+    additional memory not visible to the PHP process. For large sets this
+    may easily kill the process for no apparant reason.
+
 
 Bulk Deletes
 ------------


### PR DESCRIPTION
> instead of loading the whole result into memory at once

is not the full truth.

There is a certain risk of processes getting killed due to memory allocation with large iteration. This is caused by result buffering of the client. It is not always being visible to PHP as http://www.php.net/manual/en/mysqlinfo.concepts.buffering.php suggests.

This is only a proposal for discussion as I am not certain how to best add the information or if to add it at all (was it obvious before?). Is buffered iteration even a good suggestion for anything but small sets?

On a side-note: is there a way to run unbuffered queries with Doctrine?
