### PR TITLE
[2.4] Fix schema generation in the test suite

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -9,8 +9,10 @@ require_once __DIR__ . '/../../../TestInit.php';
 
 class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
+
         if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'postgresql') {
             $this->markTestSkipped('The ' . __CLASS__ .' requires the use of postgresql.');
         }
@@ -19,6 +21,7 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testPostgresMetadataSequenceIncrementedBy10()
     {
         $address = $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
+
         $this->assertEquals(1, $address->sequenceGeneratorDefinition['allocationSize']);
     }
 
@@ -97,7 +100,9 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $sql = $tool->getDropSchemaSQL($classes);
 
         $this->assertEquals(14, count($sql));
+
         $dropSequenceSQLs = 0;
+
         foreach ($sql AS $stmt) {
             if (strpos($stmt, "DROP SEQUENCE") === 0) {
                 $dropSequenceSQLs++;
@@ -115,10 +120,6 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1657Screen'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1657Avatar'),
         );
-        try {
-            $this->_em->getConnection()->exec("CREATE SCHEMA stonewood");
-        } catch(\Exception $e) {
-        }
 
         $tool = new SchemaTool($this->_em);
         $tool->createSchema($classes);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -20,7 +20,7 @@ class DDC1360Test extends OrmFunctionalTestCase
         ));
 
         $this->assertEquals(array(
-            'CREATE SCHEMA "user"',
+            'CREATE SCHEMA user',
             'CREATE TABLE "user"."user" (id INT NOT NULL, PRIMARY KEY(id))',
             'CREATE SEQUENCE "user"."user_id_seq" INCREMENT BY 1 MINVALUE 1 START 1',
         ), $sql);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -20,6 +20,7 @@ class DDC1360Test extends OrmFunctionalTestCase
         ));
 
         $this->assertEquals(array(
+            'CREATE SCHEMA "user"',
             'CREATE TABLE "user"."user" (id INT NOT NULL, PRIMARY KEY(id))',
             'CREATE SEQUENCE "user"."user_id_seq" INCREMENT BY 1 MINVALUE 1 START 1',
         ), $sql);


### PR DESCRIPTION
This PR backports doctrine/doctrine2@b314476599954086f1eaa43800901b9d817df257 into 2.4
