### PR TITLE
Refactored construction of the EntityManager out to an EntityManagerFactory

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -144,7 +144,7 @@ use Doctrine\Common\Util\ClassUtils;
      * @param \Doctrine\ORM\Configuration   $config
      * @param \Doctrine\Common\EventManager $eventManager
      */
-    protected function __construct(Connection $conn, Configuration $config, EventManager $eventManager)
+    public function __construct(Connection $conn, Configuration $config, EventManager $eventManager)
     {
         $this->conn              = $conn;
         $this->config            = $config;
@@ -826,28 +826,9 @@ use Doctrine\Common\Util\ClassUtils;
      */
     public static function create($conn, Configuration $config, EventManager $eventManager = null)
     {
-        if ( ! $config->getMetadataDriverImpl()) {
-            throw ORMException::missingMappingDriverImpl();
-        }
+        $emf = new EntityManagerFactory;
 
-        switch (true) {
-            case (is_array($conn)):
-                $conn = \Doctrine\DBAL\DriverManager::getConnection(
-                    $conn, $config, ($eventManager ?: new EventManager())
-                );
-                break;
-
-            case ($conn instanceof Connection):
-                if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
-                     throw ORMException::mismatchedEventManager();
-                }
-                break;
-
-            default:
-                throw new \InvalidArgumentException("Invalid argument: " . $conn);
-        }
-
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return $emf->create($conn, $config, $eventManager);
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManagerFactory.php
+++ b/lib/Doctrine/ORM/EntityManagerFactory.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Common\EventManager;
+
+/**
+ * The EntityManagerFactory is a simple factory object that
+ * encapsulates the logic to create EntityManagers
+ *
+ * @since   2.5
+ * @author  Guido Contreras Woda <guiwoda@gmail.com>
+ *
+ * @todo Dependency Injection of the DriverManager
+ */
+class EntityManagerFactory 
+{
+	public function create($conn, Configuration $config, EventManager $eventManager = null)
+	{
+		if ( ! $config->getMetadataDriverImpl()) {
+			throw ORMException::missingMappingDriverImpl();
+		}
+
+		switch (true) {
+			case (is_array($conn)):
+				$conn = \Doctrine\DBAL\DriverManager::getConnection(
+					$conn, $config, ($eventManager ?: new EventManager())
+				);
+				break;
+
+			case ($conn instanceof Connection):
+				if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
+					throw ORMException::mismatchedEventManager();
+				}
+				break;
+
+			default:
+				throw new \InvalidArgumentException("Invalid argument: " . $conn);
+		}
+
+		return new EntityManager($conn, $config, $conn->getEventManager());
+	}
+}

--- a/lib/Doctrine/ORM/EntityManagerFactory.php
+++ b/lib/Doctrine/ORM/EntityManagerFactory.php
@@ -31,31 +31,33 @@ use Doctrine\Common\EventManager;
  *
  * @todo Dependency Injection of the DriverManager
  */
-class EntityManagerFactory 
+class EntityManagerFactory
 {
-	public function create($conn, Configuration $config, EventManager $eventManager = null)
-	{
-		if ( ! $config->getMetadataDriverImpl()) {
-			throw ORMException::missingMappingDriverImpl();
-		}
+    public function create($conn, Configuration $config, EventManager $eventManager = null)
+    {
+        if (! $config->getMetadataDriverImpl()) {
+            throw ORMException::missingMappingDriverImpl();
+        }
 
-		switch (true) {
-			case (is_array($conn)):
-				$conn = \Doctrine\DBAL\DriverManager::getConnection(
-					$conn, $config, ($eventManager ?: new EventManager())
-				);
-				break;
+        switch (true) {
+            case (is_array($conn)):
+                $conn = \Doctrine\DBAL\DriverManager::getConnection(
+                    $conn,
+                    $config,
+                    ($eventManager?: new EventManager())
+                );
+                break;
 
-			case ($conn instanceof Connection):
-				if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
-					throw ORMException::mismatchedEventManager();
-				}
-				break;
+            case ($conn instanceof Connection):
+                if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
+                    throw ORMException::mismatchedEventManager();
+                }
+                break;
 
-			default:
-				throw new \InvalidArgumentException("Invalid argument: " . $conn);
-		}
+            default:
+                throw new \InvalidArgumentException("Invalid argument: " . $conn);
+        }
 
-		return new EntityManager($conn, $config, $conn->getEventManager());
-	}
+        return new EntityManager($conn, $config, $conn->getEventManager());
+    }
 }

--- a/tests/Doctrine/Tests/ORM/EntityManagerFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\Tests\OrmTestCase;
+use Doctrine\ORM\EntityManagerFactory;
+
+class EntityManagerFactoryTest extends OrmTestCase
+{
+    public function testCreateEntityManager()
+    {
+        $emf = new EntityManagerFactory();
+
+        $config = $this->getMockConfiguration();
+        $conn = $this->getMockConnection(null, $config, null);
+
+        $this->assertInstanceOf('Doctrine\ORM\EntityManagerInterface', $emf->create(
+            $conn,
+            $config,
+            null
+        ));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/EntityManagerFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerFactoryTest.php
@@ -12,7 +12,7 @@ class EntityManagerFactoryTest extends OrmTestCase
         $emf = new EntityManagerFactory();
 
         $config = $this->getMockConfiguration();
-        $conn = $this->getMockConnection(null, $config, null);
+        $conn = $this->getMockDBALConnection(null, $config, null);
 
         $this->assertInstanceOf('Doctrine\ORM\EntityManagerInterface', $emf->create(
             $conn,

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -172,14 +172,14 @@ abstract class OrmTestCase extends DoctrineTestCase
     }
 
     /**
-     * @param $conn
-     * @param $config
-     * @param $eventManager
+     * @param array|\Doctrine\DBAL\Connection $conn
+     * @param \Doctrine\ORM\Configuration $config
+     * @param \Doctrine\Common\EventManager|null $eventManager
      *
      * @return \Doctrine\DBAL\Connection
      * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getMockDBALConnection($conn, $config, $eventManager)
+    protected function getMockDBALConnection($conn, \Doctrine\ORM\Configuration $config, \Doctrine\Common\EventManager $eventManager = null)
     {
         if ($conn === null) {
             $conn = $this->getMockConnectionData();
@@ -193,7 +193,7 @@ abstract class OrmTestCase extends DoctrineTestCase
     }
 
     /**
-     * @param $withSharedMetadata
+     * @param bool $withSharedMetadata
      *
      * @return \Doctrine\ORM\Configuration
      */

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -111,7 +111,7 @@ abstract class OrmTestCase extends DoctrineTestCase
     protected function _getTestEntityManager($conn = null, $conf = null, $eventManager = null, $withSharedMetadata = true)
     {
         $config = $this->getMockConfiguration($withSharedMetadata);
-        $conn = $this->getMockConnection($conn, $config, $eventManager);
+        $conn   = $this->getMockConnection($conn, $config, $eventManager);
 
         return \Doctrine\Tests\Mocks\EntityManagerMock::create($conn, $config, $eventManager);
     }
@@ -156,9 +156,11 @@ abstract class OrmTestCase extends DoctrineTestCase
         }
 
         return $this->secondLevelCacheDriverImpl;
-    }/**
- * @return array
- */
+    }
+
+    /**
+     * @return array
+     */
     protected function getMockConnectionData()
     {
         return array(
@@ -216,8 +218,7 @@ abstract class OrmTestCase extends DoctrineTestCase
             )
         );
 
-        if ($this->isSecondLevelCacheEnabled)
-        {
+        if ($this->isSecondLevelCacheEnabled) {
             $cacheConfig = new \Doctrine\ORM\Cache\CacheConfiguration();
             $cache       = $this->getSharedSecondLevelCacheDriverImpl();
             $factory     = new DefaultCacheFactory($cacheConfig->getRegionsConfiguration(), $cache);

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -111,7 +111,7 @@ abstract class OrmTestCase extends DoctrineTestCase
     protected function _getTestEntityManager($conn = null, $conf = null, $eventManager = null, $withSharedMetadata = true)
     {
         $config = $this->getMockConfiguration($withSharedMetadata);
-        $conn   = $this->getMockConnection($conn, $config, $eventManager);
+        $conn   = $this->getMockDBALConnection($conn, $config, $eventManager);
 
         return \Doctrine\Tests\Mocks\EntityManagerMock::create($conn, $config, $eventManager);
     }
@@ -179,7 +179,7 @@ abstract class OrmTestCase extends DoctrineTestCase
      * @return \Doctrine\DBAL\Connection
      * @throws \Doctrine\DBAL\DBALException
      */
-    protected function getMockConnection($conn, $config, $eventManager)
+    protected function getMockDBALConnection($conn, $config, $eventManager)
     {
         if ($conn === null) {
             $conn = $this->getMockConnectionData();


### PR DESCRIPTION
Added tests for the factory (needed to refactor the OrmTestCase so I could reuse mock config and mock connections).

This pattern is well established in Hibernate, I've been wondering why we don't have it in Doctrine.
