### PR TITLE
Exporter support for association fetch modes

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -201,6 +201,25 @@ abstract class AbstractExporter
     }
 
     /**
+     * @param int $mode
+     *
+     * @return string
+     */
+    protected function _getFetchModeString($mode)
+    {
+        switch ($mode) {
+            case ClassMetadataInfo::FETCH_EAGER:
+                return 'EAGER';
+
+            case ClassMetadataInfo::FETCH_EXTRA_LAZY:
+                return 'EXTRA_LAZY';
+
+            case ClassMetadataInfo::FETCH_LAZY:
+                return 'LAZY';
+        }
+    }
+
+    /**
      * @param int $policy
      *
      * @return string

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -108,7 +108,7 @@ class PhpExporter extends AbstractExporter
                 'cascade'     => $cascade,
             );
 
-            if(isset($associationMapping['fetch'])){
+            if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $associationMapping['fetch'];
             }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -108,6 +108,10 @@ class PhpExporter extends AbstractExporter
                 'cascade'     => $cascade,
             );
 
+            if(isset($associationMapping['fetch'])){
+                $associationMappingArray['fetch'] = $associationMapping['fetch'];
+            }
+
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $method = 'mapOneToOne';
                 $oneToOneMappingArray = array(

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -260,6 +260,10 @@ class XmlExporter extends AbstractExporter
             if (isset($associationMapping['orphanRemoval']) && $associationMapping['orphanRemoval'] !== false) {
                 $associationMappingXml->addAttribute('orphan-removal', 'true');
             }
+
+            if (isset($associationMapping['fetch'])) {
+                $associationMappingXml->addAttribute('fetch', $this->_getFetchModeString($associationMapping['fetch']));
+            }
             
             $cascade = array();
             if ($associationMapping['isCascadeRemove']) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -150,7 +150,7 @@ class YamlExporter extends AbstractExporter
                 'cascade'     => $cascade,
             );
 
-            if(isset($associationMapping['fetch'])){
+            if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $this->_getFetchModeString($associationMapping['fetch']);
             }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -150,6 +150,10 @@ class YamlExporter extends AbstractExporter
                 'cascade'     => $cascade,
             );
 
+            if(isset($associationMapping['fetch'])){
+                $associationMappingArray['fetch'] = $this->_getFetchModeString($associationMapping['fetch']);
+            }
+
             if (isset($mapping['id']) && $mapping['id'] === true) {
                 $array['id'][$name]['associationKey'] = true;
             }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -226,7 +226,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
             $this->assertEquals(1, count($nodes));
         }
         else {
-            $this->markTestSkipped('Test available only for '.$type.' driver');
+            $this->markTestSkipped('Test not available for '.$type.' driver');
         }
     }
 
@@ -248,6 +248,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         $this->assertFalse($class->associationMappings['address']['isCascadeMerge']);
         $this->assertFalse($class->associationMappings['address']['isCascadeDetach']);
         $this->assertTrue($class->associationMappings['address']['orphanRemoval']);
+        $this->assertEquals(ClassMetadataInfo::FETCH_EAGER, $class->associationMappings['address']['fetch']);
 
         return $class;
     }
@@ -279,6 +280,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         $this->assertTrue($class->associationMappings['phonenumbers']['isCascadeMerge']);
         $this->assertFalse($class->associationMappings['phonenumbers']['isCascadeDetach']);
         $this->assertTrue($class->associationMappings['phonenumbers']['orphanRemoval']);
+        $this->assertEquals(ClassMetadataInfo::FETCH_LAZY, $class->associationMappings['phonenumbers']['fetch']);
 
         return $class;
     }
@@ -306,6 +308,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         $this->assertTrue($class->associationMappings['groups']['isCascadeRefresh']);
         $this->assertTrue($class->associationMappings['groups']['isCascadeMerge']);
         $this->assertTrue($class->associationMappings['groups']['isCascadeDetach']);
+        $this->assertEquals(ClassMetadataInfo::FETCH_EXTRA_LAZY, $class->associationMappings['groups']['fetch']);
 
         return $class;
     }
@@ -376,7 +379,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
             $this->assertEquals('all', $value['Doctrine\Tests\ORM\Tools\Export\ExportedUser']['oneToMany']['interests']['cascade'][0]);
 
         } else {
-            $this->markTestSkipped('Test available only for '.$type.' driver');
+            $this->markTestSkipped('Test not available for '.$type.' driver');
         }
     }
     public function __destruct()

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -23,7 +23,7 @@ class User
     public $email;
 
     /**
-     * @OneToOne(targetEntity="Doctrine\Tests\ORM\Tools\Export\Address", inversedBy="user", cascade={"persist"}, orphanRemoval=true)
+     * @OneToOne(targetEntity="Doctrine\Tests\ORM\Tools\Export\Address", inversedBy="user", cascade={"persist"}, orphanRemoval=true, fetch="EAGER")
      * @JoinColumn(name="address_id", onDelete="CASCADE")
      */
     public $address;

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -41,7 +41,7 @@ class User
     public $phonenumbers;
 
     /**
-     * @ManyToMany(targetEntity="Doctrine\Tests\ORM\Tools\Export\Group", cascade={"all"})
+     * @ManyToMany(targetEntity="Doctrine\Tests\ORM\Tools\Export\Group", cascade={"all"}, fetch="EXTRA_LAZY")
      * @JoinTable(name="cms_users_groups",
      *    joinColumns={@JoinColumn(name="user_id", referencedColumnName="id", nullable=false, unique=false)},
      *    inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id", columnDefinition="INT NULL")}

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -54,6 +54,7 @@ $metadata->mapOneToOne(array(
    ),
    ),
    'orphanRemoval' => true,
+   'fetch' => ClassMetadataInfo::FETCH_EAGER,
   ));
 $metadata->mapOneToMany(array(
    'fieldName' => 'phonenumbers',
@@ -65,6 +66,7 @@ $metadata->mapOneToMany(array(
    ),
    'mappedBy' => 'user',
    'orphanRemoval' => true,
+   'fetch' => ClassMetadataInfo::FETCH_LAZY,
    'orderBy' =>
    array(
    'number' => 'ASC',
@@ -73,6 +75,7 @@ $metadata->mapOneToMany(array(
 $metadata->mapManyToMany(array(
    'fieldName' => 'groups',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Group',
+   'fetch' => ClassMetadataInfo::FETCH_EXTRA_LAZY,
    'cascade' =>
    array(
    0 => 'remove',

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
@@ -20,14 +20,14 @@
         <field name="name" column="name" type="string" length="50" nullable="true" unique="true" />
         <field name="email" column="user_email" type="string" column-definition="CHAR(32) NOT NULL" />
 
-        <one-to-one field="address" target-entity="Doctrine\Tests\ORM\Tools\Export\Address" inversed-by="user" orphan-removal="true">
+        <one-to-one field="address" target-entity="Doctrine\Tests\ORM\Tools\Export\Address" inversed-by="user" orphan-removal="true" fetch="EAGER">
             <cascade><cascade-persist /></cascade>
             <join-column name="address_id" referenced-column-name="id" on-delete="CASCADE" on-update="CASCADE"/>
         </one-to-one>
 
         <many-to-one field="mainGroup" target-entity="Doctrine\Tests\ORM\Tools\Export\Group" />
 
-        <one-to-many field="phonenumbers" target-entity="Doctrine\Tests\ORM\Tools\Export\Phonenumber" mapped-by="user" orphan-removal="true">
+        <one-to-many field="phonenumbers" target-entity="Doctrine\Tests\ORM\Tools\Export\Phonenumber" mapped-by="user" orphan-removal="true" fetch="LAZY">
             <cascade>
                 <cascade-persist/>
                 <cascade-merge/>
@@ -47,7 +47,7 @@
             </cascade>
         </one-to-many>
 
-        <many-to-many field="groups" target-entity="Doctrine\Tests\ORM\Tools\Export\Group">
+        <many-to-many field="groups" target-entity="Doctrine\Tests\ORM\Tools\Export\Group" fetch="EXTRA_LAZY">
             <cascade>
                 <cascade-all/>
             </cascade>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -26,6 +26,7 @@ Doctrine\Tests\ORM\Tools\Export\User:
       cascade: [ persist ]
       inversedBy: user
       orphanRemoval: true
+      fetch: EAGER
   manyToOne:
     mainGroup:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Group
@@ -37,6 +38,7 @@ Doctrine\Tests\ORM\Tools\Export\User:
         number: ASC
       cascade: [ persist, merge ]
       orphanRemoval: true
+      fetch: LAZY
     interests:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Interests
       mappedBy: user
@@ -45,6 +47,7 @@ Doctrine\Tests\ORM\Tools\Export\User:
   manyToMany:
     groups:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Group
+      fetch: EXTRA_LAZY
       joinTable:
         name: cms_users_groups
         joinColumns:


### PR DESCRIPTION
As reported here: http://www.doctrine-project.org/jira/browse/DDC-3047

Also noticed the fetch modes were not supported for PHP and YAML exporters.
