### PR TITLE
Make EntityRepository iterateable

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -38,7 +38,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class EntityRepository implements ObjectRepository, Selectable
+class EntityRepository implements ObjectRepository, Selectable, \IteratorAggregate
 {
     /**
      * @var string
@@ -302,5 +302,16 @@ class EntityRepository implements ObjectRepository, Selectable
         $persister = $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName);
 
         return new ArrayCollection($persister->loadCriteria($criteria));
+    }
+
+    /**
+     * Finds all entities in the repository
+     * and creates ArrayIterator of them
+     *
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->findBy([]));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -253,6 +253,15 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(4, count($users));
     }
 
+    public function testIterator()
+    {
+        $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
+        $iterator = $repository->getIterator();
+
+        $this->assertInstanceOf('ArrayIterator', $iterator);
+        $this->assertEquals(4, count($iterator));
+    }
+
     public function testFindByAlias()
     {
         $user1Id = $this->loadFixture();


### PR DESCRIPTION
I am often write code like this

``` php
foreach ($em->getRepository(User::class)->findAll() as $user) {
    // do smth
}
```

Its would be wonderful write less code:

``` php
foreach ($em->getRepository(User::class) as $user) {
    // do smth
}
```
