### PR TITLE
Fix wrong annotation

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3157,7 +3157,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Map Embedded Class
      *
-     * @array $mapping
+     * @param array $mapping
      * @return void
      */
     public function mapEmbedded(array $mapping)


### PR DESCRIPTION
Without above fix I'm getting 

```
[Semantical Error] The annotation "@array" in method Doctrine\ORM\Mapping\ClassMetadataInfo::mapEmbedded() was never imported. Did you maybe forget to add a "use" statement for this annotation?"
```
