### PR TITLE
DDC-3493 - fixed EntityGenerator parsing for php 5.5 "::class" syntax

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -827,7 +827,7 @@ public function __construct(<params>)
             if ($token[0] == T_NAMESPACE) {
                 $lastSeenNamespace = "";
                 $inNamespace = true;
-            } elseif ($token[0] == T_CLASS) {
+            } elseif ($token[0] == T_CLASS && $tokens[$i-1][0] != T_DOUBLE_COLON) {
                 $inClass = true;
             } elseif ($token[0] == T_FUNCTION) {
                 if ($tokens[$i+2][0] == T_STRING) {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1035,6 +1035,16 @@ class
      ',
                 array('Foo\Bar\Baz'),
             ),
+            array(
+                '
+<?php namespace Foo\Bar; class Baz {
+    public static function someMethod(){
+        return self::class;
+    }
+}
+',
+                array('Foo\Bar\Baz'),
+            ),
         );
     }
 


### PR DESCRIPTION
I did not check for `$i > 0` because at least a php opening tag is needed for the src to be valid PHP, so the class token can never be at index 0 (it can be at index 1 at the very least, e.g. `<?class Foo ...`. Please let me know if you think I should add that check anyway.

See pull request #1250.
