### PR TITLE
fix instantiation of embedded object in ReflectionEmbeddedProperty

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -49,6 +49,11 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
     private $instantiator;
 
     /**
+     * @var string
+     */
+    private $reflectionClass;
+
+    /**
      * @param ReflectionProperty $parentProperty
      * @param ReflectionProperty $childProperty
      * @param string             $class
@@ -57,6 +62,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
     {
         $this->parentProperty = $parentProperty;
         $this->childProperty  = $childProperty;
+        $this->reflectionClass = $class;
 
         parent::__construct($childProperty->getDeclaringClass()->getName(), $childProperty->getName());
     }
@@ -85,7 +91,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
         if (null === $embeddedObject) {
             $this->instantiator = $this->instantiator ?: new Instantiator();
 
-            $embeddedObject = $this->instantiator->instantiate($this->class);
+            $embeddedObject = $this->instantiator->instantiate($this->reflectionClass);
 
             $this->parentProperty->setValue($object, $embeddedObject);
         }

--- a/tests/Doctrine/Tests/Models/Mapping/AbstractEmbedded.php
+++ b/tests/Doctrine/Tests/Models/Mapping/AbstractEmbedded.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * Class AbstractEmbedded
+ * @package Doctrine\Tests\Models\Mapping
+ */
+abstract class AbstractEmbedded
+{
+    /**
+     * @var
+     */
+    protected $foo;
+
+    /**
+     * @return mixed
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    /**
+     * @param $foo
+     * @return $this
+     */
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/Embedded.php
+++ b/tests/Doctrine/Tests/Models/Mapping/Embedded.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * Class Embedded
+ * @package Doctrine\Tests\Models\Mapping
+ */
+class Embedded extends AbstractEmbedded
+{
+    /**
+     * @var mixed
+     */
+    protected $bar;
+
+    /**
+     * @return mixed
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    /**
+     * @param $bar
+     * @return $this
+     */
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Mapping/Entity.php
+++ b/tests/Doctrine/Tests/Models/Mapping/Entity.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\Models\Mapping;
+
+/**
+ * Class Entity
+ * @package Doctrine\Tests\Models\Mapping
+ */
+class Entity
+{
+    /**
+     * @var \Doctrine\Tests\Models\Mapping\Embedded
+     */
+    protected $embedded;
+
+    /**
+     * @return Embedded
+     */
+    public function getEmbedded()
+    {
+        return $this->embedded;
+    }
+
+    /**
+     * @param Embedded $embedded
+     * @return $this
+     */
+    public function setEmbedded($embedded)
+    {
+        $this->embedded = $embedded;
+        return $this;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\ORM\Mapping\ReflectionEmbeddedProperty;
+use Doctrine\Tests\Models\Mapping\Entity;
 use ReflectionProperty;
 
 /**
@@ -64,6 +65,24 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($embeddedPropertyReflection->getValue(
             $instantiator->instantiate($parentProperty->getDeclaringClass()->getName())
         ));
+    }
+
+    public function testSetValueCanInstantiateObject()
+    {
+        $entity = new Entity();
+        $parentProperty = new ReflectionProperty('Doctrine\Tests\Models\Mapping\Entity', 'embedded');
+        $parentProperty->setAccessible(true);
+        $childProperty = new ReflectionProperty('Doctrine\Tests\Models\Mapping\Embedded', 'foo');
+        $childProperty->setAccessible(true);
+        $embeddedPropertyReflection = new ReflectionEmbeddedProperty(
+            $parentProperty,
+            $childProperty,
+            'Doctrine\Tests\Models\Mapping\Embedded'
+        );
+
+        $embeddedPropertyReflection->setValue($entity, 4);
+
+        $this->assertEquals(4, $entity->getEmbedded()->getFoo());
     }
 
     /**


### PR DESCRIPTION
Recently, ReflectionEmbeddedProperty was updated to extend ReflectionProperty.  This broke any embeddable that extends an abstract class. That's because if a property is defined in the abstract class, <code>$this->class</code> is alway the abstract class and thus cannot be instantiated. The <code>$class</code> parameter that is passed into the constructor needs to be stored, and that class should be instantiated, not the the property's declaring class.
