### PR TITLE
Enabled colors for the PHPUnit output on Travis

### DIFF
--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php" colors="true">
     <php>
         <var name="db_type" value="pdo_mysql"/>
         <var name="db_host" value="localhost" />

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php" colors="true">
     <php>
    <!-- "Real" test database -->
         <var name="db_type" value="pdo_pgsql"/>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit bootstrap="../Doctrine/Tests/TestInit.php">
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php" colors="true">
 
    <testsuites>
      <testsuite name="Doctrine ORM Test Suite">


### PR DESCRIPTION
This makes the build output nicer, especially to locate errors when there is a failure
