### PR TITLE
Added options attribute export to Annotation, Xml & Yaml exporters.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -123,7 +123,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 }
             }
 
-            if ($tableAnnot->options !== null) {
+            if ($tableAnnot->options) {
                 $primaryTable['options'] = $tableAnnot->options;
             }
 

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -48,5 +48,5 @@ final class Table implements Annotation
     /**
      * @var array
      */
-    public $options = array();
+    public $options;
 }

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -48,5 +48,5 @@ final class Table implements Annotation
     /**
      * @var array
      */
-    public $options;
+    public $options = array();
 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -910,6 +910,10 @@ public function __construct()
             $table[] = 'name="' . $metadata->table['name'] . '"';
         }
 
+        if (isset($metadata->table['options']) && $metadata->table['options']) {
+            $table[] = 'options={' . $this->_exportOptions((array) $metadata->table['options']) . '}';
+        }
+
         if (isset($metadata->table['uniqueConstraints']) && $metadata->table['uniqueConstraints']) {
             $constraints = $this->generateTableConstraints('UniqueConstraint', $metadata->table['uniqueConstraints']);
             $table[] = 'uniqueConstraints={' . $constraints . '}';
@@ -1555,5 +1559,26 @@ public function __construct()
         }
 
         return static::$generatorStrategyMap[$type];
+    }
+
+    /**
+     * Exports (nested) option elements.
+     *
+     * @param array $options
+     */
+    private function _exportOptions(array $options)
+    {
+        $optionsStr = array();
+        
+        foreach($options as $name => $option)
+        {
+            if (is_array($option)) {
+                $optionsStr[] = '"' . $name . '"={' . $this->_exportOptions($option) . '}';
+            } else {
+                $optionsStr[] = '"' . $name . '"="' . (string) $option . '"';
+            }            
+        }
+        
+        return implode(',', $optionsStr);
     }
 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1570,8 +1570,7 @@ public function __construct()
     {
         $optionsStr = array();
         
-        foreach($options as $name => $option)
-        {
+        foreach($options as $name => $option) {
             if (is_array($option)) {
                 $optionsStr[] = '"' . $name . '"={' . $this->_exportOptions($option) . '}';
             } else {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -911,7 +911,7 @@ public function __construct()
         }
 
         if (isset($metadata->table['options']) && $metadata->table['options']) {
-            $table[] = 'options={' . $this->_exportOptions((array) $metadata->table['options']) . '}';
+            $table[] = 'options={' . $this->exportTableOptions((array) $metadata->table['options']) . '}';
         }
 
         if (isset($metadata->table['uniqueConstraints']) && $metadata->table['uniqueConstraints']) {
@@ -1566,13 +1566,13 @@ public function __construct()
      *
      * @param array $options
      */
-    private function _exportOptions(array $options)
+    private function exportTableOptions(array $options)
     {
         $optionsStr = array();
         
         foreach($options as $name => $option) {
             if (is_array($option)) {
-                $optionsStr[] = '"' . $name . '"={' . $this->_exportOptions($option) . '}';
+                $optionsStr[] = '"' . $name . '"={' . $this->exportTableOptions($option) . '}';
             } else {
                 $optionsStr[] = '"' . $name . '"="' . (string) $option . '"';
             }            

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -72,7 +72,7 @@ class XmlExporter extends AbstractExporter
         if (isset($metadata->table['options'])) {
             $optionsXml = $root->addChild('options');
 
-            $this->_exportOptions($optionsXml, $metadata->table['options']);
+            $this->exportTableOptions($optionsXml, $metadata->table['options']);
         }
 
         if ($metadata->discriminatorColumn) {
@@ -391,14 +391,14 @@ class XmlExporter extends AbstractExporter
      * @param \SimpleXMLElement $parentXml
      * @param array $options
      */
-    private function _exportOptions(\SimpleXMLElement $parentXml, array $options)
+    private function exportTableOptions(\SimpleXMLElement $parentXml, array $options)
     {        
         foreach ($options as $name => $option) {
             $optionXml = $parentXml->addChild('option');
             $optionXml->addAttribute('name', (string) $name);
             
             if (is_array($option)) {
-                $this->_exportOptions($optionXml, $option);
+                $this->exportTableOptions($optionXml, $option);
             } else {
                 $optionXml[0] = (string) $option;
             }

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -85,6 +85,10 @@ class YamlExporter extends AbstractExporter
             $array['uniqueConstraints'] = $metadata->table['uniqueConstraints'];
         }
 
+        if (isset($metadata->table['options'])) {
+            $array['options'] = $metadata->table['options'];
+        }
+
         $fieldMappings = $metadata->fieldMappings;
 
         $ids = array();

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -157,6 +157,8 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
     public function testTableIsExported($class)
     {
         $this->assertEquals('cms_users', $class->table['name']);
+        $this->assertEquals(array('engine' => 'MyISAM', 'foo' => array('bar' => 'baz')),
+            $class->table['options']);
 
         return $class;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ORM\Tools\Export;
 /**
  * @Entity
  * @HasLifecycleCallbacks
- * @Table(name="cms_users")
+ * @Table(name="cms_users",options={"engine"="MyISAM","foo"={"bar"="baz"}})
  */
 class User
 {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -5,6 +5,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(array(
    'name' => 'cms_users',
+   'options' => array('engine' => 'MyISAM', 'foo' => array('bar' => 'baz')),
   ));
 $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
@@ -6,7 +6,12 @@
                           http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <entity name="Doctrine\Tests\ORM\Tools\Export\User" table="cms_users">
-
+        <options>
+            <option name="engine">MyISAM</option>
+            <option name="foo">
+                <option name="bar">baz</option>
+            </option>
+        </options>
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="doStuffOnPrePersist"/>
             <lifecycle-callback type="prePersist" method="doOtherStuffOnPrePersistToo"/>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -1,6 +1,9 @@
 Doctrine\Tests\ORM\Tools\Export\User:
   type: entity
   table: cms_users
+  options:
+    engine: MyISAM
+    foo: { bar: baz }
   id:
     id:
       type: integer


### PR DESCRIPTION
Options were already supported in annotation/xml/yaml drivers. So now they are taken into account eg in orm:convert-mapping task.
