### PR TITLE
Fix for no dot on Class Names

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -301,16 +301,15 @@ class DatabaseDriver implements MappingDriver
             } else {
                 // If you work with PostgreSQL Schemas you need tu filter the names of table to generate
                 // Correct name for PHP Classes
+                $schema = 'public';
+                $realTableName = $tableName;
                 if (strpos($tableName, ".") !== false) {
-                    list($schema, $tableShortName) = explode(".", $tableName);
-                } else {
-                    $schema = 'public';
-                    $tableShortName = $tableName;
+                    list($schema, $realTableName) = explode(".", $tableName);
                 }
                 
                 // lower-casing is necessary because of Oracle Uppercase Tablenames,
                 // assumption is lower-case + underscore separated.
-                $className = $this->getClassNameForTable($tableShortName);
+                $className = $this->getClassNameForTable($realTableName);
 
                 $this->tables[$tableName] = $table;
                 $this->classToTableNames[$className] = $tableName;

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -299,9 +299,18 @@ class DatabaseDriver implements MappingDriver
             if ($pkColumns == $allForeignKeyColumns && count($foreignKeys) == 2) {
                 $this->manyToManyTables[$tableName] = $table;
             } else {
+                // If you work with PostgreSQL Schemas you need tu filter the names of table to generate
+                // Correct name for PHP Classes
+                if (strpos($tableName, ".") !== false) {
+                    list($schema, $tableShortName) = explode(".", $tableName);
+                } else {
+                    $schema = 'public';
+                    $tableShortName = $tableName;
+                }
+                
                 // lower-casing is necessary because of Oracle Uppercase Tablenames,
                 // assumption is lower-case + underscore separated.
-                $className = $this->getClassNameForTable($tableName);
+                $className = $this->getClassNameForTable($tableShortName);
 
                 $this->tables[$tableName] = $table;
                 $this->classToTableNames[$className] = $tableName;


### PR DESCRIPTION
If you work with PostgreSQL Schemas, You should filter the names of table to generate Correct name for PHP Classes. This way allow not write dots (.) as part of the Class Name.

In addition I have added two properties in which data from a table schema and namespace of a class are stored, this is useful when working with PostgreSQL Schemas.

Additionally, there is a variable ($schema) that must be contained in the class "Doctrine\DBAL\Schema\Table" on an $schema possible property but this is not available. Or can be the value of "name" property of the Class "Doctrine\DBAL\Schema\SchemaConfig". (This last is recomended)

This is a fix because Doctrine entityGenerate proccess is generating the name of PHP classes with dots (.) when you work with schemas on PostgreSQL. The Name of Classes on PHP can not have dot on its Name. Therefore Doctrine2 can't generate PHP Classes with dots on its names.

These data are also placed in the metadata.
