### PR TITLE
Export tests for downstream packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/tests export-ignore
 /tools export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
@@ -8,5 +7,3 @@ build.properties export-ignore
 build.properties.dev export-ignore
 build.xml export-ignore
 CONTRIBUTING.md export-ignore
-phpunit.xml.dist export-ignore
-run-all.sh export-ignore


### PR DESCRIPTION
It would be very helpful to run tests when packaging this library for Fedora/EPEL.  This cannot currently be done because tests are ignored on export (which is how RPM packaging downloads this library from GitHub).
