### PR TITLE
Fix inheritance hierarchy wrong exception message

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -248,7 +248,7 @@ class QueryException extends \Doctrine\ORM\ORMException
     public static function instanceOfUnrelatedClass($className, $rootClass)
     {
         return new self("Cannot check if a child of '" . $rootClass . "' is instanceof '" . $className . "', " .
-                "inheritance hierarchy exists between these two classes.");
+                "inheritance hierarchy does not exists between these two classes.");
     }
 
     /**


### PR DESCRIPTION
Hi,

I've fixed this exception message.

It is only throws when trying to make a query with an entity which is not defined in the discriminator mapping here: https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Query/SqlWalker.php#L2075
