### PR TITLE
Stop executeDeletions when there is nothing to to delete anymore

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -373,7 +373,7 @@ class UnitOfWork implements PropertyChangedListener
 
             // Entity deletions come last and need to be in reverse commit order
             if ($this->entityDeletions) {
-                for ($count = count($commitOrder), $i = $count - 1; $i >= 0; --$i) {
+                for ($count = count($commitOrder), $i = $count - 1; $i >= 0 && $this->entityDeletions; --$i) {
                     $this->executeDeletions($commitOrder[$i]);
                 }
             }


### PR DESCRIPTION
A small improvement in `UOW::commit`. Only continue executing the for-loop when there's something to delete. This may save quite some calls to `UOW::executeDeletions`.
