### PR TITLE
Fixed new line in docblock

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -219,6 +219,7 @@ class EntityGenerator
 '/**
  * <description>
  *
+ *
  * @return <variableType>
  */
 public function <methodName>()
@@ -232,6 +233,7 @@ public function <methodName>()
     protected static $setMethodTemplate =
 '/**
  * <description>
+ *
  *
  * @param <variableType> $<variableName>
  *
@@ -251,6 +253,7 @@ public function <methodName>(<methodTypeHint>$<variableName><variableDefault>)
 '/**
  * <description>
  *
+ *
  * @param <variableType> $<variableName>
  *
  * @return <entity>
@@ -268,6 +271,7 @@ public function <methodName>(<methodTypeHint>$<variableName>)
     protected static $removeMethodTemplate =
 '/**
  * <description>
+ *
  *
  * @param <variableType> $<variableName>
  */
@@ -1173,7 +1177,7 @@ public function __construct()
         }
 
         $replacements = array(
-          '<description>'       => ucfirst($type) . ' ' . $variableName . ".\n",
+          '<description>'       => ucfirst($type) . ' ' . $variableName,
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
           '<variableName>'      => $variableName,

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -219,7 +219,6 @@ class EntityGenerator
 '/**
  * <description>
  *
- *
  * @return <variableType>
  */
 public function <methodName>()
@@ -233,7 +232,6 @@ public function <methodName>()
     protected static $setMethodTemplate =
 '/**
  * <description>
- *
  *
  * @param <variableType> $<variableName>
  *
@@ -253,7 +251,6 @@ public function <methodName>(<methodTypeHint>$<variableName><variableDefault>)
 '/**
  * <description>
  *
- *
  * @param <variableType> $<variableName>
  *
  * @return <entity>
@@ -271,7 +268,6 @@ public function <methodName>(<methodTypeHint>$<variableName>)
     protected static $removeMethodTemplate =
 '/**
  * <description>
- *
  *
  * @param <variableType> $<variableName>
  */


### PR DESCRIPTION
Fixes docblock generation for `set`, `get`, `add` and `remove` methods (change introduced in #1067 247803715bd7e5ded75e25dbbb4eb2c5b7fbd2f2):

Before:

``` php
/**
 * Set myProp.

 *
 * @param integer $myProp
 *
 * @return MyEntity
 */
```

After:

``` php
/**
 * Set myProp.
 *
 *
 * @param integer $myProp
 *
 * @return MyEntity
 */
```
