### PR TITLE
Use newInstanceWithoutConstructor when available.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -908,7 +908,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function newInstance()
     {
         if ($this->_prototype === null) {
-            if (PHP_VERSION_ID === 50429 || PHP_VERSION_ID === 50513) {
+            if (method_exists($this->reflClass, 'newInstanceWithoutConstructor')) {
                 $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
             } else {
                 $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -910,6 +910,9 @@ class ClassMetadataInfo implements ClassMetadata
         if ($this->_prototype === null) {
             if (method_exists($this->reflClass, 'newInstanceWithoutConstructor')) {
                 $this->_prototype = $this->reflClass->newInstanceWithoutConstructor();
+                if (method_exists($this->_prototype, '__wakeup')) {
+                    $this->_prototype->__wakeup();
+                }
             } else {
                 $this->_prototype = unserialize(sprintf('O:%d:"%s":0:{}', strlen($this->name), $this->name));
             }


### PR DESCRIPTION
Changed ClassMetadataInfo::newInstance to always use ReflectionClass::newInstanceWithoutConstructor when available, not just for specific versions. 

As discussed here: https://github.com/doctrine/doctrine2/commit/530c01b5e3ed7345cde564bd511794ac72f49b65#commitcomment-6635975

It also calls `__wakeup` when available because some libraries (Typo3) rely on it. https://github.com/doctrine/doctrine2/commit/530c01b5e3ed7345cde564bd511794ac72f49b65#commitcomment-6645339 

Be sure to also read my point about why this is better: https://github.com/doctrine/doctrine2/pull/1056#discussion_r13665544
