### PR TITLE
Update second level cache doc

### DIFF
--- a/docs/en/reference/second-level-cache.rst
+++ b/docs/en/reference/second-level-cache.rst
@@ -447,6 +447,8 @@ It caches the primary keys of association and cache each element will be cached 
                 usage : NONSTRICT_READ_WRITE
 
 
+> Note: for this to work, the target entity must also be marked as cacheable.
+
 Cache usage
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Hi,

While testing the second level cache (side note: this is truly awesome and flexible, I love the fact it works with Criteria too), I realized that if you add the "Cache" annotation to an association, it won't put in cache the associated entities, until you also mark the target entity as cacheable. This is not obvious from reading the doc (and I don't know if that's expected behavior neither).
