### PR TITLE
Extended the docs for mapping attributes precision and scale

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -99,10 +99,13 @@ Optional attributes:
    string values for you.
 
 -  **precision**: The precision for a decimal (exact numeric) column
-   (Applies only for decimal column)
+   (applies only for decimal column), which is the maximum number of
+   digits that are stored for the values.
 
--  **scale**: The scale for a decimal (exact numeric) column (Applies
-   only for decimal column)
+-  **scale**: The scale for a decimal (exact numeric) column (applies
+   only for decimal column), which represents the number of digits
+   to the right of the decimal point and must not be greater than
+   *precision*.
 
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -199,9 +199,12 @@ list:
 - ``nullable``: (optional, default FALSE) Whether the database
   column is nullable.
 - ``precision``: (optional, default 0) The precision for a decimal
-  (exact numeric) column. (Applies only if a decimal column is used.)
+  (exact numeric) column (applies only for decimal column),
+  which is the maximum number of digits that are stored for the values.
 - ``scale``: (optional, default 0) The scale for a decimal (exact
-  numeric) column. (Applies only if a decimal column is used.)
+  numeric) column (applies only for decimal column), which represents
+  the number of digits to the right of the decimal point and must
+  not be greater than *precision*.
 - ``columnDefinition``: (optional) Allows to define a custom
   DDL snippet that is used to create the column. Warning: This normally
   confuses the SchemaTool to always detect the column as changed.


### PR DESCRIPTION
I for myself am always confused about precision and scale and have to lookup what is the numer of maximum digits and what is the number for digits right of the decimal point. Other people seem to have the same [problem](http://stackoverflow.com/questions/14940574/what-do-scale-and-precision-mean-when-specifying-a-decimal-field-type-in-doctrin).

So I have extended the docs to make it more clear.
