### PR TITLE
Embeddables in metadata builder

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -80,6 +80,15 @@ class ClassMetadataBuilder
         return $this;
     }
 
+    /**
+     * Adds and embedded class
+     *
+     * @param string      $fieldName
+     * @param string      $class
+     * @param string|null $columnPrefix
+     *
+     * @return $this
+     */
     public function addEmbedded($fieldName, $class, $columnPrefix = null)
     {
         $this->cm->mapEmbedded(array(

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -62,6 +62,31 @@ class ClassMetadataBuilder
     public function setMappedSuperClass()
     {
         $this->cm->isMappedSuperclass = true;
+        $this->cm->isEmbeddedClass = false;
+
+        return $this;
+    }
+
+    /**
+     * Marks the class as embeddable.
+     *
+     * @return ClassMetadataBuilder
+     */
+    public function setEmbeddable()
+    {
+        $this->cm->isEmbeddedClass = true;
+        $this->cm->isMappedSuperclass = false;
+
+        return $this;
+    }
+
+    public function addEmbedded($fieldName, $class, $columnPrefix = null)
+    {
+        $this->cm->mapEmbedded(array(
+            'fieldName'    => $fieldName,
+            'class'        => $class,
+            'columnPrefix' => $columnPrefix
+        ));
 
         return $this;
     }
@@ -294,6 +319,26 @@ class ClassMetadataBuilder
             array(
                 'fieldName' => $name,
                 'type'      => $type
+            )
+        );
+    }
+
+    /**
+     * Creates an embedded builder.
+     *
+     * @param string $fieldName
+     * @param string $class
+     *
+     * @return EmbeddedBuilder
+     */
+    public function createEmbedded($fieldName, $class)
+    {
+        return new EmbeddedBuilder(
+            $this,
+            array(
+                'fieldName'    => $fieldName,
+                'class'        => $class,
+                'columnPrefix' => null
             )
         );
     }

--- a/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Mapping\Builder;
+
+/**
+ * Embedded Builder
+ *
+ * @license     http://www.opensource.org/licenses/mit-license.php MIT
+ * @link        www.doctrine-project.com
+ * @since       2.5
+ * @author      Guido Contreras Woda <guiwoda@gmail.com>
+ */
+class EmbeddedBuilder
+{
+    /**
+     * @var ClassMetadataBuilder
+     */
+    private $builder;
+
+    /**
+     * @var array
+     */
+    private $mapping;
+
+    /**
+     * @param ClassMetadataBuilder $builder
+     * @param array                $mapping
+     */
+    public function __construct(ClassMetadataBuilder $builder, array $mapping)
+    {
+        $this->builder = $builder;
+        $this->mapping = $mapping;
+    }
+
+    public function setColumnPrefix($columnPrefix)
+    {
+        $this->mapping['columnPrefix'] = $columnPrefix;
+
+        return $this;
+    }
+
+    /**
+     * Finalizes this embeddable and attach it to the ClassMetadata.
+     *
+     * Without this call an EmbeddedBuilder has no effect on the ClassMetadata.
+     *
+     * @return ClassMetadataBuilder
+     */
+    public function build()
+    {
+        $cm = $this->builder->getClassMetadata();
+
+        $cm->mapEmbedded($this->mapping);
+
+        return $this->builder;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
@@ -49,6 +49,12 @@ class EmbeddedBuilder
         $this->mapping = $mapping;
     }
 
+    /**
+     * Sets the column prefix for all of the embedded columns.
+     *
+     * @param string $columnPrefix
+     * @return $this
+     */
     public function setColumnPrefix($columnPrefix)
     {
         $this->mapping['columnPrefix'] = $columnPrefix;

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -48,6 +48,91 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertIsFluent($this->builder->setMappedSuperClass());
         $this->assertTrue($this->cm->isMappedSuperclass);
+        $this->assertFalse($this->cm->isEmbeddedClass);
+    }
+
+    public function testSetEmbedable()
+    {
+        $this->assertIsFluent($this->builder->setEmbeddable());
+        $this->assertTrue($this->cm->isEmbeddedClass);
+        $this->assertFalse($this->cm->isMappedSuperclass);
+    }
+
+    public function testAddEmbeddedWithOnlyRequiredParams()
+    {
+        $this->assertIsFluent(
+            $this->builder->addEmbedded(
+                'name',
+                'Doctrine\Tests\Models\ValueObjects\Name'
+            )
+        );
+
+        $this->assertEquals(array(
+            'name' => array(
+                'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
+                'columnPrefix' => null,
+                'declaredField' => null,
+                'originalField' => null,
+            )
+        ), $this->cm->embeddedClasses);
+    }
+
+    public function testAddEmbeddedWithPrefix()
+    {
+        $this->assertIsFluent(
+            $this->builder->addEmbedded(
+                'name',
+                'Doctrine\Tests\Models\ValueObjects\Name',
+                'nm_'
+            )
+        );
+
+        $this->assertEquals(array(
+            'name' => array(
+                'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
+                'columnPrefix' => 'nm_',
+                'declaredField' => null,
+                'originalField' => null,
+            )
+        ), $this->cm->embeddedClasses);
+    }
+
+    public function testCreateEmbeddedWithoutExtraParams()
+    {
+        $embeddedBuilder = ($this->builder->createEmbedded('name', 'Doctrine\Tests\Models\ValueObjects\Name'));
+        $this->assertInstanceOf('Doctrine\ORM\Mapping\Builder\EmbeddedBuilder', $embeddedBuilder);
+
+        $this->assertFalse(isset($this->cm->embeddedClasses['name']));
+
+        $this->assertIsFluent($embeddedBuilder->build());
+        $this->assertEquals(
+            array(
+                'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
+                'columnPrefix' => null,
+                'declaredField' => null,
+                'originalField' => null
+            ),
+            $this->cm->embeddedClasses['name']
+        );
+    }
+
+    public function testCreateEmbeddedWithColumnPrefix()
+    {
+        $embeddedBuilder = ($this->builder->createEmbedded('name', 'Doctrine\Tests\Models\ValueObjects\Name'));
+
+        $this->assertEquals($embeddedBuilder, $embeddedBuilder->setColumnPrefix('nm_'));
+
+        $this->assertIsFluent($embeddedBuilder->build());
+
+        $this->assertEquals(
+            array(
+                'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
+                'columnPrefix' => 'nm_',
+                'declaredField' => null,
+                'originalField' => null
+            ),
+            $this->cm->embeddedClasses['name']
+        );
     }
 
     public function testSetCustomRepositoryClass()


### PR DESCRIPTION
Embeddables set the `$classMetadata->isEmbeddedClass = true` and sets `$classMetadata->isMappedSuperclass = false`, imitating the `switch` in xml / yml drivers.

Embeddeds have 2 methods, as other types have: `addEmbedded` is a one-off adder with fluent behavior, and `createEmbedded` returns an instance of `EmbeddedBuilder`. The class is very thin right now, but it's a good way to lay ground for improvements on embedded creation in the future.

This one is probably more useful than the last one, @Ocramius ;-)
