### PR TITLE
matching should not change critera

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -879,6 +879,7 @@ final class PersistentCollection implements Collection, Selectable
         $expression      = $criteria->getWhereExpression();
         $expression      = $expression ? $builder->andX($expression, $ownerExpression) : $ownerExpression;
 
+        $criteria = clone $critera;
         $criteria->where($expression);
 
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->association['targetEntity']);

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -879,7 +879,7 @@ final class PersistentCollection implements Collection, Selectable
         $expression      = $criteria->getWhereExpression();
         $expression      = $expression ? $builder->andX($expression, $ownerExpression) : $ownerExpression;
 
-        $criteria = clone $critera;
+        $criteria = clone $criteria;
         $criteria->where($expression);
 
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->association['targetEntity']);


### PR DESCRIPTION
The matching should behave like in ArrayCollection, where it is not changed.
The criteria should be cloned so that it could be used for more than one matching operation.
