### PR TITLE
Added prev to collections

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -787,6 +787,16 @@ final class PersistentCollection implements Collection, Selectable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function prev()
+    {
+        $this->initialize();
+
+        return $this->coll->prev();
+    }
+
+    /**
      * Retrieves the wrapped Collection instance.
      *
      * @return \Doctrine\Common\Collections\Collection


### PR DESCRIPTION
Added prev() to array collections.  This is needed when you want to cycle through the array in reverse order.  
