### PR TITLE
improved error handling for invalid association values

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -707,7 +707,11 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            $this->computeAssociationChanges($assoc, $val);
+            try {
+                $this->computeAssociationChanges($assoc, $val);
+            } catch (\Exception $ex) {
+                throw new Exception('Expected an Object for relation '.get_class($entity).'::'.$assoc['fieldName'].' got '.gettype($ex->value).' '.var_export($ex->value, true).' instead.');
+            }
 
             if ( ! isset($this->entityChangeSets[$oid]) &&
                 $assoc['isOwningSide'] &&
@@ -809,6 +813,12 @@ class UnitOfWork implements PropertyChangedListener
         $targetClass    = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($unwrappedValue as $key => $entry) {
+            if (! is_object($entry)) {
+                $ex = new \Exception(gettype($entry) . ' ' . var_export($entry, true).' is not an Object.');
+                $ex->value = $entry;
+                throw $ex;
+            }
+
             $state = $this->getEntityState($entry, self::STATE_NEW);
 
             if ( ! ($entry instanceof $assoc['targetEntity'])) {


### PR DESCRIPTION
Possibly to do:
1. Make custom Exception for line 713
2. Make custom Exception for line 817
3. Does the object check on line 816 slow down the code too much? Alternatively a try-catch could be put around line 1415 or higher up.
