### PR TITLE
DBAL-878 Wrong mapping type

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -392,7 +392,7 @@ class DatabaseDriver implements MappingDriver
         $fieldMapping = array(
             'fieldName'  => $this->getFieldNameForColumn($tableName, $column->getName(), false),
             'columnName' => $column->getName(),
-            'type'       => strtolower((string) $column->getType()),
+            'type'       => $column->getType()->getName(),
             'nullable'   => ( ! $column->getNotNull()),
         );
 


### PR DESCRIPTION
the type should be the mapping type, and not the name of the type. This
does the difference for simple_array, as the result should be
simple_array and not simplearray
