### PR TITLE
Fix Yaml::parse() errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.6-dev",
         "doctrine/instantiator": "~1.0.1",
-        "symfony/console": "~2.3"
+        "symfony/console": "~2.3",
+        "symfony/yaml": "<2.7-dev"
     },
     "require-dev": {
         "symfony/yaml": "~2.1",


### PR DESCRIPTION
Of course this might be just a temporary fix for:

"The ability to pass file names to Yaml::parse() was deprecated in 2.7 and will be removed in 3.0. Please, pass the contents of the file instead."
