### PR TITLE
Update composer before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
+  - composer self-update
   - composer install --prefer-dist --dev
 
 script: phpunit --configuration tests/travis/$DB.travis.xml


### PR DESCRIPTION
Updating composer before install seems like a good idea. At the moment for example the travis build is failing because of the new composer syntax with '^' and it would be fixed by composer self-update.
