### PR TITLE
Incorrect @throws doc. in getSingleScalarResult

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -825,7 +825,8 @@ abstract class AbstractQuery
      *
      * @return mixed
      *
-     * @throws QueryException If the query result is not unique.
+     * @throws NonUniqueResultException If the query result is not unique.
+     * @throws NoResultException        If the query returned no result.
      */
     public function getSingleScalarResult()
     {


### PR DESCRIPTION
This method doesn't throw QueryException. 

The documentation should says that it throws: "NoResultException" or "NonUniqueResultException"
