### PR TITLE
Add cache invalidation strategy to AbstractQuery

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1101,10 +1101,12 @@ abstract class AbstractQuery
      */
     protected function getHash()
     {
-        $self   = $this;
-        $query  = $this->getSQL();
-        $hints  = $this->getHints();
-        $params = array_map(function(Parameter $parameter) use ($self) {
+        $self       = $this;
+        $query      = $this->getSQL();
+        $hints      = $this->getHints();
+        $aliasMap   = array_unique($this->getResultSetMapping()->getAliasMap());
+        $timestamps = array();
+        $params     = array_map(function(Parameter $parameter) use ($self) {
             // Small optimization
             // Does not invoke processParameterValue for scalar values
             if (is_scalar($value = $parameter->getValue())) {
@@ -1116,22 +1118,13 @@ abstract class AbstractQuery
 
         ksort($hints);
 
-        $timestamps = array();
-        $alias = $this->getResultSetMapping()->getAliasMap();
-
         // Use the cached timestamps of all the involved entities
         // to make sure we refresh the cache when needed
-        foreach ($alias as $alias => $className) {
-            $timestamps = array_merge($timestamps, $this->getCachedTimestamps($className));
+        foreach ($aliasMap as $alias => $className) {
+            $this->getCachedTimestamps($className, $timestamps);
         }
 
-        $key = $query . '-' . serialize($params) . '-' . serialize($hints);
-
-        if( ! empty($timestamps)) {
-            $key .= '-' . serialize($timestamps);
-        }
-
-        return sha1($key);
+        return sha1($query . '-' . serialize($params) . '-' . serialize($hints) . '-' . implode('-', $timestamps));
     }
 
     /**
@@ -1139,22 +1132,20 @@ abstract class AbstractQuery
      * @param  string $className Class name
      * @return array The retrieved cached timestamps
      */
-    private function getCachedTimestamps($className) {
-        $metadata = $this->_em->getClassMetadata($className);
-        $tableName = $metadata->getTableName();
-        $timestampKey = new TimestampCacheKey($tableName);
+    private function getCachedTimestamps($className, &$timestamps) {
+        $metadata       = $this->_em->getClassMetadata($className);
+        $tableName      = $metadata->getTableName();
+        $timestampKey   = new TimestampCacheKey($tableName);
+        $timestamp      = $this->timestampRegion->get($timestampKey);
 
-        $timestamps = array();
-        $timestamp = $this->timestampRegion->get($timestampKey);
-
-        if( ! is_null($timestamp)) {
-            $timestamps[] = $timestamp;
+        if (null !== $timestamp) {
+            $timestamps[$className] = $timestamp->time;
         }
 
-        if(isset($metadata->subClasses)) {
+        if (isset($metadata->subClasses)) {
             // Process subclasses recursively
             foreach ($metadata->subClasses as $key => $subClass) {
-                $timestamps = array_merge($timestamps, $this->getCachedTimestamps($subClass));
+                $timestamps = $this->getCachedTimestamps($subClass, $timestamps);
             }
         }
 

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1127,7 +1127,7 @@ abstract class AbstractQuery
 
         $key = $query . '-' . serialize($params) . '-' . serialize($hints);
 
-        if(!empty($timestamps)) {
+        if( ! empty($timestamps)) {
             $key .= '-' . serialize($timestamps);
         }
 
@@ -1147,7 +1147,7 @@ abstract class AbstractQuery
         $timestamps = array();
         $timestamp = $this->timestampRegion->get($timestampKey);
 
-        if(!is_null($timestamp)) {
+        if( ! is_null($timestamp)) {
             $timestamps[] = $timestamp;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1040,7 +1040,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $result = $query->setCacheable(true)->getResult();
 
         // Create and persist new Bar (Attraction subclass)
-        $city   = $this->_em->find('Doctrine\Tests\Models\Cache\City', 1);
+        $city   = $this->_em->getRepository('Doctrine\Tests\Models\Cache\City')->findOneByName('Berlin');
         $bar    = new Bar('Coyote', $city);
         $city->addAttraction($bar);
         $this->_em->persist($bar);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -6,6 +6,7 @@ use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\Models\Cache\City;
+use Doctrine\Tests\Models\Cache\Bar;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\EntityCacheEntry;
@@ -997,6 +998,58 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->assertFalse($this->cache->containsEntity('Doctrine\Tests\Models\Cache\Country', $this->countries[0]->getId()));
         $this->assertFalse($this->cache->containsEntity('Doctrine\Tests\Models\Cache\Country', $this->countries[1]->getId()));
+    }
+
+    public function testQueryCacheInvalidation()
+    {
+        $this->evictRegions();
+        $this->loadFixturesCountries();
+
+        $this->_em->clear();
+
+        // Select and cache results
+        $dql    = 'SELECT c FROM Doctrine\Tests\Models\Cache\Country c';
+        $query  = $this->_em->createQuery($dql);
+        
+        $result = $query->setCacheable(true)->getResult();
+
+        // Create and persist new country
+        $country = new Country('United Kingdom');
+        $this->_em->persist($country);
+        $this->_em->flush();
+
+        // The cached results should have been invalidated
+        $result2 = $query->setCacheable(true)->getResult();
+
+        $this->assertCount(count($result)+1, $result2);
+    }
+
+    public function testQueryCacheInvalidationSubclasses()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+
+        $this->_em->clear();
+
+        // Select and cache results
+        $dql    = 'SELECT a FROM Doctrine\Tests\Models\Cache\Attraction a';
+        $query  = $this->_em->createQuery($dql);
+
+        $result = $query->setCacheable(true)->getResult();
+
+        // Create and persist new Bar (Attraction subclass)
+        $city   = $this->_em->find('Doctrine\Tests\Models\Cache\City', 1);
+        $bar    = new Bar('Coyote', $city);
+        $city->addAttraction($bar);
+        $this->_em->persist($bar);
+        $this->_em->flush();
+
+        // The cached results should have been invalidated
+        $result2 = $query->setCacheable(true)->getResult();
+
+        $this->assertCount(count($result)+1, $result2);
     }
 
     /**


### PR DESCRIPTION
By adding the cached timestamps of the involved entity tables to the query hash, we will invalidate the cache when any of those tables have changed.
