### PR TITLE
Document that AUTOGENERATE_ constants are allowed

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -25,6 +25,7 @@ use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache as CacheDriver;
+use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\DefaultEntityListenerResolver;
@@ -75,29 +76,28 @@ class Configuration extends \Doctrine\DBAL\Configuration
     }
 
     /**
-     * Gets a boolean flag that indicates whether proxy classes should always be regenerated
-     * during each script execution.
+     * Gets the strategy for automatically generating proxy classes.
      *
-     * @return boolean
+     * @return int Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
      */
     public function getAutoGenerateProxyClasses()
     {
         return isset($this->_attributes['autoGenerateProxyClasses'])
             ? $this->_attributes['autoGenerateProxyClasses']
-            : true;
+            : AbstractProxyFactory::AUTOGENERATE_ALWAYS;
     }
 
     /**
-     * Sets a boolean flag that indicates whether proxy classes should always be regenerated
-     * during each script execution.
+     * Sets the strategy for automatically generating proxy classes.
      *
-     * @param boolean|int $bool Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory
+     * @param boolean|int $autoGenerate Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
+     *                                  True is converted to AUTOGENERATE_ALWAYS, false to AUTOGENERATE_NEVER.
      *
      * @return void
      */
-    public function setAutoGenerateProxyClasses($bool)
+    public function setAutoGenerateProxyClasses($autoGenerate)
     {
-        $this->_attributes['autoGenerateProxyClasses'] = $bool;
+        $this->_attributes['autoGenerateProxyClasses'] = (int)$autoGenerate;
     }
 
     /**

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -61,7 +61,8 @@ class ProxyFactory extends AbstractProxyFactory
      * @param \Doctrine\ORM\EntityManager $em           The EntityManager the new factory works for.
      * @param string                      $proxyDir     The directory to use for the proxy classes. It must exist.
      * @param string                      $proxyNs      The namespace to use for the proxy classes.
-     * @param boolean|int                 $autoGenerate Whether to automatically generate proxy classes.
+     * @param boolean|int                 $autoGenerate The strategy for automatically generating proxy classes. Possible
+     *                                                  values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
      */
     public function __construct(EntityManager $em, $proxyDir, $proxyNs, $autoGenerate = AbstractProxyFactory::AUTOGENERATE_NEVER)
     {

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -37,10 +37,16 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testSetGetAutoGenerateProxyClasses()
     {
-        $this->assertSame(true, $this->configuration->getAutoGenerateProxyClasses()); // defaults
+        $this->assertSame(AbstractProxyFactory::AUTOGENERATE_ALWAYS, $this->configuration->getAutoGenerateProxyClasses()); // defaults
 
         $this->configuration->setAutoGenerateProxyClasses(false);
-        $this->assertSame(false, $this->configuration->getAutoGenerateProxyClasses());
+        $this->assertSame(AbstractProxyFactory::AUTOGENERATE_NEVER, $this->configuration->getAutoGenerateProxyClasses());
+
+        $this->configuration->setAutoGenerateProxyClasses(true);
+        $this->assertSame(AbstractProxyFactory::AUTOGENERATE_ALWAYS, $this->configuration->getAutoGenerateProxyClasses());
+
+        $this->configuration->setAutoGenerateProxyClasses(AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS);
+        $this->assertSame(AbstractProxyFactory::AUTOGENERATE_FILE_NOT_EXISTS, $this->configuration->getAutoGenerateProxyClasses());
     }
 
     public function testSetGetProxyNamespace()


### PR DESCRIPTION
As of Doctrine Common 2.4, there are four strategies for generating proxy classes. Previously there were just two. This is supported by Doctrine ORM (implemented in bee74f898da0474b4bad44d41df84f1807036880 and 88754622419524bf92cfc18f9ab7fac148c35924), but the change is not fully reflected in the documentation and variable names used in Doctrine ORM.

This PR updates the documentation and variable names.
