### PR TITLE
Fix bulk insert code example

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -42,6 +42,8 @@ internally but also mean more work during ``flush``.
             $em->clear(); // Detaches all objects from Doctrine!
         }
     }
+    $em->flush(); //Persist objects that did not make up an entire batch
+    $em->clear();
 
 Bulk Updates
 ------------


### PR DESCRIPTION
Previous code example did not flush all entities when entity count was not a multiple of batch count.
