### PR TITLE
Fix sequence-generator in MetaData exporter for XML Driver.

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -171,6 +171,12 @@ class XmlExporter extends AbstractExporter
                 if ($idGeneratorType = $this->_getIdGeneratorTypeString($metadata->generatorType)) {
                     $generatorXml = $idXml->addChild('generator');
                     $generatorXml->addAttribute('strategy', $idGeneratorType);
+                    if($metadata->generatorType === ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE && $metadata->sequenceGeneratorDefinition) {
+                        $sequenceGeneratorXml = $idXml->addChild('sequence-generator');
+                        $sequenceGeneratorXml->addAttribute('sequence-name', $metadata->sequenceGeneratorDefinition['sequenceName']);
+                        $sequenceGeneratorXml->addAttribute('allocation-size', $metadata->sequenceGeneratorDefinition['allocationSize']);
+                        $sequenceGeneratorXml->addAttribute('initial-value', $metadata->sequenceGeneratorDefinition['initialValue']);
+                    }
                 }
             }
         }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -37,4 +37,36 @@ class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
     {
         return 'xml';
     }
+
+
+    public function testSequenceGenerator() {
+        $exporter = new \Doctrine\ORM\Tools\Export\Driver\XmlExporter();
+        $metadata = new \Doctrine\ORM\Mapping\ClassMetadata('entityTest');
+        $metadata->mapField(array(
+            "fieldName" => 'id',
+            "type" => 'integer',
+            "columnName" => 'id',
+            "id" => true,
+        ));
+
+        $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
+        $metadata->setSequenceGeneratorDefinition(array(
+            'sequenceName' => 'seq_entity_test_id',
+            'allocationSize' => 5,
+            'initialValue' => 1
+        ));
+
+
+        $fileContent = '<?xml version="1.0" encoding="utf-8"?>'."\n".
+'<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">'."\n".
+'  <entity name="entityTest">'."\n".
+'    <id name="id" type="integer" column="id">'."\n".
+'      <generator strategy="SEQUENCE"/>'."\n".
+'      <sequence-generator sequence-name="seq_entity_test_id" allocation-size="5" initial-value="1"/>'."\n".
+'    </id>'."\n".
+'  </entity>'."\n".
+'</doctrine-mapping>'."\n";
+        $exportClassMetadata = $exporter->exportClassMetadata($metadata);
+        $this->assertEquals($fileContent, $exportClassMetadata);
+    }
 }


### PR DESCRIPTION
Make XMLExporter writes sequence-generator if a definition about it exists.
