### PR TITLE
Bypass metadata cache in console commands

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -115,6 +115,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
 
         if ($input->getOption('from-database') === true) {
             $databaseDriver = new DatabaseDriver(

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -115,6 +115,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
 
         $cmf = new DisconnectedClassMetadataFactory();
         $cmf->setEntityManager($em);

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -69,6 +69,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
         $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -69,6 +69,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
         $metadatas = MetadataFilter::filter($metadatas, $input->getOption('filter'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -56,6 +56,7 @@ EOT
     {
         /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $this->getHelper('em')->getEntityManager();
+        $entityManager->getMetadataFactory()->setCacheDriver(null);
 
         $entityClassNames = $entityManager->getConfiguration()
                                           ->getMetadataDriverImpl()

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -55,6 +55,7 @@ abstract class AbstractCommand extends Command
 
         /* @var $em \Doctrine\ORM\EntityManager */
         $em = $emHelper->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -71,6 +71,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $em = $this->getHelper('em')->getEntityManager();
+        $em->getMetadataFactory()->setCacheDriver(null);
         $validator = new SchemaValidator($em);
         $exit = 0;
 


### PR DESCRIPTION
The console commands use the metadata cache. If the metadata has been updated, you manually need to run `console orm:clear-cache:metadata`.

For most commands, e.g.  `console orm:schema-tool:update`, this is rather annoying. I don't see any good reason why you would generate queries to make your database match the stale metadata in the cache rather than the fresh metadata stored in files.

This patch disables the metadata cache for most commands.
