### PR TITLE
Very simple refactoring of the setup class

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -164,6 +164,6 @@ class Setup
     {
         $name = 'do' . ucfirst($name);
 
-        return call_user_func_array([new static, $name], $arguments);
+        return call_user_func_array(array(new static, $name), $arguments);
     }
 }

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -42,7 +42,7 @@ class Setup
      *
      * @return void
      */
-    public static function registerAutoloadDirectory($directory)
+    public function doRegisterAutoloadDirectory($directory)
     {
         if (!class_exists('Doctrine\Common\ClassLoader', false)) {
             require_once $directory . "/Doctrine/Common/ClassLoader.php";
@@ -51,7 +51,7 @@ class Setup
         $loader = new ClassLoader("Doctrine", $directory);
         $loader->register();
 
-        $loader = new ClassLoader("Symfony\Component", $directory . "/Doctrine");
+        $loader = new ClassLoader("Symfony\\Component", $directory . "/Doctrine");
         $loader->register();
     }
 
@@ -66,9 +66,9 @@ class Setup
      *
      * @return Configuration
      */
-    public static function createAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null, $useSimpleAnnotationReader = true)
+    public function doCreateAnnotationMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null, $useSimpleAnnotationReader = true)
     {
-        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config = $this->doCreateConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver($paths, $useSimpleAnnotationReader));
 
         return $config;
@@ -84,9 +84,9 @@ class Setup
      *
      * @return Configuration
      */
-    public static function createXMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null)
+    public function doCreateXMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null)
     {
-        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config = $this->doCreateConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new XmlDriver($paths));
 
         return $config;
@@ -102,9 +102,9 @@ class Setup
      *
      * @return Configuration
      */
-    public static function createYAMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null)
+    public function doCreateYAMLMetadataConfiguration(array $paths, $isDevMode = false, $proxyDir = null, Cache $cache = null)
     {
-        $config = self::createConfiguration($isDevMode, $proxyDir, $cache);
+        $config = $this->doCreateConfiguration($isDevMode, $proxyDir, $cache);
         $config->setMetadataDriverImpl(new YamlDriver($paths));
 
         return $config;
@@ -119,7 +119,7 @@ class Setup
      *
      * @return Configuration
      */
-    public static function createConfiguration($isDevMode = false, $proxyDir = null, Cache $cache = null)
+    public function doCreateConfiguration($isDevMode = false, $proxyDir = null, Cache $cache = null)
     {
         $proxyDir = $proxyDir ?: sys_get_temp_dir();
 
@@ -158,5 +158,12 @@ class Setup
         $config->setAutoGenerateProxyClasses($isDevMode);
 
         return $config;
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        $name = 'do' . ucfirst($name);
+
+        return call_user_func_array([new static, $name], $arguments);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -93,12 +93,89 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
     /**
      * @group DDC-3190
      */
-    public function testConfigureCacheCustomInstance()
+    public function testConfigureCacheCustom()
     {
         $cache = $this->getMock('Doctrine\Common\Cache\Cache');
         $cache->expects($this->never())->method('setNamespace');
 
         $config = Setup::createConfiguration(array(), true, $cache);
+
+        $this->assertSame($cache, $config->getResultCacheImpl());
+        $this->assertSame($cache, $config->getMetadataCacheImpl());
+        $this->assertSame($cache, $config->getQueryCacheImpl());
+    }
+
+    public function testDirectoryAutoloadInstance()
+    {
+        $setup = new Setup;
+        $setup->doRegisterAutoloadDirectory(__DIR__ . "/../../../../../vendor/doctrine/common/lib");
+
+        $this->assertEquals($this->originalAutoloaderCount + 2, count(spl_autoload_functions()));
+    }
+
+    public function testAnnotationConfigurationInstance()
+    {
+        $setup = new Setup;
+        $config = $setup->doCreateAnnotationMetadataConfiguration(array(), true);
+
+        $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
+        $this->assertEquals(sys_get_temp_dir(), $config->getProxyDir());
+        $this->assertEquals('DoctrineProxies', $config->getProxyNamespace());
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\AnnotationDriver', $config->getMetadataDriverImpl());
+    }
+
+    public function testXMLConfigurationInstance()
+    {
+        $setup = new Setup;
+        $config = $setup->doCreateXMLMetadataConfiguration(array(), true);
+
+        $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\XmlDriver', $config->getMetadataDriverImpl());
+    }
+
+    public function testYAMLConfigurationInstance()
+    {
+        $setup = new Setup;
+        $config = $setup->doCreateYAMLMetadataConfiguration(array(), true);
+
+        $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\YamlDriver', $config->getMetadataDriverImpl());
+    }
+
+    /**
+     * @group DDC-1350
+     */
+    public function testConfigureProxyDirInstance()
+    {
+        $setup = new Setup;
+        $config = $setup->doCreateAnnotationMetadataConfiguration(array(), true, "/foo");
+        $this->assertEquals('/foo', $config->getProxyDir());
+    }
+
+    /**
+     * @group DDC-1350
+     */
+    public function testConfigureCacheInstance()
+    {
+        $cache = new ArrayCache();
+        $setup = new Setup;
+        $config = $setup->doCreateAnnotationMetadataConfiguration(array(), true, null, $cache);
+
+        $this->assertSame($cache, $config->getResultCacheImpl());
+        $this->assertSame($cache, $config->getMetadataCacheImpl());
+        $this->assertSame($cache, $config->getQueryCacheImpl());
+    }
+
+    /**
+     * @group DDC-3190
+     */
+    public function testConfigureCacheCustomInstance()
+    {
+        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache->expects($this->never())->method('setNamespace');
+
+        $setup = new Setup;
+        $config = $setup->doCreateConfiguration(array(), true, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());
         $this->assertSame($cache, $config->getMetadataCacheImpl());


### PR DESCRIPTION
Moved logic to instance methods.

This way, a project could depend on a Setup class instance (or extend it) and resolve it through a DI container.
 To allow for BC, instance methods were renamed and a `__callStatic` magic method deals with finding them.
 Tests were duplicated to test for static access and instance access.
