### PR TITLE
Fixing associations using a value-conversion type as identifiers

### DIFF
--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -21,9 +21,7 @@ namespace Doctrine\ORM\Persisters;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\Query\QueryException;
 
 /**
  * Base class for all collection persisters.

--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -265,45 +265,4 @@ abstract class AbstractCollectionPersister implements CollectionPersister
      * @return array
      */
     abstract protected function getInsertRowSQLParameters(PersistentCollection $coll, $element);
-
-    /**
-     * Infers the binding type of a field by parameter type casting.
-     *
-     * @param string $field
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $class
-     *
-     * @return int|string|null
-     *
-     * @throws QueryException
-     */
-    protected function getType($field, ClassMetadata $class)
-    {
-        switch (true) {
-            case (isset($class->fieldMappings[$field])):
-                $type = $class->fieldMappings[$field]['type'];
-                break;
-
-            case (isset($class->associationMappings[$field])):
-                $assoc = $class->associationMappings[$field];
-
-                if (count($assoc['sourceToTargetKeyColumns']) > 1) {
-                    throw QueryException::associationPathCompositeKeyNotSupported();
-                }
-
-                $targetClass  = $this->em->getClassMetadata($assoc['targetEntity']);
-                $targetColumn = $assoc['joinColumns'][0]['referencedColumnName'];
-                $type         = null;
-
-                if (isset($targetClass->fieldNames[$targetColumn])) {
-                    $type = $targetClass->fieldMappings[$targetClass->fieldNames[$targetColumn]]['type'];
-                }
-                break;
-
-            default:
-                $type = null;
-                break;
-        }
-
-        return $type;
-    }
 }

--- a/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/AbstractCollectionPersister.php
@@ -87,9 +87,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
             return; // ignore inverse side
         }
 
-        // DDC-3380: getDeleteSQLParameters() now returns array of params and types.
         list($params, $types) = $this->getDeleteSQLParameters($coll);
-
         $this->conn->executeUpdate($this->getDeleteSQL($coll), $params, $types);
     }
 
@@ -105,8 +103,6 @@ abstract class AbstractCollectionPersister implements CollectionPersister
     /**
      * Gets the SQL parameters and binding types for the corresponding SQL
      * statement to delete the given collection.
-     *
-     * DDC-3380: Should return an array of parameters and binding types.
      *
      * @param \Doctrine\ORM\PersistentCollection $coll
      *
@@ -138,9 +134,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
         $sql    = $this->getDeleteRowSQL($coll);
 
         foreach ($diff as $element) {
-            // DDC-3380: getDeleteRowSQLParameters() now returns array of params and types.
             list($params, $types) = $this->getDeleteRowSQLParameters($coll, $element);
-
             $this->conn->executeUpdate($sql, $params, $types);
         }
     }
@@ -154,9 +148,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
         $sql    = $this->getInsertRowSQL($coll);
 
         foreach ($diff as $element) {
-            // DDC-3380: getInsertRowSQLParameters() now returns array of params and types.
             list($params, $types) = $this->getInsertRowSQLParameters($coll, $element);
-
             $this->conn->executeUpdate($sql, $params, $types);
         }
     }
@@ -238,8 +230,6 @@ abstract class AbstractCollectionPersister implements CollectionPersister
      * Gets the SQL parameters for the corresponding SQL statement to delete the given
      * element from the given collection.
      *
-     * DDC-3380: Should return an array of parameters and binding types.
-     *
      * @param \Doctrine\ORM\PersistentCollection $coll
      * @param mixed                              $element
      *
@@ -269,8 +259,6 @@ abstract class AbstractCollectionPersister implements CollectionPersister
      * Gets the SQL parameters for the corresponding SQL statement to insert the given
      * element of the given collection into the database.
      *
-     * DDC-3380: Should return an array of parameters and binding types.
-     *
      * @param \Doctrine\ORM\PersistentCollection $coll
      * @param mixed                              $element
      *
@@ -280,11 +268,6 @@ abstract class AbstractCollectionPersister implements CollectionPersister
 
     /**
      * Infers the binding type of a field by parameter type casting.
-     *
-     * DDC-3380:
-     *     {@see \Doctrine\ORM\Persisters\OneToManyPersister::getDeleteRowSQLParameters()}
-     *     {@see \Doctrine\ORM\Persisters\ManyToManyPersister::collectJoinTableColumnParameters()}
-     *     {@see \Doctrine\ORM\Persisters\ManyToManyPersister::getDeleteSQLParameters()}
      *
      * @param string $field
      * @param \Doctrine\ORM\Mapping\ClassMetadata $class

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -667,7 +667,7 @@ class BasicEntityPersister implements EntityPersister
                 $quotedColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
 
                 $this->quotedColumns[$sourceColumn] = $quotedColumn;
-                $this->columnTypes[$sourceColumn]   = $targetClass->getTypeOfColumn($targetColumn);
+                $this->columnTypes[$sourceColumn]   = $this->getColumnType($targetColumn, null, $targetClass);
 
                 switch (true) {
                     case $newVal === null:
@@ -722,6 +722,7 @@ class BasicEntityPersister implements EntityPersister
     {
         $sql = $this->getSelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
         list($params, $types) = $this->expandParameters($criteria);
+
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         if ($entity !== null) {
@@ -977,11 +978,12 @@ class BasicEntityPersister implements EntityPersister
      */
     private function getManyToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {
-        $sourceClass    = $this->em->getClassMetadata($assoc['sourceEntity']);
-        $class          = $sourceClass;
-        $association    = $assoc;
-        $criteria       = array();
+        $criteria   = array();
+        $parameters = array();
 
+        $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
+        $class       = $sourceClass;
+        $association = $assoc;
 
         if ( ! $assoc['isOwningSide']) {
             $class       = $this->em->getClassMetadata($assoc['targetEntity']);
@@ -996,8 +998,8 @@ class BasicEntityPersister implements EntityPersister
 
         foreach ($joinColumns as $joinColumn) {
 
-            $sourceKeyColumn    = $joinColumn['referencedColumnName'];
-            $quotedKeyColumn    = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
+            $sourceKeyColumn = $joinColumn['referencedColumnName'];
+            $quotedKeyColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
 
             switch (true) {
                 case $sourceClass->containsForeignIdentifier:
@@ -1024,10 +1026,11 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $criteria[$quotedJoinTable . '.' . $quotedKeyColumn] = $value;
+            $parameters[] = array('value' => $value, 'field' => $field, 'class' => $sourceClass);
         }
 
         $sql = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
-        list($params, $types) = $this->expandParameters($criteria);
+        list($params, $types) = $this->expandToManyParameters($parameters);
 
         return $this->conn->executeQuery($sql, $params, $types);
     }
@@ -1315,16 +1318,12 @@ class BasicEntityPersister implements EntityPersister
         $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($assoc['joinColumns'] as $joinColumn) {
-            $type             = null;
+            $type             = $this->getColumnType($joinColumn['referencedColumnName'], null, $targetClass);
             $isIdentifier     = isset($assoc['id']) && $assoc['id'] === true;
             $quotedColumn     = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
             $resultColumnName = $this->getSQLColumnAlias($joinColumn['name']);
             $columnList[]     = $this->getSQLTableAlias($class->name, ($alias == 'r' ? '' : $alias) )
                                 . '.' . $quotedColumn . ' AS ' . $resultColumnName;
-
-            if (isset($targetClass->fieldNames[$joinColumn['referencedColumnName']])) {
-                $type  = $targetClass->fieldMappings[$targetClass->fieldNames[$joinColumn['referencedColumnName']]]['type'];
-            }
 
             $this->rsm->addMetaResult($alias, $resultColumnName, $quotedColumn, $isIdentifier, $type);
         }
@@ -1710,7 +1709,9 @@ class BasicEntityPersister implements EntityPersister
      */
     private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {
-        $criteria = array();
+        $criteria   = array();
+        $parameters = array();
+
         $owningAssoc = $this->class->associationMappings[$assoc['mappedBy']];
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
 
@@ -1727,15 +1728,20 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
+                $parameters[] = array('value' => $value, 'field' => $field, 'class' => $sourceClass);
 
                 continue;
             }
 
-            $criteria[$tableAlias . "." . $targetKeyColumn] = $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
+            $field = $sourceClass->fieldNames[$sourceKeyColumn];
+            $value = $sourceClass->reflFields[$field]->getValue($sourceEntity);
+
+            $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
+            $parameters[] = array('value' => $value, 'field' => $field, 'class' => $sourceClass);
         }
 
         $sql = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
-        list($params, $types) = $this->expandParameters($criteria);
+        list($params, $types) = $this->expandToManyParameters($parameters);
 
         return $this->conn->executeQuery($sql, $params, $types);
     }
@@ -1761,24 +1767,58 @@ class BasicEntityPersister implements EntityPersister
     }
 
     /**
-     * Infers field type to be used by parameter type casting.
+     * Expands the parameters from the given criteria and use the correct binding types if found,
+     * specialized for OneToMany or ManyToMany associations.
      *
-     * @param string $field
-     * @param mixed  $value
+     * DDC-3380: {@see getManyToManyStatement()} and {@see getOneToManyStatement()}.
      *
-     * @return integer
+     * @param array $criteria
+     *
+     * @return array
+     */
+    private function expandToManyParameters($criteria)
+    {
+        $params = array();
+        $types  = array();
+
+        foreach ($criteria as $criterion) {
+            if ($criterion['value'] === null) {
+                continue; // skip null values.
+            }
+
+            $types[]  = $this->getType($criterion['field'], $criterion['value'], $criterion['class']);
+            $params[] = $this->getValue($criterion['value']);
+        }
+
+        return array($params, $types);
+    }
+
+    /**
+     * Infers the binding type of a field by parameter type casting.
+     *
+     * DDC-3380: Added optional $class argument.
+     *
+     * @param string             $field
+     * @param mixed              $value
+     * @param ClassMetadata|null $class
+     *
+     * @return int|string|null
      *
      * @throws \Doctrine\ORM\Query\QueryException
      */
-    private function getType($field, $value)
+    private function getType($field, $value, ClassMetadata $class = null)
     {
+        if ($class === null) {
+            $class = $this->class;
+        }
+
         switch (true) {
-            case (isset($this->class->fieldMappings[$field])):
-                $type = $this->class->fieldMappings[$field]['type'];
+            case (isset($class->fieldMappings[$field])):
+                $type = $class->fieldMappings[$field]['type'];
                 break;
 
-            case (isset($this->class->associationMappings[$field])):
-                $assoc = $this->class->associationMappings[$field];
+            case (isset($class->associationMappings[$field])):
+                $assoc = $class->associationMappings[$field];
 
                 if (count($assoc['sourceToTargetKeyColumns']) > 1) {
                     throw Query\QueryException::associationPathCompositeKeyNotSupported();
@@ -1804,6 +1844,67 @@ class BasicEntityPersister implements EntityPersister
         }
 
         return $type;
+    }
+
+    /**
+     * Infers the binding type of a column by parameter type casting.
+     *
+     * @param string        $columnName
+     * @param mixed         $value
+     * @param ClassMetadata $class
+     * @return int|string|null
+     */
+    private function getColumnType($columnName, $value, ClassMetadata $class)
+    {
+        $type = null;
+
+        switch (true) {
+            case (isset($class->fieldNames[$columnName])):
+                $fieldName = $class->fieldNames[$columnName];
+
+                if (isset($class->fieldMappings[$fieldName])) {
+                    $type = $class->fieldMappings[$fieldName]['type'];
+                }
+
+                break;
+
+            default:
+                $type = $this->getAssociationColumnType($columnName, $class);
+        }
+
+        if (is_array($value)) {
+            $type = Type::getType($type)->getBindingType();
+            $type += Connection::ARRAY_PARAM_OFFSET;
+        }
+
+        return $type;
+    }
+
+    /**
+     * Infers the binding type of a column by traversing association mappings.
+     *
+     * @param string        $columnName
+     * @param ClassMetadata $class
+     * @return string|null
+     */
+    private function getAssociationColumnType($columnName, ClassMetadata $class)
+    {
+        foreach ($class->associationMappings as $assoc) {
+            foreach ($assoc['joinColumns'] as $joinColumn) {
+                if ($joinColumn['name'] == $columnName) {
+                    $targetClass  = $this->em->getClassMetadata($assoc['targetEntity']);
+                    $targetColumn = $joinColumn['referencedColumnName'];
+
+                    if (isset($targetClass->fieldNames[$targetColumn])) {
+                        return $targetClass->fieldMappings[$targetClass->fieldNames[$targetColumn]]['type'];
+                    }
+
+                    return $this->getAssociationColumnType($targetColumn, $class);
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1770,8 +1770,6 @@ class BasicEntityPersister implements EntityPersister
      * Expands the parameters from the given criteria and use the correct binding types if found,
      * specialized for OneToMany or ManyToMany associations.
      *
-     * DDC-3380: {@see getManyToManyStatement()} and {@see getOneToManyStatement()}.
-     *
      * @param array $criteria
      *
      * @return array
@@ -1795,8 +1793,6 @@ class BasicEntityPersister implements EntityPersister
 
     /**
      * Infers the binding type of a field by parameter type casting.
-     *
-     * DDC-3380: Added optional $class argument.
      *
      * @param string             $field
      * @param mixed              $value

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -35,7 +35,7 @@ use Doctrine\ORM\Utility\IdentifierFlattener;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
-use Doctrine\ORM\Utility\PersisterHelper as Helper;
+use Doctrine\ORM\Utility\PersisterHelper;
 
 /**
  * A BasicEntityPersister maps an entity to a single table in a relational database.
@@ -667,7 +667,11 @@ class BasicEntityPersister implements EntityPersister
                 $quotedColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
 
                 $this->quotedColumns[$sourceColumn] = $quotedColumn;
-                $this->columnTypes[$sourceColumn]   = Helper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
+                $this->columnTypes[$sourceColumn]   = PersisterHelper::getTypeOfColumn(
+                    $targetColumn,
+                    $targetClass,
+                    $this->em
+                );
 
                 switch (true) {
                     case $newVal === null:
@@ -875,7 +879,7 @@ class BasicEntityPersister implements EntityPersister
         list($params, $types) = $valueVisitor->getParamsAndTypes();
 
         foreach ($params as $param) {
-            $sqlParams[] = Helper::getValue($param, $this->em);
+            $sqlParams[] = PersisterHelper::getValue($param, $this->em);
         }
 
         foreach ($types as $type) {
@@ -1324,7 +1328,7 @@ class BasicEntityPersister implements EntityPersister
             $columnList[]     = $this->getSQLTableAlias($class->name, ($alias == 'r' ? '' : $alias) )
                                 . '.' . $quotedColumn . ' AS ' . $resultColumnName;
 
-            $type = Helper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
+            $type = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
             $this->rsm->addMetaResult($alias, $resultColumnName, $quotedColumn, $isIdentifier, $type);
         }
@@ -1761,7 +1765,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $types[]  = $this->getType($field, $value, $this->class);
-            $params[] = Helper::getValue($value, $this->em);
+            $params[] = PersisterHelper::getValue($value, $this->em);
         }
 
         return array($params, $types);
@@ -1786,7 +1790,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $types[]  = $this->getType($criterion['field'], $criterion['value'], $criterion['class']);
-            $params[] = Helper::getValue($criterion['value'], $this->em);
+            $params[] = PersisterHelper::getValue($criterion['value'], $this->em);
         }
 
         return array($params, $types);
@@ -1805,7 +1809,7 @@ class BasicEntityPersister implements EntityPersister
      */
     private function getType($fieldName, $value, ClassMetadata $class)
     {
-        $type = Helper::getTypeOfField($fieldName, $class, $this->em);
+        $type = PersisterHelper::getTypeOfField($fieldName, $class, $this->em);
 
         if (is_array($value)) {
             $type = Type::getType($type)->getBindingType();

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1873,7 +1873,9 @@ class BasicEntityPersister implements EntityPersister
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $columnName
+     *
+     * @return string
      */
     public function getSQLColumnAlias($columnName)
     {

--- a/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/BasicEntityPersister.php
@@ -1832,20 +1832,21 @@ class BasicEntityPersister implements EntityPersister
              . $this->getLockTablesSql(null)
              . ' WHERE ' . $this->getSelectConditionSQL($criteria);
 
-        list($params) = $this->expandParameters($criteria);
+        list($params, $types) = $this->expandParameters($criteria);
 
         if (null !== $extraConditions) {
-            $sql                           .= ' AND ' . $this->getSelectConditionCriteriaSQL($extraConditions);
-            list($criteriaParams, $values) = $this->expandCriteriaParameters($extraConditions);
+            $sql                            .= ' AND ' . $this->getSelectConditionCriteriaSQL($extraConditions);
+            list($extraParams, $extraTypes) = $this->expandCriteriaParameters($extraConditions);
 
-            $params = array_merge($params, $criteriaParams);
+            $params = array_merge($params, $extraParams);
+            $types  = array_merge($types, $extraTypes);
         }
 
         if ($filterSql = $this->generateFilterConditionSQL($this->class, $alias)) {
             $sql .= ' AND ' . $filterSql;
         }
 
-        return (bool) $this->conn->fetchColumn($sql, $params);
+        return (bool) $this->conn->fetchColumn($sql, $params, 0, $types);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Utility\PersisterHelper as Helper;
 
 /**
  * Persister for many-to-many collections.
@@ -146,7 +147,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $field  = $class1->getFieldForColumn($column);
 
                 $params[] = $identifier1[$field];
-                $types[]  = $this->getType($field, $class1);
+                $types[]  = Helper::getTypeOfField($field, $class1, $this->em);
 
                 continue;
             }
@@ -155,7 +156,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $field  = $class2->getFieldForColumn($column);
 
             $params[] = $identifier2[$field];
-            $types[]  = $this->getType($field, $class2);
+            $types[]  = Helper::getTypeOfField($field, $class2, $this->em);
         }
 
         return array($params, $types);
@@ -203,7 +204,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 : $sourceClass->getFieldForColumn($columnName);
 
             $params[] = $identifier[$field];
-            $types[]  = $this->getType($field, $sourceClass);
+            $types[]  = Helper::getTypeOfField($field, $sourceClass, $this->em);
         }
 
         return array($params, $types);

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\ORM\Utility\PersisterHelper as Helper;
+use Doctrine\ORM\Utility\PersisterHelper;
 
 /**
  * Persister for many-to-many collections.
@@ -147,7 +147,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $field  = $class1->getFieldForColumn($column);
 
                 $params[] = $identifier1[$field];
-                $types[]  = Helper::getTypeOfField($field, $class1, $this->em);
+                $types[]  = PersisterHelper::getTypeOfField($field, $class1, $this->em);
 
                 continue;
             }
@@ -156,7 +156,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $field  = $class2->getFieldForColumn($column);
 
             $params[] = $identifier2[$field];
-            $types[]  = Helper::getTypeOfField($field, $class2, $this->em);
+            $types[]  = PersisterHelper::getTypeOfField($field, $class2, $this->em);
         }
 
         return array($params, $types);
@@ -204,7 +204,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 : $sourceClass->getFieldForColumn($columnName);
 
             $params[] = $identifier[$field];
-            $types[]  = Helper::getTypeOfField($field, $sourceClass, $this->em);
+            $types[]  = PersisterHelper::getTypeOfField($field, $sourceClass, $this->em);
         }
 
         return array($params, $types);
@@ -237,7 +237,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $referencedName = $joinColumn['referencedColumnName'];
             $conditions[]   = 't.' . $columnName . ' = ?';
             $params[]       = $id[$class->getFieldForColumn($referencedName)];
-            $types[]        = Helper::getTypeOfColumn($referencedName, $class, $this->em);
+            $types[]        = PersisterHelper::getTypeOfColumn($referencedName, $class, $this->em);
         }
 
         $joinTableName = $this->quoteStrategy->getJoinTableName($association, $class, $this->platform);
@@ -377,7 +377,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
             $whereClauses[] = 'tr.' . $columnName . ' = ?';
             $params[] = $key;
-            $types[] = Helper::getTypeOfColumn($columnName, $targetClass, $this->em);
+            $types[] = PersisterHelper::getTypeOfColumn($columnName, $targetClass, $this->em);
         }
 
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
@@ -388,13 +388,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $params[] = $sourceClass->containsForeignIdentifier
                     ? $id[$sourceClass->getFieldForColumn($column)]
                     : $id[$sourceClass->fieldNames[$column]];
-                $types[] = Helper::getTypeOfColumn($column, $sourceClass, $this->em);
+                $types[] = PersisterHelper::getTypeOfColumn($column, $sourceClass, $this->em);
             } elseif ( ! $joinNeeded) {
                 $column = $mapping[$targetRelationMode][$joinTableColumn];
 
                 $whereClauses[] = 't.' . $joinTableColumn . ' = ?';
                 $params[] = $key;
-                $types[] = Helper::getTypeOfColumn($column, $targetClass, $this->em);
+                $types[] = PersisterHelper::getTypeOfColumn($column, $targetClass, $this->em);
             }
         }
 
@@ -451,7 +451,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
                 $params[] = $targetClass->containsForeignIdentifier
                     ? $targetId[$targetClass->getFieldForColumn($column)]
                     : $targetId[$targetClass->fieldNames[$column]];
-                $types[] = Helper::getTypeOfColumn($column, $targetClass, $this->em);
+                $types[] = PersisterHelper::getTypeOfColumn($column, $targetClass, $this->em);
 
                 continue;
             }
@@ -462,7 +462,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $params[] = $sourceClass->containsForeignIdentifier
                 ? $sourceId[$sourceClass->getFieldForColumn($column)]
                 : $sourceId[$sourceClass->fieldNames[$column]];
-            $types[] = Helper::getTypeOfColumn($column, $sourceClass, $this->em);
+            $types[] = PersisterHelper::getTypeOfColumn($column, $sourceClass, $this->em);
         }
 
         if ($addFilters) {

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -123,8 +123,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * Collects the parameters for inserting/deleting on the join table in the order
      * of the join table columns as specified in ManyToManyMapping#joinTableColumns.
      *
-     * DDC-3380: We need to return parameters as well as binding types.
-     *
      * @param \Doctrine\ORM\PersistentCollection $coll
      * @param object                             $element
      *

--- a/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/ManyToManyPersister.php
@@ -75,6 +75,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
     /**
      * {@inheritdoc}
      *
+     * @override
+     *
      * @throws \BadMethodCallException Not used for OneToManyPersister
      */
     protected function getUpdateRowSQL(PersistentCollection $coll)

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -71,10 +71,11 @@ class OneToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * DDC-3380: Should return an array of parameters and binding types.
+     * Gets the SQL parameters for the corresponding SQL statement to delete the given
+     * element from the given collection.
      *
-     * @param PersistentCollection $coll
-     * @param mixed $element
+     * @param \Doctrine\ORM\PersistentCollection $coll
+     * @param mixed                              $element
      *
      * @return array
      */

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -22,7 +22,7 @@ namespace Doctrine\ORM\Persisters;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\ORM\Utility\PersisterHelper as Helper;
+use Doctrine\ORM\Utility\PersisterHelper;
 
 /**
  * Persister for one-to-many collections.
@@ -90,7 +90,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         foreach ($identifier as $field => $value) {
             $params[] = $value;
-            $types[]  = Helper::getTypeOfField($field, $class, $this->em);
+            $types[]  = PersisterHelper::getTypeOfField($field, $class, $this->em);
         }
 
         return array($params, $types);
@@ -183,7 +183,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         $whereClauses[] = $sourceColumn . ' = ?';
         $params[]       = $key;
-        $types[]        = Helper::getTypeOfColumn($sourceColumn, $sourceClass, $this->em);
+        $types[]        = PersisterHelper::getTypeOfColumn($sourceColumn, $sourceClass, $this->em);
 
         $sql = 'SELECT 1 FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
 
@@ -206,7 +206,7 @@ class OneToManyPersister extends AbstractCollectionPersister
             $whereClauses[] = $joinColumn['name'] . ' = ?';
 
             $params[] = $id[$sourceClass->getFieldForColumn($joinColumn['referencedColumnName'])];
-            $types[]  = Helper::getTypeOfColumn($joinColumn['referencedColumnName'], $sourceClass, $this->em);
+            $types[]  = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $sourceClass, $this->em);
         }
 
         if ($addFilters) {

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Persisters;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\Utility\PersisterHelper as Helper;
 
 /**
  * Persister for one-to-many collections.
@@ -89,7 +90,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
         foreach ($identifier as $field => $value) {
             $params[] = $value;
-            $types[]  = $this->getType($field, $class);
+            $types[]  = Helper::getTypeOfField($field, $class, $this->em);
         }
 
         return array($params, $types);

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -51,12 +51,7 @@ class OneToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * Generates the SQL UPDATE that updates a particular row's foreign
-     * key to null.
-     *
-     * @param \Doctrine\ORM\PersistentCollection $coll
-     *
-     * @return string
+     * {@inheritdoc}
      *
      * @override
      */
@@ -72,13 +67,9 @@ class OneToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * Gets the SQL parameters for the corresponding SQL statement to delete the given
-     * element from the given collection.
+     * {@inheritdoc}
      *
-     * @param \Doctrine\ORM\PersistentCollection $coll
-     * @param mixed                              $element
-     *
-     * @return array
+     * @override
      */
     protected function getDeleteRowSQLParameters(PersistentCollection $coll, $element)
     {
@@ -99,6 +90,8 @@ class OneToManyPersister extends AbstractCollectionPersister
     /**
      * {@inheritdoc}
      *
+     * @override
+     *
      * @throws \BadMethodCallException Not used for OneToManyPersister.
      */
     protected function getInsertRowSQL(PersistentCollection $coll)
@@ -108,6 +101,8 @@ class OneToManyPersister extends AbstractCollectionPersister
 
     /**
      * {@inheritdoc}
+     *
+     * @override
      *
      * @throws \BadMethodCallException Not used for OneToManyPersister.
      */
@@ -119,6 +114,8 @@ class OneToManyPersister extends AbstractCollectionPersister
     /**
      * {@inheritdoc}
      *
+     * @override
+     *
      * @throws \BadMethodCallException Not used for OneToManyPersister.
      */
     protected function getUpdateRowSQL(PersistentCollection $coll)
@@ -129,6 +126,8 @@ class OneToManyPersister extends AbstractCollectionPersister
     /**
      * {@inheritdoc}
      *
+     * @override
+     *
      * @throws \BadMethodCallException Not used for OneToManyPersister.
      */
     protected function getDeleteSQL(PersistentCollection $coll)
@@ -138,6 +137,8 @@ class OneToManyPersister extends AbstractCollectionPersister
 
     /**
      * {@inheritdoc}
+     *
+     * @override
      *
      * @throws \BadMethodCallException Not used for OneToManyPersister.
      */
@@ -190,6 +191,14 @@ class OneToManyPersister extends AbstractCollectionPersister
         return (bool) $this->conn->fetchColumn($sql, $params, 0, $types);
     }
 
+    /**
+     * @param \Doctrine\ORM\PersistentCollection $coll
+     * @param boolean                            $addFilters
+     *
+     * @return array
+     *
+     * @throws \Doctrine\ORM\Mapping\MappingException
+     */
     private function getJoinTableRestrictions(PersistentCollection $coll, $addFilters)
     {
         $mapping     = $coll->getMapping();

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -76,8 +76,9 @@ class PersisterHelper
      * @param ClassMetadata          $class
      * @param EntityManagerInterface $em
      *
-     * @throws QueryException
      * @return string|null
+     *
+     * @throws QueryException
      */
     public static function getTypeOfField($fieldName, ClassMetadata $class, EntityManagerInterface $em)
     {

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -20,9 +20,9 @@
 
 namespace Doctrine\ORM\Utility;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\QueryException;
 
 /**
@@ -49,8 +49,8 @@ class PersisterHelper
 
         $newValue = array();
 
-        foreach ($value as $itemValue) {
-            $newValue[] = self::getIndividualValue($itemValue, $em);
+        foreach ($value as $fieldName => $fieldValue) {
+            $newValue[$fieldName] = self::getIndividualValue($fieldValue, $em);
         }
 
         return $newValue;
@@ -82,8 +82,6 @@ class PersisterHelper
      */
     public static function getTypeOfField($fieldName, ClassMetadata $class, EntityManagerInterface $em)
     {
-        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $class */
-
         if (isset($class->fieldMappings[$fieldName])) {
             return $class->fieldMappings[$fieldName]['type'];
         }
@@ -113,8 +111,6 @@ class PersisterHelper
      */
     public static function getTypeOfColumn($columnName, ClassMetadata $class, EntityManagerInterface $em)
     {
-        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $class */
-
         if (isset($class->fieldNames[$columnName])) {
             $fieldName = $class->fieldNames[$columnName];
 
@@ -126,7 +122,7 @@ class PersisterHelper
         }
 
         foreach ($class->associationMappings as $assoc) {
-            if (!isset($assoc['joinColumns'])) {
+            if ( ! isset($assoc['joinColumns'])) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Utility;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\QueryException;
+
+/**
+ * The PersisterHelper contains logic to infer binding types which is used in
+ * several persisters.
+ *
+ * @link   www.doctrine-project.org
+ * @since  2.5
+ * @author Jasper N. Brouwer <jasper@nerdsweide.nl>
+ */
+class PersisterHelper
+{
+    /**
+     * @param mixed                  $value
+     * @param EntityManagerInterface $em
+     *
+     * @return mixed
+     */
+    public static function getValue($value, EntityManagerInterface $em)
+    {
+        if ( ! is_array($value)) {
+            return self::getIndividualValue($value, $em);
+        }
+
+        $newValue = array();
+
+        foreach ($value as $itemValue) {
+            $newValue[] = self::getIndividualValue($itemValue, $em);
+        }
+
+        return $newValue;
+    }
+
+    /**
+     * @param mixed                  $value
+     * @param EntityManagerInterface $em
+     *
+     * @return mixed
+     */
+    private static function getIndividualValue($value, EntityManagerInterface $em)
+    {
+        if ( ! is_object($value) || ! $em->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($value))) {
+            return $value;
+        }
+
+        return $em->getUnitOfWork()->getSingleIdentifierValue($value);
+    }
+
+    /**
+     * @param string                 $fieldName
+     * @param ClassMetadata          $class
+     * @param EntityManagerInterface $em
+     *
+     * @throws QueryException
+     * @return string|null
+     */
+    public static function getTypeOfField($fieldName, ClassMetadata $class, EntityManagerInterface $em)
+    {
+        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $class */
+
+        if (isset($class->fieldMappings[$fieldName])) {
+            return $class->fieldMappings[$fieldName]['type'];
+        }
+
+        if ( ! isset($class->associationMappings[$fieldName])) {
+            return null;
+        }
+
+        $assoc = $class->associationMappings[$fieldName];
+
+        if (count($assoc['sourceToTargetKeyColumns']) > 1) {
+            throw QueryException::associationPathCompositeKeyNotSupported();
+        }
+
+        $targetColumnName = $assoc['joinColumns'][0]['referencedColumnName'];
+        $targetClass      = $em->getClassMetadata($assoc['targetEntity']);
+
+        return self::getTypeOfColumn($targetColumnName, $targetClass, $em);
+    }
+
+    /**
+     * @param string                 $columnName
+     * @param ClassMetadata          $class
+     * @param EntityManagerInterface $em
+     *
+     * @return string|null
+     */
+    public static function getTypeOfColumn($columnName, ClassMetadata $class, EntityManagerInterface $em)
+    {
+        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $class */
+
+        if (isset($class->fieldNames[$columnName])) {
+            $fieldName = $class->fieldNames[$columnName];
+
+            if (isset($class->fieldMappings[$fieldName])) {
+                return $class->fieldMappings[$fieldName]['type'];
+            }
+
+            return null;
+        }
+
+        foreach ($class->associationMappings as $assoc) {
+            if (!isset($assoc['joinColumns'])) {
+                continue;
+            }
+
+            foreach ($assoc['joinColumns'] as $joinColumn) {
+                if ($joinColumn['name'] == $columnName) {
+                    $targetColumnName = $joinColumn['referencedColumnName'];
+                    $targetClass      = $em->getClassMetadata($assoc['targetEntity']);
+
+                    return self::getTypeOfColumn($targetColumnName, $targetClass, $em);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Doctrine/Tests/DbalTypes/Rot13Type.php
+++ b/tests/Doctrine/Tests/DbalTypes/Rot13Type.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Shifts every letter by 13 places in the alphabet (ROT13 encoding).
+ */
+class Rot13Type extends Type
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null      $value
+     * @param AbstractPlatform $platform
+     *
+     * @return string|null
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return str_rot13($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param string|null      $value
+     * @param AbstractPlatform $platform
+     *
+     * @return string|null
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return str_rot13($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array            $fieldDeclaration
+     * @param AbstractPlatform $platform
+     *
+     * @return string
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param AbstractPlatform $platform
+     *
+     * @return int|null
+     */
+    public function getDefaultLength(AbstractPlatform $platform)
+    {
+        return $platform->getVarcharDefaultLength();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'rot13';
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_auxiliary")
+ */
+class AuxiliaryEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/AuxiliaryEntity.php
@@ -12,5 +12,5 @@ class AuxiliaryEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id4;
 }

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_manytomany_compositeid")
+ */
+class InversedManyToManyCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id1;
+
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id2;
+
+    /**
+     * @ManyToMany(targetEntity="OwningManyToManyCompositeIdEntity", mappedBy="associatedEntities")
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
@@ -14,11 +14,11 @@ class InversedManyToManyCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id1;
 
     /**
      * @ManyToOne(targetEntity="AuxiliaryEntity")
-     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id4")
      * @Id
      */
     public $foreignEntity;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyCompositeIdForeignKeyEntity.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_manytomany_compositeid_foreignkey")
+ */
+class InversedManyToManyCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="AuxiliaryEntity")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @Id
+     */
+    public $foreignEntity;
+
+    /**
+     * @ManyToMany(targetEntity="OwningManyToManyCompositeIdForeignKeyEntity", mappedBy="associatedEntities")
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_manytomany")
+ */
+class InversedManyToManyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity="OwningManyToManyEntity", mappedBy="associatedEntities")
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedManyToManyExtraLazyEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_manytomany_extralazy")
+ */
+class InversedManyToManyExtraLazyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id1;
+
+    /**
+     * @ManyToMany(
+     *     targetEntity="OwningManyToManyExtraLazyEntity",
+     *     mappedBy="associatedEntities",
+     *     fetch="EXTRA_LAZY",
+     *     indexBy="id2"
+     * )
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdEntity.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetomany_compositeid")
+ */
+class InversedOneToManyCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id1;
+
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id2;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    /**
+     * @OneToMany(targetEntity="OwningManyToOneCompositeIdEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetomany_compositeid_foreignkey")
+ */
+class InversedOneToManyCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="AuxiliaryEntity")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @Id
+     */
+    public $foreignEntity;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    /**
+     * @OneToMany(targetEntity="OwningManyToOneCompositeIdForeignKeyEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyCompositeIdForeignKeyEntity.php
@@ -14,11 +14,11 @@ class InversedOneToManyCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id1;
 
     /**
      * @ManyToOne(targetEntity="AuxiliaryEntity")
-     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id4")
      * @Id
      */
     public $foreignEntity;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetomany")
+ */
+class InversedOneToManyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity="OwningManyToOneEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntities;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyEntity.php
@@ -14,7 +14,7 @@ class InversedOneToManyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id1;
 
     /**
      * @OneToMany(targetEntity="OwningManyToOneEntity", mappedBy="associatedEntity")

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToManyExtraLazyEntity.php
@@ -6,9 +6,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * @Entity
- * @Table(name="vct_inversed_manytomany")
+ * @Table(name="vct_inversed_onetomany_extralazy")
  */
-class InversedManyToManyEntity
+class InversedOneToManyExtraLazyEntity
 {
     /**
      * @Column(type="rot13")
@@ -17,7 +17,12 @@ class InversedManyToManyEntity
     public $id1;
 
     /**
-     * @ManyToMany(targetEntity="OwningManyToManyEntity", mappedBy="associatedEntities")
+     * @OneToMany(
+     *     targetEntity="OwningManyToOneExtraLazyEntity",
+     *     mappedBy="associatedEntity",
+     *     fetch="EXTRA_LAZY",
+     *     indexBy="id2"
+     * )
      */
     public $associatedEntities;
 

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetoone_compositeid")
+ */
+class InversedOneToOneCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id1;
+
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id2;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    /**
+     * @OneToOne(targetEntity="OwningOneToOneCompositeIdEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetoone_compositeid_foreignkey")
+ */
+class InversedOneToOneCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="AuxiliaryEntity")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @Id
+     */
+    public $foreignEntity;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    /**
+     * @OneToOne(targetEntity="OwningOneToOneCompositeIdForeignKeyEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneCompositeIdForeignKeyEntity.php
@@ -12,11 +12,11 @@ class InversedOneToOneCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id1;
 
     /**
      * @ManyToOne(targetEntity="AuxiliaryEntity")
-     * @JoinColumn(name="foreign_id", referencedColumnName="id")
+     * @JoinColumn(name="foreign_id", referencedColumnName="id4")
      * @Id
      */
     public $foreignEntity;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_inversed_onetoone")
+ */
+class InversedOneToOneEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @Column(type="string", name="some_property")
+     */
+    public $someProperty;
+
+    /**
+     * @OneToOne(targetEntity="OwningOneToOneEntity", mappedBy="associatedEntity")
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/InversedOneToOneEntity.php
@@ -12,7 +12,7 @@ class InversedOneToOneEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id1;
 
     /**
      * @Column(type="string", name="some_property")

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
@@ -14,13 +14,13 @@ class OwningManyToManyCompositeIdEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id3;
 
     /**
      * @ManyToMany(targetEntity="InversedManyToManyCompositeIdEntity", inversedBy="associatedEntities")
      * @JoinTable(
      *     name="vct_xref_manytomany_compositeid",
-     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id3")},
      *     inverseJoinColumns={
      *         @JoinColumn(name="inversed_id1", referencedColumnName="id1"),
      *         @JoinColumn(name="inversed_id2", referencedColumnName="id2")

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytomany_compositeid")
+ */
+class OwningManyToManyCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity="InversedManyToManyCompositeIdEntity", inversedBy="associatedEntities")
+     * @JoinTable(
+     *     name="vct_xref_manytomany_compositeid",
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
+     *     inverseJoinColumns={
+     *         @JoinColumn(name="inversed_id1", referencedColumnName="id1"),
+     *         @JoinColumn(name="inversed_id2", referencedColumnName="id2")
+     *     }
+     * )
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
@@ -14,15 +14,15 @@ class OwningManyToManyCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id2;
 
     /**
      * @ManyToMany(targetEntity="InversedManyToManyCompositeIdForeignKeyEntity", inversedBy="associatedEntities")
      * @JoinTable(
      *     name="vct_xref_manytomany_compositeid_foreignkey",
-     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id2")},
      *     inverseJoinColumns={
-     *         @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *         @JoinColumn(name="associated_id", referencedColumnName="id1"),
      *         @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
      *     }
      * )

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyCompositeIdForeignKeyEntity.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytomany_compositeid_foreignkey")
+ */
+class OwningManyToManyCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity="InversedManyToManyCompositeIdForeignKeyEntity", inversedBy="associatedEntities")
+     * @JoinTable(
+     *     name="vct_xref_manytomany_compositeid_foreignkey",
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
+     *     inverseJoinColumns={
+     *         @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *         @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
+     *     }
+     * )
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytomany")
+ */
+class OwningManyToManyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity="InversedManyToManyEntity", inversedBy="associatedEntities")
+     * @JoinTable(
+     *     name="vct_xref_manytomany",
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@JoinColumn(name="inversed_id", referencedColumnName="id")}
+     * )
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyEntity.php
@@ -14,14 +14,14 @@ class OwningManyToManyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id2;
 
     /**
      * @ManyToMany(targetEntity="InversedManyToManyEntity", inversedBy="associatedEntities")
      * @JoinTable(
      *     name="vct_xref_manytomany",
-     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id")},
-     *     inverseJoinColumns={@JoinColumn(name="inversed_id", referencedColumnName="id")}
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id2")},
+     *     inverseJoinColumns={@JoinColumn(name="inversed_id", referencedColumnName="id1")}
      * )
      */
     public $associatedEntities;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToManyExtraLazyEntity.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytomany_extralazy")
+ */
+class OwningManyToManyExtraLazyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id2;
+
+    /**
+     * @ManyToMany(
+     *     targetEntity="InversedManyToManyExtraLazyEntity",
+     *     inversedBy="associatedEntities",
+     *     fetch="EXTRA_LAZY",
+     *     indexBy="id1"
+     * )
+     * @JoinTable(
+     *     name="vct_xref_manytomany_extralazy",
+     *     joinColumns={@JoinColumn(name="owning_id", referencedColumnName="id2")},
+     *     inverseJoinColumns={@JoinColumn(name="inversed_id", referencedColumnName="id1")}
+     * )
+     */
+    public $associatedEntities;
+
+    public function __construct()
+    {
+        $this->associatedEntities = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytoone_compositeid")
+ */
+class OwningManyToOneCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="InversedOneToManyCompositeIdEntity", inversedBy="associatedEntities")
+     * @JoinColumns({
+     *     @JoinColumn(name="associated_id1", referencedColumnName="id1"),
+     *     @JoinColumn(name="associated_id2", referencedColumnName="id2")
+     * })
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdEntity.php
@@ -12,7 +12,7 @@ class OwningManyToOneCompositeIdEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id3;
 
     /**
      * @ManyToOne(targetEntity="InversedOneToManyCompositeIdEntity", inversedBy="associatedEntities")

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
@@ -12,12 +12,12 @@ class OwningManyToOneCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id2;
 
     /**
      * @ManyToOne(targetEntity="InversedOneToManyCompositeIdForeignKeyEntity", inversedBy="associatedEntities")
      * @JoinColumns({
-     *     @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *     @JoinColumn(name="associated_id", referencedColumnName="id1"),
      *     @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
      * })
      */

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneCompositeIdForeignKeyEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytoone_compositeid_foreignkey")
+ */
+class OwningManyToOneCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="InversedOneToManyCompositeIdForeignKeyEntity", inversedBy="associatedEntities")
+     * @JoinColumns({
+     *     @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *     @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
+     * })
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
@@ -12,11 +12,11 @@ class OwningManyToOneEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id2;
 
     /**
      * @ManyToOne(targetEntity="InversedOneToManyEntity", inversedBy="associatedEntities")
-     * @JoinColumn(name="associated_id", referencedColumnName="id")
+     * @JoinColumn(name="associated_id", referencedColumnName="id1")
      */
     public $associatedEntity;
 }

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_manytoone")
+ */
+class OwningManyToOneEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="InversedOneToManyEntity", inversedBy="associatedEntities")
+     * @JoinColumn(name="associated_id", referencedColumnName="id")
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneExtraLazyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningManyToOneExtraLazyEntity.php
@@ -4,9 +4,9 @@ namespace Doctrine\Tests\Models\ValueConversionType;
 
 /**
  * @Entity
- * @Table(name="vct_owning_onetoone")
+ * @Table(name="vct_owning_manytoone_extralazy")
  */
-class OwningOneToOneEntity
+class OwningManyToOneExtraLazyEntity
 {
     /**
      * @Column(type="rot13")
@@ -15,7 +15,7 @@ class OwningOneToOneEntity
     public $id2;
 
     /**
-     * @OneToOne(targetEntity="InversedOneToOneEntity", inversedBy="associatedEntity")
+     * @ManyToOne(targetEntity="InversedOneToManyExtraLazyEntity", inversedBy="associatedEntities")
      * @JoinColumn(name="associated_id", referencedColumnName="id1")
      */
     public $associatedEntity;

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_onetoone_compositeid")
+ */
+class OwningOneToOneCompositeIdEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="InversedOneToOneCompositeIdEntity", inversedBy="associatedEntity")
+     * @JoinColumns({
+     *     @JoinColumn(name="associated_id1", referencedColumnName="id1"),
+     *     @JoinColumn(name="associated_id2", referencedColumnName="id2")
+     * })
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdEntity.php
@@ -12,7 +12,7 @@ class OwningOneToOneCompositeIdEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id3;
 
     /**
      * @OneToOne(targetEntity="InversedOneToOneCompositeIdEntity", inversedBy="associatedEntity")

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
@@ -17,12 +17,12 @@ class OwningOneToOneCompositeIdForeignKeyEntity
      * @Column(type="rot13")
      * @Id
      */
-    public $id;
+    public $id2;
 
     /**
      * @OneToOne(targetEntity="InversedOneToOneCompositeIdForeignKeyEntity", inversedBy="associatedEntity")
      * @JoinColumns({
-     *     @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *     @JoinColumn(name="associated_id", referencedColumnName="id1"),
      *     @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
      * })
      */

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneCompositeIdForeignKeyEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(
+ *     name="vct_owning_onetoone_compositeid_foreignkey",
+ *     uniqueConstraints={
+ *         @UniqueConstraint(name="associated_entity_uniq", columns={"associated_id", "associated_foreign_id"})
+ *     }
+ * )
+ */
+class OwningOneToOneCompositeIdForeignKeyEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="InversedOneToOneCompositeIdForeignKeyEntity", inversedBy="associatedEntity")
+     * @JoinColumns({
+     *     @JoinColumn(name="associated_id", referencedColumnName="id"),
+     *     @JoinColumn(name="associated_foreign_id", referencedColumnName="foreign_id")
+     * })
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneEntity.php
+++ b/tests/Doctrine/Tests/Models/ValueConversionType/OwningOneToOneEntity.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueConversionType;
+
+/**
+ * @Entity
+ * @Table(name="vct_owning_onetoone")
+ */
+class OwningOneToOneEntity
+{
+    /**
+     * @Column(type="rot13")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="InversedOneToOneEntity", inversedBy="associatedEntity")
+     * @JoinColumn(name="associated_id", referencedColumnName="id")
+     */
+    public $associatedEntity;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Tools\SchemaValidator;
 
 /**
@@ -18,6 +19,16 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
             if ($modelSet == "customtype") {
                 continue;
             }
+
+            // DDC-3380: Register DBAL type for these modelsets
+            if (substr($modelSet, 0, 4) == 'vct_') {
+                if (DBALType::hasType('rot13')) {
+                    DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+                } else {
+                    DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+                }
+            }
+
             $modelSets[] = array($modelSet);
         }
         return $modelSets;

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that ManyToMany associations with composite id of which one is a
+ * association itself work correctly.
+ *
+ * @group DDC-3380
+ */
+class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_manytomany_compositeid_foreignkey');
+        parent::setUp();
+
+        $auxiliary = new Entity\AuxiliaryEntity();
+        $auxiliary->id = 'abc';
+
+        $inversed = new Entity\InversedManyToManyCompositeIdForeignKeyEntity();
+        $inversed->id = 'def';
+        $inversed->foreignEntity = $auxiliary;
+
+        $owning = new Entity\OwningManyToManyCompositeIdForeignKeyEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntities->add($inversed);
+
+        $this->_em->persist($auxiliary);
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany_compositeid_foreignkey LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('def', $inversed->id);
+        $this->assertEquals('abc', $inversed->foreignEntity->id);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertCount(1, $owning->associatedEntities);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+
+    /**
+     * @depends testThatTheCollectionFromOwningToInversedIsLoaded
+     * @depends testThatTheCollectionFromInversedToOwningIsLoaded
+     */
+    public function testThatTheJoinTableRowsAreRemovedWhenRemovingTheAssociation()
+    {
+        $conn = $this->_em->getConnection();
+
+        // remove association
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        foreach ($inversed->associatedEntities as $owning) {
+            $inversed->associatedEntities->removeElement($owning);
+            $owning->associatedEntities->removeElement($inversed);
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // test association is removed
+
+        $this->assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid_foreignkey'));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -29,14 +29,14 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $auxiliary = new Entity\AuxiliaryEntity();
-        $auxiliary->id = 'abc';
+        $auxiliary->id4 = 'abc';
 
         $inversed = new Entity\InversedManyToManyCompositeIdForeignKeyEntity();
-        $inversed->id = 'def';
+        $inversed->id1 = 'def';
         $inversed->foreignEntity = $auxiliary;
 
         $owning = new Entity\OwningManyToManyCompositeIdForeignKeyEntity();
-        $owning->id = 'ghi';
+        $owning->id2 = 'ghi';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntities->add($inversed);
@@ -63,10 +63,12 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytomany_compositeid_foreignkey LIMIT 1'));
 
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
@@ -78,9 +80,14 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatEntitiesAreFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -88,6 +95,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity', $auxiliary);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity', $inversed);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity', $owning);
     }
@@ -97,9 +105,14 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -107,9 +120,28 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
-        $this->assertEquals('def', $inversed->id);
-        $this->assertEquals('abc', $inversed->foreignEntity->id);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('abc', $auxiliary->id4);
+        $this->assertEquals('def', $inversed->id1);
+        $this->assertEquals('abc', $inversed->foreignEntity->id4);
+        $this->assertEquals('ghi', $owning->id2);
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase
+     */
+    public function testThatInversedEntityIsFetchedFromTheDatabaseUsingAuxiliaryEntityAsId()
+    {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity', $inversed);
     }
 
     /**
@@ -132,7 +164,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $this->assertCount(1, $inversed->associatedEntities);
@@ -150,7 +182,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         foreach ($inversed->associatedEntities as $owning) {

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -32,7 +32,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
         $inversed->id2 = 'def';
 
         $owning = new Entity\OwningManyToManyCompositeIdEntity();
-        $owning->id = 'ghi';
+        $owning->id3 = 'ghi';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntities->add($inversed);
@@ -60,7 +60,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
         $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany_compositeid LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_manytomany_compositeid LIMIT 1'));
 
         $this->assertEquals('nop', $conn->fetchColumn('SELECT inversed_id1 FROM vct_xref_manytomany_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT inversed_id2 FROM vct_xref_manytomany_compositeid LIMIT 1'));
@@ -103,7 +103,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
 
         $this->assertEquals('abc', $inversed->id1);
         $this->assertEquals('def', $inversed->id2);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('ghi', $owning->id3);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that ManyToMany associations with composite id work correctly.
+ *
+ * @group DDC-3380
+ */
+class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_manytomany_compositeid');
+        parent::setUp();
+
+        $inversed = new Entity\InversedManyToManyCompositeIdEntity();
+        $inversed->id1 = 'abc';
+        $inversed->id2 = 'def';
+
+        $owning = new Entity\OwningManyToManyCompositeIdEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntities->add($inversed);
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid');
+        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid');
+        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany_compositeid LIMIT 1'));
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT inversed_id1 FROM vct_xref_manytomany_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT inversed_id2 FROM vct_xref_manytomany_compositeid LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany_compositeid LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $inversed->id2);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertCount(1, $owning->associatedEntities);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+
+    /**
+     * @depends testThatTheCollectionFromOwningToInversedIsLoaded
+     * @depends testThatTheCollectionFromInversedToOwningIsLoaded
+     */
+    public function testThatTheJoinTableRowsAreRemovedWhenRemovingTheAssociation()
+    {
+        $conn = $this->_em->getConnection();
+
+        // remove association
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        foreach ($inversed->associatedEntities as $owning) {
+            $inversed->associatedEntities->removeElement($owning);
+            $owning->associatedEntities->removeElement($inversed);
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // test association is removed
+
+        $this->assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid'));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that ManyToMany associations work correctly, focusing on EXTRA_LAZY
+ * functionality.
+ *
+ * @group DDC-3380
+ */
+class ManyToManyExtraLazyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_manytomany_extralazy');
+        parent::setUp();
+
+        $inversed1 = new Entity\InversedManyToManyExtraLazyEntity();
+        $inversed1->id1 = 'abc';
+
+        $inversed2 = new Entity\InversedManyToManyExtraLazyEntity();
+        $inversed2->id1 = 'def';
+
+        $owning1 = new Entity\OwningManyToManyExtraLazyEntity();
+        $owning1->id2 = 'ghi';
+
+        $owning2 = new Entity\OwningManyToManyExtraLazyEntity();
+        $owning2->id2 = 'jkl';
+
+        $inversed1->associatedEntities->add($owning1);
+        $owning1->associatedEntities->add($inversed1);
+        $inversed1->associatedEntities->add($owning2);
+        $owning2->associatedEntities->add($inversed1);
+
+        $inversed2->associatedEntities->add($owning1);
+        $owning1->associatedEntities->add($inversed2);
+        $inversed2->associatedEntities->add($owning2);
+        $owning2->associatedEntities->add($inversed2);
+
+        $this->_em->persist($inversed1);
+        $this->_em->persist($inversed2);
+        $this->_em->persist($owning1);
+        $this->_em->persist($owning2);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_extralazy');
+        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_extralazy');
+        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_extralazy');
+    }
+
+    public function testThatTheExtraLazyCollectionFromOwningToInversedIsCounted()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity',
+            'ghi'
+        );
+
+        $this->assertEquals(2, $owning->associatedEntities->count());
+    }
+
+    public function testThatTheExtraLazyCollectionFromInversedToOwningIsCounted()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertEquals(2, $inversed->associatedEntities->count());
+    }
+
+    public function testThatTheExtraLazyCollectionFromOwningToInversedContainsAnEntity()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity',
+            'ghi'
+        );
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertTrue($owning->associatedEntities->contains($inversed));
+    }
+
+    public function testThatTheExtraLazyCollectionFromInversedToOwningContainsAnEntity()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity',
+            'ghi'
+        );
+
+        $this->assertTrue($inversed->associatedEntities->contains($owning));
+    }
+
+    public function testThatTheExtraLazyCollectionFromOwningToInversedContainsAnIndexbyKey()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity',
+            'ghi'
+        );
+
+        $this->assertTrue($owning->associatedEntities->containsKey('abc'));
+    }
+
+    public function testThatTheExtraLazyCollectionFromInversedToOwningContainsAnIndexbyKey()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertTrue($inversed->associatedEntities->containsKey('ghi'));
+    }
+
+    public function testThatASliceOfTheExtraLazyCollectionFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity',
+            'ghi'
+        );
+
+        $this->assertCount(1, $owning->associatedEntities->slice(0, 1));
+    }
+
+    public function testThatASliceOfTheExtraLazyCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities->slice(1, 1));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that ManyToMany associations work correctly.
+ *
+ * @group DDC-3380
+ */
+class ManyToManyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_manytomany');
+        parent::setUp();
+
+        $inversed = new Entity\InversedManyToManyEntity();
+        $inversed->id = 'abc';
+
+        $owning = new Entity\OwningManyToManyEntity();
+        $owning->id = 'def';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntities->add($inversed);
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_xref_manytomany');
+        $conn->executeUpdate('DROP TABLE vct_owning_manytomany');
+        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_manytomany LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany LIMIT 1'));
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT inversed_id FROM vct_xref_manytomany LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity',
+            'def'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity',
+            'def'
+        );
+
+        $this->assertEquals('abc', $inversed->id);
+        $this->assertEquals('def', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity',
+            'def'
+        );
+
+        $this->assertCount(1, $owning->associatedEntities);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
+            'abc'
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+
+    /**
+     * @depends testThatTheCollectionFromOwningToInversedIsLoaded
+     * @depends testThatTheCollectionFromInversedToOwningIsLoaded
+     */
+    public function testThatTheJoinTableRowsAreRemovedWhenRemovingTheAssociation()
+    {
+        $conn = $this->_em->getConnection();
+
+        // remove association
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
+            'abc'
+        );
+
+        foreach ($inversed->associatedEntities as $owning) {
+            $inversed->associatedEntities->removeElement($owning);
+            $owning->associatedEntities->removeElement($inversed);
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // test association is removed
+
+        $this->assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany'));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
@@ -28,10 +28,10 @@ class ManyToManyTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $inversed = new Entity\InversedManyToManyEntity();
-        $inversed->id = 'abc';
+        $inversed->id1 = 'abc';
 
         $owning = new Entity\OwningManyToManyEntity();
-        $owning->id = 'def';
+        $owning->id2 = 'def';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntities->add($inversed);
@@ -56,9 +56,9 @@ class ManyToManyTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_manytomany LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany LIMIT 1'));
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_manytomany LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytomany LIMIT 1'));
 
         $this->assertEquals('nop', $conn->fetchColumn('SELECT inversed_id FROM vct_xref_manytomany LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany LIMIT 1'));
@@ -98,8 +98,8 @@ class ManyToManyTest extends OrmFunctionalTestCase
             'def'
         );
 
-        $this->assertEquals('abc', $inversed->id);
-        $this->assertEquals('def', $owning->id);
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $owning->id2);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToMany associations with composite id of which one is a
+ * association itself work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetomany_compositeid_foreignkey');
+        parent::setUp();
+
+        $auxiliary = new Entity\AuxiliaryEntity();
+        $auxiliary->id = 'abc';
+
+        $inversed = new Entity\InversedOneToManyCompositeIdForeignKeyEntity();
+        $inversed->id = 'def';
+        $inversed->foreignEntity = $auxiliary;
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningManyToOneCompositeIdForeignKeyEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($auxiliary);
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('def', $inversed->id);
+        $this->assertEquals('abc', $inversed->foreignEntity->id);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -29,15 +29,15 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $auxiliary = new Entity\AuxiliaryEntity();
-        $auxiliary->id = 'abc';
+        $auxiliary->id4 = 'abc';
 
         $inversed = new Entity\InversedOneToManyCompositeIdForeignKeyEntity();
-        $inversed->id = 'def';
+        $inversed->id1 = 'def';
         $inversed->foreignEntity = $auxiliary;
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningManyToOneCompositeIdForeignKeyEntity();
-        $owning->id = 'ghi';
+        $owning->id2 = 'ghi';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntity = $inversed;
@@ -63,10 +63,12 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
     }
@@ -76,9 +78,14 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatEntitiesAreFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -86,6 +93,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity', $auxiliary);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity', $inversed);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity', $owning);
     }
@@ -95,9 +103,14 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -105,9 +118,28 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
-        $this->assertEquals('def', $inversed->id);
-        $this->assertEquals('abc', $inversed->foreignEntity->id);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('abc', $auxiliary->id4);
+        $this->assertEquals('def', $inversed->id1);
+        $this->assertEquals('abc', $inversed->foreignEntity->id4);
+        $this->assertEquals('ghi', $owning->id2);
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase
+     */
+    public function testThatInversedEntityIsFetchedFromTheDatabaseUsingAuxiliaryEntityAsId()
+    {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
+            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity', $inversed);
     }
 
     /**
@@ -132,7 +164,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $this->assertCount(1, $inversed->associatedEntities);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -33,7 +33,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningManyToOneCompositeIdEntity();
-        $owning->id = 'ghi';
+        $owning->id3 = 'ghi';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntity = $inversed;
@@ -60,7 +60,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
         $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_manytoone_compositeid LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_manytoone_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_manytoone_compositeid LIMIT 1'));
     }
@@ -101,7 +101,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
 
         $this->assertEquals('abc', $inversed->id1);
         $this->assertEquals('def', $inversed->id2);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('ghi', $owning->id3);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToMany associations with composite id work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToManyCompositeIdTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetomany_compositeid');
+        parent::setUp();
+
+        $inversed = new Entity\InversedOneToManyCompositeIdEntity();
+        $inversed->id1 = 'abc';
+        $inversed->id2 = 'def';
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningManyToOneCompositeIdEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_manytoone_compositeid LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $inversed->id2);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToMany associations work correctly, focusing on EXTRA_LAZY
+ * functionality.
+ *
+ * @group DDC-3380
+ */
+class OneToManyExtraLazyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetomany_extralazy');
+        parent::setUp();
+
+        $inversed = new Entity\InversedOneToManyExtraLazyEntity();
+        $inversed->id1 = 'abc';
+
+        $owning1 = new Entity\OwningManyToOneExtraLazyEntity();
+        $owning1->id2 = 'def';
+
+        $owning2 = new Entity\OwningManyToOneExtraLazyEntity();
+        $owning2->id2 = 'ghi';
+
+        $owning3 = new Entity\OwningManyToOneExtraLazyEntity();
+        $owning3->id2 = 'jkl';
+
+        $inversed->associatedEntities->add($owning1);
+        $owning1->associatedEntity = $inversed;
+        $inversed->associatedEntities->add($owning2);
+        $owning2->associatedEntity = $inversed;
+        $inversed->associatedEntities->add($owning3);
+        $owning3->associatedEntity = $inversed;
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning1);
+        $this->_em->persist($owning2);
+        $this->_em->persist($owning3);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_extralazy');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_extralazy');
+    }
+
+    public function testThatExtraLazyCollectionIsCounted()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertEquals(3, $inversed->associatedEntities->count());
+    }
+
+    public function testThatExtraLazyCollectionContainsAnEntity()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneExtraLazyEntity',
+            'def'
+        );
+
+        $this->assertTrue($inversed->associatedEntities->contains($owning));
+    }
+
+    public function testThatExtraLazyCollectionContainsAnIndexbyKey()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertTrue($inversed->associatedEntities->containsKey('def'));
+    }
+
+    public function testThatASliceOfTheExtraLazyCollectionIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
+            'abc'
+        );
+
+        $this->assertCount(2, $inversed->associatedEntities->slice(0, 2));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToMany associations work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToManyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetomany');
+        parent::setUp();
+
+        $inversed = new Entity\InversedOneToManyEntity();
+        $inversed->id = 'abc';
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningManyToOneEntity();
+        $owning->id = 'def';
+
+        $inversed->associatedEntities->add($owning);
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_manytoone');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_onetomany LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity',
+            'def'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity',
+            'def'
+        );
+
+        $this->assertEquals('abc', $inversed->id);
+        $this->assertEquals('def', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity',
+            'def'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheCollectionFromInversedToOwningIsLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity',
+            'abc'
+        );
+
+        $this->assertCount(1, $inversed->associatedEntities);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -28,11 +28,11 @@ class OneToManyTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $inversed = new Entity\InversedOneToManyEntity();
-        $inversed->id = 'abc';
+        $inversed->id1 = 'abc';
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningManyToOneEntity();
-        $owning->id = 'def';
+        $owning->id2 = 'def';
 
         $inversed->associatedEntities->add($owning);
         $owning->associatedEntity = $inversed;
@@ -56,9 +56,9 @@ class OneToManyTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_onetomany LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany LIMIT 1'));
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_manytoone LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytoone LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone LIMIT 1'));
     }
 
@@ -96,8 +96,8 @@ class OneToManyTest extends OrmFunctionalTestCase
             'def'
         );
 
-        $this->assertEquals('abc', $inversed->id);
-        $this->assertEquals('def', $owning->id);
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $owning->id2);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToOne associations with composite id of which one is a
+ * association itself work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetoone_compositeid_foreignkey');
+        parent::setUp();
+
+        $auxiliary = new Entity\AuxiliaryEntity();
+        $auxiliary->id = 'abc';
+
+        $inversed = new Entity\InversedOneToOneCompositeIdForeignKeyEntity();
+        $inversed->id = 'def';
+        $inversed->foreignEntity = $auxiliary;
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningOneToOneCompositeIdForeignKeyEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntity = $owning;
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($auxiliary);
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid_foreignkey');
+        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('def', $inversed->id);
+        $this->assertEquals('abc', $inversed->foreignEntity->id);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity',
+            'ghi'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheEntityFromInversedToOwningIsEagerLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
+            array('id' => 'def', 'foreignEntity' => 'abc')
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity', $inversed->associatedEntity);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -29,15 +29,15 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $auxiliary = new Entity\AuxiliaryEntity();
-        $auxiliary->id = 'abc';
+        $auxiliary->id4 = 'abc';
 
         $inversed = new Entity\InversedOneToOneCompositeIdForeignKeyEntity();
-        $inversed->id = 'def';
+        $inversed->id1 = 'def';
         $inversed->foreignEntity = $auxiliary;
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningOneToOneCompositeIdForeignKeyEntity();
-        $owning->id = 'ghi';
+        $owning->id2 = 'ghi';
 
         $inversed->associatedEntity = $owning;
         $owning->associatedEntity = $inversed;
@@ -63,10 +63,12 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
     }
@@ -76,9 +78,14 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatEntitiesAreFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -86,6 +93,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity', $auxiliary);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity', $inversed);
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity', $owning);
     }
@@ -95,9 +103,14 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
      */
     public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
     {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $owning = $this->_em->find(
@@ -105,9 +118,28 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
             'ghi'
         );
 
-        $this->assertEquals('def', $inversed->id);
-        $this->assertEquals('abc', $inversed->foreignEntity->id);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('abc', $auxiliary->id4);
+        $this->assertEquals('def', $inversed->id1);
+        $this->assertEquals('abc', $inversed->foreignEntity->id4);
+        $this->assertEquals('ghi', $owning->id2);
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase
+     */
+    public function testThatInversedEntityIsFetchedFromTheDatabaseUsingAuxiliaryEntityAsId()
+    {
+        $auxiliary = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'abc'
+        );
+
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
+            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity', $inversed);
     }
 
     /**
@@ -132,7 +164,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id' => 'def', 'foreignEntity' => 'abc')
+            array('id1' => 'def', 'foreignEntity' => 'abc')
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity', $inversed->associatedEntity);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToOne associations with composite id work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToOneCompositeIdTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetoone_compositeid');
+        parent::setUp();
+
+        $inversed = new Entity\InversedOneToOneCompositeIdEntity();
+        $inversed->id1 = 'abc';
+        $inversed->id2 = 'def';
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningOneToOneCompositeIdEntity();
+        $owning->id = 'ghi';
+
+        $inversed->associatedEntity = $owning;
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
+
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_onetoone_compositeid LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $inversed->id2);
+        $this->assertEquals('ghi', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity',
+            'ghi'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheEntityFromInversedToOwningIsEagerLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
+            array('id1' => 'abc', 'id2' => 'def')
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity', $inversed->associatedEntity);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -33,7 +33,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningOneToOneCompositeIdEntity();
-        $owning->id = 'ghi';
+        $owning->id3 = 'ghi';
 
         $inversed->associatedEntity = $owning;
         $owning->associatedEntity = $inversed;
@@ -60,7 +60,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
         $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
 
-        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        $this->assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_onetoone_compositeid LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_onetoone_compositeid LIMIT 1'));
         $this->assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_onetoone_compositeid LIMIT 1'));
     }
@@ -101,7 +101,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
 
         $this->assertEquals('abc', $inversed->id1);
         $this->assertEquals('def', $inversed->id2);
-        $this->assertEquals('ghi', $owning->id);
+        $this->assertEquals('ghi', $owning->id3);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
@@ -28,11 +28,11 @@ class OneToOneTest extends OrmFunctionalTestCase
         parent::setUp();
 
         $inversed = new Entity\InversedOneToOneEntity();
-        $inversed->id = 'abc';
+        $inversed->id1 = 'abc';
         $inversed->someProperty = 'some value to be loaded';
 
         $owning = new Entity\OwningOneToOneEntity();
-        $owning->id = 'def';
+        $owning->id2 = 'def';
 
         $inversed->associatedEntity = $owning;
         $owning->associatedEntity = $inversed;
@@ -56,9 +56,9 @@ class OneToOneTest extends OrmFunctionalTestCase
     {
         $conn = $this->_em->getConnection();
 
-        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_onetoone LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone LIMIT 1'));
 
-        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone LIMIT 1'));
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_onetoone LIMIT 1'));
         $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone LIMIT 1'));
     }
 
@@ -96,8 +96,8 @@ class OneToOneTest extends OrmFunctionalTestCase
             'def'
         );
 
-        $this->assertEquals('abc', $inversed->id);
-        $this->assertEquals('def', $owning->id);
+        $this->assertEquals('abc', $inversed->id1);
+        $this->assertEquals('def', $owning->id2);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\Models\ValueConversionType as Entity;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * The entities all use a custom type that converst the value as identifier(s).
+ * {@see \Doctrine\Tests\DbalTypes\Rot13Type}
+ *
+ * Test that OneToOne associations work correctly.
+ *
+ * @group DDC-3380
+ */
+class OneToOneTest extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        if (DBALType::hasType('rot13')) {
+            DBALType::overrideType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        } else {
+            DBALType::addType('rot13', 'Doctrine\Tests\DbalTypes\Rot13Type');
+        }
+
+        $this->useModelSet('vct_onetoone');
+        parent::setUp();
+
+        $inversed = new Entity\InversedOneToOneEntity();
+        $inversed->id = 'abc';
+        $inversed->someProperty = 'some value to be loaded';
+
+        $owning = new Entity\OwningOneToOneEntity();
+        $owning->id = 'def';
+
+        $inversed->associatedEntity = $owning;
+        $owning->associatedEntity = $inversed;
+
+        $this->_em->persist($inversed);
+        $this->_em->persist($owning);
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        $conn = static::$_sharedConn;
+
+        $conn->executeUpdate('DROP TABLE vct_owning_onetoone');
+        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone');
+    }
+
+    public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
+    {
+        $conn = $this->_em->getConnection();
+
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT id FROM vct_inversed_onetoone LIMIT 1'));
+
+        $this->assertEquals('qrs', $conn->fetchColumn('SELECT id FROM vct_owning_onetoone LIMIT 1'));
+        $this->assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone LIMIT 1'));
+    }
+
+    /**
+     * @depends testThatTheValueOfIdentifiersAreConvertedInTheDatabase
+     */
+    public function testThatEntitiesAreFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity',
+            'def'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity', $inversed);
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity', $owning);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheValueOfIdentifiersAreConvertedBackAfterBeingFetchedFromTheDatabase()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity',
+            'abc'
+        );
+
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity',
+            'def'
+        );
+
+        $this->assertEquals('abc', $inversed->id);
+        $this->assertEquals('def', $owning->id);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheProxyFromOwningToInversedIsLoaded()
+    {
+        $owning = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity',
+            'def'
+        );
+
+        $inversedProxy = $owning->associatedEntity;
+
+        $this->assertEquals('some value to be loaded', $inversedProxy->someProperty);
+    }
+
+    /**
+     * @depends testThatEntitiesAreFetchedFromTheDatabase
+     */
+    public function testThatTheEntityFromInversedToOwningIsEagerLoaded()
+    {
+        $inversed = $this->_em->find(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity',
+            'abc'
+        );
+
+        $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity', $inversed->associatedEntity);
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -213,6 +213,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity'
         ),
+        'vct_onetomany_extralazy' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneExtraLazyEntity'
+        ),
         'vct_manytomany' => array(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity'
@@ -407,6 +411,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM vct_owning_manytoone_compositeid_foreignkey');
             $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_compositeid_foreignkey');
             $conn->executeUpdate('DELETE FROM vct_auxiliary');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetomany_extralazy'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_extralazy');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_extralazy');
         }
 
         if (isset($this->_usedModelSets['vct_manytomany'])) {

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -229,6 +229,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity'
+        ),
+        'vct_manytomany_extralazy' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity'
         )
     );
 
@@ -435,6 +439,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM vct_owning_manytomany_compositeid_foreignkey');
             $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_compositeid_foreignkey');
             $conn->executeUpdate('DELETE FROM vct_auxiliary');
+        }
+
+        if (isset($this->_usedModelSets['vct_manytomany_extralazy'])) {
+            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_extralazy');
+            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_extralazy');
+            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_extralazy');
         }
 
         $this->_em->clear();

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -186,6 +186,45 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'tweet' => array(
             'Doctrine\Tests\Models\Tweet\User',
             'Doctrine\Tests\Models\Tweet\Tweet'
+        ),
+        'vct_onetoone' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity'
+        ),
+        'vct_onetoone_compositeid' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity'
+        ),
+        'vct_onetoone_compositeid_foreignkey' => array(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity'
+        ),
+        'vct_onetomany' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity'
+        ),
+        'vct_onetomany_compositeid' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity'
+        ),
+        'vct_onetomany_compositeid_foreignkey' => array(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity'
+        ),
+        'vct_manytomany' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity'
+        ),
+        'vct_manytomany_compositeid' => array(
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity'
+        ),
+        'vct_manytomany_compositeid_foreignkey' => array(
+            'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
+            'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
+            'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity'
         )
     );
 
@@ -336,6 +375,57 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM cache_city');
             $conn->executeUpdate('DELETE FROM cache_state');
             $conn->executeUpdate('DELETE FROM cache_country');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetoone'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_onetoone');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetoone_compositeid'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_onetoone_compositeid');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone_compositeid');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetoone_compositeid_foreignkey'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_onetoone_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_auxiliary');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetomany'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_manytoone');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetomany_compositeid'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_compositeid');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_compositeid');
+        }
+
+        if (isset($this->_usedModelSets['vct_onetomany_compositeid_foreignkey'])) {
+            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_auxiliary');
+        }
+
+        if (isset($this->_usedModelSets['vct_manytomany'])) {
+            $conn->executeUpdate('DELETE FROM vct_xref_manytomany');
+            $conn->executeUpdate('DELETE FROM vct_owning_manytomany');
+            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany');
+        }
+
+        if (isset($this->_usedModelSets['vct_manytomany_compositeid'])) {
+            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_compositeid');
+            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_compositeid');
+            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_compositeid');
+        }
+
+        if (isset($this->_usedModelSets['vct_manytomany_compositeid_foreignkey'])) {
+            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_compositeid_foreignkey');
+            $conn->executeUpdate('DELETE FROM vct_auxiliary');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
This is a port of #1174.

I was running an experiment using a custom DBAL type, which converts a UUID string (in PHP) to 16 bytes binary string (in SQL) and vice versa, as identifier for a couple of entities. I noticed some associations weren't loaded correctly. This PR attempts to fix that issue.

**Remaining issue**

There are 2 tests that involve OneToOne and OneToMany associations with composite ids of which one is a foreign one. When the owning side is fetched from the DB, a Proxy object is created for the inversed side. But this Proxy contains incorrect identifiers:

```
public $id => string(36) "12345678-9abc-def0-1234-56789abcdef0"
public $foreignEntity => string(16) "????????????????"
```

Those question-marks represent 16 bytes of binary data. The thing is that `$foreignEntity` should contain another Proxy object (or perhaps the UUID of the foreign entity, I'm not sure).

I'm at a loss here :( Hopefully someone can point me to where identity through foreign Entities is managed!
