### PR TITLE
Adds error message when the key is composite

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -748,6 +748,12 @@ class Parser
             $class = $qComp['metadata'];
 
             if (($field = $pathExpression->field) === null) {
+                if ($class->isIdentifierComposite) {
+                    $this->semanticalError(
+                        'Class ' . $class->name . ' has a composite identifier. Use them explicitly',
+                        $deferredItem['token']
+                    );
+                }
                 $field = $pathExpression->field = $class->identifier[0];
             }
 


### PR DESCRIPTION
An example is:

```
SELECT u FROM User u INNER JOIN Address a ON a.user = u
```

When User has a composite key.
