### PR TITLE
Ensure metadata cache is not ArrayCache in production

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -388,6 +388,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
         if ( ! $this->getMetadataCacheImpl()) {
             throw ORMException::metadataCacheNotConfigured();
         }
+        if ($this->getMetadataCacheImpl() instanceof ArrayCache) {
+            throw ORMException::metadataCacheUsesArrayCache();
+        }
 
         if ($this->getAutoGenerateProxyClasses()) {
             throw ORMException::proxyClassesAlwaysRegenerating();

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -385,11 +385,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
             throw ORMException::queryCacheNotConfigured();
         }
 
-        if ( ! $this->getMetadataCacheImpl()) {
+        $metadataCacheImpl = $this->getMetadataCacheImpl();
+
+        if ( ! $metadataCacheImpl) {
             throw ORMException::metadataCacheNotConfigured();
         }
-        if ($this->getMetadataCacheImpl() instanceof ArrayCache) {
-            throw ORMException::metadataCacheUsesArrayCache();
+
+        if ($metadataCacheImpl instanceof ArrayCache) {
+            throw ORMException::metadataCacheUsesNonPersistentCache($metadataCacheImpl);
         }
 
         if ($this->getAutoGenerateProxyClasses()) {

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM;
 
+use Doctrine\Common\Cache\Cache;
 use Exception;
 
 /**
@@ -233,11 +234,13 @@ class ORMException extends Exception
     }
 
     /**
+     * @param Cache $cache
+     *
      * @return ORMException
      */
-    public static function metadataCacheUsesArrayCache()
+    public static function metadataCacheUsesNonPersistentCache(Cache $cache)
     {
-        return new self('Metadata Cache uses ArrayCache.');
+        return new self('Metadata Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');
     }
 
     /**

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -235,6 +235,14 @@ class ORMException extends Exception
     /**
      * @return ORMException
      */
+    public static function metadataCacheUsesArrayCache()
+    {
+        return new self('Metadata Cache uses ArrayCache.');
+    }
+
+    /**
+     * @return ORMException
+     */
     public static function proxyClassesAlwaysRegenerating()
     {
         return new self('Proxy Classes are always regenerating.');

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Cache as CacheDriver;
 use Exception;
 
 /**
@@ -234,11 +234,11 @@ class ORMException extends Exception
     }
 
     /**
-     * @param Cache $cache
+     * @param \Doctrine\Common\Cache\Cache $cache
      *
      * @return ORMException
      */
-    public static function metadataCacheUsesNonPersistentCache(Cache $cache)
+    public static function metadataCacheUsesNonPersistentCache(CacheDriver $cache)
     {
         return new self('Metadata Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');
     }


### PR DESCRIPTION
This PR adds a new check to Configuration::ensureProductionSettings(). It ensures that the metadata cache does not use ArrayCache in production.

The ArrayCache forgets everything at the end of each request, while the other bundled cache engines (Memcache, MongoDB, FileCache etc.) may keep entries for much longer. The metadata only changes when the source files are changed, so in production the metadata cache only needs to be cleared when new files are deployed, just like the generation of proxy classes.

It is possible to specify/modify metadata dynamically at runtime e.g. using the loadClassMetadata event so that the metadata changes without any changes to the source files, but I assume this is not a supported use-case (at least not without clearing the metadata cache manually). Agree?

The ArrayCache is the default cache engine added by e.g. [Doctrine Bundle](https://github.com/doctrine/DoctrineBundle) (for Symfony) and [Doctrine ORM Service Provider](https://github.com/dflydev/dflydev-doctrine-orm-service-provider/) (for Silex), so most developers are probably not aware of it. However, accessing the metadata at run-time has a significant performance impact (for some anecdotal evidence, see https://github.com/doctrine/common/pull/319#issuecomment-60945429), so a warning in ensureProductionSettings() is relevant.

The PR also fixes the units for ensureProductionSettings() that were previously not being run due to a missing "test" prefix on the ConfigurationTest::ensureProductionSettings method name.
