### PR TITLE
Fix embeddables class metadata (work-in-progress)

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -148,26 +148,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         if (!$class->isMappedSuperclass) {
             foreach ($class->embeddedClasses as $property => $embeddableClass) {
-
-                if (isset($embeddableClass['inherited'])) {
-                    continue;
-                }
-
-                if (isset($this->embeddablesActiveNesting[$embeddableClass['class']])) {
-                    throw MappingException::infiniteEmbeddableNesting($class->name, $property);
-                }
-
-                $this->embeddablesActiveNesting[$class->name] = true;
-
-                $embeddableMetadata = $this->getMetadataFor($embeddableClass['class']);
-
-                if ($embeddableMetadata->isEmbeddedClass) {
-                    $this->addNestedEmbeddedClasses($embeddableMetadata, $class, $property);
-                }
-
-                $class->inlineEmbeddable($property, $embeddableMetadata);
-
-                unset($this->embeddablesActiveNesting[$class->name]);
+                $class->fieldMappings[$property] = $embeddableClass;
             }
         }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3199,6 +3199,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function inlineEmbeddable($property, ClassMetadataInfo $embeddable)
     {
+        var_dump($embeddable->fieldMappings);
         foreach ($embeddable->fieldMappings as $fieldMapping) {
             $fieldMapping['originalClass'] = isset($fieldMapping['originalClass'])
                 ? $fieldMapping['originalClass']

--- a/tests/Doctrine/Tests/Models/Mapping/ClassMetadataFactoryTestSubject.php
+++ b/tests/Doctrine/Tests/Models/Mapping/ClassMetadataFactoryTestSubject.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+use InvalidArgumentException;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
+
+/**
+ * Test subject class with overridden factory method for mocking purposes
+ */
+class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
+{
+    private $mockMetadata     = array();
+    private $requestedClasses = array();
+
+    /** @override */
+    protected function newClassMetadataInstance($className)
+    {
+        $this->requestedClasses[] = $className;
+        if (!isset($this->mockMetadata[$className])) {
+            throw new InvalidArgumentException("No mock metadata found for class $className.");
+        }
+        return $this->mockMetadata[$className];
+    }
+
+    public function setMetadataForClass($className, $metadata)
+    {
+        $this->mockMetadata[$className] = $metadata;
+    }
+
+    public function getRequestedClasses()
+    {
+        return $this->requestedClasses;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/CustomIdGenerator.php
+++ b/tests/Doctrine/Tests/Models/Mapping/CustomIdGenerator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use Doctrine\ORM\EntityManager;
+
+class CustomIdGenerator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity)
+    {
+
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/DDC2700MappedSuperClass.php
+++ b/tests/Doctrine/Tests/Models/Mapping/DDC2700MappedSuperClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * @MappedSuperclass
+ */
+class DDC2700MappedSuperClass
+{
+    /**
+     * @Column
+     */
+    private $foo;
+}

--- a/tests/Doctrine/Tests/Models/Mapping/EmbeddableObject.php
+++ b/tests/Doctrine/Tests/Models/Mapping/EmbeddableObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * @Embeddable 
+ */
+class EmbeddableObject
+{
+    /**
+     * @Column(type = "string") 
+     */
+    protected $foo;
+
+    /**
+     * @Column(type = "string") 
+     */
+    protected $bar;
+}

--- a/tests/Doctrine/Tests/Models/Mapping/EmbeddedMappedEntity.php
+++ b/tests/Doctrine/Tests/Models/Mapping/EmbeddedMappedEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * @Entity
+ */
+class EmbeddedMappedEntity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+    
+    /**
+     * @Embedded(class = "Doctrine\Tests\Models\Mapping\EmbeddableObject")
+     */
+    protected $embedded;
+}

--- a/tests/Doctrine/Tests/Models/Mapping/MyArrayObjectEntity.php
+++ b/tests/Doctrine/Tests/Models/Mapping/MyArrayObjectEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+use ArrayObject;
+
+class MyArrayObjectEntity extends ArrayObject
+{
+
+}

--- a/tests/Doctrine/Tests/Models/Mapping/MyNamespacedNamingStrategy.php
+++ b/tests/Doctrine/Tests/Models/Mapping/MyNamespacedNamingStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+
+class MyNamespacedNamingStrategy extends DefaultNamingStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function classToTableName($className)
+    {
+        if (strpos($className, '\\') !== false) {
+            $className = str_replace(
+                '\\',
+                '_',
+                str_replace('Doctrine\Tests\Models\\', '', $className)
+            );
+        }
+
+        return strtolower($className);
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/MyPrefixNamingStrategy.php
+++ b/tests/Doctrine/Tests/Models/Mapping/MyPrefixNamingStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+
+class MyPrefixNamingStrategy extends DefaultNamingStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function propertyToColumnName($propertyName, $className = null)
+    {
+        return strtolower($this->classToTableName($className)).'_'.$propertyName;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/TestEntity1.php
+++ b/tests/Doctrine/Tests/Models/Mapping/TestEntity1.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+class TestEntity1
+{
+    private $id;
+    private $name;
+    private $other;
+    private $association;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
-use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\Tests\Models\Mapping;
 
 require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 
@@ -106,9 +106,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
             array(
-            'fieldName' => 'groups',
-            'targetEntity' => 'CmsGroup'
-        ));
+                'fieldName' => 'groups',
+                'targetEntity' => 'CmsGroup'
+            )
+        );
 
         $assoc = $cm->associationMappings['groups'];
         //$this->assertInstanceOf('Doctrine\ORM\Mapping\ManyToManyMapping', $assoc);
@@ -126,9 +127,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
             array(
-            'fieldName' => 'groups',
-            'targetEntity' => 'CmsGroup'
-        ));
+                'fieldName' => 'groups',
+                'targetEntity' => 'CmsGroup'
+            )
+        );
 
         /* @var $assoc \Doctrine\ORM\Mapping\ManyToManyMapping */
         $assoc = $cm->associationMappings['groups'];
@@ -169,7 +171,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     /**
      * @group DDC-268
      */
-    public function testSetInvalidVersionMapping_ThrowsException()
+    public function testSetInvalidVersionMappingThrowsException()
     {
         $field = array();
         $field['fieldName'] = 'foo';
@@ -182,7 +184,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->setVersionMapping($field);
     }
 
-    public function testGetSingleIdentifierFieldName_MultipleIdentifierEntity_ThrowsException()
+    public function testGetSingleIdentifierFieldNameMultipleIdentifierEntityThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -205,7 +207,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->addInheritedAssociationMapping($a2);
     }
 
-    public function testDuplicateColumnName_ThrowsMappingException()
+    public function testDuplicateColumnNameThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -216,7 +218,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->mapField(array('fieldName' => 'username', 'columnName' => 'name'));
     }
 
-    public function testDuplicateColumnName_DiscriminatorColumn_ThrowsMappingException()
+    public function testDuplicateColumnNameDiscriminatorColumnThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -227,7 +229,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->setDiscriminatorColumn(array('name' => 'name'));
     }
 
-    public function testDuplicateColumnName_DiscriminatorColumn2_ThrowsMappingException()
+    public function testDuplicateColumnNameDiscriminatorColumn2ThrowsMappingException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -238,7 +240,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
     }
 
-    public function testDuplicateFieldAndAssociationMapping1_ThrowsException()
+    public function testDuplicateFieldAndAssociationMapping1ThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -249,7 +251,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
     }
 
-    public function testDuplicateFieldAndAssociationMapping2_ThrowsException()
+    public function testDuplicateFieldAndAssociationMapping2ThrowsException()
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
@@ -487,8 +489,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testEmptyFieldNameThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException',
-            "The field or association mapping misses the 'fieldName' attribute in entity 'Doctrine\Tests\Models\CMS\CmsUser'.");
+        $this->setExpectedException(
+            'Doctrine\ORM\Mapping\MappingException',
+            "The field or association mapping misses the 'fieldName' attribute in entity 'Doctrine\Tests\Models\CMS\CmsUser'."
+        );
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -916,10 +920,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFullyQualifiedClassNameShouldBeGivenToNamingStrategy()
     {
-        $namingStrategy     = new MyNamespacedNamingStrategy();
+        $namingStrategy     = new Mapping\MyNamespacedNamingStrategy();
         $addressMetadata    = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', $namingStrategy);
         $articleMetadata    = new ClassMetadata('DoctrineGlobal_Article', $namingStrategy);
-        $routingMetadata    = new ClassMetadata('Doctrine\Tests\Models\Routing\RoutingLeg',$namingStrategy);
+        $routingMetadata    = new ClassMetadata('Doctrine\Tests\Models\Routing\RoutingLeg', $namingStrategy);
 
         $addressMetadata->initializeReflection(new RuntimeReflectionService());
         $articleMetadata->initializeReflection(new RuntimeReflectionService());
@@ -946,7 +950,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFullyQualifiedClassNameShouldBeGivenToNamingStrategyPropertyToColumnName()
     {
-        $namingStrategy = new MyPrefixNamingStrategy();
+        $namingStrategy = new Mapping\MyPrefixNamingStrategy();
         $metadata       = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', $namingStrategy);
 
         $metadata->initializeReflection(new RuntimeReflectionService());
@@ -972,7 +976,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
 
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass', 'cascade' => array('invalid')));
-     }
+    }
 
     /**
      * @group DDC-964
@@ -1098,7 +1102,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testIsIdentifierMappedSuperClass()
     {
-        $class = new ClassMetadata(__NAMESPACE__ . '\\DDC2700MappedSuperClass');
+        $class = new ClassMetadata('Doctrine\\Tests\\Models\\Mapping\\DDC2700MappedSuperClass');
 
         $this->assertFalse($class->isIdentifier('foo'));
     }
@@ -1108,9 +1112,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testCanInstantiateInternalPhpClassSubclass()
     {
-        $classMetadata = new ClassMetadata(__NAMESPACE__ . '\\MyArrayObjectEntity');
+        $classMetadata = new ClassMetadata('Doctrine\\Tests\\Models\\Mapping\\MyArrayObjectEntity');
 
-        $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+        $this->assertInstanceOf('Doctrine\\Tests\\Models\\Mapping\\MyArrayObjectEntity', $classMetadata->newInstance());
     }
 
     /**
@@ -1119,49 +1123,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     public function testCanInstantiateInternalPhpClassSubclassFromUnserializedMetadata()
     {
         /* @var $classMetadata ClassMetadata */
-        $classMetadata = unserialize(serialize(new ClassMetadata(__NAMESPACE__ . '\\MyArrayObjectEntity')));
+        $classMetadata = unserialize(serialize(new ClassMetadata('Doctrine\\Tests\\Models\\Mapping\\MyArrayObjectEntity')));
 
         $classMetadata->wakeupReflection(new RuntimeReflectionService());
 
-        $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+        $this->assertInstanceOf('Doctrine\\Tests\\Models\\Mapping\\MyArrayObjectEntity', $classMetadata->newInstance());
     }
-}
-
-/**
- * @MappedSuperclass
- */
-class DDC2700MappedSuperClass
-{
-    /** @Column */
-    private $foo;
-}
-
-class MyNamespacedNamingStrategy extends DefaultNamingStrategy
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function classToTableName($className)
-    {
-        if (strpos($className, '\\') !== false) {
-            $className = str_replace('\\', '_', str_replace('Doctrine\Tests\Models\\', '', $className));
-        }
-
-        return strtolower($className);
-    }
-}
-
-class MyPrefixNamingStrategy extends DefaultNamingStrategy
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function propertyToColumnName($propertyName, $className = null)
-    {
-        return strtolower($this->classToTableName($className)) . '_' . $propertyName;
-    }
-}
-
-class MyArrayObjectEntity extends \ArrayObject
-{
 }


### PR DESCRIPTION
ClassMetadataInfo is returning more than one result in getFieldNames() for the embeddables properties. This method is used by DoctrineModule\Stdlib\Hydrator\DoctrineObject in the extraction process. 

Since its returning a number of results equal the number of properties of the embedded object, it will never find the correct setter for the extraction and that causes that property to be removed from the extracted array.

I was able to solve the issue by hacking into the getFieldNames() for testing and merging the duplicated entries, and then the object was successfully extracted. 

By digging into the code, i found out that there is a mapEmbedded(), but instead of using that for embeddeds, its using the default mapField, which may be the root cause of the problem.
- [x] Hack into the getFieldNames() method to see if the expected solution would work
- [x] Remove multiple class declaration in the same file from the files i'll work with
- [x] Create a failing testcase
- [ ] Create a solution
