### PR TITLE
Closed php tag in pagination.rst

### DIFF
--- a/docs/en/tutorials/pagination.rst
+++ b/docs/en/tutorials/pagination.rst
@@ -23,6 +23,7 @@ has a very simple API and implements the SPL interfaces ``Countable`` and
     foreach ($paginator as $post) {
         echo $post->getHeadline() . "\n";
     }
+    ?>
 
 Paginating Doctrine queries is not as simple as you might think in the
 beginning. If you have complex fetch-join scenarios with one-to-many or


### PR DESCRIPTION
Netbeans complained about the text below the PHP code section since the code block wasn't closed and the text interpreted as PHP.
