### PR TITLE
[DDC-3005] Defer invoking of postLoad event to the end of hydration cycle.

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -186,13 +186,6 @@ the life-time of their registered entities.
 
 .. warning::
 
-    Note that the postLoad event occurs for an entity
-    before any associations have been initialized. Therefore it is not
-    safe to access associations in a postLoad callback or event
-    handler.
-
-.. warning::
-
     Note that the postRemove event or any events triggered after an entity removal
     can receive an uninitializable proxy in case you have configured an entity to
     cascade remove relations. In this case, you should load yourself the proxy in

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -96,6 +96,8 @@ class DefaultCollectionHydrator implements CollectionHydrator
             $collection->hydrateSet($index, $entity);
         });
 
+        $this->uow->hydrationComplete();
+
         return $list;
     }
 }

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -151,6 +151,9 @@ class DefaultEntityHydrator implements EntityHydrator
             $this->uow->registerManaged($entity, $key->identifier, $data);
         }
 
-        return $this->uow->createEntity($entry->class, $data, $hints);
+        $result = $this->uow->createEntity($entry->class, $data, $hints);
+        $this->uow->hydrationComplete();
+
+        return $result;
     }
 }

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -148,6 +148,7 @@ class DefaultQueryCache implements QueryCache
                         if ($this->cacheLogger !== null) {
                             $this->cacheLogger->entityCacheMiss($assocRegion->getName(), $assocKey);
                         }
+                        $this->uow->hydrationComplete();
 
                         return null;
                     }
@@ -175,6 +176,7 @@ class DefaultQueryCache implements QueryCache
                         if ($this->cacheLogger !== null) {
                             $this->cacheLogger->entityCacheMiss($assocRegion->getName(), $assocKey);
                         }
+                        $this->uow->hydrationComplete();
 
                         return null;
                     }
@@ -195,6 +197,8 @@ class DefaultQueryCache implements QueryCache
 
             $result[$index] = $this->uow->createEntity($entityEntry->class, $data, self::$hints);
         }
+
+        $this->uow->hydrationComplete();
 
         return $result;
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -163,8 +163,10 @@ class ObjectHydrator extends AbstractHydrator
         $this->resultPointers = array();
 
         if ($eagerLoad) {
-            $this->_em->getUnitOfWork()->triggerEagerLoads();
+            $this->_uow->triggerEagerLoads();
         }
+
+        $this->_uow->hydrationComplete();
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -43,6 +43,7 @@ class SimpleObjectHydrator extends AbstractHydrator
         if ($this->_rsm->scalarMappings) {
             throw new \RuntimeException("Cannot use SimpleObjectHydrator with a ResultSetMapping that contains scalar mappings.");
         }
+
         $this->class = $this->getClassMetadata(reset($this->_rsm->aliasMap));
     }
 
@@ -87,7 +88,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             if ($metaMappingDiscrColumnName = array_search($discrColumnName, $this->_rsm->metaMappings)) {
                 $discrColumnName = $metaMappingDiscrColumnName;
             }
-            
+
             if ( ! isset($sqlResult[$discrColumnName])) {
                 throw HydrationException::missingDiscriminatorColumn($entityName, $discrColumnName, key($this->_rsm->aliasMap));
             }

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -48,9 +48,18 @@ class SimpleObjectHydrator extends AbstractHydrator
             $this->hydrateRowData($row, $cache, $result);
         }
 
-        $this->_em->getUnitOfWork()->triggerEagerLoads();
-
         return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function cleanup()
+    {
+        parent::cleanup();
+
+        $this->_uow->triggerEagerLoads();
+        $this->_uow->hydrationComplete();
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -55,8 +55,6 @@ class HydrationCompleteHandler
      * @param UnitOfWork $uow
      * @param \Doctrine\ORM\Event\ListenersInvoker $listenersInvoker
      * @param \Doctrine\ORM\EntityManager $em
-     *
-     * @since 2.5
      */
     public function __construct(UnitOfWork $uow, ListenersInvoker $listenersInvoker, EntityManager $em)
     {
@@ -68,8 +66,6 @@ class HydrationCompleteHandler
     /**
      * Method schedules invoking of postLoad entity to the very end of current hydration cycle.
      *
-     * @since 2.5
-     *
      * @param ClassMetadata $class
      * @param object $entity
      */
@@ -80,7 +76,6 @@ class HydrationCompleteHandler
 
     /**
      * This method should me called after any hydration cycle completed.
-     * @since 2.5
      */
     public function hydrationComplete()
     {
@@ -89,7 +84,6 @@ class HydrationCompleteHandler
 
     /**
      * Method fires all deferred invocations of postLoad events
-     * @since 2.5
      */
     private function invokeAllDeferredPostLoadEvents()
     {

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Internal;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\ListenersInvoker;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
+
+/**
+ * Class, which can handle completion of hydration cycle and produce some of tasks.
+ * In current implementation triggers deferred postLoad event.
+ *
+ * TODO Move deferred eager loading here
+ *
+ * @author Artur Eshenbrener <strate@yandex.ru>
+ * @since 2.5
+ */
+class HydrationCompleteHandler
+{
+    /** @var \Doctrine\ORM\UnitOfWork */
+    private $uow;
+
+    /** @var \Doctrine\ORM\Event\ListenersInvoker */
+    private $listenersInvoker;
+
+    /** @var \Doctrine\ORM\EntityManager */
+    private $em;
+
+    /** @var array */
+    private $deferredPostLoadInvocations = array();
+
+    /**
+     * Constructor for this object
+     *
+     * @param UnitOfWork $uow
+     * @param \Doctrine\ORM\Event\ListenersInvoker $listenersInvoker
+     * @param \Doctrine\ORM\EntityManager $em
+     *
+     * @since 2.5
+     */
+    public function __construct(UnitOfWork $uow, ListenersInvoker $listenersInvoker, EntityManager $em)
+    {
+        $this->uow = $uow;
+        $this->listenersInvoker = $listenersInvoker;
+        $this->em = $em;
+    }
+
+    /**
+     * Method schedules invoking of postLoad entity to the very end of current hydration cycle.
+     *
+     * @since 2.5
+     *
+     * @param ClassMetadata $class
+     * @param object $entity
+     */
+    public function deferPostLoadInvoking(ClassMetadata $class, $entity)
+    {
+        $this->deferredPostLoadInvocations[] = array($class, $entity);
+    }
+
+    /**
+     * This method should me called after any hydration cycle completed.
+     * @since 2.5
+     */
+    public function hydrationComplete()
+    {
+        $this->invokeAllDeferredPostLoadEvents();
+    }
+
+    /**
+     * Method fires all deferred invocations of postLoad events
+     * @since 2.5
+     */
+    private function invokeAllDeferredPostLoadEvents()
+    {
+        $toInvoke = $this->deferredPostLoadInvocations;
+        $this->deferredPostLoadInvocations = array();
+        foreach ($toInvoke as $classAndEntity) {
+            list($class, $entity) = $classAndEntity;
+
+            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postLoad);
+
+            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
+                $this->listenersInvoker->invoke($class, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+            }
+        }
+    }
+}

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -268,6 +268,15 @@ class UnitOfWork implements PropertyChangedListener
     protected $hasCache = false;
 
     /**
+     * Map of entities, loaded in current hydration cycle.
+     * After hydration cycle is finished, some of events should be fired for this entities.
+     * Array contains arrays of two values. First value is ClassMetadata object, second is entity object
+     *
+     * @var array
+     */
+    private $deferredToInvokeLoadEventEntities = array();
+
+    /**
      * Initializes a new UnitOfWork instance, bound to the given EntityManager.
      *
      * @param \Doctrine\ORM\EntityManager $em
@@ -2790,11 +2799,8 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         if ($overrideLocalValues) {
-            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postLoad);
-
-            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
-            }
+            // defer invoking of postLoad event to hydration complete step
+            $this->deferredToInvokeLoadEventEntities[] = array($class, $entity);
         }
 
         return $entity;
@@ -3367,5 +3373,24 @@ class UnitOfWork implements PropertyChangedListener
             : $this->flattenIdentifier($class, $class->getIdentifierValues($entity2));
 
         return $id1 === $id2 || implode(' ', $id1) === implode(' ', $id2);
+    }
+
+    /**
+     * This method called by hydrators, and indicates that hydrator totally completed current hydration cycle.
+     * Unit of work able to fire deferred events, related to loading events here.
+     *
+     * @internal should be called internally from object hydrators
+     */
+    public function hydrationComplete()
+    {
+        foreach ($this->deferredToInvokeLoadEventEntities as $metaAndEntity) {
+            list($class, $entity) = $metaAndEntity;
+            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postLoad);
+
+            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
+                $this->listenersInvoker->invoke($class, Events::postLoad, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
+            }
+        }
+        $this->deferredToInvokeLoadEventEntities = array();
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -236,6 +236,9 @@ class CmsUser
         }
     }
 
+    /**
+     * @return CmsEmail
+     */
     public function getEmail() { return $this->email; }
 
     public function setEmail(CmsEmail $email = null) {
@@ -387,7 +390,7 @@ class CmsUser
                   )
             )
         ));
-        
+
         $metadata->addSqlResultSetMapping(array(
             'name'      => 'mappingMultipleJoinsEntityResults',
             'entities'  => array(array(

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -219,6 +220,17 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertTrue($checkerListener->populated, 'Association of email is not populated in postLoad event');
     }
 
+    public function testEventRaisedCorrectTimesWhenOtherEntityLoadedInEventHandler()
+    {
+        $eventManager = $this->_em->getEventManager();
+        $listener = new PostLoadListener_LoadEntityInEventHandler();
+        $eventManager->addEventListener(array(Events::postLoad), $listener);
+
+        $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+        $this->assertSame(1, $listener->countHandledEvents('Doctrine\Tests\Models\CMS\CmsUser'), 'Doctrine\Tests\Models\CMS\CmsUser should be handled once!');
+        $this->assertSame(1, $listener->countHandledEvents('Doctrine\Tests\Models\CMS\CmsEmail'), '\Doctrine\Tests\Models\CMS\CmsEmail should be handled once!');
+    }
+
     private function loadFixture()
     {
         $user = new CmsUser;
@@ -281,5 +293,29 @@ class PostLoadListener_CheckAssociationsArePopulated
             $this->checked = true;
             $this->populated = null !== $object->getEmail();
         }
+    }
+}
+
+class PostLoadListener_LoadEntityInEventHandler
+{
+    private $firedByClasses = array();
+
+    public function postLoad(LifecycleEventArgs $event)
+    {
+        $object = $event->getObject();
+        $class = ClassUtils::getClass($object);
+        if (!isset($this->firedByClasses[$class])) {
+            $this->firedByClasses[$class] = 1;
+        } else {
+            $this->firedByClasses[$class]++;
+        }
+        if ($object instanceof CmsUser) {
+            $object->getEmail()->getEmail();
+        }
+    }
+
+    public function countHandledEvents($className)
+    {
+        return isset($this->firedByClasses[$className]) ? $this->firedByClasses[$className] : 0;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -208,7 +208,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testAssociationsArePopulatedWhenEventIsFired()
     {
-        $checkerListener = new PostLoadListener_CheckAssociationsArePopulated();
+        $checkerListener = new PostLoadListenerCheckAssociationsArePopulated();
         $this->_em->getEventManager()->addEventListener(array(Events::postLoad), $checkerListener);
 
         $qb = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->createQueryBuilder('u');
@@ -223,7 +223,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testEventRaisedCorrectTimesWhenOtherEntityLoadedInEventHandler()
     {
         $eventManager = $this->_em->getEventManager();
-        $listener = new PostLoadListener_LoadEntityInEventHandler();
+        $listener = new PostLoadListenerLoadEntityInEventHandler();
         $eventManager->addEventListener(array(Events::postLoad), $listener);
 
         $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
@@ -277,7 +277,7 @@ class PostLoadListener
     }
 }
 
-class PostLoadListener_CheckAssociationsArePopulated
+class PostLoadListenerCheckAssociationsArePopulated
 {
     public $checked = false;
 
@@ -296,7 +296,7 @@ class PostLoadListener_CheckAssociationsArePopulated
     }
 }
 
-class PostLoadListener_LoadEntityInEventHandler
+class PostLoadListenerLoadEntityInEventHandler
 {
     private $firedByClasses = array();
 


### PR DESCRIPTION
This feature makes guarantee, that postLoad event fires after all associations are populated.
Test case also provided.

http://www.doctrine-project.org/jira/browse/DDC-3005
