### PR TITLE
[2.4] Skip public property validation if no reflection class instance present

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -236,18 +236,21 @@ class SchemaValidator
             }
         }
 
-        foreach ($class->reflClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $publicAttr) {
-            if ($publicAttr->isStatic()) {
-                continue;
-            }
+        // Only validate if there is a reflection class instance.
+        if ($class->reflClass instanceof \ReflectionClass) {
+            foreach ($class->reflClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $publicAttr) {
+                if ($publicAttr->isStatic()) {
+                    continue;
+                }
 
-            if ( ! isset($class->fieldMappings[$publicAttr->getName()]) &&
-                ! isset($class->associationMappings[$publicAttr->getName()])) {
-                continue;
-            }
+                if ( ! isset($class->fieldMappings[$publicAttr->getName()]) &&
+                    ! isset($class->associationMappings[$publicAttr->getName()])) {
+                    continue;
+                }
 
-            $ce[] = "Field '".$publicAttr->getName()."' in class '".$class->name."' must be private ".
-                    "or protected. Public fields may break lazy-loading.";
+                $ce[] = "Field '".$publicAttr->getName()."' in class '".$class->name."' must be private ".
+                        "or protected. Public fields may break lazy-loading.";
+            }
         }
 
         foreach ($class->subClasses as $subClass) {

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\SchemaValidator;
 
 /**
@@ -46,5 +47,12 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
             $this->assertEquals(0, count($ce), "Invalid Modelset: " . $modelSet . " class " . $class->name . ": ". implode("\n", $ce));
         }
+    }
+
+    public function testSkipsPublicPropertyValidationIfReflectionClassAbsent()
+    {
+        $validator = new SchemaValidator($this->_em);
+
+        $this->assertEmpty($validator->validateClass(new ClassMetadataInfo('Foo\Bar')));
     }
 }


### PR DESCRIPTION
The schema validator triggers a fatal error if you try to validate a class metadata that does not have the `ClassMetadataInfo::$reflClass` set.
This currently breaks the DoctrineBundle test suite. Therefore it's best to skip that validation part if the property is not set.
