### PR TITLE
Changed table name to be more appropriate.

### DIFF
--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -114,7 +114,7 @@ from newly opened EntityManager.
     $article = $em->find('Article', 1);
 
 This code only retrieves the ``Article`` instance with id 1 executing
-a single SELECT statement against the user table in the database.
+a single SELECT statement against the articles table in the database.
 You can still access the associated properties author and comments
 and the associated objects they contain.
 


### PR DESCRIPTION
Docs stated that this code `$article = $em->find('Article', 1);` executes a single select against the user, when we probably wanted articles.
