### PR TITLE
JoinedSubclassPersister: Consistent return type confirming with interface

### DIFF
--- a/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/JoinedSubclassPersister.php
@@ -127,7 +127,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return;
+            return array();
         }
 
         $postInsertIds  = array();


### PR DESCRIPTION
The BasicEntityPersister always returns an array as specified in the interface. With this change the JoinedSubclassPersister has the same behaviour and strictly follows the interface.

There's no known issue but this PR was for the little monk inside me ;-)
