### PR TITLE
Ensure query cache is not ArrayCache in production

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -381,8 +381,14 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function ensureProductionSettings()
     {
-        if ( ! $this->getQueryCacheImpl()) {
+        $queryCacheImpl = $this->getQueryCacheImpl();
+
+        if ( ! $queryCacheImpl) {
             throw ORMException::queryCacheNotConfigured();
+        }
+
+        if ($queryCacheImpl instanceof ArrayCache) {
+            throw ORMException::queryCacheUsesNonPersistentCache($queryCacheImpl);
         }
 
         $metadataCacheImpl = $this->getMetadataCacheImpl();

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -238,6 +238,16 @@ class ORMException extends Exception
      *
      * @return ORMException
      */
+    public static function queryCacheUsesNonPersistentCache(CacheDriver $cache)
+    {
+        return new self('Query Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');
+    }
+
+    /**
+     * @param \Doctrine\Common\Cache\Cache $cache
+     *
+     * @return ORMException
+     */
     public static function metadataCacheUsesNonPersistentCache(CacheDriver $cache)
     {
         return new self('Metadata Cache uses a non-persistent cache driver, ' . get_class($cache) . '.');

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -147,7 +147,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     /**
      * Configures $this->configuration to use production settings.
      *
-     * @param boolean $skipCache Do not configure a cache of this type, either "query" or "metadata".
+     * @param string $skipCache Do not configure a cache of this type, either "query" or "metadata".
      */
     protected function setProductionSettings($skipCache = false)
     {
@@ -181,6 +181,16 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->setProductionSettings('metadata');
         $this->setExpectedException('Doctrine\ORM\ORMException', 'Metadata Cache is not configured.');
+        $this->configuration->ensureProductionSettings();
+    }
+
+    public function testEnsureProductionSettingsQueryArrayCache()
+    {
+        $this->setProductionSettings();
+        $this->configuration->setQueryCacheImpl(new ArrayCache());
+        $this->setExpectedException(
+            'Doctrine\ORM\ORMException',
+            'Query Cache uses a non-persistent cache driver, Doctrine\Common\Cache\ArrayCache.');
         $this->configuration->ensureProductionSettings();
     }
 


### PR DESCRIPTION
This PR applies the same check for the query cache that was done for the metadata cache in #1177 (as suggested by @stof).
