### PR TITLE
Checks key exists rather than isset

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -433,7 +433,7 @@ class SchemaTool
             $knownOptions = array('comment', 'unsigned', 'fixed', 'default');
 
             foreach ($knownOptions as $knownOption) {
-                if ( isset($mapping['options'][$knownOption])) {
+                if (array_key_exists($knownOption, $mapping['options'])) {
                     $options[$knownOption] = $mapping['options'][$knownOption];
 
                     unset($mapping['options'][$knownOption]);

--- a/tests/Doctrine/Tests/Models/NullDefault/NullDefaultColumn.php
+++ b/tests/Doctrine/Tests/Models/NullDefault/NullDefaultColumn.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\Models\NullDefault;
+
+/**
+ * @Entity
+ * @Table(name="null-default")
+ */
+class NullDefaultColumn
+{
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(name="`null-default`",nullable=true,options={"default":NULL})
+     */
+    public $nullDefault;
+}

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -99,6 +99,23 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(count($classes), $listener->tableCalls);
         $this->assertTrue($listener->schemaCalled);
     }
+
+    public function testNullDefaultNotAddedToCustomSchemaOptions()
+    {
+        $em = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $classes = array(
+            $em->getClassMetadata('Doctrine\Tests\Models\NullDefault\NullDefaultColumn'),
+        );
+
+        $customSchemaOptions = $schemaTool->getSchemaFromMetadata($classes)
+            ->getTable('null-default')
+            ->getColumn('null-default')
+            ->getCustomSchemaOptions();
+
+        $this->assertSame(array(), $customSchemaOptions);
+    }
 }
 
 /**


### PR DESCRIPTION
If the default value is set to `null`, `isset` will return `false` even though the key is actually there for a reason.
