### PR TITLE
Support arithmetic expressions in `COUNT()`

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1626,8 +1626,7 @@ Aggregate Expressions
 
 .. code-block:: php
 
-    AggregateExpression ::= ("AVG" | "MAX" | "MIN" | "SUM") "(" ["DISTINCT"] StateFieldPathExpression ")" |
-                            "COUNT" "(" ["DISTINCT"] (IdentificationVariable | SingleValuedPathExpression) ")"
+    AggregateExpression ::= ("AVG" | "MAX" | "MIN" | "SUM" | "COUNT") "(" ["DISTINCT"] SimpleArithmeticExpression ")"
 
 Case Expressions
 ~~~~~~~~~~~~~~~~

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2962,9 +2962,7 @@ class Parser
             $isDistinct = true;
         }
 
-        $pathExp = ($lookaheadType === Lexer::T_COUNT)
-            ? $this->SingleValuedPathExpression()
-            : $this->SimpleArithmeticExpression();
+        $pathExp = $this->SimpleArithmeticExpression();
 
         $this->match(Lexer::T_CLOSE_PARENTHESIS);
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2939,8 +2939,7 @@ class Parser
 
     /**
      * AggregateExpression ::=
-     *  ("AVG" | "MAX" | "MIN" | "SUM") "(" ["DISTINCT"] StateFieldPathExpression ")" |
-     *  "COUNT" "(" ["DISTINCT"] (IdentificationVariable | SingleValuedPathExpression) ")"
+     *  ("AVG" | "MAX" | "MIN" | "SUM" | "COUNT") "(" ["DISTINCT"] SimpleArithmeticExpression ")"
      *
      * @return \Doctrine\ORM\Query\AST\AggregateExpression
      */

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -263,6 +263,9 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    /**
+     * @group DDC-3276
+     */
     public function testSupportsAggregateCountFunctionWithSimpleArithmetic()
     {
         $connMock = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -263,6 +263,21 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
+    public function testSupportsAggregateCountFunctionWithSimpleArithmetic()
+    {
+        $connMock = $this->_em->getConnection();
+        $orgPlatform = $connMock->getDatabasePlatform();
+
+        $connMock->setDatabasePlatform(new \Doctrine\DBAL\Platforms\MySqlPlatform);
+
+        $this->assertSqlGeneration(
+            'SELECT COUNT(CONCAT(u.id, u.name)) FROM Doctrine\Tests\Models\CMS\CmsUser u GROUP BY u.id',
+            'SELECT COUNT(CONCAT(c0_.id, c0_.name)) AS sclr_0 FROM cms_users c0_ GROUP BY c0_.id'
+        );
+
+        $connMock->setDatabasePlatform($orgPlatform);
+    }
+
     public function testSupportsWhereClauseWithPositionalParameter()
     {
         $this->assertSqlGeneration(


### PR DESCRIPTION
tl;dr:

Following is now allowed (example):

``` sql
SELECT COUNT(DISTINCT CONCAT(u.name, u.surname)) FROM User u
```

I am not aware of RDBMS implementations that do not support this. Ping @guilhermeblanco 
