### PR TITLE
Throw exception for invalid mappedBys rather than PHP undefined index warning

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1641,9 +1641,17 @@ class BasicEntityPersister implements EntityPersister
      * @param int|null $limit
      *
      * @return \Doctrine\DBAL\Statement
+     * @throws \Doctrine\ORM\Mapping\MappingException
      */
     private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {
+        if (!array_key_exists($assoc['mappedBy'], $this->class->associationMappings)) {
+            throw new MappingException(
+                'Property ' . $assoc['fieldName'] . ' in ' . $assoc['sourceEntity'] . ' specified mappedBy="'
+                . $assoc['mappedBy'] . '" but ' . $assoc['mappedBy'] . ' is not a property of ' . $assoc['targetEntity']
+            );
+        }
+
         $criteria = array();
         $owningAssoc = $this->class->associationMappings[$assoc['mappedBy']];
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);


### PR DESCRIPTION
This fix throws an appropriate MappingException with an explanation of what is wrong with the mapping rather than just throwing an un-actionable php warning.

Example old error message: "Undefined index: item in /www/apps/rwriter/vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php on line 2079”

Example new MappingException message: “Property items in RcmShoppingCart\Entity\TempOrder specified mappedBy="tempOrderItem" but tempOrderItem is not a property of RcmShoppingCart\Entity\TempOrderItem”
