### PR TITLE
Extend the "getRepository" method to accept objects as parameter.

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -689,12 +689,15 @@ use Doctrine\Common\Util\ClassUtils;
     /**
      * Gets the repository for an entity class.
      *
-     * @param string $entityName The name of the entity.
+     * @param string|mixed $entityName The name of the entity or a object, from which the FQNS will be used.
      *
      * @return \Doctrine\ORM\EntityRepository The repository class.
      */
     public function getRepository($entityName)
     {
+        if(is_object($entityName)){
+            $entityName = get_class($entityName);
+        }
         return $this->repositoryFactory->getRepository($this, $entityName);
     }
 


### PR DESCRIPTION
This small change in the method "getRepository" will increase the development speed, since the developer isn't anymore forced to insert the FQNS as a string.
Is this change reasonable?
