### PR TITLE
[DDC-357] Effective toOne joins

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -119,7 +119,17 @@ class ObjectHydrator extends AbstractHydrator
 
             $sourceClassName = $this->_rsm->aliasMap[$this->_rsm->parentAliasMap[$dqlAlias]];
             $sourceClass     = $this->getClassMetadata($sourceClassName);
-            $assoc           = $sourceClass->associationMappings[$this->_rsm->relationMap[$dqlAlias]];
+            $assocName       = $this->_rsm->relationMap[$dqlAlias];
+
+            if (!isset($sourceClass->associationMappings[$assocName])) {
+                foreach ($sourceClass->subClasses as $parentClass) {
+                    $sourceClass = $this->getClassMetadata($parentClass);
+                    if (isset($sourceClass->associationMappings[$assocName])) {
+                        break;
+                    }
+                }
+            }
+            $assoc = $sourceClass->associationMappings[$assocName];
 
             $this->_hints['fetched'][$this->_rsm->parentAliasMap[$dqlAlias]][$assoc['fieldName']] = true;
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -276,6 +276,7 @@ class ObjectHydrator extends AbstractHydrator
         }
 
         $this->_hints['fetchAlias'] = $dqlAlias;
+        $this->_hints[Query::HINT_BACK_REFERENCE_PROXY] = !empty($this->_rsm->isProxy[$dqlAlias]);
 
         return $this->_uow->createEntity($className, $data, $this->_hints);
     }

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -111,6 +111,11 @@ final class Query extends AbstractQuery
      */
     const HINT_CUSTOM_OUTPUT_WALKER = 'doctrine.customOutputWalker';
 
+    /**
+     * @var string
+     */
+    const HINT_BACK_REFERENCE_PROXY = 'doctrine.backReferenceProxy';
+
     //const HINT_READ_ONLY = 'doctrine.readOnly';
 
     /**

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -169,6 +169,13 @@ class ResultSetMapping
     public $metadataParameterMapping = array();
 
     /**
+     * Whether or not the entity should be created as proxy instead of partial
+     *
+     * @var array
+     */
+    public $isProxy = array();
+
+    /**
      * Adds an entity result to this ResultSetMapping.
      *
      * @param string $class            The class name of the entity.
@@ -354,11 +361,12 @@ class ResultSetMapping
      *
      * @todo Rename: addJoinedEntity
      */
-    public function addJoinedEntityResult($class, $alias, $parentAlias, $relation)
+    public function addJoinedEntityResult($class, $alias, $parentAlias, $relation, $proxy = FALSE)
     {
         $this->aliasMap[$alias]       = $class;
         $this->parentAliasMap[$alias] = $parentAlias;
         $this->relationMap[$alias]    = $relation;
+        $this->isProxy[$alias]        = $proxy;
 
         return $this;
     }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -820,7 +820,7 @@ class SqlWalker implements TreeWalker
             }
         }
 
-        $sql .= implode(', ', $sqlSelectExpressions);
+        $sql .= implode(', ', array_filter($sqlSelectExpressions));
 
         return $sql;
     }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -839,7 +839,7 @@ class SqlWalker implements TreeWalker
                 continue;
             }
 
-            if ($assoc['isOwningSide'] && empty($this->queryComponents[$dqlAlias]['backReference'])) {
+            if ($assoc['isOwningSide']) {
                 $owningClass = (isset($assoc['inherited']) && !$skipInherited) ? $this->em->getClassMetadata($assoc['inherited']) : $class;
                 $sqlTableAlias = $this->getSQLTableAlias($owningClass->getTableName(), $dqlAlias);
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -454,6 +454,11 @@ class SqlWalker implements TreeWalker
             $sql .= $this->_generateToOneAutoJoins($targetClass, $targetTableAlias);
         }
 
+        foreach ($class->subClasses as $subClassName) {
+            $subClass = $this->em->getClassMetadata($subClassName);
+            $sql .= $this->_generateToOneAutoJoins($subClass, $dqlAlias);
+        }
+
         return $sql;
     }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -395,7 +395,7 @@ class SqlWalker implements TreeWalker
         $sql = '';
 
         foreach ($class->getAssociationMappings() as $relation) {
-            if (!$class->isSingleValuedAssociation($relation['fieldName'])) {
+            if ( ! $class->isSingleValuedAssociation($relation['fieldName'])) {
                 continue;
             }
 
@@ -411,7 +411,7 @@ class SqlWalker implements TreeWalker
                 }
             }
 
-            if (!$targetTableAlias) {
+            if ( ! $targetTableAlias) {
                 continue;
             }
 
@@ -422,7 +422,7 @@ class SqlWalker implements TreeWalker
             $sourceTableAlias = $this->getSQLTableAlias($sourceClass->getTableName(), $dqlAlias);
 
             // Ensure we got the owning side, since it has all mapping info
-            $assoc = (!$relation['isOwningSide']) ? $targetClass->associationMappings[$relation['mappedBy']] : $relation;
+            $assoc = ( ! $relation['isOwningSide']) ? $targetClass->associationMappings[$relation['mappedBy']] : $relation;
 
             $conditions = array();
             foreach ($assoc['joinColumns'] as $joinColumn) {
@@ -826,11 +826,11 @@ class SqlWalker implements TreeWalker
         $sqlSelectExpressions = array();
 
         foreach ($class->associationMappings as $assoc) {
-            if (!($assoc['type'] & ClassMetadata::TO_ONE)) {
+            if ( ! ($assoc['type'] & ClassMetadata::TO_ONE)) {
                 continue;
-            } elseif (!$addMetaColumns && !isset($assoc['id'])) {
+            } elseif ( ! $addMetaColumns && !isset($assoc['id'])) {
                 continue;
-            } elseif (!empty($assoc['inherited']) && $skipInherited) {
+            } elseif ( ! empty($assoc['inherited']) && $skipInherited) {
                 continue;
             }
 
@@ -914,21 +914,22 @@ class SqlWalker implements TreeWalker
         $this->selectedClasses[$sqlTableAlias]['autoJoin'] = TRUE;
         $this->queryComponents[$sqlTableAlias]['autoJoin'] = TRUE;
 
-        if ($assoc['fetch'] !== ClassMetadata::FETCH_EAGER) {
-            foreach ($targetClass->getIdentifierColumnNames() as $idColumn) {
-                $idField = $targetClass->getFieldForColumn($idColumn);
-                $columnAlias = $this->getSQLColumnAlias($idColumn);
-                $sqlSelectExpressions[] = $sqlTableAlias . '.' . $idColumn . ' AS ' . $columnAlias;
-
-                if (isset($targetClass->associationMappings[$idField])) {
-                    $this->rsm->addMetaResult($sqlTableAlias, $columnAlias, $idColumn, TRUE);
-                } else {
-                    $this->rsm->addMetaResult($sqlTableAlias, $columnAlias, $idField, TRUE);
-                }
-            }
-
-        } else {
+        if ($assoc['fetch'] === ClassMetadata::FETCH_EAGER) {
             $sqlSelectExpressions[] = $this->_expandSelectExpressionToColumns($sqlTableAlias);
+
+            return $sqlSelectExpressions;
+        }
+
+        foreach ($targetClass->getIdentifierColumnNames() as $idColumn) {
+            $idField = $targetClass->getFieldForColumn($idColumn);
+            $columnAlias = $this->getSQLColumnAlias($idColumn);
+            $sqlSelectExpressions[] = $sqlTableAlias . '.' . $idColumn . ' AS ' . $columnAlias;
+
+            if (isset($targetClass->associationMappings[$idField])) {
+                $this->rsm->addMetaResult($sqlTableAlias, $columnAlias, $idColumn, TRUE);
+            } else {
+                $this->rsm->addMetaResult($sqlTableAlias, $columnAlias, $idField, TRUE);
+            }
         }
 
         return $sqlSelectExpressions;
@@ -936,7 +937,7 @@ class SqlWalker implements TreeWalker
 
     private function _generateDiscriminatorSelectColumns(ClassMetadata $class, $dqlAlias)
     {
-        if (!$class->isInheritanceTypeSingleTable() && !$class->isInheritanceTypeJoined()) {
+        if ( ! $class->isInheritanceTypeSingleTable() && ! $class->isInheritanceTypeJoined()) {
             return NULL;
         }
 
@@ -1522,7 +1523,7 @@ class SqlWalker implements TreeWalker
         /** @var ClassMetadata $class */
         $class = $queryComp['metadata'];
 
-        if (!isset($this->selectedClasses[$dqlAlias])) {
+        if ( ! isset($this->selectedClasses[$dqlAlias])) {
             $this->selectedClasses[$dqlAlias] = array(
                 'class' => $class,
                 'dqlAlias' => $dqlAlias,

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2569,20 +2569,17 @@ class UnitOfWork implements PropertyChangedListener
                 $this->originalEntityData[$oid] = $data;
             }
         } else {
-            $entity = $this->newInstance($class);
-            $oid    = spl_object_hash($entity);
+            if (empty($hints[Query::HINT_BACK_REFERENCE_PROXY])) {
+                $entity = $this->newInstance($class);
+                $overrideLocalValues = true;
 
-            $this->entityIdentifiers[$oid]  = $id;
-            $this->entityStates[$oid]       = self::STATE_MANAGED;
-            $this->originalEntityData[$oid] = $data;
-
-            $this->identityMap[$class->rootEntityName][$idHash] = $entity;
-
-            if ($entity instanceof NotifyPropertyChanged) {
-                $entity->addPropertyChangedListener($this);
+            } else {
+                $entity = $this->em->getProxyFactory()->getProxy($class->getName(), $id);
+                $overrideLocalValues = false;
             }
 
-            $overrideLocalValues = true;
+            $this->registerManaged($entity, $id, $overrideLocalValues ? $data : array());
+            $oid = spl_object_hash($entity);
         }
 
         if ( ! $overrideLocalValues) {

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -135,9 +135,9 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->setParameter(1, $userId)
                 ->getSingleResult();
 
-        // Address has been eager-loaded because it cant be lazy
+        // Address is a proxy because it wasn't joined in the query
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $user2->address);
-        $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $user2->address);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $user2->address);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -79,19 +79,36 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
         $this->assertEquals('Giorgio', $cart->getCustomer()->getName());
     }
 
-    public function testInverseSideIsNeverLazy()
+    public function testInverseSideIsEager()
     {
         $this->_createFixture();
         $metadata = $this->_em->getClassMetadata('Doctrine\Tests\Models\ECommerce\ECommerceCustomer');
-        $metadata->associationMappings['mentor']['fetch'] = ClassMetadata::FETCH_EAGER;
+        $metadata->associationMappings['cart']['fetch'] = ClassMetadata::FETCH_EAGER;
 
         $query = $this->_em->createQuery('select c from Doctrine\Tests\Models\ECommerce\ECommerceCustomer c');
         $result = $query->getResult();
         $customer = $result[0];
 
         $this->assertNull($customer->getMentor());
-        $this->assertInstanceOF('Doctrine\Tests\Models\ECommerce\ECommerceCart', $customer->getCart());
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCart', $customer->getCart());
         $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $customer->getCart());
+        $this->assertEquals('paypal', $customer->getCart()->getPayment());
+
+        // change back to not interfere with other tests
+        $metadata->associationMappings['cart']['fetch'] = ClassMetadata::FETCH_LAZY;
+    }
+
+    public function testInverseSideCanBeLazy()
+    {
+        $this->_createFixture();
+
+        $query = $this->_em->createQuery('select c from Doctrine\Tests\Models\ECommerce\ECommerceCustomer c');
+        $result = $query->getResult();
+        $customer = $result[0];
+
+        $this->assertNull($customer->getMentor());
+        $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCart', $customer->getCart());
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $customer->getCart());
         $this->assertEquals('paypal', $customer->getCart()->getPayment());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -55,9 +55,10 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
 
-        // CmsUser and CmsAddres, because it's a ToOne inverse side on CmsUser
+        // CmsUser
+        // Shouldn't be called for CmsAddress (ToOne inverse side)
         $mockListener
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(1))
             ->method('postLoad')
             ->will($this->returnValue(true));
 
@@ -75,9 +76,10 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
 
-        // CmsUser (root), CmsAddress (ToOne inverse side), CmsEmail (joined association)
+        // CmsUser (root), CmsEmail (joined association)
+        // Shouldn't be called for CmsAddress (ToOne inverse side)
         $mockListener
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(2))
             ->method('postLoad')
             ->will($this->returnValue(true));
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
@@ -19,7 +19,7 @@ class DDC448Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $q = $this->_em->createQuery("select b from ".__NAMESPACE__."\\DDC448SubTable b where b.connectedClassId = ?1");
         $this->assertEquals(
-            strtolower('SELECT d0_.id AS id0, d0_.discr AS discr1, d0_.connectedClassId AS connectedClassId2 FROM SubTable s1_ INNER JOIN DDC448MainTable d0_ ON s1_.id = d0_.id WHERE d0_.connectedClassId = ?'),
+            strtolower('SELECT d0_.id AS id0, d0_.discr AS discr1, d0_.connectedClassId AS connectedClassId2, c1_.id as id3 FROM SubTable s2_ INNER JOIN DDC448MainTable d0_ ON s2_.id = d0_.id LEFT JOIN connectedClass c1_ ON d0_.connectedClassId = c1_.id WHERE d0_.connectedClassId = ?'),
             strtolower($q->getSQL())
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -66,8 +66,8 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $appointments = $this->_em->createQuery("SELECT a FROM " . __NAMESPACE__ . "\DDC633Appointment a")->getResult();
 
         foreach ($appointments AS $eagerAppointment) {
-            $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $eagerAppointment->patient);
-            $this->assertTrue($eagerAppointment->patient->__isInitialized__, "Proxy should already be initialized due to eager loading!");
+            $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $eagerAppointment);
+            $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $eagerAppointment->patient);
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
@@ -64,7 +64,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u',
-            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.email_id AS email_id4 FROM cms_users c0_ WHERE c0_.id = 1",
+            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c0_.email_id AS email_id5 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id WHERE c0_.id = 1",
             array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
         );
     }
@@ -73,7 +73,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u where u.name = :name or u.name = :otherName',
-            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.email_id AS email_id4 FROM cms_users c0_ WHERE (c0_.name = ? OR c0_.name = ?) AND c0_.id = 1",
+            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c0_.email_id AS email_id5 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id WHERE (c0_.name = ? OR c0_.name = ?) AND c0_.id = 1",
             array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
         );
     }
@@ -82,7 +82,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u where u.name = :name',
-            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.email_id AS email_id4 FROM cms_users c0_ WHERE c0_.name = ? AND c0_.id = 1",
+            "SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c0_.email_id AS email_id5 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id WHERE c0_.name = ? AND c0_.id = 1",
             array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
         );
     }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../../TestInit.php';
 
 class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 {
+    /** @var \Doctrine\ORM\EntityManager */
     private $_em;
 
     protected function setUp()
@@ -49,6 +50,8 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             );
 
             $query->free();
+        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+            throw $e;
         } catch (\Exception $e) {
             $this->fail($e->getMessage() ."\n".$e->getTraceAsString());
         }
@@ -729,7 +732,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             ->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u')
             ->setMaxResults(10);
 
-        $this->assertEquals('SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.email_id AS email_id4 FROM cms_users c0_ LIMIT 10', $q->getSql());
+        $this->assertEquals('SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c0_.email_id AS email_id5 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id LIMIT 10', $q->getSql());
     }
 
     public function testLimitAndOffsetFromQueryClass()
@@ -739,7 +742,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             ->setMaxResults(10)
             ->setFirstResult(0);
 
-        $this->assertEquals('SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c0_.email_id AS email_id4 FROM cms_users c0_ LIMIT 10 OFFSET 0', $q->getSql());
+        $this->assertEquals('SELECT c0_.id AS id0, c0_.status AS status1, c0_.username AS username2, c0_.name AS name3, c1_.id AS id4, c0_.email_id AS email_id5 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id LIMIT 10 OFFSET 0', $q->getSql());
     }
 
     public function testSizeFunction()

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -411,6 +411,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         $this->_sqlLoggerStack->enabled = true;
+
+        // set new empty cache so the tests cannot interfere
+        $this->_em->getConfiguration()->setQueryCacheImpl(new \Doctrine\Common\Cache\ArrayCache());
     }
 
     /**


### PR DESCRIPTION
# What is this?

I've kind of rewriten querying of toOne relations. It is more data and query-count effective.
# How?

Let's demonstrate it on `CmsUser` and `CmsAddress` from tests models. Let's solve behaviour for toOne relations that are not mentioned in the query.

``` sql
SELECT u FROM CmsUser u
```
## lazy + mapped by side

Already implemented, result is that CmsAddress would be proxy.
## lazy + inverse side

`CmsUser` has `CmsAddress` relation that is mapped and owned by `CmsAddress` entity.

What has to happen? The identifier of `CmsAddress` cannot be loaded from users table nad has to be added automatic join for the table. Because it's lazy it will be hydrated as proxy, becase that is exactly what I've asked for.

If it would have been eagerly loaded, It would create 1+N queries problem that I'm trying to avoid with this. I have the relation as lazy, if I knew I would have needed it and wanned to optimized, I'd join it, but I didn't.

Result is therefore `CmsUser` entity + `CmsAddress` proxy 
## eager - both inverse and mapped by sides

The appropriate query component is generated with autojoin and auto selecting of the entity.

If it is self-referencing, the auto join is not generated becase it would cause infinite recursion.
# Why?

I've given this a lot of thought and tested it on our not-so-small application. We have unfortunately lot of entitiy relations that are mapped on the inverse side than we need to select, which is effectively killing performace [DDC-357](http://www.doctrine-project.org/jira/browse/DDC-357) 

I would have to go and list all the entities as partials to save performace creating such monsters as this

``` php
$builder = $repository->createQueryBuilder("o")
    ->leftJoin("o.voucher", "vu")->addSelect("partial vu.{id}")
    ->leftJoin("o.address", "a")->addSelect("a")
    ->leftJoin("o.restaurant", "r")->addSelect("partial r.{id, name}")
    ->leftJoin("o.payment", "p")->addSelect("partial p.{id}")
    ->leftJoin("o.rating", "rat")->addSelect("partial rat.{id}")
    ->leftJoin("r.settings", "rs")->addSelect("partial rs.{id}")
    ->leftJoin("r.address", "ra")->addSelect("ra")
    ->leftJoin("r.position", "rp")->addSelect("partial rp.{id}");
# plus about five more just to make save performace
```

We all know that hydrating a large result set is a bottleneck and if I say the relation is lazy and I'm not joining it I **really don't want it to be joined with all it's data**!

Now imagine I just want to select few orders and render some data on the page.. I have tens of queries like this just because I have to. This is wrong that the ORM is tripping my feet like this.
# What now?

I know I have to solve theese: 
- [ ] more refactoring?
- [ ] more tests
- [ ] what to do with issue tests that now have changed behaviour?

Any suggestions? Let's have a reasonable discussion, please don't just close this, I've put a lot of effort into this.
