### PR TITLE
Handling invalid discriminator values

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -88,4 +88,18 @@ class HydrationException extends \Doctrine\ORM\ORMException
             $discrColumnName, $entityName, $dqlAlias
         ));
     }
+    
+    /**
+     * @param string $discrValue
+     * @param array  $discrMap
+     *
+     * @return HydrationException
+     */
+    public static function invalidDiscriminatorValue($discrValue, $discrMap)
+    {
+        return new self(sprintf(
+            'The discriminator value "%s" is invalid. It must be one of "%s".',
+            $discrValue, implode('", "', $discrMap)
+        ));
+    }
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -266,7 +266,13 @@ class ObjectHydrator extends AbstractHydrator
                 throw HydrationException::emptyDiscriminatorValue($dqlAlias);
             }
 
-            $className = $this->ce[$className]->discriminatorMap[$data[$discrColumn]];
+            $discrMap = $this->ce[$className]->discriminatorMap;
+
+            if ( ! isset($discrMap[$data[$discrColumn]])) {
+                throw HydrationException::invalidDiscriminatorValue($data[$discrColumn], array_keys($discrMap));
+            }
+
+            $className = $discrMap[$data[$discrColumn]];
 
             unset($data[$discrColumn]);
         }

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -98,7 +98,13 @@ class SimpleObjectHydrator extends AbstractHydrator
                 throw HydrationException::emptyDiscriminatorValue(key($this->_rsm->aliasMap));
             }
 
-            $entityName = $this->class->discriminatorMap[$sqlResult[$discrColumnName]];
+            $discrMap = $this->class->discriminatorMap;
+
+            if ( ! isset($discrMap[$sqlResult[$discrColumnName]])) {
+                throw HydrationException::invalidDiscriminatorValue($sqlResult[$discrColumnName], array_keys($discrMap));
+            }
+            
+            $entityName = $discrMap[$sqlResult[$discrColumnName]];
 
             unset($sqlResult[$discrColumnName]);
         }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1926,4 +1926,34 @@ class ObjectHydratorTest extends HydrationTestCase
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
+
+    /**
+     * @group DDC-3076
+     *
+     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
+     * @expectedExceptionMessage The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".
+     */
+    public function testInvalidDiscriminatorValueException()
+    {
+        $rsm = new ResultSetMapping;
+
+        $rsm->addEntityResult('Doctrine\Tests\Models\Company\CompanyPerson', 'p');
+
+        $rsm->addFieldResult('p', 'p__id', 'id');
+        $rsm->addFieldResult('p', 'p__name', 'name');
+        $rsm->addMetaResult('p', 'discr', 'discr');
+        $rsm->setDiscriminatorColumn('p', 'discr');
+
+        $resultSet = array(
+              array(
+                  'p__id'   => '1',
+                  'p__name' => 'Fabio B. Silva',
+                  'discr'   => 'subworker'
+              ),
+         );
+
+        $stmt       = new HydratorMockStatement($resultSet);
+        $hydrator   = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator->hydrateAll($stmt, $rsm);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -56,4 +56,31 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $result = $hydrator->hydrateAll($stmt, $rsm);
         $this->assertEquals($result[0], $expectedEntity);
     }
+
+    /**
+     * @group DDC-3076
+     *
+     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
+     * @expectedExceptionMessage The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".
+     */
+    public function testInvalidDiscriminatorValueException()
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addEntityResult('Doctrine\Tests\Models\Company\CompanyPerson', 'p');
+        $rsm->addFieldResult('p', 'p__id', 'id');
+        $rsm->addFieldResult('p', 'p__name', 'name');
+        $rsm->addMetaResult('p ', 'discr', 'discr');
+        $rsm->setDiscriminatorColumn('p', 'discr');
+        $resultSet = array(
+              array(
+                  'u__id'   => '1',
+                  'u__name' => 'Fabio B. Silva',
+                  'discr'   => 'subworker'
+              ),
+         );
+
+        $stmt       = new HydratorMockStatement($resultSet);
+        $hydrator   = new \Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator($this->_em);
+        $hydrator->hydrateAll($stmt, $rsm);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -66,15 +66,18 @@ class SimpleObjectHydratorTest extends HydrationTestCase
     public function testInvalidDiscriminatorValueException()
     {
         $rsm = new ResultSetMapping;
+
         $rsm->addEntityResult('Doctrine\Tests\Models\Company\CompanyPerson', 'p');
+
         $rsm->addFieldResult('p', 'p__id', 'id');
         $rsm->addFieldResult('p', 'p__name', 'name');
-        $rsm->addMetaResult('p ', 'discr', 'discr');
+        $rsm->addMetaResult('p', 'discr', 'discr');
         $rsm->setDiscriminatorColumn('p', 'discr');
+
         $resultSet = array(
               array(
-                  'u__id'   => '1',
-                  'u__name' => 'Fabio B. Silva',
+                  'p__id'   => '1',
+                  'p__name' => 'Fabio B. Silva',
                   'discr'   => 'subworker'
               ),
          );


### PR DESCRIPTION
Two scenarios:
- **The DiscriminatorMap is specified via metadata**. In case the entity's discriminator value is not matching with a value of the DiscriminatorMap it will result in a `Notice: Undefined index ... on line 102` and `exception 'Doctrine\Common\Persistence\Mapping\MappingException' with message 'Class '' does not exist' in`. The proposed changes deal with this.
- **The DiscriminatorMap is automatically generated**. The discriminator value may no longer be invalid if there's just metadata missing for the automatically generated class names. I'm not sure how to deal with that properly.
