### PR TITLE
Support filter parameters in Configuration

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -638,12 +638,16 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Adds a filter to the list of possible filters.
      *
-     * @param string $name      The name of the filter.
-     * @param string $className The class name of the filter.
+     * @param string $name       The name of the filter.
+     * @param string $className  The class name of the filter.
+     * @param array  $parameters The parameters for the filter.
      */
-    public function addFilter($name, $className)
+    public function addFilter($name, $className, array $parameters = array())
     {
-        $this->_attributes['filters'][$name] = $className;
+        $this->_attributes['filters'][$name] = array(
+            'class' => $className,
+            'parameters' => $parameters
+        );
     }
 
     /**
@@ -651,13 +655,26 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name The name of the filter.
      *
-     * @return string The class name of the filter, or null of it is not
-     *  defined.
+     * @return string|null The class name of the filter, or null if it is undefined
      */
     public function getFilterClassName($name)
     {
         return isset($this->_attributes['filters'][$name])
-            ? $this->_attributes['filters'][$name]
+            ? $this->_attributes['filters'][$name]['class']
+            : null;
+    }
+
+    /**
+     * Gets the parameters for a given filter name.
+     *
+     * @param string $name The name of the filter.
+     *
+     * @return array The parameters for the filter, or null if it is undefined
+     */
+    public function getFilterParameters($name)
+    {
+        return isset($this->_attributes['filters'][$name])
+            ? $this->_attributes['filters'][$name]['parameters']
             : null;
     }
 

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -46,7 +46,7 @@ abstract class SQLFilter
      *
      * @var array
      */
-    private $parameters;
+    private $parameters = array();
 
     /**
      * Constructs the SQLFilter object.

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -109,8 +109,14 @@ class FilterCollection
 
         if ( ! $this->isEnabled($name)) {
             $filterClass = $this->config->getFilterClassName($name);
+            $filterParameters = $this->config->getFilterParameters($name);
+            $filter = new $filterClass($this->em);
 
-            $this->enabledFilters[$name] = new $filterClass($this->em);
+            foreach ($filterParameters as $param => $value) {
+                $filter->setParameter($param, $value);
+            }
+
+            $this->enabledFilters[$name] = $filter;
 
             // Keep the enabled filters sorted for the hash
             ksort($this->enabledFilters);

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -231,6 +231,15 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertSame(null, $this->configuration->getFilterClassName('NonExistingFilter'));
         $this->configuration->addFilter('FilterName', __CLASS__);
         $this->assertSame(__CLASS__, $this->configuration->getFilterClassName('FilterName'));
+        $this->assertSame(array(), $this->configuration->getFilterParameters('FilterName'));
+    }
+
+    public function testAddGetFiltersWithParameters()
+    {
+        $this->assertSame(null, $this->configuration->getFilterClassName('NonExistingFilter'));
+        $this->configuration->addFilter('FilterName', __CLASS__, array('foo' => 'bar'));
+        $this->assertSame(__CLASS__, $this->configuration->getFilterClassName('FilterName'));
+        $this->assertSame(array('foo' => 'bar'), $this->configuration->getFilterParameters('FilterName'));
     }
 
     public function setDefaultRepositoryClassName()


### PR DESCRIPTION
Based on work done in doctrine/mongodb-odm#908

My understanding is that this makes it easier to setup filters at boot time, instead of having to fetch them from the collection later on.

For added context, the related PR from MongoDB ODM's Symfony bundle is  doctrine/DoctrineMongoDBBundle#255
