### PR TITLE
Ability to define custom functions with callback instead of class name

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -3350,10 +3350,13 @@ class Parser
     public function CustomFunctionsReturningNumerics()
     {
         // getCustomNumericFunction is case-insensitive
-        $funcName  = strtolower($this->lexer->lookahead['value']);
-        $funcClass = $this->em->getConfiguration()->getCustomNumericFunction($funcName);
+        $functionName  = strtolower($this->lexer->lookahead['value']);
+        $functionClass = $this->em->getConfiguration()->getCustomNumericFunction($functionName);
 
-        $function = new $funcClass($funcName);
+        $function = is_string($functionClass)
+            ? new $functionClass($functionName)
+            : $functionClass($functionName);
+
         $function->parse($this);
 
         return $function;
@@ -3381,10 +3384,13 @@ class Parser
     public function CustomFunctionsReturningDatetime()
     {
         // getCustomDatetimeFunction is case-insensitive
-        $funcName  = $this->lexer->lookahead['value'];
-        $funcClass = $this->em->getConfiguration()->getCustomDatetimeFunction($funcName);
+        $functionName  = $this->lexer->lookahead['value'];
+        $functionClass = $this->em->getConfiguration()->getCustomDatetimeFunction($functionName);
 
-        $function = new $funcClass($funcName);
+        $function = is_string($functionClass)
+            ? new $functionClass($functionName)
+            : $functionClass($functionName);
+
         $function->parse($this);
 
         return $function;
@@ -3417,10 +3423,13 @@ class Parser
     public function CustomFunctionsReturningStrings()
     {
         // getCustomStringFunction is case-insensitive
-        $funcName  = $this->lexer->lookahead['value'];
-        $funcClass = $this->em->getConfiguration()->getCustomStringFunction($funcName);
+        $functionName  = $this->lexer->lookahead['value'];
+        $functionClass = $this->em->getConfiguration()->getCustomStringFunction($functionName);
 
-        $function = new $funcClass($funcName);
+        $function = is_string($functionClass)
+            ? new $functionClass($functionName)
+            : $functionClass($functionName);
+
         $function->parse($this);
 
         return $function;

--- a/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\PathExpression;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+require_once __DIR__ . '/../../TestInit.php';
+
+class CustomFunctionsTest extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+    }
+
+    public function testCustomFunctionDefinedWithCallback()
+    {
+        $user = new CmsUser();
+        $user->name = 'Bob';
+        $user->username = 'Dylan';
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        // Instead of defining the function with the class name, we use a callback
+        $this->_em->getConfiguration()->addCustomStringFunction('FOO', function($funcName) {
+            return new NoOp($funcName);
+        });
+        $this->_em->getConfiguration()->addCustomNumericFunction('BAR', function($funcName) {
+            return new NoOp($funcName);
+        });
+
+        $query = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u'
+            . ' WHERE FOO(u.name) = \'Bob\''
+            . ' AND BAR(1) = 1');
+
+        $users = $query->getResult();
+
+        $this->assertEquals(1, count($users));
+        $this->assertSame($user, $users[0]);
+    }
+}
+
+class NoOp extends FunctionNode
+{
+    /**
+     * @var PathExpression
+     */
+    private $field;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->field = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->field->dispatch($sqlWalker);
+    }
+}
+


### PR DESCRIPTION
Right now the only way to define custom DQL functions is by giving the class name, and Doctrine will create the class:

``` php
$config->addCustomNumericFunction('FOO', 'My\Custom\DqlFunction');
```

This is very limiting when the custom functions has dependencies, for example it can't be created by a DI container.

The approach I have taken here is very simple: it allows to define a callback instead of the class name: the callback will be called and it should return the instance:

``` php
$config->addCustomNumericFunction('FOO', function($funcName) {
    return new My\Custom\DqlFunction($funcName);
});
```

On a side note, I think it would be great to generalize that approach because currently there are a lot of places where the same constraints apply.
