### PR TITLE
Add "additional commands" to the Console Runner

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -32,6 +32,15 @@ use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
  */
 class ConsoleRunner
 {
+    
+    /**
+     * Collection of commands to be added to the cli.
+     * Used for registering commands for other Doctrine related projects, such as Migrations.
+     *
+     * @var array|Command[]
+     */
+    static protected $additionalCommands = array();
+    
     /**
      * Create a Symfony Console HelperSet
      *
@@ -61,6 +70,7 @@ class ConsoleRunner
         $cli->setHelperSet($helperSet);
         self::addCommands($cli);
         $cli->addCommands($commands);
+        $cli->addCommands(self::$additionalCommands);
         $cli->run();
     }
 
@@ -93,6 +103,14 @@ class ConsoleRunner
             new \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand(),
             new \Doctrine\ORM\Tools\Console\Command\InfoCommand()
         ));
+    }
+
+    /**
+     * @param Command $command
+     */
+    static public function addAdditionalCommand(Command $command)
+    {
+        self::$additionalCommands[] = $command;
     }
 
     static public function printCliConfigTemplate()


### PR DESCRIPTION
Currently, using Migrations in a Doctrine projects requires you to roll your own CLI. We already have a cli-config.php which is called when running /vendor/bin/doctrine.php - however, that only allows us to inject a HelperSet. It does not offer a mechanism to inject additional commands into the CLI application.

If this patch is accepted, I'll submit a suggestion for Migrations' documentation to call:

ConsoleRunner::addAdditionalCommand(new \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand);
ConsoleRunner::addAdditionalCommand(new \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand);
... etc

I'm not 100% whether line 73 should be in ConsoleRunner::addCommands() or ConsoleRunner::run() - I've placed it in run() for now.
