### PR TITLE
[DDC-3239] [Test] Failing test, comments wanted; do not merge. `expandParameters`/`getType` in BasicEntityPersister seems to really cover just few cases

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3239Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3239Test.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Query;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-3239
+ * @group non-cacheable
+ */
+class DDC3239Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (Type::hasType('ddc3239_currency_code')) {
+            $this->fail(
+                'Type ddc3239_currency_code exists for testing DDC-3239 only, ' .
+                'but it has already been registered for some reason'
+            );
+        }
+
+        Type::addType('ddc3239_currency_code', __NAMESPACE__ . '\DDC3239CurrencyCode');
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(DDC3239Currency::CLASSNAME),
+            $this->_em->getClassMetadata(DDC3239Transaction::CLASSNAME),
+        ));
+    }
+
+    public function testIssue()
+    {
+        $currency = new DDC3239Currency('BYR');
+
+        $this->_em->persist($currency);
+        $this->_em->flush();
+
+        $amount = 50;
+        $transaction = new DDC3239Transaction($amount, $currency);
+
+        $this->_em->persist($transaction);
+        $this->_em->flush();
+        $this->_em->close();
+
+        $fetchedCurrency = $this->_em->find(DDC3239Currency::CLASSNAME, 'BYR');
+        $this->assertEquals(1, count($fetchedCurrency->transactions));
+
+    }
+}
+
+/**
+ * @Table(name="ddc3239_currency")
+ * @Entity
+ */
+class DDC3239Currency
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="ddc3239_currency_code")
+     */
+    public $code;
+
+    /**
+     * @var \Doctrine\Common\Collections\Collection
+     *
+     * @OneToMany(targetEntity="DDC3239Transaction", mappedBy="currency")
+     */
+    public $transactions;
+
+    public function __construct($code)
+    {
+        $this->code = $code;
+    }
+}
+
+/**
+ * @Table(name="ddc3239_transaction")
+ * @Entity
+ */
+class DDC3239Transaction
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @var int
+     *
+     * @Column(type="integer")
+     */
+    public $amount;
+
+    /**
+     * @var \Doctrine\Tests\ORM\Functional\Ticket\DDC3239Currency
+     *
+     * @ManyToOne(targetEntity="DDC3239Currency", inversedBy="transactions")
+     * @JoinColumn(name="currency_id", referencedColumnName="code", nullable=false)
+     */
+    public $currency;
+
+    public function __construct($amount, DDC3239Currency $currency)
+    {
+        $this->amount = $amount;
+        $this->currency = $currency;
+    }
+}
+
+class DDC3239CurrencyCode extends Type
+{
+    private static $map = array(
+        'BYR' => 974,
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getSmallIntTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return self::$map[$value];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return array_search($value, self::$map);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ddc3239_currency_code';
+    }
+}


### PR DESCRIPTION
The test case below seems fairly simple, but I believe that it might uncover a bigger issue.

Attached test fails: one record is expected, none records are returned. The problem looks rather simple: custom type is ignored and entity persister tries to load relation using PHP value, not a database one.

It seems odd that [`getType` (and, hence, `expandParameters`)](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php#L1731-1795) in BasicEntityPersister clearly expects field name but often gets different things.

Just set a breakpoint there and watch values through the test suite. There might be not just field name, but a column with alias as well. This works (note variables at the bottom):
![screenshot from 2014-08-01 14 03 44](https://cloud.githubusercontent.com/assets/231518/3778796/c5cc3e66-1979-11e4-9279-5c322b7e8402.png)

But this, apparently, doesn't:
![screenshot from 2014-08-01 14 07 29](https://cloud.githubusercontent.com/assets/231518/3778816/20da192c-197a-11e4-90b4-4c37ee454fb6.png)

There are multiple places (more than one) that call `expandParameters` with criteria that can't be resolved with `getType`. Is this situation expected or worth further investigation/fixing?
