### PR TITLE
add a new method that return the mapped properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,21 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"}
     ],
     "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/fabiocarneiro/common"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/fabiocarneiro/dbal"
+        }
+    ],
     "require": {
         "php": ">=5.3.2",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
-        "doctrine/dbal": ">=2.5-dev,<2.6-dev",
+        "doctrine/dbal": "dev-temporary-doctrine-common-fork-import",
         "doctrine/instantiator": "~1.0.1",
         "symfony/console": "~2.3"
     },

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Types\Type;
 use ReflectionClass;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\ClassLoader;
+use Doctrine\Common\Persistence\Mapping\PropertyNamesAware;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata
@@ -46,7 +47,7 @@ use Doctrine\Common\ClassLoader;
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @since 2.0
  */
-class ClassMetadataInfo implements ClassMetadata
+class ClassMetadataInfo implements ClassMetadata, PropertyNamesAware
 {
     /* The inheritance mapping types */
     /**
@@ -3004,6 +3005,23 @@ class ClassMetadataInfo implements ClassMetadata
     public function getAssociationNames()
     {
         return array_keys($this->associationMappings);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getMappedPropertyNames()
+    {
+        return array_merge(
+            array_keys(
+                array_flip(
+                    array_map(function ($value) {
+                        return isset($value['declaredField'] ) ? $value['declaredField'] : $value['fieldName'];
+                    }, $this->fieldMappings)
+                )
+            ),
+            array_keys($this->associationMappings)
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1125,6 +1125,23 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
     }
+
+    public function testCanPropertyReturnAllMappedProperties()
+    {
+        $classMetadata      = new ClassMetadata(__NAMESPACE__.'\\EmbeddedMappedEntity');
+
+        $classMetadata->mapField(array('fieldName'=>'id'));
+        $classMetadata->mapField(array('fieldName'=>'embedded.foo', 'declaredField' => 'embedded'));
+        $classMetadata->mapField(array('fieldName'=>'embedded.bar', 'declaredField' => 'embedded'));
+
+        $this->assertSame(
+            array(
+                'id',
+                'embedded'
+            ),
+            $classMetadata->getMappedPropertyNames()
+        );
+    }
 }
 
 /**
@@ -1164,4 +1181,38 @@ class MyPrefixNamingStrategy extends DefaultNamingStrategy
 
 class MyArrayObjectEntity extends \ArrayObject
 {
+}
+
+/**
+ * @Embeddable
+ */
+class EmbeddableObject
+{
+    /**
+     * @Column(type = "string")
+     */
+    protected $foo;
+
+    /**
+     * @Column(type = "string")
+     */
+    protected $bar;
+
+}
+
+/**
+ * @Entity
+ */
+class EmbeddedMappedEntity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @Embedded(class = "Doctrine\Tests\ORM\Mapping\EmbeddableObject")
+     */
+    protected $embedded;
 }


### PR DESCRIPTION
There are some implementations that use the doctrine metadata to get the properties of a entity (DoctrineObject), and it currently uses the getFieldNames and getAssociationNames methods to retrieve and merge it. 

Since the embeddables feature was added, that method will return more than one metadata for each embeddable property, and then the hydrator can never find the appropriate setter for that property.

This method allows some implementation to retrieve all mapped fields from an entity, something that can't be done using get_class_vars for example.

Of course this implementation could be done in the hydrator, but i don't think it is its responsibility to filter and merge data received from the ClassMetadata. Since you have methods to retrieve the metadata formatted as the database structure, you should also have methods to retrieve the information to the other side, in object structure.

There is a new interface to make sure this metadata implementation has the necessary fields https://github.com/doctrine/common/pull/343

**This modification in composer.json is purposeful and will be removed as soon as/if doctrine/common PR gets merged w/ forced push. The objective is to make it possible to travis test the doctrine/orm with the new interface and show that this pr is dependent from a pr in doctrine/common**
