### PR TITLE
DDC-3434 - paginator ignores `HIDDEN` fields in `ORDER BY` query

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -93,7 +93,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
     public function walkSelectStatement(SelectStatement $AST)
     {
         // Set every select expression as visible(hidden = false) to
-        // make $AST to have scalar mappings properly
+        // make $AST have scalar mappings properly - this is relevant for referencing selected
+        // fields from outside the subquery, for example in the ORDER BY segment
         $hiddens = array();
 
         foreach ($AST->selectClause->selectExpressions as $idx => $expr) {

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -92,25 +92,21 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform instanceof PostgreSqlPlatform) {
-            // Set every select expression as visible(hidden = false) to
-            // make $AST to have scalar mappings properly
-            $hiddens = array();
-            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
-                $hiddens[$idx] = $expr->hiddenAliasResultVariable;
-                $expr->hiddenAliasResultVariable = false;
-            }
+        // Set every select expression as visible(hidden = false) to
+        // make $AST to have scalar mappings properly
+        $hiddens = array();
 
-            $innerSql = parent::walkSelectStatement($AST);
-
-            // Restore hiddens
-            foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
-                $expr->hiddenAliasResultVariable = $hiddens[$idx];
-            }
-        } else {
-            $innerSql = parent::walkSelectStatement($AST);
+        foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+            $hiddens[$idx] = $expr->hiddenAliasResultVariable;
+            $expr->hiddenAliasResultVariable = false;
         }
 
+        $innerSql = parent::walkSelectStatement($AST);
+
+        // Restore hiddens
+        foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
+            $expr->hiddenAliasResultVariable = $hiddens[$idx];
+        }
 
         // Find out the SQL alias of the identifier column of the root entity.
         // It may be possible to make this work with multiple root entities but that

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -200,7 +200,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testCountQueryWithArithmeticOrderByCondition()
     {
         $query = $this->entityManager->createQuery(
-            'SELECT a FROM Doctrine\\Tests\\ORM\\Tools\\Pagination\\Author a ORDER BY (1 - 1000) * 1 DESC'
+            'SELECT a FROM Doctrine\Tests\ORM\Tools\Pagination\Author a ORDER BY (1 - 1000) * 1 DESC'
         );
         $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -211,5 +211,22 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
             $query->getSQL()
         );
     }
+
+    /**
+     * @group DDC-3434
+     */
+    public function testLimitSubqueryWithHiddenSelectionInOrderBy()
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT a, a.name AS HIDDEN ord FROM Doctrine\Tests\ORM\Tools\Pagination\Author a ORDER BY ord DESC'
+        );
+
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0, name_2 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, a0_.name AS name_2 FROM Author a0_ ORDER BY name_2 DESC) dctrn_result ORDER BY name_2 DESC',
+            $query->getSql()
+        );
+    }
 }
 


### PR DESCRIPTION
See DDC-3434 ( http://www.doctrine-project.org/jira/browse/DDC-3434 )
