### PR TITLE
DDC-3120 -- Catch ReflectionException for internal classes in ClassMetad...

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -909,7 +909,11 @@ class ClassMetadataInfo implements ClassMetadata
     {
         if ($this->_prototype === null) {
             if (PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513) {
-                $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
+                try {
+                    $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
+                } catch (\ReflectionException $e) {
+                    $this->_prototype = $this->reflClass->newInstance();
+                }
             } else {
                 $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
             }

--- a/tests/Doctrine/Tests/Models/DDC3120/DDC3120EntityOne.php
+++ b/tests/Doctrine/Tests/Models/DDC3120/DDC3120EntityOne.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3120;
+
+/**
+ * @Entity
+ */
+class DDC3120EntityOne extends \ArrayObject
+{
+   /**
+    * @Id
+    * @Column(type="integer", nullable=false)
+    * @GeneratedValue(strategy="IDENTITY")
+    */
+    protected $entity_one_id;
+
+    public function offsetExists($offset) {
+        return isset($this->$offset);
+    }
+
+    public function offsetSet($offset, $value) {
+        $this->$offset = $value;
+    }
+
+    public function offsetGet($offset) {
+        return $this->$offset;
+    }
+
+    public function offsetUnset($offset) {
+        $this->$offset = null;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -67,9 +67,9 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
     {
         $rsm = new \Doctrine\ORM\Query\ResultSetMapping();
         $this->_em->getConfiguration()->addNamedNativeQuery('foo', 'SELECT foo', $rsm);
-        
+
         $query = $this->_em->createNamedNativeQuery('foo');
-        
+
         $this->assertInstanceOf('Doctrine\ORM\NativeQuery', $query);
     }
 
@@ -111,14 +111,14 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
         $this->assertInstanceOf('Doctrine\ORM\Query', $q);
         $this->assertEquals('SELECT 1', $q->getDql());
     }
-    
+
     /**
      * @covers Doctrine\ORM\EntityManager::createNamedQuery
      */
     public function testCreateNamedQuery()
     {
         $this->_em->getConfiguration()->addNamedQuery('foo', 'SELECT 1');
-        
+
         $query = $this->_em->createNamedQuery('foo');
         $this->assertInstanceOf('Doctrine\ORM\Query', $query);
         $this->assertEquals('SELECT 1', $query->getDql());
@@ -194,5 +194,14 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertSame($this->_em, $em);
         return 'callback';
+    }
+    /**
+     * @group DDC-3156
+     * @group DDC-3120
+     */
+    public function testDDC3120EntityCanExtendSPLClass()
+    {
+        $one = $this->_em->getPartialReference('Doctrine\Tests\Models\DDC3120\DDC3120EntityOne', 1);
+        $this->assertInstanceOf('Doctrine\Tests\Models\DDC3120\DDC3120EntityOne', $one);
     }
 }


### PR DESCRIPTION
...ataInfo

I’m having an issue in relation to http://www.doctrine-project.org/jira/browse/DDC-3120 — When using ReflectionClass#newInstanceWithoutConstructor(); I’m getting a ReflectionException due to the class not being internal… it’s resolveable by adding a try/catch to use ReflectionClass#newInstance. BUT, I’d like to know if there is something else going on here… running PHP 5.5.13
