### PR TITLE
Update JoinColumn.php

### DIFF
--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -33,7 +33,7 @@ final class JoinColumn implements Annotation
     /**
      * @var string
      */
-    public $referencedColumnName = 'id';
+    public $referencedColumnName;
 
     /**
      * @var boolean


### PR DESCRIPTION
If $referencedColumnName = 'id' by default, it doesn't make sense to make checks like:

``` php
if (empty($joinColumn['referencedColumnName'])) {
```

(ClassMetaDataInfo file)

---

Considering you map your column

```
@ORM\JoinColumn(onDelete="CASCADE")
```

You'll get JoinColumn with 'id' value, which doesn't let doctrine use naming strategies for referenced column names
