### PR TITLE
[DDC-3160] Alternate fix for DDC-2996 bug

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -943,12 +943,13 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         if ($changeSet) {
-            $this->entityChangeSets[$oid] = (isset($this->entityChangeSets[$oid]))
-                ? array_merge($this->entityChangeSets[$oid], $changeSet)
-                : $changeSet;
-
+            if (isset($this->entityChangeSets[$oid])) {
+                $this->entityChangeSets[$oid] = array_merge($this->entityChangeSets[$oid], $changeSet);
+            } else if ( ! isset($this->entityInsertions[$oid])) {
+                $this->entityChangeSets[$oid] = $changeSet;
+                $this->entityUpdates[$oid]    = $entity;
+            }
             $this->originalEntityData[$oid] = $actualData;
-            $this->entityUpdates[$oid]      = $entity;
         }
     }
 
@@ -2405,12 +2406,12 @@ class UnitOfWork implements PropertyChangedListener
             }
         } else {
             $visited = array();
-            
+
             foreach ($this->identityMap as $className => $entities) {
                 if ($className !== $entityName) {
                     continue;
                 }
-                
+
                 foreach ($entities as $entity) {
                     $this->doDetach($entity, $visited, false);
                 }
@@ -2522,7 +2523,7 @@ class UnitOfWork implements PropertyChangedListener
 
             $id = array($class->identifier[0] => $id);
         }
-        
+
         $idHash = implode(' ', $id);
 
         if (isset($this->identityMap[$class->rootEntityName][$idHash])) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
@@ -3,16 +3,16 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
  * FlushEventTest
  *
  * @author robo
  */
-class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
+class DDC3160Test extends OrmFunctionalTestCase
 {
     protected function setUp() {
         $this->useModelSet('cms');
@@ -24,7 +24,7 @@ class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testNoUpdateOnInsert()
     {
-        $listener = new OnFlushListener();
+        $listener = new DDC3160OnFlushListener();
         $this->_em->getEventManager()->addEventListener(Events::onFlush, $listener);
 
         $user = new CmsUser;
@@ -43,7 +43,7 @@ class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 }
 
-class OnFlushListener
+class DDC3160OnFlushListener
 {
     public $inserts = 0;
     public $updates = 0;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * FlushEventTest
+ *
+ * @author robo
+ */
+class FlushEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp() {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    /**
+     * @group DDC-3160
+     */
+    public function testNoUpdateOnInsert()
+    {
+        $listener = new OnFlushListener();
+        $this->_em->getEventManager()->addEventListener(Events::onFlush, $listener);
+
+        $user = new CmsUser;
+        $user->username = 'romanb';
+        $user->name = 'Roman';
+        $user->status = 'Dev';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->refresh($user);
+
+        $this->assertEquals('romanc', $user->username);
+        $this->assertEquals(1, $listener->inserts);
+        $this->assertEquals(0, $listener->updates);
+    }
+}
+
+class OnFlushListener
+{
+    public $inserts = 0;
+    public $updates = 0;
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        $em = $args->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            $this->inserts++;
+            if ($entity instanceof CmsUser) {
+                $entity->username = 'romanc';
+                $cm = $em->getClassMetadata(get_class($entity));
+                $uow->recomputeSingleEntityChangeSet($cm, $entity);
+            }
+        }
+
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            $this->updates++;
+        }
+    }
+}
+


### PR DESCRIPTION
The fix implemented for DDC-2996 seems to have broken quite a bit of code outside of Doctrine (for instance, the popular DoctrineExtensions project).

I'm not too well versed in Doctrine internals, but looking at the fix, I found it odd that an entity would live in both the insertion and update tracking in the unit of work.

This implementation should fix the case described in DDC-2996, while not creating any side effects with objects that are scheduled to be inserted.

I've ran this test with the Doctrine test suite and have also tested this change with the DoctrineExtensions project; unless I'm doing something wrong, it seems to have good results.

Again, I'm not too well versed in the inner workings of Doctrine, but I did a little research, poked around some code, and came up with this.
