### PR TITLE
DDC-3078 SLC Cache interface ctor removal

### DIFF
--- a/lib/Doctrine/ORM/Cache.php
+++ b/lib/Doctrine/ORM/Cache.php
@@ -55,13 +55,6 @@ interface Cache
     const MODE_REFRESH = 4;
 
     /**
-     * Construct
-     *
-     * @param \Doctrine\ORM\EntityManagerInterface $em
-     */
-    public function __construct(EntityManagerInterface $em);
-
-    /**
      * @param string $className The entity class.
      *
      * @return \Doctrine\ORM\Cache\Region|null

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -58,11 +58,6 @@ class CacheConfiguration
     private $cacheInstantiator;
 
     /**
-     * @var string
-     */
-    private $cacheClassName = 'Doctrine\ORM\Cache\DefaultCache';
-
-    /**
      * @return \Doctrine\ORM\Cache\CacheFactory|null
      */
     public function getCacheFactory()
@@ -163,29 +158,5 @@ class CacheConfiguration
         }
 
         return $this->cacheInstantiator;
-    }
-
-    /**
-     * @param string $className
-     *
-     * @throws \Doctrine\ORM\ORMException If is not a \Doctrine\ORM\Cache
-     */
-    public function setCacheClassName($className)
-    {
-        $reflectionClass = new \ReflectionClass($className);
-
-        if ( ! $reflectionClass->implementsInterface('Doctrine\ORM\Cache')) {
-            throw ORMException::invalidSecondLevelCache($className);
-        }
-
-        $this->cacheClassName = $className;
-    }
-
-    /**
-     * @return string A \Doctrine\ORM\Cache class name
-     */
-    public function getCacheClassName()
-    {
-        return $this->cacheClassName;
     }
 }

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -20,6 +20,7 @@
 
 namespace Doctrine\ORM\Cache;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
 
@@ -50,6 +51,11 @@ class CacheConfiguration
      * @var \Doctrine\ORM\Cache\QueryCacheValidator|null
      */
     private $queryValidator;
+
+    /**
+     * @var callable|null
+     */
+    private $cacheInstantiator;
 
     /**
      * @var string
@@ -128,6 +134,35 @@ class CacheConfiguration
     public function setQueryValidator(QueryCacheValidator $validator)
     {
         $this->queryValidator = $validator;
+    }
+
+    /**
+     * @param callable $instantiator responsible of retrieving an {@see \Doctrine\ORM\Cache} instance given
+     *                               a {@see \Doctrine\ORM\EntityManagerInterface} instance
+     *
+     * @throws ORMException if the given instantiator is not a valid callable
+     */
+    public function setCacheInstantiator($instantiator)
+    {
+        if ( ! is_callable($instantiator)) {
+            throw ORMException::invalidSecondLevelCacheInstantiator($instantiator);
+        }
+
+        $this->cacheInstantiator = $instantiator;
+    }
+
+    /**
+     * @return callable that
+     */
+    public function getCacheInstantiator()
+    {
+        if ( ! $this->cacheInstantiator) {
+            $this->cacheInstantiator = function (EntityManagerInterface $entityManager) {
+                return new DefaultCache($entityManager);
+            };
+        }
+
+        return $this->cacheInstantiator;
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -20,8 +20,6 @@
 
 namespace Doctrine\ORM\Cache;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
 
 /**

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -53,7 +53,7 @@ class CacheConfiguration
     private $queryValidator;
 
     /**
-     * @var callable|null
+     * @var CacheInstantiator|null
      */
     private $cacheInstantiator;
 
@@ -132,31 +132,18 @@ class CacheConfiguration
     }
 
     /**
-     * @param callable $instantiator responsible of retrieving an {@see \Doctrine\ORM\Cache} instance given
-     *                               a {@see \Doctrine\ORM\EntityManagerInterface} instance
-     *
-     * @throws ORMException if the given instantiator is not a valid callable
+     * @param CacheInstantiator
      */
-    public function setCacheInstantiator($instantiator)
+    public function setCacheInstantiator(CacheInstantiator $cacheInstantiator)
     {
-        if ( ! is_callable($instantiator)) {
-            throw ORMException::invalidSecondLevelCacheInstantiator($instantiator);
-        }
-
-        $this->cacheInstantiator = $instantiator;
+        $this->cacheInstantiator = $cacheInstantiator;
     }
 
     /**
-     * @return callable that
+     * @return CacheInstantiator
      */
     public function getCacheInstantiator()
     {
-        if ( ! $this->cacheInstantiator) {
-            $this->cacheInstantiator = function (EntityManagerInterface $entityManager) {
-                return new DefaultCache($entityManager);
-            };
-        }
-
-        return $this->cacheInstantiator;
+        return $this->cacheInstantiator ?: $this->cacheInstantiator = new DefaultCacheInstantiator();
     }
 }

--- a/lib/Doctrine/ORM/Cache/CacheInstantiator.php
+++ b/lib/Doctrine/ORM/Cache/CacheInstantiator.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Cache;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Contract for building second level cache instances.
+ *
+ * @since   2.5
+ * @author  Marco Pivetta <ocramius@gmail.com>
+ */
+interface CacheInstantiator
+{
+    /**
+     * Build timestamp cache region
+     *
+     * @param EntityManagerInterface $entityManager
+     *
+     * @return \Doctrine\ORM\Cache
+     */
+    public function getCache(EntityManagerInterface $entityManager);
+}

--- a/lib/Doctrine/ORM/Cache/DefaultCacheInstantiator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheInstantiator.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Cache;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Default implementation of the {@see \Doctrine\ORM\Cache\CacheInstantiator}, responsible
+ * for producing an {@see \Doctrine\ORM\Cache\DefaultCache}
+ *
+ * @since   2.5
+ * @author  Marco Pivetta <ocramius@gmail.com>
+ */
+class DefaultCacheInstantiator implements CacheInstantiator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getCache(EntityManagerInterface $entityManager)
+    {
+        return new DefaultCache($entityManager);
+    }
+}

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -166,8 +166,7 @@ use Doctrine\Common\Util\ClassUtils;
         );
 
         if ($config->isSecondLevelCacheEnabled()) {
-            $cacheInstantiator = $config->getSecondLevelCacheConfiguration()->getCacheInstantiator();
-            $this->cache       = $cacheInstantiator($this);
+            $this->cache = $config->getSecondLevelCacheConfiguration()->getCacheInstantiator()->getCache($this);
         }
     }
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -166,8 +166,8 @@ use Doctrine\Common\Util\ClassUtils;
         );
 
         if ($config->isSecondLevelCacheEnabled()) {
-            $cacheClass  = $config->getSecondLevelCacheConfiguration()->getCacheClassName();
-            $this->cache = new $cacheClass($this);
+            $cacheInstantiator = $config->getSecondLevelCacheConfiguration()->getCacheInstantiator();
+            $this->cache       = $cacheInstantiator($this);
         }
     }
 

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -263,19 +263,6 @@ class ORMException extends Exception
     }
 
     /**
-     * @param mixed $instantiator
-     *
-     * @return ORMException
-     */
-    public static function invalidSecondLevelCacheInstantiator($instantiator)
-    {
-        return new self(sprintf(
-            'The provided instantiator is not a valid callable, "%s" given.',
-            is_object($instantiator) ? get_class($instantiator) : gettype($instantiator)
-        ));
-    }
-
-    /**
      * @param string $className
      * @param string $fieldName
      *

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -263,6 +263,19 @@ class ORMException extends Exception
     }
 
     /**
+     * @param mixed $instantiator
+     *
+     * @return ORMException
+     */
+    public static function invalidSecondLevelCacheInstantiator($instantiator)
+    {
+        return new self(sprintf(
+            'The provided instantiator is not a valid callable, "%s" given.',
+            is_object($instantiator) ? get_class($instantiator) : gettype($instantiator)
+        ));
+    }
+
+    /**
      * @param string $className
      *
      * @return ORMException

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -277,16 +277,6 @@ class ORMException extends Exception
 
     /**
      * @param string $className
-     *
-     * @return ORMException
-     */
-    public static function invalidSecondLevelCache($className)
-    {
-        return new self(sprintf('Invalid cache class "%s". It must be a Doctrine\ORM\Cache.', $className));
-    }
-
-    /**
-     * @param string $className
      * @param string $fieldName
      *
      * @return ORMException

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -27,18 +27,6 @@ class CacheConfigTest extends DoctrineTestCase
         $this->config = new CacheConfiguration();
     }
 
-    public function testSetGetCacheClassName()
-    {
-        $mockClass = get_class($this->getMock('Doctrine\ORM\Cache'));
-
-        $this->assertEquals('Doctrine\ORM\Cache\DefaultCache', $this->config->getCacheClassName());
-        $this->config->setCacheClassName($mockClass);
-        $this->assertEquals($mockClass, $this->config->getCacheClassName());
-
-        $this->setExpectedException('Doctrine\ORM\ORMException');
-        $this->config->setCacheClassName(__CLASS__);
-    }
-
     /**
      * @covers \Doctrine\ORM\Cache\CacheConfiguration::getCacheInstantiator
      */

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -32,18 +32,7 @@ class CacheConfigTest extends DoctrineTestCase
      */
     public function testGetDefaultCacheIstantiator()
     {
-        $entityManager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
-        $config        = $this->getMock('Doctrine\ORM\Configuration');
-
-        $entityManager->expects($this->any())->method('getConfiguration')->will($this->returnValue($config));
-        $config
-            ->expects($this->any())
-            ->method('getSecondLevelCacheConfiguration')
-            ->will($this->returnValue($this->config));
-
-        $defaultIstantiator = $this->config->getCacheInstantiator();
-
-        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCache', $defaultIstantiator($entityManager));
+        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultInstantiator', $this->config->getCacheInstantiator());
     }
 
     /**
@@ -51,14 +40,10 @@ class CacheConfigTest extends DoctrineTestCase
      */
     public function testSetGetCacheIstantiator()
     {
-        $istantiator = function () {};
+        $istantiator = $this->getMock('Doctrine\ORM\Cache\CacheInstantiator');
 
         $this->config->setCacheInstantiator($istantiator);
         $this->assertSame($istantiator, $this->config->getCacheInstantiator());
-
-        $this->setExpectedException('Doctrine\ORM\ORMException');
-
-        $this->config->setCacheInstantiator(null);
     }
 
     public function testSetGetRegionLifetime()

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Cache\CacheConfiguration;
 
 /**
  * @group DDC-2183
+ *
+ * @covers \Doctrine\ORM\Cache\CacheConfiguration
  */
 class CacheConfigTest extends DoctrineTestCase
 {
@@ -15,6 +17,9 @@ class CacheConfigTest extends DoctrineTestCase
      */
     private $config;
 
+    /**
+     * {@inheritDoc}
+     */
     protected function setUp()
     {
         parent::setUp();
@@ -32,6 +37,40 @@ class CacheConfigTest extends DoctrineTestCase
 
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->config->setCacheClassName(__CLASS__);
+    }
+
+    /**
+     * @covers \Doctrine\ORM\Cache\CacheConfiguration::getCacheInstantiator
+     */
+    public function testGetDefaultCacheIstantiator()
+    {
+        $entityManager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $config        = $this->getMock('Doctrine\ORM\Configuration');
+
+        $entityManager->expects($this->any())->method('getConfiguration')->will($this->returnValue($config));
+        $config
+            ->expects($this->any())
+            ->method('getSecondLevelCacheConfiguration')
+            ->will($this->returnValue($this->config));
+
+        $defaultIstantiator = $this->config->getCacheInstantiator();
+
+        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCache', $defaultIstantiator($entityManager));
+    }
+
+    /**
+     * @covers \Doctrine\ORM\Cache\CacheConfiguration::getCacheInstantiator
+     */
+    public function testSetGetCacheIstantiator()
+    {
+        $istantiator = function () {};
+
+        $this->config->setCacheInstantiator($istantiator);
+        $this->assertSame($istantiator, $this->config->getCacheInstantiator());
+
+        $this->setExpectedException('Doctrine\ORM\ORMException');
+
+        $this->config->setCacheInstantiator(null);
     }
 
     public function testSetGetRegionLifetime()

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -32,7 +32,7 @@ class CacheConfigTest extends DoctrineTestCase
      */
     public function testGetDefaultCacheIstantiator()
     {
-        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultInstantiator', $this->config->getCacheInstantiator());
+        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCacheInstantiator', $this->config->getCacheInstantiator());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheInstantiatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheInstantiatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Cache;
+
+use Doctrine\ORM\Cache\DefaultCacheInstantiator;
+use Doctrine\Tests\OrmTestCase;
+
+/**
+ * @covers \Doctrine\ORM\Cache\DefaultCacheInstantiator
+ */
+class DefaultCacheInstantiatorTest extends OrmTestCase
+{
+    public function testGetCache()
+    {
+        $entityManager = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $config        = $this->getMock('Doctrine\ORM\Configuration');
+        $cacheConfig   = $this->getMock('Doctrine\ORM\Cache\CacheConfiguration');
+
+        $entityManager->expects($this->any())->method('getConfiguration')->will($this->returnValue($config));
+        $config
+            ->expects($this->any())
+            ->method('getSecondLevelCacheConfiguration')
+            ->will($this->returnValue($cacheConfig));
+
+        $instantiator = new DefaultCacheInstantiator();
+
+        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCache', $instantiator->getCache($entityManager));
+    }
+}


### PR DESCRIPTION
See DDC-3078 ( http://www.doctrine-project.org/jira/browse/DDC-3078 ) - the cache interface should NOT cover a constructor.
