### PR TITLE
Update DefaultRepositoryFactory.php

### DIFF
--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -42,6 +42,7 @@ class DefaultRepositoryFactory implements RepositoryFactory
     public function getRepository(EntityManagerInterface $entityManager, $entityName)
     {
         $className = $entityManager->getClassMetadata($entityName)->getName();
+        $className = $entityManager->getConnection()->getDatabase().$className; // Support multiple databases on the same entity
 
         if (isset($this->repositoryList[$className])) {
             return $this->repositoryList[$className];


### PR DESCRIPTION
getRepository() does not support different databases for the same entity class due to the lookup in repositoryList. By adding the database name (or any other unique name for the specific database/connection) the lookup works for identical entities in different databases.
