### PR TITLE
Fixed inconsistent which cause error

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1024,7 +1024,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
+            if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE && ! empty($this->entityChangeSets[$oid])) {
                 $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $this->entityChangeSets[$oid]), $preUpdateInvoke);
                 $this->recomputeSingleEntityChangeSet($class, $entity);
             }


### PR DESCRIPTION
If $this->entityChangeSets[$oid] can be empty as we can see from next IF statement but PreUpdateEventArgs constructor accepts only array it will cause error like this

```
Argument 3 passed to PreUpdateEventArgs::__construct() must be of the type array, null given, called in vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php on line 1028 and defined
```

It fixes http://www.doctrine-project.org/jira/browse/DDC-2726 and #126 
