### PR TITLE
Added EndFlush event

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -178,8 +178,11 @@ the life-time of their registered entities.
 -  onFlush - The onFlush event occurs after the change-sets of all
    managed entities are computed. This event is not a lifecycle
    callback.
--  postFlush - The postFlush event occurs at the end of a flush operation. This
-   event is not a lifecycle callback.
+-  postFlush - The postFlush event occurs at the end of a flush operation **before** the
+   ``UnitOfWork`` has been reinitialized. This event is not a lifecycle callback.
+-  endFlush - The endFlush event occurs **after** the ``UnitOfWork`
+   has been reinitialized. It is possible to call the ``flush`` method within this
+   event. This event is not a lifecycle callback.
 -  onClear - The onClear event occurs when the EntityManager#clear() operation is
    invoked, after all references to entities have been removed from the unit of
    work. This event is not a lifecycle callback.
@@ -619,7 +622,9 @@ The following restrictions apply to the onFlush event:
 postFlush
 ~~~~~~~~~
 
-``postFlush`` is called at the end of ``EntityManager#flush()``.
+``postFlush`` is called after the ``EntityManager#flush()`` has completed, but
+before the ``UnitOfWork`` has been reinitialized. 
+
 ``EntityManager#flush()`` can **NOT** be called safely inside its listeners.
 
 .. code-block:: php
@@ -631,6 +636,29 @@ postFlush
     class PostFlushExampleListener
     {
         public function postFlush(PostFlushEventArgs $args)
+        {
+            // ...
+        }
+    }
+
+endFlush
+~~~~~~~~
+
+``endFlush`` is called after the ``EntityManager#flush()`` has completed and
+the ``UnitOfWork`` has been reinitialized. The event will only be fired  when
+there are pending changes in the ``UnitOfWork``.
+
+``EntityManager#flush()`` can safely be called inside its listeners.
+
+.. code-block:: php
+
+    <?php
+
+    use Doctrine\ORM\Event\EndFlushEventArgs;
+
+    class EndFlushExampleListener
+    {
+        public function endFlush(EndFlushEventArgs $args)
         {
             // ...
         }

--- a/lib/Doctrine/ORM/Event/EndFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/EndFlushEventArgs.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+namespace Doctrine\ORM\Event;
+
+/**
+ * Provides event arguments for the endFlush event.
+ *
+ * @license     http://www.opensource.org/licenses/mit-license.php MIT
+ * @link        www.doctrine-project.org
+ * @since       2.5
+ * @author      Daniel Leech <daniel@dantleech.com>
+ */
+class EndFlushEventArgs extends PostFlushEventArgs
+{
+}

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -150,6 +150,14 @@ final class Events
     const postFlush = 'postFlush';
 
     /**
+     * The endFlush event is identical to postFlush except that it is fired after the state
+     * of the UOW has been reset -- i.e. it is "safe" for listeners to call EntityManager#flush().
+     *
+     * @var string
+     */
+    const endFlush = 'endFlush';
+
+    /**
      * The onClear event occurs when the EntityManager#clear() operation is invoked,
      * after all references to entities have been removed from the unit of work.
      *

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -45,6 +45,7 @@ use Doctrine\ORM\Persisters\SingleTablePersister;
 use Doctrine\ORM\Persisters\JoinedSubclassPersister;
 use Doctrine\ORM\Persisters\OneToManyPersister;
 use Doctrine\ORM\Persisters\ManyToManyPersister;
+use Doctrine\ORM\Event\EndFlushEventArgs;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
@@ -408,6 +409,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections =
         $this->scheduledForDirtyCheck =
         $this->orphanRemovals = array();
+
+        $this->dispatchEndFlushEvent();
     }
 
     /**
@@ -3325,6 +3328,9 @@ class UnitOfWork implements PropertyChangedListener
         }
     }
 
+    /**
+     * Dispatch the Doctrine\ORM\Events::onFlush event
+     */
     private function dispatchOnFlushEvent()
     {
         if ($this->evm->hasListeners(Events::onFlush)) {
@@ -3332,10 +3338,23 @@ class UnitOfWork implements PropertyChangedListener
         }
     }
 
+    /**
+     * Dispatch the Doctrine\ORM\Events::postFlush event
+     */
     private function dispatchPostFlushEvent()
     {
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
+        }
+    }
+
+    /**
+     * Dispatch the Doctrine\ORM\Events::endFlush event
+     */
+    private function dispatchEndFlushEvent()
+    {
+        if ($this->evm->hasListeners(Events::endFlush)) {
+            $this->evm->dispatchEvent(Events::endFlush, new EndFlushEventArgs($this->em));
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -67,6 +67,24 @@ class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(2, $listener->preFlush);
         $this->assertEquals(2, $listener->onFlush);
     }
+
+    public function testEndFlush()
+    {
+        $listener = new OnFlushCalledListener();
+        $this->_em->getEventManager()->addEventListener(Events::endFlush, $listener);
+
+        // end flush is not called when there is nothing to flush
+        $this->_em->flush();
+        $this->assertEquals(0, $listener->endFlush);
+
+        $phone = new CmsPhonenumber;
+        $phone->phonenumber = 12345;
+
+        $this->_em->persist($phone);
+        $this->_em->flush();
+
+        $this->assertEquals(1, $listener->endFlush);
+    }
 }
 
 class OnFlushListener
@@ -115,6 +133,7 @@ class OnFlushCalledListener
     public $preFlush = 0;
     public $onFlush = 0;
     public $postFlush = 0;
+    public $endFlush = 0;
 
     public function preFlush($args)
     {
@@ -130,5 +149,9 @@ class OnFlushCalledListener
     {
         $this->postFlush++;
     }
-}
 
+    public function endFlush($args)
+    {
+        $this->endFlush++;
+    }
+}


### PR DESCRIPTION
This was mentioned on Twitter, this is just a POC to further the discussion.

**Updated 10-05-2014**

The flush terminate event would be fired _after_ the flush has finished _only_ when there are pending changes. 

My primary use case is to enable enitities to be persisted recursively after the initial flush.

The existing `endFlush` event is fired before the UOW is cleaned up, i.e. whilst the UOW is still dirty.
### Use cases
- Recursively persisting documents
### Example problem

For example, we flush an `Article` entity. 
- There is a listener which must create a `Route` entity automatically
  for the `Article` entity.
- There is a listener which must create a `Version` entity for each `Route`.

In the first listener would listen to the `onFlush` event, check the changesets for any `Article`
enitities, create a new `Route` entity and recompute the changeset. The new `Route` entity would
then be committed in one flush.

There is however no sensible way to implement the second listener - if we were to 
implement it in `onFlush` we would have to be sure that the listener was called _after_ the first listener.

This "order of precendence" problem doesn't scale.
### With the `terminateFlush` event.
- The `Article` entity would be persisted
- User calls `flush()`
- An `RouteEventSubscriber` subscriber listens to the `onFlush` event and tracks any `Route` objects which are due to be persisted.
- The UOW completes the transaction, and the flush has finished.
- The `flushTerminate` event would be fired
- The `RouteEventSubscriber` checks to see if any `Route` objects have been persisted, if so it creates a new `Route` object, perists
  it, and calls flush again.

The same process now take place with a `VersionEventSubscriber`.

So in summary, when an Article is comitted, 3 flushes take place and three enitities are persisted.
### Transactions

I think that any additional flushes should _not_ be part of the same transaction.
