### PR TITLE
Hotfix - #1169 - extra lazy one to many must be no-op when not doing orphan removal

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -78,9 +78,13 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
      */
     public function delete($entity)
     {
-        $this->persister->delete($entity);
+        $key = new EntityCacheKey($this->class->rootEntityName, $this->uow->getEntityIdentifier($entity));
 
-        $this->queuedCache['delete'][] = new EntityCacheKey($this->class->rootEntityName, $this->uow->getEntityIdentifier($entity));
+        if ($this->persister->delete($entity)) {
+            $this->region->evict($key);
+        }
+
+        $this->queuedCache['delete'][] = $key;
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -103,7 +103,9 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
         $key   = new EntityCacheKey($this->class->rootEntityName, $this->uow->getEntityIdentifier($entity));
         $lock  = $this->region->lock($key);
 
-        $this->persister->delete($entity);
+        if ($this->persister->delete($entity)) {
+            $this->region->evict($key);
+        }
 
         if ($lock === null) {
             return;

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -168,22 +168,10 @@ class OneToManyPersister extends AbstractCollectionPersister
             return false;
         }
 
-        $persister = $this->uow->getEntityPersister($mapping['targetEntity']);
-
-        $targetMetadata = $this->em->getClassMetadata($mapping['targetEntity']);
-
-        if ($element instanceof Proxy && ! $element->__isInitialized()) {
-            $element->__load();
-        }
-
-        // clearing owning side value
-        $targetMetadata->reflFields[$mapping['mappedBy']]->setValue($element, null);
-
-        $this->uow->computeChangeSet($targetMetadata, $element);
-
-        $persister->update($element);
-
-        return true;
+        return $this
+            ->uow
+            ->getEntityPersister($mapping['targetEntity'])
+            ->delete($element);
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -157,11 +157,17 @@ class OneToManyPersister extends AbstractCollectionPersister
      */
     public function removeElement(PersistentCollection $collection, $element)
     {
+        $mapping = $collection->getMapping();
+
+        if ( ! $mapping['orphanRemoval']) {
+            // no-op: this is not the owning side, therefore no operations should be applied
+            return false;
+        }
+
         if ( ! $this->isValidEntityState($element)) {
             return false;
         }
 
-        $mapping   = $collection->getMapping();
         $persister = $this->uow->getEntityPersister($mapping['targetEntity']);
 
         $targetMetadata = $this->em->getClassMetadata($mapping['targetEntity']);

--- a/tests/Doctrine/Tests/Models/Tweet/User.php
+++ b/tests/Doctrine/Tests/Models/Tweet/User.php
@@ -29,14 +29,26 @@ class User
      */
     public $tweets;
 
+    /**
+     * @OneToMany(targetEntity="UserList", mappedBy="owner", fetch="EXTRA_LAZY", orphanRemoval=true)
+     */
+    public $userLists;
+
     public function __construct()
     {
-        $this->tweets = new ArrayCollection();
+        $this->tweets    = new ArrayCollection();
+        $this->userLists = new ArrayCollection();
     }
 
     public function addTweet(Tweet $tweet)
     {
         $tweet->setAuthor($this);
         $this->tweets->add($tweet);
+    }
+
+    public function addUserList(UserList $userList)
+    {
+        $userList->owner = $this;
+        $this->userLists->add($userList);
     }
 }

--- a/tests/Doctrine/Tests/Models/Tweet/UserList.php
+++ b/tests/Doctrine/Tests/Models/Tweet/UserList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\Models\Tweet;
+
+/**
+ * @Entity
+ * @Table(name="tweet_user_list")
+ */
+class UserList
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $listName;
+
+    /**
+     * @ManyToOne(targetEntity="User", inversedBy="userLists")
+     */
+    public $owner;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -485,7 +485,6 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $user->articles->removeElement($article);
 
         $this->assertFalse($user->articles->isInitialized(), "Post-Condition: Collection is not initialized.");
-        // NOTE: +2 queries because CmsArticle is a versioned entity, and that needs to be handled accordingly
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
 
         // Test One to Many removal with Entity state as new

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -1141,7 +1141,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);
 
-        $user->tweets->removeElement($this->_em->find(UserList::CLASSNAME, $userListId));
+        $user->userLists->removeElement($this->_em->find(UserList::CLASSNAME, $userListId));
 
         $this->_em->clear();
 
@@ -1194,7 +1194,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);
 
-        $user->tweets->removeElement($this->_em->getReference(UserList::CLASSNAME, $userListId));
+        $user->userLists->removeElement($this->_em->getReference(UserList::CLASSNAME, $userListId));
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -485,7 +485,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
 
         $this->assertFalse($user->articles->isInitialized(), "Post-Condition: Collection is not initialized.");
         // NOTE: +2 queries because CmsArticle is a versioned entity, and that needs to be handled accordingly
-        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
 
         // Test One to Many removal with Entity state as new
         $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
@@ -1123,7 +1123,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
             'Even though the collection is extra lazy, the tweet should not have been deleted'
         );
 
-        $this->assertNull($tweet->author);
+        $this->assertInstanceOf(User::CLASSNAME, $tweet->author);
 
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -296,10 +296,12 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
 
         $this->_em->clear();
 
-        $this->assertTrue($this->cache->containsEntity(Country::CLASSNAME, $countryId));
+        $this->assertFalse(
+            $this->cache->containsEntity(Country::CLASSNAME, $countryId),
+            'Removal attempts should clear the cache entry corresponding to the entity'
+        );
 
-        $country = $this->_em->find(Country::CLASSNAME, $countryId);
-        $this->assertInstanceOf(Country::CLASSNAME, $country);
+        $this->assertInstanceOf(Country::CLASSNAME, $this->_em->find(Country::CLASSNAME, $countryId));
     }
 
     public function testCachedNewEntityExists()

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -186,7 +186,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         ),
         'tweet' => array(
             'Doctrine\Tests\Models\Tweet\User',
-            'Doctrine\Tests\Models\Tweet\Tweet'
+            'Doctrine\Tests\Models\Tweet\Tweet',
+            'Doctrine\Tests\Models\Tweet\UserList',
         ),
         'ddc2504' => array(
             'Doctrine\Tests\Models\DDC2504\DDC2504RootClass',
@@ -385,6 +386,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM taxi_ride');
             $conn->executeUpdate('DELETE FROM taxi_car');
             $conn->executeUpdate('DELETE FROM taxi_driver');
+        }
+
+        if (isset($this->_usedModelSets['tweet'])) {
+            $conn->executeUpdate('DELETE FROM tweet_tweet');
+            $conn->executeUpdate('DELETE FROM tweet_user_list');
+            $conn->executeUpdate('DELETE FROM tweet_user');
         }
 
         if (isset($this->_usedModelSets['cache'])) {


### PR DESCRIPTION
See https://github.com/doctrine/doctrine2/pull/1281#issuecomment-71403668

Linking #1169
