### PR TITLE
[DDC-3520] self-update composer before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
   - if [ $DB = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi
   - if [ $DB = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi
   - if [ $DB = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi
+  - composer self-update
   - composer install --prefer-source --dev
 
 script: 


### PR DESCRIPTION
Updating composer before install seems like a good idea. At the moment for example the travis build is failing because of the new composer syntax with '^' and it would be fixed by composer self-update.

Sorry for the spam, opened the pull request against master this time.
