### PR TITLE
XML export driver: fix the options export

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -206,7 +206,8 @@ class XmlExporter extends AbstractExporter
                 if (isset($field['options'])) {
                     $optionsXml = $fieldXml->addChild('options');
                     foreach ($field['options'] as $key => $value) {
-                        $optionsXml->addAttribute($key, $value);
+                        $optionXml = $optionsXml->addChild('option', $value);
+                        $optionXml->addAttribute('name', $key);
                     }
                 }
 


### PR DESCRIPTION
Currently `Doctrine\ORM\Tools\Export\Driver\XmlExporter` produce next result for the field options (example for `default => 1`):

``` xml
<options default="1" />
```

but `Doctrine\ORM\Mapping\Driver\XmlDriver` expect:

``` xml
<options>
  <option name="default">1</option>
</options>
```

This pull request should fix it :wink:
