### PR TITLE
Use boolean values for 'unique' attribute

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -193,7 +193,7 @@ class XmlExporter extends AbstractExporter
                 }
 
                 if (isset($field['unique']) && $field['unique']) {
-                    $fieldXml->addAttribute('unique', $field['unique']);
+                    $fieldXml->addAttribute('unique', $field['unique'] ? 'true' : 'false');
                 }
 
                 if (isset($field['options'])) {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -210,6 +210,27 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
     }
 
     /**
+     * @depends testExportDirectoryAndFilesAreCreated
+     */
+    public function testFieldsAreProperlySerialized()
+    {
+        $type = $this->_getType();
+        if ($type == 'xml') {
+            $xml = simplexml_load_file(__DIR__ . '/export/'.$type.'/Doctrine.Tests.ORM.Tools.Export.ExportedUser.dcm.xml');
+
+            $xml->registerXPathNamespace("d", "http://doctrine-project.org/schemas/orm/doctrine-mapping");
+            $nodes = $xml->xpath("/d:doctrine-mapping/d:entity/d:field[@name='name' and @type='string' and @nullable='true']");
+            $this->assertEquals(1, count($nodes));
+
+            $nodes = $xml->xpath("/d:doctrine-mapping/d:entity/d:field[@name='name' and @type='string' and @unique='true']");
+            $this->assertEquals(1, count($nodes));
+        }
+        else {
+            $this->markTestSkipped('Test available only for '.$type.' driver');
+        }
+    }
+
+    /**
      * @depends testFieldsAreExported
      * @param ClassMetadataInfo $class
      */


### PR DESCRIPTION
As defined in: https://github.com/doctrine/doctrine2/blob/master/doctrine-mapping.xsd#L294

Same as 'nullable' attribute. 

It was being exported as a "1" for TRUE and "0" for false
