### PR TITLE
Setup::createConfiguration breaks Cache interface contract

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\ClassLoader;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
@@ -144,7 +145,9 @@ class Setup
             $cache = new ArrayCache();
         }
 
-        $cache->setNamespace("dc2_" . md5($proxyDir) . "_"); // to avoid collisions
+        if ($cache instanceof CacheProvider) {
+            $cache->setNamespace("dc2_" . md5($proxyDir) . "_"); // to avoid collisions
+        }
 
         $config = new Configuration();
         $config->setMetadataCacheImpl($cache);

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -89,4 +89,19 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSame($cache, $config->getMetadataCacheImpl());
         $this->assertSame($cache, $config->getQueryCacheImpl());
     }
+
+    /**
+     * @group DDC-3190
+     */
+    public function testConfigureCacheCustomInstance()
+    {
+        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache->expects($this->never())->method('setNamespace');
+
+        $config = Setup::createConfiguration(array(), true, $cache);
+
+        $this->assertSame($cache, $config->getResultCacheImpl());
+        $this->assertSame($cache, $config->getMetadataCacheImpl());
+        $this->assertSame($cache, $config->getQueryCacheImpl());
+    }
 }


### PR DESCRIPTION
Method `setNamespace` is called in `Setup::createConfiguration`, but at the moment there can be an instance of `Doctrine\Common\Cache\Cache` (when given in the 3rd parameter), which does not define this method. This method is defined in `Doctrine\Common\Cache\CacheProvider` from which are the defaults being instantiated in this method extended.

So there should be an condition (as proposed in this PR now) or the 3rd parameter should declare a dependency on `CacheProvider` rather than just `Cache` interface. Or maybe the namespace should be set only if the Cache instance is not given by the 3rd parameter, assuming that when someone is giving a ready instance of Cache, it is configured properly.

If you want to take another approach, I can change this PR.
