### PR TITLE
[DDC-3205] Metadata info

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -93,6 +93,14 @@ EOT
         return 0;
     }
 
+    /**
+     * List all the mapped classes
+     *
+     * Returns the exit code, which will be 1 if there are any mapping exceptions
+     * encountered when listing the mapped classes.
+     *
+     * @return integer
+     */
     private function displayAll()
     {
         $entityClassNames = $this->getMappedEntities();
@@ -117,6 +125,11 @@ EOT
         return $failure ? 1 : 0;
     }
 
+    /**
+     * Display all the mapping information for a single Entity.
+     *
+     * @param string $entityName Full or partial entity class name
+     */
     private function displayEntity($entityName)
     {
         $meta = $this->getClassMetadata($entityName);
@@ -169,6 +182,11 @@ EOT
         }
     }
 
+    /**
+     * Return all mapped entity class names
+     *
+     * @return array
+     */
     private function getMappedEntities()
     {
         $entityClassNames = $this->entityManager->getConfiguration()
@@ -185,6 +203,12 @@ EOT
         return $entityClassNames;
     }
 
+    /**
+     * Return the class metadata for the given entity
+     * name
+     *
+     * @param string $entityName Full or partial entity name
+     */
     private function getClassMetadata($entityName)
     {
         try {
@@ -192,7 +216,7 @@ EOT
         } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
             $mappedEntities = $this->getMappedEntities();
             $matches = array_filter($mappedEntities, function ($mappedEntity) use ($entityName) {
-                if (preg_match('{' . $entityName . '}', $mappedEntity)) {
+                if (preg_match('{' . preg_quote($entityName) . '}', $mappedEntity)) {
                     return true;
                 }
 
@@ -219,6 +243,11 @@ EOT
         return $meta;
     }
 
+    /**
+     * Format the given value for console output
+     *
+     * @param mixed $value
+     */
     private function formatValue($value)
     {
         if ('' === $value) {
@@ -256,6 +285,13 @@ EOT
         throw new \InvalidArgumentException(sprintf('Do not know how to format value "%s"', print_r($value, true)));
     }
 
+    /**
+     * Add the given label and value to the two column table
+     * output
+     *
+     * @param string $label Label for the value
+     * @param mixed $valueA Value to show
+     */
     private function formatField($label, $value)
     {
         if (null === $value) {
@@ -265,6 +301,11 @@ EOT
         $this->out[] = array(sprintf('<info>%s</info>', $label), $this->formatValue($value));
     }
 
+    /**
+     * Format the association mappings
+     *
+     * @param array
+     */
     private function formatAssociationMappings($associationMappings)
     {
         $this->formatField('Association mappings:', '');
@@ -276,6 +317,11 @@ EOT
         }
     }
 
+    /**
+     * Format the entity listeners
+     *
+     * @param array $entityListeners
+     */
     private function formatEntityListeners($entityListeners)
     {
         $entityListenerNames = array();
@@ -286,6 +332,11 @@ EOT
         $this->formatField('Entity listeners', $entityListenerNames);
     }
 
+    /**
+     * Form the field mappings
+     *
+     * @param array $fieldMappings
+     */
     private function formatFieldMappings($fieldMappings)
     {
         $this->formatField('Field mappings:', '');

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Helper\TableHelper;
  * @link    www.doctrine-project.org
  * @since   2.1
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
+ * @author  Daniel Leech <daniel@dantleech.com>
  */
 class InfoCommand extends Command
 {
@@ -62,6 +63,10 @@ or not.
 You can display the complete metadata for a given entity by specifying it, e.g.
 
     <info>%command.full_name%</info> My\Namespace\Entity\MyEntity
+
+You can also specify a partial class name (as a regex):
+
+    <info>%command.full_name%</info> MyEntity
 EOT
         );
     }
@@ -253,7 +258,7 @@ EOT
     protected function formatListField($label, $values)
     {
         if (!$values) {
-            $out = '<comment>Empty</comment>';
+            $this->formatField($label, '<comment>Empty</comment>');
         } else {
             $this->formatField($label, array_shift($values));
 
@@ -261,8 +266,6 @@ EOT
                 $this->formatField($label, $value);
             }
         }
-
-        $this->formatField($label, $out);
     }
 
     protected function formatAssociationMappings($associationMappings)

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -23,8 +23,6 @@ use Doctrine\ORM\Mapping\MappingException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Helper\TableHelper;
 
 /**
  * Show information about mapped entities.
@@ -32,20 +30,9 @@ use Symfony\Component\Console\Helper\TableHelper;
  * @link    www.doctrine-project.org
  * @since   2.1
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
- * @author  Daniel Leech <daniel@dantleech.com>
  */
 class InfoCommand extends Command
 {
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * @var array
-     */
-    private $out;
-
     /**
      * {@inheritdoc}
      */
@@ -53,20 +40,11 @@ class InfoCommand extends Command
     {
         $this
             ->setName('orm:info')
-            ->addArgument('entityName', InputArgument::OPTIONAL, 'Show detailed information about the given class')
-            ->setDescription('Display information about mapped objects')
+            ->setDescription('Show basic information about all mapped entities')
             ->setHelp(<<<EOT
-The <info>%command.name%</info> without arguments shows basic information about
-which entities exist and possibly if their mapping information contains errors
-or not.
-
-You can display the complete metadata for a given entity by specifying it, e.g.
-
-    <info>%command.full_name%</info> My\Namespace\Entity\MyEntity
-
-You can also specify a partial class name (as a regex):
-
-    <info>%command.full_name%</info> MyEntity
+The <info>%command.name%</info> shows basic information about which
+entities exist and possibly if their mapping information contains errors or
+not.
 EOT
         );
     }
@@ -76,275 +54,37 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entityName = $input->getArgument('entityName');
-
         /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
-        $this->output = $output;
-        $this->entityManager = $entityManager;
+        $entityClassNames = $entityManager->getConfiguration()
+                                          ->getMetadataDriverImpl()
+                                          ->getAllClassNames();
 
-        if (null === $entityName) {
-            return $this->displayAll($output);
+        if (!$entityClassNames) {
+            throw new \Exception(
+                'You do not have any mapped Doctrine ORM entities according to the current configuration. '.
+                'If you have entities or mapping files you should check your mapping configuration for errors.'
+            );
         }
 
-        $this->displayEntity($entityName);
-
-        return 0;
-    }
-
-    /**
-     * List all the mapped classes
-     *
-     * Returns the exit code, which will be 1 if there are any mapping exceptions
-     * encountered when listing the mapped classes.
-     *
-     * @return integer
-     */
-    private function displayAll()
-    {
-        $entityClassNames = $this->getMappedEntities();
-
-        $this->output->writeln(sprintf("Found <info>%d</info> mapped entities:", count($entityClassNames)));
+        $output->writeln(sprintf("Found <info>%d</info> mapped entities:", count($entityClassNames)));
 
         $failure = false;
 
         foreach ($entityClassNames as $entityClassName) {
             try {
-                $meta = $this->entityManager->getClassMetadata($entityClassName);
-                $this->output->writeln(sprintf("<info>[OK]</info>   %s", $entityClassName));
+                $entityManager->getClassMetadata($entityClassName);
+                $output->writeln(sprintf("<info>[OK]</info>   %s", $entityClassName));
             } catch (MappingException $e) {
-                $this->output->writeln("<error>[FAIL]</error> ".$entityClassName);
-                $this->output->writeln(sprintf("<comment>%s</comment>", $e->getMessage()));
-                $this->output->writeln('');
+                $output->writeln("<error>[FAIL]</error> ".$entityClassName);
+                $output->writeln(sprintf("<comment>%s</comment>", $e->getMessage()));
+                $output->writeln('');
 
                 $failure = true;
             }
         }
 
         return $failure ? 1 : 0;
-    }
-
-    /**
-     * Display all the mapping information for a single Entity.
-     *
-     * @param string $entityName Full or partial entity class name
-     */
-    private function displayEntity($entityName)
-    {
-        $meta = $this->getClassMetadata($entityName);
-
-        $this->formatField('Name', $meta->name);
-        $this->formatField('Root entity name', $meta->rootEntityName);
-        $this->formatField('Custom generator definition', $meta->customGeneratorDefinition);
-        $this->formatField('Custom repository class', $meta->customRepositoryClassName);
-        $this->formatField('Mapped super class?', $meta->isMappedSuperclass);
-        $this->formatField('Embedded class?', $meta->isEmbeddedClass);
-        $this->formatField('Parent classes', $meta->parentClasses);
-        $this->formatField('Sub classes', $meta->subClasses);
-        $this->formatField('Embedded classes', $meta->subClasses);
-        $this->formatField('Named queries', $meta->namedQueries);
-        $this->formatField('Named native queries', $meta->namedNativeQueries);
-        $this->formatField('SQL result set mappings', $meta->sqlResultSetMappings);
-        $this->formatField('Identifier', $meta->identifier);
-        $this->formatField('Inheritance type', $meta->inheritanceType);
-        $this->formatField('Discriminator column', $meta->discriminatorColumn);
-        $this->formatField('Discriminator value', $meta->discriminatorValue);
-        $this->formatField('Discriminator map', $meta->discriminatorMap);
-        $this->formatField('Generator type', $meta->generatorType);
-        $this->formatField('Table', $meta->table);
-        $this->formatField('Composite identifier?', $meta->isIdentifierComposite);
-        $this->formatField('Foreign identifier?', $meta->containsForeignIdentifier);
-        $this->formatField('Sequence generator definition', $meta->sequenceGeneratorDefinition);
-        $this->formatField('Table generator definition', $meta->tableGeneratorDefinition);
-        $this->formatField('Change tracking policy', $meta->changeTrackingPolicy);
-        $this->formatField('Versioned?', $meta->isVersioned);
-        $this->formatField('Version field', $meta->versionField);
-        $this->formatField('Read only?', $meta->isReadOnly);
-        $this->formatField('Foo', array('Foo', 'Bar', 'Boo'));
-
-        $this->formatEntityListeners($meta->entityListeners);
-        $this->formatAssociationMappings($meta->associationMappings);
-        $this->formatFieldMappings($meta->fieldMappings);
-
-        if (class_exists('Symfony\Component\Console\Helper\TableHelper')) {
-            $table = new TableHelper();
-            $table->setHeaders(array('Field', 'Value'));
-            foreach ($this->out as $tuple) {
-                $table->addRow($tuple);
-            }
-            $table->render($this->output);
-        } else {
-            foreach ($this->out as $tuple) {
-                list($label, $value) = $tuple;
-                $this->output->writeln(sprintf('<info>%s</info>: %s', $label, $value));
-            }
-        }
-    }
-
-    /**
-     * Return all mapped entity class names
-     *
-     * @return array
-     */
-    private function getMappedEntities()
-    {
-        $entityClassNames = $this->entityManager->getConfiguration()
-                                          ->getMetadataDriverImpl()
-                                          ->getAllClassNames();
-
-        if (!$entityClassNames) {
-            throw new \InvalidArgumentException(
-                'You do not have any mapped Doctrine ORM entities according to the current configuration. '.
-                'If you have entities or mapping files you should check your mapping configuration for errors.'
-            );
-        }
-
-        return $entityClassNames;
-    }
-
-    /**
-     * Return the class metadata for the given entity
-     * name
-     *
-     * @param string $entityName Full or partial entity name
-     */
-    private function getClassMetadata($entityName)
-    {
-        try {
-            $meta = $this->entityManager->getClassMetadata($entityName);
-        } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
-            $mappedEntities = $this->getMappedEntities();
-            $matches = array_filter($mappedEntities, function ($mappedEntity) use ($entityName) {
-                if (preg_match('{' . preg_quote($entityName) . '}', $mappedEntity)) {
-                    return true;
-                }
-
-                return false;
-            });
-
-            if (0 === count($matches)) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Could not find any mapped Entity classes matching "%s"',
-                    $entityName
-                ));
-            }
-
-            if (1 === count($matches)) {
-                $meta = $this->entityManager->getClassMetadata(current($matches));
-            } else {
-                throw new \InvalidArgumentException(sprintf(
-                    'Entity name "%s" is ambigous, possible matches: "%s"',
-                    $entityName, implode(', ', $matches)
-                ));
-            }
-        }
-
-        return $meta;
-    }
-
-    /**
-     * Format the given value for console output
-     *
-     * @param mixed $value
-     */
-    private function formatValue($value)
-    {
-        if ('' === $value) {
-            return '';
-        }
-
-        if (null === $value) {
-            return '<comment>Null</comment>';
-        }
-
-        if (is_bool($value)) {
-            return '<comment>' . ($value ? 'True' : 'False') . '</comment>';
-        }
-
-        if (empty($value)) {
-            return '<comment>Empty</comment>';
-        }
-
-        if (is_array($value)) {
-            if (version_compare(phpversion(), '5.4.0', '>=')) {
-                return json_encode($value, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
-            }
-
-            return json_encode($value);
-        }
-
-        if (is_object($value)) {
-            return sprintf('<%s>', get_class($value));
-        }
-
-        if (is_scalar($value)) {
-            return $value;
-        }
-
-        throw new \InvalidArgumentException(sprintf('Do not know how to format value "%s"', print_r($value, true)));
-    }
-
-    /**
-     * Add the given label and value to the two column table
-     * output
-     *
-     * @param string $label Label for the value
-     * @param mixed $valueA Value to show
-     */
-    private function formatField($label, $value)
-    {
-        if (null === $value) {
-            $value = '<comment>None</comment>';
-        }
-
-        $this->out[] = array(sprintf('<info>%s</info>', $label), $this->formatValue($value));
-    }
-
-    /**
-     * Format the association mappings
-     *
-     * @param array
-     */
-    private function formatAssociationMappings($associationMappings)
-    {
-        $this->formatField('Association mappings:', '');
-        foreach ($associationMappings as $associationName => $mapping) {
-            $this->formatField(sprintf('  %s',$associationName), '');
-            foreach ($mapping as $field => $value) {
-                $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
-            }
-        }
-    }
-
-    /**
-     * Format the entity listeners
-     *
-     * @param array $entityListeners
-     */
-    private function formatEntityListeners($entityListeners)
-    {
-        $entityListenerNames = array();
-        foreach ($entityListeners as $entityListener) {
-            $entityListenerNames[] = get_class($entityListener);
-        }
-
-        $this->formatField('Entity listeners', $entityListenerNames);
-    }
-
-    /**
-     * Form the field mappings
-     *
-     * @param array $fieldMappings
-     */
-    private function formatFieldMappings($fieldMappings)
-    {
-        $this->formatField('Field mappings:', '');
-        foreach ($fieldMappings as $fieldName => $mapping) {
-            $this->formatField(sprintf('  %s',$fieldName), '');
-            foreach ($mapping as $field => $value) {
-                $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
-            }
-        }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -1,0 +1,309 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools\Console\Command;
+
+use Doctrine\ORM\Mapping\MappingException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Helper\TableHelper;
+
+/**
+ * Show information about mapped entities.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.4
+ * @author  Daniel Leech <daniel@dantleech.com>
+ */
+class MappingDescribeCommand extends Command
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var array
+     */
+    private $out;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('orm:mapping:describe')
+            ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
+            ->setDescription('Display information about mapped objects')
+            ->setHelp(<<<EOT
+The %command.full_name% command describes the metadata for the given full or partial entity class name.
+
+    <info>%command.full_name%</info> My\Namespace\Entity\MyEntity
+
+Or:
+
+    <info>%command.full_name%</info> MyEntity
+EOT
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $entityName = $input->getArgument('entityName');
+
+        /* @var $entityManager \Doctrine\ORM\EntityManager */
+        $entityManager = $this->getHelper('em')->getEntityManager();
+
+        $this->output = $output;
+        $this->entityManager = $entityManager;
+
+        $this->displayEntity($entityName);
+
+        return 0;
+    }
+
+    /**
+     * Display all the mapping information for a single Entity.
+     *
+     * @param string $entityName Full or partial entity class name
+     */
+    private function displayEntity($entityName)
+    {
+        $meta = $this->getClassMetadata($entityName);
+
+        $this->formatField('Name', $meta->name);
+        $this->formatField('Root entity name', $meta->rootEntityName);
+        $this->formatField('Custom generator definition', $meta->customGeneratorDefinition);
+        $this->formatField('Custom repository class', $meta->customRepositoryClassName);
+        $this->formatField('Mapped super class?', $meta->isMappedSuperclass);
+        $this->formatField('Embedded class?', $meta->isEmbeddedClass);
+        $this->formatField('Parent classes', $meta->parentClasses);
+        $this->formatField('Sub classes', $meta->subClasses);
+        $this->formatField('Embedded classes', $meta->subClasses);
+        $this->formatField('Named queries', $meta->namedQueries);
+        $this->formatField('Named native queries', $meta->namedNativeQueries);
+        $this->formatField('SQL result set mappings', $meta->sqlResultSetMappings);
+        $this->formatField('Identifier', $meta->identifier);
+        $this->formatField('Inheritance type', $meta->inheritanceType);
+        $this->formatField('Discriminator column', $meta->discriminatorColumn);
+        $this->formatField('Discriminator value', $meta->discriminatorValue);
+        $this->formatField('Discriminator map', $meta->discriminatorMap);
+        $this->formatField('Generator type', $meta->generatorType);
+        $this->formatField('Table', $meta->table);
+        $this->formatField('Composite identifier?', $meta->isIdentifierComposite);
+        $this->formatField('Foreign identifier?', $meta->containsForeignIdentifier);
+        $this->formatField('Sequence generator definition', $meta->sequenceGeneratorDefinition);
+        $this->formatField('Table generator definition', $meta->tableGeneratorDefinition);
+        $this->formatField('Change tracking policy', $meta->changeTrackingPolicy);
+        $this->formatField('Versioned?', $meta->isVersioned);
+        $this->formatField('Version field', $meta->versionField);
+        $this->formatField('Read only?', $meta->isReadOnly);
+        $this->formatField('Foo', array('Foo', 'Bar', 'Boo'));
+
+        $this->formatEntityListeners($meta->entityListeners);
+        $this->formatAssociationMappings($meta->associationMappings);
+        $this->formatFieldMappings($meta->fieldMappings);
+
+        if (class_exists('Symfony\Component\Console\Helper\TableHelper')) {
+            $table = new TableHelper();
+            $table->setHeaders(array('Field', 'Value'));
+            foreach ($this->out as $tuple) {
+                $table->addRow($tuple);
+            }
+            $table->render($this->output);
+        } else {
+            foreach ($this->out as $tuple) {
+                list($label, $value) = $tuple;
+                $this->output->writeln(sprintf('<info>%s</info>: %s', $label, $value));
+            }
+        }
+    }
+
+    /**
+     * Return all mapped entity class names
+     *
+     * @return array
+     */
+    private function getMappedEntities()
+    {
+        $entityClassNames = $this->entityManager->getConfiguration()
+                                          ->getMetadataDriverImpl()
+                                          ->getAllClassNames();
+
+        if (!$entityClassNames) {
+            throw new \InvalidArgumentException(
+                'You do not have any mapped Doctrine ORM entities according to the current configuration. '.
+                'If you have entities or mapping files you should check your mapping configuration for errors.'
+            );
+        }
+
+        return $entityClassNames;
+    }
+
+    /**
+     * Return the class metadata for the given entity
+     * name
+     *
+     * @param string $entityName Full or partial entity name
+     */
+    private function getClassMetadata($entityName)
+    {
+        try {
+            $meta = $this->entityManager->getClassMetadata($entityName);
+        } catch (\Doctrine\Common\Persistence\Mapping\MappingException $e) {
+            $mappedEntities = $this->getMappedEntities();
+            $matches = array_filter($mappedEntities, function ($mappedEntity) use ($entityName) {
+                if (preg_match('{' . preg_quote($entityName) . '}', $mappedEntity)) {
+                    return true;
+                }
+
+                return false;
+            });
+
+            if (0 === count($matches)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Could not find any mapped Entity classes matching "%s"',
+                    $entityName
+                ));
+            }
+
+            if (1 === count($matches)) {
+                $meta = $this->entityManager->getClassMetadata(current($matches));
+            } else {
+                throw new \InvalidArgumentException(sprintf(
+                    'Entity name "%s" is ambigous, possible matches: "%s"',
+                    $entityName, implode(', ', $matches)
+                ));
+            }
+        }
+
+        return $meta;
+    }
+
+    /**
+     * Format the given value for console output
+     *
+     * @param mixed $value
+     */
+    private function formatValue($value)
+    {
+        if ('' === $value) {
+            return '';
+        }
+
+        if (null === $value) {
+            return '<comment>Null</comment>';
+        }
+
+        if (is_bool($value)) {
+            return '<comment>' . ($value ? 'True' : 'False') . '</comment>';
+        }
+
+        if (empty($value)) {
+            return '<comment>Empty</comment>';
+        }
+
+        if (is_array($value)) {
+            if (version_compare(phpversion(), '5.4.0', '>=')) {
+                return json_encode($value, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+            }
+
+            return json_encode($value);
+        }
+
+        if (is_object($value)) {
+            return sprintf('<%s>', get_class($value));
+        }
+
+        if (is_scalar($value)) {
+            return $value;
+        }
+
+        throw new \InvalidArgumentException(sprintf('Do not know how to format value "%s"', print_r($value, true)));
+    }
+
+    /**
+     * Add the given label and value to the two column table
+     * output
+     *
+     * @param string $label Label for the value
+     * @param mixed $valueA Value to show
+     */
+    private function formatField($label, $value)
+    {
+        if (null === $value) {
+            $value = '<comment>None</comment>';
+        }
+
+        $this->out[] = array(sprintf('<info>%s</info>', $label), $this->formatValue($value));
+    }
+
+    /**
+     * Format the association mappings
+     *
+     * @param array
+     */
+    private function formatAssociationMappings($associationMappings)
+    {
+        $this->formatField('Association mappings:', '');
+        foreach ($associationMappings as $associationName => $mapping) {
+            $this->formatField(sprintf('  %s',$associationName), '');
+            foreach ($mapping as $field => $value) {
+                $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
+            }
+        }
+    }
+
+    /**
+     * Format the entity listeners
+     *
+     * @param array $entityListeners
+     */
+    private function formatEntityListeners($entityListeners)
+    {
+        $entityListenerNames = array();
+        foreach ($entityListeners as $entityListener) {
+            $entityListenerNames[] = get_class($entityListener);
+        }
+
+        $this->formatField('Entity listeners', $entityListenerNames);
+    }
+
+    /**
+     * Form the field mappings
+     *
+     * @param array $fieldMappings
+     */
+    private function formatFieldMappings($fieldMappings)
+    {
+        $this->formatField('Field mappings:', '');
+        foreach ($fieldMappings as $fieldName => $mapping) {
+            $this->formatField(sprintf('  %s',$fieldName), '');
+            foreach ($mapping as $field => $value) {
+                $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
+            }
+        }
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
@@ -53,40 +53,4 @@ class InfoCommandTest extends OrmFunctionalTestCase
         $this->assertContains('Doctrine\Tests\Models\Cache\AttractionInfo', $this->tester->getDisplay());
         $this->assertContains('Doctrine\Tests\Models\Cache\City', $this->tester->getDisplay());
     }
-
-    public function testShowSpecificFuzzySingle()
-    {
-        $this->tester->execute(array(
-            'command' => $this->command->getName(),
-            'entityName' => 'AttractionInfo',
-        ));
-
-        $display = $this->tester->getDisplay();
-        $this->assertContains('Doctrine\Tests\Models\Cache\AttractionInfo', $display);
-        $this->assertContains('Root entity name', $display);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage possible matches
-     */
-    public function testShowSpecificFuzzyAmbiguous()
-    {
-        $this->tester->execute(array(
-            'command' => $this->command->getName(),
-            'entityName' => 'Attraction',
-        ));
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find any mapped Entity classes matching "AttractionFooBar"
-     */
-    public function testShowSpecificNotFound()
-    {
-        $this->tester->execute(array(
-            'command' => $this->command->getName(),
-            'entityName' => 'AttractionFooBar'
-        ));
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
@@ -18,7 +18,7 @@ class InfoCommandTest extends OrmFunctionalTestCase
     private $application;
 
     /**
-     * @var \Doctrine\ORM\Tools\Console\Command\ClearCache\InfoCommand
+     * @var \Doctrine\ORM\Tools\Console\Command\InfoCommand
      */
     private $command;
 
@@ -68,7 +68,7 @@ class InfoCommandTest extends OrmFunctionalTestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage possible matches: "Doctrine\Tests\Models\Cache\AttractionInfo
+     * @expectedExceptionMessage possible matches
      */
     public function testShowSpecificFuzzyAmbiguous()
     {
@@ -88,22 +88,5 @@ class InfoCommandTest extends OrmFunctionalTestCase
             'command' => $this->command->getName(),
             'entityName' => 'AttractionFooBar'
         ));
-    }
-
-    /**
-     * This test takes a long time
-     */
-    public function testShowSpecificSmokeTest()
-    {
-        $entityClassNames = $this->_em->getConfiguration()
-            ->getMetadataDriverImpl()
-            ->getAllClassNames();
-
-        foreach ($entityClassNames as $entityClassName) {
-            $this->tester->Execute(array(
-                'command' => $this->command->getName(),
-                'entityName' => $entityClassName
-            ));
-        }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command;
+
+use Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Application;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand;
+
+class MappingDescribeCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Application
+     */
+    private $application;
+
+    /**
+     * @var \Doctrine\ORM\Tools\Console\Command\InfoCommand
+     */
+    private $command;
+
+    /**
+     * @var \Symfony\Component\Console\Tester\CommandTester
+     */
+    private $tester;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->application = new Application();
+        $command = new MappingDescribeCommand();
+
+        $this->application->setHelperSet(new HelperSet(array(
+            'em' => new EntityManagerHelper($this->_em)
+        )));
+
+        $this->application->add($command);
+
+        $this->command = $this->application->find('orm:mapping:describe');
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testShowSpecificFuzzySingle()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'entityName' => 'AttractionInfo',
+        ));
+
+        $display = $this->tester->getDisplay();
+        $this->assertContains('Doctrine\Tests\Models\Cache\AttractionInfo', $display);
+        $this->assertContains('Root entity name', $display);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage possible matches
+     */
+    public function testShowSpecificFuzzyAmbiguous()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'entityName' => 'Attraction',
+        ));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find any mapped Entity classes matching "AttractionFooBar"
+     */
+    public function testShowSpecificNotFound()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            'entityName' => 'AttractionFooBar'
+        ));
+    }
+}
+


### PR DESCRIPTION
This PR adds support for showing the metadata for a single entity to the `orm:info` command.
- The original behavior is preserved (running without arguments validates and lists all the entity names)
- The output is formatted using the `TableHelper` if it is available (Symfony 2.4+). If the TableHelper is not available
  it will format simply with `field: value`.
- Partial regex matches are accepted, e.g. `mapping:info Attraction`, `mapping:info Attraction.*`

E.g.:

``` bash
$ php app/console doctrine:mapping:info "Sulu\Bundle\ContactBundle\Entity\Count"
+-------------------------------+-----------------------------------------------------------------------------------------------+
| Field                         | Value                                                                                         |
+-------------------------------+-----------------------------------------------------------------------------------------------+
| Name                          | Sulu\Bundle\TagBundle\Entity\Tag                                                              |
| Root entity name              | Sulu\Bundle\TagBundle\Entity\Tag                                                              |
| Custom generator definition   | None                                                                                          |
| Custom repository class       | Sulu\Bundle\TagBundle\Entity\TagRepository                                                    |
| Mapped super class?           | Empty                                                                                         |
| Embedded class?               | Empty                                                                                         |
| Parent classes                | Empty                                                                                         |
| Sub classes                   | Empty                                                                                         |
| Embedded classes              | Empty                                                                                         |
| Named queries                 | Empty                                                                                         |
| Named native queries          | Empty                                                                                         |
| SQL result set mappings       | Empty                                                                                         |
| Identifier                    | ["id"]                                                                                        |
| Inheritance type              | 1                                                                                             |
| Discriminator column          | None                                                                                          |
| Discriminator value           | None                                                                                          |
| Discriminator map             | Empty                                                                                         |
| Generator type                | 4                                                                                             |
| Table                         | {"name":"ta_tags"}                                                                            |
| Composite identifier?         | Empty                                                                                         |
| Foreign identifier?           | Empty                                                                                         |
| Sequence generator definition | None                                                                                          |
| Table generator definition    | None                                                                                          |
| Change tracking policy        | 1                                                                                             |
| Versioned?                    | None                                                                                          |
| Version field                 | None                                                                                          |
| Read only?                    | Empty                                                                                         |
| Entity listeners              | Empty                                                                                         |
| Association mappings:         |                                                                                               |
|   creator                     |                                                                                               |
|     fieldName                 | creator                                                                                       |
|     targetEntity              | Sulu\Bundle\SecurityBundle\Entity\User                                                        |
|     joinColumns               | [{"name":"idUsersCreator","referencedColumnName":"id","nullable":true,"onDelete":"SET NULL"}] |
|     type                      | 2                                                                                             |
|     mappedBy                  | Null                                                                                          |
|     inversedBy                | Null                                                                                          |
|     isOwningSide              | 1                                                                                             |
|     sourceEntity              | Sulu\Bundle\TagBundle\Entity\Tag                                                              |
|     fetch                     | 2                                                                                             |
|     cascade                   | Empty                                                                                         |
|     isCascadeRemove           | Empty                                                                                         |
|     isCascadePersist          | Empty                                                                                         |
|     isCascadeRefresh          | Empty                                                                                         |
|     isCascadeMerge            | Empty                                                                                         |
|     isCascadeDetach           | Empty                                                                                         |
|     sourceToTargetKeyColumns  | {"idUsersCreator":"id"}                                                                       |
|     joinColumnFieldNames      | {"idUsersCreator":"idUsersCreator"}                                                           |
|     targetToSourceKeyColumns  | {"id":"idUsersCreator"}                                                                       |
|     orphanRemoval             | Empty                                                                                         |
| Field mappings:               |                                                                                               |
|   name                        |                                                                                               |
|     fieldName                 | name                                                                                          |
|     type                      | string                                                                                        |
|     columnName                | name                                                                                          |
|     unique                    | 1                                                                                             |
|   created                     |                                                                                               |
|     fieldName                 | created                                                                                       |
|     type                      | datetime                                                                                      |
|     columnName                | created                                                                                       |
+-------------------------------+-----------------------------------------------------------------------------------------------+
```
