### PR TITLE
Add support for optimized contains in LazyCriteria

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,18 +1,24 @@
 # Upgrade to 2.5
 
+## Minor BC BREAK: EntityPersister `exists` now supports Criteria object
+
+As of 2.5, `EntityPersister` interface supports a Criteria object as the `extraConditions` params. It
+was previously typehinted to be an array, so if you implement your own persister, you need to modify
+the signature.
+
 ## Minor BC BREAK: Custom Hydrators API change
 
-As of 2.5, `AbstractHydrator` does not enforce the usage of cache as part of 
+As of 2.5, `AbstractHydrator` does not enforce the usage of cache as part of
 API, and now provides you a clean API for column information through the method
 `hydrateColumnInfo($column)`.
-Cache variable being passed around by reference is no longer needed since 
+Cache variable being passed around by reference is no longer needed since
 Hydrators are per query instantiated since Doctrine 2.4.
 
 ## Minor BC BREAK: Entity based ``EntityManager#clear()`` calls follow cascade detach
 
-Whenever ``EntityManager#clear()`` method gets called with a given entity class 
-name, until 2.4, it was only detaching the specific requested entity. 
-As of 2.5, ``EntityManager`` will follow configured cascades, providing a better 
+Whenever ``EntityManager#clear()`` method gets called with a given entity class
+name, until 2.4, it was only detaching the specific requested entity.
+As of 2.5, ``EntityManager`` will follow configured cascades, providing a better
 memory management since associations will be garbage collected, optimizing
 resources consumption on long running jobs.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,11 +1,5 @@
 # Upgrade to 2.5
 
-## Minor BC BREAK: EntityPersister `exists` now supports Criteria object
-
-As of 2.5, `EntityPersister` interface supports a Criteria object as the `extraConditions` params. It
-was previously typehinted to be an array, so if you implement your own persister, you need to modify
-the signature.
-
 ## Minor BC BREAK: Custom Hydrators API change
 
 As of 2.5, `AbstractHydrator` does not enforce the usage of cache as part of

--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -190,9 +190,6 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
     /**
      * {@inheritdoc}
-     * @param object         $entity
-     * @param array|Criteria $extraConditions
-     * @return bool
      */
     public function exists($entity, $extraConditions = array())
     {

--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -190,8 +190,11 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
     /**
      * {@inheritdoc}
+     * @param object $entity
+     * @param array $extraConditions
+     * @return bool
      */
-    public function exists($entity, array $extraConditions = array())
+    public function exists($entity, $extraConditions = array())
     {
         if (empty($extraConditions)) {
             $key = new EntityCacheKey($this->class->rootEntityName, $this->class->getIdentifierValues($entity));

--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -191,9 +191,9 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function exists($entity, $extraConditions = array())
+    public function exists($entity, Criteria $extraConditions = null)
     {
-        if (empty($extraConditions)) {
+        if (null === $extraConditions) {
             $key = new EntityCacheKey($this->class->rootEntityName, $this->class->getIdentifierValues($entity));
 
             if ($this->region->contains($key)) {

--- a/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractEntityPersister.php
@@ -190,8 +190,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
     /**
      * {@inheritdoc}
-     * @param object $entity
-     * @param array $extraConditions
+     * @param object         $entity
+     * @param array|Criteria $extraConditions
      * @return bool
      */
     public function exists($entity, $extraConditions = array())

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -30,7 +30,7 @@ use Doctrine\ORM\Persisters\EntityPersister;
  * A lazy collection that allow a fast count when using criteria object
  * Once count gets executed once without collection being initialized, result
  * is cached and returned on subsequent calls until collection gets loaded,
- * then returning the number of loaded results. 
+ * then returning the number of loaded results.
  *
  * @since   2.5
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
@@ -80,6 +80,21 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
         }
 
         return $this->count = $this->entityPersister->count($this->criteria);
+    }
+
+    /**
+     * Do an optimized search of an element
+     *
+     * @param  object $element
+     * @return bool
+     */
+    public function contains($element)
+    {
+        if ($this->isInitialized()) {
+            return $this->collection->contains($element);
+        }
+
+        return $this->entityPersister->exists($element, $this->criteria);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1835,16 +1835,12 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function exists($entity, $extraConditions = array())
+    public function exists($entity, Criteria $extraConditions = null)
     {
         $criteria = $this->class->getIdentifierValues($entity);
 
         if ( ! $criteria) {
             return false;
-        }
-
-        if (is_array($extraConditions)) {
-            $criteria = array_merge($criteria, $extraConditions);
         }
 
         $alias = $this->getSQLTableAlias($this->class->name);
@@ -1855,7 +1851,7 @@ class BasicEntityPersister implements EntityPersister
 
         list($params) = $this->expandParameters($criteria);
 
-        if ($extraConditions instanceof Criteria) {
+        if (null !== $extraConditions) {
             $sql                           .= ' AND ' . $this->getSelectConditionCriteriaSQL($extraConditions);
             list($criteriaParams, $values) = $this->expandCriteriaParameters($extraConditions);
 

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1834,9 +1834,6 @@ class BasicEntityPersister implements EntityPersister
 
     /**
      * {@inheritdoc}
-     * @param object $entity
-     * @param array $extraConditions
-     * @return bool
      */
     public function exists($entity, $extraConditions = array())
     {

--- a/lib/Doctrine/ORM/Persisters/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/EntityPersister.php
@@ -319,10 +319,10 @@ interface EntityPersister
     /**
      * Checks whether the given managed entity exists in the database.
      *
-     * @param object         $entity
-     * @param array|Criteria $extraConditions
+     * @param object        $entity
+     * @param Criteria|null $extraConditions
      *
      * @return boolean TRUE if the entity exists in the database, FALSE otherwise.
      */
-    public function exists($entity, $extraConditions = array());
+    public function exists($entity, Criteria $extraConditions = null);
 }

--- a/lib/Doctrine/ORM/Persisters/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/EntityPersister.php
@@ -319,10 +319,10 @@ interface EntityPersister
     /**
      * Checks whether the given managed entity exists in the database.
      *
-     * @param object $entity
-     * @param array  $extraConditions
+     * @param object         $entity
+     * @param array|Criteria $extraConditions
      *
      * @return boolean TRUE if the entity exists in the database, FALSE otherwise.
      */
-    public function exists($entity, array $extraConditions = array());
+    public function exists($entity, $extraConditions = array());
 }

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM\Persisters;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 
@@ -227,9 +228,9 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
-        $id = current($uow->getEntityIdentifier($coll->getOwner()));
+        $criteria = new Criteria(Criteria::expr()->eq($mapping['mappedBy'], $coll->getOwner()));
 
-        return $persister->exists($element, array($mapping['mappedBy'] => $id));
+        return $persister->exists($element, $criteria);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -168,7 +168,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         return (bool) $this->conn->fetchColumn($sql, $params);
     }
-    
+
     private function getJoinTableRestrictions(PersistentCollection $coll, $addFilters)
     {
         $mapping     = $coll->getMapping();

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -87,9 +87,6 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\BasicEntityPersister
 
     /**
      * {@inheritdoc}
-     * @param object $entity
-     * @param array $extraConditions
-     * @return bool|void
      */
     public function exists($entity, $extraConditions = array())
     {

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\Mocks;
+use Doctrine\Common\Collections\Criteria;
 
 /**
  * EntityPersister implementation used for mocking during tests.
@@ -88,7 +89,7 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\BasicEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function exists($entity, $extraConditions = array())
+    public function exists($entity, Criteria $extraConditions = null)
     {
         $this->existsCalled = true;
     }

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -87,8 +87,11 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\BasicEntityPersister
 
     /**
      * {@inheritdoc}
+     * @param object $entity
+     * @param array $extraConditions
+     * @return bool|void
      */
-    public function exists($entity, array $extraConditions = array())
+    public function exists($entity, $extraConditions = array())
     {
         $this->existsCalled = true;
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/AbstractEntityPersisterTest.php
@@ -433,8 +433,8 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('exists')
-            ->with($this->equalTo($entity), $this->equalTo(array()));
+            ->with($this->equalTo($entity), $this->equalTo(null));
 
-        $this->assertNull($persister->exists($entity, array()));
+        $this->assertNull($persister->exists($entity));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
@@ -21,6 +21,8 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Tests\Models\Tweet\Tweet;
+use Doctrine\Tests\Models\Tweet\User;
 
 /**
  * @author Josiah <josiah@jjs.id.au>
@@ -30,6 +32,7 @@ class EntityRepositoryCriteriaTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('generic');
+        $this->useModelSet('tweet');
         parent::setUp();
     }
 
@@ -164,5 +167,35 @@ class EntityRepositoryCriteriaTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // Trigger a loading, to make sure collection is initialized
         $date = $dates[0];
         $this->assertTrue($dates->isInitialized());
+    }
+
+    public function testCanContainsWithoutLoadingCollection()
+    {
+        $user = new User();
+        $user->name = 'Marco';
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $tweet = new Tweet();
+        $tweet->author = $user;
+        $tweet->content = 'Criteria is awesome';
+        $this->_em->persist($tweet);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $criteria = new Criteria();
+        $criteria->andWhere($criteria->expr()->contains('content', 'Criteria'));
+
+        $user   = $this->_em->find('Doctrine\Tests\Models\Tweet\User', $user->id);
+        $tweets = $user->tweets->matching($criteria);
+
+        $this->assertInstanceOf('Doctrine\ORM\LazyCriteriaCollection', $tweets);
+        $this->assertFalse($tweets->isInitialized());
+
+        $tweets->contains($tweet);
+        $this->assertTrue($tweets->contains($tweet));
+
+        $this->assertFalse($tweets->isInitialized());
     }
 }


### PR DESCRIPTION
Hi,

This continue my work on the LazyCriteria and include a support for optimized contains that does not initialize the full collection when checking if a record exists in a collection.

Please note that I had to modify the exists method signature in EntityInterface. I'm not sure this is a problem because, as @ocramius said in the ManyToMany thread, custom persisters is not supported. However, I added a small note to be sure ;).
