### PR TITLE
Lazy criteria for ManyToMany collection

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/AbstractCollectionPersister.php
@@ -212,9 +212,16 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
 
     /**
      * {@inheritdoc}
+     * @param \Doctrine\ORM\PersistentCollection         $collection
+     * @param \Doctrine\Common\Collections\Criteria|null $criteria
+     * @return int
      */
-    public function count(PersistentCollection $collection)
+    public function count(PersistentCollection $collection, Criteria $criteria = null)
     {
+        if (null !== $criteria) {
+            return $this->persister->count($collection, $criteria);
+        }
+
         $ownerId = $this->uow->getEntityIdentifier($collection->getOwner());
         $key     = new CollectionCacheKey($this->sourceEntity->rootEntityName, $this->association['fieldName'], $ownerId);
         $entry   = $this->region->get($key);
@@ -223,7 +230,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
             return count($entry->identifiers);
         }
 
-        return $this->persister->count($collection);
+        return $this->persister->count($collection, $criteria);
     }
 
     /**

--- a/lib/Doctrine/ORM/LazyManyToManyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyManyToManyCriteriaCollection.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM;
+
+use Doctrine\Common\Collections\AbstractLazyCollection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\Persisters\BasicEntityPersister;
+use Doctrine\ORM\Persisters\CollectionPersister;
+use Doctrine\ORM\Persisters\EntityPersister;
+
+/**
+ * A lazy collection for many to many associations that is created when using the
+ * Criteria API. It allows to delay the actual execution of SQL queries and hence
+ * doing optimized queries for things like COUNT, without having to loading the
+ * full collection
+ *
+ * @since   2.5
+ * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
+ * @author  Michaël Gallego <mic.gallego@gmail.com>
+ */
+class LazyManyToManyCriteriaCollection extends AbstractLazyCollection implements Selectable
+{
+    /**
+     * @var CollectionPersister
+     */
+    protected $collectionPersister;
+
+    /**
+     * @var Criteria
+     */
+    protected $criteria;
+
+    /**
+     * @var integer
+     */
+    private $count;
+
+    /**
+     * @param PersistentCollection $persistentCollection
+     * @param CollectionPersister  $collectionPersister
+     * @param Criteria             $criteria
+     */
+    public function __construct(
+        PersistentCollection $persistentCollection,
+        CollectionPersister $collectionPersister,
+        Criteria $criteria
+    ) {
+        $this->collection           = $persistentCollection;
+        $this->collectionPersister  = $collectionPersister;
+        $this->criteria             = $criteria;
+    }
+
+    /**
+     * Do an efficient count on the collection
+     *
+     * @return integer
+     */
+    public function count()
+    {
+        if ($this->isInitialized()) {
+            return $this->collection->count();
+        }
+
+        // Return cached result in case count query was already executed
+        if ($this->count !== null) {
+            return $this->count;
+        }
+
+        return $this->count = $this->collectionPersister->count($this->collection, $this->criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function matching(Criteria $criteria)
+    {
+        $this->initialize();
+
+        return $this->collection->matching($criteria);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function doInitialize()
+    {
+        $elements         = $this->collectionPersister->loadCriteria($this->collection, $this->criteria);
+        $this->collection = new ArrayCollection($elements);
+    }
+}

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -568,7 +568,7 @@ final class PersistentCollection implements Collection, Selectable
         if ( ! $this->initialized && $this->association['fetch'] === Mapping\ClassMetadataInfo::FETCH_EXTRA_LAZY) {
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
 
-            return $persister->count($this) + ($this->isDirty ? $this->coll->count() : 0);
+            return $persister->count($this, null) + ($this->isDirty ? $this->coll->count() : 0);
         }
 
         $this->initialize();
@@ -871,7 +871,9 @@ final class PersistentCollection implements Collection, Selectable
         if ($this->association['type'] === ClassMetadata::MANY_TO_MANY) {
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
 
-            return new ArrayCollection($persister->loadCriteria($this, $criteria));
+            return ($this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY)
+                ? new LazyManyToManyCriteriaCollection($this, $persister, $criteria)
+                : new ArrayCollection($persister->loadCriteria($this, $criteria));
         }
 
         $builder         = Criteria::expr();

--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -150,8 +150,12 @@ abstract class AbstractCollectionPersister implements CollectionPersister
 
     /**
      * {@inheritdoc}
+     * @param \Doctrine\ORM\PersistentCollection $collection
+     * @param \Doctrine\Common\Collections\Criteria|null $criteria
+     * @throws \BadMethodCallException
+     * @return int|void
      */
-    public function count(PersistentCollection $coll)
+    public function count(PersistentCollection $collection, Criteria $criteria = null)
     {
         throw new \BadMethodCallException("Counting the size of this persistent collection is not supported by this CollectionPersister.");
     }
@@ -260,4 +264,27 @@ abstract class AbstractCollectionPersister implements CollectionPersister
      * @return array
      */
     abstract protected function getInsertRowSQLParameters(PersistentCollection $coll, $element);
+
+    /**
+     * Gets the Select Where Condition from a Criteria object.
+     *
+     * @param \Doctrine\ORM\PersistentCollection    $coll
+     * @param \Doctrine\Common\Collections\Criteria $criteria
+     *
+     * @return string
+     */
+    protected function getSelectConditionCriteriaSQL(PersistentCollection $coll, Criteria $criteria)
+    {
+        $mapping    = $coll->getMapping();
+        $expression = $criteria->getWhereExpression();
+        $persister  = $this->uow->getEntityPersister($mapping['targetEntity']);
+
+        if ($expression === null) {
+            return '';
+        }
+
+        $visitor = new SqlExpressionVisitor($persister, $persister->getClassMetadata());
+
+        return $visitor->dispatch($expression);
+    }
 }

--- a/lib/Doctrine/ORM/Persisters/CollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/CollectionPersister.php
@@ -71,11 +71,12 @@ interface CollectionPersister
     /**
      * Counts the size of this persistent collection.
      *
-     * @param \Doctrine\ORM\PersistentCollection $collection
+     * @param \Doctrine\ORM\PersistentCollection         $collection
+     * @param \Doctrine\Common\Collections\Criteria|null $criteria
      *
      * @return integer
      */
-    public function count(PersistentCollection $collection);
+    public function count(PersistentCollection $collection, Criteria $criteria = null);
 
     /**
      * Slices elements.

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -215,15 +215,18 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
     /**
      * {@inheritdoc}
+     * @param \Doctrine\ORM\PersistentCollection $collection
+     * @param \Doctrine\Common\Collections\Criteria|null $criteria
+     * @return int|mixed|void
      */
-    public function count(PersistentCollection $coll)
+    public function count(PersistentCollection $collection, Criteria $criteria = null)
     {
         $conditions     = array();
         $params         = array();
-        $mapping        = $coll->getMapping();
+        $mapping        = $collection->getMapping();
         $association    = $mapping;
         $class          = $this->em->getClassMetadata($mapping['sourceEntity']);
-        $id             = $this->em->getUnitOfWork()->getEntityIdentifier($coll->getOwner());
+        $id             = $this->em->getUnitOfWork()->getEntityIdentifier($collection->getOwner());
 
         if ( ! $mapping['isOwningSide']) {
             $targetEntity   = $this->em->getClassMetadata($mapping['targetEntity']);
@@ -244,6 +247,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $joinTableName = $this->quoteStrategy->getJoinTableName($association, $class, $this->platform);
+
         list($joinTargetEntitySQL, $filterSql) = $this->getFilterSql($mapping);
 
         if ($filterSql) {
@@ -254,6 +258,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . ' FROM ' . $joinTableName . ' t'
             . $joinTargetEntitySQL
             . ' WHERE ' . implode(' AND ', $conditions);
+var_dump($joinTargetEntitySQL);
+        if ($criteria) {
+            $criteriaConstraints = $this->getSelectConditionCriteriaSQL($collection, $criteria);
+            //$sql                 .= $criteriaConstraints ? ' AND ' . $criteriaConstraints : '';
+        }
 
         return $this->conn->fetchColumn($sql, $params);
     }

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM\Persisters;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 
@@ -129,10 +130,13 @@ class OneToManyPersister extends AbstractCollectionPersister
 
     /**
      * {@inheritdoc}
+     * @param \Doctrine\ORM\PersistentCollection $collection
+     * @param Criteria|null $criteria
+     * @return int|mixed|void
      */
-    public function count(PersistentCollection $coll)
+    public function count(PersistentCollection $collection, Criteria $criteria = null)
     {
-        list($quotedJoinTable, $whereClauses, $params) = $this->getJoinTableRestrictions($coll, true);
+        list($quotedJoinTable, $whereClauses, $params) = $this->getJoinTableRestrictions($collection, true);
 
         $sql = 'SELECT count(*) FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
 
@@ -168,7 +172,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         return (bool) $this->conn->fetchColumn($sql, $params);
     }
-    
+
     private function getJoinTableRestrictions(PersistentCollection $coll, $addFilters)
     {
         $mapping     = $coll->getMapping();

--- a/tests/Doctrine/Tests/Models/Quote/User.php
+++ b/tests/Doctrine/Tests/Models/Quote/User.php
@@ -73,8 +73,9 @@ class User
 
     public function __construct()
     {
-        $this->phones = new ArrayCollection;
-        $this->groups = new ArrayCollection;
+        $this->phones          = new ArrayCollection;
+        $this->groups          = new ArrayCollection;
+        $this->extraLazyGroups = new ArrayCollection;
     }
 
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -186,6 +186,14 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'tweet' => array(
             'Doctrine\Tests\Models\Tweet\User',
             'Doctrine\Tests\Models\Tweet\Tweet'
+        ),
+        'quote' => array(
+            'Doctrine\Tests\Models\Quote\Address',
+            'Doctrine\Tests\Models\Quote\Group',
+            'Doctrine\Tests\Models\Quote\NumericEntity',
+            'Doctrine\Tests\Models\Quote\Phone',
+            'Doctrine\Tests\Models\Quote\SimpleEntity',
+            'Doctrine\Tests\Models\Quote\User'
         )
     );
 


### PR DESCRIPTION
This continues my previous work on making Criteria most efficient.

Currently we are wrapping matching calls on repositories and matching calls on EXTRA_LAZY associations around a LazyCriteria. However, ManyToMany are still completely loaded: https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/PersistentCollection.php#L874

This is still problematic from a performance point of view because count, contains... cannot be optimized. I think the solution is similar to previous one, hence creating a Lazy collection for that kind of associations.

However, this is really tricky to do because of the whole mess inside the persisters (can't wait for them to be completely refactored, it's getting really hard to maintain this mess :p).
