### PR TITLE
Fixed the structure of the reverse-engineered mapping

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -407,7 +407,7 @@ class DatabaseDriver implements MappingDriver
             case Type::STRING:
             case Type::TEXT:
                 $fieldMapping['length'] = $column->getLength();
-                $fieldMapping['fixed']  = $column->getFixed();
+                $fieldMapping['options']['fixed']  = $column->getFixed();
                 break;
 
             case Type::DECIMAL:
@@ -419,18 +419,18 @@ class DatabaseDriver implements MappingDriver
             case Type::INTEGER:
             case Type::BIGINT:
             case Type::SMALLINT:
-                $fieldMapping['unsigned'] = $column->getUnsigned();
+                $fieldMapping['options']['unsigned'] = $column->getUnsigned();
                 break;
         }
 
         // Comment
         if (($comment = $column->getComment()) !== null) {
-            $fieldMapping['comment'] = $comment;
+            $fieldMapping['options']['comment'] = $comment;
         }
 
         // Default
         if (($default = $column->getDefault()) !== null) {
-            $fieldMapping['default'] = $default;
+            $fieldMapping['options']['default'] = $default;
         }
 
         return $fieldMapping;

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -189,14 +189,14 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         if ( ! $this->_em->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform AND
              ! $this->_em->getConnection()->getDatabasePlatform() instanceof SQLServerPlatform) {
             $this->assertArrayHasKey('columnUnsigned', $metadata->fieldMappings);
-            $this->assertTrue($metadata->fieldMappings['columnUnsigned']['unsigned']);
+            $this->assertTrue($metadata->fieldMappings['columnUnsigned']['options']['unsigned']);
         }
 
         $this->assertArrayHasKey('columnComment', $metadata->fieldMappings);
-        $this->assertEquals('test_comment', $metadata->fieldMappings['columnComment']['comment']);
+        $this->assertEquals('test_comment', $metadata->fieldMappings['columnComment']['options']['comment']);
 
         $this->assertArrayHasKey('columnDefault', $metadata->fieldMappings);
-        $this->assertEquals('test_default', $metadata->fieldMappings['columnDefault']['default']);
+        $this->assertEquals('test_default', $metadata->fieldMappings['columnDefault']['options']['default']);
 
         $this->assertArrayHasKey('columnDecimal', $metadata->fieldMappings);
         $this->assertEquals(4, $metadata->fieldMappings['columnDecimal']['precision']);


### PR DESCRIPTION
when using the DatabaseDriver, the field mapping being generated does not match the field mapping expected by all other drivers or the SchemaTool. This means that these mapping settings get ignored.

See https://github.com/doctrine/migrations/issues/184 for the initial report
