### PR TITLE
[DDC-3068] EntityManager::find accept array of object as id

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -377,16 +377,18 @@ use Doctrine\Common\Util\ClassUtils;
     {
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
-        if (is_object($id) && $this->metadataFactory->hasMetadataFor(ClassUtils::getClass($id))) {
-            $id = $this->unitOfWork->getSingleIdentifierValue($id);
-
-            if ($id === null) {
-                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
-            }
-        }
-
         if ( ! is_array($id)) {
             $id = array($class->identifier[0] => $id);
+        }
+
+        foreach ($id as $i => $value) {
+            if (is_object($value) && $this->metadataFactory->hasMetadataFor(ClassUtils::getClass($value))) {
+                $id[$i] = $this->unitOfWork->getSingleIdentifierValue($value);
+
+                if ($id[$i] === null) {
+                    throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+                }
+            }
         }
 
         $sortedId = array();

--- a/tests/Doctrine/Tests/Models/Taxi/Car.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Car.php
@@ -30,6 +30,11 @@ class Car
      */
     private $carRides;
 
+    public function getBrand()
+    {
+        return $this->brand;
+    }
+
     public function setBrand($brand)
     {
         $this->brand = $brand;

--- a/tests/Doctrine/Tests/Models/Taxi/Driver.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Driver.php
@@ -30,6 +30,11 @@ class Driver
      */
     private $driverRides;
 
+    public function getId()
+    {
+        return $this->id;
+    }
+
     public function setName($name)
     {
         $this->name = $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3068Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3068Test.php
@@ -1,0 +1,58 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Taxi\Car,
+    Doctrine\Tests\Models\Taxi\Driver,
+    Doctrine\Tests\Models\Taxi\Ride;
+
+/**
+ * @group DDC-3068
+ * @author Giorgio Premi <giosh94mhz@gmail.com>
+ */
+class DDC3068Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    private $foo;
+
+    private $merc;
+
+    protected function setUp()
+    {
+        $this->useModelSet('taxi');
+        parent::setUp();
+
+        $this->foo = new Driver();
+        $this->foo->setName('Foo Bar');
+        $this->_em->persist($this->foo);
+
+        $this->merc = new Car();
+        $this->merc->setBrand('Mercedes');
+        $this->merc->setModel('C-Class');
+        $this->_em->persist($this->merc);
+
+        $this->_em->flush();
+
+        $ride = new Ride($this->foo, $this->merc);
+        $this->_em->persist($ride);
+
+        $this->_em->flush();
+    }
+
+    public function testFindUsingAnArrayOfObjectAsPrimaryKey()
+    {
+        $ride1 = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', array(
+            'driver' => $this->foo->getId(),
+            'car' => $this->merc->getBrand())
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\Taxi\Ride', $ride1);
+
+        $ride2  = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', array(
+            'driver' => $this->foo,
+            'car' => $this->merc
+        ));
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\Taxi\Ride', $ride2);
+
+        $this->assertSame($ride1, $ride2);
+    }
+}


### PR DESCRIPTION
Pull Request for ticket http://www.doctrine-project.org/jira/browse/DDC-3068
Here follow the ticket description for you convenience.

According to the documentation, `EntityManager::find` should return one entity given it's primary key. When a primary key of an entity is composed of multiple associations, one (me :)) would expect that the following works, but it doesn't:

``` php
$entity = $_em->find('My\EntityClass', array(
    'assoc1' => $instance1,
    'assoc2' => $instance2
));
PHP Fatal error:  Object of class My\EntityClass could not be converted to string
```

The only working way I've found is the following:

``` php
$entity = $_em->find('My\EntityClass', array(
    'assoc1' => $instance1->getId(),
    'assoc2' => $instance2->getId()
));
```

I think that this second scenario is not correct, since expose implementation details.
