### PR TITLE
Remove some redundant clauses

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2553,12 +2553,6 @@ class UnitOfWork implements PropertyChangedListener
                 if ($entity instanceof NotifyPropertyChanged) {
                     $entity->addPropertyChangedListener($this);
                 }
-
-                // inject ObjectManager into just loaded proxies.
-                if ($overrideLocalValues && $entity instanceof ObjectManagerAware) {
-                    $entity->injectObjectManager($this->em, $class);
-                }
-
             } else {
                 $overrideLocalValues = isset($hints[Query::HINT_REFRESH]);
 
@@ -2566,14 +2560,14 @@ class UnitOfWork implements PropertyChangedListener
                 if (isset($hints[Query::HINT_REFRESH_ENTITY])) {
                     $overrideLocalValues = $hints[Query::HINT_REFRESH_ENTITY] === $entity;
                 }
-
-                // inject ObjectManager upon refresh.
-                if ($overrideLocalValues && $entity instanceof ObjectManagerAware) {
-                    $entity->injectObjectManager($this->em, $class);
-                }
             }
 
             if ($overrideLocalValues) {
+                // inject ObjectManager upon refresh.
+                if ($entity instanceof ObjectManagerAware) {
+                    $entity->injectObjectManager($this->em, $class);
+                }
+
                 $this->originalEntityData[$oid] = $data;
             }
         } else {


### PR DESCRIPTION
The objectmanager insertion logic was identical in the if and else clauses, so I replaced both occurences with one directly after the else block closes. It is semantically identical but a little more readable, especially since the method has more than 250 lines (and a cyclomatic complexity of 100 or so :-)) as it is.
