### PR TITLE
Removed all useless occurrence of require_once TestInit.php

### DIFF
--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * Tests of the commit order calculation.
  *

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -8,8 +8,6 @@ use Doctrine\ORM\ORMException;
 use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * Tests for the Configuration object
  * @author Marco Pivetta <ocramius@gmail.com>

--- a/tests/Doctrine/Tests/ORM/Entity/ConstructorTest.php
+++ b/tests/Doctrine/Tests/ORM/Entity/ConstructorTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Entity;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ConstructorTest extends \Doctrine\Tests\OrmTestCase
 {
     public function testFieldInitializationInConstructor()

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM;
 
-require_once __DIR__ . '/../TestInit.php';
-
 class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 {
     private $_em;

--- a/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\Collection;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Base class for testing a many-to-many association mapping (without inheritance).
  */

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional tests for the Single Table Inheritance mapping strategy.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\Company\CompanyEmployee,
     Doctrine\Tests\Models\Company\CompanyPerson,
     Doctrine\Tests\Models\Company\CompanyCar;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional Query tests.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -11,8 +11,6 @@ use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsComment;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional tests for the Class Table Inheritance mapping strategy.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/ClearEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClearEventTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Event\OnClearEventArgs;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * ClearEventTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\Navigation\NavTour;
 use Doctrine\Tests\Models\Navigation\NavPhotos;
 use Doctrine\Tests\Models\Navigation\NavUser;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests basic operations on entities with default values.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -8,8 +8,6 @@ use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Description of DetachedEntityTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Description of ExtraLazyCollectionTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * FlushEventTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser,
     Doctrine\Tests\Models\CMS\CmsPhonenumber,
     Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * IdentityMapTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/IndexByAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IndexByAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\StockExchange\Stock;
 use Doctrine\Tests\Models\StockExchange\Market;
 use Doctrine\Tests\Models\StockExchange\Bond;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-250
  */

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -3,8 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp() {

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsArticle,
     Doctrine\DBAL\LockMode,
     Doctrine\ORM\EntityManager;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group locking_functional
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
-require_once __DIR__ . "/../../../TestInit.php";
-
 class LockAgentWorker
 {
     private $em;

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsArticle,
     Doctrine\DBAL\LockMode,
     Doctrine\ORM\EntityManager;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group locking
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -10,8 +10,6 @@ use Doctrine\Tests\TestUtil;
 use Doctrine\DBAL\LockMode;
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser,
     Doctrine\Tests\Models\CMS\CmsGroup,
     Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Basic many-to-many association tests.
  * ("Working with associations")

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCategory;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional many-to-many association mapping (without inheritance).
  * Owning side is ECommerceProduct, inverse side is ECommerceCategory.

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Doctrine\Tests\ORM\Functional;
+
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\ORM\Events;
-require_once __DIR__ . '/../../TestInit.php';
 
 /**
  * ManyToManyEventTest

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a self referential many-to-many association mapping (from a model to the same model, without inheritance).
  * For simplicity the relation duplicates entries in the association table

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a unidirectional many-to-many association mapping (without inheritance).
  * Inverse side is not present.

--- a/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * MappedSuperclassTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -17,8 +17,6 @@ use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\Models\Company\CompanyPerson;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * NativeQueryTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-1574
  */

--- a/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
@@ -5,8 +5,6 @@ use Doctrine\Common\Collections\ArrayCollection,
     Doctrine\Common\NotifyPropertyChanged,
     Doctrine\Common\PropertyChangedListener;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * NativeQueryTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Common\Collections\Criteria;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-one association mapping (without inheritance).
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyOrphanRemovalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyOrphanRemovalTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\CMS\CmsUser,
     Doctrine\Tests\Models\CMS\CmsAddress,
     Doctrine\Tests\Models\CMS\CmsPhonenumber;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-many association mapping with orphan removal.
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCategory;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-one association mapping (without inheritance).
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\Routing\RoutingRoute;
 use Doctrine\Tests\Models\Routing\RoutingLocation;
 use Doctrine\Tests\Models\Routing\RoutingLeg;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-one association mapping (without inheritance).
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-one association mapping (without inheritance).
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-952
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneOrphanRemovalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneOrphanRemovalTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser,
     Doctrine\Tests\Models\CMS\CmsAddress,
     Doctrine\Tests\Models\CMS\CmsPhonenumber;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a bidirectional one-to-one association mapping with orphan removal.
  */

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a self referential one-to-one association mapping (without inheritance).
  * Relation is defined as the mentor that a customer choose. The mentor could

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -8,8 +8,6 @@ use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests a unidirectional one-to-one association mapping (without inheritance).
  * Inverse side is not present.

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\Routing\RoutingLocation;
 use Doctrine\Tests\Models\Routing\RoutingLeg;
 use Doctrine\Tests\Models\Routing\RoutingRouteBooking;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class OrderedCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected $locations = array();

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional tests for the Single Table Inheritance mapping strategy.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Doctrine\Tests\ORM\Functional;
+
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
-require_once __DIR__ . '/../../TestInit.php';
 
 /**
  * PostFlushEventTest

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -8,8 +8,6 @@ use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * PostLoadEventTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Common\Cache\ArrayCache;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * QueryCacheTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\Company\CompanyManager;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional Query tests.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -12,8 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional Query tests.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Functional Query tests.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -8,8 +8,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceShipping;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests the generation of a proxy object for lazy loading.
  * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Common\Cache\ArrayCache;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * ResultCacheTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -25,8 +25,6 @@ use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\Company\CompanyFlexContract;
 use Doctrine\Tests\Models\Company\CompanyFlexUltraContract;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests SQLFilter functionality.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
 use Doctrine\DBAL\Schema\Schema;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Functional tests for the Class Table Inheritance mapping strategy.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 use Doctrine\ORM\Tools\SchemaTool,
     Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp() {

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 use Doctrine\ORM\Tools\SchemaTool,
     Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Schema\Sequence;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SequenceEmulatedIdentityStrategyTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Description of SequenceGeneratorTest
  *

--- a/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
@@ -9,8 +9,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCart,
 
 use Doctrine\ORM\Mapping\AssociationMapping;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Tests capabilities of the persister.
  * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1040Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1040Test.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1040

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1041Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1041Test.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1041

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1043Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1043Test.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1043

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1050Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1050Test.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1050

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1080
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1113
  * @group DDC-1306

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1129Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1129Test.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1129

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1151
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1163
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -10,8 +10,6 @@ use Doctrine\Tests\Models\DDC117\DDC117ApproveChanges;
 use Doctrine\Tests\Models\DDC117\DDC117Editor;
 use Doctrine\Tests\Models\DDC117\DDC117Link;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-117
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC1181Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -1,8 +1,6 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use DateTime, Doctrine\DBAL\Types\Type;
 
 class DDC1193Test extends \Doctrine\Tests\OrmFunctionalTestCase

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC1209Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1225
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1228
  * @group DDC-1226

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1238
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1250
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1276Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1276Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1276
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1300
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @author asm89
  *

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1306
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1335
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
@@ -3,8 +3,6 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1383
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
@@ -1,9 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
-use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\ORM\UnitOfWork;
 
 /**
  * @group DDC-1392

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
@@ -1,9 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
-use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\ORM\UnitOfWork;
 
 /**
  * @group DDC-1400

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1404
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Tests\Models\Quote\User;
 use Doctrine\Tests\Models\Quote\Address;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1845
  * @group DDC-142

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1430
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC144Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp() {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1452
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1454
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1458Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1458Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC1258Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-1461

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1514
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1545Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1545Test.php
@@ -8,8 +8,6 @@ use Doctrine\Tests\Models\CMS\CmsComment;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1545
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC163Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Company\CompanyPerson;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC163Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC168Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected $oldMetadata;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -1,10 +1,9 @@
 <?php
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\NotifyPropertyChanged,
     Doctrine\Common\PropertyChangedListener;
-
-require_once __DIR__ . '/../../../TestInit.php';
 
 class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Quote\SimpleEntity;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1719
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1757Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1757Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC1757Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testFailingCase()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1787
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Quote\Group;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1845
  * @group DDC-1843

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -6,8 +6,6 @@ use Doctrine\Tests\Models\Taxi\Car,
     Doctrine\Tests\Models\Taxi\Ride,
     Doctrine\Tests\Models\Taxi\PaidRide;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1884
  * @author Sander Coolen <sander@jibber.nl>

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-1925
  * @group DDC-1210

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC192Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testSchemaCreation()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC199Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC211Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC2182Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testPassColumnOptionsToJoinColumns()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -3,12 +3,8 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-
 use Doctrine\Common\Persistence\ObjectManager;
-
 use Doctrine\Common\Persistence\ObjectManagerAware;
-
-require_once __DIR__ . '/../../../TestInit.php';
 
 /**
  * @group DDC-2231

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2645Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2645Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-2645
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC279Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-2931
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
@@ -1,8 +1,6 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC309Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC331Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC331Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\Tests\Models\Company\CompanyPerson,
     Doctrine\Tests\Models\Company\CompanyEmployee,
     Doctrine\Tests\Models\Company\CompanyManager,

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC345Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
@@ -1,9 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
-use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\ORM\UnitOfWork;
 
 class DDC353Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -3,8 +3,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-371
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
@@ -1,9 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
-use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
+use Doctrine\ORM\UnitOfWork;
 
 class DDC381Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC422Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
@@ -1,8 +1,6 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use DateTime, Doctrine\DBAL\Types\Type;
 
 class DDC425Test extends \Doctrine\Tests\OrmFunctionalTestCase

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC440Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC444Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
@@ -1,8 +1,6 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC448Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC493Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
@@ -8,8 +8,6 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\ORM\UnitOfWork;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * ----------------- !! NOTE !! --------------------
  * To reproduce the manyToMany-Bug it's necessary

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
@@ -1,8 +1,6 @@
 <?php
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC512Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC513Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC518Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC518Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC518Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Company\CompanyPerson;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Tests that join columns (foreign keys) can be named the same as the association
  * fields they're used on without causing issues.

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC531Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC588Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC599Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-618
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC656Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC698Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC719Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC729Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC735Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group non-cacheable
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC748Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC748Test.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC748Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC758Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC758Test.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC758Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC767Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC809Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC812Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC812Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsComment;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC812Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -1,7 +1,6 @@
 <?php
-namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class DDC837Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC849Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC849Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC849Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     private $user;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC881Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC933Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\Generic\BooleanModel;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC949Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class DDC960Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * @group DDC-992
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 class Ticket2481Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Functional tests for the Single Table Inheritance mapping strategy.
  *

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -10,8 +10,6 @@ use Doctrine\Tests\Models\Generic\SerializationModel;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\DBAL\Types\Type as DBALType;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class TypeTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
@@ -7,8 +7,6 @@ use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\CustomType\CustomTypeUpperCase;
 use Doctrine\DBAL\Types\Type as DBALType;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class TypeValueSqlTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ArrayHydratorTest extends HydrationTestCase
 {
     public function provideDataForUserEntityResult()

--- a/tests/Doctrine/Tests/ORM/Hydration/CustomHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/CustomHydratorTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 
 use PDO, Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class CustomHydratorTest extends HydrationTestCase
 {
     public function testCustomHydrator()

--- a/tests/Doctrine/Tests/ORM/Hydration/HydrationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/HydrationTestCase.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Hydration;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\Parser;
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -11,8 +11,6 @@ use Doctrine\ORM\Query;
 
 use Doctrine\Tests\Models\CMS\CmsUser;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ObjectHydratorTest extends HydrationTestCase
 {
     public function provideDataForUserEntityResult()

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Description of ResultSetMappingTest
  *

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ScalarHydratorTest extends HydrationTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SimpleObjectHydratorTest extends HydrationTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Hydration;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SingleScalarHydratorTest extends HydrationTestCase
 {
     /** Result set provider for the HYDRATE_SINGLE_SCALAR tests */

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Id;
 
 use Doctrine\ORM\Id\AssignedGenerator;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * AssignedGeneratorTest
  *

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Id;
 
 use Doctrine\ORM\Id\SequenceGenerator;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Description of SequenceGeneratorTest
  *

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -10,8 +10,6 @@ use Doctrine\Tests\Models\Cache\City;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
 {
     abstract protected function _loadDriver();

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\SchemaTool;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BasicInheritanceMappingTest extends \Doctrine\Tests\OrmTestCase
 {
     private $_factory;

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -10,8 +10,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
 {
     public function testGetMetadataForSingleClass()

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataLoadEventTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ClassMetadataLoadEventTest extends \Doctrine\Tests\OrmTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
 require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 
 class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\NamingStrategy;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-559
  */

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping\ClassMetadata,
     Doctrine\Common\Persistence\Mapping\Driver\PHPDriver,
     Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class PHPMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function _loadDriver()

--- a/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group DDC-1845
  */

--- a/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping\ClassMetadata,
     Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver,
     Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function _loadDriver()

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\Mapping\ClassMetadata,
     Doctrine\ORM\Mapping\Driver\XmlDriver,
     Doctrine\ORM\Mapping\Driver\YamlDriver;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class XmlMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function _loadDriver()

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping\ClassMetadata,
     Doctrine\ORM\Mapping\Driver\XmlDriver,
     Doctrine\ORM\Mapping\Driver\YamlDriver;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class YamlMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function _loadDriver()

--- a/tests/Doctrine/Tests/ORM/Performance/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Performance/DDC2602Test.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group performance
  * @group DDC-2602

--- a/tests/Doctrine/Tests/ORM/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/HydrationPerformanceTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Performance;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\Tests\Mocks\HydratorMockStatement,
     Doctrine\ORM\Query\ResultSetMapping,
     Doctrine\ORM\Query;

--- a/tests/Doctrine/Tests/ORM/Performance/InheritancePersisterPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/InheritancePersisterPerformanceTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Performance;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
 * @group performance
  */

--- a/tests/Doctrine/Tests/ORM/Performance/InsertPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/InsertPerformanceTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Performance;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
@@ -11,8 +11,6 @@ use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsComment;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * @group performance
  */

--- a/tests/Doctrine/Tests/ORM/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/UnitOfWorkPerformanceTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Performance;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -9,8 +9,6 @@ use Doctrine\Tests\Models\CustomType\CustomTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomTypeFriend;
 use Doctrine\Common\Collections\Expr\Comparison;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
 {
     protected $_persister;

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -21,8 +21,6 @@
 
 namespace Doctrine\Tests\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Test case for testing the saving and referencing of query identifiers.
  *

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -22,8 +22,6 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Test case for the DQL Expr class used for generating DQL snippets through
  * a programmatic interface

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 use Doctrine\ORM\Mapping\ClassMetaData,
     Doctrine\ORM\Query\Filter\SQLFilter;
 

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\ORM\Query,
     Doctrine\ORM\Query\QueryException;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
 {
     private $_em;

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\ORM\Query\Lexer;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class LexerTest extends \Doctrine\Tests\OrmTestCase
 {
     //private $_lexer;

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -23,8 +23,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use PDO;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ParameterTypeInfererTest extends \Doctrine\Tests\OrmTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Query;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 {
     private $_em;

--- a/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
@@ -23,8 +23,6 @@ namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\DBAL\Types\Type as DBALType;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Test case for testing the saving and referencing of query identifiers.
  *

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -28,8 +28,6 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * Test case for the QueryBuilder class used to build DQL query string in a
  * object oriented way.

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -31,8 +31,6 @@ use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 /**
  * Test case for converting a Doctrine 1 style schema to Doctrine 2 mapping files
  *

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -10,8 +10,6 @@ use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\Tests\Models\DDC2372\DDC2372User;
 use Doctrine\Tests\Models\DDC2372\DDC2372Admin;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -33,8 +33,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Test case for ClassMetadataExporter
  *

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
@@ -21,8 +21,6 @@
 
 namespace Doctrine\Tests\ORM\Tools\Export;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Test case for AnnotationClassMetadataExporterTest
  *

--- a/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
@@ -21,8 +21,6 @@
 
 namespace Doctrine\Tests\ORM\Tools\Export;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Test case for PhpClassMetadataExporterTest
  *

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -21,8 +21,6 @@
 
 namespace Doctrine\Tests\ORM\Tools\Export;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Test case for XmlClassMetadataExporterTest
  *

--- a/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
@@ -21,8 +21,6 @@
 
 namespace Doctrine\Tests\ORM\Tools\Export;
 
-require_once __DIR__ . '/../../../TestInit.php';
-
 /**
  * Test case for YamlClassMetadataExporterTest
  *

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\Tools\ToolEvents;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
 {
     public function testAddUniqueIndexForUniqueFieldAnnotation()

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -4,8 +4,6 @@ namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\ORM\Tools\SchemaValidator;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Tools;
 use Doctrine\ORM\Tools\Setup;
 use Doctrine\Common\Cache\ArrayCache;
 
-require_once __DIR__ . '/../../TestInit.php';
-
 class SetupTest extends \Doctrine\Tests\OrmTestCase
 {
     private $originalAutoloaderCount;

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -10,8 +10,6 @@ use Doctrine\Tests\Mocks\EntityPersisterMock;
 use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
 
-require_once __DIR__ . '/../TestInit.php';
-
 /**
  * UnitOfWork tests.
  */


### PR DESCRIPTION
As @Ocramius pointed out when discussing about PR #1000, the statement `require_once [...]TestInit.php` is no longer useful.

I've removed all occurrence from the test cases.
