### PR TITLE
Allow dumping SQL query when passing DQL on cli

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -64,6 +64,10 @@ class RunDqlCommand extends Command
             new InputOption(
                 'depth', null, InputOption::VALUE_REQUIRED,
                 'Dumping depth of Entity graph.', 7
+            ),
+            new InputOption(
+                'show-sql', null, InputOption::VALUE_NONE,
+                'Dump generated SQL instead of executing query'
             )
         ))
         ->setHelp(<<<EOT
@@ -114,6 +118,11 @@ EOT
             }
 
             $query->setMaxResults((int) $maxResult);
+        }
+
+        if ($input->hasOption('show-sql')) {
+            Debug::dump($query->getSQL());
+            return;
         }
 
         $resultSet = $query->execute(array(), constant($hydrationMode));


### PR DESCRIPTION
This adds a new commandline option '--show-sql' which will dump out the generated SQL instead of querying the database with query-dql
