### PR TITLE
Classify persisters into more granular namespaces.

### DIFF
--- a/lib/Doctrine/ORM/Cache/CacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/CacheFactory.php
@@ -22,9 +22,8 @@ namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
-
-use Doctrine\ORM\Persisters\CollectionPersister;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 /**
  * Contract for building second level cache regions components.
@@ -37,22 +36,22 @@ interface CacheFactory
     /**
      * Build an entity persister for the given entity metadata.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface     $em        The entity manager.
-     * @param \Doctrine\ORM\Persisters\EntityPersister $persister The entity persister that will be cached.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata      $metadata  The entity metadata.
+     * @param \Doctrine\ORM\EntityManagerInterface            $em        The entity manager.
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister The entity persister that will be cached.
+     * @param \Doctrine\ORM\Mapping\ClassMetadata             $metadata  The entity metadata.
      *
-     * @return \Doctrine\ORM\Cache\Persister\CachedEntityPersister
+     * @return \Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister
      */
     public function buildCachedEntityPersister(EntityManagerInterface $em, EntityPersister $persister, ClassMetadata $metadata);
 
     /**
      * Build a collection persister for the given relation mapping.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface         $em        The entity manager.
-     * @param \Doctrine\ORM\Persisters\CollectionPersister $persister The collection persister that will be cached.
-     * @param array                                        $mapping   The association mapping.
+     * @param \Doctrine\ORM\EntityManagerInterface                    $em        The entity manager.
+     * @param \Doctrine\ORM\Persisters\Collection\CollectionPersister $persister The collection persister that will be cached.
+     * @param array                                                   $mapping   The association mapping.
      *
-     * @return \Doctrine\ORM\Cache\Persister\CachedCollectionPersister
+     * @return \Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister
      */
     public function buildCachedCollectionPersister(EntityManagerInterface $em, CollectionPersister $persister, array $mapping);
 

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -29,14 +29,14 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache\Region\FileLockRegion;
 use Doctrine\ORM\Cache\Region\UpdateTimestampCache;
-use Doctrine\ORM\Persisters\EntityPersister;
-use Doctrine\ORM\Persisters\CollectionPersister;
-use Doctrine\ORM\Cache\Persister\ReadOnlyCachedEntityPersister;
-use Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister;
-use Doctrine\ORM\Cache\Persister\ReadOnlyCachedCollectionPersister;
-use Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister;
-use Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedEntityPersister;
-use Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedCollectionPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\Cache\Persister\Entity\ReadOnlyCachedEntityPersister;
+use Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister;
+use Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister;
+use Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister;
+use Doctrine\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersister;
+use Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister;
 
 /**
  * @since   2.5

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -18,12 +18,12 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\CollectionCacheKey;
-use Doctrine\ORM\Persisters\CollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Cache\Region;
@@ -46,7 +46,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     protected $metadataFactory;
 
     /**
-     * @var \Doctrine\ORM\Persisters\CollectionPersister
+     * @var \Doctrine\ORM\Persisters\Collection\CollectionPersister
      */
     protected $persister;
 
@@ -91,10 +91,10 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     protected $cacheLogger;
 
     /**
-     * @param \Doctrine\ORM\Persisters\CollectionPersister $persister   The collection persister that will be cached.
-     * @param \Doctrine\ORM\Cache\Region                   $region      The collection region.
-     * @param \Doctrine\ORM\EntityManagerInterface         $em          The entity manager.
-     * @param array                                        $association The association mapping.
+     * @param \Doctrine\ORM\Persisters\Collection\CollectionPersister $persister   The collection persister that will be cached.
+     * @param \Doctrine\ORM\Cache\Region                              $region      The collection region.
+     * @param \Doctrine\ORM\EntityManagerInterface                    $em          The entity manager.
+     * @param array                                                   $association The association mapping.
      */
     public function __construct(CollectionPersister $persister, Region $region, EntityManagerInterface $em, array $association)
     {

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
@@ -18,10 +18,11 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;
-use Doctrine\ORM\Persisters\CollectionPersister;
+use Doctrine\ORM\Cache\Persister\CachedPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\PersistentCollection;
 
 /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -18,7 +18,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\PersistentCollection;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
@@ -18,24 +18,27 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Collection;
 
+use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Cache\CacheException;
 use Doctrine\Common\Util\ClassUtils;
 
 /**
- * Specific read-only region entity persister
- *
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  * @since 2.5
  */
-class ReadOnlyCachedEntityPersister extends NonStrictReadWriteCachedEntityPersister
+class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollectionPersister
 {
-    /**
+     /**
      * {@inheritdoc}
      */
-    public function update($entity)
+    public function update(PersistentCollection $collection)
     {
-        throw CacheException::updateReadOnlyEntity(ClassUtils::getClass($entity));
+        if ($collection->isDirty() && count($collection->getSnapshot()) > 0) {
+            throw CacheException::updateReadOnlyCollection(ClassUtils::getClass($collection->getOwner()), $this->association['fieldName']);
+        }
+
+        parent::update($collection);
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -18,11 +18,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Collection;
 
-use Doctrine\ORM\Persisters\CollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\EntityManagerInterface;
-
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\PersistentCollection;
@@ -34,10 +33,10 @@ use Doctrine\ORM\PersistentCollection;
 class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {
     /**
-     * @param \Doctrine\ORM\Persisters\CollectionPersister $persister   The collection persister that will be cached.
-     * @param \Doctrine\ORM\Cache\ConcurrentRegion         $region      The collection region.
-     * @param \Doctrine\ORM\EntityManagerInterface         $em          The entity manager.
-     * @param array                                        $association The association mapping.
+     * @param \Doctrine\ORM\Persisters\Collection\CollectionPersister $persister   The collection persister that will be cached.
+     * @param \Doctrine\ORM\Cache\ConcurrentRegion                    $region      The collection region.
+     * @param \Doctrine\ORM\EntityManagerInterface                    $em          The entity manager.
+     * @param array                                                   $association The association mapping.
      */
     public function __construct(CollectionPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, array $association)
     {

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -18,7 +18,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Cache\Region;
@@ -26,10 +26,11 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\TimestampCacheKey;
 use Doctrine\ORM\Cache\QueryCacheKey;
+use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Common\Collections\Criteria;
@@ -51,7 +52,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     protected $metadataFactory;
 
     /**
-     * @var \Doctrine\ORM\Persisters\EntityPersister
+     * @var \Doctrine\ORM\Persisters\Entity\EntityPersister
      */
     protected $persister;
 
@@ -108,10 +109,10 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     protected $joinedAssociations;
 
     /**
-     * @param \Doctrine\ORM\Persisters\EntityPersister $persister The entity persister to cache.
-     * @param \Doctrine\ORM\Cache\Region               $region    The entity cache region.
-     * @param \Doctrine\ORM\EntityManagerInterface     $em        The entity manager.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata      $class     The entity metadata.
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister The entity persister to cache.
+     * @param \Doctrine\ORM\Cache\Region                      $region    The entity cache region.
+     * @param \Doctrine\ORM\EntityManagerInterface            $em        The entity manager.
+     * @param \Doctrine\ORM\Mapping\ClassMetadata             $class     The entity metadata.
      */
     public function __construct(EntityPersister $persister, Region $region, EntityManagerInterface $em, ClassMetadata $class)
     {

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
@@ -18,27 +18,29 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Entity;
 
-use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\Cache\CacheException;
-use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\Cache\EntityCacheKey;
+use Doctrine\ORM\Cache\Persister\CachedPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 /**
+ * Interface for second level cache entity persisters.
+ *
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  * @since 2.5
  */
-class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollectionPersister
+interface CachedEntityPersister extends CachedPersister, EntityPersister
 {
-     /**
-     * {@inheritdoc}
+    /**
+     * @return \Doctrine\ORM\Cache\EntityHydrator
      */
-    public function update(PersistentCollection $collection)
-    {
-        if ($collection->isDirty() && count($collection->getSnapshot()) > 0) {
-            throw CacheException::updateReadOnlyCollection(ClassUtils::getClass($collection->getOwner()), $this->association['fieldName']);
-        }
+    public function getEntityHydrator();
 
-        parent::update($collection);
-    }
+    /**
+     * @param  object                             $entity
+     * @param  \Doctrine\ORM\Cache\EntityCacheKey $key
+     * @return boolean
+     */
+    public function storeEntityCache($entity, EntityCacheKey $key);
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -18,7 +18,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Cache\EntityCacheKey;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
@@ -18,28 +18,24 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Entity;
 
-use Doctrine\ORM\Cache\EntityCacheKey;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Cache\CacheException;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
- * Interface for second level cache entity persisters.
+ * Specific read-only region entity persister
  *
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
  * @since 2.5
  */
-interface CachedEntityPersister extends CachedPersister, EntityPersister
+class ReadOnlyCachedEntityPersister extends NonStrictReadWriteCachedEntityPersister
 {
     /**
-     * @return \Doctrine\ORM\Cache\EntityHydrator
+     * {@inheritdoc}
      */
-    public function getEntityHydrator();
-
-    /**
-     * @param  object                             $entity
-     * @param  \Doctrine\ORM\Cache\EntityCacheKey $key
-     * @return boolean
-     */
-    public function storeEntityCache($entity, EntityCacheKey $key);
+    public function update($entity)
+    {
+        throw CacheException::updateReadOnlyEntity(ClassUtils::getClass($entity));
+    }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -18,12 +18,11 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Cache\Persister;
+namespace Doctrine\ORM\Cache\Persister\Entity;
 
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
-
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\EntityCacheKey;
 
@@ -36,10 +35,10 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 class ReadWriteCachedEntityPersister extends AbstractEntityPersister
 {
     /**
-     * @param \Doctrine\ORM\Persister\EntityPersister $persister The entity persister to cache.
-     * @param \Doctrine\ORM\Cache\ConcurrentRegion    $region    The entity cache region.
-     * @param \Doctrine\ORM\EntityManagerInterface    $em        The entity manager.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata     $class     The entity metadata.
+     * @param \Doctrine\ORM\Persister\Entity\EntityPersister $persister The entity persister to cache.
+     * @param \Doctrine\ORM\Cache\ConcurrentRegion           $region    The entity cache region.
+     * @param \Doctrine\ORM\EntityManagerInterface           $em        The entity manager.
+     * @param \Doctrine\ORM\Mapping\ClassMetadata            $class     The entity metadata.
      */
     public function __construct(EntityPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, ClassMetadata $class)
     {

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -23,8 +23,8 @@ use Doctrine\Common\Collections\AbstractLazyCollection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
-use Doctrine\ORM\Persisters\BasicEntityPersister;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 /**
  * A lazy collection that allow a fast count when using criteria object

--- a/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;

--- a/lib/Doctrine/ORM/Persisters/Collection/CollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/CollectionPersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -17,10 +17,12 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Persisters\SqlExpressionVisitor;
+use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -17,11 +17,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
-use Doctrine\ORM\UnitOfWork;
 
 /**
  * Persister for one-to-many collections.

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
@@ -31,6 +31,8 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Persisters\SqlExpressionVisitor;
+use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMapping;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -17,7 +17,7 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\ORM\Persisters;
+namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -25,6 +25,7 @@ use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 
 /**
  * Visit Expressions and generate SQL WHERE conditions from them.
@@ -35,7 +36,7 @@ use Doctrine\Common\Collections\Expr\CompositeExpression;
 class SqlExpressionVisitor extends ExpressionVisitor
 {
     /**
-     * @var \Doctrine\ORM\Persisters\BasicEntityPersister
+     * @var \Doctrine\ORM\Persisters\Entity\BasicEntityPersister
      */
     private $persister;
 
@@ -45,7 +46,8 @@ class SqlExpressionVisitor extends ExpressionVisitor
     private $classMetadata;
 
     /**
-     * @param \Doctrine\ORM\Persisters\BasicEntityPersister $persister
+     * @param \Doctrine\ORM\Persisters\Entity\BasicEntityPersister $persister
+     * @param \Doctrine\ORM\Mapping\ClassMetadata                  $classMetadata
      */
     public function __construct(BasicEntityPersister $persister, ClassMetadata $classMetadata)
     {

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -25,7 +25,7 @@ use Doctrine\Common\Proxy\ProxyDefinition;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Common\Proxy\Proxy as BaseProxy;
 use Doctrine\Common\Proxy\ProxyGenerator;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Utility\IdentifierFlattener;
@@ -115,7 +115,7 @@ class ProxyFactory extends AbstractProxyFactory
      * Creates a closure capable of initializing a proxy
      *
      * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $classMetadata
-     * @param \Doctrine\ORM\Persisters\EntityPersister           $entityPersister
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister    $entityPersister
      *
      * @return \Closure
      *
@@ -201,7 +201,7 @@ class ProxyFactory extends AbstractProxyFactory
      * Creates a closure capable of finalizing state a cloned proxy
      *
      * @param \Doctrine\Common\Persistence\Mapping\ClassMetadata $classMetadata
-     * @param \Doctrine\ORM\Persisters\EntityPersister           $entityPersister
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister    $entityPersister
      *
      * @return \Closure
      *

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -41,11 +41,11 @@ use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\ListenersInvoker;
 
 use Doctrine\ORM\Cache\Persister\CachedPersister;
-use Doctrine\ORM\Persisters\BasicEntityPersister;
-use Doctrine\ORM\Persisters\SingleTablePersister;
-use Doctrine\ORM\Persisters\JoinedSubclassPersister;
-use Doctrine\ORM\Persisters\OneToManyPersister;
-use Doctrine\ORM\Persisters\ManyToManyPersister;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Entity\SingleTablePersister;
+use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
+use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
+use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 
 /**
@@ -3040,7 +3040,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param string $entityName The name of the Entity.
      *
-     * @return \Doctrine\ORM\Persisters\EntityPersister
+     * @return \Doctrine\ORM\Persisters\Entity\EntityPersister
      */
     public function getEntityPersister($entityName)
     {
@@ -3084,7 +3084,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param array $association
      *
-     * @return \Doctrine\ORM\Persisters\CollectionPersister
+     * @return \Doctrine\ORM\Persisters\Collection\CollectionPersister
      */
     public function getCollectionPersister(array $association)
     {

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace Doctrine\Tests\Mocks;
+
 use Doctrine\Common\Collections\Criteria;
 
 /**
  * EntityPersister implementation used for mocking during tests.
  */
-class EntityPersisterMock extends \Doctrine\ORM\Persisters\BasicEntityPersister
+class EntityPersisterMock extends \Doctrine\ORM\Persisters\Entity\BasicEntityPersister
 {
     /**
      * @var array

--- a/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
+++ b/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
@@ -42,8 +42,8 @@ class UnitOfWorkMock extends \Doctrine\ORM\UnitOfWork
      * Sets a (mock) persister for an entity class that will be returned when
      * getEntityPersister() is invoked for that class.
      *
-     * @param string                                        $entityName
-     * @param \Doctrine\ORM\Persisters\BasicEntityPersister $persister
+     * @param string                                               $entityName
+     * @param \Doctrine\ORM\Persisters\Entity\BasicEntityPersister $persister
      *
      * @return void
      */

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -7,8 +7,8 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\ConcurrentRegionMock;
-use Doctrine\ORM\Persisters\BasicEntityPersister;
-use Doctrine\ORM\Persisters\OneToManyPersister;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
 use Doctrine\ORM\Cache\RegionsConfiguration;
 
 /**
@@ -67,8 +67,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
         
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\ReadOnlyCachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\ReadOnlyCachedEntityPersister', $cachedPersister);
     }
 
     public function testBuildCachedEntityPersisterReadWrite()
@@ -88,8 +88,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', $cachedPersister);
     }
 
     public function testBuildCachedEntityPersisterNonStrictReadWrite()
@@ -109,8 +109,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $cachedPersister = $this->factory->buildCachedEntityPersister($em, $persister, $metadata);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersister', $cachedPersister);
     }
 
     public function testBuildCachedCollectionPersisterReadOnly()
@@ -132,8 +132,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedCollectionPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\ReadOnlyCachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister', $cachedPersister);
     }
 
     public function testBuildCachedCollectionPersisterReadWrite()
@@ -154,8 +154,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedCollectionPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', $cachedPersister);
     }
 
     public function testBuildCachedCollectionPersisterNonStrictReadWrite()
@@ -176,8 +176,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $cachedPersister = $this->factory->buildCachedCollectionPersister($em, $persister, $mapping);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedCollectionPersister', $cachedPersister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister', $cachedPersister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister', $cachedPersister);
     }
 
     public function testInheritedEntityCacheRegion()
@@ -192,8 +192,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $cachedPersister1 = $factory->buildCachedEntityPersister($em, $persister1, $metadata1);
         $cachedPersister2 = $factory->buildCachedEntityPersister($em, $persister2, $metadata2);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister1);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister2);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister1);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister2);
 
         $this->assertNotSame($cachedPersister1, $cachedPersister2);
         $this->assertSame($cachedPersister1->getCacheRegion(), $cachedPersister2->getCacheRegion());
@@ -211,8 +211,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $cachedPersister1 = $factory->buildCachedEntityPersister($em, $persister1, $metadata1);
         $cachedPersister2 = $factory->buildCachedEntityPersister($em, $persister2, $metadata2);
 
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister1);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $cachedPersister2);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister1);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $cachedPersister2);
 
         $this->assertNotSame($cachedPersister1, $cachedPersister2);
         $this->assertNotSame($cachedPersister1->getCacheRegion(), $cachedPersister2->getCacheRegion());

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\Tests\OrmTestCase;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Persisters\CollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -22,7 +22,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     protected $region;
 
     /**
-     * @var \Doctrine\ORM\Persisters\CollectionPersister
+     * @var \Doctrine\ORM\Persisters\Collection\CollectionPersister
      */
     protected $collectionPersister;
 
@@ -60,12 +60,12 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     );
 
     /**
-     * @param \Doctrine\ORM\EntityManager                   $em
-     * @param \Doctrine\ORM\Persisters\CollectionPersister  $persister
-     * @param \Doctrine\ORM\Cache\Region                    $region
-     * @param array                                         $mapping
+     * @param \Doctrine\ORM\EntityManager                             $em
+     * @param \Doctrine\ORM\Persisters\Collection\CollectionPersister $persister
+     * @param \Doctrine\ORM\Cache\Region                              $region
+     * @param array                                                   $mapping
      *
-     * @return Doctrine\ORM\Cache\Persister\AbstractCollectionPersister
+     * @return Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister
      */
     abstract protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping);
 
@@ -77,7 +77,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
 
         $this->em                   = $this->_getTestEntityManager();
         $this->region               = $this->createRegion();
-        $this->collectionPersister  = $this->getMock('Doctrine\ORM\Persisters\CollectionPersister', $this->collectionPersisterMockMethods);
+        $this->collectionPersister  = $this->getMock('Doctrine\ORM\Persisters\Collection\CollectionPersister', $this->collectionPersisterMockMethods);
     }
 
     /**
@@ -115,9 +115,9 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     {
         $persister = $this->createPersisterDefault();
 
-        $this->assertInstanceOf('Doctrine\ORM\Persisters\CollectionPersister', $persister);
+        $this->assertInstanceOf('Doctrine\ORM\Persisters\Collection\CollectionPersister', $persister);
         $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedPersister', $persister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedCollectionPersister', $persister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister', $persister);
     }
 
     public function testInvokeDelete()

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Persisters\CollectionPersister;
-use Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedCollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister;
 
 /**
  * @group DDC-2183

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Persisters\CollectionPersister;
-use Doctrine\ORM\Cache\Persister\ReadOnlyCachedCollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister;
 
 /**
  * @group DDC-2183

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\ORM\Cache\CollectionCacheKey;
-use Doctrine\ORM\Persisters\CollectionPersister;
-use Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister;
+use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister;
 
 /**
  * @group DDC-2183
@@ -132,7 +132,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -163,7 +163,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -194,7 +194,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -225,7 +225,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -255,7 +255,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -280,7 +280,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
         $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
-        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedCollectionPersister', 'queuedCache');
+        $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\Tests\OrmTestCase;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Persisters\EntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Common\Collections\Criteria;
@@ -25,7 +25,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     protected $region;
 
     /**
-     * @var \Doctrine\ORM\Persisters\EntityPersister
+     * @var \Doctrine\ORM\Persisters\Entity\EntityPersister
      */
     protected $entityPersister;
 
@@ -80,12 +80,12 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     );
 
     /**
-     * @param \Doctrine\ORM\EntityManager               $em
-     * @param \Doctrine\ORM\Persisters\EntityPersister  $persister
-     * @param \Doctrine\ORM\Cache\Region                $region
-     * @param \Doctrine\ORM\Mapping\ClassMetadata       $metadata
+     * @param \Doctrine\ORM\EntityManager                     $em
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister
+     * @param \Doctrine\ORM\Cache\Region                      $region
+     * @param \Doctrine\ORM\Mapping\ClassMetadata             $metadata
      *
-     * @return Doctrine\ORM\Cache\Persister\AbstractEntityPersister
+     * @return Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister
      */
     abstract protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata);
 
@@ -97,7 +97,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->em               = $this->_getTestEntityManager();
         $this->region           = $this->createRegion();
-        $this->entityPersister  = $this->getMock('Doctrine\ORM\Persisters\EntityPersister', $this->entityPersisterMockMethods);
+        $this->entityPersister  = $this->getMock('Doctrine\ORM\Persisters\Entity\EntityPersister', $this->entityPersisterMockMethods);
     }
 
     /**
@@ -120,9 +120,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     {
         $persister = $this->createPersisterDefault();
 
-        $this->assertInstanceOf('Doctrine\ORM\Persisters\EntityPersister', $persister);
+        $this->assertInstanceOf('Doctrine\ORM\Persisters\Entity\EntityPersister', $persister);
         $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedPersister', $persister);
-        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\CachedEntityPersister', $persister);
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister', $persister);
     }
 
     public function testInvokeAddInsert()

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
@@ -8,8 +8,8 @@ use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Persisters\EntityPersister;
-use Doctrine\ORM\Cache\Persister\NonStrictReadWriteCachedEntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersister;
 
 /**
  * @group DDC-2183
@@ -28,7 +28,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -50,7 +50,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
         $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -87,7 +87,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
         $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -115,7 +115,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Persisters\EntityPersister;
-use Doctrine\ORM\Cache\Persister\ReadOnlyCachedEntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\Cache\Persister\Entity\ReadOnlyCachedEntityPersister;
 
 /**
  * @group DDC-2183

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Cache\Persister;
+namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
@@ -8,8 +8,8 @@ use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\Cache\Country;
-use Doctrine\ORM\Persisters\EntityPersister;
-use Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister;
 
 /**
  * @group DDC-2183
@@ -128,7 +128,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -159,7 +159,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -189,7 +189,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -213,7 +213,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
@@ -124,7 +124,7 @@ class SecondLevelCacheOneToManyTest extends SecondLevelCacheAbstractTest
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
     }
 
-    public function testLoadOnoToManyCollectionFromDatabaseWhenEntityMissing()
+    public function testLoadOneToManyCollectionFromDatabaseWhenEntityMissing()
     {
         $this->loadFixturesCountries();
         $this->loadFixturesStates();
@@ -325,9 +325,9 @@ class SecondLevelCacheOneToManyTest extends SecondLevelCacheAbstractTest
         $this->cache->evictCollectionRegion(State::CLASSNAME, 'cities');
         $this->_em->clear();
 
-        $entitiId   = $this->states[0]->getId();
+        $entityId   = $this->states[0]->getId();
         $queryCount = $this->getCurrentQueryCount();
-        $entity     = $this->_em->find(State::CLASSNAME, $entitiId);
+        $entity     = $this->_em->find(State::CLASSNAME, $entityId);
 
         $this->assertEquals(2, $entity->getCities()->count());
         $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount());
@@ -335,7 +335,7 @@ class SecondLevelCacheOneToManyTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
 
         $queryCount = $this->getCurrentQueryCount();
-        $entity     = $this->_em->find(State::CLASSNAME, $entitiId);
+        $entity     = $this->_em->find(State::CLASSNAME, $entityId);
 
         $this->assertEquals(2, $entity->getCities()->count());
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -16,7 +16,7 @@ use PHPUnit_Framework_TestCase;
 class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Doctrine\ORM\Persisters\EntityPersister|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Doctrine\ORM\Persisters\Entity\EntityPersister|\PHPUnit_Framework_MockObject_MockObject
      */
     private $persister;
 
@@ -35,7 +35,7 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->persister              = $this->getMock('Doctrine\ORM\Persisters\EntityPersister');
+        $this->persister              = $this->getMock('Doctrine\ORM\Persisters\Entity\EntityPersister');
         $this->criteria               = new Criteria();
         $this->lazyCriteriaCollection = new LazyCriteriaCollection($this->persister, $this->criteria);
     }

--- a/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\ORM\Persisters\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 
 /**
  * Performance test used to measure performance of proxy instantiation

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -4,8 +4,7 @@ namespace Doctrine\Tests\ORM\Persisters;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Type as DBALType;
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Persisters\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomTypeFriend;

--- a/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
@@ -19,13 +19,13 @@
 
 namespace Doctrine\Tests\ORM\Persisters;
 
-use Doctrine\ORM\Persisters\JoinedSubclassPersister;
+use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
 use Doctrine\Tests\OrmTestCase;
 
 /**
- * Tests for {@see \Doctrine\ORM\Persisters\JoinedSubclassPersister}
+ * Tests for {@see \Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister}
  *
- * @covers \Doctrine\ORM\Persisters\JoinedSubclassPersister
+ * @covers \Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister
  */
 class JoinedSubClassPersisterTest extends OrmTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -55,7 +55,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         $identifier = array('id' => 42);
         $proxyClass = 'Proxies\__CG__\Doctrine\Tests\Models\ECommerce\ECommerceFeature';
-        $persister = $this->getMock('Doctrine\ORM\Persisters\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $identifier);
@@ -88,7 +88,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */
@@ -115,7 +115,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */


### PR DESCRIPTION
Basically:

`Doctrine\ORM\Cache\Persisters` got split into:
- `Doctrine\ORM\Cache\Persisters\Entity`
- `Doctrine\ORM\Cache\Persisters\Collection`

`Doctrine\ORM\Persisters` got split into:
- `Doctrine\ORM\Persisters\Entity`
- `Doctrine\ORM\Persisters\Collection`
