### PR TITLE
[WIP] Add a new QuoteStrategy that automatically escape database reserved keyword

### DIFF
--- a/lib/Doctrine/ORM/Mapping/EscapingQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/EscapingQuoteStrategy.php
@@ -1,0 +1,176 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Mapping;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+/**
+ * A set of rules for determining the physical column, alias and table quotes and automatically escape database reserved
+ * keyword
+ *
+ *@author  Xavier HUBERTY <x.huberty@thecodingmachine.com>
+ */
+class EscapingQuoteStrategy implements QuoteStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnName($fieldName, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($class->fieldMappings[$fieldName]['quoted'])){
+            return $platform->quoteIdentifier($class->fieldMappings[$fieldName]['columnName']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($fieldName)){
+            return $platform->quoteIdentifier($class->fieldMappings[$fieldName]['columnName']);
+        }
+        return $class->fieldMappings[$fieldName]['columnName'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTableName(ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($class->table['quoted'])){
+            return $platform->quoteIdentifier($class->table['name']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($class->table['name'])){
+            return $platform->quoteIdentifier($class->table['name']);
+        }
+         return $class->table['name'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSequenceName(array $definition, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($definition['quoted'])){
+            return $platform->quoteIdentifier($class->table['name']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($definition['sequenceName'])){
+            return $platform->quoteIdentifier($definition['sequenceName']);
+        }
+        return $definition['sequenceName'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJoinColumnName(array $joinColumn, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($joinColumn['quoted'])){
+            return $platform->quoteIdentifier($joinColumn['name']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($joinColumn['name'])){
+            return $platform->quoteIdentifier($joinColumn['name']);
+        }
+        return $joinColumn['name'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferencedJoinColumnName(array $joinColumn, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($joinColumn['quoted'])){
+            return $platform->quoteIdentifier($joinColumn['referencedColumnName']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($joinColumn['referencedColumnName'])){
+            return $platform->quoteIdentifier($joinColumn['referencedColumnName']);
+        }
+        return $joinColumn['referencedColumnName'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJoinTableName(array $association, ClassMetadata $class, AbstractPlatform $platform)
+    {
+        if(isset($association['joinTable']['quoted'])){
+            return $platform->quoteIdentifier($association['joinTable']['name']);
+        }
+        $reservedKeyList = $platform->getReservedKeywordsList();
+        if($reservedKeyList->isKeyword($association['joinTable']['name'])){
+            return $platform->quoteIdentifier($association['joinTable']['name']);
+        }
+        return $association['joinTable']['name'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentifierColumnNames(ClassMetadata $class, AbstractPlatform $platform)
+    {
+        $quotedColumnNames = array();
+
+        foreach ($class->identifier as $fieldName) {
+            if (isset($class->fieldMappings[$fieldName])) {
+                $quotedColumnNames[] = $this->getColumnName($fieldName, $class, $platform);
+
+                continue;
+            }
+
+            // Association defined as Id field
+            $joinColumns            = $class->associationMappings[$fieldName]['joinColumns'];
+            $assocQuotedColumnNames = array_map(
+                function ($joinColumn) use ($platform)
+                {
+                    if(isset($joinColumn['quoted'])){
+                        return $platform->quoteIdentifier($joinColumn['name']);
+                    }
+                    $reservedKeyList = $platform->getReservedKeywordsList();
+                    if($reservedKeyList->isKeyword($joinColumn['name'])){
+                        return $platform->quoteIdentifier($joinColumn['name']);
+                    }
+                    return $joinColumn['name'];
+                },
+                $joinColumns
+            );
+
+            $quotedColumnNames = array_merge($quotedColumnNames, $assocQuotedColumnNames);
+        }
+
+        return $quotedColumnNames;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getColumnAlias($columnName, $counter, AbstractPlatform $platform, ClassMetadata $class = null)
+    {
+        // 1 ) Concatenate column name and counter
+        // 2 ) Trim the column alias to the maximum identifier length of the platform.
+        //     If the alias is to long, characters are cut off from the beginning.
+        // 3 ) Strip non alphanumeric characters
+        // 4 ) Prefix with "_" if the result its numeric
+        $columnName = $columnName . '_' . $counter;
+        $columnName = substr($columnName, -$platform->getMaxIdentifierLength());
+        $columnName = preg_replace('/[^A-Za-z0-9_]/', '', $columnName);
+        $columnName = is_numeric($columnName) ? '_' . $columnName : $columnName;
+
+        return $platform->getSQLResultCasing($columnName);
+    }
+}

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -328,7 +328,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         // Compute changes done since last commit.
-        if ($entity === null) {
+        if (null === $entity) {
             $this->computeChangeSets();
         } elseif (is_object($entity)) {
             $this->computeSingleEntityChangeSet($entity);
@@ -418,17 +418,40 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->dispatchPostFlushEvent();
 
+        $this->postCommitClear($entity);
+    }
+
+    /**
+     * @param null|object|array $entity
+     */
+    private function postCommitClear($entity = null)
+    {
+
         // Clear up
         $this->entityInsertions =
         $this->entityUpdates =
         $this->entityDeletions =
         $this->extraUpdates =
-        $this->entityChangeSets =
         $this->collectionUpdates =
         $this->collectionDeletions =
         $this->visitedCollections =
-        $this->scheduledForSynchronization =
         $this->orphanRemovals = array();
+
+        if (null === $entity) {
+            $this->entityChangeSets = $this->scheduledForSynchronization = array();
+            return;
+        }
+
+        if (is_object($entity)) {
+            $entity = [$entity];
+        }
+
+        foreach ($entity as $object) {
+            $oid = spl_object_hash($object);
+            $class = $this->em->getClassMetadata(get_class($object));
+            $this->clearEntityChangeSet($oid);
+            $this->clearScheduledForSynchronization($class, $oid);
+        }
     }
 
     /**
@@ -3111,7 +3134,16 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function clearEntityChangeSet($oid)
     {
-        $this->entityChangeSets[$oid] = array();
+        unset($this->entityChangeSets[$oid]);
+    }
+
+    /**
+     * @param $class
+     * @param string $oid
+     */
+    public function clearScheduledForSynchronization($class, $oid)
+    {
+        unset($this->scheduledForSynchronization[$class->rootEntityName][$oid]);
     }
 
     /* PropertyChangedListener implementation */

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -150,7 +150,29 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $this->_unitOfWork->persist($entity);
 
         $this->_unitOfWork->commit();
-        $this->assertEquals(1, count($persister->getInserts()));
+        $this->assertCount(1, $persister->getInserts());
+
+        // Create and Set first entity
+        $entity1 = new NotifyChangedEntity;
+        $entity1->setData('thedata');
+        $this->_unitOfWork->persist($entity1);
+
+        // Create and Set second entity
+        $entity2 = new NotifyChangedEntity;
+        $entity2->setData('thedata');
+        $this->_unitOfWork->persist($entity2);
+
+        $this->_unitOfWork->commit($entity1);
+        $this->assertCount(1, $this->_unitOfWork->getEntityChangeSet($entity2));
+
+        // Create and Set third entity
+        $entity3 = new NotifyChangedEntity;
+        $entity3->setData('thedata');
+        $this->_unitOfWork->persist($entity3);
+
+        $this->_unitOfWork->commit([$entity1,$entity2]);
+        $this->assertCount(1, $this->_unitOfWork->getEntityChangeSet($entity3));
+
         $persister->reset();
 
         $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));


### PR DESCRIPTION
All the upload screenshots which are used to explain what we are doing are taken from a real project developed with Mouf dependency injection framework (http://mouf-php.com/) that we use to configure the entity manager.

We wanted to create a FAQ where admin can add question/answer and use drag and drop to set the position of the question in the FAQ.

For this, at some point, in an entity, we used a protected keyword "order" in a class FAQ:

```
    /**
     * @ORM\Column(type="integer", nullable=false)
     * @var int
     */
    private $order;
```

This fails with Doctrine. The documentation clearly explains why: http://doctrine-orm.readthedocs.org/en/latest/reference/basic-mapping.html#quoting-reserved-words

Below are a list of screenshot explaining we use the `DefaultQuoteStrategy` and the failure message we get.

![doctrineconfiguration](https://cloud.githubusercontent.com/assets/8350192/5779969/4ab5c15e-9da7-11e4-8df8-f2c718c8d66a.PNG)

In the configuration,the "quoteStrategy" setter is not set. Therefore, we use `DefaultQuoteStrategy`.

![defaultquotestrategy](https://cloud.githubusercontent.com/assets/8350192/5779977/51fe0a70-9da7-11e4-9cfa-3a86e6f8aab8.PNG)

We get this error:

![error](https://cloud.githubusercontent.com/assets/8350192/5779963/422e0bc2-9da7-11e4-902c-602a2eac7f96.PNG)
We get an error while using doctrine ORM because it doesn't auto escape protected keyword. (We can protect it manually by using  ` .)

We created a new QuoteStratigy that automaticcaly escape protected keyword **only**. We just bind it via the Mouf interface:

![escapingquotestrategy](https://cloud.githubusercontent.com/assets/8350192/5780067/d9997bae-9da7-11e4-8a23-c5fa2ebaffcc.PNG)

and then the magic begins: a screenshot of the page with no error.

![succes](https://cloud.githubusercontent.com/assets/8350192/5780085/f9b597f6-9da7-11e4-85b0-cd09fb572cd9.PNG)

We would like to submit this new `EscapingQuoteStrategy` as we think it will be easier for developers to work with it, and it should not have a big performance impact (only an additional lookup in a table)
