### PR TITLE
'EntityRepository' dependencies are accessible, using getters, after instantiation.

### DIFF
--- a/tests/Doctrine/Tests/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityRepositoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\Tests\OrmTestCase;
+use Doctrine\ORM\EntityRepository;
+
+class EntityRepositoryTest extends OrmTestCase
+{
+	public function testDependenciesAreAccessibleAfterInstantiation()
+	{
+		$entityManager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$entityRepository = new EntityRepository($entityManager, $classMetadata);
+
+		$this->assertSame($entityManager, $entityRepository->getEntityManager());
+		$this->assertSame($classMetadata, $entityRepository->getClassMetadata());
+	}
+}


### PR DESCRIPTION
Good morning,

An `EntityRepository` object is created using an `EntityManager` and a Mapping `ClassMetadata` object but -previously - those dependencies were not publicly accessible.  I've been creating a `QueryBuilder` using `EntityRepository::createQueryBuilder()` to get a hold of the `EntityManager`, which is a little silly.  

I added a unit test for `EntityRepository` and made both dependencies accessible.

Thanks,
Dan
