### PR TITLE
[DDC-3300] Added resolve entities support in discrim. map

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2725,7 +2725,7 @@ class ClassMetadataInfo implements ClassMetadata
         if ($this->name == $className) {
             $this->discriminatorValue = $name;
         } else {
-            if ( ! class_exists($className)) {
+            if ( ! class_exists($className) && ! interface_exists($className)) {
                 throw MappingException::invalidClassInDiscriminatorMap($className, $this->name);
             }
             if (is_subclass_of($className, $this->name) && ! in_array($className, $this->subClasses)) {

--- a/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
@@ -40,12 +40,11 @@ class ResolveDiscriminatorMapListener
     /**
      * Construct
      *
-     * @param string $originalEntity
-     * @param string $newEntity
+     * @param array $resolveTargetEntities
      */
-    public function __construct($originalEntity, $newEntity)
+    public function __construct(array $resolveTargetEntities)
     {
-        $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = ltrim($newEntity, "\\");
+        $this->resolveTargetEntities = $resolveTargetEntities;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+/**
+ * ResolveDiscriminatorMapListener
+ *
+ * Mechanism to overwrite interfaces or classes specified in discrimination map
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @since 2.2
+ */
+class ResolveDiscriminatorMapListener
+{
+    /**
+     * @var array
+     */
+    private $resolveTargetEntities = array();
+
+    /**
+     * Adds a target-entity class name to resolve to a new class name.
+     *
+     * @param string $originalEntity
+     * @param string $newEntity
+     * @param array  $mapping
+     *
+     * @return void
+     */
+    public function addResolveTargetEntity($originalEntity, $newEntity, array $mapping)
+    {
+        $mapping['targetEntity'] = ltrim($newEntity, "\\");
+        $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = $mapping;
+    }
+
+    /**
+     * Processes event and resolves new target entity names.
+     *
+     * @param LoadClassMetadataEventArgs $args
+     *
+     * @return void
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $args)
+    {
+        $classMetadata = $args->getClassMetadata();
+
+        if (!empty($classMetadata->discriminatorMap)) {
+
+            $this->remapDiscriminatorMap($classMetadata);
+        }
+    }
+
+    /**
+     * Replaces all Interfaces in discriminator map
+     *
+     * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadata
+     */
+    private function remapDiscriminatorMap(ClassMetadataInfo $classMetadata)
+    {
+        foreach ($classMetadata->discriminatorMap as $name => $interface) {
+
+            if (isset($this->resolveTargetEntities[$interface])) {
+
+                $classMetadata->discriminatorMap[$name] = $this->resolveTargetEntities[$interface]['targetEntity'];
+            }
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
@@ -42,9 +42,8 @@ class ResolveDiscriminatorMapListener
      *
      * @param string $originalEntity
      * @param string $newEntity
-     * @param array  $mapping
      */
-    public function __construct($originalEntity, $newEntity, array $mapping)
+    public function __construct($originalEntity, $newEntity)
     {
         $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = ltrim($newEntity, "\\");
     }

--- a/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveDiscriminatorMapListener.php
@@ -28,7 +28,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  * Mechanism to overwrite interfaces or classes specified in discrimination map
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>
- * @since 2.2
+ * @since  2.2
  */
 class ResolveDiscriminatorMapListener
 {
@@ -38,18 +38,15 @@ class ResolveDiscriminatorMapListener
     private $resolveTargetEntities = array();
 
     /**
-     * Adds a target-entity class name to resolve to a new class name.
+     * Construct
      *
      * @param string $originalEntity
      * @param string $newEntity
      * @param array  $mapping
-     *
-     * @return void
      */
-    public function addResolveTargetEntity($originalEntity, $newEntity, array $mapping)
+    public function __construct($originalEntity, $newEntity, array $mapping)
     {
-        $mapping['targetEntity'] = ltrim($newEntity, "\\");
-        $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = $mapping;
+        $this->resolveTargetEntities[ltrim($originalEntity, "\\")] = ltrim($newEntity, "\\");
     }
 
     /**
@@ -80,7 +77,7 @@ class ResolveDiscriminatorMapListener
 
             if (isset($this->resolveTargetEntities[$interface])) {
 
-                $classMetadata->discriminatorMap[$name] = $this->resolveTargetEntities[$interface]['targetEntity'];
+                $classMetadata->discriminatorMap[$name] = $this->resolveTargetEntities[$interface];
             }
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Tools\ResolveDiscriminatorMapListener;
+
+/**
+ * @group DDC-3300
+ */
+class DDC3300Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function testIssue()
+    {
+        $this
+            ->_em
+            ->getEventManager()
+            ->addEventListener(
+                Events::loadClassMetadata,
+                new ResolveDiscriminatorMapListener(array(
+                    'Doctrine\Tests\ORM\Functional\Ticket\DDC3300BossInterface'     => 'Doctrine\Tests\ORM\Functional\Ticket\DDC3300Boss',
+                    'Doctrine\Tests\ORM\Functional\Ticket\DDC3300EmployeeInterface' => 'Doctrine\Tests\ORM\Functional\Ticket\DDC3300Employee',
+                ))
+            );
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC3300Person'),
+        ));
+
+        $boss = new DDC3300Boss();
+        $this->_em->persist($boss);
+
+        $employee = new DDC3300Employee();
+        $this->_em->persist($employee);
+
+        $this->_em->flush();
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DdiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "boss" = "Doctrine\Tests\ORM\Functional\Ticket\DDC3300BossInterface",
+ *      "employee" = "Doctrine\Tests\ORM\Functional\Ticket\DDC3300EmployeeInterface"
+ * })
+ */
+abstract class DDC3300Person
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+}
+
+interface DDC3300BossInterface
+{
+
+}
+
+/**
+ * @Entity
+ */
+class DDC3300Boss extends DDC3300Person implements DDC3300BossInterface
+{
+}
+
+interface DDC3300EmployeeInterface
+{
+
+}
+
+/**
+ * @Entity
+ */
+class DDC3300Employee extends DDC3300Person implements DDC3300EmployeeInterface
+{
+}
+ 

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveDiscriminatorMapListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveDiscriminatorMapListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools;
+
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+use Doctrine\ORM\Tools\ResolveDiscriminatorMapListener;
+
+class ResolveDiscriminatorMapListenerTest extends \Doctrine\Tests\OrmTestCase
+{
+    /**
+     * @var EntityManager
+     */
+    private $em = null;
+
+    /**
+     * @var ClassMetadataFactory
+     */
+    private $factory = null;
+
+    public function setUp()
+    {
+        $annotationDriver = $this->createAnnotationDriver();
+
+        $this->em = $this->_getTestEntityManager();
+        $this->em->getConfiguration()->setMetadataDriverImpl($annotationDriver);
+        $this->factory = new ClassMetadataFactory;
+        $this->factory->setEntityManager($this->em);
+    }
+
+    /**
+     * @group DDC-3300
+     */
+    public function testResolveDiscriminatorMapListenerTestCanResolveDiscriminatorMap()
+    {
+        $evm = $this->em->getEventManager();
+        $listener = new ResolveDiscriminatorMapListener(array(
+            'Doctrine\Tests\ORM\Tools\BossInterface' => 'Doctrine\Tests\ORM\Tools\Boss',
+            'Doctrine\Tests\ORM\Tools\EmployeeInterface' => 'Doctrine\Tests\ORM\Tools\Employee',
+        ));
+
+        $evm->addEventListener(Events::loadClassMetadata, $listener);
+        $cm = $this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\Person');
+        $meta = $cm->discriminatorMap;
+        $this->assertSame('Doctrine\Tests\ORM\Tools\Boss', $meta['boss']);
+        $this->assertSame('Doctrine\Tests\ORM\Tools\Employee', $meta['employee']);
+    }
+
+    /**
+     * @group DDC-3300
+     */
+    public function testResolveDiscriminatorMapListenerTestCannotResolveWrongDiscriminatorMap()
+    {
+        $evm = $this->em->getEventManager();
+        $listener = new ResolveDiscriminatorMapListener(array(
+            'Doctrine\Tests\ORM\Tools\EmployeeInterface' => 'Doctrine\Tests\ORM\Tools\Employee',
+        ));
+
+        $evm->addEventListener(Events::loadClassMetadata, $listener);
+        $cm = $this->factory->getMetadataFor('Doctrine\Tests\ORM\Tools\Person');
+        $meta = $cm->discriminatorMap;
+        $this->assertSame('Doctrine\Tests\ORM\Tools\BossInterface', $meta['boss']);
+        $this->assertSame('Doctrine\Tests\ORM\Tools\Employee', $meta['employee']);
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "boss" = "\Doctrine\Tests\ORM\Tools\BossInterface",
+ *      "employee" = "\Doctrine\Tests\ORM\Tools\EmployeeInterface"
+ * })
+ */
+abstract class Person
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+}
+
+interface BossInterface
+{
+
+}
+
+class Boss extends Person implements BossInterface
+{
+    /**
+     * @Column(type="integer")
+     */
+    private $earnedMoneyInEuros;
+}
+
+interface EmployeeInterface
+{
+
+}
+
+class Employee extends Person implements EmployeeInterface
+{
+    /**
+     * @Column(type="integer")
+     */
+    private $daysOfLifeReducedInDays;
+}


### PR DESCRIPTION
This PR is WIP. I just wanted to know if what I am doing is wrong or I can go on with tests and documentation.

This is what happens.

I have nicely the ability to define a relation using just the interfaces, and then, resolve these relations overriding the interfaces with the implementations. This resolves a big problem: Multiple implementations of one interface.

But, when you define a discriminatorMap, you **Must** define it using specific implementations, so all this flexibility gained in the relations is lost at this point.

Using a new listener, its easy to override this interfaces.

What do you think?
