### PR TITLE
Update EntityGenerator comment

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -133,7 +133,9 @@ class EntityGenerator
     protected $regenerateEntityIfExists = false;
 
     /**
-     * @var boolean
+     * Visibility of the field
+     * 
+     * @var string
      */
     protected $fieldVisibility = 'private';
 


### PR DESCRIPTION
fieldVisibility was referred to as a boolean, where it is actually a string.
