### PR TITLE
[DDC-2987] Enable empty prefixes for inlined embeddable

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3187,7 +3187,7 @@ class ClassMetadataInfo implements ClassMetadata
             $fieldMapping['originalField'] = $fieldMapping['fieldName'];
             $fieldMapping['fieldName'] = $property . "." . $fieldMapping['fieldName'];
 
-            $fieldMapping['columnName'] = ! empty($this->embeddedClasses[$property]['columnPrefix'])
+            $fieldMapping['columnName'] = ! empty($this->embeddedClasses[$property]['columnPrefix']) || $this->embeddedClasses[$property]['columnPrefix'] === false
                     ? $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName']
                         : $this->namingStrategy->embeddedFieldToColumnName($property, $fieldMapping['columnName'], $this->reflClass->name, $embeddable->reflClass->name);
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3200,10 +3200,6 @@ class ClassMetadataInfo implements ClassMetadata
                     );
             }
 
-//            $fieldMapping['columnName'] = ! empty($this->embeddedClasses[$property]['columnPrefix']) || $this->embeddedClasses[$property]['columnPrefix'] === false
-//                    ? $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName']
-//                        : $this->namingStrategy->embeddedFieldToColumnName($property, $fieldMapping['columnName'], $this->reflClass->name, $embeddable->reflClass->name);
-
             $this->mapField($fieldMapping);
         }
     }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3158,6 +3158,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Map Embedded Class
      *
      * @param array $mapping
+     * @throws MappingException
      * @return void
      */
     public function mapEmbedded(array $mapping)
@@ -3187,9 +3188,21 @@ class ClassMetadataInfo implements ClassMetadata
             $fieldMapping['originalField'] = $fieldMapping['fieldName'];
             $fieldMapping['fieldName'] = $property . "." . $fieldMapping['fieldName'];
 
-            $fieldMapping['columnName'] = ! empty($this->embeddedClasses[$property]['columnPrefix']) || $this->embeddedClasses[$property]['columnPrefix'] === false
-                    ? $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName']
-                        : $this->namingStrategy->embeddedFieldToColumnName($property, $fieldMapping['columnName'], $this->reflClass->name, $embeddable->reflClass->name);
+            if (! empty($this->embeddedClasses[$property]['columnPrefix'])) {
+                $fieldMapping['columnName'] = $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName'];
+            } elseif ($this->embeddedClasses[$property]['columnPrefix'] !== false) {
+                $fieldMapping['columnName'] = $this->namingStrategy
+                    ->embeddedFieldToColumnName(
+                        $property,
+                        $fieldMapping['columnName'],
+                        $this->reflClass->name,
+                        $embeddable->reflClass->name
+                    );
+            }
+
+//            $fieldMapping['columnName'] = ! empty($this->embeddedClasses[$property]['columnPrefix']) || $this->embeddedClasses[$property]['columnPrefix'] === false
+//                    ? $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName']
+//                        : $this->namingStrategy->embeddedFieldToColumnName($property, $fieldMapping['columnName'], $this->reflClass->name, $embeddable->reflClass->name);
 
             $this->mapField($fieldMapping);
         }

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -32,7 +32,7 @@ final class Embedded implements Annotation
     public $class;
 
     /**
-     * @var string
+     * @var mixed
      */
     public $columnPrefix;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -180,8 +180,6 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
         ));
     }
 
-
-
     public function testInlineEmbeddableWithPrefix()
     {
         $expectedColumnName = 'foobar_id';
@@ -214,8 +212,6 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertEquals($expectedColumnName, $actualColumnName);
     }
-
-
 }
 
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -179,7 +179,45 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93PhoneNumber')
         ));
     }
+
+
+
+    public function testInlineEmbeddableWithPrefix()
+    {
+        $expectedColumnName = 'foobar_id';
+
+        $actualColumnName = $this->_em
+            ->getClassMetadata(__NAMESPACE__ . '\DDC3028PersonWithPrefix')
+            ->getColumnName('id.id');
+
+        $this->assertEquals($expectedColumnName, $actualColumnName);
+    }
+
+    public function testInlineEmbeddableEmptyPrefix()
+    {
+        $expectedColumnName = 'id_id';
+
+        $actualColumnName = $this->_em
+            ->getClassMetadata(__NAMESPACE__ . '\DDC3028PersonEmptyPrefix')
+            ->getColumnName('id.id');
+
+        $this->assertEquals($expectedColumnName, $actualColumnName);
+    }
+
+    public function testInlineEmbeddablePrefixFalse()
+    {
+        $expectedColumnName = 'id';
+
+        $actualColumnName = $this->_em
+            ->getClassMetadata(__NAMESPACE__ . '\DDC3028PersonPrefixFalse')
+            ->getColumnName('id.id');
+
+        $this->assertEquals($expectedColumnName, $actualColumnName);
+    }
+
+
 }
+
 
 /**
  * @Entity
@@ -295,4 +333,70 @@ class DDC93ContactInfo
 {
     /** @Embedded(class = "DDC93Address") */
     private $address;
+}
+
+/**
+ * @Entity
+ */
+class DDC3028PersonWithPrefix
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Embedded(class="DDC3028Id", columnPrefix = "foobar_") */
+    public $id;
+
+    public function __construct(DDC3028Id $id = null)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC3028PersonEmptyPrefix
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Embedded(class="DDC3028Id", columnPrefix = "") */
+    public $id;
+
+    public function __construct(DDC3028Id $id = null)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC3028PersonPrefixFalse
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Embedded(class="DDC3028Id", columnPrefix = false) */
+    public $id;
+
+    public function __construct(DDC3028Id $id = null)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @Embeddable
+ */
+class DDC3028Id
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id @Column(type="string")
+     */
+    public $id;
+
+    public function __construct($id = null)
+    {
+        $this->id = $id;
+    }
 }


### PR DESCRIPTION
This fixes [DDC-2987]

This makes it possible to map a field from an embeddable to a database field with the same name, without any prefix added.

Example:
- an embeddable object "Id" with a property "id"
- per default this would map inline to id_id
- supplying null or '' as columnPrefix does not work due to the ! empty() check
- with my little change, if columnPrefix : false is supplied in the mapping config this will now map to a db column "id"

To build Ids as ValueObjects is a very common approach in DDD, so ihmo this is a must have.
