### PR TITLE
[Embeddables] Improved exception message

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -153,6 +153,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     continue;
                 }
 
+                if (!isset($embeddableClass['class'])) {
+                    throw MappingException::missingEmbeddedClass($property);
+                }
+
                 if (isset($this->embeddablesActiveNesting[$embeddableClass['class']])) {
                     throw MappingException::infiniteEmbeddableNesting($class->name, $property);
                 }

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -106,6 +106,16 @@ class MappingException extends \Doctrine\ORM\ORMException
     }
 
     /**
+     * @param string $fieldName
+     *
+     * @return MappingException
+     */
+    public static function missingEmbeddedClass($fieldName)
+    {
+        return new self("The embed mapping '$fieldName' misses the 'class' attribute.");
+    }
+
+    /**
      * @param string $entityName
      * @param string $fileName
      *


### PR DESCRIPTION
Improved exception message when embeddable definition is missing 'class' attribute.
Instead of:

```
The class '' was not found in the chain configured namespaces ...
```

It shows:

```
The embed mapping 'embeddedname' misses the 'class' attribute.
```
