### PR TITLE
Improve Comparison::CONTAINS: allow to use custom position for % and _  wildcard characters

### DIFF
--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -111,9 +111,14 @@ class SqlValueVisitor extends ExpressionVisitor
     {
         $value = $comparison->getValue()->getValue();
 
-        return $comparison->getOperator() == Comparison::CONTAINS
-            ? ((strpos($value, '%') !== false && strpos($value, '\%') === false)
-                || (strpos($value, '_') !== false && strpos($value, '\_') === false) ? $value : "%{$value}%")
-            : $value;
+        // Check whether we on Comparison::CONTAINS and have no a wildcard characters
+        if ($comparison->getOperator() == Comparison::CONTAINS
+            && strpos(str_replace('\%', '', $value), '%') === false
+            && strpos(str_replace('\_', '', $value), '_') === false
+        ) {
+            return "%{$value}%";
+        } else {
+            return $value;
+        }
     }
 }

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -112,7 +112,8 @@ class SqlValueVisitor extends ExpressionVisitor
         $value = $comparison->getValue()->getValue();
 
         return $comparison->getOperator() == Comparison::CONTAINS
-            ? "%{$value}%"
+            ? ((strpos($value, '%') !== false && strpos($value, '\%') === false)
+                || (strpos($value, '_') !== false && strpos($value, '\_') === false) ? $value : "%{$value}%")
             : $value;
     }
 }


### PR DESCRIPTION
This pull prevent forced  wrapping of the value in to `%` 
and allow to use the custom position for `%` and `_`  wildcard characters in case `Comparison::CONTAINS`

Allow to build the `contains` expressions like:

``` php
Criteria::expr()->contains('myField', 'some string%');
Criteria::expr()->contains('myField', '%some string');
Criteria::expr()->contains('myField', '%10\%'); // search for 10% at end of the string
Criteria::expr()->contains('myField', 's_m_ string');
```
