### PR TITLE
Lazy-load on a per-property base (removes doctrine proxies, replaced by ProxyManager)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4",
+        "php": "~7.0",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
-        "doctrine/common": ">=2.5-dev,<2.7-dev",
         "doctrine/cache": "~1.4",
         "symfony/console": "~2.5|~3.0"
+        "ocramius/proxy-manager": "~2.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/cache": "~1.4",
-        "symfony/console": "~2.5|~3.0"
+        "symfony/console": "~2.5|~3.0",
         "ocramius/proxy-manager": "~2.0"
     },
     "require-dev": {

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -26,9 +26,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Query;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Default query cache implementation.
@@ -264,7 +264,7 @@ class DefaultQueryCache implements QueryCache
                 $metadata = $this->em->getClassMetadata($rsm->aliasMap[$rsm->parentAliasMap[$alias]]);
                 $assoc = $metadata->associationMappings[$name];
 
-                if (($assocValue = $metadata->getFieldValue($entity, $name)) === null || $assocValue instanceof Proxy) {
+                if (($assocValue = $metadata->getFieldValue($entity, $name)) === null || $assocValue instanceof GhostObjectInterface) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -28,7 +28,6 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostLoadEventDispatcher;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Proxy\Proxy;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 /**

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -29,6 +29,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\PostLoadEventDispatcher;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Proxy\Proxy;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * The ObjectHydrator constructs an object graph out of an SQL result set.
@@ -430,7 +431,7 @@ class ObjectHydrator extends AbstractHydrator
                     // PATH B: Single-valued association
                     $reflFieldValue = $reflField->getValue($parentObject);
 
-                    if ( ! $reflFieldValue || isset($this->_hints[Query::HINT_REFRESH]) || ($reflFieldValue instanceof Proxy && !$reflFieldValue->__isInitialized__)) {
+                    if ( ! $reflFieldValue || isset($this->_hints[Query::HINT_REFRESH]) || ($reflFieldValue instanceof GhostObjectInterface && !$reflFieldValue->isProxyInitialized())) {
                         // we only need to take action if this value is null,
                         // we refresh the entity or its an unitialized proxy.
                         if (isset($nonemptyComponents[$dqlAlias])) {

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -20,7 +20,6 @@
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Utility\PersisterHelper;

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -25,6 +25,8 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\EntityManager;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Use this logger to dump the identity map during the onFlush event. This is useful for debugging
@@ -103,7 +105,7 @@ class DebugUnitOfWorkListener
                         if ($value === null) {
                             fwrite($fh, " NULL\n");
                         } else {
-                            if ($value instanceof Proxy && !$value->__isInitialized()) {
+                            if ($value instanceof GhostObjectInterface && !$value->isProxyInitialized()) {
                                 fwrite($fh, "[PROXY] ");
                             }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1884,8 +1884,8 @@ class UnitOfWork implements PropertyChangedListener
             $visited[$oid] = $managedCopy; // mark visited
 
             if ($this->isLoaded($entity)) {
-                if ($managedCopy instanceof Proxy && ! $managedCopy->__isInitialized()) {
-                    $managedCopy->__load();
+                if ($managedCopy instanceof GhostObjectInterface) {
+                    $managedCopy->initializeProxy();
                 }
 
                 $this->mergeEntityStateIntoManagedCopy($entity, $managedCopy);
@@ -1917,7 +1917,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function isLoaded($entity)
     {
-        return !($entity instanceof Proxy) || $entity->__isInitialized();
+        return !($entity instanceof GhostObjectInterface) || $entity->isProxyInitialized();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -690,8 +690,10 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->getSingleResult();
 
         $this->assertInstanceOf(GhostObjectInterface::class, $address2->getUser());
+        $this->assertFalse($userRef->isProxyInitialized());
         $this->assertTrue($userRef === $address2->getUser());
         $this->assertFalse($userRef->isProxyInitialized());
+        $this->assertSame($userRef, $address2->getUser());
         $this->assertEquals('Germany', $address2->country);
         $this->assertEquals('Berlin', $address2->city);
         $this->assertEquals('12345', $address2->zip);

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -10,6 +10,7 @@ use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsComment;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -688,9 +689,9 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 ->setParameter('user', $userRef)
                 ->getSingleResult();
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $address2->getUser());
+        $this->assertInstanceOf(GhostObjectInterface::class, $address2->getUser());
         $this->assertTrue($userRef === $address2->getUser());
-        $this->assertFalse($userRef->__isInitialized__);
+        $this->assertFalse($userRef->isProxyInitialized());
         $this->assertEquals('Germany', $address2->country);
         $this->assertEquals('Berlin', $address2->city);
         $this->assertEquals('12345', $address2->zip);
@@ -999,8 +1000,8 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
                              ->setParameter(1, $article->id)
                              ->setFetchMode('Doctrine\Tests\Models\CMS\CmsArticle', 'user', \Doctrine\ORM\Mapping\ClassMetadata::FETCH_EAGER)
                              ->getSingleResult();
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $article->user, "It IS a proxy, ...");
-        $this->assertTrue($article->user->__isInitialized__, "...but its initialized!");
+        $this->assertInstanceOf(GhostObjectInterface::class, $article->user, "It IS a proxy, ...");
+        $this->assertTrue($article->user->isProxyInitialized(), "...but its initialized!");
         $this->assertEquals($qc+2, $this->getCurrentQueryCount());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -12,6 +12,7 @@ use Doctrine\Tests\Models\Company\CompanyPerson,
     Doctrine\Tests\Models\Company\CompanyCar;
 
 use Doctrine\Common\Collections\Criteria;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Functional tests for the Class Table Inheritance mapping strategy.
@@ -421,7 +422,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $ref = $this->_em->getReference('Doctrine\Tests\Models\Company\CompanyManager', $manager->getId());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $ref, "A proxy can be generated only if no subclasses exists for the requested reference.");
+        $this->assertInstanceOf(GhostObjectInterface::class, $ref, "A proxy can be generated only if no subclasses exists for the requested reference.");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -35,7 +35,7 @@ class DefaultValuesTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user2 = $this->_em->getReference(get_class($user), $userId);
 
         $this->_em->flush();
-        $this->assertFalse($user2->__isInitialized__);
+        $this->assertFalse($user2->isProxyInitialized());
 
         $a = new DefaultValueAddress;
         $a->country = 'de';
@@ -47,7 +47,7 @@ class DefaultValuesTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($a);
         $this->_em->flush();
 
-        $this->assertFalse($user2->__isInitialized__);
+        $this->assertFalse($user2->isProxyInitialized());
         $this->_em->clear();
 
         $a2 = $this->_em->find(get_class($a), $a->id);

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -146,13 +146,13 @@ class DetachedEntityTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $address2 = $this->_em->find(get_class($address), $address->id);
         $this->assertInstanceOf(GhostObjectInterface::class, $address2->user);
         $this->assertFalse($address2->user->isProxyInitialized());
-        $detachedAddress2 = unserialize(serialize($address2));
-        $this->assertInstanceOf(GhostObjectInterface::class, $detachedAddress2->user);
-        $this->assertFalse($detachedAddress2->user->isProxyInitialized());
+        $this->_em->detach($address2);
+        $this->assertInstanceOf(GhostObjectInterface::class, $address2->user);
+        $this->assertFalse($address2->user->isProxyInitialized());
 
-        $managedAddress2 = $this->_em->merge($detachedAddress2);
+        $managedAddress2 = $this->_em->merge($address2);
         $this->assertInstanceOf(GhostObjectInterface::class, $managedAddress2->user);
-        $this->assertFalse($managedAddress2->user === $detachedAddress2->user);
+        $this->assertSame($managedAddress2->user, $address2->user);
         $this->assertFalse($managedAddress2->user->isProxyInitialized());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -7,6 +7,7 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\ORM\UnitOfWork;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Description of DetachedEntityTest
@@ -143,16 +144,16 @@ class DetachedEntityTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $address2 = $this->_em->find(get_class($address), $address->id);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $address2->user);
-        $this->assertFalse($address2->user->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $address2->user);
+        $this->assertFalse($address2->user->isProxyInitialized());
         $detachedAddress2 = unserialize(serialize($address2));
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $detachedAddress2->user);
-        $this->assertFalse($detachedAddress2->user->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $detachedAddress2->user);
+        $this->assertFalse($detachedAddress2->user->isProxyInitialized());
 
         $managedAddress2 = $this->_em->merge($detachedAddress2);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $managedAddress2->user);
+        $this->assertInstanceOf(GhostObjectInterface::class, $managedAddress2->user);
         $this->assertFalse($managedAddress2->user === $detachedAddress2->user);
-        $this->assertFalse($managedAddress2->user->__isInitialized__);
+        $this->assertFalse($managedAddress2->user->isProxyInitialized());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * MappedSuperclassTest
@@ -37,7 +38,7 @@ class MappedSuperclassTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $cleanFile = $this->_em->find(get_class($file), $file->getId());
 
         $this->assertInstanceOf('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $cleanFile->getParent());
+        $this->assertInstanceOf(GhostObjectInterface::class, $cleanFile->getParent());
         $this->assertEquals($directory->getId(), $cleanFile->getParent()->getId());
         $this->assertInstanceOf('Doctrine\Tests\Models\DirectoryTree\Directory', $cleanFile->getParent()->getParent());
         $this->assertEquals($root->getId(), $cleanFile->getParent()->getParent()->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class MergeProxiesTest extends OrmFunctionalTestCase
 {
@@ -78,7 +79,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         $this->assertSame($managed, $this->_em->merge($managed));
 
-        $this->assertFalse($managed->__isInitialized());
+        $this->assertFalse($managed->isProxyInitialized());
     }
 
     /**
@@ -100,7 +101,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
 
         $managed = $this->_em->getReference(DateTimeModel::CLASSNAME, $date->id);
 
-        $this->assertInstanceOf('Doctrine\Common\Proxy\Proxy', $managed);
+        $this->assertInstanceOf(GhostObjectInterface::class, $managed);
         $this->assertFalse($managed->__isInitialized());
 
         $date->date = $dateTime = new \DateTime();
@@ -198,9 +199,9 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         $unManagedProxy = $em1->getReference(DateTimeModel::CLASSNAME, $file1->id);
         $mergedInstance = $em2->merge($unManagedProxy);
 
-        $this->assertNotInstanceOf('Doctrine\Common\Proxy\Proxy', $mergedInstance);
+        $this->assertNotInstanceOf(GhostObjectInterface::class, $mergedInstance);
         $this->assertNotSame($unManagedProxy, $mergedInstance);
-        $this->assertFalse($unManagedProxy->__isInitialized());
+        $this->assertFalse($unManagedProxy->isProxyInitialized());
 
         $this->assertCount(
             $queryCount1,
@@ -213,7 +214,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
             'Loading the merged instance was done via the second entity manager'
         );
 
-        $unManagedProxy->__load();
+        $unManagedProxy->initializeProxy();
 
         $this->assertCount(
             $queryCount1 + 1,

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceFeature;
 use Doctrine\Common\Collections\Criteria;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Tests a bidirectional one-to-one association mapping (without inheritance).
@@ -111,12 +112,13 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
         $query = $this->_em->createQuery('select f from Doctrine\Tests\Models\ECommerce\ECommerceFeature f');
         $features = $query->getResult();
 
+        /* @var $product GhostObjectInterface|ECommerceProduct */
         $product = $features[0]->getProduct();
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $product);
+        $this->assertInstanceOf(GhostObjectInterface::class, $product);
         $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $product);
-        $this->assertFalse($product->__isInitialized__);
+        $this->assertFalse($product->isProxyInitialized());
         $this->assertSame('Doctrine Cookbook', $product->getName());
-        $this->assertTrue($product->__isInitialized__);
+        $this->assertTrue($product->isProxyInitialized());
     }
 
     public function testLazyLoadsObjectsOnTheInverseSide2()

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -49,7 +49,7 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         // Considering case (a)
         $proxy = $this->_em->getProxyFactory()->getProxy('Doctrine\Tests\Models\CMS\CmsUser', array('id' => 123));
-        $proxy->__isInitialized__ = true;
+        $proxy->setProxyInitializer(null);
         $proxy->id = null;
         $proxy->username = 'ocra';
         $proxy->name = 'Marco';
@@ -70,13 +70,13 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testEntityWithIdentifier()
     {
         $userId = $this->user->getId();
-        /* @var $uninitializedProxy \Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser */
+        /* @var $uninitializedProxy \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\CMS\CmsUser */
         $uninitializedProxy = $this->_em->getReference('Doctrine\Tests\Models\CMS\CmsUser', $userId);
         $this->assertInstanceOf('Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser', $uninitializedProxy);
 
         $this->_em->persist($uninitializedProxy);
         $this->_em->flush($uninitializedProxy);
-        $this->assertFalse($uninitializedProxy->__isInitialized(), 'Proxy didn\'t get initialized during flush operations');
+        $this->assertFalse($uninitializedProxy->isProxyInitialized(), 'Proxy didn\'t get initialized during flush operations');
         $this->assertEquals($userId, $uninitializedProxy->getId());
         $this->_em->remove($uninitializedProxy);
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -11,6 +11,7 @@ use Doctrine\Tests\Models\CMS\CmsUser,
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Functional Query tests.
@@ -426,8 +427,8 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(1, count($result));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsArticle', $result[0]);
         $this->assertEquals("dr. dolittle", $result[0]->topic);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[0]->user);
-        $this->assertFalse($result[0]->user->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $result[0]->user);
+        $this->assertFalse($result[0]->user->isProxyInitialized());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Proxy\ProxyClassGenerator;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceShipping;
 use Doctrine\Tests\Models\Company\CompanyAuction;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Tests the generation of a proxy object for lazy loading.
@@ -230,12 +231,12 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\ECommerce\ECommerceProduct */
         $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
         $className = \Doctrine\Common\Util\ClassUtils::getClass($entity);
 
-        $this->assertInstanceOf('Doctrine\Common\Persistence\Proxy', $entity);
-        $this->assertFalse($entity->__isInitialized());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entity);
+        $this->assertFalse($entity->isProxyInitialized());
         $this->assertEquals('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $className);
 
         $restName = str_replace($this->_em->getConfiguration()->getProxyNamespace(), "", get_class($entity));
@@ -243,7 +244,7 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace("\\", "", $restName) . ".php";
         $this->assertTrue(file_exists($proxyFileName), "Proxy file name cannot be found generically.");
 
-        $entity->__load();
-        $this->assertTrue($entity->__isInitialized());
+        $entity->initializeProxy();
+        $this->assertTrue($entity->isProxyInitialized());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -94,14 +94,15 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
-        $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
+        /* @var $entity ECommerceProduct */
+        $entity = $this->_em->getReference(ECommerceProduct::class , $id);
 
-        /* @var $clone Doctrine\Tests\Models\ECommerce\ECommerceProduct */
         $clone = clone $entity;
 
         $this->assertEquals($id, $entity->getId());
         $this->assertEquals('Doctrine Cookbook', $entity->getName());
+
+        $this->markTestIncomplete('To be carefully verified');
 
         $this->assertFalse($this->_em->contains($clone), "Cloning a reference proxy should return an unmanaged/detached entity.");
         $this->assertEquals($id, $clone->getId(), "Cloning a reference proxy should return same id.");
@@ -143,23 +144,6 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
         $this->assertEquals('Doctrine 2 Cookbook', $entity->getName());
-    }
-
-    /**
-     * @group DDC-1022
-     */
-    public function testWakeupCalledOnProxy()
-    {
-        $id = $this->createProduct();
-
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
-        $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
-
-        $this->assertFalse($entity->wakeUp);
-
-        $entity->setName('Doctrine 2 Cookbook');
-
-        $this->assertTrue($entity->wakeUp, "Loading the proxy should call __wakeup().");
     }
 
     public function testDoNotInitializeProxyOnGettingTheIdentifier()
@@ -239,7 +223,6 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($entity->isProxyInitialized());
         $this->assertEquals('Doctrine\Tests\Models\ECommerce\ECommerceProduct', $className);
 
-        $restName = str_replace($this->_em->getConfiguration()->getProxyNamespace(), "", get_class($entity));
         $restName = substr(get_class($entity), strlen($this->_em->getConfiguration()->getProxyNamespace()) +1);
         $proxyFileName = $this->_em->getConfiguration()->getProxyDir() . DIRECTORY_SEPARATOR . str_replace("\\", "", $restName) . ".php";
         $this->assertTrue(file_exists($proxyFileName), "Proxy file name cannot be found generically.");

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -118,12 +118,12 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\ECommerce\ECommerceProduct */
         $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
 
-        $this->assertFalse($entity->__isInitialized__, "Pre-Condition: Object is unitialized proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         $this->_em->getUnitOfWork()->initializeObject($entity);
-        $this->assertTrue($entity->__isInitialized__, "Should be initialized after called UnitOfWork::initializeObject()");
+        $this->assertTrue($entity->isProxyInitialized(), "Should be initialized after called UnitOfWork::initializeObject()");
     }
 
     /**
@@ -165,12 +165,12 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\ECommerce\ECommerceProduct */
         $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
 
-        $this->assertFalse($entity->__isInitialized__, "Pre-Condition: Object is unitialized proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         $this->assertEquals($id, $entity->getId());
-        $this->assertFalse($entity->__isInitialized__, "Getting the identifier doesn't initialize the proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Getting the identifier doesn't initialize the proxy.");
     }
 
     /**
@@ -180,12 +180,12 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createAuction();
 
-        /* @var $entity Doctrine\Tests\Models\Company\CompanyAuction */
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\Company\CompanyAuction */
         $entity = $this->_em->getReference('Doctrine\Tests\Models\Company\CompanyAuction' , $id);
 
-        $this->assertFalse($entity->__isInitialized__, "Pre-Condition: Object is unitialized proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         $this->assertEquals($id, $entity->getId());
-        $this->assertFalse($entity->__isInitialized__, "Getting the identifier doesn't initialize the proxy when extending.");
+        $this->assertFalse($entity->isProxyInitialized(), "Getting the identifier doesn't initialize the proxy when extending.");
     }
     
     public function testDoNotInitializeProxyOnGettingTheIdentifierAndReturnTheRightType()
@@ -201,26 +201,26 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $id = $shipping->getId();
-
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|ECommerceProduct */
         $product = $this->_em->getRepository('Doctrine\Tests\Models\ECommerce\ECommerceProduct')->find($product->getId());
 
         $entity = $product->getShipping();
-        $this->assertFalse($entity->__isInitialized__, "Pre-Condition: Object is unitialized proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         $this->assertEquals($id, $entity->getId());
         $this->assertSame($id, $entity->getId(), "Check that the id's are the same value, and type.");
-        $this->assertFalse($entity->__isInitialized__, "Getting the identifier doesn't initialize the proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Getting the identifier doesn't initialize the proxy.");
     }
 
     public function testInitializeProxyOnGettingSomethingOtherThanTheIdentifier()
     {
         $id = $this->createProduct();
 
-        /* @var $entity Doctrine\Tests\Models\ECommerce\ECommerceProduct */
+        /* @var $entity \ProxyManager\Proxy\GhostObjectInterface|ECommerceProduct */
         $entity = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct' , $id);
 
-        $this->assertFalse($entity->__isInitialized__, "Pre-Condition: Object is unitialized proxy.");
+        $this->assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         $this->assertEquals('Doctrine Cookbook', $entity->getName());
-        $this->assertTrue($entity->__isInitialized__, "Getting something other than the identifier initializes the proxy.");
+        $this->assertTrue($entity->isProxyInitialized(), "Getting something other than the identifier initializes the proxy.");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -871,7 +871,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->assertNotNull($state2->getCountry());
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state2);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $state2->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $state2->getCountry());
         $this->assertEquals($countryName, $state2->getCountry()->getName());
         $this->assertEquals($stateId, $state2->getId());
     }
@@ -962,7 +962,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state2);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $state2->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $state2->getCountry());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\City', $state2->getCities()->get(0));
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state2->getCities()->get(0)->getState());
         $this->assertSame($state2, $state2->getCities()->get(0)->getState());

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Cache;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2183
@@ -852,7 +853,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->assertNotNull($state1->getCountry());
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state1);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $state1->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $state1->getCountry());
         $this->assertEquals($countryName, $state1->getCountry()->getName());
         $this->assertEquals($stateId, $state1->getId());
 
@@ -944,7 +945,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state1);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $state1->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $state1->getCountry());
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\City', $state1->getCities()->get(0));
         $this->assertInstanceOf('Doctrine\Tests\Models\Cache\State', $state1->getCities()->get(0)->getState());
         $this->assertSame($state1, $state1->getCities()->get(0)->getState());

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -212,8 +212,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->assertInstanceOf(State::CLASSNAME, $entities[1]);
         $this->assertInstanceOf(Country::CLASSNAME, $entities[0]->getCountry());
         $this->assertInstanceOf(Country::CLASSNAME, $entities[1]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[0]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[1]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[0]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[1]->getCountry());
 
         // invalidate cache
         $this->_em->persist(new State('foo', $this->_em->find(Country::CLASSNAME, $this->countries[0]->getId())));
@@ -231,8 +231,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->assertInstanceOf(State::CLASSNAME, $entities[1]);
         $this->assertInstanceOf(Country::CLASSNAME, $entities[0]->getCountry());
         $this->assertInstanceOf(Country::CLASSNAME, $entities[1]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[0]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[1]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[0]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[1]->getCountry());
 
         // load from cache
         $queryCount = $this->getCurrentQueryCount();
@@ -245,7 +245,7 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->assertInstanceOf(State::CLASSNAME, $entities[1]);
         $this->assertInstanceOf(Country::CLASSNAME, $entities[0]->getCountry());
         $this->assertInstanceOf(Country::CLASSNAME, $entities[1]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[0]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[1]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[0]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[1]->getCountry());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Tests\Models\Cache\State;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2183
@@ -197,8 +198,8 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         $this->assertInstanceOf(State::CLASSNAME, $entities[1]);
         $this->assertInstanceOf(Country::CLASSNAME, $entities[0]->getCountry());
         $this->assertInstanceOf(Country::CLASSNAME, $entities[0]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[0]->getCountry());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $entities[1]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[0]->getCountry());
+        $this->assertInstanceOf(GhostObjectInterface::class, $entities[1]->getCountry());
 
         // load from cache
         $queryCount = $this->getCurrentQueryCount();

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\Collections\Criteria;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -389,7 +390,7 @@ class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $ref = $this->_em->getReference('Doctrine\Tests\Models\Company\CompanyFixContract', $this->fix->getId());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $ref, "A proxy can be generated only if no subclasses exists for the requested reference.");
+        $this->assertInstanceOf(GhostObjectInterface::class, $ref, "A proxy can be generated only if no subclasses exists for the requested reference.");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-1163
@@ -69,7 +70,7 @@ class DDC1163Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $specialProduct = $this->_em->find(__NAMESPACE__ . '\\DDC1163SpecialProduct', $this->productId);
 
         $this->assertInstanceOf(__NAMESPACE__.'\\DDC1163SpecialProduct', $specialProduct);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $specialProduct);
+        $this->assertInstanceOf(GhostObjectInterface::class, $specialProduct);
 
         $specialProduct->setSubclassProperty('foobar');
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -41,7 +41,7 @@ class DDC1193Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $company = $this->_em->find(get_class($company), $companyId);
 
         $this->assertTrue($this->_em->getUnitOfWork()->isInIdentityMap($company), "Company is in identity map.");
-        $this->assertFalse($company->member->__isInitialized__, "Pre-Condition");
+        $this->assertFalse($company->member->isProxyInitialized(), "Pre-Condition");
         $this->assertTrue($this->_em->getUnitOfWork()->isInIdentityMap($company->member), "Member is in identity map.");
 
         $this->_em->remove($company);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -38,9 +38,9 @@ class DDC1228Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $user = $this->_em->find(__NAMESPACE__ . '\\DDC1228User', $user->id);
 
-        $this->assertFalse($user->getProfile()->__isInitialized__, "Proxy is not initialized");
+        $this->assertFalse($user->getProfile()->isProxyInitialized(), "Proxy is not initialized");
         $user->getProfile()->setName("Bar");
-        $this->assertTrue($user->getProfile()->__isInitialized__, "Proxy is not initialized");
+        $this->assertTrue($user->getProfile()->isProxyInitialized(), "Proxy is not initialized");
 
         $this->assertEquals("Bar", $user->getProfile()->getName());
         $this->assertEquals(array("id" => 1, "name" => "Foo"), $this->_em->getUnitOfWork()->getOriginalEntityData($user->getProfile()));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
@@ -45,7 +45,7 @@ class DDC1392Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $file = $picture->getFile();
 
         // With this activated there will be no problem
-        //$file->__load();
+        //$file->isProxyInitialized();
 
         $picture->setFile(null);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\UnitOfWork;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-1452
@@ -46,7 +47,7 @@ class DDC1452Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $results = $this->_em->createQuery($dql)->setMaxResults(1)->getResult();
 
         $this->assertSame($results[0], $results[0]->entitiesB[0]->entityAFrom);
-        $this->assertFalse( $results[0]->entitiesB[0]->entityATo instanceof \Doctrine\ORM\Proxy\Proxy );
+        $this->assertFalse($results[0]->entitiesB[0]->entityATo instanceof GhostObjectInterface);
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $results[0]->entitiesB[0]->entityATo->getEntitiesB());
     }
 
@@ -74,12 +75,12 @@ class DDC1452Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $data = $this->_em->createQuery($dql)->getResult();
         $this->_em->clear();
 
-        $this->assertFalse($data[0]->user instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertFalse($data[0]->user instanceof GhostObjectInterface);
 
         $dql = "SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.address a";
         $data = $this->_em->createQuery($dql)->getResult();
 
-        $this->assertFalse($data[0]->address instanceof \Doctrine\ORM\Proxy\Proxy);
+        $this->assertFalse($data[0]->address instanceof GhostObjectInterface);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -56,7 +56,7 @@ class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
             'Verifying that $child is a proxy before using proxy API'
         );
         $this->assertCount(0, $child->listeners);
-        $child->__load();
+        $child->initializeProxy();
         $this->assertCount(1, $child->listeners);
         unset($parent, $child);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\NotifyPropertyChanged,
     Doctrine\Common\PropertyChangedListener;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -50,7 +51,7 @@ class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertEquals(1, count($parent->listeners));
         $this->assertInstanceOf(
-            'Doctrine\\ORM\\Proxy\\Proxy',
+            GhostObjectInterface::class,
             $child,
             'Verifying that $child is a proxy before using proxy API'
         );

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\CMS\CmsGroup;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -31,8 +32,8 @@ class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $proxy = $this->getProxy($group);
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $proxy);
-        $this->assertFalse($proxy->__isInitialized());
+        $this->assertInstanceOf(GhostObjectInterface::class, $proxy);
+        $this->assertFalse($proxy->isProxyInitialized());
 
         $this->_em->detach($proxy);
         $this->_em->clear();
@@ -61,8 +62,8 @@ class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $proxy = $this->getProxy($group);
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $proxy);
-        $this->assertFalse($proxy->__isInitialized());
+        $this->assertInstanceOf(GhostObjectInterface::class, $proxy);
+        $this->assertFalse($proxy->isProxyInitialized());
 
         $this->_em->detach($proxy);
         $serializedProxy = serialize($proxy);
@@ -75,7 +76,7 @@ class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
     /**
      * @param object $object
      *
-     * @return \Doctrine\Common\Proxy\Proxy
+     * @return \ProxyManager\Proxy\GhostObjectInterface
      */
     private function getProxy($object)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -6,6 +6,7 @@ use Doctrine\Common\NotifyPropertyChanged;
 use Doctrine\Common\PropertyChangedListener;
 use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2230
@@ -40,11 +41,11 @@ class DDC2230Test extends OrmFunctionalTestCase
 
         $mergedUser = $this->_em->merge($user);
 
-        /* @var $address \Doctrine\Common\Proxy\Proxy */
+        /* @var $address GhostObjectInterface */
         $address = $mergedUser->address;
 
-        $this->assertInstanceOf('Doctrine\\ORM\\Proxy\\Proxy', $address);
-        $this->assertFalse($address->__isInitialized());
+        $this->assertInstanceOf(GhostObjectInterface::class, $address);
+        $this->assertFalse($address->isProxyInitialized());
     }
 
     public function testNotifyTrackingCalledOnProxyInitialization()
@@ -57,11 +58,11 @@ class DDC2230Test extends OrmFunctionalTestCase
 
         $addressProxy = $this->_em->getReference(__NAMESPACE__ . '\\DDC2230Address', $insertedAddress->id);
 
-        /* @var $addressProxy \Doctrine\Common\Proxy\Proxy|\Doctrine\Tests\ORM\Functional\Ticket\DDC2230Address */
-        $this->assertFalse($addressProxy->__isInitialized());
+        /* @var $addressProxy GhostObjectInterface|\Doctrine\Tests\ORM\Functional\Ticket\DDC2230Address */
+        $this->assertFalse($addressProxy->isProxyInitialized());
         $this->assertNull($addressProxy->listener);
 
-        $addressProxy->__load();
+        $addressProxy->initializeProxy();
 
         $this->assertSame($this->_em->getUnitOfWork(), $addressProxy->listener);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -36,7 +36,10 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $id = $y1ref->doSomething();
 
-        $this->assertTrue($y1ref->isProxyInitialized());
+        $this->assertFalse($y1ref->isProxyInitialized());
+
+        $y1ref->initializeProxy();
+
         $this->assertEquals($this->_em, $y1ref->om);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectManagerAware;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2231
@@ -30,12 +31,12 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $y1ref = $this->_em->getReference(get_class($y1), $y1->id);
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $y1ref);
-        $this->assertFalse($y1ref->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $y1ref);
+        $this->assertFalse($y1ref->isProxyInitialized());
 
         $id = $y1ref->doSomething();
 
-        $this->assertTrue($y1ref->__isInitialized__);
+        $this->assertTrue($y1ref->isProxyInitialized());
         $this->assertEquals($this->_em, $y1ref->om);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -55,7 +55,7 @@ class DDC2306Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         /* @var $address DDC2306Address */
         $address = $this->_em->find(__NAMESPACE__ . '\\DDC2306Address', $address->id);
-        /* @var $user DDC2306User|\Doctrine\ORM\Proxy\Proxy */
+        /* @var $user DDC2306User|GhostObjectInterface */
         $user    = $address->users->first()->user;
 
         $this->assertInstanceOf(GhostObjectInterface::class, $user);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2306
@@ -57,7 +58,7 @@ class DDC2306Test extends \Doctrine\Tests\OrmFunctionalTestCase
         /* @var $user DDC2306User|\Doctrine\ORM\Proxy\Proxy */
         $user    = $address->users->first()->user;
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $user);
+        $this->assertInstanceOf(GhostObjectInterface::class, $user);
         $this->assertInstanceOf(__NAMESPACE__ . '\\DDC2306User', $user);
 
         $userId = $user->id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -65,7 +65,7 @@ class DDC2306Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertNotNull($userId);
 
-        $user->__load();
+        $user->isProxyInitialized();
 
         $this->assertEquals(
             $userId,

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use ProxyManager\Proxy\GhostObjectInterface;
+
 class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()
@@ -35,16 +37,16 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $x2 = $this->_em->find(get_class($x), $x->id); // proxy injected for Y
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $x2->y);
-        $this->assertFalse($x2->y->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $x2->y);
+        $this->assertFalse($x2->y->isProxyInitialized());
 
         // proxy for Y is in identity map
 
         $z2 = $this->_em->createQuery('select z,y from ' . get_class($z) . ' z join z.y y where z.id = ?1')
                 ->setParameter(1, $z->id)
                 ->getSingleResult();
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $z2->y);
-        $this->assertTrue($z2->y->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $z2->y);
+        $this->assertTrue($z2->y->isProxyInitialized());
         $this->assertEquals('Y', $z2->y->data);
         $this->assertEquals($y->id, $z2->y->id);
 
@@ -54,7 +56,7 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertNotSame($x, $x2);
         $this->assertNotSame($z, $z2);
         $this->assertSame($z2->y, $x2->y);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $z2->y);
+        $this->assertInstanceOf(GhostObjectInterface::class, $z2->y);
 
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -50,20 +50,20 @@ class DDC2494Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $queryCount = $this->getCurrentQueryCount();
 
         $this->assertInstanceOf(GhostObjectInterface::class, $item->getCurrency());
-        $this->assertFalse($item->getCurrency()->__isInitialized());
+        $this->assertFalse($item->getCurrency()->isProxyInitialized());
 
         $this->assertArrayHasKey('convertToPHPValue', DDC2494TinyIntType::$calls);
         $this->assertCount(1, DDC2494TinyIntType::$calls['convertToPHPValue']);
 
         $this->assertInternalType('integer', $item->getCurrency()->getId());
         $this->assertCount(1, DDC2494TinyIntType::$calls['convertToPHPValue']);
-        $this->assertFalse($item->getCurrency()->__isInitialized());
+        $this->assertFalse($item->getCurrency()->isProxyInitialized());
 
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
 
         $this->assertInternalType('integer', $item->getCurrency()->getTemp());
         $this->assertCount(3, DDC2494TinyIntType::$calls['convertToPHPValue']);
-        $this->assertTrue($item->getCurrency()->__isInitialized());
+        $this->assertTrue($item->getCurrency()->isProxyInitialized());
 
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2494
@@ -48,7 +49,7 @@ class DDC2494Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $queryCount = $this->getCurrentQueryCount();
 
-        $this->assertInstanceOf('\Doctrine\Common\Proxy\Proxy', $item->getCurrency());
+        $this->assertInstanceOf(GhostObjectInterface::class, $item->getCurrency());
         $this->assertFalse($item->getCurrency()->__isInitialized());
 
         $this->assertArrayHasKey('convertToPHPValue', DDC2494TinyIntType::$calls);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Legacy\LegacyUser;
 use Doctrine\Tests\Models\Legacy\LegacyUserReference;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2519
@@ -37,15 +38,15 @@ class DDC2519Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertInstanceOf('Doctrine\Tests\Models\Legacy\LegacyUser', $result[1]->source());
         $this->assertInstanceOf('Doctrine\Tests\Models\Legacy\LegacyUser', $result[1]->target());
 
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[0]->source());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[0]->target());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[1]->source());
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $result[1]->target());
+        $this->assertInstanceOf(GhostObjectInterface::class, $result[0]->source());
+        $this->assertInstanceOf(GhostObjectInterface::class, $result[0]->target());
+        $this->assertInstanceOf(GhostObjectInterface::class, $result[1]->source());
+        $this->assertInstanceOf(GhostObjectInterface::class, $result[1]->target());
 
-        $this->assertFalse($result[0]->target()->__isInitialized());
-        $this->assertFalse($result[0]->source()->__isInitialized());
-        $this->assertFalse($result[1]->target()->__isInitialized());
-        $this->assertFalse($result[1]->source()->__isInitialized());
+        $this->assertFalse($result[0]->target()->isProxyInitialized());
+        $this->assertFalse($result[0]->source()->isProxyInitialized());
+        $this->assertFalse($result[1]->target()->isProxyInitialized());
+        $this->assertFalse($result[1]->source()->isProxyInitialized());
 
         $this->assertNotNull($result[0]->source()->getId());
         $this->assertNotNull($result[0]->target()->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Company\CompanyPerson;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * Tests that join columns (foreign keys) can be named the same as the association
@@ -60,8 +61,8 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $fkt2 = $this->_em->find(get_class($fkt), $fkt->id);
         $this->assertEquals($fkt->cart->id, $fkt2->cartId);
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $fkt2->cart);
-        $this->assertFalse($fkt2->cart->__isInitialized__);
+        $this->assertInstanceOf(GhostObjectInterface::class, $fkt2->cart);
+        $this->assertFalse($fkt2->cart->isProxyInitialized());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -64,8 +65,8 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $appointments = $this->_em->createQuery("SELECT a FROM " . __NAMESPACE__ . "\DDC633Appointment a")->getResult();
 
         foreach ($appointments AS $eagerAppointment) {
-            $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $eagerAppointment->patient);
-            $this->assertTrue($eagerAppointment->patient->__isInitialized__, "Proxy should already be initialized due to eager loading!");
+            $this->assertInstanceOf(GhostObjectInterface::class, $eagerAppointment->patient);
+            $this->assertTrue($eagerAppointment->patient->isProxyInitialized(), "Proxy should already be initialized due to eager loading!");
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -6,6 +6,7 @@ use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST;
+use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -70,7 +71,7 @@ class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         /* @var $cart2 Doctrine\Tests\Models\ECommerce\ECommerceCart */
         $cart2 = $result[0][0];
-        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $cart2->getCustomer());
+        $this->assertInstanceOf(GhostObjectInterface::class, $cart2->getCustomer());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
@@ -68,18 +68,16 @@ class ProxyPerformanceTest extends OrmPerformanceTestCase
     {
         $em              = new MockEntityManager($this->_getEntityManager());
         $proxyFactory    = $em->getProxyFactory();
-        /* @var $user \Doctrine\Common\Proxy\Proxy */
         $user            = $proxyFactory->getProxy($entityName, array('id' => 1));
-        $initializer     = $user->__getInitializer();
+        $initializer     = $user->getProxyInitializer();
 
         $this->setMaxRunningTime(5);
         $start = microtime(true);
 
         for ($i = 0; $i < 100000;  $i += 1) {
-            $user->__setInitialized(false);
-            $user->__setInitializer($initializer);
-            $user->__load();
-            $user->__load();
+            $user->setProxyInitializer($initializer);
+            $user->initializeProxy();
+            $user->initializeProxy();
         }
 
         echo __FUNCTION__ . " - " . (microtime(true) - $start) . " seconds with " . $entityName . PHP_EOL;

--- a/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
@@ -20,7 +20,6 @@
 namespace Doctrine\Tests\ORM\Performance;
 
 use Doctrine\Tests\OrmPerformanceTestCase;
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Proxy\ProxyFactory;

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -91,7 +91,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
-        /* @var $proxy \Doctrine\Common\Proxy\Proxy */
+        /* @var $proxy \ProxyManager\Proxy\GhostObjectInterface|\Doctrine\Tests\Models\ECommerce\ECommerceFeature */
         $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', array('id' => 42));
 
         $persister
@@ -105,9 +105,9 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         } catch (EntityNotFoundException $exception) {
         }
 
-        $this->assertFalse($proxy->__isInitialized());
-        $this->assertInstanceOf('Closure', $proxy->__getInitializer(), 'The initializer wasn\'t removed');
-        $this->assertInstanceOf('Closure', $proxy->__getCloner(), 'The cloner wasn\'t removed');
+        $this->assertFalse($proxy->isProxyInitialized());
+        $this->assertInstanceOf('Closure', $proxy->getProxyInitializer(), 'The initializer wasn\'t removed');
+        //$this->assertInstanceOf('Closure', $proxy->__getCloner(), 'The cloner wasn\'t removed');
     }
 
     /**
@@ -118,7 +118,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
-        /* @var $proxy \Doctrine\Common\Proxy\Proxy */
+        /* @var $proxy \ProxyManager\Proxy\GhostObjectInterface */
         $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', array('id' => 42));
 
         $persister
@@ -132,9 +132,9 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         } catch (EntityNotFoundException $exception) {
         }
 
-        $this->assertFalse($proxy->__isInitialized());
-        $this->assertInstanceOf('Closure', $proxy->__getInitializer(), 'The initializer wasn\'t removed');
-        $this->assertInstanceOf('Closure', $proxy->__getCloner(), 'The cloner wasn\'t removed');
+        $this->assertFalse($proxy->isProxyInitialized());
+        $this->assertInstanceOf('Closure', $proxy->getProxyInitializer(), 'The initializer wasn\'t removed');
+        //$this->assertInstanceOf('Closure', $proxy->__getCloner(), 'The cloner wasn\'t removed');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\ORM\Proxy;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;


### PR DESCRIPTION
This is just a proof of concept that I hacked together real quick.

This changes how proxies are generated and lazy-loaded in a very radical way:
- method calls do not cause lazy-loading
- lazy-loading is triggered by access to non-transient properties (things that need to be lazy-loaded)
- access to identifiers or non-mapped properties won't cause lazy-loading
- you can now use `$class = get_class($proxy); $object = new $class();` without any side-effects, as the constructor logic is preserved

Following BC breaks need to be fixed or discussed before going forward on this idea:
- [x] proxies don't implement `Doctrine\Common\Proxy\Proxy` anymore, but `ProxyManager\Proxy\GhostObjectInterface` ~~(BC break, needs fixing, can be easily done with some effort)~~ BC break is voluntary
- [x] `serialize($proxy)` now causes proxy initialization ~~(probably needs fixing, as this is a major BC break)~~ - BC break is voluntary

Pending TODOs:
- [ ] cloning a proxy is still not fully supported (requires dedicated logic in `__clone`)
- [ ] this is just a PoC, so the code that writes proxies to disk is not yet in place
- [ ] hhvm compatibility (Ocramius/ProxyManager#210, facebook/hhvm#4560)
- [x] ProxyManager 2.0.0 is required first (release highly depends on this issue)
- [ ] Lots of dead code to remove

To give you an example, it is impossible (without reflection) to cause lazy-loading for the following class:

``` php
class Counter
{
    private $id;
    private $otherUnrelatedThing;
    public function doThings() { /* empty body (on purpose) */ }
}
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/doctrine/doctrine2/1241)

<!-- Reviewable:end -->
