### PR TITLE
Allow orderBy to reference associations

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -228,9 +228,20 @@ class SchemaValidator
 
             if (isset($assoc['orderBy']) && $assoc['orderBy'] !== null) {
                 foreach ($assoc['orderBy'] as $orderField => $orientation) {
-                    if (!$targetMetadata->hasField($orderField)) {
+                    if (!$targetMetadata->hasField($orderField) && !$targetMetadata->hasAssociation($orderField)) {
                         $ce[] = "The association " . $class->name."#".$fieldName." is ordered by a foreign field " .
-                                $orderField . " that is not a field on the target entity " . $targetMetadata->name;
+                                $orderField . " that is not a field on the target entity " . $targetMetadata->name . ".";
+                        continue;
+                    }
+                    if ($targetMetadata->isCollectionValuedAssociation($orderField)) {
+                        $ce[] = "The association " . $class->name."#".$fieldName." is ordered by an field " .
+                                $orderField . " on " . $targetMetadata->name . " that is a collection-valued association.";
+                        continue;
+                    }
+                    if ($targetMetadata->isAssociationInverseSide($orderField)) {
+                        $ce[] = "The association " . $class->name."#".$fieldName." is ordered by a field " .
+                                $orderField . " on " . $targetMetadata->name . " that is the inverse side of an association.";
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
If I specify an order-by clause on a to-many association, e.g. `@OrderBy({"foo" = "ASC"})`, where foo is a to-one-association on the target entity, the collection is sorted by foo_id (this behaviour is implemented in BasicEntityPersister::getOrderBySQL()).

This works fine. However, Doctrine\ORM\Tools\SchemaValidator complains that foo is not a field.

This change makes the validator accept order-by clauses on associations where the target entity is the owning side, and the association is single-valued (AFAICT this is the same restrictions that BasicEntityPersister uses).
