### PR TITLE
Update Composite.php for HHVM compatibility 

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -35,19 +35,20 @@ class Composite extends Base
      */
     public function __toString()
     {
-        if ($this->count() === 1) {
+        if ($this->count() === 1 && $this->parts[0] !== $this) {
             return (string) $this->parts[0];
         }
 
         $components = array();
 
         foreach ($this->parts as $part) {
-            $components[] = $this->processQueryPart($part);
+            if($part !== $this) {
+                $components[] = $this->processQueryPart($part);
+            }
         }
 
         return implode($this->separator, $components);
     }
-
     /**
      * @param string $part
      *


### PR DESCRIPTION
Not sure, why this issue is not founded in unittests, but I got HHVM crushed with message

```
Fatal error: Stack overflow in ...../vendor/doctrine/orm/lib/Doctrine/ORM/Query/Expr/Composite.php on line 58
```

The same issue is being reported here
https://github.com/facebook/hhvm/issues/1747

@LinuxDoku proposed quick patch, which works great for me and its in this PR.

Just in case, if you wonder what trigger this error - here is my repository function, which trigger it

```
    public function findOpenTeamTimeEntry($user)
    {
        $r = $this->createQueryBuilder("t")
            ->join("t.owner","u")
            ->where("t.dateEnd IS NULL")
            ->andWhere("u.id = :user_id")
             ->setParameter(":user_id",$user->getId())
            ->getQuery()
            ->getResult();
        if(is_array($r) && count($r)) {
            return $r[0];
        } else {
            return false;
        }
    }
```
