### PR TITLE
Include className in calls to NamingStrategy joinColumnName method

### DIFF
--- a/docs/en/reference/namingstrategy.rst
+++ b/docs/en/reference/namingstrategy.rst
@@ -78,7 +78,7 @@ a "naming standard" for database tables and columns.
      * @param string $propertyName A property
      * @return string A join column name
      */
-    function joinColumnName($propertyName);
+    function joinColumnName($propertyName, $className = null);
 
     /**
      * Return a join table name
@@ -124,7 +124,7 @@ You need to implements NamingStrategy first. Following is an example
         {
             return 'id';
         }
-        public function joinColumnName($propertyName)
+        public function joinColumnName($propertyName, $className = null)
         {
             return $propertyName . '_' . $this->referenceColumnName();
         }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1552,7 +1552,7 @@ class ClassMetadataInfo implements ClassMetadata
             if ( ! isset($mapping['joinColumns']) || ! $mapping['joinColumns']) {
                 // Apply default join column
                 $mapping['joinColumns'] = array(array(
-                    'name' => $this->namingStrategy->joinColumnName($mapping['fieldName']),
+                    'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                     'referencedColumnName' => $this->namingStrategy->referenceColumnName()
                 ));
             }
@@ -1570,7 +1570,7 @@ class ClassMetadataInfo implements ClassMetadata
                 }
 
                 if (empty($joinColumn['name'])) {
-                    $joinColumn['name'] = $this->namingStrategy->joinColumnName($mapping['fieldName']);
+                    $joinColumn['name'] = $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name);
                 }
 
                 if (empty($joinColumn['referencedColumnName'])) {

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -69,7 +69,7 @@ class DefaultNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinColumnName($propertyName)
+    public function joinColumnName($propertyName, $className = null)
     {
         return $propertyName . '_' . $this->referenceColumnName();
     }

--- a/lib/Doctrine/ORM/Mapping/JoinColumnClassNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnClassNamingStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Mapping;
+
+/**
+ * The default NamingStrategy
+ *
+ * 
+ * @link    www.doctrine-project.org
+ * @since   2.3
+ * @author  Fabio B. Silva <fabio.bat.silva@gmail.com>
+ */
+class JoinColumnClassNamingStrategy extends DefaultNamingStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function joinColumnName($propertyName, $className = null)
+    {
+        return strtolower($this->classToTableName($className)) . '_' . $propertyName . '_' . $this->referenceColumnName();
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -70,6 +70,7 @@ interface NamingStrategy
      * Returns a join column name for a property.
      *
      * @param string $propertyName A property name.
+     * @param string|null $className    The fully-qualified class name.
      *
      * @return string A join column name.
      */

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -73,7 +73,7 @@ interface NamingStrategy
      *
      * @return string A join column name.
      */
-    function joinColumnName($propertyName);
+    function joinColumnName($propertyName, $className = null);
 
     /**
      * Returns a join table name.

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -106,7 +106,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinColumnName($propertyName)
+    public function joinColumnName($propertyName, $className = null)
     {
         return $this->underscore($propertyName) . '_' . $this->referenceColumnName();
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\ORM\Mapping\JoinColumnClassNamingStrategy;
 use Doctrine\ORM\Mapping\NamingStrategy;
 
 /**
@@ -17,6 +18,14 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
     static private function defaultNaming()
     {
         return new DefaultNamingStrategy();
+    }
+
+    /**
+     * @return JoinColumnClassNamingStrategy
+     */
+    static private function joinColumnClassNaming()
+    {
+        return new JoinColumnClassNamingStrategy();
     }
 
     /**
@@ -176,6 +185,14 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
             array(self::underscoreNamingUpper(), 'SOME_COLUMN_ID',
                 'someColumn', null,
             ),
+
+            // JoinColumnClassNamingStrategy
+            array(self::joinColumnClassNaming(), 'classname_someColumn_id',
+                'someColumn', 'Some\ClassName',
+            ),
+            array(self::joinColumnClassNaming(), 'classname_some_column_id',
+                'some_column', 'ClassName',
+            ),
         );
     }
 
@@ -186,9 +203,9 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      * @param string $expected
      * @param string $propertyName
      */
-    public function testJoinColumnName(NamingStrategy $strategy, $expected, $propertyName)
+    public function testJoinColumnName(NamingStrategy $strategy, $expected, $propertyName, $className = null)
     {
-        $this->assertEquals($expected, $strategy->joinColumnName($propertyName));
+        $this->assertEquals($expected, $strategy->joinColumnName($propertyName, $className));
     }
 
     /**


### PR DESCRIPTION
For consistency with `propertyToColumnName`, include the class name when generating names for join columns as well, for instances where you want to name columns (inc. join columns) based on the class that defined them.
