### PR TITLE
wrong access modifiers "private" instead of "protected"

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -629,7 +629,7 @@ class XmlDriver extends FileDriver
      *
      * @return array The options array.
      */
-    private function _parseOptions(SimpleXMLElement $options)
+    protected function _parseOptions(SimpleXMLElement $options)
     {
         $array = array();
 
@@ -661,7 +661,7 @@ class XmlDriver extends FileDriver
      *
      * @return array The mapping array.
      */
-    private function joinColumnToArray(SimpleXMLElement $joinColumnElement)
+    protected function joinColumnToArray(SimpleXMLElement $joinColumnElement)
     {
         $joinColumn = array(
             'name' => (string)$joinColumnElement['name'],
@@ -694,7 +694,7 @@ class XmlDriver extends FileDriver
      *
      * @return array
      */
-    private function columnToArray(SimpleXMLElement $fieldMapping)
+    protected function columnToArray(SimpleXMLElement $fieldMapping)
     {
         $mapping = array(
             'fieldName' => (string) $fieldMapping['name'],
@@ -750,7 +750,7 @@ class XmlDriver extends FileDriver
      *
      * @return array
      */
-    private function cacheToArray(SimpleXMLElement $cacheMapping)
+    protected function cacheToArray(SimpleXMLElement $cacheMapping)
     {
         $region = isset($cacheMapping['region']) ? (string) $cacheMapping['region'] : null;
         $usage  = isset($cacheMapping['usage']) ? strtoupper($cacheMapping['usage']) : null;
@@ -776,7 +776,7 @@ class XmlDriver extends FileDriver
      *
      * @return array The list of cascade options.
      */
-    private function _getCascadeMappings($cascadeElement)
+    protected function _getCascadeMappings($cascadeElement)
     {
         $cascades = array();
         /* @var $action SimpleXmlElement */


### PR DESCRIPTION
In symfony2 in file: https://github.com/doctrine/DoctrineBundle/blob/master/Resources/config/orm.xml
In configuration is parameter:

```
<parameter key="doctrine.orm.metadata.xml.class">Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver</parameter>
```

that suggest that is designed to override in private bundles but when you try to do that it's nessesary to repeat entire body of methods in own class because of "private" access modifiers, i suggest to change them to 'protected' because without that it's makes extending this class more difficult and not clear to understand what is going on inside of this classes. I need to override this class to create own versioning system, and i need to extend xml mapping of entities.

I see this mistake often in symfony2 but now i see this also in doctrine2 itself, I suggest to change this modifiers not only in this class...
