### PR TITLE
Join column index names

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
@@ -10,14 +10,14 @@ class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
         $sql = $schemaTool->getCreateSchemaSql(array(
-            $this->_em->getClassMetadata(__NAMESPACE__ . '\Car'),
-            $this->_em->getClassMetadata(__NAMESPACE__ . '\Maker'),
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\JoinColumnIndexNameTest_Car'),
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\JoinColumnIndexNameTest_Maker'),
         ));
 
         $expected = array (
-            0 => 'CREATE TABLE Car (id INTEGER NOT NULL, maker_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, year INTEGER NOT NULL, PRIMARY KEY(id), CONSTRAINT FK_4F70A07D68DA5EC3 FOREIGN KEY (maker_id) REFERENCES Maker (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
-            1 => 'CREATE INDEX idx_maker_id ON Car (maker_id)',
-            2 => 'CREATE TABLE Maker (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
+            0 => 'CREATE TABLE JoinColumnIndexNameTest_Car (id INTEGER NOT NULL, maker_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, year INTEGER NOT NULL, PRIMARY KEY(id), CONSTRAINT FK_4F70A07D68DA5EC3 FOREIGN KEY (maker_id) REFERENCES Maker (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            1 => 'CREATE INDEX idx_maker_id ON JoinColumnIndexNameTest_Car (maker_id)',
+            2 => 'CREATE TABLE JoinColumnIndexNameTest_Maker (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
         );
 
         $this->assertEquals(
@@ -29,8 +29,8 @@ class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testUpdateSchemaJoinColumnExplicitIndexName()
     {
         $classes = array(
-            $this->_em->getClassMetadata(__NAMESPACE__ . '\Car'),
-            $this->_em->getClassMetadata(__NAMESPACE__ . '\Maker'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\JoinColumnIndexNameTest_Car'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\JoinColumnIndexNameTest_Maker'),
         );
 
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
@@ -40,9 +40,9 @@ class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
-        $carTable = $schema->getTable('Car');
+        $carTable = $schema->getTable('JoinColumnIndexNameTest_Car');
 
-        $indexes = $this->_em->getConnection()->getSchemaManager()->listTableIndexes('Car');
+        $indexes = $this->_em->getConnection()->getSchemaManager()->listTableIndexes('JoinColumnIndexNameTest_Car');
 
         unset($indexes['primary']);
 
@@ -52,7 +52,7 @@ class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->getConnection()->getSchemaManager()->dropIndex($makerIdIndex, $carTable);
 
         $query = $this->_em->createNativeQuery(
-            'CREATE INDEX idx_maker_id ON Car(maker_id)',
+            'CREATE INDEX idx_maker_id ON JoinColumnIndexNameTest_Car(maker_id)',
             $rsm = new ResultSetMapping()
         );
         $query->execute();
@@ -69,7 +69,7 @@ class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
  * )
  * @Entity()
  */
-class Car
+class JoinColumnIndexNameTest_Car
 {
     /**
      * @Id
@@ -89,52 +89,17 @@ class Car
     protected $year;
 
     /**
-     * @ManyToOne(targetEntity="Maker")
+     * @ManyToOne(targetEntity="JoinColumnIndexNameTest_Maker")
      * @JoinColumn(name="maker_id", referencedColumnName="id", unique=false)
      */
     protected $maker;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function setName($name)
-    {
-        $this->name = $name;
-    }
-
-    public function getYear()
-    {
-        return $this->year;
-    }
-
-    public function setYear($year)
-    {
-        $this->year = $year;
-    }
-
-    public function getMaker()
-    {
-        return $this->maker;
-    }
-
-    public function setMaker(Maker $maker)
-    {
-        $this->maker = $maker;
-    }
 }
 
 /**
  * @Table()
  * @Entity()
  */
-class Maker
+class JoinColumnIndexNameTest_Maker
 {
     /**
      * @Id
@@ -147,19 +112,4 @@ class Maker
      * @Column(type="string")
      */
     protected $name;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function setName($name)
-    {
-        $this->name = $name;
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function testMergeManyToMany()
+    {
+        $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
+        $sql = $schemaTool->getCreateSchemaSql(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\Car'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\Maker'),
+        ));
+
+        $expected = array (
+            0 => 'CREATE TABLE Car (id INTEGER NOT NULL, maker_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, year INTEGER NOT NULL, PRIMARY KEY(id), CONSTRAINT FK_4F70A07D68DA5EC3 FOREIGN KEY (maker_id) REFERENCES Maker (id) NOT DEFERRABLE INITIALLY IMMEDIATE)',
+            1 => 'CREATE INDEX idx_maker_id ON Car (maker_id)',
+            2 => 'CREATE TABLE Maker (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))',
+        );
+
+        $this->assertEquals(
+            $expected,
+            $sql
+        );
+    }
+}
+
+/**
+ * @Table(
+ *   indexes={@Index(name="idx_maker_id", columns={"maker_id"})})
+ * )
+ * @Entity()
+ */
+class Car
+{
+    /**
+     * @Id
+     * @GeneratedValue(strategy="IDENTITY")
+     * @Column(type="integer", nullable=false)
+     */
+    protected $id;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $name;
+
+    /**
+     * @Column(type="integer", length=4)
+     */
+    protected $year;
+
+    /**
+     * @ManyToOne(targetEntity="Maker")
+     * @JoinColumn(name="maker_id", referencedColumnName="id", unique=false)
+     */
+    protected $maker;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getYear()
+    {
+        return $this->year;
+    }
+
+    public function setYear($year)
+    {
+        $this->year = $year;
+    }
+
+    public function getMaker()
+    {
+        return $this->maker;
+    }
+
+    public function setMaker(Maker $maker)
+    {
+        $this->maker = $maker;
+    }
+}
+
+/**
+ * @Table()
+ * @Entity()
+ */
+class Maker
+{
+    /**
+     * @Id
+     * @GeneratedValue(strategy="IDENTITY")
+     * @Column(type="integer", nullable=false)
+     */
+    protected $id;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/JoinColumnIndexNameTest.php
@@ -4,7 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 class JoinColumnIndexNameTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    public function testMergeManyToMany()
+    public function testCreateSchemaJoinColumnExplicitIndexName()
     {
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
         $sql = $schemaTool->getCreateSchemaSql(array(


### PR DESCRIPTION
@Ocramius recommended I open this up to discuss the issue I am seeing.

I am trying to explicitly name the index on a column which is used in a join.  I've attempted to add two functional tests in this PR to demonstrate what I am seeing. Please forgive me if these tests are not correctly, this is the first time I've attempted to submit a PR like this.

There are two situations I am encountering...

First, I explicitly name the index in the `@Table` annotation on the column used in the join - but the SQL generated from `SchemaTool` appears to be a random hash.

Second, when I have an existing database table with an existing index and it's named properly (in this example, idx_maker_id) and then I run `SchemaTool->updateSchema()` it drops the index with the proper name and creates a new randomly hashed name.

Is there a different way of accomplishing what I am trying to do here, or is this a bug?

Thanks for your help and assistance!
