### PR TITLE
Orphan removal does not work nicely with `preRemove` listeners

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+
+/**
+ * Functional tests for cascade remove with orphanRemoval.
+ *
+ * @author Lallement Thomas <thomas.lallement@9online.fr>
+ */
+class DDC0000Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema(array(
+            'Doctrine\Tests\ORM\Functional\Ticket\User',
+            'Doctrine\Tests\ORM\Functional\Ticket\Role',
+            'Doctrine\Tests\ORM\Functional\Ticket\ActionLog',
+        ));
+    }
+
+    public function testIssueCascadeRemoveOrphanRemoval()
+    {
+        $user = new User();
+        $role = new Role();
+
+        $user->addRole($role);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $role = $user->roles->get(0);
+
+        $this->assertEquals(1, count($user->roles));
+
+        $user->roles->removeElement($role);
+        //$this->_em->remove($role);
+
+        $this->assertEquals(0, count($user->roles));
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+
+        $this->assertEquals(0, count($user->roles));
+
+        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\ActionLog', 1);
+
+        $this->assertEquals('1 - remove', $actionLog->id.' - '.$actionLog->action);
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0000_role") @HasLifecycleCallbacks
+ */
+class Role
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="User", inversedBy="roles")
+     */
+    public $user;
+
+    /**
+     * @PreRemove
+     */
+    public function preRemove(LifecycleEventArgs $eventArgs)
+    {
+        $em = $eventArgs->getEntityManager();
+
+        $actionLog = new ActionLog();
+        $actionLog->action = 'remove';
+        $em->persist($actionLog);
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0000_user")
+ */
+class User
+{
+    public $changeSet = array();
+
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity="Role", mappedBy="user", cascade={"all"}, orphanRemoval=true)
+     */
+    public $roles;
+
+    public function addRole(Role $role)
+    {
+        $this->roles[] = $role;
+        $role->user = $this;
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0000_action_log")
+ */
+class ActionLog
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+    */
+    public $id;
+
+    /**
+     * @Column(name="action", type="string", length=255, nullable=true)
+     */
+    public $action;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
@@ -17,16 +17,16 @@ class DDC0000Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->setUpEntitySchema(array(
-            'Doctrine\Tests\ORM\Functional\Ticket\User',
-            'Doctrine\Tests\ORM\Functional\Ticket\Role',
-            'Doctrine\Tests\ORM\Functional\Ticket\ActionLog',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0000_User',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0000_Role',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0000_ActionLog',
         ));
     }
 
     public function testIssueCascadeRemoveOrphanRemoval()
     {
-        $user = new User();
-        $role = new Role();
+        $user = new DDC0000_User();
+        $role = new DDC0000_Role();
 
         $user->addRole($role);
 
@@ -34,7 +34,7 @@ class DDC0000Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0000_User', $user->id);
         $role = $user->roles->get(0);
 
         $this->assertEquals(1, count($user->roles));
@@ -47,11 +47,11 @@ class DDC0000Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0000_User', $user->id);
 
         $this->assertEquals(0, count($user->roles));
 
-        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\ActionLog', 1);
+        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0000_ActionLog', 1);
 
         $this->assertEquals('1 - remove', $actionLog->id.' - '.$actionLog->action);
     }
@@ -60,7 +60,7 @@ class DDC0000Test extends OrmFunctionalTestCase
 /**
  * @Entity @Table(name="ddc0000_role") @HasLifecycleCallbacks
  */
-class Role
+class DDC0000_Role
 {
     /**
      * @Id @Column(type="integer")
@@ -89,7 +89,7 @@ class Role
 /**
  * @Entity @Table(name="ddc0000_user")
  */
-class User
+class DDC0000_User
 {
     public $changeSet = array();
 
@@ -114,7 +114,7 @@ class User
 /**
  * @Entity @Table(name="ddc0000_action_log")
  */
-class ActionLog
+class DDC0000_ActionLog
 {
     /**
      * @Id @Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
@@ -80,7 +80,7 @@ class DDC0000_Role
     {
         $em = $eventArgs->getEntityManager();
 
-        $actionLog = new ActionLog();
+        $actionLog = new DDC0000_ActionLog();
         $actionLog->action = 'remove';
         $em->persist($actionLog);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
@@ -69,7 +69,7 @@ class DDC0000_Role
     public $id;
 
     /**
-     * @ManyToOne(targetEntity="User", inversedBy="roles")
+     * @ManyToOne(targetEntity="DDC0000_User", inversedBy="roles")
      */
     public $user;
 
@@ -100,7 +100,7 @@ class DDC0000_User
     public $id;
 
     /**
-     * @OneToMany(targetEntity="Role", mappedBy="user", cascade={"all"}, orphanRemoval=true)
+     * @OneToMany(targetEntity="DDC0000_Role", mappedBy="user", cascade={"all"}, orphanRemoval=true)
      */
     public $roles;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0000Test.php
@@ -104,7 +104,7 @@ class DDC0000_User
      */
     public $roles;
 
-    public function addRole(Role $role)
+    public function addRole(DDC0000_Role $role)
     {
         $this->roles[] = $role;
         $role->user = $this;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0001Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0001Test.php
@@ -17,16 +17,16 @@ class DDC0001Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->setUpEntitySchema(array(
-            'Doctrine\Tests\ORM\Functional\Ticket\User',
-            'Doctrine\Tests\ORM\Functional\Ticket\Role',
-            'Doctrine\Tests\ORM\Functional\Ticket\ActionLog',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0001_User',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0001_Role',
+            'Doctrine\Tests\ORM\Functional\Ticket\DDC0001_ActionLog',
         ));
     }
 
     public function testIssueCascadeRemoveNotOrphanRemoval()
     {
-        $user = new User();
-        $role = new Role();
+        $user = new DDC0001_User();
+        $role = new DDC0001_Role();
 
         $user->addRole($role);
 
@@ -34,7 +34,7 @@ class DDC0001Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0001_User', $user->id);
         $role = $user->roles->get(0);
 
         $this->assertEquals(1, count($user->roles));
@@ -47,11 +47,11 @@ class DDC0001Test extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0001_User', $user->id);
 
         $this->assertEquals(0, count($user->roles));
 
-        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\ActionLog', 1);
+        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\DDC0001_ActionLog', 1);
 
         $this->assertEquals('1 - remove', $actionLog->id.' - '.$actionLog->action);
     }
@@ -60,7 +60,7 @@ class DDC0001Test extends OrmFunctionalTestCase
 /**
  * @Entity @Table(name="ddc0001_role") @HasLifecycleCallbacks
  */
-class Role
+class DDC0001_Role
 {
     /**
      * @Id @Column(type="integer")
@@ -69,7 +69,7 @@ class Role
     public $id;
 
     /**
-     * @ManyToOne(targetEntity="User", inversedBy="roles")
+     * @ManyToOne(targetEntity="DDC0001_User", inversedBy="roles")
      */
     public $user;
 
@@ -80,7 +80,7 @@ class Role
     {
         $em = $eventArgs->getEntityManager();
 
-        $actionLog = new ActionLog();
+        $actionLog = new DDC0001_ActionLog();
         $actionLog->action = 'remove';
         $em->persist($actionLog);
     }
@@ -89,7 +89,7 @@ class Role
 /**
  * @Entity @Table(name="ddc0001_user")
  */
-class User
+class DDC0001_User
 {
     public $changeSet = array();
 
@@ -100,11 +100,11 @@ class User
     public $id;
 
     /**
-     * @OneToMany(targetEntity="Role", mappedBy="user", cascade={"all"})
+     * @OneToMany(targetEntity="DDC0001_Role", mappedBy="user", cascade={"all"})
      */
     public $roles;
 
-    public function addRole(Role $role)
+    public function addRole(DDC0001_Role $role)
     {
         $this->roles[] = $role;
         $role->user = $this;
@@ -114,7 +114,7 @@ class User
 /**
  * @Entity @Table(name="ddc0001_action_log")
  */
-class ActionLog
+class DDC0001_ActionLog
 {
     /**
      * @Id @Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0001Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC0001Test.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\ORM\Event\LifecycleEventArgs;
+
+/**
+ * Functional tests for cascade remove without orphanRemoval.
+ *
+ * @author Lallement Thomas <thomas.lallement@9online.fr>
+ */
+class DDC0001Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema(array(
+            'Doctrine\Tests\ORM\Functional\Ticket\User',
+            'Doctrine\Tests\ORM\Functional\Ticket\Role',
+            'Doctrine\Tests\ORM\Functional\Ticket\ActionLog',
+        ));
+    }
+
+    public function testIssueCascadeRemoveNotOrphanRemoval()
+    {
+        $user = new User();
+        $role = new Role();
+
+        $user->addRole($role);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+        $role = $user->roles->get(0);
+
+        $this->assertEquals(1, count($user->roles));
+
+        $user->roles->removeElement($role);
+        $this->_em->remove($role);
+
+        $this->assertEquals(0, count($user->roles));
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\User', $user->id);
+
+        $this->assertEquals(0, count($user->roles));
+
+        $actionLog = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\ActionLog', 1);
+
+        $this->assertEquals('1 - remove', $actionLog->id.' - '.$actionLog->action);
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0001_role") @HasLifecycleCallbacks
+ */
+class Role
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="User", inversedBy="roles")
+     */
+    public $user;
+
+    /**
+     * @PreRemove
+     */
+    public function preRemove(LifecycleEventArgs $eventArgs)
+    {
+        $em = $eventArgs->getEntityManager();
+
+        $actionLog = new ActionLog();
+        $actionLog->action = 'remove';
+        $em->persist($actionLog);
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0001_user")
+ */
+class User
+{
+    public $changeSet = array();
+
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity="Role", mappedBy="user", cascade={"all"})
+     */
+    public $roles;
+
+    public function addRole(Role $role)
+    {
+        $this->roles[] = $role;
+        $role->user = $this;
+    }
+}
+
+/**
+ * @Entity @Table(name="ddc0001_action_log")
+ */
+class ActionLog
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+    */
+    public $id;
+
+    /**
+     * @Column(name="action", type="string", length=255, nullable=true)
+     */
+    public $action;
+}


### PR DESCRIPTION
Hi,

I created 2 tests to show that we encounter a problem when using orphanRemoval (see https://github.com/raziel057/doctrine2/commit/e0365f0d1837edc2459990041398ade472354e5e).

-> The ActionLog is created with no value in the "action" column.

That's not the case when removing manually (see https://github.com/raziel057/doctrine2/commit/62fbf49654b3ea751bec824e9a047d45aa899b7a).

-> The ActionLog is created with value "remove" in the "action" column.

I think the behavior must be the same in the 2 Tests.

For information, I discovered the problem when using https://github.com/KnpLabs/DoctrineBehaviors/blob/master/src/Knp/DoctrineBehaviors/ORM/Loggable/LoggableListener.php with a custom callable DB logger.
