### PR TITLE
Correction Events.rs - Entity Listeners Resolver

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -942,8 +942,9 @@ Implementing your own resolver :
         }
     }
 
-    // configure the listener resolver.
-    $em->getConfiguration()->setEntityListenerResolver($container->get('my_resolver'));
+    // Configure the listener resolver only before instantiating the EntityManager
+    $configurations->setEntityListenerResolver(new MyEntityListenerResolver);
+    EntityManager::create(.., $configurations, ..);
 
 Load ClassMetadata Event
 ------------------------


### PR DESCRIPTION
Configuring the Entity Listener Resolver can only be done before Entity Manager is initialized as described here https://github.com/doctrine/doctrine2/pull/1193
