### PR TITLE
[DDC-3179] EntityNotFoundException on the postRemove event if the entity is a proxy

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -191,6 +191,12 @@ the life-time of their registered entities.
     safe to access associations in a postLoad callback or event
     handler.
 
+.. warning::
+
+    Note that the postRemove event or any events triggered after an entity removal
+    can receive an uninitializable proxy in case you have configured an entity to
+    cascade remove relations. In this case, you should load yourself the proxy in
+    the associated pre event.
 
 You can access the Event constants from the ``Events`` class in the
 ORM package.


### PR DESCRIPTION
This PR tries to fix [DDC-3179](http://www.doctrine-project.org/jira/browse/DDC-3179).

I'm not sure if it is the way to go as this PR has a big drawback: it **always** loads proxies which needs to be removed regardless if there is an postRemove event for it. Anyway, there is no way to determine if there is an event for a specific entity in a lifecycle callback context.

For now, to fix it in our side, we have registered a listener on the preRemove event and load the proxy there.
