### PR TITLE
[QueryBuilder] Remove unused method parameters to run on HHVM/PHP7

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1026,7 +1026,7 @@ class QueryBuilder
      *
      * @see where()
      */
-    public function andWhere($where)
+    public function andWhere()
     {
         $args  = func_get_args();
         $where = $this->getDQLPart('where');
@@ -1059,7 +1059,7 @@ class QueryBuilder
      *
      * @see where()
      */
-    public function orWhere($where)
+    public function orWhere()
     {
         $args  = func_get_args();
         $where = $this->getDqlPart('where');


### PR DESCRIPTION
PHP5 treats the left part of an assignment to a method parameter as an independent local variable, while HHVM/PHP7 treats it as a reference to the method parameter. This leads to the value of the parameter being changed, which, in turn, causes func_get_args() to return not what is expected.

This commit is a part of the effort to make Symfony run flawlessly on HHVM. This issue causes a bunch of Symfony tests to fail on HHVM.

The master is currently broken, so the best thing I could do was to make sure the number of test failures remained the same after the change.

If possible, please merge this to version 2.2 used by Symfony 2.4.
