### PR TITLE
[DDC-1952] Support for array parameters on the SQLFilter

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -107,7 +107,7 @@ abstract class SQLFilter
 
         $param = $this->parameters[$name];
         $isIterable = is_array($param['value']) || $param['value'] instanceof \Iterator;
-        if ($isIterable && !in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
+        if ($isIterable && ! in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
             foreach ($param['value'] as $key => & $value) {
                 $value = $this->em->getConnection()->quote($value, $param['type']);
             }

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Query\Filter;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ParameterTypeInferer;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * The base class that user defined filters should extend.

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -106,12 +106,14 @@ abstract class SQLFilter
         }
 
         $param = $this->parameters[$name];
-        $isIterable = is_array($param['value']) || $param['value'] instanceof \Traversable;
-        if ($isIterable && ! in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
-            foreach ($param['value'] as $key => & $value) {
-                $value = $this->em->getConnection()->quote($value, $param['type']);
-            }
-            return implode(',', $param['value']);
+        $isTraversable = is_array($param['value']) || $param['value'] instanceof \Traversable;
+        if ($isTraversable && ! in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
+            $connection = $this->em->getConnection();
+            $quoted = array_map(function($value) use ($connection, $param) {
+                return $connection->quote($value, $param['type']);
+            }, $param['value']);
+
+            return implode(',', $quoted);
         }
 
         return $this->em->getConnection()->quote($param['value'], $param['type']);

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -106,7 +106,7 @@ abstract class SQLFilter
         }
 
         $param = $this->parameters[$name];
-        $isIterable = is_array($param['value']) || $param['value'] instanceof \Iterator;
+        $isIterable = is_array($param['value']) || $param['value'] instanceof \Traversable;
         if ($isIterable && ! in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
             foreach ($param['value'] as $key => & $value) {
                 $value = $this->em->getConnection()->quote($value, $param['type']);

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -104,7 +104,16 @@ abstract class SQLFilter
             throw new \InvalidArgumentException("Parameter '" . $name . "' does not exist.");
         }
 
-        return $this->em->getConnection()->quote($this->parameters[$name]['value'], $this->parameters[$name]['type']);
+        $param = $this->parameters[$name];
+        $isIterable = is_array($param['value']) || $param['value'] instanceof \Iterator;
+        if ($isIterable && !in_array($param['type'], array(Type::TARRAY, Type::SIMPLE_ARRAY, Type::JSON_ARRAY))) {
+            foreach ($param['value'] as $key => & $value) {
+                $value = $this->em->getConnection()->quote($value, $param['type']);
+            }
+            return implode(',', $param['value']);
+        }
+
+        return $this->em->getConnection()->quote($param['value'], $param['type']);
     }
 
     /**


### PR DESCRIPTION
Allows passing an array to SQLFilter parameter and have each item pass through quote() before turning the whole array into a comma-separated list.

For purpose see here:
http://www.doctrine-project.org/jira/browse/DDC-1952

Exception is made for types that Doctrine already recognizes as an array and stores as their derivate (array, simple_array, json_array).
