### PR TITLE
[DDC-3087] Add readonly attribute to Field ORM Mapping to avoid generating a setter

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -65,6 +65,11 @@ final class Column implements Annotation
     public $nullable = false;
 
     /**
+     * @var boolean
+     */
+    public $readonly = false;
+
+    /**
      * @var array
      */
     public $options = array();

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -593,6 +593,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             'length'    => $column->length,
             'unique'    => $column->unique,
             'nullable'  => $column->nullable,
+            'readonly'  => $column->readonly,
             'precision' => $column->precision
         );
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -728,6 +728,10 @@ class XmlDriver extends FileDriver
             $mapping['nullable'] = $this->evaluateBoolean($fieldMapping['nullable']);
         }
 
+        if (isset($fieldMapping['readonly'])) {
+            $mapping['readonly'] = $this->evaluateBoolean($fieldMapping['readonly']);
+        }
+
         if (isset($fieldMapping['version']) && $fieldMapping['version']) {
             $mapping['version'] = $this->evaluateBoolean($fieldMapping['version']);
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -741,6 +741,10 @@ class YamlDriver extends FileDriver
             $mapping['nullable'] = $column['nullable'];
         }
 
+        if (isset($column['readonly'])) {
+            $mapping['readonly'] = $column['readonly'];
+        }
+
         if (isset($column['version']) && $column['version']) {
             $mapping['version'] = $column['version'];
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1158,7 +1158,7 @@ public function __construct()
         }
 
         // Skips generating the SET method if the field is marked read-only
-        $fieldMapping = $metadata->fieldMappings[$fieldName];
+        $fieldMapping = isset($metadata->fieldMappings[$fieldName]) ? $metadata->fieldMappings[$fieldName] : array();
         if ($type === 'set' && isset($fieldMapping['readonly']) && $fieldMapping['readonly'] === true) {
             return '';
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1156,6 +1156,13 @@ public function __construct()
         if ($this->hasMethod($methodName, $metadata)) {
             return '';
         }
+
+        // Skips generating the SET method if the field is marked read-only
+        $fieldMapping = $metadata->fieldMappings[$fieldName];
+        if ($type === 'set' && isset($fieldMapping['readonly']) && $fieldMapping['readonly'] === true) {
+            return '';
+        }
+
         $this->staticReflection[$metadata->name]['methods'][] = strtolower($methodName);
 
         $var = sprintf('%sMethodTemplate', $type);


### PR DESCRIPTION
The change allows one to enter a field attribute called "readonly". What this does is when using doctrine:generate:entities, only a getter is generated, setter is omitted. 

Example use on a created field that uses Timestampable and should not have a setter:

``` php
    /**
     * @var /DateTime $createdAt
     *
     * @Gedmo\Timestampable(on="create")
     * @ORM\Column(type="datetime", readonly=true)
     */
    private $createdAt;
```
