### PR TITLE
Fixed query cache id generation: added platform to hash

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -682,8 +682,13 @@ final class Query extends AbstractQuery
     {
         ksort($this->_hints);
 
+        $platform = $this->getEntityManager()
+            ->getConnection()
+            ->getDatabasePlatform()
+            ->getName();
+
         return md5(
-            $this->getDql() . serialize($this->_hints) .
+            $this->getDql() . serialize($this->_hints) . $platform .
             ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
             '&firstResult=' . $this->_firstResult . '&maxResult=' . $this->_maxResults .
             '&hydrationMode='.$this->_hydrationMode.'DOCTRINE_QUERY_CACHE_SALT'

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -688,7 +688,8 @@ final class Query extends AbstractQuery
             ->getName();
 
         return md5(
-            $this->getDql() . serialize($this->_hints) . $platform .
+            $this->getDql() . serialize($this->_hints) .
+            '&platform=' . $platform .
             ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
             '&firstResult=' . $this->_firstResult . '&maxResult=' . $this->_maxResults .
             '&hydrationMode='.$this->_hydrationMode.'DOCTRINE_QUERY_CACHE_SALT'


### PR DESCRIPTION
There's an issue with the query cache id generation in `Doctrine\ORM\Query::_getQueryCacheId()`.

If you happen to use different connections to different platforms on the same project and you're using the query cache, you will get an exception the moment you try to execute a query which SQL is different depending on the platform and it has been previously cached for the other platform, as they will share the same cache id.

In order to reproduce the bug it is sufficient with using the Doctrine Paginator in a query:

```
$query = $queryBuilder->setFirstResult(0)
    ->setMaxResults(50)
    ->getQuery()
    ->getResult();
```

If we run the query for the first time with an empty cache in an Oracle connection and later on we try to run the same query in a MySQL connection, we get the following exception:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ROWNUM' in 'where clause'
```

As it's trying to execute the SQL for Oracle in the MySQL connection due to the same cache id.

This issue can be easily fixed just by taking the platform type into account in the cache id generation.
