### PR TITLE
Implemented an ObjectPersisterInterface for entity/object storage

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -59,7 +59,7 @@ use Doctrine\Common\Util\ClassUtils;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-/* final */class EntityManager implements EntityManagerInterface
+/* final */class EntityManager implements EntityManagerInterface, ObjectPersisterInterface
 {
     /**
      * The used Configuration.

--- a/lib/Doctrine/ORM/ObjectPersisterInterface.php
+++ b/lib/Doctrine/ORM/ObjectPersisterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\ORM;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+interface ObjectPersisterInterface
+{
+    /**
+     * @see \Doctrine\Common\Persistence\ObjectManager::persist()
+     */
+    public function persist($entity);
+
+    /**
+     * @see \Doctrine\Common\Persistence\ObjectManager::flush()
+     */
+    public function flush($entity = null);
+}


### PR DESCRIPTION
Moved to: https://github.com/doctrine/common/pull/317
### Why is this useful?

Instead of using the `repositoryClass`, we use 'Repository as a Service'. This means that we inject our repository service instead of doing `$em->getRepository('MyEntity')`, this provides typehinting and autocomplete in IDEs. This introduces a minor inconvenience, we need to inject an `EntityManagerInterface` to provide persist/flush. We don't want the entire `EntityManagerInterface` capabilities just to store an object.

Using the `ObjectPersisterInterface` we can "hide" the `EntityManagerInterface` and only let the code know we have the persist and flush methods available. By default this is implemented on the `EntityManager`, but is also possible to be mocked or replaced by a custom implementation (rotating entity managers?).
#### Example

``` php

class MyService
{
    private $op;
    private $es;

    public function __construct(ObjectPersisterInterface $op, MyEntityService $es)
    {
        $this->op = $op;
        $this->es = $es;
    }

    public function doSomething($value)
    {
        $entity = $this->es->findByValue($value)->setValue('something');
        $this->op->flush();
    }
}

```
