### PR TITLE
DDC-3065 null value in in criteria support

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1534,7 +1534,13 @@ class BasicEntityPersister implements EntityPersister
         }
 
         if (is_array($value)) {
-            return sprintf('%s IN (%s)' , $condition, $placeholder);
+            $in = sprintf('%s IN (%s)' , $condition, $placeholder);
+
+            if (false !== array_search(null, $value, true)) {
+                return sprintf('(%s OR %s IS NULL)' , $in, $condition);
+            }
+
+            return $in;
         }
 
         if ($value === null) {

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -942,9 +942,18 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('email' => array(null)));
+        $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' => array(null)));
 
         $this->assertCount(1, $users);
+        $this->assertSame($user, reset($users));
+
+        $users = $this
+            ->_em
+            ->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
+            ->findBy(array('status' => array('foo', null)));
+
+        $this->assertCount(1, $users);
+        $this->assertSame($user, reset($users));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -928,5 +928,23 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repository->find(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test', 'id' => 1));
     }
+
+    /**
+     * @group DDC-3056
+     */
+    public function testFindByNullValueInInCondition()
+    {
+        $user = new CmsUser();
+
+        $user->username = 'ocramius';
+        $user->name = 'Marco';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('email' => array(null)));
+
+        $this->assertCount(1, $users);
+    }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -934,18 +934,44 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testFindByNullValueInInCondition()
     {
-        $user = new CmsUser();
+        $user1 = new CmsUser();
+        $user2 = new CmsUser();
 
-        $user->username = 'ocramius';
-        $user->name = 'Marco';
+        $user1->username = 'ocramius';
+        $user1->name = 'Marco';
+        $user2->status = null;
+        $user2->username = 'deeky666';
+        $user2->name = 'Steve';
+        $user2->status = 'dbal maintainer';
 
-        $this->_em->persist($user);
+        $this->_em->persist($user1);
+        $this->_em->persist($user2);
         $this->_em->flush();
 
         $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' => array(null)));
 
         $this->assertCount(1, $users);
-        $this->assertSame($user, reset($users));
+        $this->assertSame($user1, reset($users));
+    }
+
+    /**
+     * @group DDC-3056
+     */
+    public function testFindByNullValueInMultipleInCriteriaValues()
+    {
+        $user1 = new CmsUser();
+        $user2 = new CmsUser();
+
+        $user1->username = 'ocramius';
+        $user1->name = 'Marco';
+        $user2->status = null;
+        $user2->username = 'deeky666';
+        $user2->name = 'Steve';
+        $user2->status = 'dbal maintainer';
+
+        $this->_em->persist($user1);
+        $this->_em->persist($user2);
+        $this->_em->flush();
 
         $users = $this
             ->_em
@@ -953,7 +979,38 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
             ->findBy(array('status' => array('foo', null)));
 
         $this->assertCount(1, $users);
-        $this->assertSame($user, reset($users));
+        $this->assertSame($user1, reset($users));
+    }
+
+    /**
+     * @group DDC-3056
+     */
+    public function testFindMultipleByNullValueInMultipleInCriteriaValues()
+    {
+        $user1 = new CmsUser();
+        $user2 = new CmsUser();
+
+        $user1->username = 'ocramius';
+        $user1->name = 'Marco';
+        $user2->status = null;
+        $user2->username = 'deeky666';
+        $user2->name = 'Steve';
+        $user2->status = 'dbal maintainer';
+
+        $this->_em->persist($user1);
+        $this->_em->persist($user2);
+        $this->_em->flush();
+
+        $users = $this
+            ->_em
+            ->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
+            ->findBy(array('status' => array('dbal maintainer', null)));
+
+        $this->assertCount(2, $users);
+
+        foreach ($users as $user) {
+            $this->assertTrue(in_array($user, array($user1, $user2)));
+        }
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -13,9 +13,19 @@ require_once __DIR__ . '/../../TestInit.php';
 
 class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
 {
+    /**
+     * @var BasicEntityPersister
+     */
     protected $_persister;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
     protected $_em;
 
+    /**
+     * {@inheritDoc}
+     */
     protected function setUp()
     {
         parent::setUp();
@@ -109,5 +119,26 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
     {
         $statement = $this->_persister->getSelectConditionStatementSQL('test', null, array(), Comparison::NEQ);
         $this->assertEquals('test IS NOT NULL', $statement);
+    }
+
+    /**
+     * @group DDC-3056
+     */
+    public function testSelectConditionStatementWithMultipleValuesContainingNull()
+    {
+        $this->assertEquals(
+            '(t0.id IN (?) OR t0.id IS NULL)',
+            $this->_persister->getSelectConditionStatementSQL('id', array(null))
+        );
+
+        $this->assertEquals(
+            '(t0.id IN (?) OR t0.id IS NULL)',
+            $this->_persister->getSelectConditionStatementSQL('id', array(null, 123))
+        );
+
+        $this->assertEquals(
+            '(t0.id IN (?) OR t0.id IS NULL)',
+            $this->_persister->getSelectConditionStatementSQL('id', array(123, null))
+        );
     }
 }


### PR DESCRIPTION
See DDC-3065 (http://www.doctrine-project.org/jira/browse/DDC-3065)

This _MAY_ be a breakage, since the following API now works as expected:

``` php
$repository->findBy(['fieldName' => [null]]);
$repository->findBy(['fieldName' => [123, null]]);
```

Where before, `null` was just ignored
