### PR TITLE
Json_Array type returns empty array when used with nullable annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/localheinz/dbal"
+            "url": "https://github.com/localheinz/dbal.git"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.3.2",
         "ext-pdo": "*",
         "doctrine/collections": "~1.1",
-        "doctrine/dbal": ">=2.5-dev,<2.6-dev",
+        "doctrine/dbal": "dev-bugfix/nullable-json-array-mapped-to-empty-array",
         "symfony/console": "2.*"
     },
     "require-dev": {
@@ -26,6 +26,12 @@
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/localheinz/dbal"
+        }
+    ],
     "autoload": {
         "psr-0": { "Doctrine\\ORM\\": "lib/" }
     },

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
@@ -2,14 +2,14 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\Tests\OrmFunctionalTestCase;
 
-class DDC446Test extends \Doctrine\Tests\OrmFunctionalTestCase
+class DDC446Test extends OrmFunctionalTestCase
 {
     public function setUp()
     {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
+
         $this->_schemaTool->createSchema(array(
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC446Entity'),
         ));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
@@ -29,7 +29,7 @@ class DDC446Test extends OrmFunctionalTestCase
             $entity->getId()
         );
 
-        $this->assertInstanceOf(DDC446Entity::class, $entity);
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC446Entity', $entity);
         $this->assertNull($entity->getData());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
@@ -25,7 +25,7 @@ class DDC446Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $entity = $this->_em->find(
-            DDC446Entity::class,
+            __NAMESPACE__ . '\DDC446Entity',
             $entity->getId()
         );
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC446Test.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+require_once __DIR__ . '/../../../TestInit.php';
+
+class DDC446Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC446Entity'),
+        ));
+    }
+
+    public function testNullableJsonArrayIsNull()
+    {
+        $entity = new DDC446Entity();
+
+        $this->_em->persist($entity);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $entity = $this->_em->find(
+            DDC446Entity::class,
+            $entity->getId()
+        );
+
+        $this->assertInstanceOf(DDC446Entity::class, $entity);
+        $this->assertNull($entity->getData());
+    }
+}
+
+
+/**
+ * @Entity
+ * @Table(name = "ddc446")
+ */
+class DDC446Entity
+{
+    /**
+     * @Id
+     * @Column(
+     *     name = "id",
+     *     type = "integer"
+     * )
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Column(
+     *     name = "data",
+     *     type = "json_array",
+     *     nullable = true
+     * )
+     */
+    public $data;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+}


### PR DESCRIPTION
It says in http://www.doctrine-project.org/jira/browse/DBAL-446 that this issue has been fixed, but apparently, it hasn't.
