### PR TITLE
Make Doctrine\ORM\Configuration implement fluent interface

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -844,6 +844,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setRepositoryFactory(RepositoryFactory $repositoryFactory)
     {
         $this->_attributes['repositoryFactory'] = $repositoryFactory;
+
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -60,6 +60,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setProxyDir($dir)
     {
         $this->_attributes['proxyDir'] = $dir;
+
+        return $this;
     }
 
     /**
@@ -98,6 +100,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setAutoGenerateProxyClasses($bool)
     {
         $this->_attributes['autoGenerateProxyClasses'] = $bool;
+
+        return $this;
     }
 
     /**
@@ -122,6 +126,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setProxyNamespace($ns)
     {
         $this->_attributes['proxyNamespace'] = $ns;
+
+        return $this;
     }
 
     /**
@@ -137,6 +143,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setMetadataDriverImpl(MappingDriver $driverImpl)
     {
         $this->_attributes['metadataDriverImpl'] = $driverImpl;
+
+        return $this;
     }
 
     /**
@@ -178,6 +186,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function addEntityNamespace($alias, $namespace)
     {
         $this->_attributes['entityNamespaces'][$alias] = $namespace;
+
+        return $this;
     }
 
     /**
@@ -208,6 +218,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setEntityNamespaces(array $entityNamespaces)
     {
         $this->_attributes['entityNamespaces'] = $entityNamespaces;
+
+        return $this;
     }
 
     /**
@@ -256,6 +268,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setQueryCacheImpl(CacheDriver $cacheImpl)
     {
         $this->_attributes['queryCacheImpl'] = $cacheImpl;
+
+        return $this;
     }
 
     /**
@@ -280,6 +294,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setHydrationCacheImpl(CacheDriver $cacheImpl)
     {
         $this->_attributes['hydrationCacheImpl'] = $cacheImpl;
+
+        return $this;
     }
 
     /**
@@ -304,6 +320,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setMetadataCacheImpl(CacheDriver $cacheImpl)
     {
         $this->_attributes['metadataCacheImpl'] = $cacheImpl;
+
+        return $this;
     }
 
     /**
@@ -317,6 +335,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function addNamedQuery($name, $dql)
     {
         $this->_attributes['namedQueries'][$name] = $dql;
+
+        return $this;
     }
 
     /**
@@ -349,6 +369,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm)
     {
         $this->_attributes['namedNativeQueries'][$name] = array($sql, $rsm);
+
+        return $this;
     }
 
     /**
@@ -415,6 +437,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         }
 
         $this->_attributes['customStringFunctions'][strtolower($name)] = $className;
+
+        return $this;
     }
 
     /**
@@ -450,6 +474,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         foreach ($functions as $name => $className) {
             $this->addCustomStringFunction($name, $className);
         }
+
+        return $this;
     }
 
     /**
@@ -473,6 +499,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         }
 
         $this->_attributes['customNumericFunctions'][strtolower($name)] = $className;
+
+        return $this;
     }
 
     /**
@@ -489,6 +517,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         return isset($this->_attributes['customNumericFunctions'][$name])
             ? $this->_attributes['customNumericFunctions'][$name]
             : null;
+
+        return $this;
     }
 
     /**
@@ -508,6 +538,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         foreach ($functions as $name => $className) {
             $this->addCustomNumericFunction($name, $className);
         }
+
+        return $this;
     }
 
     /**
@@ -531,6 +563,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         }
 
         $this->_attributes['customDatetimeFunctions'][strtolower($name)] = $className;
+
+        return $this;
     }
 
     /**
@@ -566,6 +600,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         foreach ($functions as $name => $className) {
             $this->addCustomDatetimeFunction($name, $className);
         }
+
+        return $this;
     }
 
     /**
@@ -582,6 +618,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         foreach ($modes as $modeName => $hydrator) {
             $this->addCustomHydrationMode($modeName, $hydrator);
         }
+
+        return $this;
     }
 
     /**
@@ -609,6 +647,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function addCustomHydrationMode($modeName, $hydrator)
     {
         $this->_attributes['customHydrationModes'][$modeName] = $hydrator;
+
+        return $this;
     }
 
     /**
@@ -621,6 +661,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setClassMetadataFactoryName($cmfName)
     {
         $this->_attributes['classMetadataFactoryName'] = $cmfName;
+
+        return $this;
     }
 
     /**
@@ -644,6 +686,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function addFilter($name, $className)
     {
         $this->_attributes['filters'][$name] = $className;
+
+        return $this;
     }
 
     /**
@@ -681,6 +725,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
         }
 
         $this->_attributes['defaultRepositoryClassName'] = $className;
+
+        return $this;
     }
 
     /**
@@ -709,6 +755,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setNamingStrategy(NamingStrategy $namingStrategy)
     {
         $this->_attributes['namingStrategy'] = $namingStrategy;
+
+        return $this;
     }
 
     /**
@@ -739,6 +787,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setQuoteStrategy(QuoteStrategy $quoteStrategy)
     {
         $this->_attributes['quoteStrategy'] = $quoteStrategy;
+
+        return $this;
     }
 
     /**
@@ -766,6 +816,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setEntityListenerResolver(EntityListenerResolver $resolver)
     {
         $this->_attributes['entityListenerResolver'] = $resolver;
+
+        return $this;
     }
 
     /**
@@ -841,6 +893,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setSecondLevelCacheConfiguration(CacheConfiguration $cacheConfig)
     {
         $this->_attributes['secondLevelCacheConfiguration'] = $cacheConfig;
+
+        return $this;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -267,6 +267,15 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertSame($resolver, $this->configuration->getEntityListenerResolver());
     }
 
+    public function testSetGetRepositoryFactory()
+    {
+        $this->assertInstanceOf('Doctrine\ORM\Repository\RepositoryFactory', $this->configuration->getRepositoryFactory());
+        $this->assertInstanceOf('Doctrine\ORM\Repository\DefaultRepositoryFactory', $this->configuration->getRepositoryFactory());
+        $factory = $this->getMock('Doctrine\ORM\Repository\RepositoryFactory');
+        $this->assertSame($this->configuration, $this->configuration->setRepositoryFactory($factory));
+        $this->assertSame($factory, $this->configuration->getRepositoryFactory());
+    }
+
     /**
      * @group DDC-2183
      */

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -29,7 +29,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(null, $this->configuration->getProxyDir()); // defaults
 
-        $this->configuration->setProxyDir(__DIR__);
+        $this->assertSame($this->configuration, $this->configuration->setProxyDir(__DIR__));
         $this->assertSame(__DIR__, $this->configuration->getProxyDir());
     }
 
@@ -37,7 +37,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(true, $this->configuration->getAutoGenerateProxyClasses()); // defaults
 
-        $this->configuration->setAutoGenerateProxyClasses(false);
+        $this->assertSame($this->configuration, $this->configuration->setAutoGenerateProxyClasses(false));
         $this->assertSame(false, $this->configuration->getAutoGenerateProxyClasses());
     }
 
@@ -45,7 +45,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(null, $this->configuration->getProxyNamespace()); // defaults
 
-        $this->configuration->setProxyNamespace(__NAMESPACE__);
+        $this->assertSame($this->configuration, $this->configuration->setProxyNamespace(__NAMESPACE__));
         $this->assertSame(__NAMESPACE__, $this->configuration->getProxyNamespace());
     }
 
@@ -54,7 +54,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertSame(null, $this->configuration->getMetadataDriverImpl()); // defaults
 
         $metadataDriver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
-        $this->configuration->setMetadataDriverImpl($metadataDriver);
+        $this->assertSame($this->configuration, $this->configuration->setMetadataDriverImpl($metadataDriver));
         $this->assertSame($metadataDriver, $this->configuration->getMetadataDriverImpl());
     }
 
@@ -82,10 +82,10 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testSetGetEntityNamespace()
     {
-        $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__);
+        $this->assertSame($this->configuration, $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__));
         $this->assertSame(__NAMESPACE__, $this->configuration->getEntityNamespace('TestNamespace'));
         $namespaces = array('OtherNamespace' => __NAMESPACE__);
-        $this->configuration->setEntityNamespaces($namespaces);
+        $this->assertSame($this->configuration, $this->configuration->setEntityNamespaces($namespaces));
         $this->assertSame($namespaces, $this->configuration->getEntityNamespaces());
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->getEntityNamespace('NonExistingNamespace');
@@ -95,7 +95,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(null, $this->configuration->getQueryCacheImpl()); // defaults
         $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
-        $this->configuration->setQueryCacheImpl($queryCacheImpl);
+        $this->assertSame($this->configuration, $this->configuration->setQueryCacheImpl($queryCacheImpl));
         $this->assertSame($queryCacheImpl, $this->configuration->getQueryCacheImpl());
     }
 
@@ -103,7 +103,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(null, $this->configuration->getHydrationCacheImpl()); // defaults
         $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
-        $this->configuration->setHydrationCacheImpl($queryCacheImpl);
+        $this->assertSame($this->configuration, $this->configuration->setHydrationCacheImpl($queryCacheImpl));
         $this->assertSame($queryCacheImpl, $this->configuration->getHydrationCacheImpl());
     }
 
@@ -111,14 +111,14 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(null, $this->configuration->getMetadataCacheImpl()); // defaults
         $queryCacheImpl = $this->getMock('Doctrine\Common\Cache\Cache');
-        $this->configuration->setMetadataCacheImpl($queryCacheImpl);
+        $this->assertSame($this->configuration, $this->configuration->setMetadataCacheImpl($queryCacheImpl));
         $this->assertSame($queryCacheImpl, $this->configuration->getMetadataCacheImpl());
     }
 
     public function testAddGetNamedQuery()
     {
         $dql = 'SELECT u FROM User u';
-        $this->configuration->addNamedQuery('QueryName', $dql);
+        $this->assertSame($this->configuration, $this->configuration->addNamedQuery('QueryName', $dql));
         $this->assertSame($dql, $this->configuration->getNamedQuery('QueryName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->getNamedQuery('NonExistingQuery');
@@ -128,7 +128,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $sql = 'SELECT * FROM user';
         $rsm = $this->getMock('Doctrine\ORM\Query\ResultSetMapping');
-        $this->configuration->addNamedNativeQuery('QueryName', $sql, $rsm);
+        $this->assertSame($this->configuration, $this->configuration->addNamedNativeQuery('QueryName', $sql, $rsm));
         $fetched = $this->configuration->getNamedNativeQuery('QueryName');
         $this->assertSame($sql, $fetched[0]);
         $this->assertSame($rsm, $fetched[1]);
@@ -166,10 +166,10 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testAddGetCustomStringFunction()
     {
-        $this->configuration->addCustomStringFunction('FunctionName', __CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->addCustomStringFunction('FunctionName', __CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomStringFunction('NonExistingFunction'));
-        $this->configuration->setCustomStringFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame($this->configuration, $this->configuration->setCustomStringFunctions(array('OtherFunctionName' => __CLASS__)));
         $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomStringFunction('concat', __CLASS__);
@@ -177,10 +177,10 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testAddGetCustomNumericFunction()
     {
-        $this->configuration->addCustomNumericFunction('FunctionName', __CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->addCustomNumericFunction('FunctionName', __CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomNumericFunction('NonExistingFunction'));
-        $this->configuration->setCustomNumericFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame($this->configuration, $this->configuration->setCustomNumericFunctions(array('OtherFunctionName' => __CLASS__)));
         $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomNumericFunction('abs', __CLASS__);
@@ -188,10 +188,10 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testAddGetCustomDatetimeFunction()
     {
-        $this->configuration->addCustomDatetimeFunction('FunctionName', __CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->addCustomDatetimeFunction('FunctionName', __CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomDatetimeFunction('NonExistingFunction'));
-        $this->configuration->setCustomDatetimeFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->assertSame($this->configuration, $this->configuration->setCustomDatetimeFunctions(array('OtherFunctionName' => __CLASS__)));
         $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomDatetimeFunction('date_add', __CLASS__);
@@ -200,7 +200,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     public function testAddGetCustomHydrationMode()
     {
         $this->assertSame(null, $this->configuration->getCustomHydrationMode('NonExisting'));
-        $this->configuration->addCustomHydrationMode('HydrationModeName', __CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->addCustomHydrationMode('HydrationModeName', __CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getCustomHydrationMode('HydrationModeName'));
     }
 
@@ -209,11 +209,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->addCustomHydrationMode('HydrationModeName', __CLASS__);
         $this->assertSame(__CLASS__, $this->configuration->getCustomHydrationMode('HydrationModeName'));
 
-        $this->configuration->setCustomHydrationModes(
-            array(
-                'AnotherHydrationModeName' => __CLASS__
-            )
-        );
+        $this->assertSame($this->configuration, $this->configuration->setCustomHydrationModes(array('AnotherHydrationModeName' => __CLASS__)));
 
         $this->assertNull($this->configuration->getCustomHydrationMode('HydrationModeName'));
         $this->assertSame(__CLASS__, $this->configuration->getCustomHydrationMode('AnotherHydrationModeName'));
@@ -222,22 +218,22 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     public function testSetGetClassMetadataFactoryName()
     {
         $this->assertSame('Doctrine\ORM\Mapping\ClassMetadataFactory', $this->configuration->getClassMetadataFactoryName());
-        $this->configuration->setClassMetadataFactoryName(__CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->setClassMetadataFactoryName(__CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getClassMetadataFactoryName());
     }
 
     public function testAddGetFilters()
     {
         $this->assertSame(null, $this->configuration->getFilterClassName('NonExistingFilter'));
-        $this->configuration->addFilter('FilterName', __CLASS__);
+        $this->assertSame($this->configuration, $this->configuration->addFilter('FilterName', __CLASS__));
         $this->assertSame(__CLASS__, $this->configuration->getFilterClassName('FilterName'));
     }
 
-    public function setDefaultRepositoryClassName()
+    public function testSetDefaultRepositoryClassName()
     {
         $this->assertSame('Doctrine\ORM\EntityRepository', $this->configuration->getDefaultRepositoryClassName());
         $repositoryClass = 'Doctrine\Tests\Models\DDC753\DDC753CustomRepository';
-        $this->configuration->setDefaultRepositoryClassName($repositoryClass);
+        $this->assertSame($this->configuration, $this->configuration->setDefaultRepositoryClassName($repositoryClass));
         $this->assertSame($repositoryClass, $this->configuration->getDefaultRepositoryClassName());
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->setDefaultRepositoryClassName(__CLASS__);
@@ -247,7 +243,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Doctrine\ORM\Mapping\NamingStrategy', $this->configuration->getNamingStrategy());
         $namingStrategy = $this->getMock('Doctrine\ORM\Mapping\NamingStrategy');
-        $this->configuration->setNamingStrategy($namingStrategy);
+        $this->assertSame($this->configuration, $this->configuration->setNamingStrategy($namingStrategy));
         $this->assertSame($namingStrategy, $this->configuration->getNamingStrategy());
     }
 
@@ -255,7 +251,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Doctrine\ORM\Mapping\QuoteStrategy', $this->configuration->getQuoteStrategy());
         $quoteStrategy = $this->getMock('Doctrine\ORM\Mapping\QuoteStrategy');
-        $this->configuration->setQuoteStrategy($quoteStrategy);
+        $this->assertSame($this->configuration, $this->configuration->setQuoteStrategy($quoteStrategy));
         $this->assertSame($quoteStrategy, $this->configuration->getQuoteStrategy());
     }
 
@@ -267,7 +263,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Doctrine\ORM\Mapping\EntityListenerResolver', $this->configuration->getEntityListenerResolver());
         $this->assertInstanceOf('Doctrine\ORM\Mapping\DefaultEntityListenerResolver', $this->configuration->getEntityListenerResolver());
         $resolver = $this->getMock('Doctrine\ORM\Mapping\EntityListenerResolver');
-        $this->configuration->setEntityListenerResolver($resolver);
+        $this->assertSame($this->configuration, $this->configuration->setEntityListenerResolver($resolver));
         $this->assertSame($resolver, $this->configuration->getEntityListenerResolver());
     }
 
@@ -279,7 +275,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $mockClass = $this->getMock('Doctrine\ORM\Cache\CacheConfiguration');
 
         $this->assertNull($this->configuration->getSecondLevelCacheConfiguration());
-        $this->configuration->setSecondLevelCacheConfiguration($mockClass);
+        $this->assertSame($this->configuration, $this->configuration->setSecondLevelCacheConfiguration($mockClass));
         $this->assertEquals($mockClass, $this->configuration->getSecondLevelCacheConfiguration());
     }
 }


### PR DESCRIPTION
Enabled chaining of calls to set_() and add_() methods in Configuration class.
Added relevant tests.

Created missing test for Doctrine\ORM\Configuration::setRepositoryFactory().
