### PR TITLE
Updated the type hint for Type::DECIMAL

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -154,7 +154,7 @@ class EntityGenerator
         Type::SMALLINT      => 'integer',
         Type::TEXT          => 'string',
         Type::BLOB          => 'string',
-        Type::DECIMAL       => 'string',
+        Type::DECIMAL       => 'float',
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
     );


### PR DESCRIPTION
Fields of this type return floats so the type hint should reflect that. However, I'm not sure if this is used anywhere else apart from the phpdoc block?
