### PR TITLE
func_get_args() call order fix for HHVM bug

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -894,8 +894,8 @@ class QueryBuilder
      */
     public function andWhere($where)
     {
-        $where = $this->getDQLPart('where');
         $args  = func_get_args();
+        $where = $this->getDQLPart('where');
 
         if ($where instanceof Expr\Andx) {
             $where->addMultiple($args);
@@ -927,8 +927,8 @@ class QueryBuilder
      */
     public function orWhere($where)
     {
-        $where = $this->getDqlPart('where');
         $args  = func_get_args();
+        $where = $this->getDqlPart('where');
 
         if ($where instanceof Expr\Orx) {
             $where->addMultiple($args);
@@ -1007,8 +1007,8 @@ class QueryBuilder
      */
     public function andHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Andx) {
             $having->addMultiple($args);
@@ -1030,8 +1030,8 @@ class QueryBuilder
      */
     public function orHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Orx) {
             $having->addMultiple($args);


### PR DESCRIPTION
Firstly, so no-one closes this as ENOTONMASTER, @Ocramius told me to open it directly against 2.4. :)

This PR fixes bugs in `Doctrine\ORM\QueryBuilder` where the values provided to method arguments to `::andWhere()`, `::orWhere()`, `::andHaving()`, and `::orHaving()` are overwritten by code within the methods in HHVM and PHP7.

After much fun and headscratching in both #doctrine and #hhvm on Freenode, we discovered that in the following code, `$where = $this->getDqlPart('where');` overwrites the values stored internally for the `$where` parameter of the function which is returned by `func_get_args()`:

```
public function orWhere($where)
{
    $where = $this->getDqlPart('where');
    $args  = func_get_args();
}
```

This means that instead of `$args` being set as expected to an array containing the string or object provided to the function, it actually contains the object returned by `QueryBuilder::getDqlPart()`, which causes all the problems you'd expect it to.

This PR simply swaps the order of the calls so that the function arguments are retrieved via `func_get_args()` before the `$where` variable is modified, fixing the problem.
