### PR TITLE
Include IDs in the exception message to ease debugging

### DIFF
--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -30,8 +30,14 @@ class EntityNotFoundException extends ORMException
     /**
      * Constructor.
      */
-    public function __construct($class)
+    public function __construct($class, array $id = array())
     {
-        parent::__construct("Entity of type '{$class}' was not found.");
+        $ids = array();
+        foreach ($id as $key => $value) {
+            $ids[] = "{$key}({$value})";
+        }
+        $idsFormatted = implode(', ', $ids);
+        $message = "Entity of type '" . $class . "'" . ($idsFormatted ? ' for IDs ' . $idsFormatted : '') . ' was not found';
+        parent::__construct($message);
     }
 }

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -28,6 +28,7 @@ use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\ORM\Persisters\EntityPersister;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\ORM\Utility\IdentifierFlattener;
 
 /**
  * This factory is used to create proxy objects for entities at runtime.
@@ -55,6 +56,13 @@ class ProxyFactory extends AbstractProxyFactory
     private $proxyNs;
 
     /**
+     * The IdentifierFlattener used for manipulating identifiers
+     *
+     * @var \Doctrine\ORM\Utility\IdentifierFlattener
+     */
+    private $identifierFlattener;
+
+    /**
      * Initializes a new instance of the <tt>ProxyFactory</tt> class that is
      * connected to the given <tt>EntityManager</tt>.
      *
@@ -71,10 +79,10 @@ class ProxyFactory extends AbstractProxyFactory
         $proxyGenerator->setPlaceholder('baseProxyInterface', 'Doctrine\ORM\Proxy\Proxy');
         parent::__construct($proxyGenerator, $em->getMetadataFactory(), $autoGenerate);
 
-        $this->em      = $em;
-        $this->uow     = $em->getUnitOfWork();
-        $this->proxyNs = $proxyNs;
-
+        $this->em                  = $em;
+        $this->uow                 = $em->getUnitOfWork();
+        $this->proxyNs             = $proxyNs;
+        $this->identifierFlattener = new IdentifierFlattener($this->uow, $em->getMetadataFactory());
     }
 
     /**
@@ -115,8 +123,9 @@ class ProxyFactory extends AbstractProxyFactory
      */
     private function createInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {
+        $identifierFlattener = $this->identifierFlattener;
         if ($classMetadata->getReflectionClass()->hasMethod('__wakeup')) {
-            return function (BaseProxy $proxy) use ($entityPersister, $classMetadata) {
+            return function (BaseProxy $proxy) use ($entityPersister, $classMetadata, $identifierFlattener) {
                 $initializer = $proxy->__getInitializer();
                 $cloner      = $proxy->__getCloner();
 
@@ -138,17 +147,18 @@ class ProxyFactory extends AbstractProxyFactory
                 $proxy->__setInitialized(true);
                 $proxy->__wakeup();
 
-                if (null === $entityPersister->loadById($classMetadata->getIdentifierValues($proxy), $proxy)) {
+                $id = $classMetadata->getIdentifierValues($proxy);
+                if (null === $entityPersister->loadById($id, $proxy)) {
                     $proxy->__setInitializer($initializer);
                     $proxy->__setCloner($cloner);
                     $proxy->__setInitialized(false);
 
-                    throw new EntityNotFoundException($classMetadata->getName());
+                    throw new EntityNotFoundException($classMetadata->getName(), $identifierFlattener->flattenIdentifier($classMetadata, $id));
                 }
             };
         }
 
-        return function (BaseProxy $proxy) use ($entityPersister, $classMetadata) {
+        return function (BaseProxy $proxy) use ($entityPersister, $classMetadata, $identifierFlattener) {
             $initializer = $proxy->__getInitializer();
             $cloner      = $proxy->__getCloner();
 
@@ -169,12 +179,13 @@ class ProxyFactory extends AbstractProxyFactory
 
             $proxy->__setInitialized(true);
 
-            if (null === $entityPersister->loadById($classMetadata->getIdentifierValues($proxy), $proxy)) {
+            $id = $classMetadata->getIdentifierValues($proxy);
+            if (null === $entityPersister->loadById($id, $proxy)) {
                 $proxy->__setInitializer($initializer);
                 $proxy->__setCloner($cloner);
                 $proxy->__setInitialized(false);
 
-                throw new EntityNotFoundException($classMetadata->getName());
+                throw new EntityNotFoundException($classMetadata->getName(), $identifierFlattener->flattenIdentifier($classMetadata, $id));
             }
         };
     }
@@ -191,19 +202,21 @@ class ProxyFactory extends AbstractProxyFactory
      */
     private function createCloner(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {
-        return function (BaseProxy $proxy) use ($entityPersister, $classMetadata) {
+        $identifierFlattener = $this->identifierFlattener;
+        return function (BaseProxy $proxy) use ($entityPersister, $classMetadata, $identifierFlattener) {
             if ($proxy->__isInitialized()) {
                 return;
             }
 
             $proxy->__setInitialized(true);
             $proxy->__setInitializer(null);
- 
+
             $class    = $entityPersister->getClassMetadata();
-            $original = $entityPersister->loadById($classMetadata->getIdentifierValues($proxy));
+            $id       = $classMetadata->getIdentifierValues($proxy);
+            $original = $entityPersister->loadById($id);
 
             if (null === $original) {
-                throw new EntityNotFoundException($classMetadata->getName());
+                throw new EntityNotFoundException($classMetadata->getName(), $identifierFlattener->flattenIdentifier($classMetadata, $id));
             }
 
             foreach ($class->getReflectionClass()->getProperties() as $property) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1834,7 +1834,7 @@ class UnitOfWork implements PropertyChangedListener
                     // If the identifier is ASSIGNED, it is NEW, otherwise an error
                     // since the managed entity was not found.
                     if ( ! $class->isIdentifierNatural()) {
-                        throw new EntityNotFoundException($class->getName());
+                        throw new EntityNotFoundException($class->getName(), $this->identifierFlattener->flattenIdentifier($class, $id));
                     }
 
                     $managedCopy = $this->newInstance($class);


### PR DESCRIPTION
Include IDs in the exception message of the EntityNotFoundException to ease debugging.
