### PR TITLE
[DDC-3274] Improve schema validator error message for invalid bi-directional relations

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -124,7 +124,7 @@ class SchemaValidator
                     $ce[] = "The field " . $class->name . "#" . $fieldName . " is on the inverse side of a ".
                             "bi-directional relationship, but the specified mappedBy association on the target-entity ".
                             $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " does not contain the required ".
-                            "'inversedBy=".$fieldName."' attribute.";
+                            "'inversedBy=\"" . $fieldName . "\"' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc['mappedBy']]['inversedBy'] != $fieldName) {
                     $ce[] = "The mappings " . $class->name . "#" . $fieldName . " and " .
                             $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " are ".

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -134,6 +134,24 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
             "The referenced column name 'id' has to be a primary key column on the target entity class 'Doctrine\Tests\ORM\Tools\DDC1649Two'."
         ), $ce);
     }
+
+    /**
+     * @group DDC-3274
+     */
+    public function testInvalidBiDirectionalRelationMappingMissingInversedByAttribute()
+    {
+        $class = $this->em->getClassMetadata(__NAMESPACE__ . '\DDC3274One');
+        $ce = $this->validator->validateClass($class);
+
+        $this->assertEquals(
+            array(
+                "The field Doctrine\Tests\ORM\Tools\DDC3274One#two is on the inverse side of a bi-directional " .
+                "relationship, but the specified mappedBy association on the target-entity " .
+                "Doctrine\Tests\ORM\Tools\DDC3274Two#one does not contain the required 'inversedBy=\"two\"' attribute."
+            ),
+            $ce
+        );
+    }
 }
 
 /**
@@ -263,3 +281,30 @@ class DDC1649Three
     private $two;
 }
 
+/**
+ * @Entity
+ */
+class DDC3274One
+{
+    /**
+     * @Id @Column @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="DDC3274Two", mappedBy="one")
+     */
+    private $two;
+}
+
+/**
+ * @Entity
+ */
+class DDC3274Two
+{
+    /**
+     * @Id
+     * @ManyToOne(targetEntity="DDC3274One")
+     */
+    private $one;
+}


### PR DESCRIPTION
Replaces `'inversedBy=users'` with `'inversedBy="users"'` in schema validator error message for invalid bi-directional relations to avoid errors with missing double quotes when copy-pasting.
