### PR TITLE
Improvements for complex select statements when using new object expression

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -272,8 +272,6 @@ abstract class AbstractHydrator
 
                     $rowData['newObjects'][$objIndex]['class']           = $cacheKeyInfo['class'];
                     $rowData['newObjects'][$objIndex]['args'][$argIndex] = $value;
-
-                    $rowData['scalars'][$fieldName] = $value;
                     break;
 
                 case (isset($cacheKeyInfo['isScalar'])):

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -246,14 +246,15 @@ class ArrayHydrator extends AbstractHydrator
                 $resultKey = $this->_resultCounter - 1;
             }
 
-            $count = count($rowData['newObjects']);
+            $scalarCount = (isset($rowData['scalars'])? count($rowData['scalars']): 0);
 
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class  = $newObject['class'];
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if ($count === 1) {
+                // if ($count === 1) {
+                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects'])) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -253,7 +253,7 @@ class ArrayHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']))) {
+                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']) == 1)) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -253,8 +253,7 @@ class ArrayHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                // if ($count === 1) {
-                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects'])) {
+                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']))) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -553,7 +553,6 @@ class ObjectHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                // if (count($args) == $scalarCount) {
                 if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']))) {
                     $result[$resultKey] = $obj;
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -553,7 +553,7 @@ class ObjectHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']))) {
+                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']) == 1 )) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -546,7 +546,7 @@ class ObjectHydrator extends AbstractHydrator
             }
 
 
-            $scalarCount = count($rowData['scalars']);
+            $scalarCount = (isset($rowData['scalars'])? count($rowData['scalars']): 0);
 
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class  = $newObject['class'];

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -545,14 +545,15 @@ class ObjectHydrator extends AbstractHydrator
                 $resultKey = $this->resultCounter - 1;
             }
 
-            $count = count($rowData['newObjects']);
+
+            $scalarCount = count($rowData['scalars']);
 
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class  = $newObject['class'];
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if ($count === 1) {
+                if (count($args) == $scalarCount) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -553,7 +553,8 @@ class ObjectHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if (count($args) == $scalarCount) {
+                // if (count($args) == $scalarCount) {
+                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']))) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -553,7 +553,7 @@ class ObjectHydrator extends AbstractHydrator
                 $args   = $newObject['args'];
                 $obj    = $class->newInstanceArgs($args);
 
-                if (count($args) == $scalarCount || ($scalarCount == 0 && count($rowData['newObjects']) == 1 )) {
+                if ($scalarCount == 0 && count($rowData['newObjects']) == 1 ) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1353,8 +1353,7 @@ class SqlWalker implements TreeWalker
                 break;
 
             case ($expr instanceof AST\NewObjectExpression):
-                $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
-                $sql .= $this->walkNewObject($expr,$resultAlias);
+                $sql .= $this->walkNewObject($expr,$selectExpression->fieldIdentificationVariable);
                 break;
 
             default:

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1353,7 +1353,8 @@ class SqlWalker implements TreeWalker
                 break;
 
             case ($expr instanceof AST\NewObjectExpression):
-                $sql .= $this->walkNewObject($expr);
+                $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
+                $sql .= $this->walkNewObject($expr,$resultAlias);
                 break;
 
             default:
@@ -1519,10 +1520,10 @@ class SqlWalker implements TreeWalker
      *
      * @return string The SQL.
      */
-    public function walkNewObject($newObjectExpression)
+    public function walkNewObject($newObjectExpression, $newObjectResultAlias=null)
     {
         $sqlSelectExpressions = array();
-        $objIndex             = $this->newObjectCounter++;
+        $objIndex             = $newObjectResultAlias?:$this->newObjectCounter++;
 
         foreach ($newObjectExpression->args as $argIndex => $e) {
             $resultAlias = $this->scalarResultCounter++;


### PR DESCRIPTION
My update allows you to alias objects created with the ["new" object expression](http://doctrine-orm.readthedocs.org/en/latest/reference/dql-doctrine-query-language.html#new-operator-syntax), as well as the ability to create queries that allow you to have multiple "new" object expressions and mixed scalar results.

Suppose you create a query as such:

``` dql
SELECT new UserDTO(u.id,u.name) as user,new AddressDTO(a.street,a.postalCode) as address, a.id as addressId FROM User u INNER JOIN u.addresses a WITH a.isPrimary = true
```

upon executing this query, you'll end up with a result set that looks like the following:

``` php
array(
    0=>array(
        0=>{UserDTO object},
        1=>{AddressDTO object},
        2=>{u.id scalar},
        3=>{u.name scalar},
        4=>{a.street scalar},
        5=>{a.postalCode scalar},
        'addressId'=>{a.id scalar},
    ),
    ...
)
```

My changes fix that so you'd end up with a more usable result set:

``` php
array(
    0=>array(
        'user'=>{UserDTO object},
        'address'=>{AddressDTO object},
        'addressId'=>{a.id scalar}
    )
    ...
)
```
