### PR TITLE
added more informative error messages when invalid parameter count

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -287,9 +287,13 @@ final class Query extends AbstractQuery
 
         // Prepare parameters
         $paramMappings = $this->_parserResult->getParameterMappings();
+        $paramCount = count($this->parameters);
+        $mappingCount = count($paramMappings);
 
-        if (count($paramMappings) != count($this->parameters)) {
-            throw QueryException::invalidParameterNumber();
+        if ($paramCount > $mappingCount) {
+            throw QueryException::tooManyParameters($mappingCount, $paramCount);
+        } elseif ($paramCount < $mappingCount) {
+            throw QueryException::tooFewParameters($mappingCount, $paramCount);
         }
 
         // evict all cache for the entity region

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -93,11 +93,25 @@ class QueryException extends \Doctrine\ORM\ORMException
     }
 
     /**
+     * @param integer $expected
+     * @param integer $received
+     *
      * @return QueryException
      */
-    public static function invalidParameterNumber()
+    public static function tooManyParameters($expected, $received)
     {
-        return new self("Invalid parameter number: number of bound variables does not match number of tokens");
+        return new self('Too many parameters: the query defines ' . $expected . ' parameters and you bound ' . $received);
+    }
+
+    /**
+     * @param integer $expected
+     * @param integer $received
+     *
+     * @return QueryException
+     */
+    public static function tooFewParameters($expected, $received)
+    {
+        return new self('Too few parameters: the query defines ' . $expected . ' parameters but you only bound ' . $received);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -127,16 +127,28 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $q->getSingleResult();
     }
 
-    public function testMismatchingParamExpectedParamCount()
+    public function testTooManyParametersShouldThrowException()
     {
         $this->setExpectedException(
             "Doctrine\ORM\Query\QueryException",
-            "Invalid parameter number: number of bound variables does not match number of tokens"
+            "Too many parameters: the query defines 1 parameters and you bound 2"
         );
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
         $q->setParameter(1, 'jwage');
         $q->setParameter(2, 'jwage');
+
+        $user = $q->getSingleResult();
+    }
+
+    public function testTooFewParametersShouldThrowException()
+    {
+        $this->setExpectedException(
+            "Doctrine\ORM\Query\QueryException",
+            "Too few parameters: the query defines 1 parameters but you only bound 0"
+        );
+
+        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
 
         $user = $q->getSingleResult();
     }


### PR DESCRIPTION
When an invalid number of parameters is bound current it's not indicated if there are too few or too many (which could help a lot in trying to debug the problem). This change alters the exception message to be more informative as to whether too few or too many parameters have been bound in the query.
