### PR TITLE
Fixed multiple table inheritance loading from middle tables when using b...

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2720,6 +2720,11 @@ class ClassMetadataInfo implements ClassMetadata
             }
             if (is_subclass_of($className, $this->name) && ! in_array($className, $this->subClasses)) {
                 $this->subClasses[] = $className;
+                foreach(array_values(class_parents($className)) as $childClass) {
+                    if ($childClass != $this->name && is_subclass_of($className, $childClass) && ! in_array($childClass, $this->subClasses)) {
+                        $this->subClasses[] = $childClass;
+                    }
+                }
             }
         }
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -167,6 +167,16 @@ class BasicInheritanceMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertInstanceOf('Doctrine\ORM\Id\SequenceGenerator', $class->idGenerator);
         $this->assertEquals(array('allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'), $class->sequenceGeneratorDefinition);
     }
+
+    /**
+     * @group DDC-3250
+     */
+    public function testSubClassesHierarchy() {
+        $class = $this->_factory->getMetadataFor(__NAMESPACE__ . '\\HierarchyBase');
+
+        $this->assertContains("Doctrine\\Tests\\ORM\\Mapping\\HierarchyFEntity", $class->subClasses);
+        $this->assertContains("Doctrine\\Tests\\ORM\\Mapping\\HierarchyG", $class->subClasses);
+    }
 }
 
 class TransientBaseClass {
@@ -213,7 +223,8 @@ class EntitySubClass2 extends MappedSuperclassBase {
  * @DiscriminatorMap({
  *     "c"   = "HierarchyC",
  *     "d"   = "HierarchyD",
- *     "e"   = "HierarchyE"
+ *     "e"   = "HierarchyE",
+ *     "g"   = "HierarchyG"
  * })
  */
 abstract class HierarchyBase
@@ -270,6 +281,27 @@ class HierarchyE extends HierarchyBEntity
     /** @Column(type="string") */
     public $e;
 }
+
+/**
+ * @Entity
+ */
+abstract class HierarchyFEntity extends HierarchyBase
+{
+    /** @Column(type="string") */
+    public $f;
+}
+
+/**
+ * @Entity
+ */
+class HierarchyG extends HierarchyFEntity
+{
+    /** @Column(type="string") */
+    public $g;
+}
+
+
+
 
 /**
  * @Entity


### PR DESCRIPTION
...ase table as source

Simply said when u use doctrine multiple table inheritance and depth is more then 2, doctrine ignores middle tables and does not load their data, this seems to fix the problem. 
