### PR TITLE
Adding ` quote into INSERT SQL statement

### DIFF
--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1392,7 +1392,7 @@ class BasicEntityPersister implements EntityPersister
         $columns = implode(', ', $columns);
         $values  = implode(', ', $values);
 
-        $this->insertSql = sprintf('INSERT INTO %s (%s) VALUES (%s)', $tableName, $columns, $values);
+        $this->insertSql = sprintf('INSERT INTO `%s` (%s) VALUES (%s)', $tableName, $columns, $values);
 
         return $this->insertSql;
     }


### PR DESCRIPTION
It is not working for table names which are the same as SQL keywords (such as `order`).

Getting exception:

```
Doctrine\DBAL\DBALException
An exception occurred while executing 'INSERT INTO order ( ... ) VALUES ( ... )' with params [ ... ]: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'order ( ... , ' at line 1
```

Solved by adding quotes.
