### PR TITLE
[2.4] travis: run coverage just once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ env:
   - DB=sqlite
 
 before_script:
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi"
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' && $DB = 'sqlite' ]]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; else PHPUNIT_FLAGS=""; fi
+  - if [ $DB = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests;' -U postgres; fi
+  - if [ $DB = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS doctrine_tests_tmp;' -U postgres; fi
+  - if [ $DB = 'pgsql' ]; then psql -c 'create database doctrine_tests;' -U postgres; fi
+  - if [ $DB = 'pgsql' ]; then psql -c 'create database doctrine_tests_tmp;' -U postgres; fi
+  - if [ $DB = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS doctrine_tests_tmp;create database IF NOT EXISTS doctrine_tests;'; fi
   - composer install --prefer-dist --dev
 
-script: phpunit --configuration tests/travis/$DB.travis.xml
+script: phpunit $PHPUNIT_FLAGS --configuration tests/travis/$DB.travis.xml
 
 after_script:
   - php vendor/bin/coveralls -v

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -16,10 +16,6 @@
         <var name="tmpdb_port" value="3306"/>
     </php>
 
-    <logging>
-        <log type="coverage-clover" target="../../build/logs/clover.xml"/>
-    </logging>
-
     <testsuites>
         <testsuite name="Doctrine ORM Test Suite">
             <directory>./../Doctrine/Tests/ORM</directory>

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -19,10 +19,6 @@
         <var name="tmpdb_port" value="5432"/>
     </php>
 
-    <logging>
-        <log type="coverage-clover" target="../../build/logs/clover.xml"/>
-    </logging>
-
     <testsuites>
         <testsuite name="Doctrine ORM Test Suite">
             <directory>./../Doctrine/Tests/ORM</directory>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit>
 
-    <logging>
-        <log type="coverage-clover" target="../../build/logs/clover.xml"/>
-    </logging>
-
    <testsuites>
      <testsuite name="Doctrine ORM Test Suite">
         <directory>./../Doctrine/Tests/ORM</directory>


### PR DESCRIPTION
Another speedup, just for 2.4 branch. Ref: https://github.com/doctrine/doctrine2/pull/1251

2.3 and bellow don't use coverage, so that should be all.
