### PR TITLE
Fix the problem when the lifecycle event can be triggered more then once...

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -970,6 +970,10 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
+            if (! isset($this->entityInsertions[$oid])) {
+                continue;
+            }
+
             $persister->addInsert($entity);
 
             unset($this->entityInsertions[$oid]);
@@ -1022,6 +1026,10 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
+            if (! isset($this->entityUpdates[$oid])) {
+                continue;
+            }
+
             if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
                 $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $this->entityChangeSets[$oid]), $preUpdateInvoke);
                 $this->recomputeSingleEntityChangeSet($class, $entity);
@@ -1054,6 +1062,10 @@ class UnitOfWork implements PropertyChangedListener
 
         foreach ($this->entityDeletions as $oid => $entity) {
             if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
+                continue;
+            }
+
+            if (! isset($this->entityDeletions[$oid])) {
                 continue;
             }
 


### PR DESCRIPTION
We recently saw the postUpdate event get trigger multiple time incorrectly, it typically happens when flushing a set of entities persisted whose listener persist and flush another type of entity in it.

Php passes variables to foreach by value, for the function executeUpdates in the UnitOfWork, for example, entities in the $this->entityUpdates could be updated and unset in the listener of the first entity, while them will be updated and trigger listeners again when the process of first entity finishes (although they have already been unset from $this->entityUpdates). Similar for executeInsertion and executeDeletion.
