### PR TITLE
[DDC-3108] Fix regression where join aliases were no longer accessible in Criteria expressions

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -135,21 +135,17 @@ class QueryExpressionVisitor extends ExpressionVisitor
         if ( ! isset($this->queryAliases[0])) {
             throw new QueryException('No aliases are set before invoking walkComparison().');
         }
-        $field = $comparison->getField();
 
-        $hasValidAlias = false;
+        $field = $this->queryAliases[0] . '.' . $comparison->getField();
+
         foreach($this->queryAliases as $alias) {
-            if(strpos($field . '.', $alias . '.') === 0) {
-                $hasValidAlias = true;
+            if(strpos($comparison->getField() . '.', $alias . '.') === 0) {
+                $field = $comparison->getField();
                 break;
             }
         }
 
-        $parameterName = str_replace('.', '_', $field);
-
-        if(!$hasValidAlias) {
-            $field = $this->queryAliases[0] . '.' . $field;
-        }
+        $parameterName = str_replace('.', '_', $comparison->getField());
 
         foreach($this->parameters as $parameter) {
             if($parameter->getName() === $parameterName) {

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -62,7 +62,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /**
      * Constructor
      *
-     * @param string $queryAliases
+     * @param array $queryAliases
      */
     public function __construct($queryAliases)
     {
@@ -133,7 +133,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
     {
 
         if ( ! isset($this->queryAliases[0])) {
-            throw new \RuntimeException('No aliases are set before invoking walkComparison().');
+            throw new QueryException('No aliases are set before invoking walkComparison().');
         }
         $field = $comparison->getField();
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -473,7 +473,7 @@ class QueryBuilder
      * </code>
      * @return array
      */
-    public function getAllAliases() {
+    private function getAllAliases() {
         return array_merge($this->getRootAliases(),array_keys($this->joinRootAliases));
     }
 
@@ -1234,14 +1234,14 @@ class QueryBuilder
      * Overrides firstResult and maxResults if they're set.
      *
      * @param Criteria $criteria
-     *
      * @return QueryBuilder
+     * @throws Query\QueryException
      */
     public function addCriteria(Criteria $criteria)
     {
         $allAliases = $this->getAllAliases();
         if ( ! isset($allAliases[0])) {
-            throw new \RuntimeException('No aliases are set before invoking addCriteria().');
+            throw new Query\QueryException('No aliases are set before invoking addCriteria().');
         }
 
         $visitor = new QueryExpressionVisitor($this->getAllAliases());

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -47,7 +47,7 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->visitor = new QueryExpressionVisitor('o');
+        $this->visitor = new QueryExpressionVisitor(['o','p']);
     }
 
     /**
@@ -89,6 +89,10 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
 
             // Test parameter conversion
             array($cb->eq('object.field', 'value'), $qb->eq('o.object.field', ':object_field'), new Parameter('object_field', 'value')),
+
+            // Test alternative rootAlias
+            array($cb->eq('p.field', 'value'), $qb->eq('p.field', ':p_field'), new Parameter('p_field', 'value')),
+            array($cb->eq('p.object.field', 'value'), $qb->eq('p.object.field', ':p_object_field'), new Parameter('p_object_field', 'value')),
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -47,7 +47,7 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->visitor = new QueryExpressionVisitor(['o','p']);
+        $this->visitor = new QueryExpressionVisitor(array('o','p'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -522,6 +522,9 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('u.field DESC', (string) $orderBy[0]);
     }
 
+    /**
+     * @group DDC-3108
+     */
     public function testAddCriteriaOrderOnJoinAlias()
     {
         $qb = $this->_em->createQueryBuilder();
@@ -978,17 +981,6 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u2');
 
         $this->assertEquals(array('u', 'u2'), $qb->getRootAliases());
-        $this->assertEquals('u', $qb->getRootAlias());
-    }
-
-    public function testGetAliasesAddedWithJoins()
-    {
-        $qb = $this->_em->createQueryBuilder()
-            ->select('u')
-            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
-            ->join('u.articles','a');
-
-        $this->assertEquals(array('u', 'a'), $qb->getAllAliases());
         $this->assertEquals('u', $qb->getRootAlias());
     }
 


### PR DESCRIPTION
The solution to issue DDC-2764 was to blanket prefix all the fields with the root alias. The result was then impossible to use fields from multiple FROM tables or a JOIN. 

This patch injects all available aliases into the comparison, if a field uses one of the aliases it will pass without modification. If it is an unknown alias it will prefix the first rootAlias listed using the same functionality as the deprecated getRootAlias() function.

Also improves the ORDER BY on Criteria expressions, again introduced by [DDC-2764] using the above functionality, this was out of scope of bug [DDC-3108].

Added unit tests to test new functionality.
