### PR TITLE
Avoid prefixing columns when `false` is assigned to `column-prefix`

### DIFF
--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -141,6 +141,12 @@ directly, set ``columnPrefix=false`` (not yet supported with XML configuration):
               class: Address
               columnPrefix: false
 
+    .. code-block:: xml
+
+        <entity name="User">
+            <embedded name="address" class="Address" use-column-prefix="false" />
+        </entity>
+
 
 DQL
 ---

--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -117,7 +117,7 @@ The following example shows you how to set your prefix to ``myPrefix_``:
               columnPrefix: myPrefix_
 
 To have Doctrine drop the prefix and use the value object's property name
-directly, set ``columnPrefix=false`` (not yet supported with XML configuration):
+directly, set ``columnPrefix=false`` (``use-column-prefix="false"`` for XML):
 
 .. configuration-block::
 

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -304,6 +304,7 @@
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="class" type="xs:string" use="required" />
     <xs:attribute name="column-prefix" type="xs:string" use="optional" />
+    <xs:attribute name="use-column-prefix" type="xs:boolean" default="true" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="discriminator-column">

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -790,7 +790,7 @@ class XmlDriver extends FileDriver
      *
      * @return array The list of cascade options.
      */
-    private function _getCascadeMappings($cascadeElement)
+    private function _getCascadeMappings(SimpleXMLElement $cascadeElement)
     {
         $cascades = array();
         /* @var $action SimpleXmlElement */

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -842,6 +842,6 @@ class XmlDriver extends FileDriver
     {
         $flag = (string)$element;
 
-        return ($flag === true || $flag == "true" || $flag == "1");
+        return ($flag == "true" || $flag == "1");
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -255,11 +255,20 @@ class XmlDriver extends FileDriver
 
         if (isset($xmlRoot->embedded)) {
             foreach ($xmlRoot->embedded as $embeddedMapping) {
+                $columnPrefix = isset($embeddedMapping['column-prefix'])
+                    ? (string) $embeddedMapping['column-prefix']
+                    : null;
+
+                $preventPrefixing = (
+                    $columnPrefix === '0' || $columnPrefix === 'false'
+                );
+
                 $mapping = array(
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
-                    'columnPrefix' => isset($embeddedMapping['column-prefix']) ? (string) $embeddedMapping['column-prefix'] : null,
+                    'columnPrefix' => $preventPrefixing ? false : $columnPrefix
                 );
+
                 $metadata->mapEmbedded($mapping);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -259,14 +259,16 @@ class XmlDriver extends FileDriver
                     ? (string) $embeddedMapping['column-prefix']
                     : null;
 
-                $preventPrefixing = (
-                    $columnPrefix === '0' || $columnPrefix === 'false'
-                );
+                $useColumnPrefix = isset($embeddedMapping['use-column-prefix'])
+                    ? $this->evaluateBoolean(
+                        $embeddedMapping['use-column-prefix']
+                    )
+                    : true;
 
                 $mapping = array(
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
-                    'columnPrefix' => $preventPrefixing ? false : $columnPrefix
+                    'columnPrefix' => !$useColumnPrefix ? false : $columnPrefix
                 );
 
                 $metadata->mapEmbedded($mapping);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -260,15 +260,13 @@ class XmlDriver extends FileDriver
                     : null;
 
                 $useColumnPrefix = isset($embeddedMapping['use-column-prefix'])
-                    ? $this->evaluateBoolean(
-                        $embeddedMapping['use-column-prefix']
-                    )
+                    ? $this->evaluateBoolean($embeddedMapping['use-column-prefix'])
                     : true;
 
                 $mapping = array(
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
-                    'columnPrefix' => !$useColumnPrefix ? false : $columnPrefix
+                    'columnPrefix' => $useColumnPrefix ? $columnPrefix : false
                 );
 
                 $metadata->mapEmbedded($mapping);

--- a/tests/Doctrine/Tests/Models/DDC3293/DDC3293Address.php
+++ b/tests/Doctrine/Tests/Models/DDC3293/DDC3293Address.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3293;
+
+class DDC3293Address
+{
+    public $street;
+    public $city;
+    public $country;
+}

--- a/tests/Doctrine/Tests/Models/DDC3293/DDC3293User.php
+++ b/tests/Doctrine/Tests/Models/DDC3293/DDC3293User.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3293;
+
+class DDC3293User
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var Doctrine\Tests\Models\DDC3293\DDC3293Address
+     */
+    protected $address;
+}

--- a/tests/Doctrine/Tests/Models/DDC3293/DDC3293UserPrefixed.php
+++ b/tests/Doctrine/Tests/Models/DDC3293/DDC3293UserPrefixed.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3293;
+
+class DDC3293UserPrefixed
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var Doctrine\Tests\Models\DDC3293\DDC3293Address
+     */
+    protected $address;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -57,6 +57,25 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $this->assertEquals(true, $class->isEmbeddedClass);
     }
 
+    public function testEmbeddedUseColumnPrefix()
+    {
+        $em = $this->_getTestEntityManager();
+        $em->getConfiguration()->setMetadataDriverImpl($this->_loadDriver());
+
+        $factory = new ClassMetadataFactory();
+        $factory->setEntityManager($em);
+
+        $class = $factory->getMetadataFor('Doctrine\Tests\Models\DDC3293\DDC3293User');
+        $this->assertFalse($class->embeddedClasses['address']['columnPrefix']);
+
+        $class = $factory->getMetadataFor('Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed');
+
+        $this->assertEquals(
+            '__prefix__',
+            $class->embeddedClasses['address']['columnPrefix']
+        );
+    }
+
     public function testEmbeddedMapping()
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\ValueObjects\Person');

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293Address.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293Address.dcm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <embeddable name="Doctrine\Tests\Models\DDC3293\DDC3293Address">
+        <field name="street" type="string" />
+        <field name="city" type="string" />
+        <field name="country" type="string" />
+    </embeddable>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293User.dcm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\DDC3293\DDC3293User" table="user">
+        <id name="id" column="id">
+            <generator strategy="UUID" />
+        </id>
+        <embedded
+            name="address"
+            class="Doctrine\Tests\Models\DDC3293\DDC3293Address"
+            column-prefix="__prefix__"
+            use-column-prefix="false" />
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293UserPrefixed.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293UserPrefixed.dcm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping
+        xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed" table="user">
+        <id name="id" column="id">
+            <generator strategy="UUID" />
+        </id>
+        <embedded
+            name="address"
+            class="Doctrine\Tests\Models\DDC3293\DDC3293Address"
+            column-prefix="__prefix__"
+            use-column-prefix="true" />
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
http://www.doctrine-project.org/jira/browse/DDC-3293

As the issue on JIRA wasn't updated since September/2014, here's a PR.

@Ocramius suggested on [issue](http://www.doctrine-project.org/jira/browse/DDC-3293) about introducing a new attribute called `use-column-prefix`, I'd say that keeping the same attribute as in others drivers would be better.

That's it.
