### PR TITLE
Hotfix: Cache region should not mutate injected cache instance settings

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -198,7 +198,11 @@ class DefaultCacheFactory implements CacheFactory
             return $this->regions[$cache['region']];
         }
 
-        $region = new DefaultRegion($cache['region'], clone $this->cache, $this->regionsConfig->getLifetime($cache['region']));
+        $cacheAdapter = clone $this->cache;
+
+        $cacheAdapter->setNamespace($cache['region']);
+
+        $region = new DefaultRegion($cache['region'], $cacheAdapter, $this->regionsConfig->getLifetime($cache['region']));
 
         if ($cache['usage'] === ClassMetadata::CACHE_USAGE_READ_WRITE) {
 

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -59,8 +59,6 @@ class DefaultRegion implements Region
         $this->cache    = $cache;
         $this->name     = (string) $name;
         $this->lifetime = (integer) $lifetime;
-
-        $this->cache->setNamespace($this->name);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -274,7 +274,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
             'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
         ));
         $barRegion = $factory->getRegion(array(
-            'region' => 'foo',
+            'region' => 'bar',
             'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
         ));
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -257,11 +257,28 @@ class DefaultCacheFactoryTest extends OrmTestCase
      */
     public function testInvalidFileLockRegionDirectoryException()
     {
-        $factory = new \Doctrine\ORM\Cache\DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
+        $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
 
         $factory->getRegion(array(
             'usage'   => ClassMetadata::CACHE_USAGE_READ_WRITE,
             'region'  => 'foo'
         ));
+    }
+
+    public function testBuildsNewNamespacedCacheInstancePerRegionInstance()
+    {
+        $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
+
+        $fooRegion = $factory->getRegion(array(
+            'region' => 'foo',
+            'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+        ));
+        $barRegion = $factory->getRegion(array(
+            'region' => 'foo',
+            'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+        ));
+
+        $this->assertSame('foo', $fooRegion->getCache()->getNamespace());
+        $this->assertSame('bar', $barRegion->getCache()->getNamespace());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Cache;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
@@ -46,5 +47,17 @@ class DefaultRegionTest extends AbstractRegionTest
 
         $this->assertFalse($region1->contains($key));
         $this->assertTrue($region2->contains($key));
+    }
+
+    public function testDoesNotModifyCacheNamespace()
+    {
+        $cache = new ArrayCache();
+
+        $cache->setNamespace('foo');
+
+        new DefaultRegion('bar', $cache);
+        new DefaultRegion('baz', $cache);
+
+        $this->assertSame('foo', $cache->getNamespace());
     }
 }


### PR DESCRIPTION
This is strictly related to https://github.com/doctrine/cache/pull/48#discussion_r19059174 as well
