### PR TITLE
singularize variable name on add/remove methods for EntityGenerator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1149,8 +1149,10 @@ public function __construct()
     protected function generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null,  $defaultValue = null)
     {
         $methodName = $type . Inflector::classify($fieldName);
+        $variableName = Inflector::camelize($fieldName);
         if (in_array($type, array("add", "remove"))) {
             $methodName = Inflector::singularize($methodName);
+            $variableName = Inflector::singularize($variableName);
         }
 
         if ($this->hasMethod($methodName, $metadata)) {
@@ -1171,10 +1173,10 @@ public function __construct()
         }
 
         $replacements = array(
-          '<description>'       => ucfirst($type) . ' ' . $fieldName,
+          '<description>'       => ucfirst($type) . ' ' . $variableName,
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
-          '<variableName>'      => Inflector::camelize($fieldName),
+          '<variableName>'      => $variableName,
           '<methodName>'        => $methodName,
           '<fieldName>'         => $fieldName,
           '<variableDefault>'   => ($defaultValue !== null ) ? (' = '.$defaultValue) : '',

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -133,6 +133,14 @@ class EntityGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $book->setName('Jonathan H. Wage');
         $this->assertEquals('Jonathan H. Wage', $book->getName());
 
+        $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
+        $addCommentParameters = $reflMethod->getParameters();
+        $this->assertEquals('comment', $addCommentParameters[0]->getName());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
+        $removeCommentParameters = $reflMethod->getParameters();
+        $this->assertEquals('comment', $removeCommentParameters[0]->getName());
+
         $author = new EntityGeneratorAuthor();
         $book->setAuthor($author);
         $this->assertEquals($author, $book->getAuthor());


### PR DESCRIPTION
Not a big change but corrects an error of plural.

Previously :

``` php
    public function addComment(EntityGeneratorComment $comments)
    {
        $this->comments[] = $comments;

        return $this;
    }
```

With this PR :

``` php
    public function addComment(EntityGeneratorComment $comment)
    {
        $this->comments[] = $comment;

        return $this;
    }
```
