### PR TITLE
Fixed wrongly initialized property.

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -95,7 +95,7 @@ class QueryBuilder
      *
      * @var \Doctrine\Common\Collections\ArrayCollection
      */
-    private $parameters = array();
+    private $parameters;
 
     /**
      * The index of the first result to retrieve.


### PR DESCRIPTION
This removes an incorrect `= array()` initialization on `$parameters`, which is actually an `ArrayCollection` and has its value set in the constructor.
