### PR TITLE
Fix the composer autoload paths for the doctrine CLT

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 
 $autoloadFiles = array(__DIR__ . '/../vendor/autoload.php',
-                       __DIR__ . '/../vendor/autoload.php');
+                       __DIR__ . '/../../../autoload.php');
 
 foreach ($autoloadFiles as $autoloadFile) {
     if (file_exists($autoloadFile)) {


### PR DESCRIPTION
When installed as a composer dependency, this fixes the path for the vendor/autoload.php file.
