### PR TITLE
DDC-3120 - PHP 5.6-RC3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.6-dev",
-        "doctrine/instantiator": "1.0.*",
+        "doctrine/instantiator": "~1.0.1",
         "symfony/console": "2.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.6-dev",
+        "doctrine/instantiator": "1.0.*",
         "symfony/console": "2.*"
     },
     "require-dev": {

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1100,6 +1100,16 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertFalse($class->isIdentifier('foo'));
     }
+
+    /**
+     * @group DDC-3120
+     */
+    public function testCanInstantiateInternalPhpClassSubclass()
+    {
+        $classMetadata = new ClassMetadata(__NAMESPACE__ . '\\MyArrayObjectEntity');
+
+        $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+    }
 }
 
 /**
@@ -1135,4 +1145,8 @@ class MyPrefixNamingStrategy extends \Doctrine\ORM\Mapping\DefaultNamingStrategy
     {
         return strtolower($this->classToTableName($className)) . '_' . $propertyName;
     }
+}
+
+class MyArrayObjectEntity extends \ArrayObject
+{
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1110,6 +1110,17 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
     }
+
+    /**
+     * @group DDC-3120
+     */
+    public function testCanInstantiateInternalPhpClassSubclassFromUnserializedMetadata()
+    {
+        /* @var $classMetadata ClassMetadata */
+        $classMetadata = unserialize(serialize(new ClassMetadata(__NAMESPACE__ . '\\MyArrayObjectEntity')));
+
+        $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -2,8 +2,10 @@
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 
 require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 
@@ -12,7 +14,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testClassMetadataInstanceSerialization()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         // Test initial state
         $this->assertTrue(count($cm->getReflectionProperties()) == 0);
@@ -36,7 +38,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $serialized = serialize($cm);
         $cm = unserialize($serialized);
-        $cm->wakeupReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->wakeupReflection(new RuntimeReflectionService());
 
         // Check state
         $this->assertTrue(count($cm->getReflectionProperties()) > 0);
@@ -61,7 +63,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testFieldIsNullable()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         // Explicit Nullable
         $cm->mapField(array('fieldName' => 'status', 'nullable' => true, 'type' => 'string', 'length' => 50));
@@ -84,7 +86,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         require_once __DIR__."/../../Models/Global/GlobalNamespaceModel.php";
 
         $cm = new ClassMetadata('DoctrineGlobal_Article');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(array(
             'fieldName' => 'author',
             'targetEntity' => 'DoctrineGlobal_User',
@@ -101,7 +103,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testMapManyToManyJoinTableDefaults()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
             array(
             'fieldName' => 'groups',
@@ -121,7 +123,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testSerializeManyToManyJoinTableCascade()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
             array(
             'fieldName' => 'groups',
@@ -143,7 +145,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         require_once __DIR__."/../../Models/Global/GlobalNamespaceModel.php";
 
         $cm = new ClassMetadata('DoctrineGlobal_User');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setDiscriminatorMap(array('descr' => 'DoctrineGlobal_Article', 'foo' => 'DoctrineGlobal_User'));
 
         $this->assertEquals("DoctrineGlobal_Article", $cm->discriminatorMap['descr']);
@@ -158,7 +160,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         require_once __DIR__."/../../Models/Global/GlobalNamespaceModel.php";
 
         $cm = new ClassMetadata('DoctrineGlobal_User');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setSubclasses(array('DoctrineGlobal_Article'));
 
         $this->assertEquals("DoctrineGlobal_Article", $cm->subClasses[0]);
@@ -174,7 +176,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $field['type'] = 'string';
 
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
         $cm->setVersionMapping($field);
@@ -183,7 +185,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testGetSingleIdentifierFieldName_MultipleIdentifierEntity_ThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->isIdentifierComposite  = true;
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
@@ -193,7 +195,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateAssociationMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $a1 = array('fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo');
         $a2 = array('fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo');
@@ -206,7 +208,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateColumnName_ThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
@@ -217,7 +219,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateColumnName_DiscriminatorColumn_ThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
@@ -228,7 +230,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateColumnName_DiscriminatorColumn2_ThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->setDiscriminatorColumn(array('name' => 'name'));
 
@@ -239,7 +241,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateFieldAndAssociationMapping1_ThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
@@ -250,7 +252,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDuplicateFieldAndAssociationMapping2_ThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
 
@@ -264,7 +266,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testGetTemporaryTableNameSchema()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->setTableName('foo.bar');
 
@@ -274,7 +276,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDefaultTableName()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         // When table's name is not given
         $primaryTable = array();
@@ -284,7 +286,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('CmsUser', $cm->table['name']);
 
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         // When joinTable's name is not given
         $cm->mapManyToMany(array(
             'fieldName' => 'user',
@@ -298,7 +300,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testDefaultJoinColumnName()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         // this is really dirty, but it's the simplest way to test whether
         // joinColumn's name will be automatically set to user_id
@@ -309,7 +311,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('user_id', $cm->associationMappings['user']['joinColumns'][0]['name']);
 
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(array(
             'fieldName' => 'user',
             'targetEntity' => 'CmsUser',
@@ -372,7 +374,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testSetMultipleIdentifierSetsComposite()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapField(array('fieldName' => 'name'));
         $cm->mapField(array('fieldName' => 'username'));
@@ -387,7 +389,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testMappingNotFound()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', "No mapping found for field 'foo' on class 'Doctrine\Tests\Models\CMS\CmsUser'.");
         $cm->getFieldMapping('foo');
@@ -399,7 +401,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testJoinTableMappingDefaults()
     {
         $cm = new ClassMetadata('DoctrineGlobal_Article');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapManyToMany(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\Models\CMS\CmsUser'));
 
@@ -412,7 +414,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testMapIdentifierAssociation()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapOneToOne(array(
             'fieldName' => 'article',
@@ -431,7 +433,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testOrphanRemovalIdentifierAssociation()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'The orphan removal option is not allowed on an association that');
         $cm->mapOneToOne(array(
@@ -449,7 +451,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInverseIdentifierAssociation()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'An inverse association is not allowed to be identifier in');
@@ -468,7 +470,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testIdentifierAssociationManyToMany()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'Many-to-many or one-to-many associations are not allowed to be identifier in');
@@ -488,7 +490,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException',
             "The field or association mapping misses the 'fieldName' attribute in entity 'Doctrine\Tests\Models\CMS\CmsUser'.");
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->mapField(array('fieldName' => ''));
     }
@@ -496,7 +498,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrievalOfNamedQueries()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $this->assertEquals(0, count($cm->getNamedQueries()));
@@ -515,7 +517,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrievalOfResultSetMappings()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $this->assertEquals(0, count($cm->getSqlResultSetMappings()));
@@ -535,7 +537,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testExistanceOfNamedQuery()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $cm->addNamedQuery(array(
@@ -553,7 +555,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrieveOfNamedNativeQuery()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addNamedNativeQuery(array(
             'name'              => 'find-all',
@@ -586,7 +588,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrieveOfSqlResultSetMapping()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addSqlResultSetMapping(array(
             'name'      => 'find-all',
@@ -644,7 +646,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testExistanceOfSqlResultSetMapping()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addSqlResultSetMapping(array(
             'name'      => 'find-all',
@@ -665,7 +667,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testExistanceOfNamedNativeQuery()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $cm->addNamedNativeQuery(array(
@@ -682,7 +684,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrieveOfNamedQuery()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
 
         $cm->addNamedQuery(array(
@@ -699,7 +701,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testRetrievalOfNamedNativeQueries()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->assertEquals(0, count($cm->getNamedNativeQueries()));
 
@@ -720,7 +722,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $metadata = new ClassMetadata('Doctrine\Tests\Models\Company\CompanyContract');
 
-        $metadata->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $metadata->initializeReflection(new RuntimeReflectionService());
         $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyContractListener', 'prePersistHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CompanyContractListener', 'postPersistHandler');
 
@@ -737,7 +739,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNamingCollisionNamedQueryShouldThrowException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addNamedQuery(array(
             'name'  => 'userById',
@@ -759,7 +761,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNamingCollisionNamedNativeQueryShouldThrowException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addNamedNativeQuery(array(
             'name'              => 'find-all',
@@ -785,7 +787,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNamingCollisionSqlResultSetMappingShouldThrowException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addSqlResultSetMapping(array(
             'name'      => 'find-all',
@@ -813,7 +815,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $user = new \Doctrine\Tests\Models\CMS\CmsUser();
         $cm = new ClassMetadata('DOCTRINE\TESTS\MODELS\CMS\CMSUSER');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
     }
@@ -824,11 +826,11 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testLifecycleCallbackNotFound()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addLifecycleCallback('notfound', 'postLoad');
 
         $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "Entity 'Doctrine\Tests\Models\CMS\CmsUser' has no method 'notfound' to be registered as lifecycle callback.");
-        $cm->validateLifecycleCallbacks(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->validateLifecycleCallbacks(new RuntimeReflectionService());
     }
 
     /**
@@ -837,7 +839,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testTargetEntityNotFound()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass'));
 
         $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "The target-entity Doctrine\Tests\Models\CMS\UnknownClass cannot be found in 'Doctrine\Tests\Models\CMS\CmsUser#address'.");
@@ -853,7 +855,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNameIsMandatoryForNamedQueryMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addNamedQuery(array(
             'query' => 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u',
         ));
@@ -868,7 +870,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNameIsMandatoryForNameNativeQueryMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addNamedQuery(array(
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
@@ -885,7 +887,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNameIsMandatoryForEntityNameSqlResultSetMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addSqlResultSetMapping(array(
             'name'      => 'find-all',
             'entities'  => array(
@@ -903,7 +905,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testNameIsMandatoryForDiscriminatorColumnsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setDiscriminatorColumn(array());
     }
 
@@ -919,9 +921,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $articleMetadata    = new ClassMetadata('DoctrineGlobal_Article', $namingStrategy);
         $routingMetadata    = new ClassMetadata('Doctrine\Tests\Models\Routing\RoutingLeg',$namingStrategy);
 
-        $addressMetadata->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $articleMetadata->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $routingMetadata->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $addressMetadata->initializeReflection(new RuntimeReflectionService());
+        $articleMetadata->initializeReflection(new RuntimeReflectionService());
+        $routingMetadata->initializeReflection(new RuntimeReflectionService());
 
         $addressMetadata->mapManyToMany(array(
             'fieldName'     => 'user',
@@ -947,7 +949,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $namingStrategy = new MyPrefixNamingStrategy();
         $metadata       = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', $namingStrategy);
 
-        $metadata->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $metadata->initializeReflection(new RuntimeReflectionService());
 
         $metadata->mapField(array('fieldName'=>'country'));
         $metadata->mapField(array('fieldName'=>'city'));
@@ -964,7 +966,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidCascade()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "You have specified invalid cascade options for Doctrine\Tests\Models\CMS\CmsUser::\$address: 'invalid'; available options: 'remove', 'persist', 'refresh', 'merge', and 'detach'");
 
@@ -980,7 +982,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidPropertyAssociationOverrideNameException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Admin');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'DDC964Address'));
 
         $cm->setAssociationOverride('invalidPropertyName', array());
@@ -994,7 +996,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidPropertyAttributeOverrideNameException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Guest');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapField(array('fieldName' => 'name'));
 
         $cm->setAttributeOverride('invalidPropertyName', array());
@@ -1008,7 +1010,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidOverrideAttributeFieldTypeException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Guest');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapField(array('fieldName' => 'name', 'type'=>'string'));
 
         $cm->setAttributeOverride('name', array('type'=>'date'));
@@ -1023,7 +1025,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidEntityListenerClassException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addEntityListener(Events::postLoad, '\InvalidClassName', 'postLoadHandler');
     }
@@ -1037,7 +1039,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testInvalidEntityListenerMethodException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->addEntityListener(Events::postLoad, '\Doctrine\Tests\Models\Company\CompanyContractListener', 'invalidMethod');
     }
@@ -1045,7 +1047,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testManyToManySelfReferencingNamingStrategyDefaults()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CustomType\CustomTypeParent');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
             array(
                 'fieldName' => 'friendsWithMe',
@@ -1072,7 +1074,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testSetSequenceGeneratorThrowsExceptionWhenSequenceNameIsMissing()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
         $cm->setSequenceGeneratorDefinition(array());
@@ -1084,7 +1086,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testQuotedSequenceName()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
+        $cm->initializeReflection(new RuntimeReflectionService());
 
         $cm->setSequenceGeneratorDefinition(array('sequenceName' => '`foo`'));
 
@@ -1119,6 +1121,8 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         /* @var $classMetadata ClassMetadata */
         $classMetadata = unserialize(serialize(new ClassMetadata(__NAMESPACE__ . '\\MyArrayObjectEntity')));
 
+        $classMetadata->wakeupReflection(new RuntimeReflectionService());
+
         $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
     }
 }
@@ -1132,7 +1136,7 @@ class DDC2700MappedSuperClass
     private $foo;
 }
 
-class MyNamespacedNamingStrategy extends \Doctrine\ORM\Mapping\DefaultNamingStrategy
+class MyNamespacedNamingStrategy extends DefaultNamingStrategy
 {
     /**
      * {@inheritdoc}
@@ -1147,7 +1151,7 @@ class MyNamespacedNamingStrategy extends \Doctrine\ORM\Mapping\DefaultNamingStra
     }
 }
 
-class MyPrefixNamingStrategy extends \Doctrine\ORM\Mapping\DefaultNamingStrategy
+class MyPrefixNamingStrategy extends DefaultNamingStrategy
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This PR replaces the current serialization hack used by doctrine with the polyfill provided by [`doctrine/instantiator`](https://github.com/doctrine/instantiator).

This will allows users of PHP 5.6 to rely on entities extending internal PHP classes again.
