### PR TITLE
DefaultRepositoryFactory: single repository for aliased entities

### DIFF
--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -43,13 +43,15 @@ class DefaultRepositoryFactory implements RepositoryFactory
     {
         $entityName = ltrim($entityName, '\\');
 
-        if (isset($this->repositoryList[$entityName])) {
-            return $this->repositoryList[$entityName];
+        $class = $entityManager->getClassMetadata($entityName)->getName();
+
+        if (isset($this->repositoryList[$class])) {
+            return $this->repositoryList[$class];
         }
 
         $repository = $this->createRepository($entityManager, $entityName);
 
-        $this->repositoryList[$entityName] = $repository;
+        $this->repositoryList[$class] = $repository;
 
         return $repository;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -611,6 +611,23 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->getConfiguration()->setDefaultRepositoryClassName("Doctrine\Tests\Models\DDC753\DDC753InvalidRepository");
     }
 
+    public function testSingleRepositoryInstanceForAnEntity()
+    {
+        $config = $this->_em->getConfiguration();
+        $config->addEntityNamespace('Aliased', 'Doctrine\Tests\Models\CMS');
+        $config->addEntityNamespace('AliasedAgain', 'Doctrine\Tests\Models\CMS');
+
+        $this->assertSame(
+            $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser'),
+            $this->_em->getRepository('Aliased:CmsUser')
+        );
+
+        $this->assertSame(
+            $this->_em->getRepository('Aliased:CmsUser'),
+            $this->_em->getRepository('AliasedAgain:CmsUser')
+        );
+    }
+
     /**
      * @group DDC-1376
      *


### PR DESCRIPTION
The actual implementation of `DefaultRepositoryFactory` create multiple instances for a single entity if is accessed by multiple namespace aliases.

I've patched `DefaultRepositoryFactory::getRepository` so that aliases are resolved before saving the reference into the `repositoryList`.

~~Just to not affect performance of existing implementation, I've added to the `repositoryList` both the aliased class name and the fully-qualified class name, but only the latter is required.~~
