### PR TITLE
Fix merging of entities with associations to identical entities.

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+
+namespace Doctrine\Tests\ORM\Functional;
+
+
+use Doctrine\ORM\Tools\ToolsException;
+
+class MergeSharedEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try {
+            $this->_schemaTool->createSchema(
+                array(
+                    $this->_em->getClassMetadata(__NAMESPACE__ . '\MSEFile'),
+                    $this->_em->getClassMetadata(__NAMESPACE__ . '\MSEPicture'),
+                )
+            );
+        } catch (ToolsException $ignored) {
+        }
+    }
+
+    public function testMergeSharedNewEntities()
+    {
+
+        /** @var MSEPicture $picture */
+        $file = new MSEFile;
+
+        $picture = new MSEPicture;
+        $picture->file = $file;
+        $picture->otherFile = $file;
+
+        $em = $this->_em;
+
+        $picture = $em->merge($picture);
+
+        $this->assertEquals($picture->file, $picture->otherFile, "Identical entities must remain identical");
+    }
+
+    public function testMergeSharedManagedEntities()
+    {
+
+        /** @var MSEPicture $picture */
+        $file = new MSEFile;
+
+        $picture = new MSEPicture;
+        $picture->file = $file;
+        $picture->otherFile = $file;
+
+        $em = $this->_em;
+        $em->persist($file);
+        $em->flush();
+        $em->clear();
+
+        $picture = $em->merge($picture);
+
+        $this->assertEquals($picture->file, $picture->otherFile, "Identical entities must remain identical");
+    }
+
+    public function testMergeSharedManagedEntitiesSerialize()
+    {
+
+        /** @var MSEPicture $picture */
+        $file = new MSEFile;
+
+        $picture = new MSEPicture;
+        $picture->file = $file;
+        $picture->otherFile = $file;
+
+        $serializedPicture = serialize($picture);
+
+        $em = $this->_em;
+        $em->persist($file);
+        $em->flush();
+        $em->clear();
+
+        $picture = unserialize($serializedPicture);
+        $picture = $em->merge($picture);
+
+        $this->assertEquals($picture->file, $picture->otherFile, "Identical entities must remain identical");
+    }
+
+}
+
+/**
+ * @Entity
+ */
+class MSEPicture
+{
+    /**
+     * @Column(name="picture_id", type="integer")
+     * @Id @GeneratedValue
+     */
+    public $pictureId;
+
+    /**
+     * @ManyToOne(targetEntity="MSEFile", cascade={"persist", "merge"})
+     * @JoinColumn(name="file_id", referencedColumnName="file_id")
+     */
+    public $file;
+
+    /**
+     * @ManyToOne(targetEntity="MSEFile", cascade={"persist", "merge"})
+     * @JoinColumn(name="other_file_id", referencedColumnName="file_id")
+     */
+    public $otherFile;
+}
+
+/**
+ * @Entity
+ */
+class MSEFile
+{
+    /**
+     * @Column(name="file_id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $fileId;
+
+}


### PR DESCRIPTION
Without this patch, when an entity that refers multiple times to the same
associated entity gets merged, the second references becomes null.

The main issue is that even though doMerge returns a managed copy, that value
is not used while cascading the merge. These identicial entities are already
detected through the visitor map, but they are ignored.  There should be some
refactoring so cascadeMerge calls a function that checks if the parent must be
updated, based on the return value of its call to doMerge.  However, this patch
tries to impact the code as little as possible, and only introduces a new
function to avoid duplicate code.

The secondary issue arises when using inverted associations. In that case, it
is possible that an entity to be merged is already merged, so the the visitor
map is looked up by the hash of a managed copy instead of the original entity.
This means that in this case the visitor map entries should also be set to the
entity, instead of being set to 'true'.
