### PR TITLE
Override joins

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -911,6 +911,15 @@ class QueryBuilder
 
         $rootAlias = $this->findRootAlias($alias, $parentAlias);
 
+        $joins = $this->getDQLPart('join');
+        if (isset($joins[$parentAlias])) {
+            foreach ($joins[$parentAlias] as $existedJoin) {
+                if ($join == $existedJoin->getJoin()) {
+                    return $this;
+                }
+            }
+        }
+
         $join = new Expr\Join(
             Expr\Join::INNER_JOIN, $join, $alias, $conditionType, $condition, $indexBy
         );

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -128,6 +128,17 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidQueryBuilder($qb, 'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a');
     }
 
+    public function testInnerJoinOverride()
+    {
+        $qb = $this->_em->createQueryBuilder()
+            ->select('u', 'a')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->innerJoin('u.articles', 'a')
+            ->innerJoin('u.articles', 'a');
+
+        $this->assertValidQueryBuilder($qb, 'SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a');
+    }
+
     public function testComplexInnerJoin()
     {
         $qb = $this->_em->createQueryBuilder()


### PR DESCRIPTION
It will eliminate error: INNER JOIN': Error: ... is already defined during creating a sql query.

Scenario:
We have a sorting feature on the page which allows users to order by a most reviewed/customer rating, on the same time we might have a filter by an average rating.
