### PR TITLE
Added index flags support in annotation, xml & yaml mapping drivers.

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -341,6 +341,7 @@
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
     <xs:attribute name="columns" type="xs:string" use="required"/>
+    <xs:attribute name="flags" type="xs:string" use="optional"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
   

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -105,7 +105,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                         'columns' => $indexAnnot->columns,
                     );
                     
-                    if( ! empty($indexAnnot->flags)) {
+                    if ( ! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
                     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -103,8 +103,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 foreach ($tableAnnot->indexes as $indexAnnot) {
                     $index = array(
                         'columns' => $indexAnnot->columns,
-                        'flags' => $indexAnnot->flags
                     );
+                    
+                    if( ! empty($indexAnnot->flags)) {
+                        $index['flags'] = $indexAnnot->flags;
+                    }
 
                     if ( ! empty($indexAnnot->name)) {
                         $primaryTable['indexes'][$indexAnnot->name] = $index;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -101,7 +101,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             if ($tableAnnot->indexes !== null) {
                 foreach ($tableAnnot->indexes as $indexAnnot) {
-                    $index = array('columns' => $indexAnnot->columns);
+                    $index = array(
+                        'columns' => $indexAnnot->columns,
+                        'flags' => $indexAnnot->flags
+                    );
 
                     if ( ! empty($indexAnnot->name)) {
                         $primaryTable['indexes'][$indexAnnot->name] = $index;

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -197,7 +197,7 @@ class XmlDriver extends FileDriver
             foreach ($xmlRoot->indexes->index as $index) {
                 $columns = explode(',', (string)$index['columns']);
                 
-                if(!isset($index['flags'])) {
+                if( ! isset($index['flags'])) {
                     $flags = array();
                 } else {
                     $flags = explode(',', (string)$index['flags']);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -201,7 +201,7 @@ class XmlDriver extends FileDriver
                   'columns' => $columns  
                 );
                 
-                if( isset($indexXml['flags'])) {
+                if (isset($indexXml['flags'])) {
                     $index['flags'] = explode(',', (string)$indexXml['flags']);
                 }
                 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -196,14 +196,22 @@ class XmlDriver extends FileDriver
             $metadata->table['indexes'] = array();
             foreach ($xmlRoot->indexes->index as $index) {
                 $columns = explode(',', (string)$index['columns']);
-
+                
+                if(!isset($index['flags'])) {
+                    $flags = array();
+                } else {
+                    $flags = explode(',', (string)$index['flags']);
+                }
+                
                 if (isset($index['name'])) {
                     $metadata->table['indexes'][(string)$index['name']] = array(
-                        'columns' => $columns
+                        'columns' => $columns,
+                        'flags' => $flags
                     );
                 } else {
                     $metadata->table['indexes'][] = array(
-                        'columns' => $columns
+                        'columns' => $columns,
+                        'flags' => $flags
                     );
                 }
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -194,25 +194,21 @@ class XmlDriver extends FileDriver
         // Evaluate <indexes...>
         if (isset($xmlRoot->indexes)) {
             $metadata->table['indexes'] = array();
-            foreach ($xmlRoot->indexes->index as $index) {
-                $columns = explode(',', (string)$index['columns']);
+            foreach ($xmlRoot->indexes->index as $indexXml) {
+                $columns = explode(',', (string)$indexXml['columns']);
                 
-                if( ! isset($index['flags'])) {
-                    $flags = array();
-                } else {
-                    $flags = explode(',', (string)$index['flags']);
+                $index = array(
+                  'columns' => $columns  
+                );
+                
+                if( isset($indexXml['flags'])) {
+                    $index['flags'] = explode(',', (string)$indexXml['flags']);
                 }
                 
-                if (isset($index['name'])) {
-                    $metadata->table['indexes'][(string)$index['name']] = array(
-                        'columns' => $columns,
-                        'flags' => $flags
-                    );
+                if (isset($indexXml['name'])) {
+                    $metadata->table['indexes'][(string)$indexXml['name']] = $index;
                 } else {
-                    $metadata->table['indexes'][] = array(
-                        'columns' => $columns,
-                        'flags' => $flags
-                    );
+                    $metadata->table['indexes'][] = $index;
                 }
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -201,31 +201,32 @@ class YamlDriver extends FileDriver
 
         // Evaluate indexes
         if (isset($element['indexes'])) {
-            foreach ($element['indexes'] as $name => $index) {
-                if ( ! isset($index['name'])) {
-                    $index['name'] = $name;
+            foreach ($element['indexes'] as $name => $indexYml) {
+                if ( ! isset($indexYml['name'])) {
+                    $indexYml['name'] = $name;
                 }
 
-                if (is_string($index['columns'])) {
-                    $columns = explode(',', $index['columns']);
+                if (is_string($indexYml['columns'])) {
+                    $columns = explode(',', $indexYml['columns']);
                     $columns = array_map('trim', $columns);
                 } else {
-                    $columns = $index['columns'];
+                    $columns = $indexYml['columns'];
                 }
-
-                if( ! isset($index['flags'])) {
-                    $flags = array();
-                } elseif (is_string($index['flags'])) {
-                    $flags = explode(',', $index['flags']);
-                    $flags = array_map('trim', $flags);
-                } else {
-                    $flags = $index['flags'];
-                }
-
-                $metadata->table['indexes'][$index['name']] = array(
-                    'columns' => $columns,
-                    'flags' => $flags
+                
+                $index = array(
+                  'columns' => $columns  
                 );
+
+                if(isset($indexYml['flags'])) {
+                    if (is_string($indexYml['flags'])) {
+                        $flags = explode(',', $indexYml['flags']);
+                        $index['flags'] = array_map('trim', $flags);
+                    } else {
+                        $index['flags'] = $indexYml['flags'];
+                    }
+                }
+
+                $metadata->table['indexes'][$indexYml['name']] = $index;
             }
         }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -213,8 +213,7 @@ class YamlDriver extends FileDriver
                     $columns = $index['columns'];
                 }
 
-                if(!isset($index['flags']))
-                {
+                if( ! isset($index['flags'])) {
                     $flags = array();
                 } elseif (is_string($index['flags'])) {
                     $flags = explode(',', $index['flags']);

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -213,8 +213,19 @@ class YamlDriver extends FileDriver
                     $columns = $index['columns'];
                 }
 
+                if(!isset($index['flags']))
+                {
+                    $flags = array();
+                } elseif (is_string($index['flags'])) {
+                    $flags = explode(',', $index['flags']);
+                    $flags = array_map('trim', $flags);
+                } else {
+                    $flags = $index['flags'];
+                }
+
                 $metadata->table['indexes'][$index['name']] = array(
-                    'columns' => $columns
+                    'columns' => $columns,
+                    'flags' => $flags
                 );
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -34,4 +34,9 @@ final class Index implements Annotation
      * @var array<string>
      */
     public $columns;
+
+    /**
+     * @var array<string>
+     */
+    public $flags;
 }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -264,12 +264,11 @@ class SchemaTool
 
             if (isset($class->table['indexes'])) {
                 foreach ($class->table['indexes'] as $indexName => $indexData) {
-                    if(!isset($indexData['flags']))
-                    {
+                    if( ! isset($indexData['flags'])) {
                         $indexData['flags'] = array();
                     }
                     
-                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array) $indexData['flags']);
+                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array)$indexData['flags']);
                 }
             }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -264,7 +264,12 @@ class SchemaTool
 
             if (isset($class->table['indexes'])) {
                 foreach ($class->table['indexes'] as $indexName => $indexData) {
-                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName);
+                    if(!isset($indexData['flags']))
+                    {
+                        $indexData['flags'] = array();
+                    }
+                    
+                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array) $indexData['flags']);
                 }
             }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -75,6 +75,18 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         return $class;
     }
 
+    public function testEntityIndexFlags()
+    {
+        $class = $this->createClassMetadata('Doctrine\Tests\ORM\Mapping\Comment');
+
+        $this->assertEquals(array(
+            0 => array(
+                'columns' => array('content'),
+                'flags' => array('fulltext')
+            )
+        ), $class->table['indexes']);
+    }
+
     /**
      * @depends testEntityTableNameAndInheritance
      * @param ClassMetadata $class
@@ -1268,3 +1280,15 @@ class DDC807SubClasse2 {}
 class Address {}
 class Phonenumber {}
 class Group {}
+
+/**
+ * @Entity
+ * @Table(indexes={@Index(columns={"content"}, flags={"fulltext"})})
+ */
+class Comment
+{
+    /**
+     * @Column(type="text")
+     */
+    private $content;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1291,4 +1291,25 @@ class Comment
      * @Column(type="text")
      */
     private $content;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata)
+    {
+        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable(array(
+            'indexes' => array(
+                array('columns' => array('content'), 'flags' => array('fulltext'))
+            )
+        ));
+
+        $metadata->mapField(array(
+            'fieldName' => 'content',
+            'type' => 'text',
+            'scale' => 0,
+            'length' => NULL,
+            'unique' => false,
+            'nullable' => false,
+            'precision' => 0,
+            'columnName' => 'content',
+        ));
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
@@ -9,7 +9,6 @@ $metadata->setPrimaryTable(array(
    )
   ));
 
-
 $metadata->mapField(array(
     'fieldName' => 'content',
     'type' => 'text',

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
@@ -1,0 +1,22 @@
+<?php
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setPrimaryTable(array(
+   'indexes' => array(
+       array('columns' => array('content'), 'flags' => array('fulltext'))
+   )
+  ));
+
+
+$metadata->mapField(array(
+    'fieldName' => 'content',
+    'type' => 'text',
+    'scale' => 0,
+    'length' => NULL,
+    'unique' => false,
+    'nullable' => false,
+    'precision' => 0,
+    'columnName' => 'content',
+));

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.Comment.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.Comment.dcm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\ORM\Mapping\Comment">
+
+        <indexes>
+            <index columns="content" flags="fulltext"/>
+        </indexes>
+
+        <field name="content" type="text"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.Comment.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.Comment.dcm.yml
@@ -1,0 +1,9 @@
+Doctrine\Tests\ORM\Mapping\Comment:
+  type: entity
+  fields:
+    content:
+      type: text
+  indexes:
+    0:
+      columns: content
+      flags: fulltext


### PR DESCRIPTION
It allows specifying eg. fulltext index for MysqlPlatform (the platform already supports it - https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/Platforms/MySqlPlatform.php#L714 , but it couldn't be used in annotations/xml/yaml/php schemas). And also other platforms use flags for indexes (virtual, clustered etc.).

So now flags can be used like:

``` php
/**
 * @Table(...,indexes={@Index(columns={"description"},flags={"fulltext"})})
 */
class Foo
{ ... }
```

``` xml
...
    <indexes>
      <index name="0" columns="description" flags="fulltext"/>
    </indexes>
...
```

``` yml
Foo:
  ...
  indexes:
    -
      columns: [ description ]
      flags: [ fulltext ]
```

``` php
$metadata->setPrimaryTable(array(
   ...
   'indexes' => array(
       array(
          'columns' => array('description'),
          'flags' => array('fulltext'),
       )
   ),
   ...
));
```
