### PR TITLE
Added proxy identifier values to the EntityNotFoundException

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -142,7 +142,11 @@ class ProxyFactory extends AbstractProxyFactory
                     $proxy->__setCloner($cloner);
                     $proxy->__setInitialized(false);
 
-                    throw new EntityNotFoundException($classMetadata->getName());
+                    $json = json_encode($classMetadata->getIdentifierValues($proxy));
+                    $message = "Entity of type '{$classMetadata->getName()}'"
+                        . " was not found with identifier(s) '{$json}'";
+
+                    throw new EntityNotFoundException($message);
                 }
             };
         }
@@ -173,7 +177,11 @@ class ProxyFactory extends AbstractProxyFactory
                 $proxy->__setCloner($cloner);
                 $proxy->__setInitialized(false);
 
-                throw new EntityNotFoundException($classMetadata->getName());
+                $json = json_encode($classMetadata->getIdentifierValues($proxy));
+                $message = "Entity of type '{$classMetadata->getName()}'"
+                    . " was not found with identifier(s) '{$json}'";
+
+                throw new EntityNotFoundException($message);
             }
         };
     }
@@ -197,12 +205,16 @@ class ProxyFactory extends AbstractProxyFactory
 
             $proxy->__setInitialized(true);
             $proxy->__setInitializer(null);
- 
+
             $class    = $entityPersister->getClassMetadata();
             $original = $entityPersister->loadById($classMetadata->getIdentifierValues($proxy));
 
             if (null === $original) {
-                throw new EntityNotFoundException($classMetadata->getName());
+                $json = json_encode($classMetadata->getIdentifierValues($proxy));
+                $message = "Entity of type '{$classMetadata->getName()}'"
+                    . " was not found with identifier(s) '{$json}'";
+
+                throw new EntityNotFoundException($message);
             }
 
             foreach ($class->getReflectionClass()->getProperties() as $property) {


### PR DESCRIPTION
It would be very nice if the identifier values are included in the EntityNotFoundException. That information saves a whole lot of time finding the missing association in the database. 
