### PR TITLE
Updated setParameters function for not replace all parameters

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -555,7 +555,7 @@ class QueryBuilder
     {
         // BC compatibility with 2.3-
         if (is_array($parameters)) {
-            $parameterCollection = new ArrayCollection();
+            $parameterCollection = $this->parameters;
 
             foreach ($parameters as $key => $value) {
                 $parameter = new Query\Parameter($key, $value);


### PR DESCRIPTION
When you create QueryBuilder and you bind some parameters, if you use setParameters function after bind other parameters, previous parameters are removed(https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/QueryBuilder.php#L558). This would not be a problem if it was the same behaviour with the attribute $_parameterMappings (in ParserResult), but it's not the case, given that it keeps the number of parameters introduced, throwing an exception(https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Query.php#L293). To prevent this, I've made it initialize the setParameters with the existing ones.
