### PR TITLE
Conversion to PHP 5.4's short array syntax

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -20,8 +20,8 @@
 use Symfony\Component\Console\Helper\HelperSet;
 use Doctrine\ORM\Tools\Console\ConsoleRunner;
 
-$autoloadFiles = array(__DIR__ . '/../vendor/autoload.php',
-                       __DIR__ . '/../../../autoload.php');
+$autoloadFiles = [__DIR__ . '/../vendor/autoload.php',
+                       __DIR__ . '/../../../autoload.php'];
 
 foreach ($autoloadFiles as $autoloadFile) {
     if (file_exists($autoloadFile)) {
@@ -29,7 +29,7 @@ foreach ($autoloadFiles as $autoloadFile) {
     }
 }
 
-$directories = array(getcwd(), getcwd() . DIRECTORY_SEPARATOR . 'config');
+$directories = [getcwd(), getcwd() . DIRECTORY_SEPARATOR . 'config'];
 
 $configFile = null;
 foreach ($directories as $directory) {
@@ -50,7 +50,7 @@ if ( ! is_readable($configFile)) {
     exit(1);
 }
 
-$commands = array();
+$commands = [];
 
 $helperSet = require $configFile;
 

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -96,7 +96,7 @@ abstract class AbstractQuery
      *
      * @var array
      */
-    protected $_hints = array();
+    protected $_hints = [];
 
     /**
      * The hydration mode.
@@ -956,7 +956,7 @@ abstract class AbstractQuery
             }
 
             if ( ! $result) {
-                $result = array();
+                $result = [];
             }
 
             $setCacheEntry = function($data) use ($cache, $result, $cacheKey, $realCacheKey, $queryCacheProfile) {
@@ -1028,7 +1028,7 @@ abstract class AbstractQuery
      */
     protected function getHydrationCacheId()
     {
-        $parameters = array();
+        $parameters = [];
 
         foreach ($this->getParameters() as $parameter) {
             $parameters[$parameter->getName()] = $this->processParameterValue($parameter->getValue());
@@ -1090,7 +1090,7 @@ abstract class AbstractQuery
     {
         $this->parameters = new ArrayCollection();
 
-        $this->_hints = array();
+        $this->_hints = [];
         $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
     }
 

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -53,7 +53,7 @@ class DefaultCache implements Cache
     /**
      * @var \Doctrine\ORM\Cache\QueryCache[]
      */
-    private $queryCaches = array();
+    private $queryCaches = [];
 
     /**
      * @var \Doctrine\ORM\Cache\QueryCache
@@ -336,7 +336,7 @@ class DefaultCache implements Cache
             }
         }
 
-        return array($metadata->identifier[0] => $identifier);
+        return [$metadata->identifier[0] => $identifier];
     }
 
 }

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -64,7 +64,7 @@ class DefaultCacheFactory implements CacheFactory
     /**
      * @var \Doctrine\ORM\Cache\Region[]
      */
-    private $regions = array();
+    private $regions = [];
 
     /**
      * @var string|null
@@ -167,10 +167,10 @@ class DefaultCacheFactory implements CacheFactory
         return new DefaultQueryCache(
             $em,
             $this->getRegion(
-                array(
+                [
                     'region' => $regionName ?: Cache::DEFAULT_QUERY_REGION_NAME,
                     'usage'  => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
-                )
+                ]
             )
         );
     }

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -46,7 +46,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
@@ -62,7 +62,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
      */
     public function buildCacheEntry(ClassMetadata $metadata, CollectionCacheKey $key, $collection)
     {
-        $data = array();
+        $data = [];
 
         foreach ($collection as $index => $entity) {
             $data[$index] = new EntityCacheKey($metadata->name, $this->uow->getEntityIdentifier($entity));
@@ -79,7 +79,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
         /* @var $targetPersister \Doctrine\ORM\Cache\Persister\CachedPersister */
         $targetPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
         $targetRegion    = $targetPersister->getCacheRegion();
-        $list            = array();
+        $list            = [];
 
         $entityEntries = $targetRegion->getMultiple($entry);
 

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -47,7 +47,7 @@ class DefaultEntityHydrator implements EntityHydrator
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
@@ -98,7 +98,7 @@ class DefaultEntityHydrator implements EntityHydrator
                 $data[reset($assoc['joinColumnFieldNames'])] = $targetId;
 
                 $targetEntity = $this->em->getClassMetadata($assoc['targetEntity']);
-                $targetId     = array($targetEntity->identifier[0] => $targetId);
+                $targetId     = [$targetEntity->identifier[0] => $targetId];
             }
 
             $data[$name] = new AssociationCacheEntry($assoc['targetEntity'], $targetId);

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -66,7 +66,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em     The entity manager.
@@ -86,7 +86,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * {@inheritdoc}
      */
-    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = array())
+    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = [])
     {
         if ( ! ($key->cacheMode & Cache::MODE_GET)) {
             return null;
@@ -104,7 +104,7 @@ class DefaultQueryCache implements QueryCache
             return null;
         }
 
-        $result      = array();
+        $result      = [];
         $entityName  = reset($rsm->aliasMap);
         $hasRelation = ( ! empty($rsm->relationMap));
         $persister   = $this->uow->getEntityPersister($entityName);
@@ -208,7 +208,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * {@inheritdoc}
      */
-    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = array())
+    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = [])
     {
         if ($rsm->scalarMappings) {
             throw new CacheException("Second level cache does not support scalar results.");
@@ -230,7 +230,7 @@ class DefaultQueryCache implements QueryCache
             return false;
         }
 
-        $data        = array();
+        $data        = [];
         $entityName  = reset($rsm->aliasMap);
         $hasRelation = ( ! empty($rsm->relationMap));
         $metadata    = $this->em->getClassMetadata($entityName);
@@ -245,7 +245,7 @@ class DefaultQueryCache implements QueryCache
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
             $data[$index]['identifier']     = $identifier;
-            $data[$index]['associations']   = array();
+            $data[$index]['associations']   = [];
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey = new EntityCacheKey($entityName, $identifier))) {
                 // Cancel put result if entity put fail
@@ -287,17 +287,17 @@ class DefaultQueryCache implements QueryCache
                         }
                     }
 
-                    $data[$index]['associations'][$name] = array(
+                    $data[$index]['associations'][$name] = [
                         'targetEntity'  => $assocMetadata->rootEntityName,
                         'identifier'    => $assocIdentifier,
                         'type'          => $assoc['type']
-                    );
+                    ];
 
                     continue;
                 }
 
                 // Handle *-to-many associations
-                $list = array();
+                $list = [];
 
                 foreach ($assocValue as $assocItemIndex => $assocItem) {
                     $assocIdentifier = $this->uow->getEntityIdentifier($assocItem);
@@ -313,11 +313,11 @@ class DefaultQueryCache implements QueryCache
                     $list[$assocItemIndex] = $assocIdentifier;
                 }
 
-                $data[$index]['associations'][$name] = array(
+                $data[$index]['associations'][$name] = [
                     'targetEntity'  => $assocMetadata->rootEntityName,
                     'type'          => $assoc['type'],
                     'list'          => $list,
-                );
+                ];
             }
         }
 

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -35,7 +35,7 @@ class CacheLoggerChain implements CacheLogger
     /**
      * @var array<\Doctrine\ORM\Cache\Logging\CacheLogger>
      */
-    private $loggers = array();
+    private $loggers = [];
 
     /**
      * @param string                                  $name

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -35,17 +35,17 @@ class StatisticsCacheLogger implements CacheLogger
     /**
      * @var array
      */
-    private $cacheMissCountMap = array();
+    private $cacheMissCountMap = [];
 
     /**
      * @var array
      */
-    private $cacheHitCountMap = array();
+    private $cacheHitCountMap = [];
 
     /**
      * @var array
      */
-    private $cachePutCountMap = array();
+    private $cachePutCountMap = [];
 
     /**
      * {@inheritdoc}
@@ -214,9 +214,9 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function clearStats()
     {
-        $this->cachePutCountMap  = array();
-        $this->cacheHitCountMap  = array();
-        $this->cacheMissCountMap = array();
+        $this->cachePutCountMap  = [];
+        $this->cacheHitCountMap  = [];
+        $this->cacheMissCountMap = [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -69,7 +69,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      /**
      * @var array
      */
-    protected $queuedCache = array();
+    protected $queuedCache = [];
 
     /**
      * @var \Doctrine\ORM\Cache\Region

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -46,7 +46,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -54,7 +54,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
      */
     public function afterTransactionRolledBack()
     {
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -96,9 +96,9 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
 
         $this->persister->update($collection);
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = array(
+        $this->queuedCache['update'][spl_object_hash($collection)] = [
             'key'   => $key,
             'list'  => $collection
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -60,7 +60,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -80,7 +80,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -98,10 +98,10 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = array(
+        $this->queuedCache['delete'][spl_object_hash($collection)] = [
             'key'   => $key,
             'lock'  => $lock
-        );
+        ];
     }
 
     /**
@@ -126,9 +126,9 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = array(
+        $this->queuedCache['update'][spl_object_hash($collection)] = [
             'key'   => $key,
             'lock'  => $lock
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -64,7 +64,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      /**
      * @var array
      */
-    protected $queuedCache = array();
+    protected $queuedCache = [];
 
     /**
      * @var \Doctrine\ORM\Cache\Region
@@ -160,7 +160,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         return $this->persister->getCountSQL($criteria);
     }
@@ -249,7 +249,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     private function storeJoinedAssociations($entity)
     {
         if ($this->joinedAssociations === null) {
-            $associations = array();
+            $associations = [];
 
             foreach ($this->class->associationMappings as $name => $assoc) {
                 if (isset($assoc['cache']) &&
@@ -361,7 +361,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null)
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null)
     {
         if ($entity !== null || $assoc !== null || ! empty($hints) || $lockMode !== null) {
             return $this->persister->load($criteria, $entity, $assoc, $hints, $lockMode, $limit, $orderBy);
@@ -388,7 +388,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             return null;
         }
 
-        $cached = $queryCache->put($querykey, $rsm, array($result));
+        $cached = $queryCache->put($querykey, $rsm, [$result]);
 
         if ($this->cacheLogger) {
             if ($result) {
@@ -406,7 +406,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null)
     {
         $timestamp  = $this->timestampRegion->get($this->timestampKey);
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
@@ -497,7 +497,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritDoc}
      */
-    public function count($criteria = array())
+    public function count($criteria = [])
     {
         return $this->persister->count($criteria);
     }
@@ -613,7 +613,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array())
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = [])
     {
         return $this->persister->loadOneToOneEntity($assoc, $sourceEntity, $identifier);
     }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -62,7 +62,7 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
             $this->timestampRegion->update($this->timestampKey);
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -70,7 +70,7 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
      */
     public function afterTransactionRolledBack()
     {
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -72,7 +72,7 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             $this->timestampRegion->update($this->timestampKey);
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -92,7 +92,7 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -111,10 +111,10 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             return;
         }
 
-        $this->queuedCache['delete'][] = array(
+        $this->queuedCache['delete'][] = [
             'lock'   => $lock,
             'key'    => $key
-        );
+        ];
     }
 
     /**
@@ -131,9 +131,9 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             return;
         }
 
-        $this->queuedCache['update'][] = array(
+        $this->queuedCache['update'][] = [
             'lock'   => $lock,
             'key'    => $key
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/QueryCache.php
+++ b/lib/Doctrine/ORM/Cache/QueryCache.php
@@ -44,7 +44,7 @@ interface QueryCache
      *
      * @return boolean
      */
-    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = array());
+    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = []);
 
     /**
      * @param \Doctrine\ORM\Cache\QueryCacheKey     $key
@@ -53,7 +53,7 @@ interface QueryCache
      *
      * @return array|null
      */
-    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = array());
+    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = []);
 
     /**
      * @return \Doctrine\ORM\Cache\Region

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -56,7 +56,7 @@ class DefaultMultiGetRegion extends DefaultRegion
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $keysToRetrieve = array();
+        $keysToRetrieve = [];
         foreach ($collection->identifiers as $index => $key) {
             $keysToRetrieve[$index] = $this->name . '_' . $key->hash;
         }
@@ -66,7 +66,7 @@ class DefaultMultiGetRegion extends DefaultRegion
             return null;
         }
 
-        $returnableItems = array();
+        $returnableItems = [];
         foreach ($keysToRetrieve as $index => $key) {
             $returnableItems[$index] = $items[$key];
         }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -100,7 +100,7 @@ class DefaultRegion implements Region
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $keysToRetrieve = array();
+        $keysToRetrieve = [];
 
         foreach ($collection->identifiers as $index => $key) {
             $keysToRetrieve[$index] = $this->name . '_' . $key->hash;
@@ -117,7 +117,7 @@ class DefaultRegion implements Region
             return null;
         }
 
-        $returnableItems = array();
+        $returnableItems = [];
 
         foreach ($keysToRetrieve as $index => $key) {
             $returnableItems[$index] = $items[$key];

--- a/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
@@ -31,12 +31,12 @@ class RegionsConfiguration
     /**
      * @var array
      */
-    private $lifetimes = array();
+    private $lifetimes = [];
 
     /**
      * @var array
      */
-    private $lockLifetimes = array();
+    private $lockLifetimes = [];
 
     /**
      * @var integer

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -148,7 +148,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @return AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array(), $useSimpleAnnotationReader = true)
+    public function newDefaultAnnotationDriver($paths = [], $useSimpleAnnotationReader = true)
     {
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
@@ -348,7 +348,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm)
     {
-        $this->_attributes['namedNativeQueries'][$name] = array($sql, $rsm);
+        $this->_attributes['namedNativeQueries'][$name] = [$sql, $rsm];
     }
 
     /**
@@ -589,7 +589,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function setCustomHydrationModes($modes)
     {
-        $this->_attributes['customHydrationModes'] = array();
+        $this->_attributes['customHydrationModes'] = [];
 
         foreach ($modes as $modeName => $hydrator) {
             $this->addCustomHydrationMode($modeName, $hydrator);
@@ -880,7 +880,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getDefaultQueryHints()
     {
-        return isset($this->_attributes['defaultQueryHints']) ? $this->_attributes['defaultQueryHints'] : array();
+        return isset($this->_attributes['defaultQueryHints']) ? $this->_attributes['defaultQueryHints'] : [];
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -383,7 +383,7 @@ use Doctrine\Common\Util\ClassUtils;
                 throw ORMInvalidArgumentException::invalidCompositeIdentifier();
             }
 
-            $id = array($class->identifier[0] => $id);
+            $id = [$class->identifier[0] => $id];
         }
 
         foreach ($id as $i => $value) {
@@ -396,7 +396,7 @@ use Doctrine\Common\Util\ClassUtils;
             }
         }
 
-        $sortedId = array();
+        $sortedId = [];
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
@@ -456,7 +456,7 @@ use Doctrine\Common\Util\ClassUtils;
                     throw TransactionRequiredException::transactionRequired();
                 }
 
-                return $persister->load($sortedId, null, null, array(), $lockMode);
+                return $persister->load($sortedId, null, null, [], $lockMode);
 
             default:
                 return $persister->loadById($sortedId);
@@ -471,10 +471,10 @@ use Doctrine\Common\Util\ClassUtils;
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
         if ( ! is_array($id)) {
-            $id = array($class->identifier[0] => $id);
+            $id = [$class->identifier[0] => $id];
         }
 
-        $sortedId = array();
+        $sortedId = [];
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
@@ -494,12 +494,12 @@ use Doctrine\Common\Util\ClassUtils;
         }
 
         if ( ! is_array($sortedId)) {
-            $sortedId = array($class->identifier[0] => $sortedId);
+            $sortedId = [$class->identifier[0] => $sortedId];
         }
 
         $entity = $this->proxyFactory->getProxy($class->name, $sortedId);
 
-        $this->unitOfWork->registerManaged($entity, $sortedId, array());
+        $this->unitOfWork->registerManaged($entity, $sortedId, []);
 
         return $entity;
     }
@@ -517,14 +517,14 @@ use Doctrine\Common\Util\ClassUtils;
         }
 
         if ( ! is_array($identifier)) {
-            $identifier = array($class->identifier[0] => $identifier);
+            $identifier = [$class->identifier[0] => $identifier];
         }
 
         $entity = $class->newInstance();
 
         $class->setIdentifierValues($entity, $identifier);
 
-        $this->unitOfWork->registerManaged($entity, $identifier, array());
+        $this->unitOfWork->registerManaged($entity, $identifier, []);
         $this->unitOfWork->markReadOnly($entity);
 
         return $entity;

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -37,7 +37,7 @@ class EntityNotFoundException extends ORMException
      */
     public static function fromClassNameAndIdentifier($className, array $id)
     {
-        $ids = array();
+        $ids = [];
 
         foreach ($id as $key => $value) {
             $ids[] = $key . '(' . $value . ')';

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -161,7 +161,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function findAll()
     {
-        return $this->findBy(array());
+        return $this->findBy([]);
     }
 
     /**
@@ -193,7 +193,7 @@ class EntityRepository implements ObjectRepository, Selectable
     {
         $persister = $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName);
 
-        return $persister->load($criteria, null, null, array(), null, 1, $orderBy);
+        return $persister->load($criteria, null, null, [], null, 1, $orderBy);
     }
 
     /**
@@ -238,16 +238,16 @@ class EntityRepository implements ObjectRepository, Selectable
         if ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName)) {
             switch (count($arguments)) {
                 case 1:
-                    return $this->$method(array($fieldName => $arguments[0]));
+                    return $this->$method([$fieldName => $arguments[0]]);
 
                 case 2:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1]);
 
                 case 3:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1], $arguments[2]);
 
                 case 4:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2], $arguments[3]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1], $arguments[2], $arguments[3]);
 
                 default:
                     // Do nothing

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -44,7 +44,7 @@ class AssignedGenerator extends AbstractIdGenerator
     {
         $class      = $em->getClassMetadata(get_class($entity));
         $idFields   = $class->getIdentifierFieldNames();
-        $identifier = array();
+        $identifier = [];
 
         foreach ($idFields as $idField) {
             $value = $class->getFieldValue($entity, $idField);

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -108,10 +108,10 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
      */
     public function serialize()
     {
-        return serialize(array(
+        return serialize([
             'allocationSize' => $this->_allocationSize,
             'sequenceName'   => $this->_sequenceName
-        ));
+        ]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -92,7 +92,7 @@ class TableGenerator extends AbstractIdGenerator
                         $this->_tableName, $this->_sequenceName, $this->_allocationSize
                     );
 
-                    if ($conn->executeUpdate($updateSql, array(1 => $currentLevel, 2 => $currentLevel+1)) !== 1) {
+                    if ($conn->executeUpdate($updateSql, [1 => $currentLevel, 2 => $currentLevel+1]) !== 1) {
                         // no affected rows, concurrency issue, throw exception
                     }
                 } else {

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -36,24 +36,24 @@ class CommitOrderCalculator
     /**
      * @var array
      */
-    private $_nodeStates = array();
+    private $_nodeStates = [];
 
     /**
      * The nodes to sort.
      *
      * @var array
      */
-    private $_classes = array();
+    private $_classes = [];
 
     /**
      * @var array
      */
-    private $_relatedClasses = array();
+    private $_relatedClasses = [];
 
     /**
      * @var array
      */
-    private $_sorted = array();
+    private $_sorted = [];
 
     /**
      * Clears the current graph.
@@ -62,8 +62,8 @@ class CommitOrderCalculator
      */
     public function clear()
     {
-        $this->_classes = array();
-        $this->_relatedClasses = array();
+        $this->_classes = [];
+        $this->_relatedClasses = [];
     }
 
     /**
@@ -80,7 +80,7 @@ class CommitOrderCalculator
         $nodeCount = count($this->_classes);
 
         if ($nodeCount <= 1) {
-            return ($nodeCount == 1) ? array_values($this->_classes) : array();
+            return ($nodeCount == 1) ? array_values($this->_classes) : [];
         }
 
         // Init
@@ -97,7 +97,7 @@ class CommitOrderCalculator
 
         $sorted = array_reverse($this->_sorted);
 
-        $this->_sorted = $this->_nodeStates = array();
+        $this->_sorted = $this->_nodeStates = [];
 
         return $sorted;
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -69,14 +69,14 @@ abstract class AbstractHydrator
      *
      * @var array
      */
-    protected $_metadataCache = array();
+    protected $_metadataCache = [];
 
     /**
      * The cache used during row-by-row hydration.
      *
      * @var array
      */
-    protected $_cache = array();
+    protected $_cache = [];
 
     /**
      * The statement that provides the data to hydrate.
@@ -113,14 +113,14 @@ abstract class AbstractHydrator
      *
      * @return IterableResult
      */
-    public function iterate($stmt, $resultSetMapping, array $hints = array())
+    public function iterate($stmt, $resultSetMapping, array $hints = [])
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;
         $this->_hints = $hints;
 
         $evm = $this->_em->getEventManager();
-        $evm->addEventListener(array(Events::onClear), $this);
+        $evm->addEventListener([Events::onClear], $this);
 
         $this->prepare();
 
@@ -136,7 +136,7 @@ abstract class AbstractHydrator
      *
      * @return array
      */
-    public function hydrateAll($stmt, $resultSetMapping, array $hints = array())
+    public function hydrateAll($stmt, $resultSetMapping, array $hints = [])
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;
@@ -167,7 +167,7 @@ abstract class AbstractHydrator
             return false;
         }
 
-        $result = array();
+        $result = [];
 
         $this->hydrateRowData($row, $result);
 
@@ -208,8 +208,8 @@ abstract class AbstractHydrator
 
         $this->_stmt          = null;
         $this->_rsm           = null;
-        $this->_cache         = array();
-        $this->_metadataCache = array();
+        $this->_cache         = [];
+        $this->_metadataCache = [];
     }
 
     /**
@@ -254,7 +254,7 @@ abstract class AbstractHydrator
      */
     protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents)
     {
-        $rowData = array('data' => array());
+        $rowData = ['data' => []];
 
         foreach ($data as $key => $value) {
             if (($cacheKeyInfo = $this->hydrateColumnInfo($key)) === null) {
@@ -322,7 +322,7 @@ abstract class AbstractHydrator
      */
     protected function gatherScalarRowData(&$data)
     {
-        $rowData = array();
+        $rowData = [];
 
         foreach ($data as $key => $value) {
             if (($cacheKeyInfo = $this->hydrateColumnInfo($key)) === null) {
@@ -368,18 +368,18 @@ abstract class AbstractHydrator
                 $fieldName     = $this->_rsm->fieldMappings[$key];
                 $fieldMapping  = $classMetadata->fieldMappings[$fieldName];
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isIdentifier' => in_array($fieldName, $classMetadata->identifier),
                     'fieldName'    => $fieldName,
                     'type'         => Type::getType($fieldMapping['type']),
                     'dqlAlias'     => $this->_rsm->columnOwnerMap[$key],
-                );
+                ];
 
             case (isset($this->_rsm->newObjectMappings[$key])):
                 // WARNING: A NEW object is also a scalar, so it must be declared before!
                 $mapping = $this->_rsm->newObjectMappings[$key];
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isScalar'             => true,
                     'isNewObjectParameter' => true,
                     'fieldName'            => $this->_rsm->scalarMappings[$key],
@@ -387,14 +387,14 @@ abstract class AbstractHydrator
                     'argIndex'             => $mapping['argIndex'],
                     'objIndex'             => $mapping['objIndex'],
                     'class'                => new \ReflectionClass($mapping['className']),
-                );
+                ];
 
             case (isset($this->_rsm->scalarMappings[$key])):
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isScalar'  => true,
                     'fieldName' => $this->_rsm->scalarMappings[$key],
                     'type'      => Type::getType($this->_rsm->typeMappings[$key]),
-                );
+                ];
 
             case (isset($this->_rsm->metaMappings[$key])):
                 // Meta column (has meaning in relational schema only, i.e. foreign keys or discriminator columns).
@@ -405,13 +405,13 @@ abstract class AbstractHydrator
                     ? Type::getType($this->_rsm->typeMappings[$key])
                     : null;
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isIdentifier' => isset($this->_rsm->isIdentifierColumn[$dqlAlias][$key]),
                     'isMetaColumn' => true,
                     'fieldName'    => $fieldName,
                     'type'         => $type,
                     'dqlAlias'     => $dqlAlias,
-                );
+                ];
         }
 
         // this column is a left over, maybe from a LIMIT query hack for example in Oracle or DB2
@@ -449,7 +449,7 @@ abstract class AbstractHydrator
     protected function registerManaged(ClassMetadata $class, $entity, array $data)
     {
         if ($class->isIdentifierComposite) {
-            $id = array();
+            $id = [];
 
             foreach ($class->identifier as $fieldName) {
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
@@ -458,11 +458,11 @@ abstract class AbstractHydrator
             }
         } else {
             $fieldName = $class->identifier[0];
-            $id        = array(
+            $id        = [
                 $fieldName => isset($class->associationMappings[$fieldName])
                     ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
                     : $data[$fieldName]
-            );
+            ];
         }
 
         $this->_em->getUnitOfWork()->registerManaged($entity, $id, $data);

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -35,7 +35,7 @@ class ArrayHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $_rootAliases = array();
+    private $_rootAliases = [];
 
     /**
      * @var bool
@@ -45,17 +45,17 @@ class ArrayHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $_identifierMap = array();
+    private $_identifierMap = [];
 
     /**
      * @var array
      */
-    private $_resultPointers = array();
+    private $_resultPointers = [];
 
     /**
      * @var array
      */
-    private $_idTemplate = array();
+    private $_idTemplate = [];
 
     /**
      * @var int
@@ -70,8 +70,8 @@ class ArrayHydrator extends AbstractHydrator
         $this->_isSimpleQuery = count($this->_rsm->aliasMap) <= 1;
 
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
-            $this->_identifierMap[$dqlAlias]  = array();
-            $this->_resultPointers[$dqlAlias] = array();
+            $this->_identifierMap[$dqlAlias]  = [];
+            $this->_resultPointers[$dqlAlias] = [];
             $this->_idTemplate[$dqlAlias]     = '';
         }
     }
@@ -81,7 +81,7 @@ class ArrayHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($data = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($data, $result);
@@ -97,7 +97,7 @@ class ArrayHydrator extends AbstractHydrator
     {
         // 1) Initialize
         $id = $this->_idTemplate; // initialize the id-memory
-        $nonemptyComponents = array();
+        $nonemptyComponents = [];
         $rowData = $this->gatherRowData($row, $id, $nonemptyComponents);
 
         // 2) Now hydrate the data found in the current row.
@@ -138,7 +138,7 @@ class ArrayHydrator extends AbstractHydrator
                     $oneToOne = false;
 
                     if ( ! isset($baseElement[$relationAlias])) {
-                        $baseElement[$relationAlias] = array();
+                        $baseElement[$relationAlias] = [];
                     }
 
                     if (isset($nonemptyComponents[$dqlAlias])) {
@@ -187,7 +187,7 @@ class ArrayHydrator extends AbstractHydrator
                 // if this row has a NULL value for the root result id then make it a null result.
                 if ( ! isset($nonemptyComponents[$dqlAlias]) ) {
                     $result[] = $this->_rsm->isMixed
-                        ? array($entityKey => null)
+                        ? [$entityKey => null]
                         : null;
 
                     $resultKey = $this->_resultCounter;
@@ -199,7 +199,7 @@ class ArrayHydrator extends AbstractHydrator
                 // Check for an existing element
                 if ($this->_isSimpleQuery || ! isset($this->_identifierMap[$dqlAlias][$id[$dqlAlias]])) {
                     $element = $this->_rsm->isMixed
-                        ? array($entityKey => $data)
+                        ? [$entityKey => $data]
                         : $data;
 
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -45,17 +45,17 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $identifierMap = array();
+    private $identifierMap = [];
 
     /**
      * @var array
      */
-    private $resultPointers = array();
+    private $resultPointers = [];
 
     /**
      * @var array
      */
-    private $idTemplate = array();
+    private $idTemplate = [];
 
     /**
      * @var integer
@@ -65,17 +65,17 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $rootAliases = array();
+    private $rootAliases = [];
 
     /**
      * @var array
      */
-    private $initializedCollections = array();
+    private $initializedCollections = [];
 
     /**
      * @var array
      */
-    private $existingCollections = array();
+    private $existingCollections = [];
 
     /**
      * {@inheritdoc}
@@ -87,7 +87,7 @@ class ObjectHydrator extends AbstractHydrator
         }
 
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
-            $this->identifierMap[$dqlAlias] = array();
+            $this->identifierMap[$dqlAlias] = [];
             $this->idTemplate[$dqlAlias]    = '';
 
             // Remember which associations are "fetch joined", so that we know where to inject
@@ -145,7 +145,7 @@ class ObjectHydrator extends AbstractHydrator
         $this->identifierMap =
         $this->initializedCollections =
         $this->existingCollections =
-        $this->resultPointers = array();
+        $this->resultPointers = [];
 
         if ($eagerLoad) {
             $this->_uow->triggerEagerLoads();
@@ -159,7 +159,7 @@ class ObjectHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($row = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($row, $result);
@@ -328,7 +328,7 @@ class ObjectHydrator extends AbstractHydrator
     {
         // Initialize
         $id = $this->idTemplate; // initialize the id-memory
-        $nonemptyComponents = array();
+        $nonemptyComponents = [];
         // Split the row data into chunks of class data.
         $rowData = $this->gatherRowData($row, $id, $nonemptyComponents);
 
@@ -477,7 +477,7 @@ class ObjectHydrator extends AbstractHydrator
                 // if this row has a NULL value for the root result id then make it a null result.
                 if ( ! isset($nonemptyComponents[$dqlAlias]) ) {
                     if ($this->_rsm->isMixed) {
-                        $result[] = array($entityKey => null);
+                        $result[] = [$entityKey => null];
                     } else {
                         $result[] = null;
                     }
@@ -491,7 +491,7 @@ class ObjectHydrator extends AbstractHydrator
                     $element = $this->getEntity($data, $dqlAlias);
 
                     if ($this->_rsm->isMixed) {
-                        $element = array($entityKey => $element);
+                        $element = [$entityKey => $element];
                     }
 
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {
@@ -586,10 +586,10 @@ class ObjectHydrator extends AbstractHydrator
         parent::onClear($eventArgs);
 
         $aliases             = array_keys($this->identifierMap);
-        $this->identifierMap = array();
+        $this->identifierMap = [];
 
         foreach ($aliases as $alias) {
-            $this->identifierMap[$alias] = array();
+            $this->identifierMap[$alias] = [];
         }
     }
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
@@ -35,7 +35,7 @@ class ScalarHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($data = $this->_stmt->fetch(\PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($data, $result);

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -63,7 +63,7 @@ class SimpleObjectHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($row = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($row, $result);
@@ -80,7 +80,7 @@ class SimpleObjectHydrator extends AbstractHydrator
     protected function hydrateRowData(array $sqlResult, array &$result)
     {
         $entityName = $this->class->name;
-        $data       = array();
+        $data       = [];
 
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -47,7 +47,7 @@ final class HydrationCompleteHandler
     /**
      * @var array[]
      */
-    private $deferredPostLoadInvocations = array();
+    private $deferredPostLoadInvocations = [];
 
     /**
      * Constructor for this object
@@ -75,7 +75,7 @@ final class HydrationCompleteHandler
             return;
         }
 
-        $this->deferredPostLoadInvocations[] = array($class, $invoke, $entity);
+        $this->deferredPostLoadInvocations[] = [$class, $invoke, $entity];
     }
 
     /**
@@ -86,7 +86,7 @@ final class HydrationCompleteHandler
     public function hydrationComplete()
     {
         $toInvoke                          = $this->deferredPostLoadInvocations;
-        $this->deferredPostLoadInvocations = array();
+        $this->deferredPostLoadInvocations = [];
 
         foreach ($toInvoke as $classAndEntity) {
             list($class, $invoke, $entity) = $classAndEntity;

--- a/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
@@ -82,7 +82,7 @@ class AssociationBuilder
      */
     public function cascadeAll()
     {
-        $this->mapping['cascade'] = array("ALL");
+        $this->mapping['cascade'] = ["ALL"];
         return $this;
     }
 
@@ -172,14 +172,14 @@ class AssociationBuilder
      */
     public function addJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
-        $this->joinColumns[] = array(
+        $this->joinColumns[] = [
             'name' => $columnName,
             'referencedColumnName' => $referencedColumnName,
             'nullable' => $nullable,
             'unique' => $unique,
             'onDelete' => $onDelete,
             'columnDefinition' => $columnDef,
-        );
+        ];
         return $this;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -101,7 +101,7 @@ class ClassMetadataBuilder
      */
     public function setTable($name)
     {
-        $this->cm->setPrimaryTable(array('name' => $name));
+        $this->cm->setPrimaryTable(['name' => $name]);
 
         return $this;
     }
@@ -117,10 +117,10 @@ class ClassMetadataBuilder
     public function addIndex(array $columns, $name)
     {
         if (!isset($this->cm->table['indexes'])) {
-            $this->cm->table['indexes'] = array();
+            $this->cm->table['indexes'] = [];
         }
 
-        $this->cm->table['indexes'][$name] = array('columns' => $columns);
+        $this->cm->table['indexes'][$name] = ['columns' => $columns];
 
         return $this;
     }
@@ -136,10 +136,10 @@ class ClassMetadataBuilder
     public function addUniqueConstraint(array $columns, $name)
     {
         if ( ! isset($this->cm->table['uniqueConstraints'])) {
-            $this->cm->table['uniqueConstraints'] = array();
+            $this->cm->table['uniqueConstraints'] = [];
         }
 
-        $this->cm->table['uniqueConstraints'][$name] = array('columns' => $columns);
+        $this->cm->table['uniqueConstraints'][$name] = ['columns' => $columns];
 
         return $this;
     }
@@ -154,10 +154,10 @@ class ClassMetadataBuilder
      */
     public function addNamedQuery($name, $dqlQuery)
     {
-        $this->cm->addNamedQuery(array(
+        $this->cm->addNamedQuery([
             'name' => $name,
             'query' => $dqlQuery,
-        ));
+        ]);
 
         return $this;
     }
@@ -197,11 +197,11 @@ class ClassMetadataBuilder
      */
     public function setDiscriminatorColumn($name, $type = 'string', $length = 255)
     {
-        $this->cm->setDiscriminatorColumn(array(
+        $this->cm->setDiscriminatorColumn([
             'name' => $name,
             'type' => $type,
             'length' => $length,
-        ));
+        ]);
 
         return $this;
     }
@@ -269,7 +269,7 @@ class ClassMetadataBuilder
      *
      * @return ClassMetadataBuilder
      */
-    public function addField($name, $type, array $mapping = array())
+    public function addField($name, $type, array $mapping = [])
     {
         $mapping['fieldName'] = $name;
         $mapping['type'] = $type;
@@ -291,10 +291,10 @@ class ClassMetadataBuilder
     {
         return new FieldBuilder(
             $this,
-            array(
+            [
                 'fieldName' => $name,
                 'type'      => $type
-            )
+            ]
         );
     }
 
@@ -332,10 +332,10 @@ class ClassMetadataBuilder
     {
         return new AssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::MANY_TO_ONE
         );
     }
@@ -352,10 +352,10 @@ class ClassMetadataBuilder
     {
         return new AssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::ONE_TO_ONE
         );
     }
@@ -409,10 +409,10 @@ class ClassMetadataBuilder
     {
         return new ManyToManyAssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::MANY_TO_MANY
         );
     }
@@ -466,10 +466,10 @@ class ClassMetadataBuilder
     {
         return new OneToManyAssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::ONE_TO_MANY
         );
     }

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -34,7 +34,7 @@ class EntityListenerBuilder
     /**
      * @var array Hash-map to handle event names.
      */
-    static private $events = array(
+    static private $events = [
         Events::preRemove   => true,
         Events::postRemove  => true,
         Events::prePersist  => true,
@@ -43,7 +43,7 @@ class EntityListenerBuilder
         Events::postUpdate  => true,
         Events::postLoad    => true,
         Events::preFlush    => true
-    );
+    ];
 
     /**
      * Lookup the entity class to find methods that match to event lifecycle names

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -200,11 +200,11 @@ class FieldBuilder
      */
     public function setSequenceGenerator($sequenceName, $allocationSize = 1, $initialValue = 1)
     {
-        $this->sequenceDef = array(
+        $this->sequenceDef = [
             'sequenceName' => $sequenceName,
             'allocationSize' => $allocationSize,
             'initialValue' => $initialValue,
-        );
+        ];
         return $this;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -37,7 +37,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     /**
      * @var array
      */
-    private $inverseJoinColumns = array();
+    private $inverseJoinColumns = [];
 
     /**
      * @param string $name
@@ -64,14 +64,14 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
      */
     public function addInverseJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
-        $this->inverseJoinColumns[] = array(
+        $this->inverseJoinColumns[] = [
             'name' => $columnName,
             'referencedColumnName' => $referencedColumnName,
             'nullable' => $nullable,
             'unique' => $unique,
             'onDelete' => $onDelete,
             'columnDefinition' => $columnDef,
-        );
+        ];
         return $this;
     }
 
@@ -81,7 +81,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     public function build()
     {
         $mapping = $this->mapping;
-        $mapping['joinTable'] = array();
+        $mapping['joinTable'] = [];
         if ($this->joinColumns) {
             $mapping['joinTable']['joinColumns'] = $this->joinColumns;
         }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -68,7 +68,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * @var array
      */
-    private $embeddablesActiveNesting = array();
+    private $embeddablesActiveNesting = [];
 
     /**
      * {@inheritDoc}
@@ -356,9 +356,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         $allClasses = $this->driver->getAllClassNames();
         $fqcn = $class->getName();
-        $map = array($this->getShortName($class->name) => $fqcn);
+        $map = [$this->getShortName($class->name) => $fqcn];
 
-        $duplicates = array();
+        $duplicates = [];
         foreach ($allClasses as $subClassCandidate) {
             if (is_subclass_of($subClassCandidate, $fqcn)) {
                 $shortName = $this->getShortName($subClassCandidate);
@@ -480,7 +480,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
             $embeddableMetadata = $this->getMetadataFor($embeddableClass['class']);
 
-            $parentClass->mapEmbedded(array(
+            $parentClass->mapEmbedded([
                 'fieldName' => $prefix . '.' . $property,
                 'class' => $embeddableMetadata->name,
                 'columnPrefix' => $embeddableClass['columnPrefix'],
@@ -488,7 +488,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         ? $prefix . '.' . $embeddableClass['declaredField']
                         : $prefix,
                 'originalField' => $embeddableClass['originalField'] ?: $property,
-            ));
+            ]);
         }
     }
 
@@ -506,7 +506,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             return;
         }
 
-        foreach (array('uniqueConstraints', 'indexes') as $indexType) {
+        foreach (['uniqueConstraints', 'indexes'] as $indexType) {
             if (isset($parentClass->table[$indexType])) {
                 foreach ($parentClass->table[$indexType] as $indexName => $index) {
                     if (isset($subClass->table[$indexType][$indexName])) {
@@ -533,10 +533,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedQueries as $name => $query) {
             if ( ! isset ($subClass->namedQueries[$name])) {
-                $subClass->addNamedQuery(array(
+                $subClass->addNamedQuery([
                     'name'  => $query['name'],
                     'query' => $query['query']
-                ));
+                ]);
             }
         }
     }
@@ -555,13 +555,13 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedNativeQueries as $name => $query) {
             if ( ! isset ($subClass->namedNativeQueries[$name])) {
-                $subClass->addNamedNativeQuery(array(
+                $subClass->addNamedNativeQuery([
                     'name'              => $query['name'],
                     'query'             => $query['query'],
                     'isSelfClass'       => $query['isSelfClass'],
                     'resultSetMapping'  => $query['resultSetMapping'],
                     'resultClass'       => $query['isSelfClass'] ? $subClass->name : $query['resultClass'],
-                ));
+                ]);
             }
         }
     }
@@ -580,21 +580,21 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->sqlResultSetMappings as $name => $mapping) {
             if ( ! isset ($subClass->sqlResultSetMappings[$name])) {
-                $entities = array();
+                $entities = [];
                 foreach ($mapping['entities'] as $entity) {
-                    $entities[] = array(
+                    $entities[] = [
                         'fields'                => $entity['fields'],
                         'isSelfClass'           => $entity['isSelfClass'],
                         'discriminatorColumn'   => $entity['discriminatorColumn'],
                         'entityClass'           => $entity['isSelfClass'] ? $subClass->name : $entity['entityClass'],
-                    );
+                    ];
                 }
 
-                $subClass->addSqlResultSetMapping(array(
+                $subClass->addSqlResultSetMapping([
                     'name'          => $mapping['name'],
                     'columns'       => $mapping['columns'],
                     'entities'      => $entities,
-                ));
+                ]);
             }
         }
     }
@@ -634,9 +634,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
                     $sequencePrefix = $class->getSequencePrefix($this->targetPlatform);
                     $sequenceName   = $this->targetPlatform->getIdentitySequenceName($sequencePrefix, $columnName);
-                    $definition     = array(
+                    $definition     = [
                         'sequenceName' => $this->targetPlatform->fixSchemaElementName($sequenceName)
-                    );
+                    ];
 
                     if ($quoted) {
                         $definition['quoted'] = true;
@@ -666,11 +666,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $sequenceName   = $class->getSequenceName($this->targetPlatform);
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
 
-                    $definition = array(
+                    $definition = [
                         'sequenceName'      => $this->targetPlatform->fixSchemaElementName($sequenceName),
                         'allocationSize'    => 1,
                         'initialValue'      => 1,
-                    );
+                    ];
 
                     if ($quoted) {
                         $definition['quoted'] = true;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -274,28 +274,28 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $parentClasses = array();
+    public $parentClasses = [];
 
     /**
      * READ-ONLY: The names of all subclasses (descendants).
      *
      * @var array
      */
-    public $subClasses = array();
+    public $subClasses = [];
 
     /**
      * READ-ONLY: The names of all embedded classes based on properties.
      *
      * @var array
      */
-    public $embeddedClasses = array();
+    public $embeddedClasses = [];
 
     /**
      * READ-ONLY: The named queries allowed to be called directly from Repository.
      *
      * @var array
      */
-    public $namedQueries = array();
+    public $namedQueries = [];
 
     /**
      * READ-ONLY: The named native queries allowed to be called directly from Repository.
@@ -312,7 +312,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $namedNativeQueries = array();
+    public $namedNativeQueries = [];
 
     /**
      * READ-ONLY: The mappings of the results of native SQL queries.
@@ -328,7 +328,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $sqlResultSetMappings = array();
+    public $sqlResultSetMappings = [];
 
     /**
      * READ-ONLY: The field names of all fields that are part of the identifier/primary key
@@ -336,7 +336,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $identifier = array();
+    public $identifier = [];
 
     /**
      * READ-ONLY: The inheritance mapping type used by the class.
@@ -393,7 +393,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $fieldMappings = array();
+    public $fieldMappings = [];
 
     /**
      * READ-ONLY: An array of field names. Used to look up field names from column names.
@@ -402,7 +402,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $fieldNames = array();
+    public $fieldNames = [];
 
     /**
      * READ-ONLY: A map of field names to column names. Keys are field names and values column names.
@@ -413,7 +413,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @todo We could get rid of this array by just using $fieldMappings[$fieldName]['columnName'].
      */
-    public $columnNames = array();
+    public $columnNames = [];
 
     /**
      * READ-ONLY: The discriminator value of this class.
@@ -437,7 +437,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see discriminatorColumn
      */
-    public $discriminatorMap = array();
+    public $discriminatorMap = [];
 
     /**
      * READ-ONLY: The definition of the discriminator column used in JOINED and SINGLE_TABLE
@@ -465,14 +465,14 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $lifecycleCallbacks = array();
+    public $lifecycleCallbacks = [];
 
     /**
      * READ-ONLY: The registered entity listeners.
      *
      * @var array
      */
-    public $entityListeners = array();
+    public $entityListeners = [];
 
     /**
      * READ-ONLY: The association mappings of this class.
@@ -529,7 +529,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $associationMappings = array();
+    public $associationMappings = [];
 
     /**
      * READ-ONLY: Flag indicating whether the identifier/primary key of the class is composite.
@@ -642,7 +642,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var \ReflectionProperty[]
      */
-    public $reflFields = array();
+    public $reflFields = [];
 
     /**
      * @var \Doctrine\Instantiator\InstantiatorInterface|null
@@ -714,7 +714,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function getIdentifierValues($entity)
     {
         if ($this->isIdentifierComposite) {
-            $id = array();
+            $id = [];
 
             foreach ($this->identifier as $idField) {
                 $value = $this->reflFields[$idField]->getValue($entity);
@@ -731,10 +731,10 @@ class ClassMetadataInfo implements ClassMetadata
         $value = $this->reflFields[$id]->getValue($entity);
 
         if (null === $value) {
-            return array();
+            return [];
         }
 
-        return array($id => $value);
+        return [$id => $value];
     }
 
     /**
@@ -809,7 +809,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function __sleep()
     {
         // This metadata is always serialized/cached.
-        $serialized = array(
+        $serialized = [
             'associationMappings',
             'columnNames', //TODO: Not really needed. Can use fieldMappings[$fieldName]['columnName']
             'fieldMappings',
@@ -822,7 +822,7 @@ class ClassMetadataInfo implements ClassMetadata
             'table',
             'rootEntityName',
             'idGenerator', //TODO: Does not really need to be serialized. Could be moved to runtime.
-        );
+        ];
 
         // The rest of the metadata is only serialized if necessary.
         if ($this->changeTrackingPolicy != self::CHANGETRACKING_DEFERRED_IMPLICIT) {
@@ -924,7 +924,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->reflClass    = $reflService->getClass($this->name);
         $this->instantiator = $this->instantiator ?: new Instantiator();
 
-        $parentReflFields = array();
+        $parentReflFields = [];
 
         foreach ($this->embeddedClasses as $property => $embeddedClass) {
             if (isset($embeddedClass['declaredField'])) {
@@ -1507,15 +1507,15 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         // Cascades
-        $cascades = isset($mapping['cascade']) ? array_map('strtolower', $mapping['cascade']) : array();
+        $cascades = isset($mapping['cascade']) ? array_map('strtolower', $mapping['cascade']) : [];
 
         if (in_array('all', $cascades)) {
-            $cascades = array('remove', 'persist', 'refresh', 'merge', 'detach');
+            $cascades = ['remove', 'persist', 'refresh', 'merge', 'detach'];
         }
 
-        if (count($cascades) !== count(array_intersect($cascades, array('remove', 'persist', 'refresh', 'merge', 'detach')))) {
+        if (count($cascades) !== count(array_intersect($cascades, ['remove', 'persist', 'refresh', 'merge', 'detach']))) {
             throw MappingException::invalidCascadeOption(
-                array_diff($cascades, array_intersect($cascades, array('remove', 'persist', 'refresh', 'merge', 'detach'))),
+                array_diff($cascades, array_intersect($cascades, ['remove', 'persist', 'refresh', 'merge', 'detach'])),
                 $this->name,
                 $mapping['fieldName']
             );
@@ -1552,13 +1552,13 @@ class ClassMetadataInfo implements ClassMetadata
         if ($mapping['isOwningSide']) {
             if ( ! isset($mapping['joinColumns']) || ! $mapping['joinColumns']) {
                 // Apply default join column
-                $mapping['joinColumns'] = array(array(
+                $mapping['joinColumns'] = [[
                     'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                     'referencedColumnName' => $this->namingStrategy->referenceColumnName()
-                ));
+                ]];
             }
 
-            $uniqueConstraintColumns = array();
+            $uniqueConstraintColumns = [];
             foreach ($mapping['joinColumns'] as &$joinColumn) {
                 if ($mapping['type'] === self::ONE_TO_ONE && ! $this->isInheritanceTypeSingleTable()) {
                     if (count($mapping['joinColumns']) == 1) {
@@ -1597,9 +1597,9 @@ class ClassMetadataInfo implements ClassMetadata
                 if ( ! $this->table) {
                     throw new RuntimeException("ClassMetadataInfo::setTable() has to be called before defining a one to one relationship.");
                 }
-                $this->table['uniqueConstraints'][$mapping['fieldName']."_uniq"] = array(
+                $this->table['uniqueConstraints'][$mapping['fieldName']."_uniq"] = [
                     'columns' => $uniqueConstraintColumns
-                );
+                ];
             }
 
             $mapping['targetToSourceKeyColumns'] = array_flip($mapping['sourceToTargetKeyColumns']);
@@ -1672,19 +1672,19 @@ class ClassMetadataInfo implements ClassMetadata
                 && (! (isset($mapping['joinTable']['joinColumns']) || isset($mapping['joinTable']['inverseJoinColumns'])));
 
             if ( ! isset($mapping['joinTable']['joinColumns'])) {
-                $mapping['joinTable']['joinColumns'] = array(array(
+                $mapping['joinTable']['joinColumns'] = [[
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
-                        'onDelete' => 'CASCADE'));
+                        'onDelete' => 'CASCADE']];
             }
             if ( ! isset($mapping['joinTable']['inverseJoinColumns'])) {
-                $mapping['joinTable']['inverseJoinColumns'] = array(array(
+                $mapping['joinTable']['inverseJoinColumns'] = [[
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
-                        'onDelete' => 'CASCADE'));
+                        'onDelete' => 'CASCADE']];
             }
 
-            $mapping['joinTableColumns'] = array();
+            $mapping['joinTableColumns'] = [];
 
             foreach ($mapping['joinTable']['joinColumns'] as &$joinColumn) {
                 if (empty($joinColumn['name'])) {
@@ -1832,7 +1832,7 @@ class ClassMetadataInfo implements ClassMetadata
         if ($fieldNames === null) {
             return array_keys($this->fieldNames);
         } else {
-            $columnNames = array();
+            $columnNames = [];
             foreach ($fieldNames as $fieldName) {
                 $columnNames[] = $this->getColumnName($fieldName);
             }
@@ -1847,7 +1847,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getIdentifierColumnNames()
     {
-        $columnNames = array();
+        $columnNames = [];
 
         foreach ($this->identifier as $idProperty) {
             if (isset($this->fieldMappings[$idProperty])) {
@@ -2373,11 +2373,11 @@ class ClassMetadataInfo implements ClassMetadata
         $name   = $queryMapping['name'];
         $query  = $queryMapping['query'];
         $dql    = str_replace('__CLASS__', $this->name, $query);
-        $this->namedQueries[$name] = array(
+        $this->namedQueries[$name] = [
             'name'  => $name,
             'query' => $query,
             'dql'   => $dql
-        );
+        ];
     }
 
     /**
@@ -2611,7 +2611,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getLifecycleCallbacks($event)
     {
-        return isset($this->lifecycleCallbacks[$event]) ? $this->lifecycleCallbacks[$event] : array();
+        return isset($this->lifecycleCallbacks[$event]) ? $this->lifecycleCallbacks[$event] : [];
     }
 
     /**
@@ -2656,10 +2656,10 @@ class ClassMetadataInfo implements ClassMetadata
     public function addEntityListener($eventName, $class, $method)
     {
         $class    = $this->fullyQualifiedClassName($class);
-        $listener = array(
+        $listener = [
             'class'  => $class,
             'method' => $method
-        );
+        ];
 
         if ( ! class_exists($class)) {
             throw MappingException::entityListenerClassNotFound($class, $this->name);
@@ -2706,7 +2706,7 @@ class ClassMetadataInfo implements ClassMetadata
                 $columnDef['type'] = "string";
             }
 
-            if (in_array($columnDef['type'], array("boolean", "array", "object", "datetime", "time", "date"))) {
+            if (in_array($columnDef['type'], ["boolean", "array", "object", "datetime", "time", "date"])) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
             }
 
@@ -2971,7 +2971,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->versionField = $mapping['fieldName'];
 
         if ( ! isset($mapping['default'])) {
-            if (in_array($mapping['type'], array('integer', 'bigint', 'smallint'))) {
+            if (in_array($mapping['type'], ['integer', 'bigint', 'smallint'])) {
                 $mapping['default'] = 1;
             } else if ($mapping['type'] == 'datetime') {
                 $mapping['default'] = 'CURRENT_TIMESTAMP';
@@ -3065,7 +3065,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getQuotedIdentifierColumnNames($platform)
     {
-        $quotedColumnNames = array();
+        $quotedColumnNames = [];
 
         foreach ($this->identifier as $idProperty) {
             if (isset($this->fieldMappings[$idProperty])) {
@@ -3162,7 +3162,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getAssociationsByTargetClass($targetClass)
     {
-        $relations = array();
+        $relations = [];
         foreach ($this->associationMappings as $mapping) {
             if ($mapping['targetEntity'] == $targetClass) {
                 $relations[$mapping['fieldName']] = $mapping;
@@ -3213,12 +3213,12 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->assertFieldNotMapped($mapping['fieldName']);
 
-        $this->embeddedClasses[$mapping['fieldName']] = array(
+        $this->embeddedClasses[$mapping['fieldName']] = [
             'class' => $this->fullyQualifiedClassName($mapping['class']),
             'columnPrefix' => $mapping['columnPrefix'],
             'declaredField' => isset($mapping['declaredField']) ? $mapping['declaredField'] : null,
             'originalField' => isset($mapping['originalField']) ? $mapping['originalField'] : null,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -67,7 +67,7 @@ final class Column implements Annotation
     /**
      * @var array
      */
-    public $options = array();
+    public $options = [];
 
     /**
      * @var string

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -31,7 +31,7 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
     /**
      * @var array Map to store entity listener instances.
      */
-    private $instances = array();
+    private $instances = [];
 
     /**
      * {@inheritdoc}
@@ -39,7 +39,7 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
     public function clear($className = null)
     {
         if ($className === null) {
-            $this->instances = array();
+            $this->instances = [];
 
             return;
         }

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -106,7 +106,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
      */
     public function getIdentifierColumnNames(ClassMetadata $class, AbstractPlatform $platform)
     {
-        $quotedColumnNames = array();
+        $quotedColumnNames = [];
 
         foreach ($class->identifier as $fieldName) {
             if (isset($class->fieldMappings[$fieldName])) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -42,10 +42,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
     /**
      * {@inheritDoc}
      */
-    protected $entityAnnotationClasses = array(
+    protected $entityAnnotationClasses = [
         'Doctrine\ORM\Mapping\Entity' => 1,
         'Doctrine\ORM\Mapping\MappedSuperclass' => 2,
-    );
+    ];
 
     /**
      * {@inheritDoc}
@@ -94,14 +94,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
         // Evaluate Table annotation
         if (isset($classAnnotations['Doctrine\ORM\Mapping\Table'])) {
             $tableAnnot   = $classAnnotations['Doctrine\ORM\Mapping\Table'];
-            $primaryTable = array(
+            $primaryTable = [
                 'name'   => $tableAnnot->name,
                 'schema' => $tableAnnot->schema
-            );
+            ];
 
             if ($tableAnnot->indexes !== null) {
                 foreach ($tableAnnot->indexes as $indexAnnot) {
-                    $index = array('columns' => $indexAnnot->columns);
+                    $index = ['columns' => $indexAnnot->columns];
 
                     if ( ! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
@@ -121,7 +121,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             if ($tableAnnot->uniqueConstraints !== null) {
                 foreach ($tableAnnot->uniqueConstraints as $uniqueConstraintAnnot) {
-                    $uniqueConstraint = array('columns' => $uniqueConstraintAnnot->columns);
+                    $uniqueConstraint = ['columns' => $uniqueConstraintAnnot->columns];
 
                     if ( ! empty($uniqueConstraintAnnot->options)) {
                         $uniqueConstraint['options'] = $uniqueConstraintAnnot->options;
@@ -145,10 +145,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
         // Evaluate @Cache annotation
         if (isset($classAnnotations['Doctrine\ORM\Mapping\Cache'])) {
             $cacheAnnot = $classAnnotations['Doctrine\ORM\Mapping\Cache'];
-            $cacheMap   = array(
+            $cacheMap   = [
                 'region' => $cacheAnnot->region,
                 'usage'  => constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $cacheAnnot->usage),
-            );
+            ];
 
             $metadata->enableCache($cacheMap);
         }
@@ -158,12 +158,12 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $namedNativeQueriesAnnot = $classAnnotations['Doctrine\ORM\Mapping\NamedNativeQueries'];
 
             foreach ($namedNativeQueriesAnnot->value as $namedNativeQuery) {
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => $namedNativeQuery->name,
                     'query'             => $namedNativeQuery->query,
                     'resultClass'       => $namedNativeQuery->resultClass,
                     'resultSetMapping'  => $namedNativeQuery->resultSetMapping,
-                ));
+                ]);
             }
         }
 
@@ -172,36 +172,36 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $sqlResultSetMappingsAnnot = $classAnnotations['Doctrine\ORM\Mapping\SqlResultSetMappings'];
 
             foreach ($sqlResultSetMappingsAnnot->value as $resultSetMapping) {
-                $entities = array();
-                $columns  = array();
+                $entities = [];
+                $columns  = [];
                 foreach ($resultSetMapping->entities as $entityResultAnnot) {
-                    $entityResult = array(
-                        'fields'                => array(),
+                    $entityResult = [
+                        'fields'                => [],
                         'entityClass'           => $entityResultAnnot->entityClass,
                         'discriminatorColumn'   => $entityResultAnnot->discriminatorColumn,
-                    );
+                    ];
 
                     foreach ($entityResultAnnot->fields as $fieldResultAnnot) {
-                        $entityResult['fields'][] = array(
+                        $entityResult['fields'][] = [
                             'name'      => $fieldResultAnnot->name,
                             'column'    => $fieldResultAnnot->column
-                        );
+                        ];
                     }
 
                     $entities[] = $entityResult;
                 }
 
                 foreach ($resultSetMapping->columns as $columnResultAnnot) {
-                    $columns[] = array(
+                    $columns[] = [
                         'name' => $columnResultAnnot->name,
-                    );
+                    ];
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => $resultSetMapping->name,
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -217,10 +217,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 if ( ! ($namedQuery instanceof \Doctrine\ORM\Mapping\NamedQuery)) {
                     throw new \UnexpectedValueException("@NamedQueries should contain an array of @NamedQuery annotations.");
                 }
-                $metadata->addNamedQuery(array(
+                $metadata->addNamedQuery([
                     'name'  => $namedQuery->name,
                     'query' => $namedQuery->query
-                ));
+                ]);
             }
         }
 
@@ -233,14 +233,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 // Evaluate DiscriminatorColumn annotation
                 if (isset($classAnnotations['Doctrine\ORM\Mapping\DiscriminatorColumn'])) {
                     $discrColumnAnnot = $classAnnotations['Doctrine\ORM\Mapping\DiscriminatorColumn'];
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name' => $discrColumnAnnot->name,
                         'type' => $discrColumnAnnot->type,
                         'length' => $discrColumnAnnot->length,
                         'columnDefinition'    => $discrColumnAnnot->columnDefinition
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate DiscriminatorMap annotation
@@ -271,11 +271,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 continue;
             }
 
-            $mapping = array();
+            $mapping = [];
             $mapping['fieldName'] = $property->getName();
 
             // Check for JoinColumn/JoinColumns annotations
-            $joinColumns = array();
+            $joinColumns = [];
 
             if ($joinColumnAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinColumn')) {
                 $joinColumns[] = $this->joinColumnToArray($joinColumnAnnot);
@@ -310,17 +310,17 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 // Check for SequenceGenerator/TableGenerator definition
                 if ($seqGeneratorAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\SequenceGenerator')) {
-                    $metadata->setSequenceGeneratorDefinition(array(
+                    $metadata->setSequenceGeneratorDefinition([
                         'sequenceName' => $seqGeneratorAnnot->sequenceName,
                         'allocationSize' => $seqGeneratorAnnot->allocationSize,
                         'initialValue' => $seqGeneratorAnnot->initialValue
-                    ));
+                    ]);
                 } else if ($this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\TableGenerator')) {
                     throw MappingException::tableIdGeneratorNotImplemented($className);
                 } else if ($customGeneratorAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\CustomIdGenerator')) {
-                    $metadata->setCustomGeneratorDefinition(array(
+                    $metadata->setCustomGeneratorDefinition([
                         'class' => $customGeneratorAnnot->class
-                    ));
+                    ]);
                 }
             } else if ($oneToOneAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\OneToOne')) {
                 if ($idAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Id')) {
@@ -360,13 +360,13 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $mapping['fetch'] = $this->getFetchMode($className, $manyToOneAnnot->fetch);
                 $metadata->mapManyToOne($mapping);
             } else if ($manyToManyAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\ManyToMany')) {
-                $joinTable = array();
+                $joinTable = [];
 
                 if ($joinTableAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinTable')) {
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => $joinTableAnnot->name,
                         'schema' => $joinTableAnnot->schema
-                    );
+                    ];
 
                     foreach ($joinTableAnnot->joinColumns as $joinColumn) {
                         $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumn);
@@ -399,10 +399,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             // Evaluate @Cache annotation
             if (($cacheAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Cache')) !== null) {
-                $metadata->enableAssociationCache($mapping['fieldName'], array(
+                $metadata->enableAssociationCache($mapping['fieldName'], [
                     'usage'         => constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $cacheAnnot->usage),
                     'region'        => $cacheAnnot->region,
-                ));
+                ]);
             }
         }
 
@@ -411,12 +411,12 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $associationOverridesAnnot = $classAnnotations['Doctrine\ORM\Mapping\AssociationOverrides'];
 
             foreach ($associationOverridesAnnot->value as $associationOverride) {
-                $override   = array();
+                $override   = [];
                 $fieldName  = $associationOverride->name;
 
                 // Check for JoinColumn/JoinColumns annotations
                 if ($associationOverride->joinColumns) {
-                    $joinColumns = array();
+                    $joinColumns = [];
                     foreach ($associationOverride->joinColumns as $joinColumn) {
                         $joinColumns[] = $this->joinColumnToArray($joinColumn);
                     }
@@ -426,10 +426,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 // Check for JoinTable annotations
                 if ($associationOverride->joinTable) {
                     $joinTableAnnot = $associationOverride->joinTable;
-                    $joinTable      = array(
+                    $joinTable      = [
                         'name'      => $joinTableAnnot->name,
                         'schema'    => $joinTableAnnot->schema
-                    );
+                    ];
 
                     foreach ($joinTableAnnot->joinColumns as $joinColumn) {
                         $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumn);
@@ -526,40 +526,40 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function getMethodCallbacks(\ReflectionMethod $method)
     {
-        $callbacks   = array();
+        $callbacks   = [];
         $annotations = $this->reader->getMethodAnnotations($method);
 
         foreach ($annotations as $annot) {
             if ($annot instanceof \Doctrine\ORM\Mapping\PrePersist) {
-                $callbacks[] = array($method->name, Events::prePersist);
+                $callbacks[] = [$method->name, Events::prePersist];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostPersist) {
-                $callbacks[] = array($method->name, Events::postPersist);
+                $callbacks[] = [$method->name, Events::postPersist];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreUpdate) {
-                $callbacks[] = array($method->name, Events::preUpdate);
+                $callbacks[] = [$method->name, Events::preUpdate];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostUpdate) {
-                $callbacks[] = array($method->name, Events::postUpdate);
+                $callbacks[] = [$method->name, Events::postUpdate];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreRemove) {
-                $callbacks[] = array($method->name, Events::preRemove);
+                $callbacks[] = [$method->name, Events::preRemove];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostRemove) {
-                $callbacks[] = array($method->name, Events::postRemove);
+                $callbacks[] = [$method->name, Events::postRemove];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostLoad) {
-                $callbacks[] = array($method->name, Events::postLoad);
+                $callbacks[] = [$method->name, Events::postLoad];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreFlush) {
-                $callbacks[] = array($method->name, Events::preFlush);
+                $callbacks[] = [$method->name, Events::preFlush];
             }
         }
 
@@ -574,14 +574,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function joinColumnToArray(JoinColumn $joinColumn)
     {
-        return array(
+        return [
             'name' => $joinColumn->name,
             'unique' => $joinColumn->unique,
             'nullable' => $joinColumn->nullable,
             'onDelete' => $joinColumn->onDelete,
             'columnDefinition' => $joinColumn->columnDefinition,
             'referencedColumnName' => $joinColumn->referencedColumnName,
-        );
+        ];
     }
 
     /**
@@ -594,7 +594,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function columnToArray($fieldName, Column $column)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => $fieldName,
             'type'      => $column->type,
             'scale'     => $column->scale,
@@ -602,7 +602,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             'unique'    => $column->unique,
             'nullable'  => $column->nullable,
             'precision' => $column->precision
-        );
+        ];
 
         if ($column->options) {
             $mapping['options'] = $column->options;
@@ -627,7 +627,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *
      * @return AnnotationDriver
      */
-    static public function create($paths = array(), AnnotationReader $reader = null)
+    static public function create($paths = [], AnnotationReader $reader = null)
     {
         if ($reader == null) {
             $reader = new AnnotationReader();

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -54,22 +54,22 @@ class DatabaseDriver implements MappingDriver
     /**
      * @var array
      */
-    private $classToTableNames = array();
+    private $classToTableNames = [];
 
     /**
      * @var array
      */
-    private $manyToManyTables = array();
+    private $manyToManyTables = [];
 
     /**
      * @var array
      */
-    private $classNamesForTables = array();
+    private $classNamesForTables = [];
 
     /**
      * @var array
      */
-    private $fieldNamesForColumns = array();
+    private $fieldNamesForColumns = [];
 
     /**
      * The namespace for the generated entities.
@@ -153,7 +153,7 @@ class DatabaseDriver implements MappingDriver
      */
     public function setTables($entityTables, $manyToManyTables)
     {
-        $this->tables = $this->manyToManyTables = $this->classToTableNames = array();
+        $this->tables = $this->manyToManyTables = $this->classToTableNames = [];
 
         foreach ($entityTables as $table) {
             $className = $this->getClassNameForTable($table->getName());
@@ -212,36 +212,36 @@ class DatabaseDriver implements MappingDriver
 
                 $localColumn = current($myFk->getColumns());
 
-                $associationMapping = array();
+                $associationMapping = [];
                 $associationMapping['fieldName'] = $this->getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
                 $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
 
                 if (current($manyTable->getColumns())->getName() == $localColumn) {
                     $associationMapping['inversedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
-                    $associationMapping['joinTable'] = array(
+                    $associationMapping['joinTable'] = [
                         'name' => strtolower($manyTable->getName()),
-                        'joinColumns' => array(),
-                        'inverseJoinColumns' => array(),
-                    );
+                        'joinColumns' => [],
+                        'inverseJoinColumns' => [],
+                    ];
 
                     $fkCols = $myFk->getForeignColumns();
                     $cols = $myFk->getColumns();
 
                     for ($i = 0; $i < count($cols); $i++) {
-                        $associationMapping['joinTable']['joinColumns'][] = array(
+                        $associationMapping['joinTable']['joinColumns'][] = [
                             'name' => $cols[$i],
                             'referencedColumnName' => $fkCols[$i],
-                        );
+                        ];
                     }
 
                     $fkCols = $otherFk->getForeignColumns();
                     $cols = $otherFk->getColumns();
 
                     for ($i = 0; $i < count($cols); $i++) {
-                        $associationMapping['joinTable']['inverseJoinColumns'][] = array(
+                        $associationMapping['joinTable']['inverseJoinColumns'][] = [
                             'name' => $cols[$i],
                             'referencedColumnName' => $fkCols[$i],
-                        );
+                        ];
                     }
                 } else {
                     $associationMapping['mappedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
@@ -265,20 +265,20 @@ class DatabaseDriver implements MappingDriver
             return;
         }
 
-        $tables = array();
+        $tables = [];
 
         foreach ($this->_sm->listTableNames() as $tableName) {
             $tables[$tableName] = $this->_sm->listTableDetails($tableName);
         }
 
-        $this->tables = $this->manyToManyTables = $this->classToTableNames = array();
+        $this->tables = $this->manyToManyTables = $this->classToTableNames = [];
 
         foreach ($tables as $tableName => $table) {
             $foreignKeys = ($this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints())
                 ? $table->getForeignKeys()
-                : array();
+                : [];
 
-            $allForeignKeyColumns = array();
+            $allForeignKeyColumns = [];
 
             foreach ($foreignKeys as $foreignKey) {
                 $allForeignKeyColumns = array_merge($allForeignKeyColumns, $foreignKey->getLocalColumns());
@@ -345,14 +345,14 @@ class DatabaseDriver implements MappingDriver
         $columns        = $this->tables[$tableName]->getColumns();
         $primaryKeys    = $this->getTablePrimaryKeys($this->tables[$tableName]);
         $foreignKeys    = $this->getTableForeignKeys($this->tables[$tableName]);
-        $allForeignKeys = array();
+        $allForeignKeys = [];
 
         foreach ($foreignKeys as $foreignKey) {
             $allForeignKeys = array_merge($allForeignKeys, $foreignKey->getLocalColumns());
         }
 
-        $ids           = array();
-        $fieldMappings = array();
+        $ids           = [];
+        $fieldMappings = [];
 
         foreach ($columns as $column) {
             if (in_array($column->getName(), $allForeignKeys)) {
@@ -389,12 +389,12 @@ class DatabaseDriver implements MappingDriver
      */
     private function buildFieldMapping($tableName, Column $column)
     {
-        $fieldMapping = array(
+        $fieldMapping = [
             'fieldName'  => $this->getFieldNameForColumn($tableName, $column->getName(), false),
             'columnName' => $column->getName(),
             'type'       => $column->getType()->getName(),
             'nullable'   => ( ! $column->getNotNull()),
-        );
+        ];
 
         // Type specific elements
         switch ($fieldMapping['type']) {
@@ -452,10 +452,10 @@ class DatabaseDriver implements MappingDriver
             $fkColumns          = $foreignKey->getColumns();
             $fkForeignColumns   = $foreignKey->getForeignColumns();
             $localColumn        = current($fkColumns);
-            $associationMapping = array(
+            $associationMapping = [
                 'fieldName'    => $this->getFieldNameForColumn($tableName, $localColumn, true),
                 'targetEntity' => $this->getClassNameForTable($foreignTableName),
-            );
+            ];
 
             if (isset($metadata->fieldMappings[$associationMapping['fieldName']])) {
                 $associationMapping['fieldName'] .= '2'; // "foo" => "foo2"
@@ -466,10 +466,10 @@ class DatabaseDriver implements MappingDriver
             }
 
             for ($i = 0; $i < count($fkColumns); $i++) {
-                $associationMapping['joinColumns'][] = array(
+                $associationMapping['joinColumns'][] = [
                     'name'                 => $fkColumns[$i],
                     'referencedColumnName' => $fkForeignColumns[$i],
-                );
+                ];
             }
 
             // Here we need to check if $fkColumns are the same as $primaryKeys
@@ -492,7 +492,7 @@ class DatabaseDriver implements MappingDriver
     {
         return ($this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints())
             ? $table->getForeignKeys()
-            : array();
+            : [];
     }
 
     /**
@@ -510,7 +510,7 @@ class DatabaseDriver implements MappingDriver
             // Do nothing
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -76,7 +76,7 @@ class XmlDriver extends FileDriver
         }
 
         // Evaluate <entity...> attributes
-        $primaryTable = array();
+        $primaryTable = [];
 
         if (isset($xmlRoot['table'])) {
             $primaryTable['name'] = (string) $xmlRoot['table'];
@@ -96,44 +96,44 @@ class XmlDriver extends FileDriver
         // Evaluate named queries
         if (isset($xmlRoot->{'named-queries'})) {
             foreach ($xmlRoot->{'named-queries'}->{'named-query'} as $namedQueryElement) {
-                $metadata->addNamedQuery(array(
+                $metadata->addNamedQuery([
                     'name'  => (string)$namedQueryElement['name'],
                     'query' => (string)$namedQueryElement['query']
-                ));
+                ]);
             }
         }
 
         // Evaluate native named queries
         if (isset($xmlRoot->{'named-native-queries'})) {
             foreach ($xmlRoot->{'named-native-queries'}->{'named-native-query'} as $nativeQueryElement) {
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => isset($nativeQueryElement['name']) ? (string)$nativeQueryElement['name'] : null,
                     'query'             => isset($nativeQueryElement->query) ? (string)$nativeQueryElement->query : null,
                     'resultClass'       => isset($nativeQueryElement['result-class']) ? (string)$nativeQueryElement['result-class'] : null,
                     'resultSetMapping'  => isset($nativeQueryElement['result-set-mapping']) ? (string)$nativeQueryElement['result-set-mapping'] : null,
-                ));
+                ]);
             }
         }
 
         // Evaluate sql result set mapping
         if (isset($xmlRoot->{'sql-result-set-mappings'})) {
             foreach ($xmlRoot->{'sql-result-set-mappings'}->{'sql-result-set-mapping'} as $rsmElement) {
-                $entities   = array();
-                $columns    = array();
+                $entities   = [];
+                $columns    = [];
                 foreach ($rsmElement as $entityElement) {
                     //<entity-result/>
                     if (isset($entityElement['entity-class'])) {
-                        $entityResult = array(
-                            'fields'                => array(),
+                        $entityResult = [
+                            'fields'                => [],
                             'entityClass'           => (string)$entityElement['entity-class'],
                             'discriminatorColumn'   => isset($entityElement['discriminator-column']) ? (string)$entityElement['discriminator-column'] : null,
-                        );
+                        ];
 
                         foreach ($entityElement as $fieldElement) {
-                            $entityResult['fields'][] = array(
+                            $entityResult['fields'][] = [
                                 'name'      => isset($fieldElement['name']) ? (string)$fieldElement['name'] : null,
                                 'column'    => isset($fieldElement['column']) ? (string)$fieldElement['column'] : null,
-                            );
+                            ];
                         }
 
                         $entities[] = $entityResult;
@@ -141,17 +141,17 @@ class XmlDriver extends FileDriver
 
                     //<column-result/>
                     if (isset($entityElement['name'])) {
-                        $columns[] = array(
+                        $columns[] = [
                             'name' => (string)$entityElement['name'],
-                        );
+                        ];
                     }
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => (string)$rsmElement['name'],
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -163,19 +163,19 @@ class XmlDriver extends FileDriver
                 // Evaluate <discriminator-column...>
                 if (isset($xmlRoot->{'discriminator-column'})) {
                     $discrColumn = $xmlRoot->{'discriminator-column'};
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name' => isset($discrColumn['name']) ? (string)$discrColumn['name'] : null,
                         'type' => isset($discrColumn['type']) ? (string)$discrColumn['type'] : null,
                         'length' => isset($discrColumn['length']) ? (string)$discrColumn['length'] : null,
                         'columnDefinition' => isset($discrColumn['column-definition']) ? (string)$discrColumn['column-definition'] : null
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate <discriminator-map...>
                 if (isset($xmlRoot->{'discriminator-map'})) {
-                    $map = array();
+                    $map = [];
                     foreach ($xmlRoot->{'discriminator-map'}->{'discriminator-mapping'} as $discrMapElement) {
                         $map[(string)$discrMapElement['value']] = (string)$discrMapElement['class'];
                     }
@@ -193,9 +193,9 @@ class XmlDriver extends FileDriver
 
         // Evaluate <indexes...>
         if (isset($xmlRoot->indexes)) {
-            $metadata->table['indexes'] = array();
+            $metadata->table['indexes'] = [];
             foreach ($xmlRoot->indexes->index as $indexXml) {
-                $index = array('columns' => explode(',', (string) $indexXml['columns']));
+                $index = ['columns' => explode(',', (string) $indexXml['columns'])];
 
                 if (isset($indexXml['flags'])) {
                     $index['flags'] = explode(',', (string) $indexXml['flags']);
@@ -215,9 +215,9 @@ class XmlDriver extends FileDriver
 
         // Evaluate <unique-constraints..>
         if (isset($xmlRoot->{'unique-constraints'})) {
-            $metadata->table['uniqueConstraints'] = array();
+            $metadata->table['uniqueConstraints'] = [];
             foreach ($xmlRoot->{'unique-constraints'}->{'unique-constraint'} as $uniqueXml) {
-                $unique = array('columns' => explode(',', (string) $uniqueXml['columns']));
+                $unique = ['columns' => explode(',', (string) $uniqueXml['columns'])];
 
 
                 if (isset($uniqueXml->options)) {
@@ -238,7 +238,7 @@ class XmlDriver extends FileDriver
 
         // The mapping assignment is done in 2 times as a bug might occurs on some php/xml lib versions
         // The internal SimpleXmlIterator get resetted, to this generate a duplicate field exception
-        $mappings = array();
+        $mappings = [];
         // Evaluate <field ...> mappings
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $fieldMapping) {
@@ -263,11 +263,11 @@ class XmlDriver extends FileDriver
                     ? $this->evaluateBoolean($embeddedMapping['use-column-prefix'])
                     : true;
 
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
                     'columnPrefix' => $useColumnPrefix ? $columnPrefix : false
-                );
+                ];
 
                 $metadata->mapEmbedded($mapping);
             }
@@ -282,17 +282,17 @@ class XmlDriver extends FileDriver
         }
 
         // Evaluate <id ...> mappings
-        $associationIds = array();
+        $associationIds = [];
         foreach ($xmlRoot->id as $idElement) {
             if (isset($idElement['association-key']) && $this->evaluateBoolean($idElement['association-key'])) {
                 $associationIds[(string)$idElement['name']] = true;
                 continue;
             }
 
-            $mapping = array(
+            $mapping = [
                 'id' => true,
                 'fieldName' => (string)$idElement['name']
-            );
+            ];
 
             if (isset($idElement['type'])) {
                 $mapping['type'] = (string)$idElement['type'];
@@ -326,16 +326,16 @@ class XmlDriver extends FileDriver
             // Check for SequenceGenerator/TableGenerator definition
             if (isset($idElement->{'sequence-generator'})) {
                 $seqGenerator = $idElement->{'sequence-generator'};
-                $metadata->setSequenceGeneratorDefinition(array(
+                $metadata->setSequenceGeneratorDefinition([
                     'sequenceName' => (string)$seqGenerator['sequence-name'],
                     'allocationSize' => (string)$seqGenerator['allocation-size'],
                     'initialValue' => (string)$seqGenerator['initial-value']
-                ));
+                ]);
             } else if (isset($idElement->{'custom-id-generator'})) {
                 $customGenerator = $idElement->{'custom-id-generator'};
-                $metadata->setCustomGeneratorDefinition(array(
+                $metadata->setCustomGeneratorDefinition([
                     'class' => (string) $customGenerator['class']
-                ));
+                ]);
             } else if (isset($idElement->{'table-generator'})) {
                 throw MappingException::tableIdGeneratorNotImplemented($className);
             }
@@ -344,10 +344,10 @@ class XmlDriver extends FileDriver
         // Evaluate <one-to-one ...> mappings
         if (isset($xmlRoot->{'one-to-one'})) {
             foreach ($xmlRoot->{'one-to-one'} as $oneToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$oneToOneElement['field'],
                     'targetEntity' => (string)$oneToOneElement['target-entity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -363,7 +363,7 @@ class XmlDriver extends FileDriver
                     if (isset($oneToOneElement['inversed-by'])) {
                         $mapping['inversedBy'] = (string)$oneToOneElement['inversed-by'];
                     }
-                    $joinColumns = array();
+                    $joinColumns = [];
 
                     if (isset($oneToOneElement->{'join-column'})) {
                         $joinColumns[] = $this->joinColumnToArray($oneToOneElement->{'join-column'});
@@ -396,11 +396,11 @@ class XmlDriver extends FileDriver
         // Evaluate <one-to-many ...> mappings
         if (isset($xmlRoot->{'one-to-many'})) {
             foreach ($xmlRoot->{'one-to-many'} as $oneToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$oneToManyElement['field'],
                     'targetEntity' => (string)$oneToManyElement['target-entity'],
                     'mappedBy' => (string)$oneToManyElement['mapped-by']
-                );
+                ];
 
                 if (isset($oneToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string)$oneToManyElement['fetch']);
@@ -415,7 +415,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($oneToManyElement->{'order-by'})) {
-                    $orderBy = array();
+                    $orderBy = [];
                     foreach ($oneToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
                         $orderBy[(string)$orderByField['name']] = (string)$orderByField['direction'];
                     }
@@ -440,10 +440,10 @@ class XmlDriver extends FileDriver
         // Evaluate <many-to-one ...> mappings
         if (isset($xmlRoot->{'many-to-one'})) {
             foreach ($xmlRoot->{'many-to-one'} as $manyToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$manyToOneElement['field'],
                     'targetEntity' => (string)$manyToOneElement['target-entity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -457,7 +457,7 @@ class XmlDriver extends FileDriver
                     $mapping['inversedBy'] = (string)$manyToOneElement['inversed-by'];
                 }
 
-                $joinColumns = array();
+                $joinColumns = [];
 
                 if (isset($manyToOneElement->{'join-column'})) {
                     $joinColumns[] = $this->joinColumnToArray($manyToOneElement->{'join-column'});
@@ -485,10 +485,10 @@ class XmlDriver extends FileDriver
         // Evaluate <many-to-many ...> mappings
         if (isset($xmlRoot->{'many-to-many'})) {
             foreach ($xmlRoot->{'many-to-many'} as $manyToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$manyToManyElement['field'],
                     'targetEntity' => (string)$manyToManyElement['target-entity']
-                );
+                ];
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string)$manyToManyElement['fetch']);
@@ -506,9 +506,9 @@ class XmlDriver extends FileDriver
                     }
 
                     $joinTableElement = $manyToManyElement->{'join-table'};
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => (string)$joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = (string)$joinTableElement['schema'];
@@ -530,7 +530,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($manyToManyElement->{'order-by'})) {
-                    $orderBy = array();
+                    $orderBy = [];
                     foreach ($manyToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
                         $orderBy[(string)$orderByField['name']] = (string)$orderByField['direction'];
                     }
@@ -568,11 +568,11 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'association-overrides'})) {
             foreach ($xmlRoot->{'association-overrides'}->{'association-override'} as $overrideElement) {
                 $fieldName  = (string) $overrideElement['name'];
-                $override   = array();
+                $override   = [];
 
                 // Check for join-columns
                 if (isset($overrideElement->{'join-columns'})) {
-                    $joinColumns = array();
+                    $joinColumns = [];
                     foreach ($overrideElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
                         $joinColumns[] = $this->joinColumnToArray($joinColumnElement);
                     }
@@ -584,10 +584,10 @@ class XmlDriver extends FileDriver
                     $joinTable          = null;
                     $joinTableElement   = $overrideElement->{'join-table'};
 
-                    $joinTable = array(
+                    $joinTable = [
                         'name'      => (string) $joinTableElement['name'],
                         'schema'    => (string) $joinTableElement['schema']
-                    );
+                    ];
 
                     if (isset($joinTableElement->{'join-columns'})) {
                         foreach ($joinTableElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
@@ -645,7 +645,7 @@ class XmlDriver extends FileDriver
      */
     private function _parseOptions(SimpleXMLElement $options)
     {
-        $array = array();
+        $array = [];
 
         /* @var $option SimpleXMLElement */
         foreach ($options as $option) {
@@ -677,10 +677,10 @@ class XmlDriver extends FileDriver
      */
     private function joinColumnToArray(SimpleXMLElement $joinColumnElement)
     {
-        $joinColumn = array(
+        $joinColumn = [
             'name' => (string)$joinColumnElement['name'],
             'referencedColumnName' => (string)$joinColumnElement['referenced-column-name']
-        );
+        ];
 
         if (isset($joinColumnElement['unique'])) {
             $joinColumn['unique'] = $this->evaluateBoolean($joinColumnElement['unique']);
@@ -710,9 +710,9 @@ class XmlDriver extends FileDriver
      */
     private function columnToArray(SimpleXMLElement $fieldMapping)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => (string) $fieldMapping['name'],
-        );
+        ];
 
         if (isset($fieldMapping['type'])) {
             $mapping['type'] = (string) $fieldMapping['type'];
@@ -777,10 +777,10 @@ class XmlDriver extends FileDriver
             $usage = constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $usage);
         }
 
-        return array(
+        return [
             'usage'  => $usage,
             'region' => $region,
-        );
+        ];
     }
 
     /**
@@ -792,7 +792,7 @@ class XmlDriver extends FileDriver
      */
     private function _getCascadeMappings(SimpleXMLElement $cascadeElement)
     {
-        $cascades = array();
+        $cascades = [];
         /* @var $action SimpleXmlElement */
         foreach ($cascadeElement->children() as $action) {
             // According to the JPA specifications, XML uses "cascade-persist"
@@ -810,7 +810,7 @@ class XmlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        $result = array();
+        $result = [];
         $xmlElement = simplexml_load_file($file);
 
         if (isset($xmlElement->entity)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -73,7 +73,7 @@ class YamlDriver extends FileDriver
         }
 
         // Evaluate root level properties
-        $primaryTable = array();
+        $primaryTable = [];
 
         if (isset($element['table'])) {
             $primaryTable['name'] = $element['table'];
@@ -94,7 +94,7 @@ class YamlDriver extends FileDriver
         if (isset($element['namedQueries'])) {
             foreach ($element['namedQueries'] as $name => $queryMapping) {
                 if (is_string($queryMapping)) {
-                    $queryMapping = array('query' => $queryMapping);
+                    $queryMapping = ['query' => $queryMapping];
                 }
 
                 if ( ! isset($queryMapping['name'])) {
@@ -111,12 +111,12 @@ class YamlDriver extends FileDriver
                 if (!isset($mappingElement['name'])) {
                     $mappingElement['name'] = $name;
                 }
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => $mappingElement['name'],
                     'query'             => isset($mappingElement['query']) ? $mappingElement['query'] : null,
                     'resultClass'       => isset($mappingElement['resultClass']) ? $mappingElement['resultClass'] : null,
                     'resultSetMapping'  => isset($mappingElement['resultSetMapping']) ? $mappingElement['resultSetMapping'] : null,
-                ));
+                ]);
             }
         }
 
@@ -127,22 +127,22 @@ class YamlDriver extends FileDriver
                     $resultSetMapping['name'] = $name;
                 }
 
-                $entities = array();
-                $columns  = array();
+                $entities = [];
+                $columns  = [];
                 if (isset($resultSetMapping['entityResult'])) {
                     foreach ($resultSetMapping['entityResult'] as $entityResultElement) {
-                        $entityResult = array(
-                            'fields'                => array(),
+                        $entityResult = [
+                            'fields'                => [],
                             'entityClass'           => isset($entityResultElement['entityClass']) ? $entityResultElement['entityClass'] : null,
                             'discriminatorColumn'   => isset($entityResultElement['discriminatorColumn']) ? $entityResultElement['discriminatorColumn'] : null,
-                        );
+                        ];
 
                         if (isset($entityResultElement['fieldResult'])) {
                             foreach ($entityResultElement['fieldResult'] as $fieldResultElement) {
-                                $entityResult['fields'][] = array(
+                                $entityResult['fields'][] = [
                                     'name'      => isset($fieldResultElement['name']) ? $fieldResultElement['name'] : null,
                                     'column'    => isset($fieldResultElement['column']) ? $fieldResultElement['column'] : null,
-                                );
+                                ];
                             }
                         }
 
@@ -153,17 +153,17 @@ class YamlDriver extends FileDriver
 
                 if (isset($resultSetMapping['columnResult'])) {
                     foreach ($resultSetMapping['columnResult'] as $columnResultAnnot) {
-                        $columns[] = array(
+                        $columns[] = [
                             'name' => isset($columnResultAnnot['name']) ? $columnResultAnnot['name'] : null,
-                        );
+                        ];
                     }
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => $resultSetMapping['name'],
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -174,14 +174,14 @@ class YamlDriver extends FileDriver
                 // Evaluate discriminatorColumn
                 if (isset($element['discriminatorColumn'])) {
                     $discrColumn = $element['discriminatorColumn'];
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name' => isset($discrColumn['name']) ? (string)$discrColumn['name'] : null,
                         'type' => isset($discrColumn['type']) ? (string)$discrColumn['type'] : null,
                         'length' => isset($discrColumn['length']) ? (string)$discrColumn['length'] : null,
                         'columnDefinition' => isset($discrColumn['columnDefinition']) ? (string)$discrColumn['columnDefinition'] : null
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate discriminatorMap
@@ -206,9 +206,9 @@ class YamlDriver extends FileDriver
                 }
 
                 if (is_string($indexYml['columns'])) {
-                    $index = array('columns' => array_map('trim', explode(',', $indexYml['columns'])));
+                    $index = ['columns' => array_map('trim', explode(',', $indexYml['columns']))];
                 } else {
-                    $index = array('columns' => $indexYml['columns']);
+                    $index = ['columns' => $indexYml['columns']];
                 }
 
                 if (isset($indexYml['flags'])) {
@@ -235,9 +235,9 @@ class YamlDriver extends FileDriver
                 }
 
                 if (is_string($uniqueYml['columns'])) {
-                    $unique = array('columns' => array_map('trim', explode(',', $uniqueYml['columns'])));
+                    $unique = ['columns' => array_map('trim', explode(',', $uniqueYml['columns']))];
                 } else {
-                    $unique = array('columns' => $uniqueYml['columns']);
+                    $unique = ['columns' => $uniqueYml['columns']];
                 }
 
                 if (isset($uniqueYml['options'])) {
@@ -252,7 +252,7 @@ class YamlDriver extends FileDriver
             $metadata->table['options'] = $element['options'];
         }
 
-        $associationIds = array();
+        $associationIds = [];
         if (isset($element['id'])) {
             // Evaluate identifier settings
             foreach ($element['id'] as $name => $idElement) {
@@ -261,10 +261,10 @@ class YamlDriver extends FileDriver
                     continue;
                 }
 
-                $mapping = array(
+                $mapping = [
                     'id' => true,
                     'fieldName' => $name
-                );
+                ];
 
                 if (isset($idElement['type'])) {
                     $mapping['type'] = $idElement['type'];
@@ -297,9 +297,9 @@ class YamlDriver extends FileDriver
                     $metadata->setSequenceGeneratorDefinition($idElement['sequenceGenerator']);
                 } else if (isset($idElement['customIdGenerator'])) {
                     $customGenerator = $idElement['customIdGenerator'];
-                    $metadata->setCustomGeneratorDefinition(array(
+                    $metadata->setCustomGeneratorDefinition([
                         'class' => (string) $customGenerator['class']
-                    ));
+                    ]);
                 } else if (isset($idElement['tableGenerator'])) {
                     throw MappingException::tableIdGeneratorNotImplemented($className);
                 }
@@ -331,11 +331,11 @@ class YamlDriver extends FileDriver
 
         if (isset($element['embedded'])) {
             foreach ($element['embedded'] as $name => $embeddedMapping) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'class' => $embeddedMapping['class'],
                     'columnPrefix' => isset($embeddedMapping['columnPrefix']) ? $embeddedMapping['columnPrefix'] : null,
-                );
+                ];
                 $metadata->mapEmbedded($mapping);
             }
         }
@@ -343,10 +343,10 @@ class YamlDriver extends FileDriver
         // Evaluate oneToOne relationships
         if (isset($element['oneToOne'])) {
             foreach ($element['oneToOne'] as $name => $oneToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $oneToOneElement['targetEntity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -363,7 +363,7 @@ class YamlDriver extends FileDriver
                         $mapping['inversedBy'] = $oneToOneElement['inversedBy'];
                     }
 
-                    $joinColumns = array();
+                    $joinColumns = [];
 
                     if (isset($oneToOneElement['joinColumn'])) {
                         $joinColumns[] = $this->joinColumnToArray($oneToOneElement['joinColumn']);
@@ -400,11 +400,11 @@ class YamlDriver extends FileDriver
         // Evaluate oneToMany relationships
         if (isset($element['oneToMany'])) {
             foreach ($element['oneToMany'] as $name => $oneToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $oneToManyElement['targetEntity'],
                     'mappedBy' => $oneToManyElement['mappedBy']
-                );
+                ];
 
                 if (isset($oneToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $oneToManyElement['fetch']);
@@ -438,10 +438,10 @@ class YamlDriver extends FileDriver
         // Evaluate manyToOne relationships
         if (isset($element['manyToOne'])) {
             foreach ($element['manyToOne'] as $name => $manyToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $manyToOneElement['targetEntity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -455,7 +455,7 @@ class YamlDriver extends FileDriver
                     $mapping['inversedBy'] = $manyToOneElement['inversedBy'];
                 }
 
-                $joinColumns = array();
+                $joinColumns = [];
 
                 if (isset($manyToOneElement['joinColumn'])) {
                     $joinColumns[] = $this->joinColumnToArray($manyToOneElement['joinColumn']);
@@ -487,10 +487,10 @@ class YamlDriver extends FileDriver
         // Evaluate manyToMany relationships
         if (isset($element['manyToMany'])) {
             foreach ($element['manyToMany'] as $name => $manyToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $manyToManyElement['targetEntity']
-                );
+                ];
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $manyToManyElement['fetch']);
@@ -501,9 +501,9 @@ class YamlDriver extends FileDriver
                 } else if (isset($manyToManyElement['joinTable'])) {
 
                     $joinTableElement = $manyToManyElement['joinTable'];
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => $joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = $joinTableElement['schema'];
@@ -565,11 +565,11 @@ class YamlDriver extends FileDriver
         if (isset($element['associationOverride']) && is_array($element['associationOverride'])) {
 
             foreach ($element['associationOverride'] as $fieldName => $associationOverrideElement) {
-                $override   = array();
+                $override   = [];
 
                 // Check for joinColumn
                 if (isset($associationOverrideElement['joinColumn'])) {
-                    $joinColumns = array();
+                    $joinColumns = [];
                     foreach ($associationOverrideElement['joinColumn'] as $name => $joinColumnElement) {
                         if ( ! isset($joinColumnElement['name'])) {
                             $joinColumnElement['name'] = $name;
@@ -583,9 +583,9 @@ class YamlDriver extends FileDriver
                 if (isset($associationOverrideElement['joinTable'])) {
 
                     $joinTableElement   = $associationOverrideElement['joinTable'];
-                    $joinTable          =  array(
+                    $joinTable          =  [
                         'name' => $joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = $joinTableElement['schema'];
@@ -661,7 +661,7 @@ class YamlDriver extends FileDriver
      */
     private function joinColumnToArray($joinColumnElement)
     {
-        $joinColumn = array();
+        $joinColumn = [];
         if (isset($joinColumnElement['referencedColumnName'])) {
             $joinColumn['referencedColumnName'] = (string) $joinColumnElement['referencedColumnName'];
         }
@@ -703,9 +703,9 @@ class YamlDriver extends FileDriver
      */
     private function columnToArray($fieldName, $column)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => $fieldName
-        );
+        ];
 
         if (isset($column['type'])) {
             $params = explode('(', $column['type']);
@@ -776,10 +776,10 @@ class YamlDriver extends FileDriver
             $usage = constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $usage);
         }
 
-        return array(
+        return [
             'usage'  => $usage,
             'region' => $region,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/EntityListeners.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListeners.php
@@ -37,5 +37,5 @@ final class EntityListeners implements Annotation
      *
      * @var array<string>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/EntityResult.php
+++ b/lib/Doctrine/ORM/Mapping/EntityResult.php
@@ -45,7 +45,7 @@ final class EntityResult implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\FieldResult>
      */
-    public $fields = array();
+    public $fields = [];
 
     /**
      * Specifies the column name of the column in the SELECT list that is used to determine the type of the entity instance.

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -38,10 +38,10 @@ final class JoinTable implements Annotation
     /**
      * @var array<\Doctrine\ORM\Mapping\JoinColumn>
      */
-    public $joinColumns = array();
+    public $joinColumns = [];
 
     /**
      * @var array<\Doctrine\ORM\Mapping\JoinColumn>
      */
-    public $inverseJoinColumns = array();
+    public $inverseJoinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
@@ -36,5 +36,5 @@ final class NamedNativeQueries implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\NamedNativeQuery>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
@@ -43,12 +43,12 @@ final class SqlResultSetMapping implements Annotation
      * 
      * @var array<\Doctrine\ORM\Mapping\EntityResult>
      */
-    public $entities = array();
+    public $entities = [];
 
     /**
      * Specifies the result set mapping to scalar values.
      *
      * @var array<\Doctrine\ORM\Mapping\ColumnResult>
      */
-    public $columns = array();
+    public $columns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
@@ -36,5 +36,5 @@ final class SqlResultSetMappings implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\SqlResultSetMapping>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -48,5 +48,5 @@ final class Table implements Annotation
     /**
      * @var array
      */
-    public $options = array();
+    public $options = [];
 }

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -63,8 +63,8 @@ final class NativeQuery extends AbstractQuery
      */
     protected function _doExecute()
     {
-        $parameters = array();
-        $types      = array();
+        $parameters = [];
+        $types      = [];
 
         foreach ($this->getParameters() as $parameter) {
             $name  = $parameter->getName();

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -51,7 +51,7 @@ final class PersistentCollection implements Collection, Selectable
      *
      * @var array
      */
-    private $snapshot = array();
+    private $snapshot = [];
 
     /**
      * The entity that owns this collection.
@@ -225,7 +225,7 @@ final class PersistentCollection implements Collection, Selectable
         }
 
         // Has NEW objects added through add(). Remember them.
-        $newObjects = array();
+        $newObjects = [];
 
         if ($this->isDirty) {
             $newObjects = $this->coll->toArray();
@@ -714,7 +714,7 @@ final class PersistentCollection implements Collection, Selectable
      */
     public function __sleep()
     {
-        return array('coll', 'initialized');
+        return ['coll', 'initialized'];
     }
 
     /* ArrayAccess implementation */
@@ -842,7 +842,7 @@ final class PersistentCollection implements Collection, Selectable
         $this->initialize();
 
         $this->owner    = null;
-        $this->snapshot = array();
+        $this->snapshot = [];
 
         $this->changed();
     }

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -98,7 +98,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             ? $mapping['inversedBy']
             : $mapping['mappedBy'];
 
-        return $persister->load(array($mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index), null, $mapping, array(), 0, 1);
+        return $persister->load([$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index], null, $mapping, [], 0, 1);
     }
 
     /**
@@ -106,9 +106,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     public function count(PersistentCollection $collection)
     {
-        $conditions     = array();
-        $params         = array();
-        $types          = array();
+        $conditions     = [];
+        $params         = [];
+        $types          = [];
         $mapping        = $collection->getMapping();
         $id             = $this->uow->getEntityIdentifier($collection->getOwner());
         $sourceClass    = $this->em->getClassMetadata($mapping['sourceEntity']);
@@ -229,7 +229,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $mapping       = $collection->getMapping();
         $owner         = $collection->getOwner();
         $ownerMetadata = $this->em->getClassMetadata(get_class($owner));
-        $whereClauses  = $params = array();
+        $whereClauses  = $params = [];
 
         foreach ($mapping['relationToSourceKeyColumns'] as $key => $value) {
             $whereClauses[] = sprintf('t.%s = ?', $key);
@@ -289,7 +289,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $filterSql   = $this->generateFilterConditionSQL($rootClass, 'te');
 
         if ('' === $filterSql) {
-            return array('', '');
+            return ['', ''];
         }
 
         // A join is needed if there is filtering on the target entity
@@ -297,7 +297,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $joinSql   = ' JOIN ' . $tableName . ' te'
             . ' ON' . implode(' AND ', $this->getOnConditionSQL($mapping));
 
-        return array($joinSql, $filterSql);
+        return [$joinSql, $filterSql];
     }
 
     /**
@@ -310,7 +310,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function generateFilterConditionSQL(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        $filterClauses = array();
+        $filterClauses = [];
 
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ($filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {
@@ -341,7 +341,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             ? $association['joinTable']['inverseJoinColumns']
             : $association['joinTable']['joinColumns'];
 
-        $conditions = array();
+        $conditions = [];
 
         foreach ($joinColumns as $joinColumn) {
             $joinColumnName = $this->quoteStrategy->getJoinColumnName($joinColumn, $targetClass, $this->platform);
@@ -360,7 +360,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function getDeleteSQL(PersistentCollection $collection)
     {
-        $columns    = array();
+        $columns    = [];
         $mapping    = $collection->getMapping();
         $class      = $this->em->getClassMetadata(get_class($collection->getOwner()));
         $joinTable  = $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform);
@@ -387,12 +387,12 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         // Optimization for single column identifier
         if (count($mapping['relationToSourceKeyColumns']) === 1) {
-            return array(reset($identifier));
+            return [reset($identifier)];
         }
 
         // Composite identifier
         $sourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);
-        $params      = array();
+        $params      = [];
 
         foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
             $params[] = isset($sourceClass->fieldNames[$refColumnName])
@@ -416,8 +416,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $mapping     = $collection->getMapping();
         $class       = $this->em->getClassMetadata($mapping['sourceEntity']);
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
-        $columns     = array();
-        $types       = array();
+        $columns     = [];
+        $types       = [];
 
         foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {
             $columns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
@@ -429,11 +429,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]   = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
         }
 
-        return array(
+        return [
             'DELETE FROM ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
             . ' WHERE ' . implode(' = ? AND ', $columns) . ' = ?',
             $types,
-        );
+        ];
     }
 
     /**
@@ -462,8 +462,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function getInsertRowSQL(PersistentCollection $collection)
     {
-        $columns     = array();
-        $types       = array();
+        $columns     = [];
+        $types       = [];
         $mapping     = $collection->getMapping();
         $class       = $this->em->getClassMetadata($mapping['sourceEntity']);
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
@@ -478,13 +478,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]   = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
         }
 
-        return array(
+        return [
             'INSERT INTO ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
             . ' (' . implode(', ', $columns) . ')'
             . ' VALUES'
             . ' (' . implode(', ', array_fill(0, count($columns), '?')) . ')',
             $types,
-        );
+        ];
     }
 
     /**
@@ -514,7 +514,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     private function collectJoinTableColumnParameters(PersistentCollection $collection, $element)
     {
-        $params      = array();
+        $params      = [];
         $mapping     = $collection->getMapping();
         $isComposite = count($mapping['joinTableColumns']) > 2;
 
@@ -581,14 +581,14 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $quotedJoinTable = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform). ' t';
-        $whereClauses    = array();
-        $params          = array();
-        $types           = array();
+        $whereClauses    = [];
+        $params          = [];
+        $types           = [];
 
         $joinNeeded = ! in_array($indexBy, $targetClass->identifier);
 
         if ($joinNeeded) { // extra join needed if indexBy is not a @id
-            $joinConditions = array();
+            $joinConditions = [];
 
             foreach ($joinColumns as $joinTableColumn) {
                 $joinConditions[] = 't.' . $joinTableColumn['name'] . ' = tr.' . $joinTableColumn['referencedColumnName'];
@@ -629,7 +629,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             }
         }
 
-        return array($quotedJoinTable, $whereClauses, $params, $types);
+        return [$quotedJoinTable, $whereClauses, $params, $types];
     }
 
     /**
@@ -663,9 +663,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $quotedJoinTable = $this->quoteStrategy->getJoinTableName($mapping, $sourceClass, $this->platform);
-        $whereClauses    = array();
-        $params          = array();
-        $types           = array();
+        $whereClauses    = [];
+        $params          = [];
+        $types           = [];
 
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
             $whereClauses[] = ($addFilters ? 't.' : '') . $joinTableColumn . ' = ?';
@@ -695,7 +695,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             }
         }
 
-        return array($quotedJoinTable, $whereClauses, $params, $types);
+        return [$quotedJoinTable, $whereClauses, $params, $types];
     }
 
     /**
@@ -711,7 +711,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $expression = $criteria->getWhereExpression();
 
         if ($expression === null) {
-            return array();
+            return [];
         }
 
         $valueVisitor = new SqlValueVisitor();

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -69,13 +69,13 @@ class OneToManyPersister extends AbstractCollectionPersister
         $persister = $this->uow->getEntityPersister($mapping['targetEntity']);
 
         return $persister->load(
-            array(
+            [
                 $mapping['mappedBy'] => $collection->getOwner(),
                 $mapping['indexBy']  => $index
-            ),
+            ],
             null,
             $mapping,
-            array(),
+            [],
             null,
             1
         );

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -86,7 +86,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * @var array
      */
-    static private $comparisonMap = array(
+    static private $comparisonMap = [
         Comparison::EQ       => '= %s',
         Comparison::IS       => '= %s',
         Comparison::NEQ      => '!= %s',
@@ -97,7 +97,7 @@ class BasicEntityPersister implements EntityPersister
         Comparison::IN       => 'IN (%s)',
         Comparison::NIN      => 'NOT IN (%s)',
         Comparison::CONTAINS => 'LIKE %s',
-    );
+    ];
 
     /**
      * Metadata object that describes the mapping of the mapped entity class.
@@ -132,7 +132,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @var array
      */
-    protected $queuedInserts = array();
+    protected $queuedInserts = [];
 
     /**
      * The map of column names to DBAL mapping types of all prepared columns used
@@ -143,7 +143,7 @@ class BasicEntityPersister implements EntityPersister
      * @see prepareInsertData($entity)
      * @see prepareUpdateData($entity)
      */
-    protected $columnTypes = array();
+    protected $columnTypes = [];
 
     /**
      * The map of quoted column names.
@@ -153,7 +153,7 @@ class BasicEntityPersister implements EntityPersister
      * @see prepareInsertData($entity)
      * @see prepareUpdateData($entity)
      */
-    protected $quotedColumns = array();
+    protected $quotedColumns = [];
 
     /**
      * The INSERT SQL statement used for entities handled by this persister.
@@ -257,10 +257,10 @@ class BasicEntityPersister implements EntityPersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return array();
+            return [];
         }
 
-        $postInsertIds  = array();
+        $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
 
@@ -293,7 +293,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $stmt->closeCursor();
-        $this->queuedInserts = array();
+        $this->queuedInserts = [];
 
         return $postInsertIds;
     }
@@ -382,9 +382,9 @@ class BasicEntityPersister implements EntityPersister
      */
     protected final function updateTable($entity, $quotedTableName, array $updateData, $versioned = false)
     {
-        $set    = array();
-        $types  = array();
-        $params = array();
+        $set    = [];
+        $types  = [];
+        $params = [];
 
         foreach ($updateData as $columnName => $value) {
             $placeholder = '?';
@@ -413,7 +413,7 @@ class BasicEntityPersister implements EntityPersister
             $types[]    = $this->columnTypes[$columnName];
         }
 
-        $where      = array();
+        $where      = [];
         $identifier = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
 
         foreach ($this->class->identifier as $idField) {
@@ -497,9 +497,9 @@ class BasicEntityPersister implements EntityPersister
             $selfReferential = ($mapping['targetEntity'] == $mapping['sourceEntity']);
             $class           = $this->class;
             $association     = $mapping;
-            $otherColumns    = array();
-            $otherKeys       = array();
-            $keys            = array();
+            $otherColumns    = [];
+            $otherKeys       = [];
+            $keys            = [];
 
             if ( ! $mapping['isOwningSide']) {
                 $class       = $this->em->getClassMetadata($mapping['targetEntity']);
@@ -598,7 +598,7 @@ class BasicEntityPersister implements EntityPersister
     protected function prepareUpdateData($entity)
     {
         $versionField = null;
-        $result       = array();
+        $result       = [];
         $uow          = $this->em->getUnitOfWork();
 
         if (($versioned = $this->class->isVersioned) != false) {
@@ -635,7 +635,7 @@ class BasicEntityPersister implements EntityPersister
                     // The associated entity $newVal is not yet persisted, so we must
                     // set $newVal = null, in order to insert a null value and schedule an
                     // extra update on the UnitOfWork.
-                    $uow->scheduleExtraUpdate($entity, array($field => array(null, $newVal)));
+                    $uow->scheduleExtraUpdate($entity, [$field => [null, $newVal]]);
 
                     $newVal = null;
                 }
@@ -694,7 +694,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null)
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null)
     {
         $this->switchPersisterContext(null, $limit);
 
@@ -724,7 +724,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array())
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = [])
     {
         if (($foundEntity = $this->em->getUnitOfWork()->tryGetById($identifier, $assoc['targetEntity'])) != false) {
             return $foundEntity;
@@ -737,7 +737,7 @@ class BasicEntityPersister implements EntityPersister
 
             // Mark inverse side as fetched in the hints, otherwise the UoW would
             // try to load it in a separate query (remember: to-one inverse sides can not be lazy).
-            $hints = array();
+            $hints = [];
 
             if ($isInverseSingleValued) {
                 $hints['fetched']["r"][$assoc['inversedBy']] = true;
@@ -797,13 +797,13 @@ class BasicEntityPersister implements EntityPersister
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         $hydrator = $this->em->newHydrator(Query::HYDRATE_OBJECT);
-        $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(Query::HINT_REFRESH => true));
+        $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [Query::HINT_REFRESH => true]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function count($criteria = array())
+    public function count($criteria = [])
     {
         $sql = $this->getCountSQL($criteria);
 
@@ -829,7 +829,7 @@ class BasicEntityPersister implements EntityPersister
         $stmt       = $this->conn->executeQuery($query, $params, $types);
         $hydrator   = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(UnitOfWork::HINT_DEFEREAGERLOAD => true));
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
     }
 
     /**
@@ -838,11 +838,11 @@ class BasicEntityPersister implements EntityPersister
     public function expandCriteriaParameters(Criteria $criteria)
     {
         $expression = $criteria->getWhereExpression();
-        $sqlParams  = array();
-        $sqlTypes   = array();
+        $sqlParams  = [];
+        $sqlTypes   = [];
 
         if ($expression === null) {
-            return array($sqlParams, $sqlTypes);
+            return [$sqlParams, $sqlTypes];
         }
 
         $valueVisitor = new SqlValueVisitor();
@@ -860,13 +860,13 @@ class BasicEntityPersister implements EntityPersister
             $sqlTypes[]          = $this->getType($field, $value, $this->class);
         }
 
-        return array($sqlParams, $sqlTypes);
+        return [$sqlParams, $sqlTypes];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null)
     {
         $this->switchPersisterContext($offset, $limit);
 
@@ -876,7 +876,7 @@ class BasicEntityPersister implements EntityPersister
 
         $hydrator = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(UnitOfWork::HINT_DEFEREAGERLOAD => true));
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
     }
 
     /**
@@ -902,7 +902,7 @@ class BasicEntityPersister implements EntityPersister
     private function loadArrayFromStatement($assoc, $stmt)
     {
         $rsm    = $this->currentPersisterContext->rsm;
-        $hints  = array(UnitOfWork::HINT_DEFEREAGERLOAD => true);
+        $hints  = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
 
         if (isset($assoc['indexBy'])) {
             $rsm = clone ($this->currentPersisterContext->rsm); // this is necessary because the "default rsm" should be changed.
@@ -924,10 +924,10 @@ class BasicEntityPersister implements EntityPersister
     private function loadCollectionFromStatement($assoc, $stmt, $coll)
     {
         $rsm   = $this->currentPersisterContext->rsm;
-        $hints = array(
+        $hints = [
             UnitOfWork::HINT_DEFEREAGERLOAD => true,
             'collection' => $coll
-        );
+        ];
 
         if (isset($assoc['indexBy'])) {
             $rsm = clone ($this->currentPersisterContext->rsm); // this is necessary because the "default rsm" should be changed.
@@ -964,8 +964,8 @@ class BasicEntityPersister implements EntityPersister
         $sourceClass    = $this->em->getClassMetadata($assoc['sourceEntity']);
         $class          = $sourceClass;
         $association    = $assoc;
-        $criteria       = array();
-        $parameters     = array();
+        $criteria       = [];
+        $parameters     = [];
 
         if ( ! $assoc['isOwningSide']) {
             $class       = $this->em->getClassMetadata($assoc['targetEntity']);
@@ -1008,11 +1008,11 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $criteria[$quotedJoinTable . '.' . $quotedKeyColumn] = $value;
-            $parameters[] = array(
+            $parameters[] = [
                 'value' => $value,
                 'field' => $field,
                 'class' => $sourceClass,
-            );
+            ];
         }
 
         $sql = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
@@ -1086,7 +1086,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
         $tableAlias = $this->getSQLTableAlias($this->class->name);
@@ -1122,7 +1122,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected final function getOrderBySQL(array $orderBy, $baseTableAlias)
     {
-        $orderByList = array();
+        $orderByList = [];
 
         foreach ($orderBy as $fieldName => $orientation) {
 
@@ -1184,7 +1184,7 @@ class BasicEntityPersister implements EntityPersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList = array();
+        $columnList = [];
         $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r'); // r for root
 
         // Add regular columns to select list
@@ -1237,7 +1237,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $association    = $assoc;
-            $joinCondition  = array();
+            $joinCondition  = [];
 
             if (isset($assoc['indexBy'])) {
                 $this->currentPersisterContext->rsm->addIndexBy($assocAlias, $assoc['indexBy']);
@@ -1305,7 +1305,7 @@ class BasicEntityPersister implements EntityPersister
             return '';
         }
 
-        $columnList  = array();
+        $columnList  = [];
         $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($assoc['joinColumns'] as $joinColumn) {
@@ -1333,7 +1333,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getSelectManyToManyJoinSQL(array $manyToMany)
     {
-        $conditions         = array();
+        $conditions         = [];
         $association        = $manyToMany;
         $sourceTableAlias   = $this->getSQLTableAlias($this->class->name);
 
@@ -1375,7 +1375,7 @@ class BasicEntityPersister implements EntityPersister
             return $this->insertSql;
         }
 
-        $values  = array();
+        $values  = [];
         $columns = array_unique($columns);
 
         foreach ($columns as $column) {
@@ -1410,7 +1410,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getInsertColumnList()
     {
-        $columns = array();
+        $columns = [];
 
         foreach ($this->class->reflFields as $name => $field) {
             if ($this->class->isVersioned && $this->class->versionField == $name) {
@@ -1675,7 +1675,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getSelectConditionSQL(array $criteria, $assoc = null)
     {
-        $conditions = array();
+        $conditions = [];
 
         foreach ($criteria as $field => $value) {
             $conditions[] = $this->getSelectConditionStatementSQL($field, $value, $assoc);
@@ -1720,8 +1720,8 @@ class BasicEntityPersister implements EntityPersister
     {
         $this->switchPersisterContext($offset, $limit);
 
-        $criteria    = array();
-        $parameters  = array();
+        $criteria    = [];
+        $parameters  = [];
         $owningAssoc = $this->class->associationMappings[$assoc['mappedBy']];
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
 
@@ -1738,11 +1738,11 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
-                $parameters[]                                   = array(
+                $parameters[]                                   = [
                     'value' => $value,
                     'field' => $field,
                     'class' => $sourceClass,
-                );
+                ];
 
                 continue;
             }
@@ -1751,11 +1751,11 @@ class BasicEntityPersister implements EntityPersister
             $value = $sourceClass->reflFields[$field]->getValue($sourceEntity);
 
             $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
-            $parameters[] = array(
+            $parameters[] = [
                 'value' => $value,
                 'field' => $field,
                 'class' => $sourceClass,
-            );
+            ];
 
         }
 
@@ -1770,8 +1770,8 @@ class BasicEntityPersister implements EntityPersister
      */
     public function expandParameters($criteria)
     {
-        $params = array();
-        $types  = array();
+        $params = [];
+        $types  = [];
 
         foreach ($criteria as $field => $value) {
             if ($value === null) {
@@ -1782,7 +1782,7 @@ class BasicEntityPersister implements EntityPersister
             $params[] = $this->getValue($value);
         }
 
-        return array($params, $types);
+        return [$params, $types];
     }
 
     /**
@@ -1799,8 +1799,8 @@ class BasicEntityPersister implements EntityPersister
      */
     private function expandToManyParameters($criteria)
     {
-        $params = array();
-        $types  = array();
+        $params = [];
+        $types  = [];
 
         foreach ($criteria as $criterion) {
             if ($criterion['value'] === null) {
@@ -1811,7 +1811,7 @@ class BasicEntityPersister implements EntityPersister
             $params[] = PersisterHelper::getIdentifierValues($criterion['value'], $this->em);
         }
 
-        return array($params, $types);
+        return [$params, $types];
     }
 
     /**
@@ -1850,7 +1850,7 @@ class BasicEntityPersister implements EntityPersister
             return $this->getIndividualValue($value);
         }
 
-        $newValue = array();
+        $newValue = [];
 
         foreach ($value as $itemValue) {
             $newValue[] = $this->getIndividualValue($itemValue);
@@ -1946,7 +1946,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function generateFilterConditionSQL(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        $filterClauses = array();
+        $filterClauses = [];
 
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ('' !== $filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {

--- a/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
@@ -76,7 +76,7 @@ class CachedPersisterContext
      *
      * @var array
      */
-    public $sqlTableAliases = array();
+    public $sqlTableAliases = [];
 
     /**
      * Whether this persistent context is considering limit operations applied to the selection queries

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -80,7 +80,7 @@ interface EntityPersister
      * @param  array|\Doctrine\Common\Collections\Criteria $criteria
      * @return string
      */
-    public function getCountSQL($criteria = array());
+    public function getCountSQL($criteria = []);
 
     /**
      * Expands the parameters from the given criteria and use the correct binding types if found.
@@ -164,7 +164,7 @@ interface EntityPersister
      *
      * @return int
      */
-    public function count($criteria = array());
+    public function count($criteria = []);
 
     /**
      * Gets the name of the table that owns the column the given field is mapped to.
@@ -196,7 +196,7 @@ interface EntityPersister
      *
      * @todo Check identity map? loadById method? Try to guess whether $criteria is the id?
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null);
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null);
 
     /**
      * Loads an entity by identifier.
@@ -224,7 +224,7 @@ interface EntityPersister
      *
      * @throws \Doctrine\ORM\Mapping\MappingException
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array());
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = []);
 
     /**
      * Refreshes a managed entity.
@@ -259,7 +259,7 @@ interface EntityPersister
      *
      * @return array
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null);
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null);
 
     /**
      * Gets (sliced or full) elements of the given collection.

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -46,14 +46,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      *
      * @var array
      */
-    private $owningTableMap = array();
+    private $owningTableMap = [];
 
     /**
      * Map of table to quoted table names.
      *
      * @var array
      */
-    private $quotedTableMap = array();
+    private $quotedTableMap = [];
 
     /**
      * {@inheritdoc}
@@ -128,10 +128,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return array();
+            return [];
         }
 
-        $postInsertIds  = array();
+        $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
         $rootClass      = ($this->class->name !== $this->class->rootEntityName)
@@ -144,7 +144,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $rootTableStmt = $this->conn->prepare($rootPersister->getInsertSQL());
 
         // Prepare statements for sub tables.
-        $subTableStmts = array();
+        $subTableStmts = [];
 
         if ($rootClass !== $this->class) {
             $subTableStmts[$this->class->getTableName()] = $this->conn->prepare($this->getInsertSQL());
@@ -193,7 +193,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $paramIndex = 1;
                 $data       = isset($insertData[$tableName])
                     ? $insertData[$tableName]
-                    : array();
+                    : [];
 
                 foreach ((array) $id as $idName => $idVal) {
                     $type = isset($this->columnTypes[$idName]) ? $this->columnTypes[$idName] : Type::STRING;
@@ -217,7 +217,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $stmt->closeCursor();
         }
 
-        $this->queuedInserts = array();
+        $this->queuedInserts = [];
 
         return $postInsertIds;
     }
@@ -252,7 +252,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         if ($isVersioned) {
             if ( ! isset($updateData[$versionedTable])) {
                 $tableName   = $this->quoteStrategy->getTableName($versionedClass, $this->platform);
-                $this->updateTable($entity, $tableName, array(), true);
+                $this->updateTable($entity, $tableName, [], true);
             }
 
             $identifiers = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
@@ -362,7 +362,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         $tableName      = $this->quoteStrategy->getTableName($this->class, $this->platform);
         $baseTableAlias = $this->getSQLTableAlias($this->class->name);
@@ -399,7 +399,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
-            $conditions     = array();
+            $conditions     = [];
             $tableAlias     = $this->getSQLTableAlias($parentClassName);
             $parentClass    = $this->em->getClassMetadata($parentClassName);
             $joinSql       .= ' INNER JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
@@ -426,7 +426,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList         = array();
+        $columnList         = [];
         $discrColumn        = $this->class->discriminatorColumn['name'];
         $baseTableAlias     = $this->getSQLTableAlias($this->class->name);
         $resultColumnName   = $this->platform->getSQLResultCasing($discrColumn);
@@ -537,7 +537,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Identifier columns must always come first in the column list of subclasses.
         $columns = $this->class->parentClasses
             ? $this->class->getIdentifierColumnNames()
-            : array();
+            : [];
 
         foreach ($this->class->reflFields as $name => $field) {
             if (isset($this->class->fieldMappings[$name]['inherited'])
@@ -589,7 +589,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
-            $conditions   = array();
+            $conditions   = [];
             $parentClass  = $this->em->getClassMetadata($parentClassName);
             $tableAlias   = $this->getSQLTableAlias($parentClassName);
             $joinSql     .= ' INNER JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
@@ -604,7 +604,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // OUTER JOIN sub tables
         foreach ($this->class->subClasses as $subClassName) {
-            $conditions  = array();
+            $conditions  = [];
             $subClass    = $this->em->getClassMetadata($subClassName);
             $tableAlias  = $this->getSQLTableAlias($subClassName);
             $joinSql    .= ' LEFT JOIN ' . $this->quoteStrategy->getTableName($subClass, $this->platform) . ' ' . $tableAlias . ' ON ';

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -165,7 +165,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
      */
     protected function getSelectConditionDiscriminatorValueSQL()
     {
-        $values = array();
+        $values = [];
 
         if ($this->class->discriminatorValue !== null) { // discriminators can be 0
             $values[] = $this->conn->quote($this->class->discriminatorValue);

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -70,7 +70,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
         if (isset($this->classMetadata->associationMappings[$field]) &&
             $value !== null &&
             ! is_object($value) &&
-            ! in_array($comparison->getOperator(), array(Comparison::IN, Comparison::NIN))) {
+            ! in_array($comparison->getOperator(), [Comparison::IN, Comparison::NIN])) {
 
             throw PersisterException::matchingAssocationFieldRequiresObject($this->classMetadata->name, $field);
         }
@@ -89,7 +89,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
      */
     public function walkCompositeExpression(CompositeExpression $expr)
     {
-        $expressionList = array();
+        $expressionList = [];
 
         foreach ($expr->getExpressionList() as $child) {
             $expressionList[] = $this->dispatch($child);

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -34,12 +34,12 @@ class SqlValueVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private $values = array();
+    private $values = [];
 
     /**
      * @var array
      */
-    private $types  = array();
+    private $types  = [];
 
     /**
      * Converts a comparison expression into the target query language output.
@@ -61,7 +61,7 @@ class SqlValueVisitor extends ExpressionVisitor
         }
 
         $this->values[] = $value;
-        $this->types[]  = array($field, $value);
+        $this->types[]  = [$field, $value];
     }
 
     /**
@@ -97,7 +97,7 @@ class SqlValueVisitor extends ExpressionVisitor
      */
     public function getParamsAndTypes()
     {
-        return array($this->values, $this->types);
+        return [$this->values, $this->types];
     }
 
     /**

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -335,8 +335,8 @@ final class Query extends AbstractQuery
      */
     private function processParameterMappings($paramMappings)
     {
-        $sqlParams = array();
-        $types     = array();
+        $sqlParams = [];
+        $types     = [];
 
         foreach ($this->parameters as $parameter) {
             $key    = $parameter->getName();
@@ -364,7 +364,7 @@ final class Query extends AbstractQuery
 
             // optimized multi value sql positions away for now,
             // they are not allowed in DQL anyways.
-            $value = array($value);
+            $value = [$value];
             $countValue = count($value);
 
             for ($i = 0, $l = count($sqlPositions); $i < $l; $i++) {
@@ -384,7 +384,7 @@ final class Query extends AbstractQuery
             $types = array_values($types);
         }
 
-        return array($sqlParams, $types);
+        return [$sqlParams, $types];
     }
 
     /**
@@ -648,7 +648,7 @@ final class Query extends AbstractQuery
      */
     public function setLockMode($lockMode)
     {
-        if (in_array($lockMode, array(LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE), true)) {
+        if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if ( ! $this->_em->getConnection()->isTransactionActive()) {
                 throw TransactionRequiredException::transactionRequired();
             }

--- a/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
@@ -35,7 +35,7 @@ class CoalesceExpression extends Node
     /**
      * @var array
      */
-    public $scalarExpressions = array();
+    public $scalarExpressions = [];
 
     /**
      * @param array $scalarExpressions

--- a/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
@@ -33,7 +33,7 @@ class ConditionalExpression extends Node
     /**
      * @var array
      */
-    public $conditionalTerms = array();
+    public $conditionalTerms = [];
 
     /**
      * @param array $conditionalTerms

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -32,7 +32,7 @@ class ConditionalTerm extends Node
     /**
      * @var array
      */
-    public $conditionalFactors = array();
+    public $conditionalFactors = [];
 
     /**
      * @param array $conditionalFactors

--- a/lib/Doctrine/ORM/Query/AST/FromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/FromClause.php
@@ -34,7 +34,7 @@ class FromClause extends Node
     /**
      * @var array
      */
-    public $identificationVariableDeclarations = array();
+    public $identificationVariableDeclarations = [];
 
     /**
      * @param array $identificationVariableDeclarations

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -38,7 +38,7 @@ class ConcatFunction extends FunctionNode
     
     public $secondStringPrimary;
     
-    public $concatExpressions = array();
+    public $concatExpressions = [];
     
     /**
      * @override
@@ -47,13 +47,13 @@ class ConcatFunction extends FunctionNode
     {
         $platform = $sqlWalker->getConnection()->getDatabasePlatform();
         
-        $args = array();
+        $args = [];
         
         foreach ($this->concatExpressions as $expression) {
             $args[] = $sqlWalker->walkStringPrimary($expression);
         }
         
-        return call_user_func_array(array($platform,'getConcatExpression'), $args);
+        return call_user_func_array([$platform,'getConcatExpression'], $args);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -35,7 +35,7 @@ class GeneralCaseExpression extends Node
     /**
      * @var array
      */
-    public $whenClauses = array();
+    public $whenClauses = [];
 
     /**
      * @var mixed

--- a/lib/Doctrine/ORM/Query/AST/GroupByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/GroupByClause.php
@@ -33,7 +33,7 @@ class GroupByClause extends Node
     /**
      * @var array
      */
-    public $groupByItems = array();
+    public $groupByItems = [];
 
     /**
      * @param array $groupByItems

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -43,7 +43,7 @@ class IdentificationVariableDeclaration extends Node
     /**
      * @var array
      */
-    public $joins = array();
+    public $joins = [];
 
     /**
      * @param RangeVariableDeclaration|null $rangeVariableDecl

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -42,7 +42,7 @@ class InExpression extends Node
     /**
      * @var array
      */
-    public $literals = array();
+    public $literals = [];
 
     /**
      * @var Subselect|null

--- a/lib/Doctrine/ORM/Query/AST/OrderByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByClause.php
@@ -33,7 +33,7 @@ class OrderByClause extends Node
     /**
      * @var array
      */
-    public $orderByItems = array();
+    public $orderByItems = [];
 
     /**
      * @param array $orderByItems

--- a/lib/Doctrine/ORM/Query/AST/SelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectClause.php
@@ -38,7 +38,7 @@ class SelectClause extends Node
     /**
      * @var array
      */
-    public $selectExpressions = array();
+    public $selectExpressions = [];
 
     /**
      * @param array $selectExpressions

--- a/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
@@ -33,7 +33,7 @@ class SimpleArithmeticExpression extends Node
     /**
      * @var array
      */
-    public $arithmeticTerms = array();
+    public $arithmeticTerms = [];
 
     /**
      * @param array $arithmeticTerms

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -40,7 +40,7 @@ class SimpleCaseExpression extends Node
     /**
      * @var array
      */
-    public $simpleWhenClauses = array();
+    public $simpleWhenClauses = [];
 
     /**
      * @var mixed

--- a/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
@@ -33,7 +33,7 @@ class SubselectFromClause extends Node
     /**
      * @var array
      */
-    public $identificationVariableDeclarations = array();
+    public $identificationVariableDeclarations = [];
 
     /**
      * @param array $identificationVariableDeclarations

--- a/lib/Doctrine/ORM/Query/AST/UpdateClause.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateClause.php
@@ -43,7 +43,7 @@ class UpdateClause extends Node
     /**
      * @var array
      */
-    public $updateItems = array();
+    public $updateItems = [];
 
     /**
      * @param string $abstractSchemaName

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -79,7 +79,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
         $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $primaryDqlAlias);
-        $fromClause = new AST\FromClause(array(new AST\IdentificationVariableDeclaration($rangeDecl, null, array())));
+        $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
         // Append WHERE clause, if there is one.
@@ -91,7 +91,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store DELETE statements
-        $classNames = array_merge($primaryClass->parentClasses, array($primaryClass->name), $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
         foreach (array_reverse($classNames) as $className) {
             $tableName = $quoteStrategy->getTableName($em->getClassMetadata($className), $platform);
             $this->_sqlStatements[] = 'DELETE FROM ' . $tableName
@@ -99,12 +99,12 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
-        $columnDefinitions = array();
+        $columnDefinitions = [];
         foreach ($idColumnNames as $idColumnName) {
-            $columnDefinitions[$idColumnName] = array(
+            $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type' => \Doctrine\DBAL\Types\Type::getType($rootClass->getTypeOfColumn($idColumnName))
-            );
+            ];
         }
         $this->_createTempTableSql = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -52,7 +52,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
     /**
      * @var array
      */
-    private $_sqlParameters = array();
+    private $_sqlParameters = [];
 
     /**
      * @var int
@@ -92,7 +92,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
         $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $updateClause->aliasIdentificationVariable);
-        $fromClause = new AST\FromClause(array(new AST\IdentificationVariableDeclaration($rangeDecl, null, array())));
+        $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
 
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
@@ -100,7 +100,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store UPDATE statements
-        $classNames = array_merge($primaryClass->parentClasses, array($primaryClass->name), $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
         $i = -1;
 
         foreach (array_reverse($classNames) as $className) {
@@ -143,13 +143,13 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
-        $columnDefinitions = array();
+        $columnDefinitions = [];
 
         foreach ($idColumnNames as $idColumnName) {
-            $columnDefinitions[$idColumnName] = array(
+            $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type' => Type::getType($rootClass->getTypeOfColumn($idColumnName))
-            );
+            ];
         }
 
         $this->_createTempTableSql = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
@@ -178,8 +178,8 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
 
             // Execute UPDATE statements
             foreach ($this->_sqlStatements as $key => $statement) {
-                $paramValues = array();
-                $paramTypes  = array();
+                $paramValues = [];
+                $paramTypes  = [];
 
                 if (isset($this->_sqlParameters[$key])) {
                     foreach ($this->_sqlParameters[$key] as $parameterKey => $parameterName) {

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -220,7 +220,7 @@ class Expr
      */
     public function avg($x)
     {
-        return new Expr\Func('AVG', array($x));
+        return new Expr\Func('AVG', [$x]);
     }
 
     /**
@@ -232,7 +232,7 @@ class Expr
      */
     public function max($x)
     {
-        return new Expr\Func('MAX', array($x));
+        return new Expr\Func('MAX', [$x]);
     }
 
     /**
@@ -244,7 +244,7 @@ class Expr
      */
     public function min($x)
     {
-        return new Expr\Func('MIN', array($x));
+        return new Expr\Func('MIN', [$x]);
     }
 
     /**
@@ -256,7 +256,7 @@ class Expr
      */
     public function count($x)
     {
-        return new Expr\Func('COUNT', array($x));
+        return new Expr\Func('COUNT', [$x]);
     }
 
     /**
@@ -280,7 +280,7 @@ class Expr
      */
     public function exists($subquery)
     {
-        return new Expr\Func('EXISTS', array($subquery));
+        return new Expr\Func('EXISTS', [$subquery]);
     }
 
     /**
@@ -292,7 +292,7 @@ class Expr
      */
     public function all($subquery)
     {
-        return new Expr\Func('ALL', array($subquery));
+        return new Expr\Func('ALL', [$subquery]);
     }
 
     /**
@@ -304,7 +304,7 @@ class Expr
      */
     public function some($subquery)
     {
-        return new Expr\Func('SOME', array($subquery));
+        return new Expr\Func('SOME', [$subquery]);
     }
 
     /**
@@ -316,7 +316,7 @@ class Expr
      */
     public function any($subquery)
     {
-        return new Expr\Func('ANY', array($subquery));
+        return new Expr\Func('ANY', [$subquery]);
     }
 
     /**
@@ -328,7 +328,7 @@ class Expr
      */
     public function not($restriction)
     {
-        return new Expr\Func('NOT', array($restriction));
+        return new Expr\Func('NOT', [$restriction]);
     }
 
     /**
@@ -340,7 +340,7 @@ class Expr
      */
     public function abs($x)
     {
-        return new Expr\Func('ABS', array($x));
+        return new Expr\Func('ABS', [$x]);
     }
 
     /**
@@ -429,7 +429,7 @@ class Expr
      */
     public function sqrt($x)
     {
-        return new Expr\Func('SQRT', array($x));
+        return new Expr\Func('SQRT', [$x]);
     }
 
     /**
@@ -532,7 +532,7 @@ class Expr
      */
     public function concat($x, $y)
     {
-        return new Expr\Func('CONCAT', array($x, $y));
+        return new Expr\Func('CONCAT', [$x, $y]);
     }
 
     /**
@@ -546,7 +546,7 @@ class Expr
      */
     public function substring($x, $from, $len = null)
     {
-        $args = array($x, $from);
+        $args = [$x, $from];
         if (null !== $len) {
             $args[] = $len;
         }
@@ -562,7 +562,7 @@ class Expr
      */
     public function lower($x)
     {
-        return new Expr\Func('LOWER', array($x));
+        return new Expr\Func('LOWER', [$x]);
     }
 
     /**
@@ -574,7 +574,7 @@ class Expr
      */
     public function upper($x)
     {
-        return new Expr\Func('UPPER', array($x));
+        return new Expr\Func('UPPER', [$x]);
     }
 
     /**
@@ -586,7 +586,7 @@ class Expr
      */
     public function length($x)
     {
-        return new Expr\Func('LENGTH', array($x));
+        return new Expr\Func('LENGTH', [$x]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -38,12 +38,12 @@ class Andx extends Composite
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
         'Doctrine\ORM\Query\Expr\Orx',
         'Doctrine\ORM\Query\Expr\Andx',
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -48,17 +48,17 @@ abstract class Base
     /**
      * @var array
      */
-    protected $allowedClasses = array();
+    protected $allowedClasses = [];
 
     /**
      * @var array
      */
-    protected $parts = array();
+    protected $parts = [];
 
     /**
      * @param array $args
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         $this->addMultiple($args);
     }
@@ -68,7 +68,7 @@ abstract class Base
      *
      * @return Base
      */
-    public function addMultiple($args = array())
+    public function addMultiple($args = [])
     {
         foreach ((array) $args as $arg) {
             $this->add($arg);

--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -39,7 +39,7 @@ class Composite extends Base
             return (string) $this->parts[0];
         }
 
-        $components = array();
+        $components = [];
 
         foreach ($this->parts as $part) {
             $components[] = $this->processQueryPart($part);

--- a/lib/Doctrine/ORM/Query/Expr/OrderBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/OrderBy.php
@@ -48,12 +48,12 @@ class OrderBy
     /**
      * @var array
      */
-    protected $allowedClasses = array();
+    protected $allowedClasses = [];
 
     /**
      * @var array
      */
-    protected $parts = array();
+    protected $parts = [];
 
     /**
      * @param string|null $sort

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -38,12 +38,12 @@ class Orx extends Composite
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
         'Doctrine\ORM\Query\Expr\Andx',
         'Doctrine\ORM\Query\Expr\Orx',
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Expr/Select.php
+++ b/lib/Doctrine/ORM/Query/Expr/Select.php
@@ -43,9 +43,9 @@ class Select extends Base
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Func'
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -75,7 +75,7 @@ abstract class SQLFilter
             $type = ParameterTypeInferer::inferType($value);
         }
 
-        $this->parameters[$name] = array('value' => $value, 'type' => $type);
+        $this->parameters[$name] = ['value' => $value, 'type' => $type];
 
         // Keep the parameters sorted for the hash
         ksort($this->parameters);

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -59,7 +59,7 @@ class FilterCollection
      *
      * @var \Doctrine\ORM\Query\Filter\SQLFilter[]
      */
-    private $enabledFilters = array();
+    private $enabledFilters = [];
 
     /**
      * @var string The filter hash from the last time the query was parsed.

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -125,12 +125,12 @@ class Lexer extends \Doctrine\Common\Lexer
      */
     protected function getCatchablePatterns()
     {
-        return array(
+        return [
             '[a-z_\\\][a-z0-9_\:\\\]*[a-z0-9_]{1}',
             '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?',
             "'(?:[^']|'')*'",
             '\?[0-9]*|:[a-z_][a-z0-9_]*'
-        );
+        ];
     }
 
     /**
@@ -138,7 +138,7 @@ class Lexer extends \Doctrine\Common\Lexer
      */
     protected function getNonCatchablePatterns()
     {
-        return array('\s+', '(.)');
+        return ['\s+', '(.)'];
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -40,21 +40,21 @@ class Parser
      *
      * @var array
      */
-    private static $_STRING_FUNCTIONS = array(
+    private static $_STRING_FUNCTIONS = [
         'concat'    => 'Doctrine\ORM\Query\AST\Functions\ConcatFunction',
         'substring' => 'Doctrine\ORM\Query\AST\Functions\SubstringFunction',
         'trim'      => 'Doctrine\ORM\Query\AST\Functions\TrimFunction',
         'lower'     => 'Doctrine\ORM\Query\AST\Functions\LowerFunction',
         'upper'     => 'Doctrine\ORM\Query\AST\Functions\UpperFunction',
         'identity'  => 'Doctrine\ORM\Query\AST\Functions\IdentityFunction',
-    );
+    ];
 
     /**
      * READ-ONLY: Maps BUILT-IN numeric function names to AST class names.
      *
      * @var array
      */
-    private static $_NUMERIC_FUNCTIONS = array(
+    private static $_NUMERIC_FUNCTIONS = [
         'length'    => 'Doctrine\ORM\Query\AST\Functions\LengthFunction',
         'locate'    => 'Doctrine\ORM\Query\AST\Functions\LocateFunction',
         'abs'       => 'Doctrine\ORM\Query\AST\Functions\AbsFunction',
@@ -64,20 +64,20 @@ class Parser
         'date_diff' => 'Doctrine\ORM\Query\AST\Functions\DateDiffFunction',
         'bit_and'   => 'Doctrine\ORM\Query\AST\Functions\BitAndFunction',
         'bit_or'    => 'Doctrine\ORM\Query\AST\Functions\BitOrFunction',
-    );
+    ];
 
     /**
      * READ-ONLY: Maps BUILT-IN datetime function names to AST class names.
      *
      * @var array
      */
-    private static $_DATETIME_FUNCTIONS = array(
+    private static $_DATETIME_FUNCTIONS = [
         'current_date'      => 'Doctrine\ORM\Query\AST\Functions\CurrentDateFunction',
         'current_time'      => 'Doctrine\ORM\Query\AST\Functions\CurrentTimeFunction',
         'current_timestamp' => 'Doctrine\ORM\Query\AST\Functions\CurrentTimestampFunction',
         'date_add'          => 'Doctrine\ORM\Query\AST\Functions\DateAddFunction',
         'date_sub'          => 'Doctrine\ORM\Query\AST\Functions\DateSubFunction',
-    );
+    ];
 
     /*
      * Expressions that were encountered during parsing of identifiers and expressions
@@ -87,27 +87,27 @@ class Parser
     /**
      * @var array
      */
-    private $deferredIdentificationVariables = array();
+    private $deferredIdentificationVariables = [];
 
     /**
      * @var array
      */
-    private $deferredPartialObjectExpressions = array();
+    private $deferredPartialObjectExpressions = [];
 
     /**
      * @var array
      */
-    private $deferredPathExpressions = array();
+    private $deferredPathExpressions = [];
 
     /**
      * @var array
      */
-    private $deferredResultVariables = array();
+    private $deferredResultVariables = [];
 
     /**
      * @var array
      */
-    private $deferredNewObjectExpressions = array();
+    private $deferredNewObjectExpressions = [];
 
     /**
      * The lexer.
@@ -142,7 +142,7 @@ class Parser
      *
      * @var array
      */
-    private $queryComponents = array();
+    private $queryComponents = [];
 
     /**
      * Keeps the nesting level of defined ResultVariables.
@@ -156,7 +156,7 @@ class Parser
      *
      * @var array
      */
-    private $customTreeWalkers = array();
+    private $customTreeWalkers = [];
 
     /**
      * The custom last tree walker, if any, that is responsible for producing the output.
@@ -168,7 +168,7 @@ class Parser
     /**
      * @var array
      */
-    private $identVariableExpressions = array();
+    private $identVariableExpressions = [];
 
     /**
      * Checks if a function is internally defined. Used to prevent overwriting
@@ -528,7 +528,7 @@ class Parser
      */
     private function isMathOperator($token)
     {
-        return in_array($token['type'], array(Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY));
+        return in_array($token['type'], [Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY]);
     }
 
     /**
@@ -555,7 +555,7 @@ class Parser
      */
     private function isAggregateFunction($tokenType)
     {
-        return in_array($tokenType, array(Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT));
+        return in_array($tokenType, [Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT]);
     }
 
     /**
@@ -565,7 +565,7 @@ class Parser
      */
     private function isNextAllAnySome()
     {
-        return in_array($this->lexer->lookahead['type'], array(Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME));
+        return in_array($this->lexer->lookahead['type'], [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME]);
     }
 
     /**
@@ -774,7 +774,7 @@ class Parser
 
             if ( ! ($expectedType & $fieldType)) {
                 // We need to recognize which was expected type(s)
-                $expectedStringTypes = array();
+                $expectedStringTypes = [];
 
                 // Validate state field type
                 if ($expectedType & AST\PathExpression::TYPE_STATE_FIELD) {
@@ -920,11 +920,11 @@ class Parser
 
         $identVariable = $this->lexer->token['value'];
 
-        $this->deferredIdentificationVariables[] = array(
+        $this->deferredIdentificationVariables[] = [
             'expression'   => $identVariable,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $identVariable;
     }
@@ -1005,11 +1005,11 @@ class Parser
         $resultVariable = $this->lexer->token['value'];
 
         // Defer ResultVariable validation
-        $this->deferredResultVariables[] = array(
+        $this->deferredResultVariables[] = [
             'expression'   => $resultVariable,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $resultVariable;
     }
@@ -1077,11 +1077,11 @@ class Parser
         $pathExpr = new AST\PathExpression($expectedTypes, $identVariable, $field);
 
         // Defer PathExpression validation if requested to be deferred
-        $this->deferredPathExpressions[] = array(
+        $this->deferredPathExpressions[] = [
             'expression'   => $pathExpr,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $pathExpr;
     }
@@ -1160,7 +1160,7 @@ class Parser
         }
 
         // Process SelectExpressions (1..N)
-        $selectExpressions = array();
+        $selectExpressions = [];
         $selectExpressions[] = $this->SelectExpression();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1211,20 +1211,20 @@ class Parser
         $class = $this->em->getClassMetadata($abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $class,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token,
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
         $this->match(Lexer::T_SET);
 
-        $updateItems = array();
+        $updateItems = [];
         $updateItems[] = $this->UpdateItem();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1265,14 +1265,14 @@ class Parser
         $class = $this->em->getClassMetadata($deleteClause->abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $class,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token,
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
@@ -1288,7 +1288,7 @@ class Parser
     {
         $this->match(Lexer::T_FROM);
 
-        $identificationVariableDeclarations = array();
+        $identificationVariableDeclarations = [];
         $identificationVariableDeclarations[] = $this->IdentificationVariableDeclaration();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1309,7 +1309,7 @@ class Parser
     {
         $this->match(Lexer::T_FROM);
 
-        $identificationVariables = array();
+        $identificationVariables = [];
         $identificationVariables[] = $this->SubselectIdentificationVariableDeclaration();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1355,7 +1355,7 @@ class Parser
         $this->match(Lexer::T_GROUP);
         $this->match(Lexer::T_BY);
 
-        $groupByItems = array($this->GroupByItem());
+        $groupByItems = [$this->GroupByItem()];
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
@@ -1376,7 +1376,7 @@ class Parser
         $this->match(Lexer::T_ORDER);
         $this->match(Lexer::T_BY);
 
-        $orderByItems = array();
+        $orderByItems = [];
         $orderByItems[] = $this->OrderByItem();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1553,7 +1553,7 @@ class Parser
      */
     public function IdentificationVariableDeclaration()
     {
-        $joins                    = array();
+        $joins                    = [];
         $rangeVariableDeclaration = $this->RangeVariableDeclaration();
         $indexBy                  = $this->lexer->isNextToken(Lexer::T_INDEX)
             ? $this->IndexBy()
@@ -1710,14 +1710,14 @@ class Parser
         $classMetadata = $this->em->getClassMetadata($abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $classMetadata,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
@@ -1747,14 +1747,14 @@ class Parser
         $targetClass = $this->em->getClassMetadata($class->associationMappings[$field]['targetEntity']);
 
         // Building queryComponent
-        $joinQueryComponent = array(
+        $joinQueryComponent = [
             'metadata'     => $targetClass,
             'parent'       => $joinAssociationPathExpression->identificationVariable,
             'relation'     => $class->getAssociationMapping($field),
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->lookahead
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $joinQueryComponent;
 
@@ -1771,7 +1771,7 @@ class Parser
     {
         $this->match(Lexer::T_PARTIAL);
 
-        $partialFieldSet = array();
+        $partialFieldSet = [];
 
         $identificationVariable = $this->IdentificationVariable();
 
@@ -1793,11 +1793,11 @@ class Parser
         $partialObjectExpression = new AST\PartialObjectExpression($identificationVariable, $partialFieldSet);
 
         // Defer PartialObjectExpression validation
-        $this->deferredPartialObjectExpressions[] = array(
+        $this->deferredPartialObjectExpressions[] = [
             'expression'   => $partialObjectExpression,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $partialObjectExpression;
     }
@@ -1837,11 +1837,11 @@ class Parser
         $expression = new AST\NewObjectExpression($className, $args);
 
         // Defer NewObjectExpression validation
-        $this->deferredNewObjectExpressions[] = array(
+        $this->deferredNewObjectExpressions[] = [
             'token'        => $token,
             'expression'   => $expression,
             'nestingLevel' => $this->nestingLevel,
-        );
+        ];
 
         return $expression;
     }
@@ -2021,7 +2021,7 @@ class Parser
         $this->match(Lexer::T_OPEN_PARENTHESIS);
 
         // Process ScalarExpressions (1..N)
-        $scalarExpressions = array();
+        $scalarExpressions = [];
         $scalarExpressions[] = $this->ScalarExpression();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -2064,7 +2064,7 @@ class Parser
         $this->match(Lexer::T_CASE);
 
         // Process WhenClause (1..N)
-        $whenClauses = array();
+        $whenClauses = [];
 
         do {
             $whenClauses[] = $this->WhenClause();
@@ -2089,7 +2089,7 @@ class Parser
         $caseOperand = $this->StateFieldPathExpression();
 
         // Process SimpleWhenClause (1..N)
-        $simpleWhenClauses = array();
+        $simpleWhenClauses = [];
 
         do {
             $simpleWhenClauses[] = $this->SimpleWhenClause();
@@ -2243,11 +2243,11 @@ class Parser
             $aliasResultVariable = $this->AliasResultVariable();
 
             // Include AliasResultVariable in query components.
-            $this->queryComponents[$aliasResultVariable] = array(
+            $this->queryComponents[$aliasResultVariable] = [
                 'resultVariable' => $expression,
                 'nestingLevel'   => $this->nestingLevel,
                 'token'          => $token,
-            );
+            ];
         }
 
         // AST
@@ -2337,11 +2337,11 @@ class Parser
             $expr->fieldIdentificationVariable = $resultVariable;
 
             // Include AliasResultVariable in query components.
-            $this->queryComponents[$resultVariable] = array(
+            $this->queryComponents[$resultVariable] = [
                 'resultvariable' => $expr,
                 'nestingLevel'   => $this->nestingLevel,
                 'token'          => $token,
-            );
+            ];
         }
 
         return $expr;
@@ -2354,7 +2354,7 @@ class Parser
      */
     public function ConditionalExpression()
     {
-        $conditionalTerms = array();
+        $conditionalTerms = [];
         $conditionalTerms[] = $this->ConditionalTerm();
 
         while ($this->lexer->isNextToken(Lexer::T_OR)) {
@@ -2379,7 +2379,7 @@ class Parser
      */
     public function ConditionalTerm()
     {
-        $conditionalFactors = array();
+        $conditionalFactors = [];
         $conditionalFactors[] = $this->ConditionalFactor();
 
         while ($this->lexer->isNextToken(Lexer::T_AND)) {
@@ -2444,8 +2444,8 @@ class Parser
         // Peek beyond the matching closing parenthesis ')'
         $peek = $this->peekBeyondClosingParenthesis();
 
-        if (in_array($peek['value'], array("=",  "<", "<=", "<>", ">", ">=", "!=")) ||
-            in_array($peek['type'], array(Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS)) ||
+        if (in_array($peek['value'], ["=",  "<", "<=", "<>", ">", ">=", "!="]) ||
+            in_array($peek['type'], [Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS]) ||
             $this->isMathOperator($peek)) {
             $condPrimary->simpleConditionalExpression = $this->SimpleConditionalExpression();
 
@@ -2701,7 +2701,7 @@ class Parser
      */
     public function SimpleArithmeticExpression()
     {
-        $terms = array();
+        $terms = [];
         $terms[] = $this->ArithmeticTerm();
 
         while (($isPlus = $this->lexer->isNextToken(Lexer::T_PLUS)) || $this->lexer->isNextToken(Lexer::T_MINUS)) {
@@ -2727,7 +2727,7 @@ class Parser
      */
     public function ArithmeticTerm()
     {
-        $factors = array();
+        $factors = [];
         $factors[] = $this->ArithmeticFactor();
 
         while (($isMult = $this->lexer->isNextToken(Lexer::T_MULTIPLY)) || $this->lexer->isNextToken(Lexer::T_DIVIDE)) {
@@ -2948,7 +2948,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $isDistinct = false;
 
-        if ( ! in_array($lookaheadType, array(Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM))) {
+        if ( ! in_array($lookaheadType, [Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM])) {
             $this->syntaxError('One of: MAX, MIN, AVG, SUM, COUNT');
         }
 
@@ -2978,7 +2978,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $value = $this->lexer->lookahead['value'];
 
-        if ( ! in_array($lookaheadType, array(Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME))) {
+        if ( ! in_array($lookaheadType, [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME])) {
             $this->syntaxError('ALL, ANY or SOME');
         }
 
@@ -3057,7 +3057,7 @@ class Parser
         if ($this->lexer->isNextToken(Lexer::T_SELECT)) {
             $inExpression->subselect = $this->Subselect();
         } else {
-            $literals = array();
+            $literals = [];
             $literals[] = $this->InParameter();
 
             while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -3090,7 +3090,7 @@ class Parser
         $this->match(Lexer::T_INSTANCE);
         $this->match(Lexer::T_OF);
 
-        $exprValues = array();
+        $exprValues = [];
 
         if ($this->lexer->isNextToken(Lexer::T_OPEN_PARENTHESIS)) {
             $this->match(Lexer::T_OPEN_PARENTHESIS);

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -51,7 +51,7 @@ class ParserResult
      *
      * @var array
      */
-    private $_parameterMappings = array();
+    private $_parameterMappings = [];
 
     /**
      * Initializes a new instance of the <tt>ParserResult</tt> class.

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -37,12 +37,12 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private static $operatorMap = array(
+    private static $operatorMap = [
         Comparison::GT => Expr\Comparison::GT,
         Comparison::GTE => Expr\Comparison::GTE,
         Comparison::LT  => Expr\Comparison::LT,
         Comparison::LTE => Expr\Comparison::LTE
-    );
+    ];
 
     /**
      * @var array
@@ -57,7 +57,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private $parameters = array();
+    private $parameters = [];
 
     /**
      * Constructor
@@ -88,7 +88,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function clearParameters()
     {
-        $this->parameters = array();
+        $this->parameters = [];
     }
 
     /**
@@ -108,7 +108,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function walkCompositeExpression(CompositeExpression $expr)
     {
-        $expressionList = array();
+        $expressionList = [];
 
         foreach ($expr->getExpressionList() as $child) {
             $expressionList[] = $this->dispatch($child);

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -57,7 +57,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $aliasMap = array();
+    public $aliasMap = [];
 
     /**
      * Maps alias names to related association field names.
@@ -65,7 +65,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $relationMap = array();
+    public $relationMap = [];
 
     /**
      * Maps alias names to parent alias names.
@@ -73,7 +73,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $parentAliasMap = array();
+    public $parentAliasMap = [];
 
     /**
      * Maps column names in the result set to field names for each class.
@@ -81,7 +81,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $fieldMappings = array();
+    public $fieldMappings = [];
 
     /**
      * Maps column names in the result set to the alias/field name to use in the mapped result.
@@ -89,7 +89,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $scalarMappings = array();
+    public $scalarMappings = [];
 
     /**
      * Maps column names in the result set to the alias/field type to use in the mapped result.
@@ -97,7 +97,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $typeMappings = array();
+    public $typeMappings = [];
 
     /**
      * Maps entities in the result set to the alias name to use in the mapped result.
@@ -105,7 +105,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $entityMappings = array();
+    public $entityMappings = [];
 
     /**
      * Maps column names of meta columns (foreign keys, discriminator columns, ...) to field names.
@@ -113,7 +113,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $metaMappings = array();
+    public $metaMappings = [];
 
     /**
      * Maps column names in the result set to the alias they belong to.
@@ -121,7 +121,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $columnOwnerMap = array();
+    public $columnOwnerMap = [];
 
     /**
      * List of columns in the result set that are used as discriminator columns.
@@ -129,7 +129,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $discriminatorColumns = array();
+    public $discriminatorColumns = [];
 
     /**
      * Maps alias names to field names that should be used for indexing.
@@ -137,7 +137,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $indexByMap = array();
+    public $indexByMap = [];
 
     /**
      * Map from column names to class names that declare the field the column is mapped to.
@@ -145,28 +145,28 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $declaringClasses = array();
+    public $declaringClasses = [];
 
     /**
      * This is necessary to hydrate derivate foreign keys correctly.
      *
      * @var array
      */
-    public $isIdentifierColumn = array();
+    public $isIdentifierColumn = [];
 
     /**
      * Maps column names in the result set to field names for each new object expression.
      *
      * @var array
      */
-    public $newObjectMappings = array();
+    public $newObjectMappings = [];
 
     /**
      * Maps metadata parameter names to the metadata attribute.
      *
      * @var array
      */
-    public $metadataParameterMapping = array();
+    public $metadataParameterMapping = [];
 
     /**
      * Adds an entity result to this ResultSetMapping.

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -95,7 +95,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return void
      */
-    public function addRootEntityFromClassMetadata($class, $alias, $renamedColumns = array(), $renameMode = null)
+    public function addRootEntityFromClassMetadata($class, $alias, $renamedColumns = [], $renameMode = null)
     {
         $renameMode     = $renameMode ?: $this->defaultRenameMode;
         $columnAliasMap = $this->getColumnAliasMap($class, $renameMode, $renamedColumns);
@@ -117,7 +117,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return void
      */
-    public function addJoinedEntityFromClassMetadata($class, $alias, $parentAlias, $relation, $renamedColumns = array(), $renameMode = null)
+    public function addJoinedEntityFromClassMetadata($class, $alias, $parentAlias, $relation, $renamedColumns = [], $renameMode = null)
     {
         $renameMode     = $renameMode ?: $this->defaultRenameMode;
         $columnAliasMap = $this->getColumnAliasMap($class, $renameMode, $renamedColumns);
@@ -137,7 +137,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @throws \InvalidArgumentException
      */
-    protected function addAllClassFields($class, $alias, $columnAliasMap = array())
+    protected function addAllClassFields($class, $alias, $columnAliasMap = [])
     {
         $classMetadata = $this->em->getClassMetadata($class);
         $platform      = $this->em->getConnection()->getDatabasePlatform();
@@ -231,7 +231,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             $mode = self::COLUMN_RENAMING_CUSTOM;
         }
 
-        $columnAlias = array();
+        $columnAlias = [];
         $class       = $this->em->getClassMetadata($className);
 
         foreach ($class->getColumnNames() as $columnName) {
@@ -419,7 +419,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return string
      */
-    public function generateSelectClause($tableAliases = array())
+    public function generateSelectClause($tableAliases = [])
     {
         $sql = "";
 
@@ -453,6 +453,6 @@ class ResultSetMappingBuilder extends ResultSetMapping
      */
     public function __toString()
     {
-        return $this->generateSelectClause(array());
+        return $this->generateSelectClause([]);
     }
 }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -108,28 +108,28 @@ class SqlWalker implements TreeWalker
     /**
      * @var array
      */
-    private $tableAliasMap = array();
+    private $tableAliasMap = [];
 
     /**
      * Map from result variable names to their SQL column alias names.
      *
      * @var array
      */
-    private $scalarResultAliasMap = array();
+    private $scalarResultAliasMap = [];
 
     /**
      * Map from Table-Alias + Column-Name to OrderBy-Direction.
      *
      * @var array
      */
-    private $orderedColumnsMap = array();
+    private $orderedColumnsMap = [];
 
     /**
      * Map from DQL-Alias + Field-Name to SQL Column Alias.
      *
      * @var array
      */
-    private $scalarFields = array();
+    private $scalarFields = [];
 
     /**
      * Map of all components/classes that appear in the DQL query.
@@ -143,14 +143,14 @@ class SqlWalker implements TreeWalker
      *
      * @var array
      */
-    private $selectedClasses = array();
+    private $selectedClasses = [];
 
     /**
      * The DQL alias of the root class of the currently traversed query.
      *
      * @var array
      */
-    private $rootAliases = array();
+    private $rootAliases = [];
 
     /**
      * Flag that indicates whether to generate SQL table aliases in the SQL.
@@ -244,7 +244,7 @@ class SqlWalker implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);
@@ -353,7 +353,7 @@ class SqlWalker implements TreeWalker
             $sql .= isset($this->queryComponents[$dqlAlias]['relation']) ? ' LEFT ' : ' INNER ';
             $sql .= 'JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
 
-            $sqlParts = array();
+            $sqlParts = [];
 
             foreach ($this->quoteStrategy->getIdentifierColumnNames($class, $this->platform) as $columnName) {
                 $sqlParts[] = $baseTableAlias . '.' . $columnName . ' = ' . $tableAlias . '.' . $columnName;
@@ -379,7 +379,7 @@ class SqlWalker implements TreeWalker
 
             $sql .= ' LEFT JOIN ' . $this->quoteStrategy->getTableName($subClass, $this->platform) . ' ' . $tableAlias . ' ON ';
 
-            $sqlParts = array();
+            $sqlParts = [];
 
             foreach ($this->quoteStrategy->getIdentifierColumnNames($subClass, $this->platform) as $columnName) {
                 $sqlParts[] = $baseTableAlias . '.' . $columnName . ' = ' . $tableAlias . '.' . $columnName;
@@ -396,7 +396,7 @@ class SqlWalker implements TreeWalker
      */
     private function _generateOrderedCollectionOrderByItems()
     {
-        $orderedColumns = array();
+        $orderedColumns = [];
 
         foreach ($this->selectedClasses as $selectedClass) {
             $dqlAlias  = $selectedClass['dqlAlias'];
@@ -438,7 +438,7 @@ class SqlWalker implements TreeWalker
      */
     private function _generateDiscriminatorColumnConditionSQL(array $dqlAliases)
     {
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($dqlAliases as $dqlAlias) {
             $class = $this->queryComponents[$dqlAlias]['metadata'];
@@ -446,7 +446,7 @@ class SqlWalker implements TreeWalker
             if ( ! $class->isInheritanceTypeSingleTable()) continue;
 
             $conn   = $this->em->getConnection();
-            $values = array();
+            $values = [];
 
             if ($class->discriminatorValue !== null) { // discriminators can be 0
                 $values[] = $conn->quote($class->discriminatorValue);
@@ -500,7 +500,7 @@ class SqlWalker implements TreeWalker
                 break;
         }
 
-        $filterClauses = array();
+        $filterClauses = [];
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ('' !== $filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {
                 $filterClauses[] = '(' . $filterExpr . ')';
@@ -603,7 +603,7 @@ class SqlWalker implements TreeWalker
     {
         $class      = $this->queryComponents[$identVariable]['metadata'];
         $tableAlias = $this->getSQLTableAlias($class->getTableName(), $identVariable);
-        $sqlParts   = array();
+        $sqlParts   = [];
 
         foreach ($this->quoteStrategy->getIdentifierColumnNames($class, $this->platform) as $columnName) {
             $sqlParts[] = $tableAlias . '.' . $columnName;
@@ -696,7 +696,7 @@ class SqlWalker implements TreeWalker
     public function walkSelectClause($selectClause)
     {
         $sql = 'SELECT ' . (($selectClause->isDistinct) ? 'DISTINCT ' : '');
-        $sqlSelectExpressions = array_filter(array_map(array($this, 'walkSelectExpression'), $selectClause->selectExpressions));
+        $sqlSelectExpressions = array_filter(array_map([$this, 'walkSelectExpression'], $selectClause->selectExpressions));
 
         if ($this->query->getHint(Query::HINT_INTERNAL_ITERATION) == true && $selectClause->isDistinct) {
             $this->query->setHint(self::HINT_DISTINCT, true);
@@ -809,7 +809,7 @@ class SqlWalker implements TreeWalker
     public function walkFromClause($fromClause)
     {
         $identificationVarDecls = $fromClause->identificationVariableDeclarations;
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($identificationVarDecls as $identificationVariableDecl) {
             $sqlParts[] = $this->walkIdentificationVariableDeclaration($identificationVariableDecl);
@@ -934,7 +934,7 @@ class SqlWalker implements TreeWalker
         // The owning side is necessary at this point because only it contains the JoinColumn information.
         switch (true) {
             case ($assoc['type'] & ClassMetadata::TO_ONE):
-                $conditions = array();
+                $conditions = [];
 
                 foreach ($assoc['joinColumns'] as $joinColumn) {
                     $quotedSourceColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $targetClass, $this->platform);
@@ -950,7 +950,7 @@ class SqlWalker implements TreeWalker
                 }
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($joinedDqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$joinedDqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -963,10 +963,10 @@ class SqlWalker implements TreeWalker
                     $conditions[] = $filterExpr;
                 }
 
-                $targetTableJoin = array(
+                $targetTableJoin = [
                     'table' => $targetTableName . ' ' . $targetTableAlias,
                     'condition' => implode(' AND ', $conditions),
-                );
+                ];
                 break;
 
             case ($assoc['type'] == ClassMetadata::MANY_TO_MANY):
@@ -975,7 +975,7 @@ class SqlWalker implements TreeWalker
                 $joinTableAlias = $this->getSQLTableAlias($joinTable['name'], $joinedDqlAlias);
                 $joinTableName  = $this->quoteStrategy->getJoinTableName($assoc, $sourceClass, $this->platform);
 
-                $conditions      = array();
+                $conditions      = [];
                 $relationColumns = ($relation['isOwningSide'])
                     ? $assoc['joinTable']['joinColumns']
                     : $assoc['joinTable']['inverseJoinColumns'];
@@ -992,7 +992,7 @@ class SqlWalker implements TreeWalker
                 // Join target table
                 $sql .= ($joinType == AST\Join::JOIN_TYPE_LEFT || $joinType == AST\Join::JOIN_TYPE_LEFTOUTER) ? ' LEFT JOIN ' : ' INNER JOIN ';
 
-                $conditions      = array();
+                $conditions      = [];
                 $relationColumns = ($relation['isOwningSide'])
                     ? $assoc['joinTable']['inverseJoinColumns']
                     : $assoc['joinTable']['joinColumns'];
@@ -1005,7 +1005,7 @@ class SqlWalker implements TreeWalker
                 }
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($joinedDqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$joinedDqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -1018,10 +1018,10 @@ class SqlWalker implements TreeWalker
                     $conditions[] = $filterExpr;
                 }
 
-                $targetTableJoin = array(
+                $targetTableJoin = [
                     'table' => $targetTableName . ' ' . $targetTableAlias,
                     'condition' => implode(' AND ', $conditions),
-                );
+                ];
                 break;
 
             default:
@@ -1071,7 +1071,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkOrderByClause($orderByClause)
     {
-        $orderByItems = array_map(array($this, 'walkOrderByItem'), $orderByClause->orderByItems);
+        $orderByItems = array_map([$this, 'walkOrderByItem'], $orderByClause->orderByItems);
 
         if (($collectionOrderByItems = $this->_generateOrderedCollectionOrderByItems()) !== '') {
             $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
@@ -1128,10 +1128,10 @@ class SqlWalker implements TreeWalker
 
                 $sql .= $this->walkRangeVariableDeclaration($joinDeclaration);
 
-                $conditions = array($condition);
+                $conditions = [$condition];
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($dqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$dqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -1193,7 +1193,7 @@ class SqlWalker implements TreeWalker
     {
         $sql = 'COALESCE(';
 
-        $scalarExpressions = array();
+        $scalarExpressions = [];
 
         foreach ($coalesceExpression->scalarExpressions as $scalarExpression) {
             $scalarExpressions[] = $this->walkSimpleArithmeticExpression($scalarExpression);
@@ -1363,7 +1363,7 @@ class SqlWalker implements TreeWalker
                     $partialFieldSet = $expr->partialFieldSet;
                 } else {
                     $dqlAlias = $expr;
-                    $partialFieldSet = array();
+                    $partialFieldSet = [];
                 }
 
                 $queryComp   = $this->queryComponents[$dqlAlias];
@@ -1371,14 +1371,14 @@ class SqlWalker implements TreeWalker
                 $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
 
                 if ( ! isset($this->selectedClasses[$dqlAlias])) {
-                    $this->selectedClasses[$dqlAlias] = array(
+                    $this->selectedClasses[$dqlAlias] = [
                         'class'       => $class,
                         'dqlAlias'    => $dqlAlias,
                         'resultAlias' => $resultAlias
-                    );
+                    ];
                 }
 
-                $sqlParts = array();
+                $sqlParts = [];
 
                 // Select all fields from the queried class
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
@@ -1463,7 +1463,7 @@ class SqlWalker implements TreeWalker
         $useAliasesBefore  = $this->useSqlTableAliases;
         $rootAliasesBefore = $this->rootAliases;
 
-        $this->rootAliases = array(); // reset the rootAliases for the subselect
+        $this->rootAliases = []; // reset the rootAliases for the subselect
         $this->useSqlTableAliases = true;
 
         $sql  = $this->walkSimpleSelectClause($subselect->simpleSelectClause);
@@ -1486,7 +1486,7 @@ class SqlWalker implements TreeWalker
     public function walkSubselectFromClause($subselectFromClause)
     {
         $identificationVarDecls = $subselectFromClause->identificationVariableDeclarations;
-        $sqlParts               = array ();
+        $sqlParts               =  [];
 
         foreach ($identificationVarDecls as $subselectIdVarDecl) {
             $sqlParts[] = $this->walkIdentificationVariableDeclaration($subselectIdVarDecl);
@@ -1521,7 +1521,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkNewObject($newObjectExpression, $newObjectResultAlias=null)
     {
-        $sqlSelectExpressions = array();
+        $sqlSelectExpressions = [];
         $objIndex             = $newObjectResultAlias?:$this->newObjectCounter++;
 
         foreach ($newObjectExpression->args as $argIndex => $e) {
@@ -1570,11 +1570,11 @@ class SqlWalker implements TreeWalker
             $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
             $this->rsm->addScalarResult($columnAlias, $resultAlias, $fieldType);
 
-            $this->rsm->newObjectMappings[$columnAlias] = array(
+            $this->rsm->newObjectMappings[$columnAlias] = [
                 'className' => $newObjectExpression->className,
                 'objIndex'  => $objIndex,
                 'argIndex'  => $argIndex
-            );
+            ];
         }
 
         return implode(', ', $sqlSelectExpressions);
@@ -1651,7 +1651,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkGroupByClause($groupByClause)
     {
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($groupByClause->groupByItems as $groupByItem) {
             $sqlParts[] = $this->walkGroupByItem($groupByItem);
@@ -1686,7 +1686,7 @@ class SqlWalker implements TreeWalker
         }
 
         // IdentificationVariable
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($this->queryComponents[$groupByItem]['metadata']->fieldNames as $field) {
             $item       = new AST\PathExpression(AST\PathExpression::TYPE_STATE_FIELD, $groupByItem, $field);
@@ -1734,7 +1734,7 @@ class SqlWalker implements TreeWalker
         $this->setSQLTableAlias($tableName, $tableName, $updateClause->aliasIdentificationVariable);
         $this->rootAliases[] = $updateClause->aliasIdentificationVariable;
 
-        $sql .= ' SET ' . implode(', ', array_map(array($this, 'walkUpdateItem'), $updateClause->updateItems));
+        $sql .= ' SET ' . implode(', ', array_map([$this, 'walkUpdateItem'], $updateClause->updateItems));
 
         return $sql;
     }
@@ -1778,7 +1778,7 @@ class SqlWalker implements TreeWalker
         $discrSql = $this->_generateDiscriminatorColumnConditionSql($this->rootAliases);
 
         if ($this->em->hasFilters()) {
-            $filterClauses = array();
+            $filterClauses = [];
             foreach ($this->rootAliases as $dqlAlias) {
                 $class = $this->queryComponents[$dqlAlias]['metadata'];
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
@@ -1819,7 +1819,7 @@ class SqlWalker implements TreeWalker
             return $this->walkConditionalTerm($condExpr);
         }
 
-        return implode(' OR ', array_map(array($this, 'walkConditionalTerm'), $condExpr->conditionalTerms));
+        return implode(' OR ', array_map([$this, 'walkConditionalTerm'], $condExpr->conditionalTerms));
     }
 
     /**
@@ -1833,7 +1833,7 @@ class SqlWalker implements TreeWalker
             return $this->walkConditionalFactor($condTerm);
         }
 
-        return implode(' AND ', array_map(array($this, 'walkConditionalFactor'), $condTerm->conditionalFactors));
+        return implode(' AND ', array_map([$this, 'walkConditionalFactor'], $condTerm->conditionalFactors));
     }
 
     /**
@@ -1918,7 +1918,7 @@ class SqlWalker implements TreeWalker
             $sql .= $this->quoteStrategy->getTableName($targetClass, $this->platform) . ' ' . $targetTableAlias . ' WHERE ';
 
             $owningAssoc = $targetClass->associationMappings[$assoc['mappedBy']];
-            $sqlParts    = array();
+            $sqlParts    = [];
 
             foreach ($owningAssoc['targetToSourceKeyColumns'] as $targetColumn => $sourceColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($class->fieldNames[$targetColumn], $class, $this->platform);
@@ -1952,7 +1952,7 @@ class SqlWalker implements TreeWalker
 
             // join conditions
             $joinColumns  = $assoc['isOwningSide'] ? $joinTable['inverseJoinColumns'] : $joinTable['joinColumns'];
-            $joinSqlParts = array();
+            $joinSqlParts = [];
 
             foreach ($joinColumns as $joinColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($targetClass->fieldNames[$joinColumn['referencedColumnName']], $targetClass, $this->platform);
@@ -1964,7 +1964,7 @@ class SqlWalker implements TreeWalker
             $sql .= ' WHERE ';
 
             $joinColumns = $assoc['isOwningSide'] ? $joinTable['joinColumns'] : $joinTable['inverseJoinColumns'];
-            $sqlParts    = array();
+            $sqlParts    = [];
 
             foreach ($joinColumns as $joinColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($class->fieldNames[$joinColumn['referencedColumnName']], $class, $this->platform);
@@ -2027,7 +2027,7 @@ class SqlWalker implements TreeWalker
 
         $sql .= ($inExpr->subselect)
             ? $this->walkSubselect($inExpr->subselect)
-            : implode(', ', array_map(array($this, 'walkInParameter'), $inExpr->literals));
+            : implode(', ', array_map([$this, 'walkInParameter'], $inExpr->literals));
 
         $sql .= ')';
 
@@ -2054,7 +2054,7 @@ class SqlWalker implements TreeWalker
 
         $sql .= $class->discriminatorColumn['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
 
-        $sqlParameterList = array();
+        $sqlParameterList = [];
 
         foreach ($instanceOfExpr->value as $parameter) {
             if ($parameter instanceof AST\InputParameter) {
@@ -2225,7 +2225,7 @@ class SqlWalker implements TreeWalker
             return $this->walkArithmeticTerm($simpleArithmeticExpr);
         }
 
-        return implode(' ', array_map(array($this, 'walkArithmeticTerm'), $simpleArithmeticExpr->arithmeticTerms));
+        return implode(' ', array_map([$this, 'walkArithmeticTerm'], $simpleArithmeticExpr->arithmeticTerms));
     }
 
     /**
@@ -2245,7 +2245,7 @@ class SqlWalker implements TreeWalker
             return $this->walkArithmeticFactor($term);
         }
 
-        return implode(' ', array_map(array($this, 'walkArithmeticFactor'), $term->arithmeticFactors));
+        return implode(' ', array_map([$this, 'walkArithmeticFactor'], $term->arithmeticFactors));
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -72,7 +72,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -72,7 +72,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -27,7 +27,7 @@ class TreeWalkerChainIterator implements \Iterator, \ArrayAccess
     /**
      * @var TreeWalker[]
      */
-    private $walkers = array();
+    private $walkers = [];
     /**
      * @var TreeWalkerChain
      */

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -57,17 +57,17 @@ class QueryBuilder
      *
      * @var array
      */
-    private $_dqlParts = array(
+    private $_dqlParts = [
         'distinct' => false,
-        'select'  => array(),
-        'from'    => array(),
-        'join'    => array(),
-        'set'     => array(),
+        'select'  => [],
+        'from'    => [],
+        'join'    => [],
+        'set'     => [],
         'where'   => null,
-        'groupBy' => array(),
+        'groupBy' => [],
         'having'  => null,
-        'orderBy' => array()
-    );
+        'orderBy' => []
+    ];
 
     /**
      * The type of query this is. Can be select, update or delete.
@@ -116,7 +116,7 @@ class QueryBuilder
      *
      * @var array
      */
-    private $joinRootAliases = array();
+    private $joinRootAliases = [];
 
      /**
      * Whether to use second level cache, if available.
@@ -442,7 +442,7 @@ class QueryBuilder
      */
     public function getRootAliases()
     {
-        $aliases = array();
+        $aliases = [];
 
         foreach ($this->_dqlParts['from'] as &$fromClause) {
             if (is_string($fromClause)) {
@@ -493,7 +493,7 @@ class QueryBuilder
      */
     public function getRootEntities()
     {
-        $entities = array();
+        $entities = [];
 
         foreach ($this->_dqlParts['from'] as &$fromClause) {
             if (is_string($fromClause)) {
@@ -695,7 +695,7 @@ class QueryBuilder
         // This is introduced for backwards compatibility reasons.
         // TODO: Remove for 3.0
         if ($dqlPartName == 'join') {
-            $newDqlPart = array();
+            $newDqlPart = [];
 
             foreach ($dqlPart as $k => $v) {
                 $k = is_numeric($k) ? $this->getRootAlias() : $k;
@@ -715,7 +715,7 @@ class QueryBuilder
                 $this->_dqlParts[$dqlPartName][] = $dqlPart;
             }
         } else {
-            $this->_dqlParts[$dqlPartName] = ($isMultiple) ? array($dqlPart) : $dqlPart;
+            $this->_dqlParts[$dqlPartName] = ($isMultiple) ? [$dqlPart] : $dqlPart;
         }
 
         $this->_state = self::STATE_DIRTY;
@@ -933,7 +933,7 @@ class QueryBuilder
             Expr\Join::INNER_JOIN, $join, $alias, $conditionType, $condition, $indexBy
         );
 
-        return $this->add('join', array($rootAlias => $join), true);
+        return $this->add('join', [$rootAlias => $join], true);
     }
 
     /**
@@ -968,7 +968,7 @@ class QueryBuilder
             Expr\Join::LEFT_JOIN, $join, $alias, $conditionType, $condition, $indexBy
         );
 
-        return $this->add('join', array($rootAlias => $join), true);
+        return $this->add('join', [$rootAlias => $join], true);
     }
 
     /**
@@ -1315,9 +1315,9 @@ class QueryBuilder
     private function _getDQLForDelete()
     {
          return 'DELETE'
-              . $this->_getReducedDQLQueryPart('from', array('pre' => ' ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
     /**
@@ -1326,10 +1326,10 @@ class QueryBuilder
     private function _getDQLForUpdate()
     {
          return 'UPDATE'
-              . $this->_getReducedDQLQueryPart('from', array('pre' => ' ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('set', array('pre' => ' SET ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('set', ['pre' => ' SET ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
     /**
@@ -1339,11 +1339,11 @@ class QueryBuilder
     {
         $dql = 'SELECT'
              . ($this->_dqlParts['distinct']===true ? ' DISTINCT' : '')
-             . $this->_getReducedDQLQueryPart('select', array('pre' => ' ', 'separator' => ', '));
+             . $this->_getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
 
         $fromParts   = $this->getDQLPart('from');
         $joinParts   = $this->getDQLPart('join');
-        $fromClauses = array();
+        $fromClauses = [];
 
         // Loop through all FROM clauses
         if ( ! empty($fromParts)) {
@@ -1363,10 +1363,10 @@ class QueryBuilder
         }
 
         $dql .= implode(', ', $fromClauses)
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('groupBy', array('pre' => ' GROUP BY ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('having', array('pre' => ' HAVING '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('groupBy', ['pre' => ' GROUP BY ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('having', ['pre' => ' HAVING '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
 
         return $dql;
     }
@@ -1377,7 +1377,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function _getReducedDQLQueryPart($queryPartName, $options = array())
+    private function _getReducedDQLQueryPart($queryPartName, $options = [])
     {
         $queryPart = $this->getDQLPart($queryPartName);
 
@@ -1419,7 +1419,7 @@ class QueryBuilder
      */
     public function resetDQLPart($part)
     {
-        $this->_dqlParts[$part] = is_array($this->_dqlParts[$part]) ? array() : null;
+        $this->_dqlParts[$part] = is_array($this->_dqlParts[$part]) ? [] : null;
         $this->_state           = self::STATE_DIRTY;
 
         return $this;
@@ -1455,7 +1455,7 @@ class QueryBuilder
             }
         }
 
-        $parameters = array();
+        $parameters = [];
 
         foreach ($this->parameters as $parameter) {
             $parameters[] = clone $parameter;

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -34,7 +34,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
      *
      * @var \Doctrine\Common\Persistence\ObjectRepository[]
      */
-    private $repositoryList = array();
+    private $repositoryList = [];
 
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -33,7 +33,7 @@ class AttachEntityListenersListener
     /**
      * @var array[]
      */
-    private $entityListeners = array();
+    private $entityListeners = [];
 
     /**
      * Adds a entity listener for a specific entity.
@@ -47,11 +47,11 @@ class AttachEntityListenersListener
      */
     public function addEntityListener($entityClass, $listenerClass, $eventName, $listenerCallback = null)
     {
-        $this->entityListeners[ltrim($entityClass, '\\')][] = array(
+        $this->entityListeners[ltrim($entityClass, '\\')][] = [
             'event'  => $eventName,
             'class'  => $listenerClass,
             'method' => $listenerCallback ?: $eventName
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -46,12 +46,12 @@ class MetadataCommand extends Command
         $this
         ->setName('orm:clear-cache:metadata')
         ->setDescription('Clear all metadata cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the metadata cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -46,12 +46,12 @@ class QueryCommand extends Command
         $this
         ->setName('orm:clear-cache:query')
         ->setDescription('Clear all query cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the query cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -46,12 +46,12 @@ class ResultCommand extends Command
         $this
         ->setName('orm:clear-cache:result')
         ->setDescription('Clear all result cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the result cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -102,9 +102,9 @@ class ConvertDoctrine1SchemaCommand extends Command
     {
         $this
         ->setName('orm:convert-d1-schema')
-        ->setAliases(array('orm:convert:d1-schema'))
+        ->setAliases(['orm:convert:d1-schema'])
         ->setDescription('Converts Doctrine 1.X schema into a Doctrine 2.X schema.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputArgument(
                 'from-path', InputArgument::REQUIRED, 'The path of Doctrine 1.X schema information.'
             ),
@@ -118,7 +118,7 @@ class ConvertDoctrine1SchemaCommand extends Command
             new InputOption(
                 'from', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Optional paths of Doctrine 1.X schema information.',
-                array()
+                []
             ),
             new InputOption(
                 'extend', null, InputOption::VALUE_OPTIONAL,
@@ -128,7 +128,7 @@ class ConvertDoctrine1SchemaCommand extends Command
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Converts Doctrine 1.X schema into a Doctrine 2.X schema.
 EOT
@@ -141,7 +141,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Process source directories
-        $fromPaths = array_merge(array($input->getArgument('from-path')), $input->getOption('from'));
+        $fromPaths = array_merge([$input->getArgument('from-path')], $input->getOption('from'));
 
         // Process destination directory
         $destPath = realpath($input->getArgument('dest-path'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -49,9 +49,9 @@ class ConvertMappingCommand extends Command
     {
         $this
         ->setName('orm:convert-mapping')
-        ->setAliases(array('orm:convert:mapping'))
+        ->setAliases(['orm:convert:mapping'])
         ->setDescription('Convert mapping information between supported formats.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -82,7 +82,7 @@ class ConvertMappingCommand extends Command
                 'namespace', null, InputOption::VALUE_OPTIONAL,
                 'Defines a namespace for the generated entity classes, if converted from database.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Convert mapping information between supported formats.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -45,12 +45,12 @@ class EnsureProductionSettingsCommand extends Command
         $this
         ->setName('orm:ensure-production-settings')
         ->setDescription('Verify that Doctrine is properly configured for a production environment.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'complete', null, InputOption::VALUE_NONE,
                 'Flag to also inspect database connection existence.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Verify that Doctrine is properly configured for a production environment.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -47,9 +47,9 @@ class GenerateEntitiesCommand extends Command
     {
         $this
         ->setName('orm:generate-entities')
-        ->setAliases(array('orm:generate:entities'))
+        ->setAliases(['orm:generate:entities'])
         ->setDescription('Generate entity classes and method stubs from your mapping information.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -85,7 +85,7 @@ class GenerateEntitiesCommand extends Command
                 'no-backup', null, InputOption::VALUE_NONE,
                 'Flag to define if generator should avoid backuping existing entity file if it exists.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Generate entity classes and method stubs from your mapping information.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -45,9 +45,9 @@ class GenerateProxiesCommand extends Command
     {
         $this
         ->setName('orm:generate-proxies')
-        ->setAliases(array('orm:generate:proxies'))
+        ->setAliases(['orm:generate:proxies'])
         ->setDescription('Generates proxy classes for entity classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -56,7 +56,7 @@ class GenerateProxiesCommand extends Command
                 'dest-path', InputArgument::OPTIONAL,
                 'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Generates proxy classes for entity classes.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -46,9 +46,9 @@ class GenerateRepositoriesCommand extends Command
     {
         $this
         ->setName('orm:generate-repositories')
-        ->setAliases(array('orm:generate:repositories'))
+        ->setAliases(['orm:generate:repositories'])
         ->setDescription('Generate repository classes from your mapping information.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -56,7 +56,7 @@ class GenerateRepositoriesCommand extends Command
             new InputArgument(
                 'dest-path', InputArgument::REQUIRED, 'The path to generate your repository classes.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Generate repository classes from your mapping information.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -81,14 +81,14 @@ EOT
     {
         $table = new Table($output);
 
-        $table->setHeaders(array('Field', 'Value'));
+        $table->setHeaders(['Field', 'Value']);
 
         $metadata = $this->getClassMetadata($entityName, $entityManager);
 
         array_map(
-            array($table, 'addRow'),
+            [$table, 'addRow'],
             array_merge(
-                array(
+                [
                     $this->formatField('Name', $metadata->name),
                     $this->formatField('Root entity name', $metadata->rootEntityName),
                     $this->formatField('Custom generator definition', $metadata->customGeneratorDefinition),
@@ -118,10 +118,10 @@ EOT
                     $this->formatField('Read only?', $metadata->isReadOnly),
 
                     $this->formatEntityListeners($metadata->entityListeners),
-                ),
-                array($this->formatField('Association mappings:', '')),
+                ],
+                [$this->formatField('Association mappings:', '')],
                 $this->formatMappings($metadata->associationMappings),
-                array($this->formatField('Field mappings:', '')),
+                [$this->formatField('Field mappings:', '')],
                 $this->formatMappings($metadata->fieldMappings)
             )
         );
@@ -251,7 +251,7 @@ EOT
             $value = '<comment>None</comment>';
         }
 
-        return array(sprintf('<info>%s</info>', $label), $this->formatValue($value));
+        return [sprintf('<info>%s</info>', $label), $this->formatValue($value)];
     }
 
     /**
@@ -263,7 +263,7 @@ EOT
      */
     private function formatMappings(array $propertyMappings)
     {
-        $output = array();
+        $output = [];
 
         foreach ($propertyMappings as $propertyName => $mapping) {
             $output[] = $this->formatField(sprintf('  %s', $propertyName), '');

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -46,7 +46,7 @@ class RunDqlCommand extends Command
         $this
         ->setName('orm:run-dql')
         ->setDescription('Executes arbitrary DQL directly from the command line.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputArgument('dql', InputArgument::REQUIRED, 'The DQL to execute.'),
             new InputOption(
                 'hydrate', null, InputOption::VALUE_REQUIRED,
@@ -69,7 +69,7 @@ class RunDqlCommand extends Command
                 'show-sql', null, InputOption::VALUE_NONE,
                 'Dump generated SQL instead of executing query'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Executes arbitrary DQL directly from the command line.
 EOT
@@ -126,7 +126,7 @@ EOT
             return;
         }
 
-        $resultSet = $query->execute(array(), constant($hydrationMode));
+        $resultSet = $query->execute([], constant($hydrationMode));
 
         $output->writeln(Debug::dump($resultSet, $input->getOption('depth'), true, false));
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -46,12 +46,12 @@ class CreateCommand extends AbstractCommand
         ->setDescription(
             'Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'dump-sql', null, InputOption::VALUE_NONE,
                 'Instead of trying to apply generated SQLs into EntityManager Storage Connection, output them.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -46,7 +46,7 @@ class DropCommand extends AbstractCommand
         ->setDescription(
             'Drop the complete database schema of EntityManager Storage Connection or generate the corresponding SQL output.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'dump-sql', null, InputOption::VALUE_NONE,
                 'Instead of trying to apply generated SQLs into EntityManager Storage Connection, output them.'
@@ -59,7 +59,7 @@ class DropCommand extends AbstractCommand
                 'full-database', null, InputOption::VALUE_NONE,
                 'Instead of using the Class Metadata to detect the database table schema, drop ALL assets that the database contains.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Processes the schema and either drop the database schema of EntityManager Storage Connection or generate the SQL output.
 Beware that the complete database is dropped by this command, even tables that are not relevant to your metadata model.

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -53,7 +53,7 @@ class UpdateCommand extends AbstractCommand
         ->setDescription(
             'Executes (or dumps) the SQL needed to update the database schema to match the current mapping metadata.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'complete', null, InputOption::VALUE_NONE,
                 'If defined, all assets of the database which are not relevant to the current metadata will be dropped.'
@@ -67,7 +67,7 @@ class UpdateCommand extends AbstractCommand
                 'force', 'f', InputOption::VALUE_NONE,
                 'Causes the generated SQL statements to be physically executed against your database.'
             ),
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command generates the SQL needed to

--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -40,10 +40,10 @@ class ConsoleRunner
      */
     public static function createHelperSet(EntityManagerInterface $entityManager)
     {
-        return new HelperSet(array(
+        return new HelperSet([
             'db' => new ConnectionHelper($entityManager->getConnection()),
             'em' => new EntityManagerHelper($entityManager)
-        ));
+        ]);
     }
 
     /**
@@ -54,7 +54,7 @@ class ConsoleRunner
      *
      * @return void
      */
-    static public function run(HelperSet $helperSet, $commands = array())
+    static public function run(HelperSet $helperSet, $commands = [])
     {
         $cli = self::createApplication($helperSet, $commands);
         $cli->run();
@@ -69,7 +69,7 @@ class ConsoleRunner
      *
      * @return \Symfony\Component\Console\Application
      */
-    static public function createApplication(HelperSet $helperSet, $commands = array())
+    static public function createApplication(HelperSet $helperSet, $commands = [])
     {
         $cli = new Application('Doctrine Command Line Interface', Version::VERSION);
         $cli->setCatchExceptions(true);
@@ -87,7 +87,7 @@ class ConsoleRunner
      */
     static public function addCommands(Application $cli)
     {
-        $cli->addCommands(array(
+        $cli->addCommands([
             // DBAL Commands
             new \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand(),
             new \Doctrine\DBAL\Tools\Console\Command\ImportCommand(),
@@ -109,7 +109,7 @@ class ConsoleRunner
             new \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand(),
             new \Doctrine\ORM\Tools\Console\Command\InfoCommand(),
             new \Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand(),
-        ));
+        ]);
     }
 
     static public function printCliConfigTemplate()

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -35,7 +35,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
     /**
      * @var array
      */
-    private $filter = array();
+    private $filter = [];
 
     /**
      * Filter Metadatas by one or more filter options.

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -44,12 +44,12 @@ class ConvertDoctrine1Schema
     /**
      * @var array
      */
-    private $legacyTypeMap = array(
+    private $legacyTypeMap = [
         // TODO: This list may need to be updated
         'clob' => 'text',
         'timestamp' => 'datetime',
         'enum' => 'string'
-    );
+    ];
 
     /**
      * Constructor passes the directory or array of directories
@@ -72,7 +72,7 @@ class ConvertDoctrine1Schema
      */
     public function getMetadata()
     {
-        $schema = array();
+        $schema = [];
         foreach ($this->from as $path) {
             if (is_dir($path)) {
                 $files = glob($path . '/*.yml');
@@ -84,7 +84,7 @@ class ConvertDoctrine1Schema
             }
         }
 
-        $metadatas = array();
+        $metadatas = [];
         foreach ($schema as $className => $mappingInformation) {
             $metadatas[] = $this->convertToClassMetadataInfo($className, $mappingInformation);
         }
@@ -153,12 +153,12 @@ class ConvertDoctrine1Schema
         }
 
         if ( ! $id) {
-            $fieldMapping = array(
+            $fieldMapping = [
                 'fieldName' => 'id',
                 'columnName' => 'id',
                 'type' => 'integer',
                 'id' => true
-            );
+            ];
             $metadata->mapField($fieldMapping);
             $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
         }
@@ -178,7 +178,7 @@ class ConvertDoctrine1Schema
     {
         if (is_string($column)) {
             $string = $column;
-            $column = array();
+            $column = [];
             $column['type'] = $string;
         }
 
@@ -208,7 +208,7 @@ class ConvertDoctrine1Schema
             throw ToolsException::couldNotMapDoctrine1Type($column['type']);
         }
 
-        $fieldMapping = array();
+        $fieldMapping = [];
 
         if (isset($column['primary'])) {
             $fieldMapping['id'] = true;
@@ -222,7 +222,7 @@ class ConvertDoctrine1Schema
             $fieldMapping['length'] = $column['length'];
         }
 
-        $allowed = array('precision', 'scale', 'unique', 'options', 'notnull', 'version');
+        $allowed = ['precision', 'scale', 'unique', 'options', 'notnull', 'version'];
 
         foreach ($column as $key => $value) {
             if (in_array($key, $allowed)) {
@@ -237,9 +237,9 @@ class ConvertDoctrine1Schema
         } elseif (isset($column['sequence'])) {
             $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
 
-            $definition = array(
+            $definition = [
                 'sequenceName' => is_array($column['sequence']) ? $column['sequence']['name']:$column['sequence']
-            );
+            ];
 
             if (isset($column['sequence']['size'])) {
                 $definition['allocationSize'] = $column['sequence']['size'];
@@ -272,9 +272,9 @@ class ConvertDoctrine1Schema
             $type = (isset($index['type']) && $index['type'] == 'unique')
                 ? 'uniqueConstraints' : 'indexes';
 
-            $metadata->table[$type][$name] = array(
+            $metadata->table[$type][$name] = [
                 'columns' => $index['fields']
-            );
+            ];
         }
     }
 
@@ -311,17 +311,17 @@ class ConvertDoctrine1Schema
             if (isset($relation['refClass'])) {
                 $type = 'many';
                 $foreignType = 'many';
-                $joinColumns = array();
+                $joinColumns = [];
             } else {
                 $type = isset($relation['type']) ? $relation['type'] : 'one';
                 $foreignType = isset($relation['foreignType']) ? $relation['foreignType'] : 'many';
-                $joinColumns = array(
-                    array(
+                $joinColumns = [
+                    [
                         'name' => $relation['local'],
                         'referencedColumnName' => $relation['foreign'],
                         'onDelete' => isset($relation['onDelete']) ? $relation['onDelete'] : null,
-                    )
-                );
+                    ]
+                ];
             }
 
             if ($type == 'one' && $foreignType == 'one') {
@@ -332,7 +332,7 @@ class ConvertDoctrine1Schema
                 $method = 'mapOneToMany';
             }
 
-            $associationMapping = array();
+            $associationMapping = [];
             $associationMapping['fieldName'] = $relation['alias'];
             $associationMapping['targetEntity'] = $relation['class'];
             $associationMapping['mappedBy'] = $relation['foreignAlias'];

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -78,7 +78,7 @@ class EntityGenerator
     /**
      * @var array
      */
-    protected $staticReflection = array();
+    protected $staticReflection = [];
 
     /**
      * Number of spaces to use for indention in generated code.
@@ -151,7 +151,7 @@ class EntityGenerator
      *
      * @var array
      */
-    protected $typeAlias = array(
+    protected $typeAlias = [
         Type::DATETIMETZ    => '\DateTime',
         Type::DATETIME      => '\DateTime',
         Type::DATE          => '\DateTime',
@@ -164,14 +164,14 @@ class EntityGenerator
         Type::DECIMAL       => 'string',
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
-    );
+    ];
 
     /**
      * Hash-map to handle generator types string.
      *
      * @var array
      */
-    protected static $generatorStrategyMap = array(
+    protected static $generatorStrategyMap = [
         ClassMetadataInfo::GENERATOR_TYPE_AUTO      => 'AUTO',
         ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE  => 'SEQUENCE',
         ClassMetadataInfo::GENERATOR_TYPE_TABLE     => 'TABLE',
@@ -179,30 +179,30 @@ class EntityGenerator
         ClassMetadataInfo::GENERATOR_TYPE_NONE      => 'NONE',
         ClassMetadataInfo::GENERATOR_TYPE_UUID      => 'UUID',
         ClassMetadataInfo::GENERATOR_TYPE_CUSTOM    => 'CUSTOM'
-    );
+    ];
 
     /**
      * Hash-map to handle the change tracking policy string.
      *
      * @var array
      */
-    protected static $changeTrackingPolicyMap = array(
+    protected static $changeTrackingPolicyMap = [
         ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT  => 'DEFERRED_IMPLICIT',
         ClassMetadataInfo::CHANGETRACKING_DEFERRED_EXPLICIT  => 'DEFERRED_EXPLICIT',
         ClassMetadataInfo::CHANGETRACKING_NOTIFY             => 'NOTIFY',
-    );
+    ];
 
     /**
      * Hash-map to handle the inheritance type string.
      *
      * @var array
      */
-    protected static $inheritanceTypeMap = array(
+    protected static $inheritanceTypeMap = [
         ClassMetadataInfo::INHERITANCE_TYPE_NONE            => 'NONE',
         ClassMetadataInfo::INHERITANCE_TYPE_JOINED          => 'JOINED',
         ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE    => 'SINGLE_TABLE',
         ClassMetadataInfo::INHERITANCE_TYPE_TABLE_PER_CLASS => 'TABLE_PER_CLASS',
-    );
+    ];
 
     /**
      * @var string
@@ -372,7 +372,7 @@ public function __construct(<params>)
         if ( ! $this->isNew) {
             $this->parseTokensInEntityFile(file_get_contents($path));
         } else {
-            $this->staticReflection[$metadata->name] = array('properties' => array(), 'methods' => array());
+            $this->staticReflection[$metadata->name] = ['properties' => [], 'methods' => []];
         }
 
         if ($this->backupExisting && file_exists($path)) {
@@ -400,21 +400,21 @@ public function __construct(<params>)
      */
     public function generateEntityClass(ClassMetadataInfo $metadata)
     {
-        $placeHolders = array(
+        $placeHolders = [
             '<namespace>',
             '<useStatement>',
             '<entityAnnotation>',
             '<entityClassName>',
             '<entityBody>'
-        );
+        ];
 
-        $replacements = array(
+        $replacements = [
             $this->generateEntityNamespace($metadata),
             $this->generateEntityUse(),
             $this->generateEntityDocBlock($metadata),
             $this->generateEntityClassName($metadata),
             $this->generateEntityBody($metadata)
-        );
+        ];
 
         $code = str_replace($placeHolders, $replacements, static::$classTemplate) . "\n";
 
@@ -636,7 +636,7 @@ public function __construct(<params>)
         $stubMethods = $this->generateEntityStubMethods ? $this->generateEntityStubMethods($metadata) : null;
         $lifecycleCallbackMethods = $this->generateEntityLifecycleCallbackMethods($metadata);
 
-        $code = array();
+        $code = [];
 
         if ($fieldMappingProperties) {
             $code[] = $fieldMappingProperties;
@@ -678,7 +678,7 @@ public function __construct(<params>)
             return $this->generateEmbeddableConstructor($metadata);
         }
 
-        $collections = array();
+        $collections = [];
 
         foreach ($metadata->associationMappings as $mapping) {
             if ($mapping['type'] & ClassMetadataInfo::TO_MANY) {
@@ -700,14 +700,14 @@ public function __construct(<params>)
      */
     private function generateEmbeddableConstructor(ClassMetadataInfo $metadata)
     {
-        $paramTypes = array();
-        $paramVariables = array();
-        $params = array();
-        $fields = array();
+        $paramTypes = [];
+        $paramVariables = [];
+        $params = [];
+        $fields = [];
 
         // Resort fields to put optional fields at the end of the method signature.
-        $requiredFields = array();
-        $optionalFields = array();
+        $requiredFields = [];
+        $optionalFields = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if (empty($fieldMapping['nullable'])) {
@@ -772,11 +772,11 @@ public function __construct(<params>)
             $params = implode(', ', $params);
         }
 
-        $replacements = array(
+        $replacements = [
             '<paramTags>' => implode("\n * ", $paramTags),
             '<params>'    => $params,
             '<fields>'    => implode("\n" . $this->spaces, $fields),
-        );
+        ];
 
         $constructor = str_replace(
             array_keys($replacements),
@@ -805,14 +805,14 @@ public function __construct(<params>)
 
         for ($i = 0; $i < count($tokens); $i++) {
             $token = $tokens[$i];
-            if (in_array($token[0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT))) {
+            if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])) {
                 continue;
             }
 
             if ($inNamespace) {
                 if ($token[0] == T_NS_SEPARATOR || $token[0] == T_STRING) {
                     $lastSeenNamespace .= $token[1];
-                } elseif (is_string($token) && in_array($token, array(';', '{'))) {
+                } elseif (is_string($token) && in_array($token, [';', '{'])) {
                     $inNamespace = false;
                 }
             }
@@ -820,8 +820,8 @@ public function __construct(<params>)
             if ($inClass) {
                 $inClass = false;
                 $lastSeenClass = $lastSeenNamespace . ($lastSeenNamespace ? '\\' : '') . $token[1];
-                $this->staticReflection[$lastSeenClass]['properties'] = array();
-                $this->staticReflection[$lastSeenClass]['methods'] = array();
+                $this->staticReflection[$lastSeenClass]['properties'] = [];
+                $this->staticReflection[$lastSeenClass]['methods'] = [];
             }
 
             if ($token[0] == T_NAMESPACE) {
@@ -835,7 +835,7 @@ public function __construct(<params>)
                 } elseif ($tokens[$i+2] == "&" && $tokens[$i+3][0] == T_STRING) {
                     $this->staticReflection[$lastSeenClass]['methods'][] = strtolower($tokens[$i+3][1]);
                 }
-            } elseif (in_array($token[0], array(T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED)) && $tokens[$i+2][0] != T_FUNCTION) {
+            } elseif (in_array($token[0], [T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED]) && $tokens[$i+2][0] != T_FUNCTION) {
                 $this->staticReflection[$lastSeenClass]['properties'][] = substr($tokens[$i+2][1], 1);
             }
         }
@@ -915,7 +915,7 @@ public function __construct(<params>)
             ? new \ReflectionClass($metadata->name)
             : $metadata->reflClass;
 
-        $traits = array();
+        $traits = [];
 
         while ($reflClass !== false) {
             $traits = array_merge($traits, $reflClass->getTraits());
@@ -990,20 +990,20 @@ public function __construct(<params>)
      */
     protected function generateEntityDocBlock(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = '/**';
         $lines[] = ' * ' . $this->getClassName($metadata);
 
         if ($this->generateAnnotations) {
             $lines[] = ' *';
 
-            $methods = array(
+            $methods = [
                 'generateTableAnnotation',
                 'generateInheritanceAnnotation',
                 'generateDiscriminatorColumnAnnotation',
                 'generateDiscriminatorMapAnnotation',
                 'generateEntityAnnotation',
-            );
+            ];
 
             foreach ($methods as $method) {
                 if ($code = $this->$method($metadata)) {
@@ -1052,7 +1052,7 @@ public function __construct(<params>)
             return '';
         }
 
-        $table = array();
+        $table = [];
 
         if (isset($metadata->table['schema'])) {
             $table[] = 'schema="' . $metadata->table['schema'] . '"';
@@ -1087,9 +1087,9 @@ public function __construct(<params>)
      */
     protected function generateTableConstraints($constraintName, $constraints)
     {
-        $annotations = array();
+        $annotations = [];
         foreach ($constraints as $name => $constraint) {
-            $columns = array();
+            $columns = [];
             foreach ($constraint['columns'] as $column) {
                 $columns[] = '"' . $column . '"';
             }
@@ -1135,7 +1135,7 @@ public function __construct(<params>)
     protected function generateDiscriminatorMapAnnotation($metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
-            $inheritanceClassMap = array();
+            $inheritanceClassMap = [];
 
             foreach ($metadata->discriminatorMap as $type => $class) {
                 $inheritanceClassMap[] .= '"' . $type . '" = "' . $class . '"';
@@ -1152,7 +1152,7 @@ public function __construct(<params>)
      */
     protected function generateEntityStubMethods(ClassMetadataInfo $metadata)
     {
-        $methods = array();
+        $methods = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if (isset($fieldMapping['declaredField']) &&
@@ -1232,7 +1232,7 @@ public function __construct(<params>)
             $joinColumns = $associationMapping['joinColumns'];
         } else {
             //@todo there is no way to retrieve targetEntity metadata
-            $joinColumns = array();
+            $joinColumns = [];
         }
 
         foreach ($joinColumns as $joinColumn) {
@@ -1252,7 +1252,7 @@ public function __construct(<params>)
     protected function generateEntityLifecycleCallbackMethods(ClassMetadataInfo $metadata)
     {
         if (isset($metadata->lifecycleCallbacks) && $metadata->lifecycleCallbacks) {
-            $methods = array();
+            $methods = [];
 
             foreach ($metadata->lifecycleCallbacks as $name => $callbacks) {
                 foreach ($callbacks as $callback) {
@@ -1275,7 +1275,7 @@ public function __construct(<params>)
      */
     protected function generateEntityAssociationMappingProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($this->hasProperty($associationMapping['fieldName'], $metadata)) {
@@ -1297,7 +1297,7 @@ public function __construct(<params>)
      */
     protected function generateEntityFieldMappingProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if ($this->hasProperty($fieldMapping['fieldName'], $metadata) ||
@@ -1325,7 +1325,7 @@ public function __construct(<params>)
      */
     protected function generateEntityEmbeddedProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->embeddedClasses as $fieldName => $embeddedClass) {
             if (isset($embeddedClass['declaredField']) || $this->hasProperty($fieldName, $metadata)) {
@@ -1352,7 +1352,7 @@ public function __construct(<params>)
     {
         $methodName = $type . Inflector::classify($fieldName);
         $variableName = Inflector::camelize($fieldName);
-        if (in_array($type, array("add", "remove"))) {
+        if (in_array($type, ["add", "remove"])) {
             $methodName = Inflector::singularize($methodName);
             $variableName = Inflector::singularize($variableName);
         }
@@ -1374,7 +1374,7 @@ public function __construct(<params>)
             $methodTypeHint =  '\\' . $typeHint . ' ';
         }
 
-        $replacements = array(
+        $replacements = [
           '<description>'       => ucfirst($type) . ' ' . $variableName,
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
@@ -1383,7 +1383,7 @@ public function __construct(<params>)
           '<fieldName>'         => $fieldName,
           '<variableDefault>'   => ($defaultValue !== null ) ? (' = '.$defaultValue) : '',
           '<entity>'            => $this->getClassName($metadata)
-        );
+        ];
 
         $method = str_replace(
             array_keys($replacements),
@@ -1408,10 +1408,10 @@ public function __construct(<params>)
         }
         $this->staticReflection[$metadata->name]['methods'][] = $methodName;
 
-        $replacements = array(
+        $replacements = [
             '<name>'        => $this->annotationsPrefix . ucfirst($name),
             '<methodName>'  => $methodName,
-        );
+        ];
 
         $method = str_replace(
             array_keys($replacements),
@@ -1429,7 +1429,7 @@ public function __construct(<params>)
      */
     protected function generateJoinColumnAnnotation(array $joinColumn)
     {
-        $joinColumnAnnot = array();
+        $joinColumnAnnot = [];
 
         if (isset($joinColumn['name'])) {
             $joinColumnAnnot[] = 'name="' . $joinColumn['name'] . '"';
@@ -1466,7 +1466,7 @@ public function __construct(<params>)
      */
     protected function generateAssociationMappingPropertyDocBlock(array $associationMapping, ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
 
         if ($associationMapping['type'] & ClassMetadataInfo::TO_MANY) {
@@ -1501,7 +1501,7 @@ public function __construct(<params>)
                     $type = 'ManyToMany';
                     break;
             }
-            $typeOptions = array();
+            $typeOptions = [];
 
             if (isset($associationMapping['targetEntity'])) {
                 $typeOptions[] = 'targetEntity="' . $associationMapping['targetEntity'] . '"';
@@ -1516,7 +1516,7 @@ public function __construct(<params>)
             }
 
             if ($associationMapping['cascade']) {
-                $cascades = array();
+                $cascades = [];
 
                 if ($associationMapping['isCascadePersist']) $cascades[] = '"persist"';
                 if ($associationMapping['isCascadeRemove']) $cascades[] = '"remove"';
@@ -1525,7 +1525,7 @@ public function __construct(<params>)
                 if ($associationMapping['isCascadeRefresh']) $cascades[] = '"refresh"';
 
                 if (count($cascades) === 5) {
-                    $cascades = array('"all"');
+                    $cascades = ['"all"'];
                 }
 
                 $typeOptions[] = 'cascade={' . implode(',', $cascades) . '}';
@@ -1536,10 +1536,10 @@ public function __construct(<params>)
             }
 
             if (isset($associationMapping['fetch']) && $associationMapping['fetch'] !== ClassMetadataInfo::FETCH_LAZY) {
-                $fetchMap = array(
+                $fetchMap = [
                     ClassMetadataInfo::FETCH_EXTRA_LAZY => 'EXTRA_LAZY',
                     ClassMetadataInfo::FETCH_EAGER      => 'EAGER',
-                );
+                ];
 
                 $typeOptions[] = 'fetch="' . $fetchMap[$associationMapping['fetch']] . '"';
             }
@@ -1549,7 +1549,7 @@ public function __construct(<params>)
             if (isset($associationMapping['joinColumns']) && $associationMapping['joinColumns']) {
                 $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'JoinColumns({';
 
-                $joinColumnsLines = array();
+                $joinColumnsLines = [];
 
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     if ($joinColumnAnnot = $this->generateJoinColumnAnnotation($joinColumn)) {
@@ -1562,7 +1562,7 @@ public function __construct(<params>)
             }
 
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
-                $joinTable = array();
+                $joinTable = [];
                 $joinTable[] = 'name="' . $associationMapping['joinTable']['name'] . '"';
 
                 if (isset($associationMapping['joinTable']['schema'])) {
@@ -1572,7 +1572,7 @@ public function __construct(<params>)
                 $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'JoinTable(' . implode(', ', $joinTable) . ',';
                 $lines[] = $this->spaces . ' *   joinColumns={';
 
-                $joinColumnsLines = array();
+                $joinColumnsLines = [];
 
                 foreach ($associationMapping['joinTable']['joinColumns'] as $joinColumn) {
                     $joinColumnsLines[] = $this->spaces . ' *     ' . $this->generateJoinColumnAnnotation($joinColumn);
@@ -1582,7 +1582,7 @@ public function __construct(<params>)
                 $lines[] = $this->spaces . ' *   },';
                 $lines[] = $this->spaces . ' *   inverseJoinColumns={';
 
-                $inverseJoinColumnsLines = array();
+                $inverseJoinColumnsLines = [];
 
                 foreach ($associationMapping['joinTable']['inverseJoinColumns'] as $joinColumn) {
                     $inverseJoinColumnsLines[] = $this->spaces . ' *     ' . $this->generateJoinColumnAnnotation($joinColumn);
@@ -1618,14 +1618,14 @@ public function __construct(<params>)
      */
     protected function generateFieldMappingPropertyDocBlock(array $fieldMapping, ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
         $lines[] = $this->spaces . ' * @var ' . $this->getType($fieldMapping['type']);
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';
 
-            $column = array();
+            $column = [];
             if (isset($fieldMapping['columnName'])) {
                 $column[] = 'name="' . $fieldMapping['columnName'] . '"';
             }
@@ -1672,7 +1672,7 @@ public function __construct(<params>)
                 }
 
                 if ($metadata->sequenceGeneratorDefinition) {
-                    $sequenceGenerator = array();
+                    $sequenceGenerator = [];
 
                     if (isset($metadata->sequenceGeneratorDefinition['sequenceName'])) {
                         $sequenceGenerator[] = 'sequenceName="' . $metadata->sequenceGeneratorDefinition['sequenceName'] . '"';
@@ -1707,14 +1707,14 @@ public function __construct(<params>)
      */
     protected function generateEmbeddedPropertyDocBlock(array $embeddedClass)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
         $lines[] = $this->spaces . ' * @var \\' . ltrim($embeddedClass['class'], '\\');
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';
 
-            $embedded = array('class="' . $embeddedClass['class'] . '"');
+            $embedded = ['class="' . $embeddedClass['class'] . '"'];
 
             if (isset($fieldMapping['columnPrefix'])) {
                 $embedded[] = 'columnPrefix=' . var_export($embeddedClass['columnPrefix'], true);
@@ -1803,7 +1803,7 @@ public function __construct(<params>)
      */
     private function exportTableOptions(array $options)
     {
-        $optionsStr = array();
+        $optionsStr = [];
 
         foreach($options as $name => $option) {
             if (is_array($option)) {

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -57,11 +57,11 @@ class <className> extends <repositoryName>
      */
     public function generateEntityRepositoryClass($fullClassName)
     {
-        $variables = array(
+        $variables = [
             '<namespace>'       => $this->generateEntityRepositoryNamespace($fullClassName),
             '<repositoryName>'  => $this->generateEntityRepositoryName($fullClassName),
             '<className>'       => $this->generateClassName($fullClassName)
-        );
+        ];
 
         return str_replace(array_keys($variables), array_values($variables), self::$_template);
     }

--- a/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
@@ -32,13 +32,13 @@ class ClassMetadataExporter
     /**
      * @var array
      */
-    private static $_exporterDrivers = array(
+    private static $_exporterDrivers = [
         'xml' => 'Doctrine\ORM\Tools\Export\Driver\XmlExporter',
         'yaml' => 'Doctrine\ORM\Tools\Export\Driver\YamlExporter',
         'yml' => 'Doctrine\ORM\Tools\Export\Driver\YamlExporter',
         'php' => 'Doctrine\ORM\Tools\Export\Driver\PhpExporter',
         'annotation' => 'Doctrine\ORM\Tools\Export\Driver\AnnotationExporter'
-    );
+    ];
 
     /**
      * Registers a new exporter driver class under a specified name.

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -35,7 +35,7 @@ abstract class AbstractExporter
     /**
      * @var array
      */
-    protected $_metadata = array();
+    protected $_metadata = [];
 
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -40,7 +40,7 @@ class PhpExporter extends AbstractExporter
      */
     public function exportClassMetadata(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = '<?php';
         $lines[] = null;
         $lines[] = 'use Doctrine\ORM\Mapping\ClassMetadataInfo;';
@@ -91,7 +91,7 @@ class PhpExporter extends AbstractExporter
         }
 
         foreach ($metadata->associationMappings as $associationMapping) {
-            $cascade = array('remove', 'persist', 'refresh', 'merge', 'detach');
+            $cascade = ['remove', 'persist', 'refresh', 'merge', 'detach'];
             foreach ($cascade as $key => $value) {
                 if ( ! $associationMapping['isCascade'.ucfirst($value)]) {
                     unset($cascade[$key]);
@@ -99,14 +99,14 @@ class PhpExporter extends AbstractExporter
             }
 
             if (count($cascade) === 5) {
-                $cascade = array('all');
+                $cascade = ['all'];
             }
 
-            $associationMappingArray = array(
+            $associationMappingArray = [
                 'fieldName'    => $associationMapping['fieldName'],
                 'targetEntity' => $associationMapping['targetEntity'],
                 'cascade'     => $cascade,
-            );
+            ];
 
             if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $associationMapping['fetch'];
@@ -114,21 +114,21 @@ class PhpExporter extends AbstractExporter
 
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $method = 'mapOneToOne';
-                $oneToOneMappingArray = array(
+                $oneToOneMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'joinColumns'   => $associationMapping['joinColumns'],
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToOneMappingArray);
             } elseif ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_MANY) {
                 $method = 'mapOneToMany';
-                $potentialAssociationMappingIndexes = array(
+                $potentialAssociationMappingIndexes = [
                     'mappedBy',
                     'orphanRemoval',
                     'orderBy',
-                );
+                ];
                 foreach ($potentialAssociationMappingIndexes as $index) {
                     if (isset($associationMapping[$index])) {
                         $oneToManyMappingArray[$index] = $associationMapping[$index];
@@ -137,11 +137,11 @@ class PhpExporter extends AbstractExporter
                 $associationMappingArray = array_merge($associationMappingArray, $oneToManyMappingArray);
             } elseif ($associationMapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
                 $method = 'mapManyToMany';
-                $potentialAssociationMappingIndexes = array(
+                $potentialAssociationMappingIndexes = [
                     'mappedBy',
                     'joinTable',
                     'orderBy',
-                );
+                ];
                 foreach ($potentialAssociationMappingIndexes as $index) {
                     if (isset($associationMapping[$index])) {
                         $manyToManyMappingArray[$index] = $associationMapping[$index];

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -126,7 +126,7 @@ class XmlExporter extends AbstractExporter
 
         $fields = $metadata->fieldMappings;
 
-        $id = array();
+        $id = [];
         foreach ($fields as $name => $field) {
             if (isset($field['id']) && $field['id']) {
                 $id[$name] = $field;
@@ -136,10 +136,10 @@ class XmlExporter extends AbstractExporter
 
         foreach ($metadata->associationMappings as $name => $assoc) {
             if (isset($assoc['id']) && $assoc['id']) {
-                $id[$name] = array(
+                $id[$name] = [
                     'fieldName' => $name,
                     'associationKey' => true
-                );
+                ];
             }
         }
 
@@ -225,12 +225,12 @@ class XmlExporter extends AbstractExporter
             }
         }
 
-        $orderMap = array(
+        $orderMap = [
             ClassMetadataInfo::ONE_TO_ONE,
             ClassMetadataInfo::ONE_TO_MANY,
             ClassMetadataInfo::MANY_TO_ONE,
             ClassMetadataInfo::MANY_TO_MANY,
-        );
+        ];
 
         uasort($metadata->associationMappings, function($m1, $m2) use (&$orderMap){
             $a1 = array_search($m1['type'], $orderMap);
@@ -273,7 +273,7 @@ class XmlExporter extends AbstractExporter
                 $associationMappingXml->addAttribute('fetch', $this->_getFetchModeString($associationMapping['fetch']));
             }
 
-            $cascade = array();
+            $cascade = [];
             if ($associationMapping['isCascadeRemove']) {
                 $cascade[] = 'cascade-remove';
             }
@@ -295,7 +295,7 @@ class XmlExporter extends AbstractExporter
             }
 
             if (count($cascade) === 5) {
-                $cascade  = array('cascade-all');
+                $cascade  = ['cascade-all'];
             }
 
             if ($cascade) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -41,7 +41,7 @@ class YamlExporter extends AbstractExporter
      */
     public function exportClassMetadata(ClassMetadataInfo $metadata)
     {
-        $array = array();
+        $array = [];
 
         if ($metadata->isMappedSuperclass) {
             $array['type'] = 'mappedSuperclass';
@@ -91,7 +91,7 @@ class YamlExporter extends AbstractExporter
 
         $fieldMappings = $metadata->fieldMappings;
 
-        $ids = array();
+        $ids = [];
         foreach ($fieldMappings as $name => $fieldMapping) {
             $fieldMapping['column'] = $fieldMapping['columnName'];
 
@@ -118,13 +118,13 @@ class YamlExporter extends AbstractExporter
 
         if ($fieldMappings) {
             if ( ! isset($array['fields'])) {
-                $array['fields'] = array();
+                $array['fields'] = [];
             }
             $array['fields'] = array_merge($array['fields'], $fieldMappings);
         }
 
         foreach ($metadata->associationMappings as $name => $associationMapping) {
-            $cascade = array();
+            $cascade = [];
 
             if ($associationMapping['isCascadeRemove']) {
                 $cascade[] = 'remove';
@@ -146,13 +146,13 @@ class YamlExporter extends AbstractExporter
                 $cascade[] = 'detach';
             }
             if (count($cascade) === 5) {
-                $cascade = array('all');
+                $cascade = ['all'];
             }
 
-            $associationMappingArray = array(
+            $associationMappingArray = [
                 'targetEntity' => $associationMapping['targetEntity'],
                 'cascade'     => $cascade,
-            );
+            ];
 
             if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $this->_getFetchModeString($associationMapping['fetch']);
@@ -164,7 +164,7 @@ class YamlExporter extends AbstractExporter
 
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $joinColumns = $associationMapping['joinColumns'];
-                $newJoinColumns = array();
+                $newJoinColumns = [];
 
                 foreach ($joinColumns as $joinColumn) {
                     $newJoinColumns[$joinColumn['name']]['referencedColumnName'] = $joinColumn['referencedColumnName'];
@@ -174,12 +174,12 @@ class YamlExporter extends AbstractExporter
                     }
                 }
 
-                $oneToOneMappingArray = array(
+                $oneToOneMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'joinColumns'   => $newJoinColumns,
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToOneMappingArray);
 
@@ -189,22 +189,22 @@ class YamlExporter extends AbstractExporter
                     $array['manyToOne'][$name] = $associationMappingArray;
                 }
             } elseif ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_MANY) {
-                $oneToManyMappingArray = array(
+                $oneToManyMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
                     'orderBy'       => isset($associationMapping['orderBy']) ? $associationMapping['orderBy'] : null
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToManyMappingArray);
                 $array['oneToMany'][$name] = $associationMappingArray;
             } elseif ($associationMapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
-                $manyToManyMappingArray = array(
+                $manyToManyMappingArray = [
                     'mappedBy'   => $associationMapping['mappedBy'],
                     'inversedBy' => $associationMapping['inversedBy'],
                     'joinTable'  => isset($associationMapping['joinTable']) ? $associationMapping['joinTable'] : null,
                     'orderBy'    => isset($associationMapping['orderBy']) ? $associationMapping['orderBy'] : null
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $manyToManyMappingArray);
                 $array['manyToMany'][$name] = $associationMappingArray;
@@ -214,7 +214,7 @@ class YamlExporter extends AbstractExporter
             $array['lifecycleCallbacks'] = $metadata->lifecycleCallbacks;
         }
 
-        return $this->yamlDump(array($metadata->name => $array), 10);
+        return $this->yamlDump([$metadata->name => $array], 10);
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -102,7 +102,7 @@ class CountOutputWalker extends SqlWalker
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping
-        $sqlIdentifier = array();
+        $sqlIdentifier = [];
         foreach ($rootIdentifier as $property) {
             if (isset($rootClass->fieldMappings[$property])) {
                 foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -75,11 +75,11 @@ class CountWalker extends TreeWalkerAdapter
         $pathExpression->type = $pathType;
 
         $distinct = $this->_getQuery()->getHint(self::HINT_DISTINCT);
-        $AST->selectClause->selectExpressions = array(
+        $AST->selectClause->selectExpressions = [
             new SelectExpression(
                 new AggregateExpression('count', $pathExpression, $distinct), null
             )
-        );
+        ];
 
         // ORDER BY is not needed, only increases query execution through unnecessary sorting.
         $AST->orderByClause = null;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -95,7 +95,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
         // Set every select expression as visible(hidden = false) to
         // make $AST have scalar mappings properly - this is relevant for referencing selected
         // fields from outside the subquery, for example in the ORDER BY segment
-        $hiddens = array();
+        $hiddens = [];
 
         foreach ($AST->selectClause->selectExpressions as $idx => $expr) {
             $hiddens[$idx] = $expr->hiddenAliasResultVariable;
@@ -126,7 +126,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping
-        $sqlIdentifier = array();
+        $sqlIdentifier = [];
         foreach ($rootIdentifier as $property) {
             if (isset($rootClass->fieldMappings[$property])) {
                 foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {
@@ -194,8 +194,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
     public function preserveSqlOrdering(SelectStatement $AST, array $sqlIdentifier, $innerSql, $sql)
     {
         // For every order by, find out the SQL alias by inspecting the ResultSetMapping.
-        $sqlOrderColumns = array();
-        $orderBy         = array();
+        $sqlOrderColumns = [];
+        $orderBy         = [];
         if (isset($AST->orderByClause)) {
             foreach ($AST->orderByClause->orderByItems as $item) {
                 $expression = $item->expression;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -66,7 +66,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         $fromRoot  = reset($from);
         $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
         $rootClass = $queryComponents[$rootAlias]['metadata'];
-        $selectExpressions = array();
+        $selectExpressions = [];
 
         foreach ($queryComponents as $dqlAlias => $qComp) {
             // Preserve mixed data in query for ordering.

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -153,7 +153,7 @@ class Paginator implements \Countable, \IteratorAggregate
             $whereInQuery = $this->cloneQuery($this->query);
             // don't do this for an empty id array
             if (count($ids) == 0) {
-                return new \ArrayIterator(array());
+                return new \ArrayIterator([]);
             }
 
             $this->appendTreeWalker($whereInQuery, 'Doctrine\ORM\Tools\Pagination\WhereInWalker');
@@ -224,7 +224,7 @@ class Paginator implements \Countable, \IteratorAggregate
         $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
 
         if ($hints === false) {
-            $hints = array();
+            $hints = [];
         }
 
         $hints[] = $walkerClass;

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -97,7 +97,7 @@ class WhereInWalker extends TreeWalkerAdapter
         if ($count > 0) {
             $arithmeticExpression = new ArithmeticExpression();
             $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
-                array($pathExpression)
+                [$pathExpression]
             );
             $expression = new InExpression($arithmeticExpression);
             $expression->literals[] = new InputParameter(":" . self::PAGINATOR_ID_ALIAS);
@@ -113,29 +113,29 @@ class WhereInWalker extends TreeWalkerAdapter
             if ($AST->whereClause->conditionalExpression instanceof ConditionalTerm) {
                 $AST->whereClause->conditionalExpression->conditionalFactors[] = $conditionalPrimary;
             } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalPrimary) {
-                $AST->whereClause->conditionalExpression = new ConditionalExpression(array(
-                    new ConditionalTerm(array(
+                $AST->whereClause->conditionalExpression = new ConditionalExpression([
+                    new ConditionalTerm([
                         $AST->whereClause->conditionalExpression,
                         $conditionalPrimary
-                    ))
-                ));
+                    ])
+                ]);
             } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
                 || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
             ) {
                 $tmpPrimary = new ConditionalPrimary;
                 $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
-                $AST->whereClause->conditionalExpression = new ConditionalTerm(array(
+                $AST->whereClause->conditionalExpression = new ConditionalTerm([
                     $tmpPrimary,
                     $conditionalPrimary
-                ));
+                ]);
             }
         } else {
             $AST->whereClause = new WhereClause(
-                new ConditionalExpression(array(
-                    new ConditionalTerm(array(
+                new ConditionalExpression([
+                    new ConditionalTerm([
                         $conditionalPrimary
-                    ))
-                ))
+                    ])
+                ])
             );
         }
     }

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -39,17 +39,17 @@ class ResolveTargetEntityListener implements EventSubscriber
     /**
      * @var array[] indexed by original entity name
      */
-    private $resolveTargetEntities = array();
+    private $resolveTargetEntities = [];
 
     /**
      * {@inheritDoc}
      */
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             Events::loadClassMetadata,
             Events::onClassMetadataNotFound
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -141,16 +141,16 @@ class SchemaTool
     public function getSchemaFromMetadata(array $classes)
     {
         // Reminder for processed classes, used for hierarchies
-        $processedClasses       = array();
+        $processedClasses       = [];
         $eventManager           = $this->em->getEventManager();
         $schemaManager          = $this->em->getConnection()->getSchemaManager();
         $metadataSchemaConfig   = $schemaManager->createSchemaConfig();
 
         $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
-        $schema = new Schema(array(), array(), $metadataSchemaConfig);
+        $schema = new Schema([], [], $metadataSchemaConfig);
 
-        $addedFks = array();
-        $blacklistedFks = array();
+        $addedFks = [];
+        $blacklistedFks = [];
 
         foreach ($classes as $class) {
             /** @var \Doctrine\ORM\Mapping\ClassMetadata $class */
@@ -181,7 +181,7 @@ class SchemaTool
                 }
             } elseif ($class->isInheritanceTypeJoined()) {
                 // Add all non-inherited fields as columns
-                $pkColumns = array();
+                $pkColumns = [];
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
                     if ( ! isset($mapping['inherited'])) {
                         $columnName = $this->quoteStrategy->getColumnName(
@@ -204,7 +204,7 @@ class SchemaTool
                     $this->addDiscriminatorColumnDefinition($class, $table);
                 } else {
                     // Add an ID FK column to child tables
-                    $inheritedKeyColumns = array();
+                    $inheritedKeyColumns = [];
                     foreach ($class->identifier as $identifierField) {
                         $idMapping = $class->fieldMappings[$identifierField];
                         if (isset($idMapping['inherited'])) {
@@ -230,7 +230,7 @@ class SchemaTool
                             ),
                             $inheritedKeyColumns,
                             $inheritedKeyColumns,
-                            array('onDelete' => 'CASCADE')
+                            ['onDelete' => 'CASCADE']
                         );
                     }
 
@@ -245,7 +245,7 @@ class SchemaTool
                 $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
             }
 
-            $pkColumns = array();
+            $pkColumns = [];
             foreach ($class->identifier as $identifierField) {
                 if (isset($class->fieldMappings[$identifierField])) {
                     $pkColumns[] = $this->quoteStrategy->getColumnName($identifierField, $class, $this->platform);
@@ -265,16 +265,16 @@ class SchemaTool
             if (isset($class->table['indexes'])) {
                 foreach ($class->table['indexes'] as $indexName => $indexData) {
                     if( ! isset($indexData['flags'])) {
-                        $indexData['flags'] = array();
+                        $indexData['flags'] = [];
                     }
 
-                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array)$indexData['flags'], isset($indexData['options']) ? $indexData['options'] : array());
+                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array)$indexData['flags'], isset($indexData['options']) ? $indexData['options'] : []);
                 }
             }
 
             if (isset($class->table['uniqueConstraints'])) {
                 foreach ($class->table['uniqueConstraints'] as $indexName => $indexData) {
-                    $table->addUniqueIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, isset($indexData['options']) ? $indexData['options'] : array());
+                    $table->addUniqueIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, isset($indexData['options']) ? $indexData['options'] : []);
                 }
             }
 
@@ -341,10 +341,10 @@ class SchemaTool
             $discrColumn['length'] = 255;
         }
 
-        $options = array(
+        $options = [
             'length'    => isset($discrColumn['length']) ? $discrColumn['length'] : null,
             'notnull'   => true
-        );
+        ];
 
         if (isset($discrColumn['columnDefinition'])) {
             $options['columnDefinition'] = $discrColumn['columnDefinition'];
@@ -364,7 +364,7 @@ class SchemaTool
      */
     private function gatherColumns($class, Table $table)
     {
-        $pkColumns = array();
+        $pkColumns = [];
 
         foreach ($class->fieldMappings as $mapping) {
             if ($class->isInheritanceTypeSingleTable() && isset($mapping['inherited'])) {
@@ -399,14 +399,14 @@ class SchemaTool
         $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
         $columnType = $mapping['type'];
 
-        $options = array();
+        $options = [];
         $options['length'] = isset($mapping['length']) ? $mapping['length'] : null;
         $options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
         if ($class->isInheritanceTypeSingleTable() && count($class->parentClasses) > 0) {
             $options['notnull'] = false;
         }
 
-        $options['platformOptions'] = array();
+        $options['platformOptions'] = [];
         $options['platformOptions']['version'] = $class->isVersioned && $class->versionField == $mapping['fieldName'] ? true : false;
 
         if (strtolower($columnType) == 'string' && $options['length'] === null) {
@@ -430,7 +430,7 @@ class SchemaTool
         }
 
         if (isset($mapping['options'])) {
-            $knownOptions = array('comment', 'unsigned', 'fixed', 'default');
+            $knownOptions = ['comment', 'unsigned', 'fixed', 'default'];
 
             foreach ($knownOptions as $knownOption) {
                 if (array_key_exists($knownOption, $mapping['options'])) {
@@ -443,7 +443,7 @@ class SchemaTool
             $options['customSchemaOptions'] = $mapping['options'];
         }
 
-        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == array($mapping['fieldName'])) {
+        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == [$mapping['fieldName']]) {
             $options['autoincrement'] = true;
         }
         if ($class->isInheritanceTypeJoined() && $class->name != $class->rootEntityName) {
@@ -459,7 +459,7 @@ class SchemaTool
 
         $isUnique = isset($mapping['unique']) ? $mapping['unique'] : false;
         if ($isUnique) {
-            $table->addUniqueIndex(array($columnName));
+            $table->addUniqueIndex([$columnName]);
         }
     }
 
@@ -487,7 +487,7 @@ class SchemaTool
             $foreignClass = $this->em->getClassMetadata($mapping['targetEntity']);
 
             if ($mapping['type'] & ClassMetadata::TO_ONE && $mapping['isOwningSide']) {
-                $primaryKeyColumns = array(); // PK is unnecessary for this relation-type
+                $primaryKeyColumns = []; // PK is unnecessary for this relation-type
 
                 $this->gatherRelationJoinColumns(
                     $mapping['joinColumns'],
@@ -509,7 +509,7 @@ class SchemaTool
                     $this->quoteStrategy->getJoinTableName($mapping, $foreignClass, $this->platform)
                 );
 
-                $primaryKeyColumns = array();
+                $primaryKeyColumns = [];
 
                 // Build first FK constraint (relation table => source table)
                 $this->gatherRelationJoinColumns(
@@ -557,7 +557,7 @@ class SchemaTool
         $referencedFieldName = $class->getFieldName($referencedColumnName);
 
         if ($class->hasField($referencedFieldName)) {
-            return array($class, $referencedFieldName);
+            return [$class, $referencedFieldName];
         }
 
         if (in_array($referencedColumnName, $class->getIdentifierColumnNames())) {
@@ -600,11 +600,11 @@ class SchemaTool
         &$addedFks,
         &$blacklistedFks
     ) {
-        $localColumns       = array();
-        $foreignColumns     = array();
-        $fkOptions          = array();
+        $localColumns       = [];
+        $foreignColumns     = [];
+        $fkOptions          = [];
         $foreignTableName   = $this->quoteStrategy->getTableName($class, $this->platform);
-        $uniqueConstraints  = array();
+        $uniqueConstraints  = [];
 
         foreach ($joinColumns as $joinColumn) {
 
@@ -645,7 +645,7 @@ class SchemaTool
                     $columnDef = $fieldMapping['columnDefinition'];
                 }
 
-                $columnOptions = array('notnull' => false, 'columnDefinition' => $columnDef);
+                $columnOptions = ['notnull' => false, 'columnDefinition' => $columnDef];
 
                 if (isset($joinColumn['nullable'])) {
                     $columnOptions['notnull'] = !$joinColumn['nullable'];
@@ -666,7 +666,7 @@ class SchemaTool
             }
 
             if (isset($joinColumn['unique']) && $joinColumn['unique'] == true) {
-                $uniqueConstraints[] = array('columns' => array($quotedColumnName));
+                $uniqueConstraints[] = ['columns' => [$quotedColumnName]];
             }
 
             if (isset($joinColumn['onDelete'])) {
@@ -696,7 +696,7 @@ class SchemaTool
             }
             $blacklistedFks[$compositeName] = true;
         } elseif (!isset($blacklistedFks[$compositeName])) {
-            $addedFks[$compositeName] = array('foreignTableName' => $foreignTableName, 'foreignColumns' => $foreignColumns);
+            $addedFks[$compositeName] = ['foreignTableName' => $foreignTableName, 'foreignColumns' => $foreignColumns];
             $theJoinTable->addUnnamedForeignKeyConstraint(
                 $foreignTableName,
                 $localColumns,

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -63,7 +63,7 @@ class SchemaValidator
      */
     public function validateMapping()
     {
-        $errors = array();
+        $errors = [];
         $cmf = $this->em->getMetadataFactory();
         $classes = $cmf->getAllMetadata();
 
@@ -85,7 +85,7 @@ class SchemaValidator
      */
     public function validateClass(ClassMetadataInfo $class)
     {
-        $ce = array();
+        $ce = [];
         $cmf = $this->em->getMetadataFactory();
 
         foreach ($class->fieldMappings as $fieldName => $mapping) {
@@ -211,7 +211,7 @@ class SchemaValidator
                     }
 
                     if (count($identifierColumns) != count($assoc['joinColumns'])) {
-                        $ids = array();
+                        $ids = [];
 
                         foreach ($assoc['joinColumns'] as $joinColumn) {
                             $ids[] = $joinColumn['name'];

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -104,7 +104,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $identityMap = array();
+    private $identityMap = [];
 
     /**
      * Map of all identifiers of managed entities.
@@ -112,7 +112,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityIdentifiers = array();
+    private $entityIdentifiers = [];
 
     /**
      * Map of the original entity data of managed entities.
@@ -124,7 +124,7 @@ class UnitOfWork implements PropertyChangedListener
      *           A value will only really be copied if the value in the entity is modified
      *           by the user.
      */
-    private $originalEntityData = array();
+    private $originalEntityData = [];
 
     /**
      * Map of entity changes. Keys are object ids (spl_object_hash).
@@ -132,7 +132,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityChangeSets = array();
+    private $entityChangeSets = [];
 
     /**
      * The (cached) states of any known entities.
@@ -140,7 +140,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityStates = array();
+    private $entityStates = [];
 
     /**
      * Map of entities that are scheduled for dirty checking at commit time.
@@ -149,49 +149,49 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $scheduledForSynchronization = array();
+    private $scheduledForSynchronization = [];
 
     /**
      * A list of all pending entity insertions.
      *
      * @var array
      */
-    private $entityInsertions = array();
+    private $entityInsertions = [];
 
     /**
      * A list of all pending entity updates.
      *
      * @var array
      */
-    private $entityUpdates = array();
+    private $entityUpdates = [];
 
     /**
      * Any pending extra updates that have been scheduled by persisters.
      *
      * @var array
      */
-    private $extraUpdates = array();
+    private $extraUpdates = [];
 
     /**
      * A list of all pending entity deletions.
      *
      * @var array
      */
-    private $entityDeletions = array();
+    private $entityDeletions = [];
 
     /**
      * All pending collection deletions.
      *
      * @var array
      */
-    private $collectionDeletions = array();
+    private $collectionDeletions = [];
 
     /**
      * All pending collection updates.
      *
      * @var array
      */
-    private $collectionUpdates = array();
+    private $collectionUpdates = [];
 
     /**
      * List of collections visited during changeset calculation on a commit-phase of a UnitOfWork.
@@ -200,7 +200,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $visitedCollections = array();
+    private $visitedCollections = [];
 
     /**
      * The EntityManager that "owns" this UnitOfWork instance.
@@ -222,14 +222,14 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $persisters = array();
+    private $persisters = [];
 
     /**
      * The collection persister instances used to persist collections.
      *
      * @var array
      */
-    private $collectionPersisters = array();
+    private $collectionPersisters = [];
 
     /**
      * The EventManager used for dispatching events.
@@ -257,21 +257,21 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $orphanRemovals = array();
+    private $orphanRemovals = [];
 
     /**
      * Read-Only objects are never evaluated
      *
      * @var array
      */
-    private $readOnlyObjects = array();
+    private $readOnlyObjects = [];
 
     /**
      * Map of Entity Class-Names and corresponding IDs that should eager loaded when requested.
      *
      * @var array
      */
-    private $eagerLoadingEntities = array();
+    private $eagerLoadingEntities = [];
 
     /**
      * @var boolean
@@ -433,7 +433,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->collectionDeletions =
         $this->visitedCollections =
         $this->scheduledForSynchronization =
-        $this->orphanRemovals = array();
+        $this->orphanRemovals = [];
     }
 
     /**
@@ -510,7 +510,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->getEntityPersister(get_class($entity))->update($entity);
         }
 
-        $this->extraUpdates = array();
+        $this->extraUpdates = [];
     }
 
     /**
@@ -528,7 +528,7 @@ class UnitOfWork implements PropertyChangedListener
             return $this->entityChangeSets[$oid];
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -583,7 +583,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em), $invoke);
         }
 
-        $actualData = array();
+        $actualData = [];
 
         foreach ($class->reflFields as $name => $refProp) {
             $value = $refProp->getValue($entity);
@@ -627,11 +627,11 @@ class UnitOfWork implements PropertyChangedListener
             // Entity is either NEW or MANAGED but not yet fully persisted (only has an id).
             // These result in an INSERT.
             $this->originalEntityData[$oid] = $actualData;
-            $changeSet = array();
+            $changeSet = [];
 
             foreach ($actualData as $propName => $actualValue) {
                 if ( ! isset($class->associationMappings[$propName])) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = [null, $actualValue];
 
                     continue;
                 }
@@ -639,7 +639,7 @@ class UnitOfWork implements PropertyChangedListener
                 $assoc = $class->associationMappings[$propName];
 
                 if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = [null, $actualValue];
                 }
             }
 
@@ -651,7 +651,7 @@ class UnitOfWork implements PropertyChangedListener
             $isChangeTrackingNotify = $class->isChangeTrackingNotify();
             $changeSet              = ($isChangeTrackingNotify && isset($this->entityChangeSets[$oid]))
                 ? $this->entityChangeSets[$oid]
-                : array();
+                : [];
 
             foreach ($actualData as $propName => $actualValue) {
                 // skip field, its a partially omitted one!
@@ -672,7 +672,7 @@ class UnitOfWork implements PropertyChangedListener
                         continue;
                     }
 
-                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    $changeSet[$propName] = [$orgValue, $actualValue];
 
                     continue;
                 }
@@ -712,7 +712,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 if ($assoc['type'] & ClassMetadata::TO_ONE) {
                     if ($assoc['isOwningSide']) {
-                        $changeSet[$propName] = array($orgValue, $actualValue);
+                        $changeSet[$propName] = [$orgValue, $actualValue];
                     }
 
                     if ($orgValue !== null && $assoc['orphanRemoval']) {
@@ -743,7 +743,7 @@ class UnitOfWork implements PropertyChangedListener
                 $val instanceof PersistentCollection &&
                 $val->isDirty()) {
 
-                $this->entityChangeSets[$oid]   = array();
+                $this->entityChangeSets[$oid]   = [];
                 $this->originalEntityData[$oid] = $actualData;
                 $this->entityUpdates[$oid]      = $entity;
             }
@@ -783,7 +783,7 @@ class UnitOfWork implements PropertyChangedListener
                     break;
 
                 default:
-                    $entitiesToProcess = array();
+                    $entitiesToProcess = [];
 
             }
 
@@ -833,7 +833,7 @@ class UnitOfWork implements PropertyChangedListener
         // Look through the entities, and in any of their associations,
         // for transient (new) entities, recursively. ("Persistence by reachability")
         // Unwrap. Uninitialized collections will simply be empty.
-        $unwrappedValue = ($assoc['type'] & ClassMetadata::TO_ONE) ? array($value) : $value->unwrap();
+        $unwrappedValue = ($assoc['type'] & ClassMetadata::TO_ONE) ? [$value] : $value->unwrap();
         $targetClass    = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($unwrappedValue as $key => $entry) {
@@ -899,7 +899,7 @@ class UnitOfWork implements PropertyChangedListener
             $idValue = $idGen->generate($this->em, $entity);
 
             if ( ! $idGen instanceof \Doctrine\ORM\Id\AssignedGenerator) {
-                $idValue = array($class->identifier[0] => $idValue);
+                $idValue = [$class->identifier[0] => $idValue];
 
                 $class->setIdentifierValues($entity, $idValue);
             }
@@ -947,7 +947,7 @@ class UnitOfWork implements PropertyChangedListener
             $class = $this->em->getClassMetadata(get_class($entity));
         }
 
-        $actualData = array();
+        $actualData = [];
 
         foreach ($class->reflFields as $name => $refProp) {
             if (( ! $class->isIdentifier($name) || ! $class->isIdGeneratorIdentity())
@@ -962,13 +962,13 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $originalData = $this->originalEntityData[$oid];
-        $changeSet = array();
+        $changeSet = [];
 
         foreach ($actualData as $propName => $actualValue) {
             $orgValue = isset($originalData[$propName]) ? $originalData[$propName] : null;
 
             if ($orgValue !== $actualValue) {
-                $changeSet[$propName] = array($orgValue, $actualValue);
+                $changeSet[$propName] = [$orgValue, $actualValue];
             }
         }
 
@@ -992,7 +992,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeInserts($class)
     {
-        $entities   = array();
+        $entities   = [];
         $className  = $class->name;
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
@@ -1022,7 +1022,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $class->reflFields[$idField]->setValue($entity, $id);
 
-                $this->entityIdentifiers[$oid] = array($idField => $id);
+                $this->entityIdentifiers[$oid] = [$idField => $id];
                 $this->entityStates[$oid] = self::STATE_MANAGED;
                 $this->originalEntityData[$oid][$idField] = $id;
 
@@ -1132,7 +1132,7 @@ class UnitOfWork implements PropertyChangedListener
         // We have to inspect changeSet to be able to correctly build dependencies.
         // It is not possible to use IdentityMap here because post inserted ids
         // are not yet available.
-        $newNodes = array();
+        $newNodes = [];
 
         foreach ($entityChangeSet as $entity) {
             $class = $this->em->getClassMetadata(get_class($entity));
@@ -1281,12 +1281,12 @@ class UnitOfWork implements PropertyChangedListener
     public function scheduleExtraUpdate($entity, array $changeset)
     {
         $oid         = spl_object_hash($entity);
-        $extraUpdate = array($entity, $changeset);
+        $extraUpdate = [$entity, $changeset];
 
         if (isset($this->extraUpdates[$oid])) {
             list($ignored, $changeset2) = $this->extraUpdates[$oid];
 
-            $extraUpdate = array($entity, $changeset + $changeset2);
+            $extraUpdate = [$entity, $changeset + $changeset2];
         }
 
         $this->extraUpdates[$oid] = $extraUpdate;
@@ -1627,7 +1627,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function persist($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doPersist($entity, $visited);
     }
@@ -1703,7 +1703,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function remove($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doRemove($entity, $visited);
     }
@@ -1777,7 +1777,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function merge($entity)
     {
-        $visited = array();
+        $visited = [];
 
         return $this->doMerge($entity, $visited);
     }
@@ -1941,7 +1941,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function detach($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doDetach($entity, $visited);
     }
@@ -2002,7 +2002,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function refresh($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doRefresh($entity, $visited);
     }
@@ -2244,7 +2244,7 @@ class UnitOfWork implements PropertyChangedListener
             function ($assoc) { return $assoc['isCascadeRemove']; }
         );
 
-        $entitiesToCascade = array();
+        $entitiesToCascade = [];
 
         foreach ($associationMappings as $assoc) {
             if ($entity instanceof Proxy && !$entity->__isInitialized__) {
@@ -2381,13 +2381,13 @@ class UnitOfWork implements PropertyChangedListener
             $this->extraUpdates =
             $this->readOnlyObjects =
             $this->visitedCollections =
-            $this->orphanRemovals = array();
+            $this->orphanRemovals = [];
 
             if ($this->commitOrderCalculator !== null) {
                 $this->commitOrderCalculator->clear();
             }
         } else {
-            $visited = array();
+            $visited = [];
 
             foreach ($this->identityMap as $className => $entities) {
                 if ($className !== $entityName) {
@@ -2485,13 +2485,13 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @todo Rename: getOrCreateEntity
      */
-    public function createEntity($className, array $data, &$hints = array())
+    public function createEntity($className, array $data, &$hints = [])
     {
         $class = $this->em->getClassMetadata($className);
         //$isReadOnly = isset($hints[Query::HINT_READ_ONLY]);
 
         if ($class->isIdentifierComposite) {
-            $id = array();
+            $id = [];
 
             foreach ($class->identifier as $fieldName) {
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
@@ -2503,7 +2503,7 @@ class UnitOfWork implements PropertyChangedListener
                 ? $data[$class->associationMappings[$class->identifier[0]]['joinColumns'][0]['name']]
                 : $data[$class->identifier[0]];
 
-            $id = array($class->identifier[0] => $id);
+            $id = [$class->identifier[0] => $id];
         }
 
         $idHash = implode(' ', $id);
@@ -2631,7 +2631,7 @@ class UnitOfWork implements PropertyChangedListener
                         continue;
                     }
 
-                    $associatedId = array();
+                    $associatedId = [];
 
                     // TODO: Is this even computed right in all cases of composite keys?
                     foreach ($assoc['targetToSourceKeyColumns'] as $targetColumn => $srcColumn) {
@@ -2790,7 +2790,7 @@ class UnitOfWork implements PropertyChangedListener
 
         // avoid infinite recursion
         $eagerLoadingEntities       = $this->eagerLoadingEntities;
-        $this->eagerLoadingEntities = array();
+        $this->eagerLoadingEntities = [];
 
         foreach ($eagerLoadingEntities as $entityName => $ids) {
             if ( ! $ids) {
@@ -2800,7 +2800,7 @@ class UnitOfWork implements PropertyChangedListener
             $class = $this->em->getClassMetadata($entityName);
 
             $this->getEntityPersister($entityName)->loadAll(
-                array_combine($class->identifier, array(array_values($ids)))
+                array_combine($class->identifier, [array_values($ids)])
             );
         }
     }
@@ -2858,7 +2858,7 @@ class UnitOfWork implements PropertyChangedListener
             return $this->originalEntityData[$oid];
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -3102,7 +3102,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function clearEntityChangeSet($oid)
     {
-        $this->entityChangeSets[$oid] = array();
+        $this->entityChangeSets[$oid] = [];
     }
 
     /* PropertyChangedListener implementation */
@@ -3129,7 +3129,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         // Update changeset and mark entity for synchronization
-        $this->entityChangeSets[$oid][$propertyName] = array($oldValue, $newValue);
+        $this->entityChangeSets[$oid][$propertyName] = [$oldValue, $newValue];
 
         if ( ! isset($this->scheduledForSynchronization[$class->rootEntityName][$oid])) {
             $this->scheduleForDirtyCheck($entity);
@@ -3394,7 +3394,7 @@ class UnitOfWork implements PropertyChangedListener
                                         $assoc2['targetEntity'],
                                         $relatedId
                                     );
-                                    $this->registerManaged($other, $relatedId, array());
+                                    $this->registerManaged($other, $relatedId, []);
                                 }
                             }
 

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -69,7 +69,7 @@ final class IdentifierFlattener
      */
     public function flattenIdentifier(ClassMetadata $class, array $id)
     {
-        $flatId = array();
+        $flatId = [];
 
         foreach ($id as $idField => $idValue) {
             if (isset($class->associationMappings[$idField]) && is_object($idValue)) {

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -146,7 +146,7 @@ class PersisterHelper
             return self::getIndividualValue($value, $em);
         }
 
-        $newValue = array();
+        $newValue = [];
 
         foreach ($value as $fieldName => $fieldValue) {
             $newValue[$fieldName] = self::getIndividualValue($fieldValue, $em);

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -13,9 +13,9 @@ class CacheMetadataListener
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
         $metadata = $event->getClassMetadata();
-        $cache    = array(
+        $cache    = [
             'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
-        );
+        ];
 
         /** @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
         if (strstr($metadata->name, 'Doctrine\Tests\Models\Cache')) {

--- a/tests/Doctrine/Tests/Mocks/CacheRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/CacheRegionMock.php
@@ -13,8 +13,8 @@ use Doctrine\ORM\Cache\Region;
  */
 class CacheRegionMock implements Region
 {
-    public $calls   = array();
-    public $returns = array();
+    public $calls   = [];
+    public $returns = [];
     public $name;
 
     /**
@@ -50,7 +50,7 @@ class CacheRegionMock implements Region
      */
     public function getName()
     {
-        $this->calls[__FUNCTION__][] = array();
+        $this->calls[__FUNCTION__][] = [];
 
         return $this->name;
     }
@@ -60,7 +60,7 @@ class CacheRegionMock implements Region
      */
     public function contains(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         return $this->getReturn(__FUNCTION__, false);
     }
@@ -70,7 +70,7 @@ class CacheRegionMock implements Region
      */
     public function evict(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         return $this->getReturn(__FUNCTION__, true);
     }
@@ -80,7 +80,7 @@ class CacheRegionMock implements Region
      */
     public function evictAll()
     {
-        $this->calls[__FUNCTION__][] = array();
+        $this->calls[__FUNCTION__][] = [];
 
         return $this->getReturn(__FUNCTION__, true);
     }
@@ -90,7 +90,7 @@ class CacheRegionMock implements Region
      */
     public function get(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         return $this->getReturn(__FUNCTION__, null);
     }
@@ -100,7 +100,7 @@ class CacheRegionMock implements Region
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $this->calls[__FUNCTION__][] = array('collection' => $collection);
+        $this->calls[__FUNCTION__][] = ['collection' => $collection];
 
         return $this->getReturn(__FUNCTION__, null);
     }
@@ -110,7 +110,7 @@ class CacheRegionMock implements Region
      */
     public function put(CacheKey $key, CacheEntry $entry, Lock $lock = null)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key, 'entry' => $entry);
+        $this->calls[__FUNCTION__][] = ['key' => $key, 'entry' => $entry];
 
         return $this->getReturn(__FUNCTION__, true);
     }
@@ -120,7 +120,7 @@ class CacheRegionMock implements Region
      */
     public function clear()
     {
-        $this->calls   = array();
-        $this->returns = array();
+        $this->calls   = [];
+        $this->returns = [];
     }
 }

--- a/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
@@ -18,9 +18,9 @@ use Doctrine\ORM\Cache\Lock;
  */
 class ConcurrentRegionMock implements ConcurrentRegion
 {
-    public $calls       = array();
-    public $exceptions  = array();
-    public $locks       = array();
+    public $calls       = [];
+    public $exceptions  = [];
+    public $locks       = [];
 
     /**
      * @var \Doctrine\ORM\Cache\Region 
@@ -81,7 +81,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function contains(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         if (isset($this->locks[$key->hash])) {
             return false;
@@ -97,7 +97,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function evict(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         $this->throwException(__FUNCTION__);
 
@@ -109,7 +109,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function evictAll()
     {
-        $this->calls[__FUNCTION__][] = array();
+        $this->calls[__FUNCTION__][] = [];
 
         $this->throwException(__FUNCTION__);
 
@@ -121,7 +121,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function get(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         $this->throwException(__FUNCTION__);
 
@@ -137,7 +137,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $this->calls[__FUNCTION__][] = array('collection' => $collection);
+        $this->calls[__FUNCTION__][] = ['collection' => $collection];
 
         $this->throwException(__FUNCTION__);
 
@@ -149,7 +149,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function getName()
     {
-        $this->calls[__FUNCTION__][] = array();
+        $this->calls[__FUNCTION__][] = [];
 
         $this->throwException(__FUNCTION__);
 
@@ -161,7 +161,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function put(CacheKey $key, CacheEntry $entry, Lock $lock = null)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key, 'entry' => $entry);
+        $this->calls[__FUNCTION__][] = ['key' => $key, 'entry' => $entry];
 
         $this->throwException(__FUNCTION__);
 
@@ -182,7 +182,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function lock(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
 
         $this->throwException(__FUNCTION__);
 
@@ -198,7 +198,7 @@ class ConcurrentRegionMock implements ConcurrentRegion
      */
     public function unlock(CacheKey $key, Lock $lock)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key, 'lock' => $lock);
+        $this->calls[__FUNCTION__][] = ['key' => $key, 'lock' => $lock];
 
         $this->throwException(__FUNCTION__);
 

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -25,12 +25,12 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * @var array
      */
-    private $_inserts = array();
+    private $_inserts = [];
 
     /**
      * @var array
      */
-    private $_executeUpdates = array();
+    private $_executeUpdates = [];
 
     /**
      * @param array                              $params
@@ -59,7 +59,7 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function insert($tableName, array $data, array $types = array())
+    public function insert($tableName, array $data, array $types = [])
     {
         $this->_inserts[$tableName][] = $data;
     }
@@ -67,9 +67,9 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function executeUpdate($query, array $params = array(), array $types = array())
+    public function executeUpdate($query, array $params = [], array $types = [])
     {
-        $this->_executeUpdates[] = array('query' => $query, 'params' => $params, 'types' => $types);
+        $this->_executeUpdates[] = ['query' => $query, 'params' => $params, 'types' => $types];
     }
 
     /**
@@ -83,7 +83,7 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
     /**
      * {@inheritdoc}
      */
-    public function fetchColumn($statement, array $params = array(), $colnum = 0, array $types = array())
+    public function fetchColumn($statement, array $params = [], $colnum = 0, array $types = [])
     {
         return $this->_fetchOneResult;
     }
@@ -152,7 +152,7 @@ class ConnectionMock extends \Doctrine\DBAL\Connection
      */
     public function reset()
     {
-        $this->_inserts = array();
+        $this->_inserts = [];
         $this->_lastInsertId = 0;
     }
 }

--- a/tests/Doctrine/Tests/Mocks/DriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverMock.php
@@ -20,7 +20,7 @@ class DriverMock implements \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      */
-    public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
+    public function connect(array $params, $username = null, $password = null, array $driverOptions = [])
     {
         return new DriverConnectionMock();
     }

--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -90,7 +90,7 @@ class EntityManagerMock extends \Doctrine\ORM\EntityManager
             $config = new \Doctrine\ORM\Configuration();
             $config->setProxyDir(__DIR__ . '/../Proxies');
             $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
+            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], true));
         }
         if (null === $eventManager) {
             $eventManager = new \Doctrine\Common\EventManager();

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -12,17 +12,17 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\Entity\BasicEntityPer
     /**
      * @var array
      */
-    private $inserts = array();
+    private $inserts = [];
 
     /**
      * @var array
      */
-    private $updates = array();
+    private $updates = [];
 
     /**
      * @var array
      */
-    private $deletes = array();
+    private $deletes = [];
 
     /**
      * @var int
@@ -37,7 +37,7 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\Entity\BasicEntityPer
     /**
      * @var array
      */
-    private $postInsertIds = array();
+    private $postInsertIds = [];
 
     /**
      * @var bool
@@ -134,9 +134,9 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\Entity\BasicEntityPer
     {
         $this->existsCalled = false;
         $this->identityColumnValueCounter = 0;
-        $this->inserts = array();
-        $this->updates = array();
-        $this->deletes = array();
+        $this->inserts = [];
+        $this->updates = [];
+        $this->deletes = [];
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -106,7 +106,7 @@ class HydratorMockStatement implements \IteratorAggregate, \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      */
-    public function execute($params = array())
+    public function execute($params = [])
     {
     }
 

--- a/tests/Doctrine/Tests/Mocks/MetadataDriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/MetadataDriverMock.php
@@ -27,6 +27,6 @@ class MetadataDriverMock implements \Doctrine\Common\Persistence\Mapping\Driver\
      */
     public function getAllClassNames()
     {
-        return array();
+        return [];
     }
 }

--- a/tests/Doctrine/Tests/Mocks/TaskMock.php
+++ b/tests/Doctrine/Tests/Mocks/TaskMock.php
@@ -36,7 +36,7 @@ class TaskMock extends \Doctrine\Common\Cli\Tasks\AbstractTask
      *
      * @var array (TaskMock)
      */
-    static public $instances = array();
+    static public $instances = [];
 
     /**
      * @var int

--- a/tests/Doctrine/Tests/Mocks/TimestampRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/TimestampRegionMock.php
@@ -14,6 +14,6 @@ class TimestampRegionMock extends CacheRegionMock implements TimestampRegion
 {
     public function update(CacheKey $key)
     {
-        $this->calls[__FUNCTION__][] = array('key' => $key);
+        $this->calls[__FUNCTION__][] = ['key' => $key];
     }
 }

--- a/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
+++ b/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
@@ -10,7 +10,7 @@ class UnitOfWorkMock extends \Doctrine\ORM\UnitOfWork
     /**
      * @var array
      */
-    private $_mockDataChangeSets = array();
+    private $_mockDataChangeSets = [];
 
     /**
      * @var array|null

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -124,91 +124,91 @@ class CmsAddress
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->setPrimaryTable(array(
+        $metadata->setPrimaryTable([
            'name' => 'company_person',
-        ));
+        ]);
 
-        $metadata->mapField(array (
+        $metadata->mapField( [
             'id'        => true,
             'fieldName' => 'id',
             'type'      => 'integer',
-        ));
+        ]);
 
-        $metadata->mapField(array (
+        $metadata->mapField( [
             'fieldName' => 'zip',
             'length'    => 50,
-        ));
+        ]);
 
-        $metadata->mapField(array (
+        $metadata->mapField( [
             'fieldName' => 'city',
             'length'    => 50,
-        ));
+        ]);
 
-        $metadata->mapOneToOne(array(
+        $metadata->mapOneToOne([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser',
-            'joinColumns'   => array(array('referencedColumnName' => 'id'))
-        ));
+            'joinColumns'   => [['referencedColumnName' => 'id']]
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'find-all',
             'query'             => 'SELECT id, country, city FROM cms_addresses',
             'resultSetMapping'  => 'mapping-find-all',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'find-by-id',
             'query'             => 'SELECT * FROM cms_addresses WHERE id = ?',
             'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsAddress',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'count',
             'query'             => 'SELECT COUNT(*) AS count FROM cms_addresses',
             'resultSetMapping'  => 'mapping-count',
-        ));
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mapping-find-all',
-            'columns'   => array(),
-            'entities'  => array ( array (
-                'fields' => array (
-                  array (
+            'columns'   => [],
+            'entities'  =>  [  [
+                'fields' =>  [
+                   [
                     'name'      => 'id',
                     'column'    => 'id',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'city',
                     'column'    => 'city',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'country',
                     'column'    => 'country',
-                  ),
-                ),
+                  ],
+                ],
                 'entityClass' => 'Doctrine\Tests\Models\CMS\CmsAddress',
-              ),
-            ),
-        ));
+              ],
+            ],
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mapping-without-fields',
-            'columns'   => array(),
-            'entities'  => array(array (
+            'columns'   => [],
+            'entities'  => [ [
                 'entityClass' => 'Doctrine\\Tests\\Models\\CMS\\CmsAddress',
-                'fields' => array()
-              )
-            )
-        ));
+                'fields' => []
+              ]
+            ]
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name' => 'mapping-count',
-            'columns' =>array (
-                array (
+            'columns' => [
+                 [
                     'name' => 'count',
-                ),
-            )
-        ));
+                ],
+            ]
+        ]);
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CmsAddressListener', 'postPersist');
         $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CmsAddressListener', 'prePersist');

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -253,188 +253,188 @@ class CmsUser
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->setPrimaryTable(array(
+        $metadata->setPrimaryTable([
            'name' => 'cms_users',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchIdAndUsernameWithResultClass',
             'query'             => 'SELECT id, username FROM cms_users WHERE username = ?',
             'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchAllColumns',
             'query'             => 'SELECT * FROM cms_users WHERE username = ?',
             'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchJoinedAddress',
             'query'             => 'SELECT u.id, u.name, u.status, a.id AS a_id, a.country, a.zip, a.city FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?',
             'resultSetMapping'  => 'mappingJoinedAddress',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchJoinedPhonenumber',
             'query'             => 'SELECT id, name, status, phonenumber AS number FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?',
             'resultSetMapping'  => 'mappingJoinedPhonenumber',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchUserPhonenumberCount',
             'query'             => 'SELECT id, name, status, COUNT(phonenumber) AS numphones FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username IN (?) GROUP BY id, name, status, username ORDER BY username',
             'resultSetMapping'  => 'mappingUserPhonenumberCount',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             "name"              => "fetchMultipleJoinsEntityResults",
             "resultSetMapping"  => "mappingMultipleJoinsEntityResults",
             "query"             => "SELECT u.id AS u_id, u.name AS u_name, u.status AS u_status, a.id AS a_id, a.zip AS a_zip, a.country AS a_country, COUNT(p.phonenumber) AS numphones FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id INNER JOIN cms_phonenumbers p ON u.id = p.user_id GROUP BY u.id, u.name, u.status, u.username, a.id, a.zip, a.country ORDER BY u.username"
-        ));
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mappingJoinedAddress',
-            'columns'   => array(),
-            'entities'  => array(array (
-                'fields'=> array (
-                  array (
+            'columns'   => [],
+            'entities'  => [ [
+                'fields'=>  [
+                   [
                     'name'      => 'id',
                     'column'    => 'id',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'name',
                     'column'    => 'name',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'status',
                     'column'    => 'status',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'address.zip',
                     'column'    => 'zip',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'address.city',
                     'column'    => 'city',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'address.country',
                     'column'    => 'country',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'address.id',
                     'column'    => 'a_id',
-                  ),
-                ),
+                  ],
+                ],
                 'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsUser',
                 'discriminatorColumn'   => null
-              ),
-            ),
-        ));
+              ],
+            ],
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mappingJoinedPhonenumber',
-            'columns'   => array(),
-            'entities'  => array(array(
-                'fields'=> array (
-                  array (
+            'columns'   => [],
+            'entities'  => [[
+                'fields'=>  [
+                   [
                     'name'      => 'id',
                     'column'    => 'id',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'name',
                     'column'    => 'name',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'status',
                     'column'    => 'status',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'phonenumbers.phonenumber',
                     'column'    => 'number',
-                  ),
-                ),
+                  ],
+                ],
                 'entityClass'   => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
                 'discriminatorColumn'   => null
-              ),
-            ),
-        ));
+              ],
+            ],
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mappingUserPhonenumberCount',
-            'columns'   => array(),
-            'entities'  => array (
-              array(
-                'fields' => array (
-                  array (
+            'columns'   => [],
+            'entities'  =>  [
+              [
+                'fields' =>  [
+                   [
                     'name'      => 'id',
                     'column'    => 'id',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'name',
                     'column'    => 'name',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'status',
                     'column'    => 'status',
-                  )
-                ),
+                  ]
+                ],
                 'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
                 'discriminatorColumn'   => null
-              )
-            ),
-            'columns' => array (
-                  array (
+              ]
+            ],
+            'columns' =>  [
+                   [
                     'name' => 'numphones',
-                  )
-            )
-        ));
+                  ]
+            ]
+        ]);
 
-        $metadata->addSqlResultSetMapping(array(
+        $metadata->addSqlResultSetMapping([
             'name'      => 'mappingMultipleJoinsEntityResults',
-            'entities'  => array(array(
-                    'fields' => array(
-                        array(
+            'entities'  => [[
+                    'fields' => [
+                        [
                             'name'      => 'id',
                             'column'    => 'u_id',
-                        ),
-                        array(
+                        ],
+                        [
                             'name'      => 'name',
                             'column'    => 'u_name',
-                        ),
-                        array(
+                        ],
+                        [
                             'name'      => 'status',
                             'column'    => 'u_status',
-                        )
-                    ),
+                        ]
+                    ],
                     'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsUser',
                     'discriminatorColumn'   => null,
-                ),
-                array(
-                    'fields' => array(
-                        array(
+                ],
+                [
+                    'fields' => [
+                        [
                             'name'      => 'id',
                             'column'    => 'a_id',
-                        ),
-                        array(
+                        ],
+                        [
                             'name'      => 'zip',
                             'column'    => 'a_zip',
-                        ),
-                        array(
+                        ],
+                        [
                             'name'      => 'country',
                             'column'    => 'a_country',
-                        ),
-                    ),
+                        ],
+                    ],
                     'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsAddress',
                     'discriminatorColumn'   => null,
-                ),
-            ),
-            'columns' => array(array(
+                ],
+            ],
+            'columns' => [[
                     'name' => 'numphones',
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -134,28 +134,28 @@ abstract class CompanyContract
     {
         $metadata->setInheritanceType(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_JOINED);
         $metadata->setTableName( 'company_contracts');
-        $metadata->setDiscriminatorColumn(array(
+        $metadata->setDiscriminatorColumn([
             'name' => 'discr',
             'type' => 'string',
-        ));
+        ]);
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             'id'        => true,
             'name'      => 'id',
             'fieldName' => 'id',
-        ));
+        ]);
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             'type'      => 'boolean',
             'name'      => 'completed',
             'fieldName' => 'completed',
-        ));
+        ]);
 
-        $metadata->setDiscriminatorMap(array(
+        $metadata->setDiscriminatorMap([
             "fix"       => "CompanyFixContract",
             "flexible"  => "CompanyFlexContract",
             "flexultra" => "CompanyFlexUltraContract"
-        ));
+        ]);
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CompanyContractListener', 'postPersistHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyContractListener', 'prePersistHandler');

--- a/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
@@ -30,10 +30,10 @@ class CompanyFixContract extends CompanyContract
 
     static public function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
             'type'      => 'integer',
             'name'      => 'fixPrice',
             'fieldName' => 'fixPrice',
-        ));
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
@@ -110,16 +110,16 @@ class CompanyFlexContract extends CompanyContract
 
     static public function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
             'type'      => 'integer',
             'name'      => 'hoursWorked',
             'fieldName' => 'hoursWorked',
-        ));
+        ]);
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             'type'      => 'integer',
             'name'      => 'pricePerHour',
             'fieldName' => 'pricePerHour',
-        ));
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
@@ -31,11 +31,11 @@ class CompanyFlexUltraContract extends CompanyFlexContract
 
     static public function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
             'type'      => 'integer',
             'name'      => 'maxPrice',
             'fieldName' => 'maxPrice',
-        ));
+        ]);
         $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CompanyContractListener', 'postPersistHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyContractListener', 'prePersistHandler');
 

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -120,41 +120,41 @@ class CompanyPerson
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
 
-        $metadata->setPrimaryTable(array(
+        $metadata->setPrimaryTable([
            'name' => 'company_person',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchAllWithResultClass',
             'query'             => 'SELECT id, name, discr FROM company_persons ORDER BY name',
             'resultClass'       => 'Doctrine\\Tests\\Models\\Company\\CompanyPerson',
-        ));
+        ]);
 
-        $metadata->addNamedNativeQuery(array (
+        $metadata->addNamedNativeQuery( [
             'name'              => 'fetchAllWithSqlResultSetMapping',
             'query'             => 'SELECT id, name, discr AS discriminator FROM company_persons ORDER BY name',
             'resultSetMapping'  => 'mappingFetchAll',
-        ));
+        ]);
 
-        $metadata->addSqlResultSetMapping(array (
+        $metadata->addSqlResultSetMapping( [
             'name'      => 'mappingFetchAll',
-            'columns'   => array(),
-            'entities'  => array ( array (
-                'fields' => array (
-                  array (
+            'columns'   => [],
+            'entities'  =>  [  [
+                'fields' =>  [
+                   [
                     'name'      => 'id',
                     'column'    => 'id',
-                  ),
-                  array (
+                  ],
+                   [
                     'name'      => 'name',
                     'column'    => 'name',
-                  ),
-                ),
+                  ],
+                ],
                 'entityClass' => 'Doctrine\Tests\Models\Company\CompanyPerson',
                 'discriminatorColumn' => 'discriminator',
-              ),
-            ),
-        ));
+              ],
+            ],
+        ]);
     }
 }
 

--- a/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
@@ -62,13 +62,13 @@ class DDC1476EntityWithDefaultFieldType
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id'         => true,
            'fieldName'  => 'id',
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
            'fieldName'  => 'name',
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_NONE);
     }

--- a/tests/Doctrine/Tests/Models/DDC3346/DDC3346Author.php
+++ b/tests/Doctrine/Tests/Models/DDC3346/DDC3346Author.php
@@ -24,5 +24,5 @@ class DDC3346Author
     /**
      * @OneToMany(targetEntity="DDC3346Article", mappedBy="user", fetch="EAGER", cascade={"detach"})
      */
-    public $articles = array();
+    public $articles = [];
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
@@ -31,10 +31,10 @@ class DDC869ChequePayment extends DDC869Payment
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'fieldName'  => 'serialNumber',
            'type'       => 'string',
-        ));
+        ]);
     }
 
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
@@ -31,10 +31,10 @@ class DDC869CreditCardPayment extends DDC869Payment
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'fieldName'  => 'creditCardNumber',
            'type'       => 'string',
-        ));
+        ]);
     }
 
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
@@ -39,16 +39,16 @@ class DDC869Payment
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id'         => true,
            'fieldName'  => 'id',
            'type'       => 'integer',
            'columnName' => 'id',
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
            'fieldName'  => 'value',
            'type'       => 'float',
-        ));
+        ]);
         $metadata->isMappedSuperclass = true;
         $metadata->setCustomRepositoryClass("Doctrine\Tests\Models\DDC869\DDC869PaymentRepository");
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
@@ -33,12 +33,12 @@ class DDC889Class extends DDC889SuperClass
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id'         => true,
            'fieldName'  => 'id',
            'type'       => 'integer',
            'columnName' => 'id',
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_AUTO);
     }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
@@ -31,9 +31,9 @@ class DDC889SuperClass
 
     public static function loadMetadata(\Doctrine\ORM\Mapping\ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'fieldName'  => 'name',
-        ));
+        ]);
 
         $metadata->isMappedSuperclass = true;
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
@@ -25,23 +25,23 @@ class DDC964Admin extends DDC964User
 {
     public static function loadMetadata($metadata)
     {
-        $metadata->setAssociationOverride('address',array(
-            'joinColumns'=>array(array(
+        $metadata->setAssociationOverride('address',[
+            'joinColumns'=>[[
                 'name' => 'adminaddress_id',
                 'referencedColumnName' => 'id',
-            ))
-        ));
+            ]]
+        ]);
 
-        $metadata->setAssociationOverride('groups',array(
-            'joinTable' => array(
+        $metadata->setAssociationOverride('groups',[
+            'joinTable' => [
                 'name'      => 'ddc964_users_admingroups',
-                'joinColumns' => array(array(
+                'joinColumns' => [[
                     'name' => 'adminuser_id',
-                )),
-                'inverseJoinColumns' =>array (array (
+                ]],
+                'inverseJoinColumns' => [ [
                     'name'      => 'admingroup_id',
-                ))
-            )
-        ));
+                ]]
+            ]
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
@@ -28,17 +28,17 @@ class DDC964Guest extends DDC964User
 {
     public static function loadMetadata($metadata)
     {
-        $metadata->setAttributeOverride('id', array(
+        $metadata->setAttributeOverride('id', [
             'columnName'    => 'guest_id',
             'type'          => 'integer',
             'length'        => 140,
-        ));
+        ]);
 
-        $metadata->setAttributeOverride('name',array(
+        $metadata->setAttributeOverride('name',[
             'columnName'    => 'guest_name',
             'nullable'      => false,
             'unique'        => true,
             'length'        => 240,
-        ));
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -109,46 +109,46 @@ class DDC964User
 
     public static function loadMetadata($metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id'         => true,
            'fieldName'  => 'id',
            'type'       => 'integer',
            'columnName' => 'user_id',
            'length'     => 150,
-        ));
-        $metadata->mapField(array(
+        ]);
+        $metadata->mapField([
             'fieldName' => 'name',
             'type'      => 'string',
             'columnName'=> 'user_name',
             'nullable'  => true,
             'unique'    => false,
             'length'    => 250,
-        ));
+        ]);
 
-        $metadata->mapManyToOne(array(
+        $metadata->mapManyToOne([
            'fieldName'      => 'address',
            'targetEntity'   => 'DDC964Address',
-           'cascade'        => array('persist','merge'),
-           'joinColumn'     => array('name'=>'address_id', 'referencedColumnMame'=>'id'),
-        ));
+           'cascade'        => ['persist','merge'],
+           'joinColumn'     => ['name'=>'address_id', 'referencedColumnMame'=>'id'],
+        ]);
 
-        $metadata->mapManyToMany(array(
+        $metadata->mapManyToMany([
            'fieldName'      => 'groups',
            'targetEntity'   => 'DDC964Group',
            'inversedBy'     => 'users',
-           'cascade'        => array('persist','merge','detach'),
-           'joinTable'      => array(
+           'cascade'        => ['persist','merge','detach'],
+           'joinTable'      => [
                 'name'          => 'ddc964_users_groups',
-                'joinColumns'   => array(array(
+                'joinColumns'   => [[
                     'name'=>'user_id',
                     'referencedColumnName'=>'id',
-                )),
-                'inverseJoinColumns'=>array(array(
+                ]],
+                'inverseJoinColumns'=>[[
                     'name'=>'group_id',
                     'referencedColumnName'=>'id',
-                ))
-           )
-        ));
+                ]]
+           ]
+        ]);
 
         $metadata->setIdGeneratorType(\Doctrine\ORM\Mapping\ClassMetadataInfo::GENERATOR_TYPE_AUTO);
     }

--- a/tests/Doctrine/Tests/Models/Routing/RoutingRoute.php
+++ b/tests/Doctrine/Tests/Models/Routing/RoutingRoute.php
@@ -30,7 +30,7 @@ class RoutingRoute
      * @OneToMany(targetEntity="RoutingRouteBooking", mappedBy="route")
      * @OrderBy({"passengerName" = "ASC"})
      */
-    public $bookings = array();
+    public $bookings = [];
 
     public function __construct()
     {

--- a/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
@@ -37,10 +37,10 @@ abstract class AbstractRegionTest extends OrmFunctionalTestCase
 
     static public function dataProviderCacheValues()
     {
-        return array(
-            array(new CacheKeyMock('key.1'), new CacheEntryMock(array('id'=>1, 'name' => 'bar'))),
-            array(new CacheKeyMock('key.2'), new CacheEntryMock(array('id'=>2, 'name' => 'foo'))),
-        );
+        return [
+            [new CacheKeyMock('key.1'), new CacheEntryMock(['id'=>1, 'name' => 'bar'])],
+            [new CacheKeyMock('key.2'), new CacheEntryMock(['id'=>2, 'name' => 'foo'])],
+        ];
     }
 
     /**
@@ -71,8 +71,8 @@ abstract class AbstractRegionTest extends OrmFunctionalTestCase
         $this->assertFalse($this->region->contains($key1));
         $this->assertFalse($this->region->contains($key2));
 
-        $this->region->put($key1, new CacheEntryMock(array('value' => 'foo')));
-        $this->region->put($key2, new CacheEntryMock(array('value' => 'bar')));
+        $this->region->put($key1, new CacheEntryMock(['value' => 'foo']));
+        $this->region->put($key2, new CacheEntryMock(['value' => 'bar']));
 
         $this->assertTrue($this->region->contains($key1));
         $this->assertTrue($this->region->contains($key2));

--- a/tests/Doctrine/Tests/ORM/Cache/CacheKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheKeyTest.php
@@ -12,56 +12,56 @@ class CacheKeyTest extends \Doctrine\Tests\DoctrineTestCase
 {
     public function testEntityCacheKeyIdentifierCollision()
     {
-        $key1 = new EntityCacheKey('Foo', array('id'=>1));
-        $key2 = new EntityCacheKey('Bar', array('id'=>1));
+        $key1 = new EntityCacheKey('Foo', ['id'=>1]);
+        $key2 = new EntityCacheKey('Bar', ['id'=>1]);
 
         $this->assertNotEquals($key1->hash, $key2->hash);
     }
 
     public function testEntityCacheKeyIdentifierType()
     {
-        $key1 = new EntityCacheKey('Foo', array('id'=>1));
-        $key2 = new EntityCacheKey('Foo', array('id'=>'1'));
+        $key1 = new EntityCacheKey('Foo', ['id'=>1]);
+        $key2 = new EntityCacheKey('Foo', ['id'=>'1']);
 
         $this->assertEquals($key1->hash, $key2->hash);
     }
 
     public function testEntityCacheKeyIdentifierOrder()
     {
-        $key1 = new EntityCacheKey('Foo', array('foo_bar'=>1, 'bar_foo'=> 2));
-        $key2 = new EntityCacheKey('Foo', array('bar_foo'=>2, 'foo_bar'=> 1));
+        $key1 = new EntityCacheKey('Foo', ['foo_bar'=>1, 'bar_foo'=> 2]);
+        $key2 = new EntityCacheKey('Foo', ['bar_foo'=>2, 'foo_bar'=> 1]);
 
         $this->assertEquals($key1->hash, $key2->hash);
     }
 
     public function testCollectionCacheKeyIdentifierType()
     {
-        $key1 = new CollectionCacheKey('Foo', 'assoc', array('id'=>1));
-        $key2 = new CollectionCacheKey('Foo', 'assoc', array('id'=>'1'));
+        $key1 = new CollectionCacheKey('Foo', 'assoc', ['id'=>1]);
+        $key2 = new CollectionCacheKey('Foo', 'assoc', ['id'=>'1']);
 
         $this->assertEquals($key1->hash, $key2->hash);
     }
 
     public function testCollectionCacheKeyIdentifierOrder()
     {
-        $key1 = new CollectionCacheKey('Foo', 'assoc', array('foo_bar'=>1, 'bar_foo'=> 2));
-        $key2 = new CollectionCacheKey('Foo', 'assoc', array('bar_foo'=>2, 'foo_bar'=> 1));
+        $key1 = new CollectionCacheKey('Foo', 'assoc', ['foo_bar'=>1, 'bar_foo'=> 2]);
+        $key2 = new CollectionCacheKey('Foo', 'assoc', ['bar_foo'=>2, 'foo_bar'=> 1]);
 
         $this->assertEquals($key1->hash, $key2->hash);
     }
 
     public function testCollectionCacheKeyIdentifierCollision()
     {
-        $key1 = new CollectionCacheKey('Foo', 'assoc', array('id'=>1));
-        $key2 = new CollectionCacheKey('Bar', 'assoc', array('id'=>1));
+        $key1 = new CollectionCacheKey('Foo', 'assoc', ['id'=>1]);
+        $key2 = new CollectionCacheKey('Bar', 'assoc', ['id'=>1]);
 
         $this->assertNotEquals($key1->hash, $key2->hash);
     }
 
     public function testCollectionCacheKeyAssociationCollision()
     {
-        $key1 = new CollectionCacheKey('Foo', 'assoc1', array('id'=>1));
-        $key2 = new CollectionCacheKey('Foo', 'assoc2', array('id'=>1));
+        $key1 = new CollectionCacheKey('Foo', 'assoc1', ['id'=>1]);
+        $key2 = new CollectionCacheKey('Foo', 'assoc2', ['id'=>1]);
 
         $this->assertNotEquals($key1->hash, $key2->hash);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
@@ -41,13 +41,13 @@ class CacheLoggerChainTest extends DoctrineTestCase
         $this->logger->setLogger('mock', $this->mock);
 
         $this->assertSame($this->mock, $this->logger->getLogger('mock'));
-        $this->assertEquals(array('mock' => $this->mock), $this->logger->getLoggers());
+        $this->assertEquals(['mock' => $this->mock], $this->logger->getLoggers());
     }
 
     public function testEntityCacheChain()
     {
         $name = 'my_entity_region';
-        $key  = new EntityCacheKey(State::CLASSNAME, array('id' => 1));
+        $key  = new EntityCacheKey(State::CLASSNAME, ['id' => 1]);
 
         $this->logger->setLogger('mock', $this->mock);
 
@@ -71,7 +71,7 @@ class CacheLoggerChainTest extends DoctrineTestCase
     public function testCollectionCacheChain()
     {
         $name = 'my_collection_region';
-        $key  = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id' => 1));
+        $key  = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id' => 1]);
 
         $this->logger->setLogger('mock', $this->mock);
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -38,10 +38,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $this->em               = $this->_getTestEntityManager();
         $this->regionsConfig    = new RegionsConfiguration;
-        $arguments              = array($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
-        $this->factory          = $this->getMock('\Doctrine\ORM\Cache\DefaultCacheFactory', array(
+        $arguments              = [$this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl()];
+        $this->factory          = $this->getMock('\Doctrine\ORM\Cache\DefaultCacheFactory', [
             'getRegion'
-        ), $arguments);
+        ], $arguments);
     }
 
     public function testImplementsCacheFactory()
@@ -258,24 +258,24 @@ class DefaultCacheFactoryTest extends OrmTestCase
     {
         $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
 
-        $factory->getRegion(array(
+        $factory->getRegion([
             'usage'   => ClassMetadata::CACHE_USAGE_READ_WRITE,
             'region'  => 'foo'
-        ));
+        ]);
     }
 
     public function testBuildsNewNamespacedCacheInstancePerRegionInstance()
     {
         $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
 
-        $fooRegion = $factory->getRegion(array(
+        $fooRegion = $factory->getRegion([
             'region' => 'foo',
             'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
-        ));
-        $barRegion = $factory->getRegion(array(
+        ]);
+        $barRegion = $factory->getRegion([
             'region' => 'bar',
             'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
-        ));
+        ]);
 
         $this->assertSame('foo', $fooRegion->getCache()->getNamespace());
         $this->assertSame('bar', $barRegion->getCache()->getNamespace());
@@ -290,10 +290,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $this->assertInstanceOf(
             'Doctrine\ORM\Cache\Region\DefaultRegion',
-            $factory->getRegion(array(
+            $factory->getRegion([
                 'region' => 'bar',
                 'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
-            ))
+            ])
         );
     }
 
@@ -306,10 +306,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $this->assertInstanceOf(
             'Doctrine\ORM\Cache\Region\DefaultMultiGetRegion',
-            $factory->getRegion(array(
+            $factory->getRegion([
                 'region' => 'bar',
                 'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
-            ))
+            ])
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -87,9 +87,9 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testContainsEntity()
     {
-        $identifier = array('id'=>1);
+        $identifier = ['id'=>1];
         $className  = Country::CLASSNAME;
-        $cacheEntry = array_merge($identifier, array('name' => 'Brazil'));
+        $cacheEntry = array_merge($identifier, ['name' => 'Brazil']);
 
         $this->assertFalse($this->cache->containsEntity(Country::CLASSNAME, 1));
 
@@ -101,9 +101,9 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictEntity()
     {
-        $identifier = array('id'=>1);
+        $identifier = ['id'=>1];
         $className  = Country::CLASSNAME;
-        $cacheEntry = array_merge($identifier, array('name' => 'Brazil'));
+        $cacheEntry = array_merge($identifier, ['name' => 'Brazil']);
 
         $this->putEntityCacheEntry($className, $identifier, $cacheEntry);
 
@@ -117,9 +117,9 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictEntityRegion()
     {
-        $identifier = array('id'=>1);
+        $identifier = ['id'=>1];
         $className  = Country::CLASSNAME;
-        $cacheEntry = array_merge($identifier, array('name' => 'Brazil'));
+        $cacheEntry = array_merge($identifier, ['name' => 'Brazil']);
 
         $this->putEntityCacheEntry($className, $identifier, $cacheEntry);
 
@@ -133,9 +133,9 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictEntityRegions()
     {
-        $identifier = array('id'=>1);
+        $identifier = ['id'=>1];
         $className  = Country::CLASSNAME;
-        $cacheEntry = array_merge($identifier, array('name' => 'Brazil'));
+        $cacheEntry = array_merge($identifier, ['name' => 'Brazil']);
 
         $this->putEntityCacheEntry($className, $identifier, $cacheEntry);
 
@@ -148,13 +148,13 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testContainsCollection()
     {
-        $ownerId        = array('id'=>1);
+        $ownerId        = ['id'=>1];
         $className      = State::CLASSNAME;
         $association    = 'cities';
-        $cacheEntry     = array(
-            array('id' => 11),
-            array('id' => 12),
-        );
+        $cacheEntry     = [
+            ['id' => 11],
+            ['id' => 12],
+        ];
 
         $this->assertFalse($this->cache->containsCollection(State::CLASSNAME, $association, 1));
 
@@ -166,13 +166,13 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictCollection()
     {
-        $ownerId        = array('id'=>1);
+        $ownerId        = ['id'=>1];
         $className      = State::CLASSNAME;
         $association    = 'cities';
-        $cacheEntry     = array(
-            array('id' => 11),
-            array('id' => 12),
-        );
+        $cacheEntry     = [
+            ['id' => 11],
+            ['id' => 12],
+        ];
 
         $this->putCollectionCacheEntry($className, $association, $ownerId, $cacheEntry);
 
@@ -186,13 +186,13 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictCollectionRegion()
     {
-        $ownerId        = array('id'=>1);
+        $ownerId        = ['id'=>1];
         $className      = State::CLASSNAME;
         $association    = 'cities';
-        $cacheEntry     = array(
-            array('id' => 11),
-            array('id' => 12),
-        );
+        $cacheEntry     = [
+            ['id' => 11],
+            ['id' => 12],
+        ];
 
         $this->putCollectionCacheEntry($className, $association, $ownerId, $cacheEntry);
 
@@ -206,13 +206,13 @@ class DefaultCacheTest extends OrmTestCase
 
     public function testEvictCollectionRegions()
     {
-        $ownerId        = array('id'=>1);
+        $ownerId        = ['id'=>1];
         $className      = State::CLASSNAME;
         $association    = 'cities';
-        $cacheEntry     = array(
-            array('id' => 11),
-            array('id' => 12),
-        );
+        $cacheEntry     = [
+            ['id' => 11],
+            ['id' => 12],
+        ];
 
         $this->putCollectionCacheEntry($className, $association, $ownerId, $cacheEntry);
 
@@ -257,7 +257,7 @@ class DefaultCacheTest extends OrmTestCase
         $method->setAccessible(true);
         $property->setValue($entity, $identifier);
 
-        $this->assertEquals(array('id'=>$identifier), $method->invoke($this->cache, $metadata, $identifier));
+        $this->assertEquals(['id'=>$identifier], $method->invoke($this->cache, $metadata, $identifier));
     }
 
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
@@ -41,17 +41,17 @@ class DefaultCollectionHydratorTest extends OrmFunctionalTestCase
     public function testLoadCacheCollection()
     {
         $targetRegion   = $this->_em->getCache()->getEntityCacheRegion(City::CLASSNAME);
-        $entry          = new CollectionCacheEntry(array(
-            new EntityCacheKey(City::CLASSNAME, array('id'=>31)),
-            new EntityCacheKey(City::CLASSNAME, array('id'=>32)),
-        ));
+        $entry          = new CollectionCacheEntry([
+            new EntityCacheKey(City::CLASSNAME, ['id'=>31]),
+            new EntityCacheKey(City::CLASSNAME, ['id'=>32]),
+        ]);
 
-        $targetRegion->put(new EntityCacheKey(City::CLASSNAME, array('id'=>31)), new EntityCacheEntry(City::CLASSNAME, array('id'=>31, 'name'=>'Foo')));
-        $targetRegion->put(new EntityCacheKey(City::CLASSNAME, array('id'=>32)), new EntityCacheEntry(City::CLASSNAME, array('id'=>32, 'name'=>'Bar')));
+        $targetRegion->put(new EntityCacheKey(City::CLASSNAME, ['id'=>31]), new EntityCacheEntry(City::CLASSNAME, ['id'=>31, 'name'=>'Foo']));
+        $targetRegion->put(new EntityCacheKey(City::CLASSNAME, ['id'=>32]), new EntityCacheEntry(City::CLASSNAME, ['id'=>32, 'name'=>'Bar']));
 
         $sourceClass    = $this->_em->getClassMetadata(State::CLASSNAME);
         $targetClass    = $this->_em->getClassMetadata(City::CLASSNAME);
-        $key            = new CollectionCacheKey($sourceClass->name, 'cities', array('id'=>21));
+        $key            = new CollectionCacheKey($sourceClass->name, 'cities', ['id'=>21]);
         $collection     = new PersistentCollection($this->_em, $targetClass, new ArrayCollection());
         $list           = $this->structure->loadCacheEntry($sourceClass, $key, $entry, $collection);
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
@@ -43,8 +43,8 @@ class DefaultEntityHydratorTest extends OrmTestCase
     public function testCreateEntity()
     {
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
-        $key      = new EntityCacheKey($metadata->name, array('id'=>1));
-        $entry    = new EntityCacheEntry($metadata->name, array('id'=>1, 'name'=>'Foo'));
+        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
+        $entry    = new EntityCacheEntry($metadata->name, ['id'=>1, 'name'=>'Foo']);
         $entity   = $this->structure->loadCacheEntry($metadata, $key, $entry);
 
         $this->assertInstanceOf($metadata->name, $entity);
@@ -57,8 +57,8 @@ class DefaultEntityHydratorTest extends OrmTestCase
     public function testLoadProxy()
     {
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
-        $key      = new EntityCacheKey($metadata->name, array('id'=>1));
-        $entry    = new EntityCacheEntry($metadata->name, array('id'=>1, 'name'=>'Foo'));
+        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
+        $entry    = new EntityCacheEntry($metadata->name, ['id'=>1, 'name'=>'Foo']);
         $proxy    = $this->em->getReference($metadata->name, $key->identifier);
         $entity   = $this->structure->loadCacheEntry($metadata, $key, $entry, $proxy);
 
@@ -74,9 +74,9 @@ class DefaultEntityHydratorTest extends OrmTestCase
     {
         $entity   = new Country('Foo');
         $uow      = $this->em->getUnitOfWork();
-        $data     = array('id'=>1, 'name'=>'Foo');
+        $data     = ['id'=>1, 'name'=>'Foo'];
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
-        $key      = new EntityCacheKey($metadata->name, array('id'=>1));
+        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
 
         $entity->setId(1);
         $uow->registerManaged($entity, $key->identifier, $data);
@@ -88,10 +88,10 @@ class DefaultEntityHydratorTest extends OrmTestCase
 
         $this->assertArrayHasKey('id', $cache->data);
         $this->assertArrayHasKey('name', $cache->data);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'id'   => 1,
             'name' => 'Foo',
-        ), $cache->data);
+        ], $cache->data);
     }
 
     public function testBuildCacheEntryAssociation()
@@ -99,16 +99,16 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $country        = new Country('Foo');
         $state          = new State('Bat', $country);
         $uow            = $this->em->getUnitOfWork();
-        $countryData    = array('id'=>11, 'name'=>'Foo');
-        $stateData      = array('id'=>12, 'name'=>'Bar', 'country' => $country);
+        $countryData    = ['id'=>11, 'name'=>'Foo'];
+        $stateData      = ['id'=>12, 'name'=>'Bar', 'country' => $country];
         $metadata       = $this->em->getClassMetadata(State::CLASSNAME);
-        $key            = new EntityCacheKey($metadata->name, array('id'=>11));
+        $key            = new EntityCacheKey($metadata->name, ['id'=>11]);
 
         $country->setId(11);
         $state->setId(12);
 
-        $uow->registerManaged($country, array('id'=>11), $countryData);
-        $uow->registerManaged($state, array('id'=>12), $stateData);
+        $uow->registerManaged($country, ['id'=>11], $countryData);
+        $uow->registerManaged($state, ['id'=>12], $stateData);
 
         $cache = $this->structure->buildCacheEntry($metadata, $key, $state);
 
@@ -118,11 +118,11 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $this->assertArrayHasKey('id', $cache->data);
         $this->assertArrayHasKey('name', $cache->data);
         $this->assertArrayHasKey('country', $cache->data);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'id'        => 11,
             'name'      => 'Bar',
-            'country'   => new AssociationCacheEntry(Country::CLASSNAME, array('id' => 11)),
-        ), $cache->data);
+            'country'   => new AssociationCacheEntry(Country::CLASSNAME, ['id' => 11]),
+        ], $cache->data);
     }
 
     public function testBuildCacheEntryNonInitializedAssocProxy()
@@ -130,13 +130,13 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $proxy          = $this->em->getReference(Country::CLASSNAME, 11);
         $entity         = new State('Bat', $proxy);
         $uow            = $this->em->getUnitOfWork();
-        $entityData     = array('id'=>12, 'name'=>'Bar', 'country' => $proxy);
+        $entityData     = ['id'=>12, 'name'=>'Bar', 'country' => $proxy];
         $metadata       = $this->em->getClassMetadata(State::CLASSNAME);
-        $key            = new EntityCacheKey($metadata->name, array('id'=>11));
+        $key            = new EntityCacheKey($metadata->name, ['id'=>11]);
 
         $entity->setId(12);
 
-        $uow->registerManaged($entity, array('id'=>12), $entityData);
+        $uow->registerManaged($entity, ['id'=>12], $entityData);
 
         $cache = $this->structure->buildCacheEntry($metadata, $key, $entity);
 
@@ -146,10 +146,10 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $this->assertArrayHasKey('id', $cache->data);
         $this->assertArrayHasKey('name', $cache->data);
         $this->assertArrayHasKey('country', $cache->data);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'id'        => 11,
             'name'      => 'Bar',
-            'country'   => new AssociationCacheEntry(Country::CLASSNAME, array('id' => 11)),
-        ), $cache->data);
+            'country'   => new AssociationCacheEntry(Country::CLASSNAME, ['id' => 11]),
+        ], $cache->data);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -78,7 +78,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testPutBasicQueryResult()
     {
-        $result   = array();
+        $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
@@ -91,7 +91,7 @@ class DefaultQueryCacheTest extends OrmTestCase
             $result[]   = $entity;
 
             $metadata->setFieldValue($entity, 'id', $i);
-            $this->em->getUnitOfWork()->registerManaged($entity, array('id' => $i), array('name' => $name));
+            $this->em->getUnitOfWork()->registerManaged($entity, ['id' => $i], ['name' => $name]);
         }
 
         $this->assertTrue($this->queryCache->put($key, $rsm, $result));
@@ -113,7 +113,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testPutToOneAssociationQueryResult()
     {
-        $result     = array();
+        $result     = [];
         $uow        = $this->em->getUnitOfWork();
         $key        = new QueryCacheKey('query.key1', 0);
         $rsm        = new ResultSetMappingBuilder($this->em);
@@ -121,7 +121,7 @@ class DefaultQueryCacheTest extends OrmTestCase
         $stateClass = $this->em->getClassMetadata(State::CLASSNAME);
 
         $rsm->addRootEntityFromClassMetadata(City::CLASSNAME, 'c');
-        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', array('id'=>'state_id', 'name'=>'state_name'));
+        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', ['id'=>'state_id', 'name'=>'state_name']);
 
         for ($i = 0; $i < 4; $i++) {
             $state    = new State("State $i");
@@ -131,8 +131,8 @@ class DefaultQueryCacheTest extends OrmTestCase
             $cityClass->setFieldValue($city, 'id', $i);
             $stateClass->setFieldValue($state, 'id', $i*2);
 
-            $uow->registerManaged($state, array('id' => $state->getId()), array('name' => $city->getName()));
-            $uow->registerManaged($city, array('id' => $city->getId()), array('name' => $city->getName(), 'state' => $state));
+            $uow->registerManaged($state, ['id' => $state->getId()], ['name' => $city->getName()]);
+            $uow->registerManaged($city, ['id' => $city->getId()], ['name' => $city->getName(), 'state' => $state]);
         }
 
         $this->assertTrue($this->queryCache->put($key, $rsm, $result));
@@ -152,14 +152,14 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testPutToOneAssociationNullQueryResult()
     {
-        $result     = array();
+        $result     = [];
         $uow        = $this->em->getUnitOfWork();
         $key        = new QueryCacheKey('query.key1', 0);
         $rsm        = new ResultSetMappingBuilder($this->em);
         $cityClass  = $this->em->getClassMetadata(City::CLASSNAME);
 
         $rsm->addRootEntityFromClassMetadata(City::CLASSNAME, 'c');
-        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', array('id'=>'state_id', 'name'=>'state_name'));
+        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', ['id'=>'state_id', 'name'=>'state_name']);
 
         for ($i = 0; $i < 4; $i++) {
             $city     = new City("City $i", null);
@@ -167,7 +167,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
             $cityClass->setFieldValue($city, 'id', $i);
 
-            $uow->registerManaged($city, array('id' => $city->getId()), array('name' => $city->getName(), 'state' => null));
+            $uow->registerManaged($city, ['id' => $city->getId()], ['name' => $city->getName(), 'state' => null]);
         }
 
         $this->assertTrue($this->queryCache->put($key, $rsm, $result));
@@ -183,7 +183,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testPutToManyAssociationQueryResult()
     {
-        $result     = array();
+        $result     = [];
         $uow        = $this->em->getUnitOfWork();
         $key        = new QueryCacheKey('query.key1', 0);
         $rsm        = new ResultSetMappingBuilder($this->em);
@@ -191,7 +191,7 @@ class DefaultQueryCacheTest extends OrmTestCase
         $stateClass = $this->em->getClassMetadata(State::CLASSNAME);
 
         $rsm->addRootEntityFromClassMetadata(State::CLASSNAME, 's');
-        $rsm->addJoinedEntityFromClassMetadata(City::CLASSNAME, 'c', 's', 'cities', array('id'=>'c_id', 'name'=>'c_name'));
+        $rsm->addJoinedEntityFromClassMetadata(City::CLASSNAME, 'c', 's', 'cities', ['id'=>'c_id', 'name'=>'c_name']);
 
         for ($i = 0; $i < 4; $i++) {
             $state    = new State("State $i");
@@ -206,9 +206,9 @@ class DefaultQueryCacheTest extends OrmTestCase
             $state->addCity($city1);
             $state->addCity($city2);
 
-            $uow->registerManaged($city1, array('id' => $city1->getId()), array('name' => $city1->getName(), 'state' => $state));
-            $uow->registerManaged($city2, array('id' => $city2->getId()), array('name' => $city2->getName(), 'state' => $state));
-            $uow->registerManaged($state, array('id' => $state->getId()), array('name' => $state->getName(), 'cities' => $state->getCities()));
+            $uow->registerManaged($city1, ['id' => $city1->getId()], ['name' => $city1->getName(), 'state' => $state]);
+            $uow->registerManaged($city2, ['id' => $city2->getId()], ['name' => $city2->getName(), 'state' => $state]);
+            $uow->registerManaged($state, ['id' => $state->getId()], ['name' => $state->getName(), 'cities' => $state->getCities()]);
         }
 
         $this->assertTrue($this->queryCache->put($key, $rsm, $result));
@@ -220,15 +220,15 @@ class DefaultQueryCacheTest extends OrmTestCase
     {
         $rsm   = new ResultSetMappingBuilder($this->em);
         $key   = new QueryCacheKey('query.key1', 0);
-        $entry = new QueryCacheEntry(array(
-            array('identifier' => array('id' => 1)),
-            array('identifier' => array('id' => 2))
-        ));
+        $entry = new QueryCacheEntry([
+            ['identifier' => ['id' => 1]],
+            ['identifier' => ['id' => 2]]
+        ]);
 
-        $data = array(
-            array('id'=>1, 'name' => 'Foo'),
-            array('id'=>2, 'name' => 'Bar')
-        );
+        $data = [
+            ['id'=>1, 'name' => 'Foo'],
+            ['id'=>2, 'name' => 'Bar']
+        ];
 
         $this->region->addReturn('get', $entry);
         $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[0]));
@@ -249,7 +249,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testCancelPutResultIfEntityPutFails()
     {
-        $result   = array();
+        $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
@@ -262,7 +262,7 @@ class DefaultQueryCacheTest extends OrmTestCase
             $result[]   = $entity;
 
             $metadata->setFieldValue($entity, 'id', $i);
-            $this->em->getUnitOfWork()->registerManaged($entity, array('id' => $i), array('name' => $name));
+            $this->em->getUnitOfWork()->registerManaged($entity, ['id' => $i], ['name' => $name]);
         }
 
         $this->region->addReturn('put', false);
@@ -274,7 +274,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testCancelPutResultIfAssociationEntityPutFails()
     {
-        $result     = array();
+        $result     = [];
         $uow        = $this->em->getUnitOfWork();
         $key        = new QueryCacheKey('query.key1', 0);
         $rsm        = new ResultSetMappingBuilder($this->em);
@@ -282,7 +282,7 @@ class DefaultQueryCacheTest extends OrmTestCase
         $stateClass = $this->em->getClassMetadata(State::CLASSNAME);
 
         $rsm->addRootEntityFromClassMetadata(City::CLASSNAME, 'c');
-        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', array('id'=>'state_id', 'name'=>'state_name'));
+        $rsm->addJoinedEntityFromClassMetadata(State::CLASSNAME, 's', 'c', 'state', ['id'=>'state_id', 'name'=>'state_name']);
 
         $state    = new State("State 1");
         $city     = new City("City 2", $state);
@@ -291,8 +291,8 @@ class DefaultQueryCacheTest extends OrmTestCase
         $cityClass->setFieldValue($city, 'id', 1);
         $stateClass->setFieldValue($state, 'id', 11);
 
-        $uow->registerManaged($state, array('id' => $state->getId()), array('name' => $city->getName()));
-        $uow->registerManaged($city, array('id' => $city->getId()), array('name' => $city->getName(), 'state' => $state));
+        $uow->registerManaged($state, ['id' => $state->getId()], ['name' => $city->getName()]);
+        $uow->registerManaged($city, ['id' => $city->getId()], ['name' => $city->getName(), 'state' => $state]);
 
         $this->region->addReturn('put', true);  // put root entity
         $this->region->addReturn('put', false); // association fails
@@ -302,7 +302,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testCancelPutToManyAssociationQueryResult()
     {
-        $result     = array();
+        $result     = [];
         $uow        = $this->em->getUnitOfWork();
         $key        = new QueryCacheKey('query.key1', 0);
         $rsm        = new ResultSetMappingBuilder($this->em);
@@ -310,7 +310,7 @@ class DefaultQueryCacheTest extends OrmTestCase
         $stateClass = $this->em->getClassMetadata(State::CLASSNAME);
 
         $rsm->addRootEntityFromClassMetadata(State::CLASSNAME, 's');
-        $rsm->addJoinedEntityFromClassMetadata(City::CLASSNAME, 'c', 's', 'cities', array('id'=>'c_id', 'name'=>'c_name'));
+        $rsm->addJoinedEntityFromClassMetadata(City::CLASSNAME, 'c', 's', 'cities', ['id'=>'c_id', 'name'=>'c_name']);
 
         $state    = new State("State");
         $city1    = new City("City 1", $state);
@@ -324,9 +324,9 @@ class DefaultQueryCacheTest extends OrmTestCase
         $state->addCity($city1);
         $state->addCity($city2);
 
-        $uow->registerManaged($city1, array('id' => $city1->getId()), array('name' => $city1->getName(), 'state' => $state));
-        $uow->registerManaged($city2, array('id' => $city2->getId()), array('name' => $city2->getName(), 'state' => $state));
-        $uow->registerManaged($state, array('id' => $state->getId()), array('name' => $state->getName(), 'cities' => $state->getCities()));
+        $uow->registerManaged($city1, ['id' => $city1->getId()], ['name' => $city1->getName(), 'state' => $state]);
+        $uow->registerManaged($city2, ['id' => $city2->getId()], ['name' => $city2->getName(), 'state' => $state]);
+        $uow->registerManaged($state, ['id' => $state->getId()], ['name' => $state->getName(), 'cities' => $state->getCities()]);
 
         $this->region->addReturn('put', true);  // put root entity
         $this->region->addReturn('put', false); // collection association fails
@@ -340,10 +340,10 @@ class DefaultQueryCacheTest extends OrmTestCase
     {
         $rsm   = new ResultSetMappingBuilder($this->em);
         $key   = new QueryCacheKey('query.key1', 0, Cache::MODE_PUT);
-        $entry = new QueryCacheEntry(array(
-            array('identifier' => array('id' => 1)),
-            array('identifier' => array('id' => 2))
-        ));
+        $entry = new QueryCacheEntry([
+            ['identifier' => ['id' => 1]],
+            ['identifier' => ['id' => 2]]
+        ]);
 
         $rsm->addRootEntityFromClassMetadata(Country::CLASSNAME, 'c');
 
@@ -354,7 +354,7 @@ class DefaultQueryCacheTest extends OrmTestCase
 
     public function testIgnoreCacheNonPutMode()
     {
-        $result   = array();
+        $result   = [];
         $rsm      = new ResultSetMappingBuilder($this->em);
         $metadata = $this->em->getClassMetadata(Country::CLASSNAME);
         $key      = new QueryCacheKey('query.key1', 0, Cache::MODE_GET);
@@ -367,7 +367,7 @@ class DefaultQueryCacheTest extends OrmTestCase
             $result[]   = $entity;
 
             $metadata->setFieldValue($entity, 'id', $i);
-            $this->em->getUnitOfWork()->registerManaged($entity, array('id' => $i), array('name' => $name));
+            $this->em->getUnitOfWork()->registerManaged($entity, ['id' => $i], ['name' => $name]);
         }
 
         $this->assertFalse($this->queryCache->put($key, $rsm, $result));
@@ -377,14 +377,14 @@ class DefaultQueryCacheTest extends OrmTestCase
     {
         $rsm   = new ResultSetMappingBuilder($this->em);
         $key   = new QueryCacheKey('query.key1', 50);
-        $entry = new QueryCacheEntry(array(
-            array('identifier' => array('id' => 1)),
-            array('identifier' => array('id' => 2))
-        ));
-        $entities = array(
-            array('id'=>1, 'name' => 'Foo'),
-            array('id'=>2, 'name' => 'Bar')
-        );
+        $entry = new QueryCacheEntry([
+            ['identifier' => ['id' => 1]],
+            ['identifier' => ['id' => 2]]
+        ]);
+        $entities = [
+            ['id'=>1, 'name' => 'Foo'],
+            ['id'=>2, 'name' => 'Bar']
+        ];
 
         $entry->time = time() - 100;
 
@@ -401,15 +401,15 @@ class DefaultQueryCacheTest extends OrmTestCase
     {
         $rsm   = new ResultSetMappingBuilder($this->em);
         $key   = new QueryCacheKey('query.key1', 0);
-        $entry = new \ArrayObject(array(
-            array('identifier' => array('id' => 1)),
-            array('identifier' => array('id' => 2))
-        ));
+        $entry = new \ArrayObject([
+            ['identifier' => ['id' => 1]],
+            ['identifier' => ['id' => 2]]
+        ]);
 
-        $data = array(
-            array('id'=>1, 'name' => 'Foo'),
-            array('id'=>2, 'name' => 'Bar')
-        );
+        $data = [
+            ['id'=>1, 'name' => 'Foo'],
+            ['id'=>2, 'name' => 'Bar']
+        ];
 
         $this->region->addReturn('get', $entry);
         $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[0]));
@@ -424,10 +424,10 @@ class DefaultQueryCacheTest extends OrmTestCase
     {
         $rsm   = new ResultSetMappingBuilder($this->em);
         $key   = new QueryCacheKey('query.key1', 0);
-        $entry = new QueryCacheEntry(array(
-            array('identifier' => array('id' => 1)),
-            array('identifier' => array('id' => 2))
-        ));
+        $entry = new QueryCacheEntry([
+            ['identifier' => ['id' => 1]],
+            ['identifier' => ['id' => 2]]
+        ]);
 
         $this->region->addReturn('get', $entry);
         $this->region->addReturn('get', null);
@@ -448,15 +448,15 @@ class DefaultQueryCacheTest extends OrmTestCase
         $rsm        = new ResultSetMappingBuilder($this->em);
         $cityClass  = $this->em->getClassMetadata(City::CLASSNAME);
         $city       = new City("City 1", null);
-        $result     = array(
+        $result     = [
             $city
-        );
+        ];
 
         $cityClass->setFieldValue($city, 'id', 1);
 
         $rsm->addRootEntityFromClassMetadata(City::CLASSNAME, 'c');
-        $rsm->addJoinedEntityFromClassMetadata(Travel::CLASSNAME, 't', 'c', 'travels', array('id' => 't_id'));
-        $uow->registerManaged($city, array('id' => $city->getId()), array('name' => $city->getName(), 'state' => null));
+        $rsm->addJoinedEntityFromClassMetadata(Travel::CLASSNAME, 't', 'c', 'travels', ['id' => 't_id']);
+        $uow->registerManaged($city, ['id' => $city->getId()], ['name' => $city->getName(), 'state' => null]);
 
         $this->queryCache->put($key, $rsm, $result);
     }
@@ -467,7 +467,7 @@ class DefaultQueryCacheTest extends OrmTestCase
      */
     public function testScalarResultException()
     {
-        $result   = array();
+        $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
 
@@ -482,7 +482,7 @@ class DefaultQueryCacheTest extends OrmTestCase
      */
     public function testSupportMultipleRootEntitiesException()
     {
-        $result   = array();
+        $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
 
@@ -498,7 +498,7 @@ class DefaultQueryCacheTest extends OrmTestCase
      */
     public function testNotCacheableEntityException()
     {
-        $result    = array();
+        $result    = [];
         $key       = new QueryCacheKey('query.key1', 0);
         $rsm       = new ResultSetMappingBuilder($this->em);
         $className = 'Doctrine\Tests\Models\Generic\BooleanModel';
@@ -513,7 +513,7 @@ class DefaultQueryCacheTest extends OrmTestCase
             $entity->booleanField   = $boolean;
             $result[]               = $entity;
 
-            $this->em->getUnitOfWork()->registerManaged($entity, array('id' => $i), array('booleanField' => $boolean));
+            $this->em->getUnitOfWork()->registerManaged($entity, ['id' => $i], ['booleanField' => $boolean]);
         }
 
         $this->assertFalse($this->queryCache->put($key, $rsm, $result));

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -30,7 +30,7 @@ class DefaultRegionTest extends AbstractRegionTest
         }
 
         $key     = new CacheKeyMock('key');
-        $entry   = new CacheEntryMock(array('value' => 'foo'));
+        $entry   = new CacheEntryMock(['value' => 'foo']);
         $region1 = new DefaultRegion('region1', new \Doctrine\Common\Cache\ApcCache());
         $region2 = new DefaultRegion('region2', new \Doctrine\Common\Cache\ApcCache());
 

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -67,7 +67,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testLockAndUnlock()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
 
         $this->assertFalse($this->region->contains($key));
@@ -91,7 +91,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testLockWithExistingLock()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
 
         $this->assertFalse($this->region->contains($key));
@@ -114,7 +114,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testUnlockWithExistingLock()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
 
         $this->assertFalse($this->region->contains($key));
@@ -143,7 +143,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testPutWithExistingLock()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
 
         $this->assertFalse($this->region->contains($key));
@@ -166,7 +166,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testLockedEvict()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
 
         $this->assertFalse($this->region->contains($key));
@@ -186,11 +186,11 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testLockedEvictAll()
     {
         $key1    = new CacheKeyMock('key1');
-        $entry1  = new CacheEntryMock(array('foo1' => 'bar1'));
+        $entry1  = new CacheEntryMock(['foo1' => 'bar1']);
         $file1   = $this->getFileName($this->region, $key1);
 
         $key2    = new CacheKeyMock('key2');
-        $entry2  = new CacheEntryMock(array('foo2' => 'bar2'));
+        $entry2  = new CacheEntryMock(['foo2' => 'bar2']);
         $file2   = $this->getFileName($this->region, $key2);
 
         $this->assertFalse($this->region->contains($key1));
@@ -222,7 +222,7 @@ class FileLockRegionTest extends AbstractRegionTest
     public function testLockLifetime()
     {
         $key    = new CacheKeyMock('key');
-        $entry  = new CacheEntryMock(array('foo' => 'bar'));
+        $entry  = new CacheEntryMock(['foo' => 'bar']);
         $file   = $this->getFileName($this->region, $key);
         $property = new \ReflectionProperty($this->region, 'lockLifetime');
 

--- a/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
@@ -22,10 +22,10 @@ class MultiGetRegionTest extends AbstractRegionTest
     public function testGetMulti()
     {
         $key1 = new CacheKeyMock('key.1');
-        $value1 = new CacheEntryMock(array('id'=>1, 'name' => 'bar'));
+        $value1 = new CacheEntryMock(['id'=>1, 'name' => 'bar']);
 
         $key2 = new CacheKeyMock('key.2');
-        $value2 = new CacheEntryMock(array('id'=>2, 'name' => 'bar'));
+        $value2 = new CacheEntryMock(['id'=>2, 'name' => 'bar']);
 
         $this->assertFalse($this->region->contains($key1));
         $this->assertFalse($this->region->contains($key2));
@@ -33,7 +33,7 @@ class MultiGetRegionTest extends AbstractRegionTest
         $this->region->put($key1, $value1);
         $this->region->put($key2, $value2);
 
-        $actual = $this->region->getMultiple(new CollectionCacheEntry(array($key1, $key2)));
+        $actual = $this->region->getMultiple(new CollectionCacheEntry([$key1, $key2]));
 
         $this->assertEquals($value1, $actual[0]);
         $this->assertEquals($value2, $actual[1]);

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -34,7 +34,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     /**
      * @var array
      */
-    protected $regionMockMethods = array(
+    protected $regionMockMethods = [
         'getName',
         'contains',
         'get',
@@ -42,12 +42,12 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         'put',
         'evict',
         'evictAll'
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $collectionPersisterMockMethods = array(
+    protected $collectionPersisterMockMethods = [
         'delete',
         'update',
         'count',
@@ -59,7 +59,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         'get',
         'getMultiple',
         'loadCriteria'
-    );
+    ];
 
     /**
      * @param \Doctrine\ORM\EntityManager                             $em
@@ -131,7 +131,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('delete')
@@ -148,7 +148,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
 
         $collection->setDirty(true);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('update')
@@ -163,7 +163,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('count')
@@ -180,7 +180,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $collection = $this->createCollection($entity);
         $slice      = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('slice')
@@ -197,7 +197,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('contains')
@@ -213,7 +213,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('containsKey')
@@ -230,7 +230,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('removeElement')
@@ -247,7 +247,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->collectionPersister->expects($this->once())
             ->method('get')

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister;
  */
 class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersisterTest
 {
-    protected $regionMockMethods = array(
+    protected $regionMockMethods = [
         'getName',
         'contains',
         'get',
@@ -25,7 +25,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         'evictAll',
         'lock',
         'unlock',
-    );
+    ];
 
     /**
      * {@inheritdoc}
@@ -49,14 +49,14 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($collection);
     }
@@ -67,14 +67,14 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($collection);
     }
@@ -85,7 +85,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
@@ -97,7 +97,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($collection);
         $persister->afterTransactionRolledBack();
@@ -109,7 +109,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
@@ -120,7 +120,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($collection);
         $persister->afterTransactionRolledBack();
@@ -132,7 +132,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -146,7 +146,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($collection);
 
@@ -163,7 +163,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -177,7 +177,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($collection);
 
@@ -194,7 +194,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -208,7 +208,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($collection);
 
@@ -225,7 +225,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $lock       = Lock::createLockRead();
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -239,7 +239,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($collection);
 
@@ -255,7 +255,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $entity     = new State("Foo");
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -269,7 +269,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('delete')
             ->with($this->equalTo($collection));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($collection);
         $this->assertCount(0, $property->getValue($persister));
@@ -280,7 +280,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
         $entity     = new State("Foo");
         $persister  = $this->createPersisterDefault();
         $collection = $this->createCollection($entity);
-        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>1));
+        $key        = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>1]);
         $property   = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Collection\ReadWriteCachedCollectionPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -294,7 +294,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
             ->method('update')
             ->with($this->equalTo($collection));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($collection);
         $this->assertCount(0, $property->getValue($persister));

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -37,7 +37,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     /**
      * @var array
      */
-    protected $regionMockMethods = array(
+    protected $regionMockMethods = [
         'getName',
         'contains',
         'get',
@@ -45,12 +45,12 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         'put',
         'evict',
         'evictAll'
-    );
+    ];
 
     /**
      * @var array
      */
-    protected $entityPersisterMockMethods = array(
+    protected $entityPersisterMockMethods = [
         'getClassMetadata',
         'getResultSetMapping',
         'getInserts',
@@ -78,7 +78,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         'lock',
         'getOneToManyCollection',
         'exists'
-    );
+    ];
 
     /**
      * @param \Doctrine\ORM\EntityManager                     $em
@@ -148,9 +148,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('getInserts')
-            ->will($this->returnValue(array($entity)));
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->getInserts());
+        $this->assertEquals([$entity], $persister->getInserts());
     }
 
     public function testInvokeGetSelectSQL()
@@ -159,10 +159,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('getSelectSQL')
-            ->with($this->equalTo(array('name'=>'Foo')), $this->equalTo(array(0)), $this->equalTo(1), $this->equalTo(2), $this->equalTo(3), $this->equalTo(array(4)))
+            ->with($this->equalTo(['name'=>'Foo']), $this->equalTo([0]), $this->equalTo(1), $this->equalTo(2), $this->equalTo(3), $this->equalTo([4]))
             ->will($this->returnValue('SELECT * FROM foo WERE name = ?'));
 
-        $this->assertEquals('SELECT * FROM foo WERE name = ?', $persister->getSelectSQL(array('name'=>'Foo'), array(0), 1, 2, 3, array(4)));
+        $this->assertEquals('SELECT * FROM foo WERE name = ?', $persister->getSelectSQL(['name'=>'Foo'], [0], 1, 2, 3, [4]));
     }
 
     public function testInvokeGetInsertSQL()
@@ -182,10 +182,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('expandParameters')
-            ->with($this->equalTo(array('name'=>'Foo')))
-            ->will($this->returnValue(array('name'=>'Foo')));
+            ->with($this->equalTo(['name'=>'Foo']))
+            ->will($this->returnValue(['name'=>'Foo']));
 
-        $this->assertEquals(array('name'=>'Foo'), $persister->expandParameters(array('name'=>'Foo')));
+        $this->assertEquals(['name'=>'Foo'], $persister->expandParameters(['name'=>'Foo']));
     }
 
     public function testInvokeExpandCriteriaParameters()
@@ -196,9 +196,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $this->entityPersister->expects($this->once())
             ->method('expandCriteriaParameters')
             ->with($this->equalTo($criteria))
-            ->will($this->returnValue(array('name'=>'Foo')));
+            ->will($this->returnValue(['name'=>'Foo']));
 
-        $this->assertEquals(array('name'=>'Foo'), $persister->expandCriteriaParameters($criteria));
+        $this->assertEquals(['name'=>'Foo'], $persister->expandCriteriaParameters($criteria));
     }
 
     public function testInvokeSelectConditionStatementSQL()
@@ -207,10 +207,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('getSelectConditionStatementSQL')
-            ->with($this->equalTo('id'), $this->equalTo(1), $this->equalTo(array()), $this->equalTo('='))
+            ->with($this->equalTo('id'), $this->equalTo(1), $this->equalTo([]), $this->equalTo('='))
             ->will($this->returnValue('name = 1'));
 
-        $this->assertEquals('name = 1', $persister->getSelectConditionStatementSQL('id', 1, array(), '='));
+        $this->assertEquals('name = 1', $persister->getSelectConditionStatementSQL('id', 1, [], '='));
     }
 
     public function testInvokeExecuteInserts()
@@ -219,9 +219,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('executeInserts')
-            ->will($this->returnValue(array('id' => 1)));
+            ->will($this->returnValue(['id' => 1]));
 
-        $this->assertEquals(array('id' => 1), $persister->executeInserts());
+        $this->assertEquals(['id' => 1], $persister->executeInserts());
     }
 
     public function testInvokeUpdate()
@@ -233,7 +233,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
             ->method('update')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->assertNull($persister->update($entity));
     }
@@ -247,7 +247,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
             ->method('delete')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->assertNull($persister->delete($entity));
     }
@@ -271,10 +271,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('load')
-            ->with($this->equalTo(array('id' => 1)), $this->equalTo($entity), $this->equalTo(array(0)), $this->equalTo(array(1)), $this->equalTo(2), $this->equalTo(3), $this->equalTo(array(4)))
+            ->with($this->equalTo(['id' => 1]), $this->equalTo($entity), $this->equalTo([0]), $this->equalTo([1]), $this->equalTo(2), $this->equalTo(3), $this->equalTo([4]))
             ->will($this->returnValue($entity));
 
-        $this->assertEquals($entity, $persister->load(array('id' => 1), $entity, array(0), array(1), 2, 3, array(4)));
+        $this->assertEquals($entity, $persister->load(['id' => 1], $entity, [0], [1], 2, 3, [4]));
     }
 
     public function testInvokeLoadAll()
@@ -285,18 +285,18 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $rsm->addEntityResult(Country::CLASSNAME, 'c');
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $this->entityPersister->expects($this->once())
             ->method('loadAll')
-            ->with($this->equalTo(array('id' => 1)), $this->equalTo(array(0)), $this->equalTo(1), $this->equalTo(2))
-            ->will($this->returnValue(array($entity)));
+            ->with($this->equalTo(['id' => 1]), $this->equalTo([0]), $this->equalTo(1), $this->equalTo(2))
+            ->will($this->returnValue([$entity]));
 
         $this->entityPersister->expects($this->once())
             ->method('getResultSetMapping')
             ->will($this->returnValue($rsm));
 
-        $this->assertEquals(array($entity), $persister->loadAll(array('id' => 1), array(0), 1, 2));
+        $this->assertEquals([$entity], $persister->loadAll(['id' => 1], [0], 1, 2));
     }
 
     public function testInvokeLoadById()
@@ -306,10 +306,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('loadById')
-            ->with($this->equalTo(array('id' => 1)), $this->equalTo($entity))
+            ->with($this->equalTo(['id' => 1]), $this->equalTo($entity))
             ->will($this->returnValue($entity));
 
-        $this->assertEquals($entity, $persister->loadById(array('id' => 1), $entity));
+        $this->assertEquals($entity, $persister->loadById(['id' => 1], $entity));
     }
 
     public function testInvokeLoadOneToOneEntity()
@@ -319,10 +319,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('loadOneToOneEntity')
-            ->with($this->equalTo(array()), $this->equalTo('foo'), $this->equalTo(array('id' => 11)))
+            ->with($this->equalTo([]), $this->equalTo('foo'), $this->equalTo(['id' => 11]))
             ->will($this->returnValue($entity));
 
-        $this->assertEquals($entity, $persister->loadOneToOneEntity(array(), 'foo', array('id' => 11)));
+        $this->assertEquals($entity, $persister->loadOneToOneEntity([], 'foo', ['id' => 11]));
     }
 
     public function testInvokeRefresh()
@@ -332,10 +332,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('refresh')
-            ->with($this->equalTo(array('id' => 1)), $this->equalTo($entity), $this->equalTo(0))
+            ->with($this->equalTo(['id' => 1]), $this->equalTo($entity), $this->equalTo(0))
             ->will($this->returnValue($entity));
 
-        $this->assertNull($persister->refresh(array('id' => 1), $entity), 0);
+        $this->assertNull($persister->refresh(['id' => 1], $entity), 0);
     }
 
     public function testInvokeLoadCriteria()
@@ -345,7 +345,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $entity    = new Country("Foo");
         $criteria  = new Criteria();
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
         $rsm->addEntityResult(Country::CLASSNAME, 'c');
 
         $this->entityPersister->expects($this->once())
@@ -355,9 +355,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $this->entityPersister->expects($this->once())
             ->method('loadCriteria')
             ->with($this->equalTo($criteria))
-            ->will($this->returnValue(array($entity)));
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->loadCriteria($criteria));
+        $this->assertEquals([$entity], $persister->loadCriteria($criteria));
     }
 
     public function testInvokeGetManyToManyCollection()
@@ -367,10 +367,10 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('getManyToManyCollection')
-            ->with($this->equalTo(array()), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
-            ->will($this->returnValue(array($entity)));
+            ->with($this->equalTo([]), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->getManyToManyCollection(array(), 'Foo', 1 ,2));
+        $this->assertEquals([$entity], $persister->getManyToManyCollection([], 'Foo', 1 ,2));
     }
 
     public function testInvokeGetOneToManyCollection()
@@ -380,16 +380,16 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->entityPersister->expects($this->once())
             ->method('getOneToManyCollection')
-            ->with($this->equalTo(array()), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
-            ->will($this->returnValue(array($entity)));
+            ->with($this->equalTo([]), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->getOneToManyCollection(array(), 'Foo', 1 ,2));
+        $this->assertEquals([$entity], $persister->getOneToManyCollection([], 'Foo', 1 ,2));
     }
 
     public function testInvokeLoadManyToManyCollection()
     {
         $mapping   = $this->em->getClassMetadata('Doctrine\Tests\Models\Cache\Country');
-        $assoc     = array('type' => 1);
+        $assoc     = ['type' => 1];
         $coll      = new PersistentCollection($this->em, 'Foo', $mapping);
         $persister = $this->createPersisterDefault();
         $entity    = new Country("Foo");
@@ -397,15 +397,15 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $this->entityPersister->expects($this->once())
             ->method('loadManyToManyCollection')
             ->with($this->equalTo($assoc), $this->equalTo('Foo'), $coll)
-            ->will($this->returnValue(array($entity)));
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->loadManyToManyCollection($assoc, 'Foo', $coll));
+        $this->assertEquals([$entity], $persister->loadManyToManyCollection($assoc, 'Foo', $coll));
     }
 
     public function testInvokeLoadOneToManyCollection()
     {
         $mapping   = $this->em->getClassMetadata('Doctrine\Tests\Models\Cache\Country');
-        $assoc     = array('type' => 1);
+        $assoc     = ['type' => 1];
         $coll      = new PersistentCollection($this->em, 'Foo', $mapping);
         $persister = $this->createPersisterDefault();
         $entity    = new Country("Foo");
@@ -413,14 +413,14 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
         $this->entityPersister->expects($this->once())
             ->method('loadOneToManyCollection')
             ->with($this->equalTo($assoc), $this->equalTo('Foo'), $coll)
-            ->will($this->returnValue(array($entity)));
+            ->will($this->returnValue([$entity]));
 
-        $this->assertEquals(array($entity), $persister->loadOneToManyCollection($assoc, 'Foo', $coll));
+        $this->assertEquals([$entity], $persister->loadOneToManyCollection($assoc, 'Foo', $coll));
     }
 
     public function testInvokeLock()
     {
-        $identifier = array('id' => 1);
+        $identifier = ['id' => 1];
         $persister  = $this->createPersisterDefault();
 
         $this->entityPersister->expects($this->once())

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -32,7 +32,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
 
         $property->setAccessible(true);
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
         $persister->delete($entity);
@@ -48,8 +48,8 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
+        $entry     = new EntityCacheEntry(Country::CLASSNAME, ['id'=>1, 'name'=>'Foo']);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -64,12 +64,12 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
 
         $this->entityPersister->expects($this->once())
             ->method('getInserts')
-            ->will($this->returnValue(array($entity)));
+            ->will($this->returnValue([$entity]));
 
         $this->entityPersister->expects($this->once())
             ->method('executeInserts');
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->addInsert($entity);
         $persister->executeInserts();
@@ -85,8 +85,8 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
+        $entry     = new EntityCacheEntry(Country::CLASSNAME, ['id'=>1, 'name'=>'Foo']);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -99,7 +99,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
             ->method('update')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
 
@@ -114,7 +114,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -127,7 +127,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
             ->method('delete')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($entity);
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister;
  */
 class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
 {
-    protected $regionMockMethods = array(
+    protected $regionMockMethods = [
         'getName',
         'contains',
         'get',
@@ -26,7 +26,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         'evictAll',
         'lock',
         'unlock',
-    );
+    ];
 
     /**
      * {@inheritdoc}
@@ -49,14 +49,14 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($entity);
     }
@@ -66,14 +66,14 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
     }
@@ -83,7 +83,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
@@ -95,7 +95,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->with($this->equalTo($key))
             ->will($this->returnValue($lock));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
         $persister->afterTransactionRolledBack();
@@ -106,7 +106,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
 
         $this->region->expects($this->once())
             ->method('lock')
@@ -117,7 +117,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($entity);
         $persister->afterTransactionRolledBack();
@@ -128,7 +128,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -142,7 +142,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
         $persister->delete($entity);
@@ -159,7 +159,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
         $entity    = new Country("Foo");
         $lock      = Lock::createLockRead();
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -173,7 +173,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->method('evict')
             ->with($this->equalTo($key));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
         $persister->delete($entity);
@@ -189,7 +189,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -203,7 +203,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->method('delete')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->delete($entity);
         $this->assertCount(0, $property->getValue($persister));
@@ -213,7 +213,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
+        $key       = new EntityCacheKey(Country::CLASSNAME, ['id'=>1]);
         $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
 
         $property->setAccessible(true);
@@ -227,7 +227,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
             ->method('update')
             ->with($this->equalTo($entity));
 
-        $this->em->getUnitOfWork()->registerManaged($entity, array('id'=>1), array('id'=>1, 'name'=>'Foo'));
+        $this->em->getUnitOfWork()->registerManaged($entity, ['id'=>1], ['id'=>1, 'name'=>'Foo']);
 
         $persister->update($entity);
         $this->assertCount(0, $property->getValue($persister));

--- a/tests/Doctrine/Tests/ORM/Cache/StatisticsCacheLoggerTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/StatisticsCacheLoggerTest.php
@@ -29,7 +29,7 @@ class StatisticsCacheLoggerTest extends DoctrineTestCase
     public function testEntityCache()
     {
         $name = 'my_entity_region';
-        $key  = new EntityCacheKey(State::CLASSNAME, array('id' => 1));
+        $key  = new EntityCacheKey(State::CLASSNAME, ['id' => 1]);
 
         $this->logger->entityCacheHit($name, $key);
         $this->logger->entityCachePut($name, $key);
@@ -46,7 +46,7 @@ class StatisticsCacheLoggerTest extends DoctrineTestCase
     public function testCollectionCache()
     {
         $name = 'my_collection_region';
-        $key  = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id' => 1));
+        $key  = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id' => 1]);
 
         $this->logger->collectionCacheHit($name, $key);
         $this->logger->collectionCachePut($name, $key);
@@ -83,8 +83,8 @@ class StatisticsCacheLoggerTest extends DoctrineTestCase
         $entityRegion = 'my_entity_region';
         $queryRegion  = 'my_query_region';
 
-        $coolKey    = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id' => 1));
-        $entityKey  = new EntityCacheKey(State::CLASSNAME, array('id' => 1));
+        $coolKey    = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id' => 1]);
+        $entityKey  = new EntityCacheKey(State::CLASSNAME, ['id' => 1]);
         $queryKey   = new QueryCacheKey('my_query_hash');
 
         $this->logger->queryCacheHit($queryRegion, $queryKey);

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -42,7 +42,7 @@ class CommitOrderCalculatorTest extends \Doctrine\Tests\OrmTestCase
         $sorted = $this->_calc->getCommitOrder();
 
         // There is only 1 valid ordering for this constellation
-        $correctOrder = array($class5, $class1, $class2, $class3, $class4);
+        $correctOrder = [$class5, $class1, $class2, $class3, $class4];
         $this->assertSame($correctOrder, $sorted);
     }
 }

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -68,7 +68,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 
     public function testNewDefaultAnnotationDriver()
     {
-        $paths = array(__DIR__);
+        $paths = [__DIR__];
         $reflectionClass = new ReflectionClass(__NAMESPACE__ . '\ConfigurationTestAnnotationReaderChecker');
 
         $annotationDriver = $this->configuration->newDefaultAnnotationDriver($paths, false);
@@ -92,7 +92,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     {
         $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__);
         $this->assertSame(__NAMESPACE__, $this->configuration->getEntityNamespace('TestNamespace'));
-        $namespaces = array('OtherNamespace' => __NAMESPACE__);
+        $namespaces = ['OtherNamespace' => __NAMESPACE__];
         $this->configuration->setEntityNamespaces($namespaces);
         $this->assertSame($namespaces, $this->configuration->getEntityNamespaces());
         $this->setExpectedException('Doctrine\ORM\ORMException');
@@ -233,7 +233,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->addCustomStringFunction('FunctionName', __CLASS__);
         $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomStringFunction('NonExistingFunction'));
-        $this->configuration->setCustomStringFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->configuration->setCustomStringFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomStringFunction('concat', __CLASS__);
@@ -244,7 +244,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->addCustomNumericFunction('FunctionName', __CLASS__);
         $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomNumericFunction('NonExistingFunction'));
-        $this->configuration->setCustomNumericFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->configuration->setCustomNumericFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomNumericFunction('abs', __CLASS__);
@@ -255,7 +255,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->configuration->addCustomDatetimeFunction('FunctionName', __CLASS__);
         $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('FunctionName'));
         $this->assertSame(null, $this->configuration->getCustomDatetimeFunction('NonExistingFunction'));
-        $this->configuration->setCustomDatetimeFunctions(array('OtherFunctionName' => __CLASS__));
+        $this->configuration->setCustomDatetimeFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('OtherFunctionName'));
         $this->setExpectedException('Doctrine\ORM\ORMException');
         $this->configuration->addCustomDatetimeFunction('date_add', __CLASS__);
@@ -274,9 +274,9 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertSame(__CLASS__, $this->configuration->getCustomHydrationMode('HydrationModeName'));
 
         $this->configuration->setCustomHydrationModes(
-            array(
+            [
                 'AnotherHydrationModeName' => __CLASS__
-            )
+            ]
         );
 
         $this->assertNull($this->configuration->getCustomHydrationMode('HydrationModeName'));

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -15,7 +15,7 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->wrapped = $this->getMock('Doctrine\ORM\EntityManagerInterface');
         $this->decorator = $this->getMockBuilder('Doctrine\ORM\Decorator\EntityManagerDecorator')
-            ->setConstructorArgs(array($this->wrapped))
+            ->setConstructorArgs([$this->wrapped])
             ->setMethods(null)
             ->getMock();
     }
@@ -24,7 +24,7 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $class = new \ReflectionClass('Doctrine\ORM\EntityManager');
 
-        $methods = array();
+        $methods = [];
         foreach ($class->getMethods() as $method) {
             if ($method->isConstructor() || $method->isStatic() || !$method->isPublic()) {
                 continue;
@@ -32,17 +32,17 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
 
             /** Special case EntityManager::createNativeQuery() */
             if ($method->getName() === 'createNativeQuery') {
-                $methods[] = array($method->getName(), array('name', new ResultSetMapping()));
+                $methods[] = [$method->getName(), ['name', new ResultSetMapping()]];
                 continue;
             }
 
             if ($method->getNumberOfRequiredParameters() === 0) {
-                $methods[] = array($method->getName(), array());
+                $methods[] = [$method->getName(), []];
             } elseif ($method->getNumberOfRequiredParameters() > 0) {
-                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: array());
+                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfRequiredParameters(), 'req') ?: []];
             }
             if ($method->getNumberOfParameters() != $method->getNumberOfRequiredParameters()) {
-                $methods[] = array($method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: array());
+                $methods[] = [$method->getName(), array_fill(0, $method->getNumberOfParameters(), 'all') ?: []];
             }
         }
 
@@ -59,8 +59,8 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
             ->method($method)
             ->will($this->returnValue('INNER VALUE FROM ' . $method));
 
-        call_user_func_array(array($stub, 'with'), $parameters);
+        call_user_func_array([$stub, 'with'], $parameters);
 
-        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array(array($this->decorator, $method), $parameters));
+        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array([$this->decorator, $method], $parameters));
     }
 }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -126,13 +126,13 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     static public function dataMethodsAffectedByNoObjectArguments()
     {
-        return array(
-            array('persist'),
-            array('remove'),
-            array('merge'),
-            array('refresh'),
-            array('detach')
-        );
+        return [
+            ['persist'],
+            ['remove'],
+            ['merge'],
+            ['refresh'],
+            ['detach']
+        ];
     }
 
     /**
@@ -146,13 +146,13 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     static public function dataAffectedByErrorIfClosedException()
     {
-        return array(
-            array('flush'),
-            array('persist'),
-            array('remove'),
-            array('merge'),
-            array('refresh'),
-        );
+        return [
+            ['flush'],
+            ['persist'],
+            ['remove'],
+            ['merge'],
+            ['refresh'],
+        ];
     }
 
     /**
@@ -181,7 +181,7 @@ class EntityManagerTest extends \Doctrine\Tests\OrmTestCase
 
     public function testTransactionalAcceptsVariousCallables()
     {
-        $this->assertSame('callback', $this->_em->transactional(array($this, 'transactionalCallback')));
+        $this->assertSame('callback', $this->_em->transactional([$this, 'transactionalCallback']));
     }
 
     public function testTransactionalThrowsInvalidArgumentExceptionIfNonCallablePassed()

--- a/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
@@ -16,7 +16,7 @@ class EntityNotFoundExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = EntityNotFoundException::fromClassNameAndIdentifier(
             'foo',
-            array('foo' => 'bar')
+            ['foo' => 'bar']
         );
 
         $this->assertInstanceOf('Doctrine\ORM\EntityNotFoundException', $exception);
@@ -24,7 +24,7 @@ class EntityNotFoundExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = EntityNotFoundException::fromClassNameAndIdentifier(
             'foo',
-            array()
+            []
         );
 
         $this->assertInstanceOf('Doctrine\ORM\EntityNotFoundException', $exception);

--- a/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php
@@ -30,7 +30,7 @@ class AbstractManyToManyAssociationTestCase extends \Doctrine\Tests\OrmFunctiona
               FROM {$this->_table}
              WHERE {$this->_firstField} = ?
                AND {$this->_secondField} = ?
-        ", array($firstId, $secondId))->fetchAll());
+        ", [$firstId, $secondId])->fetchAll());
     }
 
     public function assertCollectionEquals(Collection $first, Collection $second)

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -14,13 +14,13 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Phrase'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\PhraseType'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Definition'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Lemma'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Type')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -123,7 +123,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         // Check that the foreign key has been set
         $userId = $this->_em->getConnection()->executeQuery(
-            "SELECT user_id FROM cms_addresses WHERE id=?", array($address->id)
+            "SELECT user_id FROM cms_addresses WHERE id=?", [$address->id]
         )->fetchColumn();
         $this->assertTrue(is_numeric($userId));
 
@@ -1071,11 +1071,11 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($userB);
         $this->_em->persist($userC);
 
-        $this->_em->flush(array($userA, $userB, $userB));
+        $this->_em->flush([$userA, $userB, $userB]);
 
         $userC->name = 'changed name';
 
-        $this->_em->flush(array($userA, $userB));
+        $this->_em->flush([$userA, $userB]);
         $this->_em->refresh($userC);
 
         $this->assertTrue($userA->id > 0, 'user a has an id');

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -72,7 +72,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $guilherme = $this->_em->getRepository(get_class($employee))->findOneBy(array('name' => 'Guilherme Blanco'));
+        $guilherme = $this->_em->getRepository(get_class($employee))->findOneBy(['name' => 'Guilherme Blanco']);
         $this->assertInstanceOf('Doctrine\Tests\Models\Company\CompanyEmployee', $guilherme);
         $this->assertEquals('Guilherme Blanco', $guilherme->getName());
 
@@ -389,12 +389,12 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\Company\CompanyManager');
-        $pmanager = $repos->findOneBy(array('spouse' => $person->getId()));
+        $pmanager = $repos->findOneBy(['spouse' => $person->getId()]);
 
         $this->assertEquals($manager->getId(), $pmanager->getId());
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\Company\CompanyPerson');
-        $pmanager = $repos->findOneBy(array('spouse' => $person->getId()));
+        $pmanager = $repos->findOneBy(['spouse' => $person->getId()]);
 
         $this->assertEquals($manager->getId(), $pmanager->getId());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
@@ -12,12 +12,12 @@ class ClassTableInheritanceTest2 extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\CTIParent'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\CTIChild'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\CTIRelated'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\CTIRelated2')
-            ));
+            ]);
         } catch (\Exception $ignored) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -27,7 +27,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function putTripAroundEurope()
     {
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
 
         $tour = new NavTour("Trip around Europe");
         $tour->addPointOfInterest($poi);
@@ -43,7 +43,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->putGermanysBrandenburderTor();
 
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
 
         $this->assertInstanceOf('Doctrine\Tests\Models\Navigation\NavPointOfInterest', $poi);
         $this->assertEquals(100, $poi->getLat());
@@ -58,7 +58,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->putGermanysBrandenburderTor();
 
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
         $photo = new NavPhotos($poi, "asdf");
         $this->_em->persist($photo);
         $this->_em->flush();
@@ -74,7 +74,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->putGermanysBrandenburderTor();
 
-        $poi    = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi    = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
         $photo  = new NavPhotos($poi, "asdf");
         $this->_em->persist($photo);
         $this->_em->flush();
@@ -133,7 +133,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testSpecifyUnknownIdentifierPrimaryKeyFails()
     {
         $this->setExpectedException('Doctrine\ORM\ORMException', 'The identifier long is missing for a query of Doctrine\Tests\Models\Navigation\NavPointOfInterest');
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('key1' => 100));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['key1' => 100]);
     }
 
     /**
@@ -143,7 +143,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->putGermanysBrandenburderTor();
 
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
         $poi->addVisitor(new NavUser("test1"));
         $poi->addVisitor(new NavUser("test2"));
 
@@ -154,7 +154,7 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 100, 'long' => 200));
+        $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', ['lat' => 100, 'long' => 200]);
         $this->assertEquals(0, count($poi->getVisitors()));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -32,15 +32,15 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         $user = new \Doctrine\DBAL\Schema\Table("ddc2059_user");
         $user->addColumn('id', 'integer');
-        $user->setPrimaryKey(array('id'));
+        $user->setPrimaryKey(['id']);
         $project = new \Doctrine\DBAL\Schema\Table("ddc2059_project");
         $project->addColumn('id', 'integer');
         $project->addColumn('user_id', 'integer');
         $project->addColumn('user', 'string');
-        $project->setPrimaryKey(array('id'));
-        $project->addForeignKeyConstraint('ddc2059_user', array('user_id'), array('id'));
+        $project->setPrimaryKey(['id']);
+        $project->addForeignKeyConstraint('ddc2059_user', ['user_id'], ['id']);
 
-        $metadata = $this->convertToClassMetadata(array($project, $user), array());
+        $metadata = $this->convertToClassMetadata([$project, $user], []);
 
         $this->assertTrue(isset($metadata['Ddc2059Project']->fieldMappings['user']));
         $this->assertTrue(isset($metadata['Ddc2059Project']->associationMappings['user2']));
@@ -54,12 +54,12 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         $table = new \Doctrine\DBAL\Schema\Table("dbdriver_foo");
         $table->addColumn('id', 'integer');
-        $table->setPrimaryKey(array('id'));
-        $table->addColumn('bar', 'string', array('notnull' => false, 'length' => 200));
+        $table->setPrimaryKey(['id']);
+        $table->addColumn('bar', 'string', ['notnull' => false, 'length' => 200]);
 
         $this->_sm->dropAndCreateTable($table);
 
-        $metadatas = $this->extractClassMetadata(array("DbdriverFoo"));
+        $metadatas = $this->extractClassMetadata(["DbdriverFoo"]);
 
         $this->assertArrayHasKey('DbdriverFoo', $metadatas);
         $metadata = $metadatas['DbdriverFoo'];
@@ -85,19 +85,19 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         $tableB = new \Doctrine\DBAL\Schema\Table("dbdriver_bar");
         $tableB->addColumn('id', 'integer');
-        $tableB->setPrimaryKey(array('id'));
+        $tableB->setPrimaryKey(['id']);
 
         $this->_sm->dropAndCreateTable($tableB);
 
         $tableA = new \Doctrine\DBAL\Schema\Table("dbdriver_baz");
         $tableA->addColumn('id', 'integer');
-        $tableA->setPrimaryKey(array('id'));
+        $tableA->setPrimaryKey(['id']);
         $tableA->addColumn('bar_id', 'integer');
-        $tableA->addForeignKeyConstraint('dbdriver_bar', array('bar_id'), array('id'));
+        $tableA->addForeignKeyConstraint('dbdriver_bar', ['bar_id'], ['id']);
 
         $this->_sm->dropAndCreateTable($tableA);
 
-        $metadatas = $this->extractClassMetadata(array("DbdriverBar", "DbdriverBaz"));
+        $metadatas = $this->extractClassMetadata(["DbdriverBar", "DbdriverBaz"]);
 
         $this->assertArrayHasKey('DbdriverBaz', $metadatas);
         $bazMetadata = $metadatas['DbdriverBaz'];
@@ -117,7 +117,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
             $this->markTestSkipped('Platform does not support foreign keys.');
         }
 
-        $metadatas = $this->extractClassMetadata(array("CmsUsers", "CmsGroups"));
+        $metadatas = $this->extractClassMetadata(["CmsUsers", "CmsGroups"]);
 
         $this->assertArrayHasKey('CmsUsers', $metadatas, 'CmsUsers entity was not detected.');
         $this->assertArrayHasKey('CmsGroups', $metadatas, 'CmsGroups entity was not detected.');
@@ -132,18 +132,18 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
     {
         $tableB = new \Doctrine\DBAL\Schema\Table("dbdriver_bar");
         $tableB->addColumn('id', 'integer');
-        $tableB->setPrimaryKey(array('id'));
+        $tableB->setPrimaryKey(['id']);
 
         $tableA = new \Doctrine\DBAL\Schema\Table("dbdriver_baz");
         $tableA->addColumn('id', 'integer');
-        $tableA->setPrimaryKey(array('id'));
+        $tableA->setPrimaryKey(['id']);
 
         $tableMany = new \Doctrine\DBAL\Schema\Table("dbdriver_bar_baz");
         $tableMany->addColumn('bar_id', 'integer');
         $tableMany->addColumn('baz_id', 'integer');
-        $tableMany->addForeignKeyConstraint('dbdriver_bar', array('bar_id'), array('id'));
+        $tableMany->addForeignKeyConstraint('dbdriver_bar', ['bar_id'], ['id']);
 
-        $metadatas = $this->convertToClassMetadata(array($tableA, $tableB), array($tableMany));
+        $metadatas = $this->convertToClassMetadata([$tableA, $tableB], [$tableMany]);
 
         $this->assertEquals(0, count($metadatas['DbdriverBaz']->associationMappings), "no association mappings should be detected.");
     }
@@ -156,24 +156,24 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         $table = new \Doctrine\DBAL\Schema\Table("dbdriver_foo");
 
-        $table->addColumn('id', 'integer', array('unsigned' => true));
-        $table->setPrimaryKey(array('id'));
-        $table->addColumn('column_unsigned', 'integer', array('unsigned' => true));
-        $table->addColumn('column_comment', 'string', array('comment' => 'test_comment'));
-        $table->addColumn('column_default', 'string', array('default' => 'test_default'));
-        $table->addColumn('column_decimal', 'decimal', array('precision' => 4, 'scale' => 3));
+        $table->addColumn('id', 'integer', ['unsigned' => true]);
+        $table->setPrimaryKey(['id']);
+        $table->addColumn('column_unsigned', 'integer', ['unsigned' => true]);
+        $table->addColumn('column_comment', 'string', ['comment' => 'test_comment']);
+        $table->addColumn('column_default', 'string', ['default' => 'test_default']);
+        $table->addColumn('column_decimal', 'decimal', ['precision' => 4, 'scale' => 3]);
 
         $table->addColumn('column_index1', 'string');
         $table->addColumn('column_index2', 'string');
-        $table->addIndex(array('column_index1','column_index2'), 'index1');
+        $table->addIndex(['column_index1','column_index2'], 'index1');
 
         $table->addColumn('column_unique_index1', 'string');
         $table->addColumn('column_unique_index2', 'string');
-        $table->addUniqueIndex(array('column_unique_index1', 'column_unique_index2'), 'unique_index1');
+        $table->addUniqueIndex(['column_unique_index1', 'column_unique_index2'], 'unique_index1');
 
         $this->_sm->dropAndCreateTable($table);
 
-        $metadatas = $this->extractClassMetadata(array("DbdriverFoo"));
+        $metadatas = $this->extractClassMetadata(["DbdriverFoo"]);
 
         $this->assertArrayHasKey('DbdriverFoo', $metadatas);
 
@@ -204,13 +204,13 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         $this->assertTrue( ! empty($metadata->table['indexes']['index1']['columns']));
         $this->assertEquals(
-            array('column_index1','column_index2'),
+            ['column_index1','column_index2'],
             $metadata->table['indexes']['index1']['columns']
         );
 
         $this->assertTrue( ! empty($metadata->table['uniqueConstraints']['unique_index1']['columns']));
         $this->assertEquals(
-            array('column_unique_index1', 'column_unique_index2'),
+            ['column_unique_index1', 'column_unique_index2'],
             $metadata->table['uniqueConstraints']['unique_index1']['columns']
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -10,13 +10,13 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  */
 abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
 {
-    protected function convertToClassMetadata(array $entityTables, array $manyTables = array())
+    protected function convertToClassMetadata(array $entityTables, array $manyTables = [])
     {
         $sm = $this->_em->getConnection()->getSchemaManager();
         $driver = new \Doctrine\ORM\Mapping\Driver\DatabaseDriver($sm);
         $driver->setTables($entityTables, $manyTables);
 
-        $metadatas = array();
+        $metadatas = [];
         foreach ($driver->getAllClassNames() AS $className) {
             $class = new ClassMetadataInfo($className);
             $driver->loadMetadataForClass($className, $class);
@@ -33,7 +33,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
     protected function extractClassMetadata(array $classNames)
     {
         $classNames = array_map('strtolower', $classNames);
-        $metadatas = array();
+        $metadatas = [];
 
         $sm = $this->_em->getConnection()->getSchemaManager();
         $driver = new \Doctrine\ORM\Mapping\Driver\DatabaseDriver($sm);

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -12,10 +12,10 @@ class DefaultValuesTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\DefaultValueUser'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\DefaultValueAddress')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
@@ -30,7 +30,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $fix = new CompanyFixContract();
         $fix->setFixPrice(2000);
 
-        $this->listener->preFlushCalls  = array();
+        $this->listener->preFlushCalls  = [];
 
         $this->_em->persist($fix);
         $this->_em->flush();
@@ -59,7 +59,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->listener->postLoadCalls  = array();
+        $this->listener->postLoadCalls  = [];
 
         $dql = "SELECT f FROM Doctrine\Tests\Models\Company\CompanyFixContract f WHERE f.id = ?1";
         $fix = $this->_em->createQuery($dql)->setParameter(1, $fix->getId())->getSingleResult();
@@ -84,7 +84,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $fix = new CompanyFixContract();
         $fix->setFixPrice(2000);
 
-        $this->listener->prePersistCalls  = array();
+        $this->listener->prePersistCalls  = [];
 
         $this->_em->persist($fix);
         $this->_em->flush();
@@ -109,7 +109,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $fix = new CompanyFixContract();
         $fix->setFixPrice(2000);
 
-        $this->listener->postPersistCalls = array();
+        $this->listener->postPersistCalls = [];
 
         $this->_em->persist($fix);
         $this->_em->flush();
@@ -137,7 +137,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($fix);
         $this->_em->flush();
 
-        $this->listener->preUpdateCalls = array();
+        $this->listener->preUpdateCalls = [];
         
         $fix->setFixPrice(2000);
 
@@ -167,7 +167,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($fix);
         $this->_em->flush();
 
-        $this->listener->postUpdateCalls = array();
+        $this->listener->postUpdateCalls = [];
 
         $fix->setFixPrice(2000);
 
@@ -197,7 +197,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($fix);
         $this->_em->flush();
 
-        $this->listener->preRemoveCalls = array();
+        $this->listener->preRemoveCalls = [];
 
         $this->_em->remove($fix);
         $this->_em->flush();
@@ -225,7 +225,7 @@ class EntityListenersTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($fix);
         $this->_em->flush();
 
-        $this->listener->postRemoveCalls = array();
+        $this->listener->postRemoveCalls = [];
 
         $this->_em->remove($fix);
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
@@ -39,7 +39,7 @@ class EntityRepositoryCriteriaTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function tearDown()
     {
         if ($this->_em) {
-            $this->_em->getConfiguration()->setEntityNamespaces(array());
+            $this->_em->getConfiguration()->setEntityNamespaces([]);
         }
         parent::tearDown();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -22,7 +22,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function tearDown()
     {
         if ($this->_em) {
-            $this->_em->getConfiguration()->setEntityNamespaces(array());
+            $this->_em->getConfiguration()->setEntityNamespaces([]);
         }
         parent::tearDown();
     }
@@ -86,7 +86,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        return array($user->id, $address->id);
+        return [$user->id, $address->id];
     }
 
     public function loadFixtureUserEmail()
@@ -130,7 +130,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        return array($user1, $user2, $user3);
+        return [$user1, $user2, $user3];
     }
 
     public function buildUser($name, $username, $status, $address)
@@ -177,7 +177,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user1Id = $this->loadFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $users = $repos->findBy(array('status' => 'dev'));
+        $users = $repos->findBy(['status' => 'dev']);
         $this->assertEquals(2, count($users));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser',$users[0]);
         $this->assertEquals('Guilherme', $users[0]->name);
@@ -202,7 +202,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
-        $addresses  = $repository->findBy(array('user' => array($user1->getId(), $user2->getId())));
+        $addresses  = $repository->findBy(['user' => [$user1->getId(), $user2->getId()]]);
 
         $this->assertEquals(2, count($addresses));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress',$addresses[0]);
@@ -226,7 +226,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
-        $addresses  = $repository->findBy(array('user' => array($user1, $user2)));
+        $addresses  = $repository->findBy(['user' => [$user1, $user2]]);
 
         $this->assertEquals(2, count($addresses));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress',$addresses[0]);
@@ -372,7 +372,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
         $this->setExpectedException('Doctrine\ORM\ORMException', "You cannot search for the association field 'Doctrine\Tests\Models\CMS\CmsUser#address', because it is the inverse side of an association. Find methods only work on owning side associations.");
-        $user = $repos->findBy(array('address' => $addressId));
+        $user = $repos->findBy(['address' => $addressId]);
     }
 
     /**
@@ -382,7 +382,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         list($userId, $addressId) = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
-        $address = $repos->findOneBy(array('user' => $userId));
+        $address = $repos->findOneBy(['user' => $userId]);
 
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsAddress', $address);
         $this->assertEquals($addressId, $address->id);
@@ -396,8 +396,8 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     	$this->loadFixture();
 
     	$repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-    	$userAsc = $repos->findOneBy(array(), array("username" => "ASC"));
-    	$userDesc = $repos->findOneBy(array(), array("username" => "DESC"));
+    	$userAsc = $repos->findOneBy([], ["username" => "ASC"]);
+    	$userDesc = $repos->findOneBy([], ["username" => "DESC"]);
 
     	$this->assertNotSame($userAsc, $userDesc);
     }
@@ -409,7 +409,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         list($userId, $addressId) = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
-        $addresses = $repos->findBy(array('user' => $userId));
+        $addresses = $repos->findBy(['user' => $userId]);
 
         $this->assertContainsOnly('Doctrine\Tests\Models\CMS\CmsAddress', $addresses);
         $this->assertEquals(1, count($addresses));
@@ -468,11 +468,11 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIsNullCriteriaDoesNotGenerateAParameter()
     {
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $users = $repos->findBy(array('status' => null, 'username' => 'romanb'));
+        $users = $repos->findBy(['status' => null, 'username' => 'romanb']);
 
         $params = $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['params'];
         $this->assertEquals(1, count($params), "Should only execute with one parameter.");
-        $this->assertEquals(array('romanb'), $params);
+        $this->assertEquals(['romanb'], $params);
     }
 
     public function testIsNullCriteria()
@@ -481,7 +481,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $users = $repos->findBy(array('status' => null));
+        $users = $repos->findBy(['status' => null]);
         $this->assertEquals(1, count($users));
     }
 
@@ -494,10 +494,10 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $users1 = $repos->findBy(array(), null, 1, 0);
-        $users2 = $repos->findBy(array(), null, 1, 1);
+        $users1 = $repos->findBy([], null, 1, 0);
+        $users2 = $repos->findBy([], null, 1, 1);
 
-        $this->assertEquals(4, count($repos->findBy(array())));
+        $this->assertEquals(4, count($repos->findBy([])));
         $this->assertEquals(1, count($users1));
         $this->assertEquals(1, count($users2));
         $this->assertNotSame($users1[0], $users2[0]);
@@ -511,8 +511,8 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->loadFixture();
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $usersAsc = $repos->findBy(array(), array("username" => "ASC"));
-        $usersDesc = $repos->findBy(array(), array("username" => "DESC"));
+        $usersAsc = $repos->findBy([], ["username" => "ASC"]);
+        $usersDesc = $repos->findBy([], ["username" => "DESC"]);
 
         $this->assertEquals(4, count($usersAsc), "Pre-condition: only four users in fixture");
         $this->assertEquals(4, count($usersDesc), "Pre-condition: only four users in fixture");
@@ -528,8 +528,8 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->loadFixtureUserEmail();
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $resultAsc  = $repository->findBy(array(), array('email' => 'ASC'));
-        $resultDesc = $repository->findBy(array(), array('email' => 'DESC'));
+        $resultAsc  = $repository->findBy([], ['email' => 'ASC']);
+        $resultDesc = $repository->findBy([], ['email' => 'DESC']);
 
         $this->assertCount(3, $resultAsc);
         $this->assertCount(3, $resultDesc);
@@ -546,8 +546,8 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->loadFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $usersAsc = $repos->findByStatus('dev', array('username' => "ASC"));
-        $usersDesc = $repos->findByStatus('dev', array('username' => "DESC"));
+        $usersAsc = $repos->findByStatus('dev', ['username' => "ASC"]);
+        $usersDesc = $repos->findByStatus('dev', ['username' => "DESC"]);
 
         $this->assertEquals(2, count($usersAsc));
         $this->assertEquals(2, count($usersDesc));
@@ -568,8 +568,8 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->loadFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $users1 = $repos->findByStatus('dev', array(), 1, 0);
-        $users2 = $repos->findByStatus('dev', array(), 1, 1);
+        $users1 = $repos->findByStatus('dev', [], 1, 0);
+        $users2 = $repos->findByStatus('dev', [], 1, 1);
 
         $this->assertEquals(1, count($users1));
         $this->assertEquals(1, count($users2));
@@ -647,7 +647,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testInvalidOrderByAssociation()
     {
         $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
-            ->findBy(array('status' => 'test'), array('address' => 'ASC'));
+            ->findBy(['status' => 'test'], ['address' => 'ASC']);
     }
 
     /**
@@ -658,7 +658,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->setExpectedException('Doctrine\ORM\ORMException', 'Invalid order by orientation specified for Doctrine\Tests\Models\CMS\CmsUser#username');
 
         $repo = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $repo->findBy(array('status' => 'test'), array('username' => 'INVALID'));
+        $repo->findBy(['status' => 'test'], ['username' => 'INVALID']);
     }
 
     /**
@@ -667,10 +667,10 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testFindByAssociationArray()
     {
         $repo = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsArticle');
-        $data = $repo->findBy(array('user' => array(1, 2, 3)));
+        $data = $repo->findBy(['user' => [1, 2, 3]]);
 
         $query = array_pop($this->_sqlLoggerStack->queries);
-        $this->assertEquals(array(1,2,3), $query['params'][0]);
+        $this->assertEquals([1,2,3], $query['params'][0]);
         $this->assertEquals(\Doctrine\DBAL\Connection::PARAM_INT_ARRAY, $query['types'][0]);
     }
 
@@ -726,7 +726,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $users = $repository->matching(new Criteria(
-            Criteria::expr()->in('username', array('beberlei', 'gblanco'))
+            Criteria::expr()->in('username', ['beberlei', 'gblanco'])
         ));
 
         $this->assertEquals(2, count($users));
@@ -741,7 +741,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $users = $repository->matching(new Criteria(
-            Criteria::expr()->notIn('username', array('beberlei', 'gblanco', 'asm89'))
+            Criteria::expr()->notIn('username', ['beberlei', 'gblanco', 'asm89'])
         ));
 
         $this->assertEquals(1, count($users));
@@ -840,7 +840,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $userId);
 
         $criteria = new Criteria(
-            Criteria::expr()->in('user', array($user))
+            Criteria::expr()->in('user', [$user])
         );
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsAddress');
@@ -907,7 +907,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $rsm = $repository->createResultSetMappingBuilder('u');
 
         $this->assertInstanceOf('Doctrine\ORM\Query\ResultSetMappingBuilder', $rsm);
-        $this->assertEquals(array('u' => 'Doctrine\Tests\Models\CMS\CmsUser'), $rsm->aliasMap);
+        $this->assertEquals(['u' => 'Doctrine\Tests\Models\CMS\CmsUser'], $rsm->aliasMap);
     }
 
     /**
@@ -918,7 +918,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized field: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $repository->findBy(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test'));
+        $repository->findBy(['username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test']);
     }
 
     /**
@@ -929,7 +929,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized field: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $repository->findOneBy(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test'));
+        $repository->findOneBy(['username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test']);
     }
 
     /**
@@ -956,7 +956,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized identifier fields: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
-        $repository->find(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test', 'id' => 1));
+        $repository->find(['username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test', 'id' => 1]);
     }
 
     /**
@@ -978,7 +978,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user2);
         $this->_em->flush();
 
-        $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(array('status' => array(null)));
+        $users = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->findBy(['status' => [null]]);
 
         $this->assertCount(1, $users);
         $this->assertSame($user1, reset($users));
@@ -1006,7 +1006,7 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $this
             ->_em
             ->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
-            ->findBy(array('status' => array('foo', null)));
+            ->findBy(['status' => ['foo', null]]);
 
         $this->assertCount(1, $users);
         $this->assertSame($user1, reset($users));
@@ -1034,12 +1034,12 @@ class EntityRepositoryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $this
             ->_em
             ->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
-            ->findBy(array('status' => array('dbal maintainer', null)));
+            ->findBy(['status' => ['dbal maintainer', null]]);
 
         $this->assertCount(2, $users);
 
         foreach ($users as $user) {
-            $this->assertTrue(in_array($user, array($user1, $user2)));
+            $this->assertTrue(in_array($user, [$user1, $user2]));
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -1225,7 +1225,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        return array($user->id, $tweet->id);
+        return [$user->id, $tweet->id];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
@@ -80,7 +80,7 @@ class IdentityMapTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertSame($user1, $address->user);
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', array($user2->getId()));
+        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', [$user2->getId()]);
 
         // But we want to have this external change!
         // Solution 1: refresh(), broken atm!
@@ -123,7 +123,7 @@ class IdentityMapTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertSame($user1, $address->user);
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', array($user2->getId()));
+        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', [$user2->getId()]);
 
         //select
         $q = $this->_em->createQuery('select a, u from Doctrine\Tests\Models\CMS\CmsAddress a join a.user u');
@@ -179,7 +179,7 @@ class IdentityMapTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertFalse($user->getPhonenumbers()->isDirty());
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', array(999, $user->getId()));
+        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
 
         //select
         $q = $this->_em->createQuery('select u, p from Doctrine\Tests\Models\CMS\CmsUser u join u.phonenumbers p');
@@ -230,7 +230,7 @@ class IdentityMapTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(3, count($user->getPhonenumbers()));
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', array(999, $user->getId()));
+        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
 
         //select
         $q = $this->_em->createQuery('select u, p from Doctrine\Tests\Models\CMS\CmsUser u join u.phonenumbers p');
@@ -282,9 +282,9 @@ class IdentityMapTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // the object hash is not reused. This is not a memory leak!
         if (defined('HHVM_VERSION')) {
             $ed = $this->_em->getUnitOfWork()->getOriginalEntityData($user);
-            $ed['phonenumbers']->setOwner(null, array('inversedBy' => 1));
-            $ed['articles']->setOwner(null, array('inversedBy' => 1));
-            $ed['groups']->setOwner(null, array('inversedBy' => 1));
+            $ed['phonenumbers']->setOwner(null, ['inversedBy' => 1]);
+            $ed['articles']->setOwner(null, ['inversedBy' => 1]);
+            $ed['groups']->setOwner(null, ['inversedBy' => 1]);
         }
 
         $em->remove($user);

--- a/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
@@ -58,7 +58,7 @@ class JoinedTableCompositeKeyTest extends OrmFunctionalTestCase
     {
         return $this->_em->find(
             'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass',
-            array('keyPart1' => 'part-1', 'keyPart2' => 'part-2')
+            ['keyPart1' => 'part-1', 'keyPart2' => 'part-2']
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -9,12 +9,12 @@ class LifecycleCallbackTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\LifecycleCallbackEventArgEntity'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\LifecycleCallbackTestEntity'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\LifecycleCallbackTestUser'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\LifecycleCallbackCascader'),
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
@@ -264,13 +264,13 @@ DQL;
     public function testLifecycleCallbacksGetInherited()
     {
         $childMeta = $this->_em->getClassMetadata(__NAMESPACE__ . '\LifecycleCallbackChildEntity');
-        $this->assertEquals(array('prePersist' => array(0 => 'doStuff')), $childMeta->lifecycleCallbacks);
+        $this->assertEquals(['prePersist' => [0 => 'doStuff']], $childMeta->lifecycleCallbacks);
     }
 
     public function testLifecycleListener_ChangeUpdateChangeSet()
     {
         $listener = new LifecycleListenerPreUpdate;
-        $this->_em->getEventManager()->addEventListener(array('preUpdate'), $listener);
+        $this->_em->getEventManager()->addEventListener(['preUpdate'], $listener);
 
         $user = new LifecycleCallbackTestUser;
         $user->setName('Bob');
@@ -286,7 +286,7 @@ DQL;
         $this->_em->flush(); // preUpdate reverts Alice to Bob
         $this->_em->clear();
 
-        $this->_em->getEventManager()->removeEventListener(array('preUpdate'), $listener);
+        $this->_em->getEventManager()->removeEventListener(['preUpdate'], $listener);
 
         $bob = $this->_em->createQuery($dql)->getSingleResult();
 
@@ -511,7 +511,7 @@ class LifecycleCallbackEventArgEntity
     /** @Column() */
     public $value;
 
-    public $calls = array();
+    public $calls = [];
 
     /**
      * @PostPersist

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
@@ -24,11 +24,11 @@ class GearmanLockTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->useModelSet('cms');
         parent::setUp();
-        $this->tasks = array();
+        $this->tasks = [];
 
         $this->gearman = new \GearmanClient();
         $this->gearman->addServer();
-        $this->gearman->setCompleteCallback(array($this, "gearmanTaskCompleted"));
+        $this->gearman->setCompleteCallback([$this, "gearmanTaskCompleted"]);
 
         $article = new CmsArticle();
         $article->text = "my article";
@@ -79,7 +79,7 @@ class GearmanLockTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testDqlWithLock()
     {
-        $this->asyncDqlWithLock('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a', array(), LockMode::PESSIMISTIC_WRITE);
+        $this->asyncDqlWithLock('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a', [], LockMode::PESSIMISTIC_WRITE);
         $this->asyncFindWithLock('Doctrine\Tests\Models\CMS\CmsArticle', $this->articleId, LockMode::PESSIMISTIC_WRITE);
 
         $this->assertLockWorked();
@@ -141,37 +141,37 @@ class GearmanLockTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     protected function asyncFindWithLock($entityName, $entityId, $lockMode)
     {
-        $this->startJob('findWithLock', array(
+        $this->startJob('findWithLock', [
             'entityName' => $entityName,
             'entityId' => $entityId,
             'lockMode' => $lockMode,
-        ));
+        ]);
     }
 
     protected function asyncDqlWithLock($dql, $params, $lockMode)
     {
-        $this->startJob('dqlWithLock', array(
+        $this->startJob('dqlWithLock', [
             'dql' => $dql,
             'dqlParams' => $params,
             'lockMode' => $lockMode,
-        ));
+        ]);
     }
 
     protected function asyncLock($entityName, $entityId, $lockMode)
     {
-        $this->startJob('lock', array(
+        $this->startJob('lock', [
             'entityName' => $entityName,
             'entityId' => $entityId,
             'lockMode' => $lockMode,
-        ));
+        ]);
     }
 
     protected function startJob($fn, $fixture)
     {
-        $this->gearman->addTask($fn, serialize(array(
+        $this->gearman->addTask($fn, serialize([
             'conn' => $this->_em->getConnection()->getParams(),
             'fixture' => $fixture
-        )));
+        ]));
 
         $this->assertEquals(GEARMAN_SUCCESS, $this->gearman->returnCode());
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -12,9 +12,9 @@ class LockAgentWorker
 
         $worker = new \GearmanWorker();
         $worker->addServer();
-        $worker->addFunction("findWithLock", array($lockAgent, "findWithLock"));
-        $worker->addFunction("dqlWithLock", array($lockAgent, "dqlWithLock"));
-        $worker->addFunction('lock', array($lockAgent, 'lock'));
+        $worker->addFunction("findWithLock", [$lockAgent, "findWithLock"]);
+        $worker->addFunction("dqlWithLock", [$lockAgent, "dqlWithLock"]);
+        $worker->addFunction('lock', [$lockAgent, 'lock']);
 
         while($worker->work()) {
             if ($worker->returnCode() != GEARMAN_SUCCESS) {
@@ -93,7 +93,7 @@ class LockAgentWorker
         $config->setProxyNamespace('MyProject\Proxies');
         $config->setAutoGenerateProxyClasses(true);
 
-        $annotDriver = $config->newDefaultAnnotationDriver(array(__DIR__ . '/../../../Models/'), true);
+        $annotDriver = $config->newDefaultAnnotationDriver([__DIR__ . '/../../../Models/'], true);
         $config->setMetadataDriverImpl($annotDriver);
 
         $cache = new \Doctrine\Common\Cache\ArrayCache();

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -14,7 +14,7 @@ class LockTest extends \Doctrine\Tests\OrmFunctionalTestCase {
     protected function setUp() {
         $this->useModelSet('cms');
         parent::setUp();
-        $this->handles = array();
+        $this->handles = [];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -17,12 +17,12 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Locking\OptimisticJoinedParent'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Locking\OptimisticJoinedChild'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Locking\OptimisticStandard'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Locking\OptimisticTimestamp')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
@@ -54,7 +54,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // Manually update/increment the version so we can try and save the same
         // $test and make sure the exception is thrown saying the record was
         // changed or updated since you read it
-        $this->_conn->executeQuery('UPDATE optimistic_joined_parent SET version = ? WHERE id = ?', array(2, $test->id));
+        $this->_conn->executeQuery('UPDATE optimistic_joined_parent SET version = ? WHERE id = ?', [2, $test->id]);
 
         // Now lets change a property and try and save it again
         $test->whatever = 'ok';
@@ -89,7 +89,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // Manually update/increment the version so we can try and save the same
         // $test and make sure the exception is thrown saying the record was
         // changed or updated since you read it
-        $this->_conn->executeQuery('UPDATE optimistic_joined_parent SET version = ? WHERE id = ?', array(2, $test->id));
+        $this->_conn->executeQuery('UPDATE optimistic_joined_parent SET version = ? WHERE id = ?', [2, $test->id]);
 
         // Now lets change a property and try and save it again
         $test->name = 'WHATT???';
@@ -139,7 +139,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // Manually update/increment the version so we can try and save the same
         // $test and make sure the exception is thrown saying the record was
         // changed or updated since you read it
-        $this->_conn->executeQuery('UPDATE optimistic_standard SET version = ? WHERE id = ?', array(2, $test->id));
+        $this->_conn->executeQuery('UPDATE optimistic_standard SET version = ? WHERE id = ?', [2, $test->id]);
 
         // Now lets change a property and try and save it again
         $test->name = 'WHATT???';
@@ -191,7 +191,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         // Manually increment the version datetime column
         $format = $this->_em->getConnection()->getDatabasePlatform()->getDateTimeFormatString();
-        $this->_conn->executeQuery('UPDATE optimistic_timestamp SET version = ? WHERE id = ?', array(date($format, strtotime($test->version->format($format)) + 3600), $test->id));
+        $this->_conn->executeQuery('UPDATE optimistic_timestamp SET version = ? WHERE id = ?', [date($format, strtotime($test->version->format($format)) + 3600), $test->id]);
 
         // Try and update the record and it should throw an exception
         $caughtException = null;

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -327,7 +327,7 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
 
         $user = $this->_em->find(get_class($user), $user->id);
 
-        $coll = new ArrayCollection(array($group1, $group2));
+        $coll = new ArrayCollection([$group1, $group2]);
         $user->groups = $coll;
         $this->_em->flush();
         $this->assertInstanceOf('Doctrine\ORM\PersistentCollection', $user->groups,

--- a/tests/Doctrine/Tests/ORM/Functional/MergeCompositeToOneKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeCompositeToOneKeyTest.php
@@ -14,10 +14,10 @@ class MergeCompositeToOneKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(Country::CLASSNAME),
             $this->_em->getClassMetadata(CompositeToOneKeyState::CLASSNAME),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -241,7 +241,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         $config->setProxyDir(realpath(__DIR__ . '/../../Proxies'));
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
-            array(realpath(__DIR__ . '/../../Models/Cache')),
+            [realpath(__DIR__ . '/../../Models/Cache')],
             true
         ));
         $config->setSQLLogger($logger);
@@ -250,10 +250,10 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         // multi-connection is not relevant for the purpose of checking locking here, but merely
         // to stub out DB-level access and intercept it
         $connection = DriverManager::getConnection(
-            array(
+            [
                 'driver' => 'pdo_sqlite',
                 'memory' => true
-            ),
+            ],
             $config
         );
 

--- a/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
@@ -32,10 +32,10 @@ class MergeSharedEntitiesTest extends OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\MSEFile'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\MSEPicture'),
-            ));
+            ]);
         } catch (ToolsException $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -281,7 +281,7 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u');
-        $rsm->addJoinedEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', 'a', 'u', 'address', array('id' => 'a_id'));
+        $rsm->addJoinedEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', 'a', 'u', 'address', ['id' => 'a_id']);
 
         $query = $this->_em->createNativeQuery('SELECT u.*, a.*, a.id AS a_id FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
         $query->setParameter(1, 'romanb');
@@ -347,7 +347,7 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u');
-        $rsm->addJoinedEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', 'a', 'un', 'address', array('id' => 'a_id'));
+        $rsm->addJoinedEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', 'a', 'un', 'address', ['id' => 'a_id']);
 
         $query = $this->_em->createNativeQuery('SELECT u.*, a.*, a.id AS a_id FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
         $query->setParameter(1, 'romanb');
@@ -557,7 +557,7 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
         $result = $repository->createNativeNamedQuery('fetchUserPhonenumberCount')
-                        ->setParameter(1, array('test','FabioBatSilva'))->getResult();
+                        ->setParameter(1, ['test','FabioBatSilva'])->getResult();
 
         $this->assertEquals(2, count($result));
         $this->assertTrue(is_array($result[0]));
@@ -745,10 +745,10 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testGenerateSelectClauseCustomRenames()
     {
         $rsm = new ResultSetMappingBuilder($this->_em);
-        $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u', array(
+        $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u', [
             'id' => 'id1',
             'username' => 'username2'
-        ));
+        ]);
 
         $selectClause = $rsm->generateSelectClause();
 
@@ -763,7 +763,7 @@ class NativeQueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\CMS\CmsUser', 'u');
 
-        $selectClause = $rsm->generateSelectClause(array('u' => 'u1'));
+        $selectClause = $rsm->generateSelectClause(['u' => 'u1']);
 
         $this->assertSQLEquals('u1.id AS id, u1.status AS status, u1.username AS username, u1.name AS name, u1.email_id AS email_id', $selectClause);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -28,10 +28,10 @@ class NewOperatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
     
     public function provideDataForHydrationMode()
     {
-        return array(
-            array(Query::HYDRATE_ARRAY),
-            array(Query::HYDRATE_OBJECT),
-        );
+        return [
+            [Query::HYDRATE_ARRAY],
+            [Query::HYDRATE_OBJECT],
+        ];
     }
 
     private function loadFixtures()
@@ -92,7 +92,7 @@ class NewOperatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->fixtures = array($u1, $u2, $u3);
+        $this->fixtures = [$u1, $u2, $u3];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
@@ -15,10 +15,10 @@ class NotifyPolicyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\NotifyUser'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\NotifyGroup')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
@@ -88,7 +88,7 @@ class NotifyPolicyTest extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 class NotifyBaseEntity implements NotifyPropertyChanged {
-    public $listeners = array();
+    public $listeners = [];
 
     public function addPropertyChangedListener(PropertyChangedListener $listener) {
         $this->listeners[] = $listener;

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -231,7 +231,7 @@ class OneToManyBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
     public function assertFeatureForeignKeyIs($value, ECommerceFeature $feature) {
         $foreignKey = $this->_em->getConnection()->executeQuery(
             'SELECT product_id FROM ecommerce_features WHERE id=?',
-            array($feature->getId())
+            [$feature->getId()]
         )->fetchColumn();
         $this->assertEquals($value, $foreignKey);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -115,7 +115,7 @@ class OneToManySelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunctio
     }
 
     public function assertForeignKeyIs($value, ECommerceCategory $child) {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT parent_id FROM ecommerce_categories WHERE id=?', array($child->getId()))->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT parent_id FROM ecommerce_categories WHERE id=?', [$child->getId()])->fetchColumn();
         $this->assertEquals($value, $foreignKey);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
@@ -11,14 +11,14 @@ use Doctrine\Tests\Models\Routing\RoutingLeg;
  */
 class OneToManyUnidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected $locations = array();
+    protected $locations = [];
 
     public function setUp()
     {
         $this->useModelSet('routing');
         parent::setUp();
 
-        $locations = array("Berlin", "Bonn", "Brasilia", "Atlanta");
+        $locations = ["Berlin", "Bonn", "Brasilia", "Atlanta"];
 
         foreach ($locations AS $locationName) {
             $location = new RoutingLocation();

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -143,7 +143,7 @@ class OneToOneBidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctional
     }
 
     public function assertCartForeignKeyIs($value) {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT customer_id FROM ecommerce_carts WHERE id=?', array($this->cart->getId()))->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT customer_id FROM ecommerce_carts WHERE id=?', [$this->cart->getId()])->fetchColumn();
         $this->assertEquals($value, $foreignKey);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -12,13 +12,13 @@ class OneToOneEagerLoadingTest extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
         try {
-            $schemaTool->createSchema(array(
+            $schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Train'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\TrainDriver'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\TrainOwner'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Waggon'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\TrainOrder'),
-            ));
+            ]);
         } catch(\Exception $e) {}
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -85,9 +85,9 @@ class OneToOneSelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunction
     public function testMultiSelfReference()
     {
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\MultiSelfReference')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
@@ -117,7 +117,7 @@ class OneToOneSelfReferentialAssociationTest extends \Doctrine\Tests\OrmFunction
     }
 
     public function assertForeignKeyIs($value) {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT mentor_id FROM ecommerce_customers WHERE id=?', array($this->customer->getId()))->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT mentor_id FROM ecommerce_customers WHERE id=?', [$this->customer->getId()])->fetchColumn();
         $this->assertEquals($value, $foreignKey);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -100,7 +100,7 @@ class OneToOneUnidirectionalAssociationTest extends \Doctrine\Tests\OrmFunctiona
     public function assertForeignKeyIs($value) {
         $foreignKey = $this->_em->getConnection()->executeQuery(
             'SELECT shipping_id FROM ecommerce_products WHERE id=?',
-            array($this->product->getId())
+            [$this->product->getId()]
         )->fetchColumn();
         $this->assertEquals($value, $foreignKey);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
@@ -9,14 +9,14 @@ use Doctrine\Tests\Models\Routing\RoutingRouteBooking;
 
 class OrderedCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected $locations = array();
+    protected $locations = [];
 
     public function setUp()
     {
         $this->useModelSet('routing');
         parent::setUp();
 
-        $locations = array("Berlin", "Bonn", "Brasilia", "Atlanta");
+        $locations = ["Berlin", "Bonn", "Brasilia", "Atlanta"];
 
         foreach ($locations AS $locationName) {
             $location = new RoutingLocation();

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -14,11 +14,11 @@ class OrderedJoinedTableInheritanceCollectionTest extends \Doctrine\Tests\OrmFun
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\OJTIC_Pet'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\OJTIC_Cat'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\OJTIC_Dog'),
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -144,7 +144,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $query = $this->_em->createQuery($dql);
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomPaginationTestTreeWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\Tests\ORM\Functional\CustomPaginationTestTreeWalker']);
 
         $paginator = new Paginator($query, true);
         $paginator->setUseOutputWalkers(false);
@@ -203,10 +203,10 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function useOutputWalkers()
     {
-        return array(
-            array(true),
-            array(false),
-        );
+        return [
+            [true],
+            [false],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
@@ -39,7 +39,7 @@ class PersistentCollectionCriteriaTest extends \Doctrine\Tests\OrmFunctionalTest
     public function tearDown()
     {
         if ($this->_em) {
-            $this->_em->getConfiguration()->setEntityNamespaces(array());
+            $this->_em->getConfiguration()->setEntityNamespaces([]);
         }
         parent::tearDown();
     }
@@ -90,7 +90,7 @@ class PersistentCollectionCriteriaTest extends \Doctrine\Tests\OrmFunctionalTest
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\Tweet\User');
 
-        $user   = $repository->findOneBy(array('name' => 'ngal'));
+        $user   = $repository->findOneBy(['name' => 'ngal']);
         $tweets = $user->tweets->matching(new Criteria());
 
         $this->assertInstanceOf('Doctrine\ORM\LazyCriteriaCollection', $tweets);

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
@@ -13,10 +13,10 @@ class PersistentCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\PersistentCollectionHolder'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\PersistentCollectionContent'),
-            ));
+            ]);
         } catch (\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
@@ -16,9 +16,9 @@ class PersistentObjectTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\PersistentEntity'),
-            ));
+            ]);
         } catch (\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -45,7 +45,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
     }
@@ -62,7 +62,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $query = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :id');
 
@@ -82,7 +82,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $query = $this->_em->createQuery('SELECT u, e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e WHERE u.id = :id');
 
@@ -102,7 +102,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $query = $this->_em->createQuery('SELECT u, p FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.phonenumbers p WHERE u.id = :id');
 
@@ -122,12 +122,12 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
             ->method('postLoad')
             ->will($this->returnValue(true));
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $userProxy = $this->_em->getReference('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
 
         // Now deactivate original listener and attach new one
-        $eventManager->removeEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->removeEventListener([Events::postLoad], $mockListener);
 
         $mockListener2 = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
 
@@ -136,7 +136,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
             ->method('postLoad')
             ->will($this->returnValue(true));
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener2);
+        $eventManager->addEventListener([Events::postLoad], $mockListener2);
 
         $userProxy->getName();
     }
@@ -154,7 +154,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
             ->method('postLoad')
             ->will($this->returnValue(true));
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $query = $this->_em->createQuery('SELECT PARTIAL u.{id, name}, p FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.phonenumbers p WHERE u.id = :id');
 
@@ -176,7 +176,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $emailProxy = $user->getEmail();
 
@@ -197,7 +197,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $eventManager = $this->_em->getEventManager();
 
-        $eventManager->addEventListener(array(Events::postLoad), $mockListener);
+        $eventManager->addEventListener([Events::postLoad], $mockListener);
 
         $phonenumbersCol = $user->getPhonenumbers();
 
@@ -210,7 +210,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testAssociationsArePopulatedWhenEventIsFired()
     {
         $checkerListener = new PostLoadListenerCheckAssociationsArePopulated();
-        $this->_em->getEventManager()->addEventListener(array(Events::postLoad), $checkerListener);
+        $this->_em->getEventManager()->addEventListener([Events::postLoad], $checkerListener);
 
         $qb = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')->createQueryBuilder('u');
         $qb->leftJoin('u.email', 'email');
@@ -228,7 +228,7 @@ class PostLoadEventTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $eventManager = $this->_em->getEventManager();
         $listener = new PostLoadListenerLoadEntityInEventHandler();
-        $eventManager->addEventListener(array(Events::postLoad), $listener);
+        $eventManager->addEventListener([Events::postLoad], $listener);
 
         $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
         $this->assertSame(1, $listener->countHandledEvents('Doctrine\Tests\Models\CMS\CmsUser'), 'Doctrine\Tests\Models\CMS\CmsUser should be handled once!');
@@ -302,7 +302,7 @@ class PostLoadListenerCheckAssociationsArePopulated
 
 class PostLoadListenerLoadEntityInEventHandler
 {
-    private $firedByClasses = array();
+    private $firedByClasses = [];
 
     public function postLoad(LifecycleEventArgs $event)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -24,14 +24,14 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
-            ));
+            ]);
         } catch (\Exception $e) {
         }
         $this->user = new CmsUser();
@@ -48,7 +48,7 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testPersistUpdate()
     {
         // Considering case (a)
-        $proxy = $this->_em->getProxyFactory()->getProxy('Doctrine\Tests\Models\CMS\CmsUser', array('id' => 123));
+        $proxy = $this->_em->getProxyFactory()->getProxy('Doctrine\Tests\Models\CMS\CmsUser', ['id' => 123]);
         $proxy->__isInitialized__ = true;
         $proxy->id = null;
         $proxy->username = 'ocra';
@@ -87,7 +87,7 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testProxyAsDqlParameterPersist()
     {
-        $proxy = $this->_em->getProxyFactory()->getProxy('Doctrine\Tests\Models\CMS\CmsUser', array('id' => $this->user->getId()));
+        $proxy = $this->_em->getProxyFactory()->getProxy('Doctrine\Tests\Models\CMS\CmsUser', ['id' => $this->user->getId()]);
         $proxy->id = $this->user->getId();
         $result = $this
             ->_em
@@ -117,7 +117,7 @@ class ProxiesLikeEntitiesTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $this
             ->_em
             ->getRepository('Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser')
-            ->findOneBy(array('username' => $this->user->username));
+            ->findOneBy(['username' => $this->user->username]);
         $this->assertSame($this->user->getId(), $result->getId());
         $this->_em->clear();
         $result = $this

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -123,7 +123,7 @@ class QueryCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $sqlExecMock = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', array('execute'));
+        $sqlExecMock = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', ['execute']);
         $sqlExecMock->expects($this->once())
                     ->method('execute')
                     ->will($this->returnValue( 10 ));
@@ -134,7 +134,7 @@ class QueryCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
                          ->will($this->returnValue($sqlExecMock));
 
         $cache = $this->getMock('Doctrine\Common\Cache\CacheProvider',
-                array('doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats'));
+                ['doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats']);
         $cache->expects($this->at(0))->method('doFetch')->will($this->returnValue(1));
         $cache->expects($this->at(1))
               ->method('doFetch')

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -177,7 +177,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testSetParametersBackwardsCompatible()
     {
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1 AND u.status = ?2');
-        $q->setParameters(array(1 => 'jwage', 2 => 'active'));
+        $q->setParameters([1 => 'jwage', 2 => 'active']);
         
         $users = $q->getResult();
     }
@@ -203,16 +203,16 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $articleId = $article1->id;
 
         $query = $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a WHERE a.topic = ?1");
-        $articles = $query->iterate(new ArrayCollection(array(new Parameter(1, 'Doctrine 2'))), Query::HYDRATE_ARRAY);
+        $articles = $query->iterate(new ArrayCollection([new Parameter(1, 'Doctrine 2')]), Query::HYDRATE_ARRAY);
 
-        $found = array();
+        $found = [];
         foreach ($articles AS $article) {
             $found[] = $article;
         }
         $this->assertEquals(1, count($found));
-        $this->assertEquals(array(
-            array(array('id' => $articleId, 'topic' => 'Doctrine 2', 'text' => 'This is an introduction to Doctrine 2.', 'version' => 1))
-        ), $found);
+        $this->assertEquals([
+            [['id' => $articleId, 'topic' => 'Doctrine 2', 'text' => 'This is an introduction to Doctrine 2.', 'version' => 1]]
+        ], $found);
     }
 
     public function testIterateResult_IterativelyBuildUpUnitOfWork()
@@ -235,7 +235,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $articles = $query->iterate();
 
         $iteratedCount = 0;
-        $topics = array();
+        $topics = [];
         foreach($articles AS $row) {
             $article = $row[0];
             $topics[] = $article->topic;
@@ -247,7 +247,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $iteratedCount++;
         }
 
-        $this->assertEquals(array("Doctrine 2", "Symfony 2"), $topics);
+        $this->assertEquals(["Doctrine 2", "Symfony 2"], $topics);
         $this->assertEquals(2, $iteratedCount);
 
         $this->_em->flush();
@@ -274,7 +274,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $articles = $query->iterate();
 
         $iteratedCount = 0;
-        $topics = array();
+        $topics = [];
         foreach($articles AS $row) {
             $article  = $row[0];
             $topics[] = $article->topic;
@@ -284,7 +284,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $iteratedCount++;
         }
 
-        $this->assertEquals(array("Doctrine 2", "Symfony 2"), $topics);
+        $this->assertEquals(["Doctrine 2", "Symfony 2"], $topics);
         $this->assertEquals(2, $iteratedCount);
 
         $this->_em->flush();
@@ -397,7 +397,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->fail($e->getMessage());
         }
 
-        $this->_em->getConfiguration()->setEntityNamespaces(array());
+        $this->_em->getConfiguration()->setEntityNamespaces([]);
     }
 
     /**
@@ -547,10 +547,10 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.status = :a AND u.id IN (:b)");
-        $query->setParameters(new ArrayCollection(array(
-            new Parameter('b', array($user1->id, $user2->id, $user3->id)),
+        $query->setParameters(new ArrayCollection([
+            new Parameter('b', [$user1->id, $user2->id, $user3->id]),
             new Parameter('a', 'developer')
-        )));
+        ]));
         $result = $query->getResult();
 
         $this->assertEquals(3, count($result));
@@ -580,7 +580,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username IN (?0)");
-        $query->setParameter(0, array('beberlei', 'jwage'));
+        $query->setParameter(0, ['beberlei', 'jwage']);
 
         $users = $query->execute();
 
@@ -625,7 +625,7 @@ class QueryTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u IN (?0) OR u.username = ?1");
-        $query->setParameter(0, array($userA, $userC));
+        $query->setParameter(0, [$userA, $userC]);
         $query->setParameter(1, 'beberlei');
 
         $users = $query->execute();

--- a/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
@@ -14,9 +14,9 @@ class ReadOnlyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\ReadOnlyEntity'),
-            ));
+            ]);
         } catch(\Exception $e) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -55,7 +55,7 @@ class ReferenceProxyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        $productProxy = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct', array('id' => $id));
+        $productProxy = $this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceProduct', ['id' => $id]);
         $this->assertEquals('Doctrine Cookbook', $productProxy->getName());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -93,7 +93,7 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $em = $this->_getEntityManager();
 
         // No enabled filters
-        $this->assertEquals(array(), $em->getFilters()->getEnabledFilters());
+        $this->assertEquals([], $em->getFilters()->getEnabledFilters());
 
         $this->configureFilters($em);
         $filter = $em->getFilters()->enable("locale");
@@ -323,10 +323,10 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $filter2->setParameter('foo', 'bar', DBALType::STRING);
         $filter2->setParameter('locale', 'en', DBALType::STRING);
 
-        $parameters = array(
-            'foo' => array('value' => 'bar', 'type' => DBALType::STRING),
-            'locale' => array('value' => 'en', 'type' => DBALType::STRING),
-        );
+        $parameters = [
+            'foo' => ['value' => 'bar', 'type' => DBALType::STRING],
+            'locale' => ['value' => 'en', 'type' => DBALType::STRING],
+        ];
 
         $this->assertEquals(serialize($parameters), ''.$filter);
         $this->assertEquals(''.$filter, ''.$filter2);
@@ -400,12 +400,12 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->loadFixtureData();
 
-        $this->assertCount(1, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findBy(array('id' => $this->groupId2)));
+        $this->assertCount(1, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findBy(['id' => $this->groupId2]));
 
         $this->useCMSGroupPrefixFilter();
         $this->_em->clear();
 
-        $this->assertCount(0, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findBy(array('id' => $this->groupId2)));
+        $this->assertCount(0, $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findBy(['id' => $this->groupId2]));
     }
 
     public function testRepositoryFindByX()
@@ -424,12 +424,12 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->loadFixtureData();
 
-        $this->assertNotNull($this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findOneBy(array('id' => $this->groupId2)));
+        $this->assertNotNull($this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findOneBy(['id' => $this->groupId2]));
 
         $this->useCMSGroupPrefixFilter();
         $this->_em->clear();
 
-        $this->assertNull($this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findOneBy(array('id' => $this->groupId2)));
+        $this->assertNull($this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsGroup')->findOneBy(['id' => $this->groupId2]));
     }
 
     public function testRepositoryFindOneByX()

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
@@ -58,9 +58,9 @@ class CompanySchemaTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->markTestSkipped("Foreign Key test");
         }
 
-        $sql = $this->_schemaTool->getDropSchemaSQL(array(
+        $sql = $this->_schemaTool->getDropSchemaSQL([
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Company\CompanyManager'),
-        ));
+        ]);
         $this->assertEquals(4, count($sql));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DBAL483Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DBAL483Test.php
@@ -22,9 +22,9 @@ class DBAL483Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $class = $this->_em->getClassMetadata(__NAMESPACE__ . '\\DBAL483Default');
 
-        $this->schemaTool->createSchema(array($class));
+        $this->schemaTool->createSchema([$class]);
 
-        $updateSql = $this->schemaTool->getUpdateSchemaSql(array($class));
+        $updateSql = $this->schemaTool->getUpdateSchemaSql([$class]);
 
         $updateSql = array_filter($updateSql, function ($sql) {
             return strpos($sql, 'DBAL483') !== false;

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Tools;
  */
 class DDC214Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    private $classes = array();
+    private $classes = [];
     private $schemaTool = null;
 
     public function setUp()
@@ -29,14 +29,14 @@ class DDC214Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testCmsAddressModel()
     {
-        $this->classes = array(
+        $this->classes = [
             'Doctrine\Tests\Models\CMS\CmsUser',
             'Doctrine\Tests\Models\CMS\CmsPhonenumber',
             'Doctrine\Tests\Models\CMS\CmsAddress',
             'Doctrine\Tests\Models\CMS\CmsGroup',
             'Doctrine\Tests\Models\CMS\CmsArticle',
             'Doctrine\Tests\Models\CMS\CmsEmail',
-        );
+        ];
 
         $this->assertCreatedSchemaNeedsNoUpdates($this->classes);
     }
@@ -46,7 +46,7 @@ class DDC214Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testCompanyModel()
     {
-        $this->classes = array(
+        $this->classes = [
             'Doctrine\Tests\Models\Company\CompanyPerson',
             'Doctrine\Tests\Models\Company\CompanyEmployee',
             'Doctrine\Tests\Models\Company\CompanyManager',
@@ -55,14 +55,14 @@ class DDC214Test extends \Doctrine\Tests\OrmFunctionalTestCase
             'Doctrine\Tests\Models\Company\CompanyAuction',
             'Doctrine\Tests\Models\Company\CompanyRaffle',
             'Doctrine\Tests\Models\Company\CompanyCar'
-        );
+        ];
 
         $this->assertCreatedSchemaNeedsNoUpdates($this->classes);
     }
 
     public function assertCreatedSchemaNeedsNoUpdates($classes)
     {
-        $classMetadata = array();
+        $classMetadata = [];
         foreach ($classes AS $class) {
             $classMetadata[] = $this->_em->getClassMetadata($class);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -16,13 +16,13 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetCreateSchemaSql()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsEmail'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -44,9 +44,9 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetCreateSchemaSql2()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Generic\DecimalModel')
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -57,9 +57,9 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetCreateSchemaSql3()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Generic\BooleanModel')
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -73,9 +73,9 @@ class MySqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testGetCreateSchemaSql4()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\MysqlSchemaNamespacedEntity')
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -25,11 +25,11 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetCreateSchemaSql()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -53,15 +53,15 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals("ALTER TABLE cms_users_groups ADD CONSTRAINT FK_7EA9409AFE54D947 FOREIGN KEY (group_id) REFERENCES cms_groups (id) NOT DEFERRABLE INITIALLY IMMEDIATE", array_shift($sql));
         $this->assertEquals("ALTER TABLE cms_phonenumbers ADD CONSTRAINT FK_F21F790FA76ED395 FOREIGN KEY (user_id) REFERENCES cms_users (id) NOT DEFERRABLE INITIALLY IMMEDIATE", array_shift($sql));
 
-        $this->assertEquals(array(), $sql, "SQL Array should be empty now.");
+        $this->assertEquals([], $sql, "SQL Array should be empty now.");
         $this->assertEquals(17, $sqlCount, "Total of 17 queries should be executed");
     }
 
     public function testGetCreateSchemaSql2()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Generic\DecimalModel')
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -74,9 +74,9 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetCreateSchemaSql3()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\Generic\BooleanModel')
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getCreateSchemaSql($classes);
@@ -88,11 +88,11 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testGetDropSchemaSql()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
             $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $sql = $tool->getDropSchemaSQL($classes);
@@ -114,10 +114,10 @@ class PostgreSqlSchemaToolTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testUpdateSchemaWithPostgreSQLSchema()
     {
-        $classes = array(
+        $classes = [
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1657Screen'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1657Avatar'),
-        );
+        ];
 
         $tool = new SchemaTool($this->_em);
         $tool->createSchema($classes);

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -14,12 +14,12 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     static public function dataValidateModelSets()
     {
-        $modelSets = array();
+        $modelSets = [];
         foreach (self::$_modelSets as $modelSet => $classes) {
             if ($modelSet == "customtype") {
                 continue;
             }
-            $modelSets[] = array($modelSet);
+            $modelSets[] = [$modelSet];
         }
         return $modelSets;
     }
@@ -31,7 +31,7 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $validator = new SchemaValidator($this->_em);
 
-        $classes = array();
+        $classes = [];
         foreach (self::$_modelSets[$modelSet] as $className) {
             $classes[] = $this->_em->getClassMetadata($className);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
@@ -25,14 +25,14 @@ use Doctrine\Tests\Models\Cache\AttractionLocationInfo;
  */
 abstract class SecondLevelCacheAbstractTest extends OrmFunctionalTestCase
 {
-    protected $countries            = array();
-    protected $states               = array();
-    protected $cities               = array();
-    protected $travels              = array();
-    protected $travelers            = array();
-    protected $attractions          = array();
-    protected $attractionsInfo      = array();
-    protected $travelersWithProfile = array();
+    protected $countries            = [];
+    protected $states               = [];
+    protected $cities               = [];
+    protected $travels              = [];
+    protected $travelers            = [];
+    protected $attractions          = [];
+    protected $attractionsInfo      = [];
+    protected $travelersWithProfile = [];
 
     /**
      * @var \Doctrine\ORM\Cache

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
@@ -24,10 +24,10 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         $leavingFrom    = $this->_em->find(City::CLASSNAME, $leavingFromId);
         $goingTo        = $this->_em->find(City::CLASSNAME, $goingToId);
         $flight         = new Flight($leavingFrom, $goingTo);
-        $id             = array(
+        $id             = [
             'leavingFrom'   => $leavingFromId,
             'goingTo'       => $goingToId,
-        );
+        ];
 
         $flight->setDeparture(new \DateTime('tomorrow'));
 
@@ -70,10 +70,10 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         $leavingFrom    = $this->_em->find(City::CLASSNAME, $leavingFromId);
         $goingTo        = $this->_em->find(City::CLASSNAME, $goingToId);
         $flight         = new Flight($leavingFrom, $goingTo);
-        $id             = array(
+        $id             = [
             'leavingFrom'   => $leavingFromId,
             'goingTo'       => $goingToId,
-        );
+        ];
 
         $flight->setDeparture(new \DateTime('tomorrow'));
 
@@ -114,10 +114,10 @@ class SecondLevelCacheCompositePrimaryKeyTest extends SecondLevelCacheAbstractTe
         $leavingFrom    = $this->_em->find(City::CLASSNAME, $leavingFromId);
         $goingTo        = $this->_em->find(City::CLASSNAME, $goingToId);
         $flight         = new Flight($leavingFrom, $goingTo);
-        $id             = array(
+        $id             = [
             'leavingFrom'   => $leavingFromId,
             'goingTo'       => $goingToId,
-        );
+        ];
 
         $flight->setDeparture($now);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -56,7 +56,7 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
 
         $countryId = $this->countries[0]->getId();
-        $cacheId   = new EntityCacheKey(Country::CLASSNAME, array('id'=>$countryId));
+        $cacheId   = new EntityCacheKey(Country::CLASSNAME, ['id'=>$countryId]);
         $region    = $this->_em->getCache()->getEntityCacheRegion(Country::CLASSNAME);
 
         $this->assertTrue($this->cache->containsEntity(Country::CLASSNAME, $countryId));
@@ -95,7 +95,7 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
         $this->secondLevelCacheLogger->clearStats();
 
         $stateId   = $this->states[0]->getId();
-        $cacheId   = new CollectionCacheKey(State::CLASSNAME, 'cities', array('id'=>$stateId));
+        $cacheId   = new CollectionCacheKey(State::CLASSNAME, 'cities', ['id'=>$stateId]);
         $region    = $this->_em->getCache()->getCollectionCacheRegion(State::CLASSNAME, 'cities');
 
         $this->assertTrue($this->cache->containsCollection(State::CLASSNAME, 'cities', $stateId));

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -189,10 +189,10 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $countryName1   = $this->countries[0]->getName();
         $countryName2   = $this->countries[1]->getName();
         
-        $key1           = new EntityCacheKey(Country::CLASSNAME, array('id'=>$countryId1));
-        $key2           = new EntityCacheKey(Country::CLASSNAME, array('id'=>$countryId2));
-        $entry1         = new EntityCacheEntry(Country::CLASSNAME, array('id'=>$countryId1, 'name'=>'outdated'));
-        $entry2         = new EntityCacheEntry(Country::CLASSNAME, array('id'=>$countryId2, 'name'=>'outdated'));
+        $key1           = new EntityCacheKey(Country::CLASSNAME, ['id'=>$countryId1]);
+        $key2           = new EntityCacheKey(Country::CLASSNAME, ['id'=>$countryId2]);
+        $entry1         = new EntityCacheEntry(Country::CLASSNAME, ['id'=>$countryId1, 'name'=>'outdated']);
+        $entry2         = new EntityCacheEntry(Country::CLASSNAME, ['id'=>$countryId2, 'name'=>'outdated']);
 
         $region->put($key1, $entry1);
         $region->put($key2, $entry2);

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -125,7 +125,7 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
 
         $this->assertFalse($this->cache->containsEntity(Country::CLASSNAME, $this->countries[0]->getId()));
 
-        $criteria   = array('name'=>$this->countries[0]->getName());
+        $criteria   = ['name'=>$this->countries[0]->getName()];
         $repository = $this->_em->getRepository(Country::CLASSNAME);
         $queryCount = $this->getCurrentQueryCount();
 
@@ -155,7 +155,7 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
 
         $this->assertFalse($this->cache->containsEntity(Country::CLASSNAME, $this->countries[0]->getId()));
 
-        $criteria   = array('name'=>$this->countries[0]->getName());
+        $criteria   = ['name'=>$this->countries[0]->getName()];
         $repository = $this->_em->getRepository(Country::CLASSNAME);
         $queryCount = $this->getCurrentQueryCount();
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -195,9 +195,9 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
 
     public function testPostFlushFailure()
     {
-        $listener = new ListenerSecondLevelCacheTest(array(Events::postFlush => function(){
+        $listener = new ListenerSecondLevelCacheTest([Events::postFlush => function(){
             throw new \RuntimeException('post flush failure');
-        }));
+        }]);
 
         $this->_em->getEventManager()
             ->addEventListener(Events::postFlush, $listener);
@@ -225,9 +225,9 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
         $this->loadFixturesStates();
         $this->_em->clear();
 
-        $listener = new ListenerSecondLevelCacheTest(array(Events::postUpdate => function(){
+        $listener = new ListenerSecondLevelCacheTest([Events::postUpdate => function(){
             throw new \RuntimeException('post update failure');
-        }));
+        }]);
 
         $this->_em->getEventManager()
             ->addEventListener(Events::postUpdate, $listener);
@@ -269,9 +269,9 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
         $this->loadFixturesCountries();
         $this->_em->clear();
 
-        $listener = new ListenerSecondLevelCacheTest(array(Events::postRemove => function(){
+        $listener = new ListenerSecondLevelCacheTest([Events::postRemove => function(){
             throw new \RuntimeException('post remove failure');
-        }));
+        }]);
 
         $this->_em->getEventManager()
             ->addEventListener(Events::postRemove, $listener);
@@ -324,7 +324,7 @@ class ListenerSecondLevelCacheTest
 {
     public $callbacks;
 
-    public function __construct(array $callbacks = array())
+    public function __construct(array $callbacks = [])
     {
         $this->callbacks = $callbacks;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -20,7 +20,7 @@ class SequenceEmulatedIdentityStrategyTest extends \Doctrine\Tests\OrmFunctional
         } else {
             try {
                 $this->_schemaTool->createSchema(
-                    array($this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\SequenceEmulatedIdentityEntity'))
+                    [$this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\SequenceEmulatedIdentityEntity')]
                 );
             } catch (\Exception $e) {
                 // Swallow all exceptions. We do not test the schema tool here.

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -18,9 +18,9 @@ class SequenceGeneratorTest extends \Doctrine\Tests\OrmFunctionalTestCase
         }
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\SequenceEntity'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
@@ -58,7 +58,7 @@ class SingleTableCompositeKeyTest extends OrmFunctionalTestCase
     {
         return $this->_em->find(
             'Doctrine\Tests\Models\CompositeKeyInheritance\SingleRootClass',
-            array('keyPart1' => 'part-1', 'keyPart2' => 'part-2')
+            ['keyPart1' => 'part-1', 'keyPart2' => 'part-2']
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\Criteria;
 class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     private $salesPerson;
-    private $engineers = array();
+    private $engineers = [];
     private $fix;
     private $flex;
     private $ultra;
@@ -226,7 +226,7 @@ class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         sort($discrValues);
 
-        $this->assertEquals(array('fix', 'flexible', 'flexultra'), $discrValues);
+        $this->assertEquals(['fix', 'flexible', 'flexultra'], $discrValues);
     }
 
     public function testQueryChildClassWithCondition()
@@ -321,19 +321,19 @@ class SingleTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->loadFullFixture();
 
         $repos = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyContract");
-        $contracts = $repos->findBy(array('salesPerson' => $this->salesPerson->getId()));
+        $contracts = $repos->findBy(['salesPerson' => $this->salesPerson->getId()]);
         $this->assertEquals(3, count($contracts), "There should be 3 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyContract'");
 
         $repos = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFixContract");
-        $contracts = $repos->findBy(array('salesPerson' => $this->salesPerson->getId()));
+        $contracts = $repos->findBy(['salesPerson' => $this->salesPerson->getId()]);
         $this->assertEquals(1, count($contracts), "There should be 1 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFixContract'");
 
         $repos = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFlexContract");
-        $contracts = $repos->findBy(array('salesPerson' => $this->salesPerson->getId()));
+        $contracts = $repos->findBy(['salesPerson' => $this->salesPerson->getId()]);
         $this->assertEquals(2, count($contracts), "There should be 2 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFlexContract'");
 
         $repos = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyFlexUltraContract");
-        $contracts = $repos->findBy(array('salesPerson' => $this->salesPerson->getId()));
+        $contracts = $repos->findBy(['salesPerson' => $this->salesPerson->getId()]);
         $this->assertEquals(1, count($contracts), "There should be 1 entities related to " . $this->salesPerson->getId() . " for 'Doctrine\Tests\Models\Company\CompanyFlexUltraContract'");
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php
@@ -38,8 +38,8 @@ class StandardEntityPersisterTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $persister = $this->_em->getUnitOfWork()->getEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceCart');
         $newCart = new ECommerceCart();
-        $this->_em->getUnitOfWork()->registerManaged($newCart, array('id' => $cardId), array());
-        $persister->load(array('customer_id' => $customer->getId()), $newCart, $class->associationMappings['customer']);
+        $this->_em->getUnitOfWork()->registerManaged($newCart, ['id' => $cardId], []);
+        $persister->load(['customer_id' => $customer->getId()], $newCart, $class->associationMappings['customer']);
         $this->assertEquals('Credit card', $newCart->getPayment());
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -9,11 +9,11 @@ class DDC1080Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testHydration()
     {
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1080Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1080Bar'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1080FooBar'),
-        ));
+        ]);
 
         $foo1 = new DDC1080Foo();
         $foo1->setFooTitle('foo title 1');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -15,12 +15,12 @@ class DDC1113Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1113Engine'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1113Vehicle'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1113Car'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1113Bus'),
-            ));
+            ]);
         } catch (\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
@@ -13,10 +13,10 @@ class DDC1151Test extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->markTestSkipped("This test is useful for all databases, but designed only for postgresql.");
         }
 
-        $sql = $this->_schemaTool->getCreateSchemaSql(array(
+        $sql = $this->_schemaTool->getCreateSchemaSql([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1151User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1151Group'),
-        ));
+        ]);
 
         $this->assertEquals("CREATE TABLE \"User\" (id INT NOT NULL, PRIMARY KEY(id))", $sql[0]);
         $this->assertEquals("CREATE TABLE ddc1151user_ddc1151group (ddc1151user_id INT NOT NULL, ddc1151group_id INT NOT NULL, PRIMARY KEY(ddc1151user_id, ddc1151group_id))", $sql[1]);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -11,12 +11,12 @@ class DDC1163Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1163Product'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1163SpecialProduct'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1163ProxyHolder'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1163Tag'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -53,7 +53,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testAssociationOnlyCompositeKey()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
 
         $mapRef = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
         $this->assertInstanceOf("Doctrine\Tests\Models\DDC117\DDC117Reference", $mapRef);
@@ -92,7 +92,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testUpdateAssociationEntity()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
 
         $mapRef = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
         $this->assertNotNull($mapRef);
@@ -126,7 +126,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testRemoveCompositeElement()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
 
         $refRep = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
 
@@ -143,7 +143,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testDqlRemoveCompositeElement()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
 
         $dql = "DELETE "."Doctrine\Tests\Models\DDC117\DDC117Reference r WHERE r.source = ?1 AND r.target = ?2";
         $this->_em->createQuery($dql)
@@ -188,7 +188,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testMixedCompositeKey()
     {
-        $idCriteria = array('article' => $this->article1->id(), 'language' => 'en');
+        $idCriteria = ['article' => $this->article1->id(), 'language' => 'en'];
 
         $this->translation = $this->_em->find('Doctrine\Tests\Models\DDC117\DDC117Translation', $idCriteria);
         $this->assertInstanceOf('Doctrine\Tests\Models\DDC117\DDC117Translation', $this->translation);
@@ -282,10 +282,10 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testReferencesToForeignKeyEntities()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
         $reference = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
 
-        $idCriteria = array('article' => $this->article1->id(), 'language' => 'en');
+        $idCriteria = ['article' => $this->article1->id(), 'language' => 'en'];
         $translation = $this->_em->find('Doctrine\Tests\Models\DDC117\DDC117Translation', $idCriteria);
 
         $approveChanges = new DDC117ApproveChanges($reference->source()->getDetails(), $reference, $translation);
@@ -429,7 +429,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testMergeForeignKeyIdentifierEntity()
     {
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
 
         $refRep = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
 
@@ -484,7 +484,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_NEW, $this->_em->getUnitOfWork()->getEntityState($this->reference));
 
-        $idCriteria = array('source' => $this->article1->id(), 'target' => $this->article2->id());
+        $idCriteria = ['source' => $this->article1->id(), 'target' => $this->article2->id()];
         $reference = $this->_em->find("Doctrine\Tests\Models\DDC117\DDC117Reference", $idCriteria);
 
         $this->assertEquals(\Doctrine\ORM\UnitOfWork::STATE_MANAGED, $this->_em->getUnitOfWork()->getEntityState($reference));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -7,11 +7,11 @@ class DDC1181Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1181Hotel'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1181Booking'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1181Room'),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -9,11 +9,11 @@ class DDC1193Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1193Company'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1193Person'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1193Account')
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -10,11 +10,11 @@ class DDC1209Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1209_1'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1209_2'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1209_3')
-            ));
+            ]);
         } catch(\Exception $e) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
@@ -14,10 +14,10 @@ class DDC1225Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1225_TestEntity1'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1225_TestEntity2'),
-            ));
+            ]);
         } catch(\PDOException $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -15,10 +15,10 @@ class DDC1228Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1228User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1228Profile'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }
@@ -43,7 +43,7 @@ class DDC1228Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertTrue($user->getProfile()->__isInitialized__, "Proxy is not initialized");
 
         $this->assertEquals("Bar", $user->getProfile()->getName());
-        $this->assertEquals(array("id" => 1, "name" => "Foo"), $this->_em->getUnitOfWork()->getOriginalEntityData($user->getProfile()));
+        $this->assertEquals(["id" => 1, "name" => "Foo"], $this->_em->getUnitOfWork()->getOriginalEntityData($user->getProfile()));
 
         $this->_em->flush();
         $this->_em->clear();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -14,9 +14,9 @@ class DDC1238Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1238User'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
@@ -14,9 +14,9 @@ class DDC1250Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1250ClientHistory'),
-            ));
+            ]);
         } catch(\PDOException $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -10,10 +10,10 @@ class DDC1300Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1300Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1300FooLocale'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -13,10 +13,10 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1335User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1335Phone'),
-            ));
+            ]);
             $this->loadFixture();
         } catch(\Exception $e) {
         }
@@ -130,9 +130,9 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     private function loadFixture()
     {
-        $p1 = array('11 xxxx-xxxx','11 yyyy-yyyy','11 zzzz-zzzz');
-        $p2 = array('22 xxxx-xxxx','22 yyyy-yyyy','22 zzzz-zzzz');
-        $p3 = array('33 xxxx-xxxx','33 yyyy-yyyy','33 zzzz-zzzz');
+        $p1 = ['11 xxxx-xxxx','11 yyyy-yyyy','11 zzzz-zzzz'];
+        $p2 = ['22 xxxx-xxxx','22 yyyy-yyyy','22 zzzz-zzzz'];
+        $p3 = ['33 xxxx-xxxx','33 yyyy-yyyy','33 zzzz-zzzz'];
 
         $u1 = new DDC1335User("foo@foo.com", "Foo",$p1);
         $u2 = new DDC1335User("bar@bar.com", "Bar",$p2);
@@ -173,7 +173,7 @@ class DDC1335User
      */
     public $phones;
 
-    public function __construct($email, $name, array $numbers = array())
+    public function __construct($email, $name, array $numbers = [])
     {
         $this->name   = $name;
         $this->email  = $email;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -15,15 +15,15 @@ class DDC1360Test extends OrmFunctionalTestCase
             $this->markTestSkipped("PostgreSQL only test.");
         }
 
-        $sql = $this->_schemaTool->getCreateSchemaSQL(array(
+        $sql = $this->_schemaTool->getCreateSchemaSQL([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1360DoubleQuote')
-        ));
+        ]);
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'CREATE SCHEMA user',
             'CREATE TABLE "user"."user" (id INT NOT NULL, PRIMARY KEY(id))',
             'CREATE SEQUENCE "user"."user_id_seq" INCREMENT BY 1 MINVALUE 1 START 1',
-        ), $sql);
+        ], $sql);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
@@ -13,10 +13,10 @@ class DDC1383Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1383AbstractEntity'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1383Entity'),
-            ));
+            ]);
         } catch(\Exception $ignored) {}
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
@@ -14,10 +14,10 @@ class DDC1392Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1392File'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1392Picture'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
@@ -14,11 +14,11 @@ class DDC1400Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1400Article'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1400User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1400UserState'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
@@ -13,10 +13,10 @@ class DDC1404Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1404ParentEntity'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1404ChildEntity'),
-            ));
+            ]);
 
             $this->loadFixtures();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
@@ -17,12 +17,12 @@ class DDC142Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\User'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Group'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Phone'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Address'),
-            ));
+            ]);
         } catch(\Exception $e) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -13,10 +13,10 @@ class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1430Order'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1430OrderProduct'),
-            ));
+            ]);
             $this->loadFixtures();
         } catch (\Exception $exc) {
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1436Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1436Test.php
@@ -13,9 +13,9 @@ class DDC1436Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1436Page'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -8,11 +8,11 @@ class DDC144Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC144FlowElement'),
         //    $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC144Expression'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC144Operand'),
-        ));
+        ]);
 
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php
@@ -16,10 +16,10 @@ class DDC1452Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1452EntityA'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1452EntityB'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
@@ -14,10 +14,10 @@ class DDC1454Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1454File'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1454Picture'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1458Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1458Test.php
@@ -11,10 +11,10 @@ class DDC1258Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\TestEntity'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\TestAdditionalEntity')
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
@@ -16,10 +16,10 @@ class DDC1461Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1461TwitterAccount'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1461User')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
@@ -15,11 +15,11 @@ class DDC1509Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1509AbstractFile'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1509File'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1509Picture'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php
@@ -15,11 +15,11 @@ class DDC1514Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1514EntityA'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1514EntityB'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1514EntityC'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1515Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1515Test.php
@@ -11,10 +11,10 @@ class DDC1515Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1515Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1515Bar'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1526Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1526Test.php
@@ -10,14 +10,14 @@ class DDC1526Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1526Menu'),
-        ));
+        ]);
     }
 
     public function testIssue()
     {
-        $parents = array();
+        $parents = [];
         for ($i = 0; $i < 9; $i++) {
             $entity = new DDC1526Menu;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1548Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1548Test.php
@@ -10,11 +10,11 @@ class DDC1548Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1548E1'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1548E2'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1548Rel'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
@@ -15,11 +15,11 @@ class DDC1595Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\DebugStack);
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1595BaseInheritance'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1595InheritedEntity1'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1595InheritedEntity2'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
@@ -10,10 +10,10 @@ class DDC1654Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->setUpEntitySchema(array(
+        $this->setUpEntitySchema([
             __NAMESPACE__ . '\\DDC1654Post',
             __NAMESPACE__ . '\\DDC1654Comment',
-        ));
+        ]);
     }
 
     public function testManyToManyRemoveFromCollectionOrphanRemoval()
@@ -88,7 +88,7 @@ class DDC1654Post
      * @ManyToMany(targetEntity="DDC1654Comment", orphanRemoval=true,
      * cascade={"persist"})
      */
-    public $comments = array();
+    public $comments = [];
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
@@ -13,11 +13,11 @@ class DDC1655Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1655Foo'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1655Bar'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1655Baz'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }
@@ -26,10 +26,10 @@ class DDC1655Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testPostLoadOneToManyInheritance()
     {
         $cm = $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1655Foo');
-        $this->assertEquals(array("postLoad" => array("postLoad")), $cm->lifecycleCallbacks);
+        $this->assertEquals(["postLoad" => ["postLoad"]], $cm->lifecycleCallbacks);
 
         $cm = $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1655Bar');
-        $this->assertEquals(array("postLoad" => array("postLoad", "postSubLoaded")), $cm->lifecycleCallbacks);
+        $this->assertEquals(["postLoad" => ["postLoad", "postSubLoaded"]], $cm->lifecycleCallbacks);
 
         $baz = new DDC1655Baz();
         $foo = new DDC1655Foo();
@@ -140,5 +140,5 @@ class DDC1655Baz
     /**
      * @OneToMany(targetEntity="DDC1655Foo", mappedBy="baz")
      */
-    public $foos = array();
+    public $foos = [];
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -10,10 +10,10 @@ class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp() {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1690Parent'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1690Child')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
@@ -75,7 +75,7 @@ class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 class NotifyBaseEntity implements NotifyPropertyChanged {
-    public $listeners = array();
+    public $listeners = [];
 
     public function addPropertyChangedListener(PropertyChangedListener $listener) {
         if (!in_array($listener, $this->listeners)) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1707Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1707Test.php
@@ -14,10 +14,10 @@ class DDC1707Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1509File'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1509Picture'),
-            ));
+            ]);
         } catch (\Exception $ignored) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
@@ -15,18 +15,18 @@ class DDC1719Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(self::CLASS_NAME),
-        ));
+        ]);
     }
 
     protected function tearDown()
     {
         parent::tearDown();
 
-        $this->_schemaTool->dropSchema(array(
+        $this->_schemaTool->dropSchema([
             $this->_em->getClassMetadata(self::CLASS_NAME),
-        ));
+        ]);
     }
 
     public function testCreateRetrieveUpdateDelete()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
@@ -10,10 +10,10 @@ class DDC1787Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1787Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC1787Bar'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
@@ -16,12 +16,12 @@ class DDC1843Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\User'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Group'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Phone'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Address'),
-            ));
+            ]);
         } catch(\Exception $e) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -74,7 +74,7 @@ class DDC1884Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($merc);
         $this->_em->persist($volvo);
 
-        return array($bimmer, $crysler, $merc, $volvo);
+        return [$bimmer, $crysler, $merc, $volvo];
     }
 
     private function createDrivers($class)
@@ -88,7 +88,7 @@ class DDC1884Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($foo);
         $this->_em->persist($john);
 
-        return array($john, $foo);
+        return [$john, $foo];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
@@ -22,11 +22,11 @@ class DDC1885Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\User'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Group'),
                 $this->_em->getClassMetadata('Doctrine\Tests\Models\Quote\Address'),
-            ));
+            ]);
         } catch(\Exception $e) {
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1918Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1918Test.php
@@ -19,7 +19,7 @@ class DDC1918Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testLastPageCorrect()
     {
-        $groups = array();
+        $groups = [];
         for ($i = 0; $i < 3; $i++) {
             $group = new CmsGroup();
             $group->name = "test";

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -12,10 +12,10 @@ class DDC1925Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testIssue()
     {
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1925User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1925Product'),
-        ));
+        ]);
 
         $user = new DDC1925User();
         $user->setTitle("Test User");

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -6,10 +6,10 @@ class DDC192Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testSchemaCreation()
     {
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC192User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC192Phonenumber')
-        ));
+        ]);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php
@@ -15,9 +15,9 @@ class DDC1998Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         Type::addType('ddc1998', __NAMESPACE__ . '\\DDC1998Type');
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC1998Entity'),
-        ));
+        ]);
 
         $entity = new DDC1998Entity();
         $entity->id = new DDC1998Id("foo");

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php
@@ -7,11 +7,11 @@ class DDC199Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC199ParentClass'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC199ChildClass'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC199RelatedClass')
-        ));
+        ]);
     }
 
     public function testPolymorphicLoading()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -17,18 +17,18 @@ class DDC2012Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         Type::addType(DDC2012TsVectorType::MYTYPE, __NAMESPACE__ . '\DDC2012TsVectorType');
 
-        DDC2012TsVectorType::$calls = array();
+        DDC2012TsVectorType::$calls = [];
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2012Item'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2012ItemPerson'),
-        ));
+        ]);
     }
 
     public function testIssue()
     {
         $item       = new DDC2012ItemPerson();
-        $item->tsv  = array('word1', 'word2', 'word3');
+        $item->tsv  = ['word1', 'word2', 'word3'];
 
         $this->_em->persist($item);
         $this->_em->flush();
@@ -45,10 +45,10 @@ class DDC2012Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(1, DDC2012TsVectorType::$calls['convertToPHPValue']);
 
         $this->assertInstanceOf(__NAMESPACE__ . '\DDC2012Item', $item);
-        $this->assertEquals(array('word1', 'word2', 'word3'), $item->tsv);
+        $this->assertEquals(['word1', 'word2', 'word3'], $item->tsv);
 
 
-        $item->tsv = array('word1', 'word2');
+        $item->tsv = ['word1', 'word2'];
 
         $this->_em->persist($item);
         $this->_em->flush();
@@ -61,7 +61,7 @@ class DDC2012Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(2, DDC2012TsVectorType::$calls['convertToPHPValue']);
 
         $this->assertInstanceOf(__NAMESPACE__ . '\DDC2012Item', $item);
-        $this->assertEquals(array('word1', 'word2'), $item->tsv);
+        $this->assertEquals(['word1', 'word2'], $item->tsv);
     }
 }
 
@@ -103,7 +103,7 @@ class DDC2012TsVectorType extends Type
 {
     const MYTYPE = 'tsvector';
 
-    public static $calls = array();
+    public static $calls = [];
 
     /**
      * {@inheritdoc}
@@ -122,10 +122,10 @@ class DDC2012TsVectorType extends Type
             $value = implode(" ", $value);
         }
 
-        self::$calls[__FUNCTION__][] = array(
+        self::$calls[__FUNCTION__][] = [
             'value'     => $value,
             'platform'  => $platform,
-        );
+        ];
 
         return $value;
     }
@@ -135,10 +135,10 @@ class DDC2012TsVectorType extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        self::$calls[__FUNCTION__][] = array(
+        self::$calls[__FUNCTION__][] = [
             'value'     => $value,
             'platform'  => $platform,
-        );
+        ];
 
         return explode(" ", strtolower($value));
     }
@@ -148,10 +148,10 @@ class DDC2012TsVectorType extends Type
      */
     public function convertToDatabaseValueSQL($sqlExpr, AbstractPlatform $platform)
     {
-        self::$calls[__FUNCTION__][] = array(
+        self::$calls[__FUNCTION__][] = [
             'sqlExpr'   => $sqlExpr,
             'platform'  => $platform,
-        );
+        ];
 
         // changed to upper expression to keep the test compatible with other Databases
         //sprintf('to_tsvector(%s)', $sqlExpr);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php
@@ -23,7 +23,7 @@ class DDC2074Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\ECommerce\ECommerceProduct');
         $product = new ECommerceProduct();
         $category = new ECommerceCategory();
-        $collection = new PersistentCollection($this->_em, $class, new ArrayCollection(array($category)));
+        $collection = new PersistentCollection($this->_em, $class, new ArrayCollection([$category]));
         $collection->setOwner($product, $class->associationMappings['categories']);
 
         $uow = $this->_em->getUnitOfWork();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
@@ -12,10 +12,10 @@ class DDC2084Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2084\MyEntity1'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2084\MyEntity2'),
-            ));
+            ]);
         } catch (\Exception $exc) {
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2090Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2090Test.php
@@ -44,11 +44,11 @@ class DDC2090Test extends \Doctrine\Tests\OrmFunctionalTestCase
             ->set('e.startDate', ':date')
             ->set('e.salary', ':salary')
             ->where('e = :e')
-            ->setParameters(array(
+            ->setParameters([
                 'e'      => $employee1,
                 'date'   => $date1,
                 'salary' => 101,
-            ))
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -58,11 +58,11 @@ class DDC2090Test extends \Doctrine\Tests\OrmFunctionalTestCase
             ->set('e.startDate', ':date')
             ->set('e.salary', ':salary')
             ->where('e = :e')
-            ->setParameters(array(
+            ->setParameters([
                 'e'      => $employee2,
                 'date'   => $date2,
                 'salary' => 102,
-            ))
+            ])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -82,7 +82,7 @@ class DDC2090Test extends \Doctrine\Tests\OrmFunctionalTestCase
             ->set('e.startDate', '?1')
             ->set('e.salary', '?2')
             ->where('e = ?0')
-            ->setParameters(array($employee1, $date1, 101))
+            ->setParameters([$employee1, $date1, 101])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();
@@ -92,7 +92,7 @@ class DDC2090Test extends \Doctrine\Tests\OrmFunctionalTestCase
             ->set('e.startDate', '?1')
             ->set('e.salary', '?2')
             ->where('e = ?0')
-            ->setParameters(array($employee2, $date2, 102))
+            ->setParameters([$employee2, $date2, 102])
             ->getQuery()
             ->useQueryCache(true)
             ->execute();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
@@ -13,9 +13,9 @@ class DDC2106Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2106Entity'),
-        ));
+        ]);
     }
 
     public function testDetachedEntityAsId()
@@ -25,7 +25,7 @@ class DDC2106Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($entity);
         $this->_em->flush();
         $this->_em->detach($entity);
-        $entity = $this->_em->getRepository(__NAMESPACE__ . '\DDC2106Entity')->findOneBy(array());
+        $entity = $this->_em->getRepository(__NAMESPACE__ . '\DDC2106Entity')->findOneBy([]);
 
         // ... and a managed entity without id
         $entityWithoutId = new DDC2106Entity();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -7,10 +7,10 @@ class DDC211Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC211User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC211Group')
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -23,7 +23,7 @@ class DDC211Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        $groupNames = array('group 1', 'group 2', 'group 3', 'group 4');
+        $groupNames = ['group 1', 'group 2', 'group 3', 'group 4'];
         foreach ($groupNames as $name) {
 
             $group = new DDC211Group;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
@@ -16,21 +16,21 @@ class DDC2138Test extends OrmFunctionalTestCase
         $em = $this->_em;
         $schemaTool = new SchemaTool($em);
 
-        $classes = array(
+        $classes = [
             $em->getClassMetadata(__NAMESPACE__ . '\DDC2138User'),
             $em->getClassMetadata(__NAMESPACE__ . '\DDC2138Structure'),
             $em->getClassMetadata(__NAMESPACE__ . '\DDC2138UserFollowedObject'),
             $em->getClassMetadata(__NAMESPACE__ . '\DDC2138UserFollowedStructure'),
             $em->getClassMetadata(__NAMESPACE__ . '\DDC2138UserFollowedUser')
-        );
+        ];
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
         $this->assertTrue($schema->hasTable('users_followed_objects'), "Table users_followed_objects should exist.");
 
         /* @var $table \Doctrine\DBAL\Schema\Table */
         $table = ($schema->getTable('users_followed_objects'));
-        $this->assertTrue($table->columnsAreIndexed(array('object_id')));
-        $this->assertTrue($table->columnsAreIndexed(array('user_id')));
+        $this->assertTrue($table->columnsAreIndexed(['object_id']));
+        $this->assertTrue($table->columnsAreIndexed(['user_id']));
         $foreignKeys = $table->getForeignKeys();
         $this->assertCount(1, $foreignKeys, 'user_id column has to have FK, but not object_id');
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
@@ -10,9 +10,9 @@ class DDC2175Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2175Entity'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
@@ -12,10 +12,10 @@ class DDC2182Test extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->markTestSkipped("This test is useful for all databases, but designed only for mysql.");
         }
 
-        $sql = $this->_schemaTool->getCreateSchemaSql(array(
+        $sql = $this->_schemaTool->getCreateSchemaSql([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2182OptionParent'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2182OptionChild'),
-        ));
+        ]);
 
         $this->assertEquals("CREATE TABLE DDC2182OptionParent (id INT UNSIGNED NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB", $sql[0]);
         $this->assertEquals("CREATE TABLE DDC2182OptionChild (id VARCHAR(255) NOT NULL, parent_id INT UNSIGNED DEFAULT NULL, INDEX IDX_B314D4AD727ACA70 (parent_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB", $sql[1]);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2214Test.php
@@ -17,10 +17,10 @@ class DDC2214Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2214Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2214Bar'),
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -44,7 +44,7 @@ class DDC2214Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $related = $this
             ->_em
             ->createQuery('SELECT b FROM '.__NAMESPACE__ . '\DDC2214Bar b WHERE b.id IN(:ids)')
-            ->setParameter('ids', array($bar))
+            ->setParameter('ids', [$bar])
             ->getResult();
 
         $query = end($logger->queries);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -17,10 +17,10 @@ class DDC2230Test extends OrmFunctionalTestCase
         parent::setup();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2230User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2230Address'),
-            ));
+            ]);
         } catch (ToolsException $e) {}
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -14,9 +14,9 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2231EntityY'),
-        ));
+        ]);
     }
 
     public function testInjectObjectManagerInProxyIfInitializedInUow()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2252Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2252Test.php
@@ -12,18 +12,18 @@ class DDC2252Test extends \Doctrine\Tests\OrmFunctionalTestCase
     private $user;
     private $merchant;
     private $membership;
-    private $privileges = array();
+    private $privileges = [];
 
     protected function setUp()
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC2252User'),
             $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC2252Privilege'),
             $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC2252Membership'),
             $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC2252MerchantAccount'),
-        ));
+        ]);
 
         $this->loadFixtures();
     }
@@ -56,10 +56,10 @@ class DDC2252Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIssue()
     {
-        $identifier = array(
+        $identifier = [
             'merchantAccount' => $this->merchant->getAccountid(),
             'userAccount'     => $this->user->getUid(),
-        );
+        ];
 
         $class      = 'Doctrine\Tests\ORM\Functional\Ticket\DDC2252Membership';
         $membership = $this->_em->find($class, $identifier);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -13,10 +13,10 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setup()
     {
         parent::setup();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2256User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2256Group')
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -53,7 +53,7 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // Test ResultSetMappingBuilder.
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('MyNamespace:DDC2256User', 'u');
-        $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', array('id' => 'group_id', 'name' => 'group_name'));
+        $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', ['id' => 'group_id', 'name' => 'group_name']);
 
         $this->_em->createNativeQuery($sql, $rsm)->getResult();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -16,12 +16,12 @@ class DDC2306Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setup();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2306Zone'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2306User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2306Address'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2306UserAddress'),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
@@ -22,11 +22,11 @@ class DDC2346Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setup();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2346Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2346Bar'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2346Baz'),
-        ));
+        ]);
 
         $this->logger = new DebugStack();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php
@@ -14,10 +14,10 @@ class DDC2350Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2350User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2350Bug'),
-        ));
+        ]);
     }
 
     public function testEagerCollectionsAreOnlyRetrievedOnce()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -17,17 +17,17 @@ class DDC2359Test extends \PHPUnit_Framework_TestCase
     public function testIssue()
     {
         $mockDriver      = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver');
-        $mockMetadata    = $this->getMock('Doctrine\\ORM\\Mapping\\ClassMetadata', array(), array(), '', false);
-        $entityManager   = $this->getMock('Doctrine\\ORM\\EntityManager', array(), array(), '', false);
+        $mockMetadata    = $this->getMock('Doctrine\\ORM\\Mapping\\ClassMetadata', [], [], '', false);
+        $entityManager   = $this->getMock('Doctrine\\ORM\\EntityManager', [], [], '', false);
 
         /* @var $metadataFactory \Doctrine\ORM\Mapping\ClassMetadataFactory|\PHPUnit_Framework_MockObject_MockObject */
         $metadataFactory = $this->getMock(
             'Doctrine\\ORM\\Mapping\\ClassMetadataFactory',
-            array('newClassMetadataInstance', 'wakeupReflection')
+            ['newClassMetadataInstance', 'wakeupReflection']
         );
         
-        $configuration   = $this->getMock('Doctrine\\ORM\\Configuration', array('getMetadataDriverImpl'));
-        $connection      = $this->getMock('Doctrine\\DBAL\\Connection', array(), array(), '', false);
+        $configuration   = $this->getMock('Doctrine\\ORM\\Configuration', ['getMetadataDriverImpl']);
+        $connection      = $this->getMock('Doctrine\\DBAL\\Connection', [], [], '', false);
 
         $configuration
             ->expects($this->any())

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -7,11 +7,11 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC237EntityX'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC237EntityY'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC237EntityZ')
-        ));
+        ]);
     }
 
     public function testUninitializedProxyIsInitializedOnFetchJoin()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2387Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2387Test.php
@@ -14,15 +14,15 @@ class DDC2387Test extends DatabaseDriverTestCase
     {
         $product = new \Doctrine\DBAL\Schema\Table('ddc2387_product');
         $product->addColumn('id', 'integer');
-        $product->setPrimaryKey(array('id'));
+        $product->setPrimaryKey(['id']);
 
         $attributes = new \Doctrine\DBAL\Schema\Table('ddc2387_attributes');
         $attributes->addColumn('product_id', 'integer');
         $attributes->addColumn('attribute_name', 'string');
-        $attributes->setPrimaryKey(array('product_id', 'attribute_name'));
-        $attributes->addForeignKeyConstraint('ddc2387_product', array('product_id'), array('product_id'));
+        $attributes->setPrimaryKey(['product_id', 'attribute_name']);
+        $attributes->addForeignKeyConstraint('ddc2387_product', ['product_id'], ['product_id']);
 
-        $metadata = $this->convertToClassMetadata(array($product, $attributes), array());
+        $metadata = $this->convertToClassMetadata([$product, $attributes], []);
 
         $this->assertEquals(ClassMetadataInfo::GENERATOR_TYPE_NONE, $metadata['Ddc2387Attributes']->generatorType);
         $this->assertEquals(ClassMetadataInfo::GENERATOR_TYPE_AUTO, $metadata['Ddc2387Product']->generatorType);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -16,12 +16,12 @@ class DDC2415Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_em->getConfiguration()->setMetadataDriverImpl(new StaticPHPDriver(array()));
+        $this->_em->getConfiguration()->setMetadataDriverImpl(new StaticPHPDriver([]));
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2415ParentEntity'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2415ChildEntity'),
-        ));
+        ]);
     }
 
     public function testTicket()
@@ -57,16 +57,16 @@ class DDC2415ParentEntity
 
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array (
+        $metadata->mapField( [
             'id'        => true,
             'fieldName' => 'id',
             'type'      => 'string',
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
-        $metadata->setCustomGeneratorDefinition(array(
+        $metadata->setCustomGeneratorDefinition([
             'class' => 'Doctrine\Tests\ORM\Functional\Ticket\DDC2415Generator'
-        ));
+        ]);
 
         $metadata->isMappedSuperclass = true;
     }
@@ -88,10 +88,10 @@ class DDC2415ChildEntity extends DDC2415ParentEntity
 
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array (
+        $metadata->mapField( [
             'fieldName' => 'name',
             'type'      => 'string',
-        ));
+        ]);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php
@@ -15,14 +15,14 @@ class DDC2494Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
 
-        DDC2494TinyIntType::$calls = array();
+        DDC2494TinyIntType::$calls = [];
 
         Type::addType('ddc2494_tinyint', __NAMESPACE__ . '\DDC2494TinyIntType');
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(DDC2494Currency::CLASSNAME),
             $this->_em->getClassMetadata(DDC2494Campaign::CLASSNAME),
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -160,7 +160,7 @@ class DDC2494Campaign
 
 class DDC2494TinyIntType extends Type
 {
-    public static $calls = array();
+    public static $calls = [];
 
     /**
      * {@inheritdoc}
@@ -177,11 +177,11 @@ class DDC2494TinyIntType extends Type
     {
         $return = (string) $value;
 
-        self::$calls[__FUNCTION__][] = array(
+        self::$calls[__FUNCTION__][] = [
             'value'     => $value,
             'return'    => $return,
             'platform'  => $platform,
-        );
+        ];
 
         return $return;
     }
@@ -193,11 +193,11 @@ class DDC2494TinyIntType extends Type
     {
         $return = (integer) $value;
 
-        self::$calls[__FUNCTION__][] = array(
+        self::$calls[__FUNCTION__][] = [
             'value'     => $value,
             'return'    => $return,
             'platform'  => $platform,
-        );
+        ];
 
         return $return;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
@@ -7,19 +7,19 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
  */
 class DDC2575Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    private $rootsEntities = array();
-    private $aEntities = array();
-    private $bEntities = array();
+    private $rootsEntities = [];
+    private $aEntities = [];
+    private $bEntities = [];
 
     protected function setUp()
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2575Root'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2575A'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2575B'),
-        ));
+        ]);
 
         $entityRoot1 = new DDC2575Root(1);
         $entityB1 = new DDC2575B(2);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
@@ -17,11 +17,11 @@ class DDC2579Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         Type::addType(DDC2579Type::NAME, DDC2579Type::CLASSNAME);
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(DDC2579Entity::CLASSNAME),
             $this->_em->getClassMetadata(DDC2579EntityAssoc::CLASSNAME),
             $this->_em->getClassMetadata(DDC2579AssocAssoc::CLASSNAME),
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -45,7 +45,7 @@ class DDC2579Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $id       = $entity->id;
         $value    = $entity->value;
-        $criteria = array('assoc' => $assoc, 'id' => $id);
+        $criteria = ['assoc' => $assoc, 'id' => $id];
         $entity   = $repository->findOneBy($criteria);
 
         $this->assertInstanceOf(DDC2579Entity::CLASSNAME, $entity);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
@@ -6,12 +6,12 @@ class DDC258Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC258Super'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC258Class1'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC258Class2'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC258Class3'),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
@@ -18,11 +18,11 @@ class DDC2660Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setup();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2660Product'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2660Customer'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2660CustomerOrder')
-            ));
+            ]);
         } catch(\Exception $e) {
             return;
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -18,9 +18,9 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setup();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2692Foo'),
-            ));
+            ]);
         } catch(\Exception $e) {
             return;
         }
@@ -29,7 +29,7 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIsListenerCalledOnlyOnceOnPreFlush()
     {
-        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\DDC2692Listener', array('preFlush'));
+        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\DDC2692Listener', ['preFlush']);
         $listener->expects($this->once())->method('preFlush');
 
         $this->_em->getEventManager()->addEventSubscriber($listener);
@@ -53,7 +53,7 @@ class DDC2692Foo
 class DDC2692Listener implements EventSubscriber {
 
     public function getSubscribedEvents() {
-        return array(\Doctrine\ORM\Events::preFlush);
+        return [\Doctrine\ORM\Events::preFlush];
     }
 
     public function preFlush(PreFlushEventArgs $args) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2759Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2759Test.php
@@ -15,12 +15,12 @@ class DDC2759Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setup();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2759Qualification'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2759Category'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2759QualificationMetadata'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2759MetadataCategory'),
-            ));
+            ]);
         } catch(\Exception $e) {
             return;
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
@@ -15,12 +15,12 @@ class DDC2775Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->setUpEntitySchema(array(
+        $this->setUpEntitySchema([
             'Doctrine\Tests\ORM\Functional\Ticket\User',
             'Doctrine\Tests\ORM\Functional\Ticket\Role',
             'Doctrine\Tests\ORM\Functional\Ticket\AdminRole',
             'Doctrine\Tests\ORM\Functional\Ticket\Authorization',
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
@@ -7,12 +7,12 @@ class DDC279Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC279EntityXAbstract'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC279EntityX'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC279EntityY'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC279EntityZ'),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php
@@ -67,7 +67,7 @@ class DDC2825Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testPersistenceOfEntityWithSchemaMapping($className)
     {
         try {
-            $this->_schemaTool->createSchema(array($this->_em->getClassMetadata($className)));
+            $this->_schemaTool->createSchema([$this->_em->getClassMetadata($className)]);
         } catch (ToolsException $e) {
             // table already exists
         }
@@ -86,11 +86,11 @@ class DDC2825Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function getTestedClasses()
     {
-        return array(
-            array(ExplicitSchemaAndTable::CLASSNAME, 'explicit_schema', 'explicit_table'),
-            array(SchemaAndTableInTableName::CLASSNAME, 'implicit_schema', 'implicit_table'),
-            array(DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::CLASSNAME, 'myschema', 'order'),
-        );
+        return [
+            [ExplicitSchemaAndTable::CLASSNAME, 'explicit_schema', 'explicit_table'],
+            [SchemaAndTableInTableName::CLASSNAME, 'implicit_schema', 'implicit_table'],
+            [DDC2825ClassWithImplicitlyDefinedSchemaAndQuotedTableName::CLASSNAME, 'myschema', 'order'],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
@@ -16,10 +16,10 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(DDC2862User::CLASSNAME),
                 $this->_em->getClassMetadata(DDC2862Driver::CLASSNAME),
-            ));
+            ]);
         } catch (ToolsException $exc) {
         }
     }
@@ -34,8 +34,8 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, array('id' => $user1->getId())));
-        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, array('id' => $driver1->getId())));
+        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, ['id' => $user1->getId()]));
+        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, ['id' => $driver1->getId()]));
 
         $queryCount = $this->getCurrentQueryCount();
         $driver2    = $this->_em->find(DDC2862Driver::CLASSNAME, $driver1->getId());
@@ -49,8 +49,8 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, array('id' => $user1->getId())));
-        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, array('id' => $driver1->getId())));
+        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, ['id' => $user1->getId()]));
+        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, ['id' => $driver1->getId()]));
 
         $queryCount = $this->getCurrentQueryCount();
         $driver3    = $this->_em->find(DDC2862Driver::CLASSNAME, $driver1->getId());
@@ -75,8 +75,8 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->getCache()->evictEntityRegion(DDC2862User::CLASSNAME);
         $this->_em->getCache()->evictEntityRegion(DDC2862Driver::CLASSNAME);
 
-        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, array('id' => $user1->getId())));
-        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, array('id' => $driver1->getId())));
+        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, ['id' => $user1->getId()]));
+        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, ['id' => $driver1->getId()]));
 
         $queryCount = $this->getCurrentQueryCount();
         $driver2    = $this->_em->find(DDC2862Driver::CLASSNAME, $driver1->getId());
@@ -87,8 +87,8 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, array('id' => $user1->getId())));
-        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, array('id' => $driver1->getId())));
+        $this->assertFalse($this->_em->getCache()->containsEntity(DDC2862User::CLASSNAME, ['id' => $user1->getId()]));
+        $this->assertTrue($this->_em->getCache()->containsEntity(DDC2862Driver::CLASSNAME, ['id' => $driver1->getId()]));
 
         $queryCount = $this->getCurrentQueryCount();
         $driver3    = $this->_em->find(DDC2862Driver::CLASSNAME, $driver1->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -13,9 +13,9 @@ class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2895'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }
@@ -26,10 +26,10 @@ class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $cm = $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2895');
 
         $this->assertEquals(
-            array(
-                "prePersist" => array("setLastModifiedPreUpdate"),
-                "preUpdate" => array("setLastModifiedPreUpdate"),
-            ),
+            [
+                "prePersist" => ["setLastModifiedPreUpdate"],
+                "preUpdate" => ["setLastModifiedPreUpdate"],
+            ],
             $cm->lifecycleCallbacks
         );
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -14,9 +14,9 @@ class DDC2931Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2931User'),
-            ));
+            ]);
         } catch (\Exception $e) {
             // no action needed - schema seems to be already in place
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
@@ -24,9 +24,9 @@ class DDC2984Test extends \Doctrine\Tests\OrmFunctionalTestCase
         }
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2984User'),
-            ));
+            ]);
         } catch (\Exception $e) {
             // no action needed - schema seems to be already in place
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php
@@ -12,10 +12,10 @@ class DDC2996Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testIssue()
     {
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2996User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC2996UserPreference'),
-        ));
+        ]);
 
         $pref = new DDC2996UserPreference();
         $pref->user = new DDC2996User();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
@@ -12,10 +12,10 @@ class DDC3033Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function testIssue()
     {
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC3033User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC3033Product'),
-        ));
+        ]);
 
         $user = new DDC3033User();
         $user->name = "Test User";
@@ -38,12 +38,12 @@ class DDC3033Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($product);
         $this->_em->flush();
 
-        $expect = array(
-            'title' => array(
+        $expect = [
+            'title' => [
                 0 => 'Test product',
                 1 => 'Test Change title',
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals($expect, $product->changeSet);
     }
@@ -55,7 +55,7 @@ class DDC3033Test extends \Doctrine\Tests\OrmFunctionalTestCase
  */
 class DDC3033Product
 {
-    public $changeSet = array();
+    public $changeSet = [];
 
     /**
      * @var integer $id

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3042Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3042Test.php
@@ -13,10 +13,10 @@ class DDC3042Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3042Foo'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3042Bar'),
-        ));
+        ]);
     }
 
     public function testSQLGenerationDoesNotProvokeAliasCollisions()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3068Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3068Test.php
@@ -40,17 +40,17 @@ class DDC3068Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFindUsingAnArrayOfObjectAsPrimaryKey()
     {
-        $ride1 = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', array(
+        $ride1 = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', [
             'driver' => $this->foo->getId(),
-            'car'    => $this->merc->getBrand())
+            'car'    => $this->merc->getBrand()]
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\Taxi\Ride', $ride1);
 
-        $ride2 = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', array(
+        $ride2 = $this->_em->find('Doctrine\Tests\Models\Taxi\Ride', [
             'driver' => $this->foo,
             'car'    => $this->merc
-        ));
+        ]);
 
         $this->assertInstanceOf('Doctrine\Tests\Models\Taxi\Ride', $ride2);
         $this->assertSame($ride1, $ride2);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php
@@ -6,10 +6,10 @@ class DDC309Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC309Country'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC309User'),
-        ));
+        ]);
     }
 
     public function testTwoIterateHydrations()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
@@ -26,9 +26,9 @@ class DDC3123Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user->username = 'ocramius';
 
         $this->_em->persist($user);
-        $uow->scheduleExtraUpdate($user, array('name' => 'changed name'));
+        $uow->scheduleExtraUpdate($user, ['name' => 'changed name']);
 
-        $listener = $this->getMock('stdClass', array(Events::postFlush));
+        $listener = $this->getMock('stdClass', [Events::postFlush]);
 
         $listener
             ->expects($this->once())

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
@@ -18,12 +18,12 @@ class DDC3170Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setup();
 
         $this->_schemaTool->createSchema(
-            array(
+            [
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3170AbstractEntityJoined'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3170ProductJoined'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3170AbstractEntitySingleTable'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3170ProductSingleTable'),
-            )
+            ]
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
@@ -25,10 +25,10 @@ class DDC3192Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         Type::addType('ddc3192_currency_code', __NAMESPACE__ . '\DDC3192CurrencyCode');
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(DDC3192Currency::CLASSNAME),
             $this->_em->getClassMetadata(DDC3192Transaction::CLASSNAME),
-        ));
+        ]);
     }
 
     public function testIssue()
@@ -130,9 +130,9 @@ class DDC3192Transaction
 
 class DDC3192CurrencyCode extends Type
 {
-    private static $map = array(
+    private static $map = [
         'BYR' => 974,
-    );
+    ];
 
     /**
      * {@inheritdoc}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3223Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3223Test.php
@@ -15,12 +15,12 @@ class DDC3223Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->setUpEntitySchema(array(
+        $this->setUpEntitySchema([
             'Doctrine\Tests\ORM\Functional\Ticket\Journalist',
             'Doctrine\Tests\ORM\Functional\Ticket\Participant',
             'Doctrine\Tests\ORM\Functional\Ticket\Status',
             'Doctrine\Tests\ORM\Functional\Ticket\ProfileStatus',
-        ));
+        ]);
     }
 
     public function testIssueGetId()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -16,20 +16,20 @@ class DDC3300Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $resolveTargetEntity->addResolveTargetEntity(
             DDC3300BossInterface::INTERFACENAME,
             DDC3300Boss::CLASSNAME,
-            array()
+            []
         );
 
         $resolveTargetEntity->addResolveTargetEntity(
             DDC3300EmployeeInterface::INTERFACENAME,
             DDC3300Employee::CLASSNAME,
-            array()
+            []
         );
 
         $this->_em->getEventManager()->addEventSubscriber($resolveTargetEntity);
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(DDC3300Person::CLASSNAME),
-        ));
+        ]);
 
         $boss     = new DDC3300Boss();
         $employee = new DDC3300Employee();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3346Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3346Test.php
@@ -23,7 +23,7 @@ class DDC3346Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         /* @var DDC3346Author $author */
         $author = $this->_em->getRepository(DDC3346Author::CLASSNAME)->findOneBy(
-            array('username' => 'bwoogy')
+            ['username' => 'bwoogy']
         );
 
         $this->assertCount(2, $author->articles);
@@ -33,7 +33,7 @@ class DDC3346Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         /* @var DDC3346Author[] $authors */
         $authors = $this->_em->getRepository(DDC3346Author::CLASSNAME)->findBy(
-            array('username' => 'bwoogy'),
+            ['username' => 'bwoogy'],
             null,
             1
         );
@@ -46,7 +46,7 @@ class DDC3346Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         /* @var DDC3346Author[] $authors */
         $authors = $this->_em->getRepository(DDC3346Author::CLASSNAME)->findBy(
-            array('username' => 'bwoogy'),
+            ['username' => 'bwoogy'],
             null,
             null,
             0 // using an explicitly defined offset

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -8,11 +8,11 @@ class DDC345Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC345User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC345Group'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC345Membership'),
-        ));
+        ]);
     }
 
     public function testTwoIterateHydrations()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
@@ -10,10 +10,10 @@ class DDC353Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC353File'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC353Picture'),
-            ));
+            ]);
         } catch(\Exception $ignored) {}
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -12,10 +12,10 @@ class DDC371Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC371Parent'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC371Child')
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
@@ -11,9 +11,9 @@ class DDC381Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC381Entity'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -8,11 +8,11 @@ class DDC422Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC422Guest'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC422Customer'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC422Contact')
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
@@ -8,10 +8,10 @@ class DDC425Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC425Entity'),
             //$this->_em->getClassMetadata(__NAMESPACE__ . '\DDC425Other')
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -9,10 +9,10 @@ class DDC440Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC440Phone'),
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC440Client')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
@@ -8,9 +8,9 @@ class DDC444Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC444User'),
-        ));
+        ]);
     }
 
     public function testExplicitPolicy()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php
@@ -6,11 +6,11 @@ class DDC448Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC448MainTable'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC448ConnectedClass'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC448SubTable'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
@@ -7,11 +7,11 @@ class DDC493Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC493Customer'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC493Distributor'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC493Contact')
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
@@ -91,13 +91,13 @@ class DDC501Test extends OrmFunctionalTestCase
         $user->username = 'lukacho';
         $user->status = 'developer';
 
-        foreach(array(1111,2222,3333,4444) as $number) {
+        foreach([1111,2222,3333,4444] as $number) {
             $phone = new CmsPhonenumber;
             $phone->phonenumber = $number;
             $user->addPhonenumber($phone);
         }
 
-        foreach(array('Moshers', 'Headbangers') as $groupName) {
+        foreach(['Moshers', 'Headbangers'] as $groupName) {
             $group = new CmsGroup;
             $group->setName($groupName);
             $user->addGroup($group);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
@@ -6,11 +6,11 @@ class DDC512Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC512Customer'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC512OfferItem'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC512Item'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
@@ -7,11 +7,11 @@ class DDC513Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC513OfferItem'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC513Item'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC513Price'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -14,11 +14,11 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC522Customer'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC522Cart'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC522ForeignKeyTest')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php
@@ -7,10 +7,10 @@ class DDC531Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC531Item'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC531SubItem'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
@@ -7,9 +7,9 @@ class DDC588Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC588Site'),
-        ));
+        ]);
     }
 
     public function testIssue()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -9,11 +9,11 @@ class DDC599Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC599Item'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC599Subitem'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC599Child'),
-            ));
+            ]);
         } catch (\Exception $ignored) {}
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -13,10 +13,10 @@ class DDC618Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC618Author'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC618Book')
-            ));
+            ]);
 
             // Create author 10/Joe with two books 22/JoeA and 20/JoeB
             $author = new DDC618Author();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -10,10 +10,10 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC633Patient'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC633Appointment'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
@@ -10,9 +10,9 @@ class DDC656Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC656Entity')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -10,10 +10,10 @@ class DDC698Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC698Role'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC698Privilege')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -8,9 +8,9 @@ class DDC719Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC719Group'),
-        ));
+        ]);
     }
 
     public function testIsEmptySqlGeneration()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
@@ -10,10 +10,10 @@ class DDC729Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         try {
             $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
-            $schemaTool->createSchema(array(
+            $schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC729A'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC729B'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
@@ -10,10 +10,10 @@ class DDC735Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC735Product'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC735Review')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -41,7 +41,7 @@ class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCart', $cart2);
         $this->assertNotInstanceOf('Doctrine\ORM\Proxy\Proxy', $cart2->getCustomer());
         $this->assertInstanceOf('Doctrine\Tests\Models\ECommerce\ECommerceCustomer', $cart2->getCustomer());
-        $this->assertEquals(array('name' => 'roman', 'payment' => 'cash'), $result);
+        $this->assertEquals(['name' => 'roman', 'payment' => 'cash'], $result);
     }
 
     /**
@@ -65,7 +65,7 @@ class DDC736Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $dql = "select c, c.name, ca, ca.payment from Doctrine\Tests\Models\ECommerce\ECommerceCart ca join ca.customer c";
         $result = $this->_em->createQuery($dql)
-                            ->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\Ticket\DisableFetchJoinTreeWalker'))
+                            ->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\Tests\ORM\Functional\Ticket\DisableFetchJoinTreeWalker'])
                             ->getResult();
 
         /* @var $cart2 Doctrine\Tests\Models\ECommerce\ECommerceCart */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -25,10 +25,10 @@ class DDC742Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->getMetadataFactory()->setCacheDriver(new FilesystemCache($testDir));
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC742User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC742Comment')
-            ));
+            ]);
         } catch(\Exception $e) {
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
@@ -49,7 +49,7 @@ class DDC767Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertNotNull($pUser, "User not retrieved from database.");
 
-        $groups = array(2, 3);
+        $groups = [2, 3];
 
         try {
             $this->_em->beginTransaction();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php
@@ -11,31 +11,31 @@ class DDC809Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC809Variant'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC809SpecificationValue')
-        ));
+        ]);
 
         $conn = $this->_em->getConnection();
-        $conn->insert('specification_value_test', array('specification_value_id' => 94589));
-        $conn->insert('specification_value_test', array('specification_value_id' => 94593));
-        $conn->insert('specification_value_test', array('specification_value_id' => 94606));
-        $conn->insert('specification_value_test', array('specification_value_id' => 94607));
-        $conn->insert('specification_value_test', array('specification_value_id' => 94609));
-        $conn->insert('specification_value_test', array('specification_value_id' => 94711));
+        $conn->insert('specification_value_test', ['specification_value_id' => 94589]);
+        $conn->insert('specification_value_test', ['specification_value_id' => 94593]);
+        $conn->insert('specification_value_test', ['specification_value_id' => 94606]);
+        $conn->insert('specification_value_test', ['specification_value_id' => 94607]);
+        $conn->insert('specification_value_test', ['specification_value_id' => 94609]);
+        $conn->insert('specification_value_test', ['specification_value_id' => 94711]);
 
-        $conn->insert('variant_test', array('variant_id' => 545208));
-        $conn->insert('variant_test', array('variant_id' => 545209));
+        $conn->insert('variant_test', ['variant_id' => 545208]);
+        $conn->insert('variant_test', ['variant_id' => 545209]);
 
-        $conn->insert('var_spec_value_test', array('variant_id' => 545208, 'specification_value_id' => 94606));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545208, 'specification_value_id' => 94607));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545208, 'specification_value_id' => 94609));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545208, 'specification_value_id' => 94711));
+        $conn->insert('var_spec_value_test', ['variant_id' => 545208, 'specification_value_id' => 94606]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545208, 'specification_value_id' => 94607]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545208, 'specification_value_id' => 94609]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545208, 'specification_value_id' => 94711]);
 
-        $conn->insert('var_spec_value_test', array('variant_id' => 545209, 'specification_value_id' => 94589));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545209, 'specification_value_id' => 94593));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545209, 'specification_value_id' => 94606));
-        $conn->insert('var_spec_value_test', array('variant_id' => 545209, 'specification_value_id' => 94607));
+        $conn->insert('var_spec_value_test', ['variant_id' => 545209, 'specification_value_id' => 94589]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545209, 'specification_value_id' => 94593]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545209, 'specification_value_id' => 94606]);
+        $conn->insert('var_spec_value_test', ['variant_id' => 545209, 'specification_value_id' => 94607]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -18,11 +18,11 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC832JoinedIndex'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC832JoinedTreeIndex'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC832Like'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -7,13 +7,13 @@ class DDC837Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC837Super'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC837Class1'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC837Class2'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC837Class3'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC837Aggregate'),
-        ));
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -10,11 +10,11 @@ class DDC881Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC881User'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC881Phonenumber'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC881Phonecall'),
-            ));
+            ]);
         } catch (\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php
@@ -29,8 +29,8 @@ class DDC949Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $true = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(array('booleanField' => true));
-        $false = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(array('booleanField' => false));
+        $true = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(['booleanField' => true]);
+        $false = $this->_em->getRepository('Doctrine\Tests\Models\Generic\BooleanModel')->findOneBy(['booleanField' => false]);
 
         $this->assertInstanceOf('Doctrine\Tests\Models\Generic\BooleanModel', $true, "True model not found");
         $this->assertTrue($true->booleanField, "True Boolean Model should be true.");

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -10,10 +10,10 @@ class DDC960Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC960Root'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\\DDC960Child')
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -13,11 +13,11 @@ class DDC992Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC992Role'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC992Parent'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC992Child'),
-            ));
+            ]);
         } catch(\Exception $e) {
 
         }
@@ -65,7 +65,7 @@ class DDC992Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(1, count($parent->childs));
         $this->assertEquals(0, count($parent->childs[0]->childs()));
 
-        $child = $parentRepository->findOneBy(array("id" => $child->id));
+        $child = $parentRepository->findOneBy(["id" => $child->id]);
         $this->assertSame($parent->childs[0], $child);
 
         $this->_em->clear();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
@@ -9,9 +9,9 @@ class Ticket2481Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\Ticket2481Product')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -14,11 +14,11 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase {
     {
         parent::setUp();
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                     $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\Lemma'),
                     $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\Relation'),
                     $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\RelationType')
-            ));
+            ]);
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -77,7 +77,7 @@ class TypeTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $dql = "SELECT s FROM Doctrine\Tests\Models\Generic\SerializationModel s";
         $serialize = $this->_em->createQuery($dql)->getSingleResult();
 
-        $this->assertEquals(array("foo" => "bar", "bar" => "baz"), $serialize->array);
+        $this->assertEquals(["foo" => "bar", "bar" => "baz"], $serialize->array);
     }
 
     public function testObject()
@@ -124,7 +124,7 @@ class TypeTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertInstanceOf('DateTime', $dateTimeDb->datetime);
         $this->assertEquals('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
 
-        $articles = $this->_em->getRepository( 'Doctrine\Tests\Models\Generic\DateTimeModel' )->findBy( array( 'datetime' => new \DateTime( "now" ) ) );
+        $articles = $this->_em->getRepository( 'Doctrine\Tests\Models\Generic\DateTimeModel' )->findBy( [ 'datetime' => new \DateTime( "now" ) ] );
         $this->assertEquals( 0, count( $articles ) );
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -14,9 +14,9 @@ class UUIDGeneratorTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->markTestSkipped('Currently restricted to MySQL platform.');
         }
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\UUIDEntity')
-        ));
+        ]);
     }
 
     public function testGenerateUUID()

--- a/tests/Doctrine/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
@@ -58,7 +58,7 @@ class UnitOfWorkLifecycleTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user = new CmsUser();
 
         $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "The given entity of type 'Doctrine\Tests\Models\CMS\CmsUser' (Doctrine\Tests\Models\CMS\CmsUser@");
-        $this->_em->getUnitOfWork()->registerManaged($user, array(), array());
+        $this->_em->getUnitOfWork()->registerManaged($user, [], []);
     }
 
     public function testMarkReadOnlyNonManaged()

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -82,7 +82,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -107,7 +107,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -133,7 +133,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+            ['id1' => 'def', 'foreignEntity' => $auxiliary]
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity', $inversed);
@@ -159,7 +159,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $this->assertCount(1, $inversed->associatedEntities);
@@ -177,7 +177,7 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         foreach ($inversed->associatedEntities as $owning) {

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -69,7 +69,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -88,7 +88,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -121,7 +121,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $this->assertCount(1, $inversed->associatedEntities);
@@ -139,7 +139,7 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         foreach ($inversed->associatedEntities as $owning) {

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -80,7 +80,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -105,7 +105,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -131,7 +131,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+            ['id1' => 'def', 'foreignEntity' => $auxiliary]
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity', $inversed);
@@ -161,7 +161,7 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $this->assertCount(1, $inversed->associatedEntities);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -67,7 +67,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -86,7 +86,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -121,7 +121,7 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $this->assertCount(1, $inversed->associatedEntities);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -79,7 +79,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -104,7 +104,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $owning = $this->_em->find(
@@ -130,7 +130,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => $auxiliary)
+            ['id1' => 'def', 'foreignEntity' => $auxiliary]
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity', $inversed);
@@ -158,7 +158,7 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
-            array('id1' => 'def', 'foreignEntity' => 'abc')
+            ['id1' => 'def', 'foreignEntity' => 'abc']
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity', $inversed->associatedEntity);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -66,7 +66,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -85,7 +85,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $owning = $this->_em->find(
@@ -120,7 +120,7 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
     {
         $inversed = $this->_em->find(
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
-            array('id1' => 'abc', 'id2' => 'def')
+            ['id1' => 'abc', 'id2' => 'def']
         );
 
         $this->assertInstanceOf('Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity', $inversed->associatedEntity);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -12,14 +12,14 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(array(
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93Person'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93Address'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93Vehicle'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC93Car'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3027Animal'),
                 $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3027Dog'),
-            ));
+            ]);
         } catch(\Exception $e) {
         }
     }
@@ -237,17 +237,17 @@ class ValueObjectsTest extends \Doctrine\Tests\OrmFunctionalTestCase
             )
         );
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\\' . $embeddableClassName),
-        ));
+        ]);
     }
 
     public function getInfiniteEmbeddableNestingData()
     {
-        return array(
-            array('DDCInfiniteNestingEmbeddable', 'DDCInfiniteNestingEmbeddable'),
-            array('DDCNestingEmbeddable1', 'DDCNestingEmbeddable4'),
-        );
+        return [
+            ['DDCInfiniteNestingEmbeddable', 'DDCInfiniteNestingEmbeddable'],
+            ['DDCNestingEmbeddable1', 'DDCNestingEmbeddable4'],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/VersionedOneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/VersionedOneToOneTest.php
@@ -21,10 +21,10 @@ class VersionedOneToOneTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         try {
             $this->_schemaTool->createSchema(
-                array(
+                [
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity'),
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToOne\SecondRelatedEntity')
-                )
+                ]
             );
         } catch (ORMException $e) {
         }
@@ -50,10 +50,10 @@ class VersionedOneToOneTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
 
         $firstEntity = $this->_em->getRepository('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity')
-            ->findOneBy(array('name' => 'Fred'));
+            ->findOneBy(['name' => 'Fred']);
 
         $secondEntity = $this->_em->getRepository('Doctrine\Tests\Models\VersionedOneToOne\SecondRelatedEntity')
-            ->findOneBy(array('name' => 'Bob'));
+            ->findOneBy(['name' => 'Bob']);
 
         $this->assertSame($firstRelatedEntity, $firstEntity);
         $this->assertSame($secondRelatedEntity, $secondEntity);

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -9,12 +9,12 @@ class ArrayHydratorTest extends HydrationTestCase
 {
     public function provideDataForUserEntityResult()
     {
-        return array(
-            array(0),
-            array('user'),
-            array('scalars'),
-            array('newObjects'),
-        );
+        return [
+            [0],
+            ['user'],
+            ['scalars'],
+            ['newObjects'],
+        ];
     }
 
     /**
@@ -29,16 +29,16 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -72,18 +72,18 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'nameUpper');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 's__id' => '1',
                 's__name' => 'romanb',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 's__id' => '2',
                 's__name' => 'jwage',
                 'sclr0' => 'JWAGE',
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -122,16 +122,16 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -165,20 +165,20 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -214,20 +214,20 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -267,20 +267,20 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -320,20 +320,20 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -375,19 +375,19 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'numPhones');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => '2',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => '1',
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -430,27 +430,27 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -502,27 +502,27 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addIndexBy('p', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            )
-        );
+            ]
+        ];
 
 
         $stmt     = new HydratorMockStatement($resultSet);
@@ -586,57 +586,57 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
                 'a__id' => '1',
                 'a__topic' => 'Getting things done!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
                 'a__id' => '1',
                 'a__topic' => 'Getting things done!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
                 'a__id' => '2',
                 'a__topic' => 'ZendCon'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
                 'a__id' => '2',
                 'a__topic' => 'ZendCon'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '3',
                 'a__topic' => 'LINQ'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
                 'a__topic' => 'PHP6'
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -713,9 +713,9 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('c', 'c__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -724,8 +724,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'Getting things done!',
                 'c__id' => '1',
                 'c__topic' => 'First!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -734,8 +734,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'Getting things done!',
                 'c__id' => '1',
                 'c__topic' => 'First!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -744,8 +744,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'ZendCon',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -754,8 +754,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'ZendCon',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
@@ -764,8 +764,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'LINQ',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
@@ -774,8 +774,8 @@ class ArrayHydratorTest extends HydrationTestCase
                 'a__topic' => 'PHP6',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -855,40 +855,40 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('b', 'b__position', 'position');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '1',
                 'b__position' => '0',
                 //'b__category_id' => '1'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '2',
                 'c__position' => '0',
                 'c__name' => 'Second',
                 'b__id' => '2',
                 'b__position' => '0',
                 //'b__category_id' => '2'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '3',
                 'b__position' => '1',
                 //'b__category_id' => '1'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '4',
                 'b__position' => '2',
                 //'b__category_id' => '1'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -924,33 +924,33 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('c__topic', 'ctopic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'a__id' => '1',
                 'a__topic' => 'The First',
                 'c__id' => '1',
                 'c__topic' => 'First Comment'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'a__id' => '1',
                 'a__topic' => 'The First',
                 'c__id' => '2',
                 'c__topic' => 'Second Comment'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'a__id' => '42',
                 'a__topic' => 'The Answer',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -989,16 +989,16 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -1033,16 +1033,16 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -1080,13 +1080,13 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'foo' => 'bar', // unknown!
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -1114,29 +1114,29 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'nameUpper');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => null,
                 'u__status' => null,
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
-            ),
-            array(
+            ],
+            [
                 'u__id' => null,
                 'u__status' => null,
                 'sclr0' => 'JWAGE',
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);
@@ -1149,9 +1149,9 @@ class ArrayHydratorTest extends HydrationTestCase
         $this->assertEquals('JWAGE', $result[2]['nameUpper']);
         $this->assertEquals('JWAGE', $result[3]['nameUpper']);
 
-        $this->assertEquals(array('id' => 1, 'status' => 'developer'), $result[0][$userEntityKey]);
+        $this->assertEquals(['id' => 1, 'status' => 'developer'], $result[0][$userEntityKey]);
         $this->assertNull($result[1][$userEntityKey]);
-        $this->assertEquals(array('id' => 2, 'status' => 'developer'), $result[2][$userEntityKey]);
+        $this->assertEquals(['id' => 2, 'status' => 'developer'], $result[2][$userEntityKey]);
         $this->assertNull($result[3][$userEntityKey]);
     }
 
@@ -1173,19 +1173,19 @@ class ArrayHydratorTest extends HydrationTestCase
         $rsm->addIndexBy('u', 'id');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ArrayHydrator($this->_em);

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -15,28 +15,28 @@ class ObjectHydratorTest extends HydrationTestCase
 {
     public function provideDataForUserEntityResult()
     {
-        return array(
-            array(0),
-            array('user'),
-        );
+        return [
+            [0],
+            ['user'],
+        ];
     }
 
     public function provideDataForMultipleRootEntityResult()
     {
-        return array(
-            array(0, 0),
-            array('user', 0),
-            array(0, 'article'),
-            array('user', 'article'),
-        );
+        return [
+            [0, 0],
+            ['user', 0],
+            [0, 'article'],
+            ['user', 'article'],
+        ];
     }
 
     public function provideDataForProductEntityResult()
     {
-        return array(
-            array(0),
-            array('product'),
-        );
+        return [
+            [0],
+            ['product'],
+        ];
     }
 
     /**
@@ -51,20 +51,20 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -90,20 +90,20 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -135,24 +135,24 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
 
@@ -189,24 +189,24 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
 
@@ -250,24 +250,24 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
 
@@ -311,24 +311,24 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'a__id' => '1',
                 'a__topic' => 'Cool things.'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'a__id' => '2',
                 'a__topic' => 'Cool things II.'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
 
@@ -374,23 +374,23 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'numPhones');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => '2',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => '1',
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -430,31 +430,31 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'nameUpper');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'p__phonenumber' => '42',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'p__phonenumber' => '43',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'p__phonenumber' => '91',
                 'sclr0' => 'JWAGE',
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -510,32 +510,32 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addIndexBy('p', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            )
-        );
+            ]
+        ];
 
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -595,61 +595,61 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('a', 'a__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
                 'a__id' => '1',
                 'a__topic' => 'Getting things done!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
                 'a__id' => '1',
                 'a__topic' => 'Getting things done!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
                 'a__id' => '2',
                 'a__topic' => 'ZendCon'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
                 'a__id' => '2',
                 'a__topic' => 'ZendCon'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '3',
                 'a__topic' => 'LINQ'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
                 'a__topic' => 'PHP6'
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -713,9 +713,9 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('c', 'c__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -724,8 +724,8 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'Getting things done!',
                 'c__id' => '1',
                 'c__topic' => 'First!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -734,8 +734,8 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'Getting things done!',
                 'c__id' => '1',
                 'c__topic' => 'First!'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -744,8 +744,8 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'ZendCon',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
@@ -754,8 +754,8 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'ZendCon',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
@@ -764,8 +764,8 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'LINQ',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
@@ -774,12 +774,12 @@ class ObjectHydratorTest extends HydrationTestCase
                 'a__topic' => 'PHP6',
                 'c__id' => null,
                 'c__topic' => null
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -855,44 +855,44 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('b', 'b__position', 'position');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '1',
                 'b__position' => '0',
                 //'b__category_id' => '1'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '2',
                 'c__position' => '0',
                 'c__name' => 'Second',
                 'b__id' => '2',
                 'b__position' => '0',
                 //'b__category_id' => '2'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '3',
                 'b__position' => '1',
                 //'b__category_id' => '1'
-            ),
-            array(
+            ],
+            [
                 'c__id' => '1',
                 'c__position' => '0',
                 'c__name' => 'First',
                 'b__id' => '4',
                 'b__position' => '2',
                 //'b__category_id' => '1'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -925,17 +925,17 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'foo' => 'bar', // unknown!
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(1, count($result));
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $result[0]);
@@ -955,20 +955,20 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr1', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'sclr0' => '1',
                 'sclr1' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'sclr0' => '2',
                 'sclr1' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -995,21 +995,21 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('p', 'p__shipping_id', 'shipping_id');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'p__id' => '1',
                 'p__name' => 'Doctrine Book',
                 'p__shipping_id' => 42
-            )
-        );
+            ]
+        ];
 
         $proxyInstance = new \Doctrine\Tests\Models\ECommerce\ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', array('getProxy'), array(), '', false, false, false);
+        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', ['getProxy'], [], '', false, false, false);
         $proxyFactory->expects($this->once())
                      ->method('getProxy')
-                     ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), array('id' => 42))
+                     ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), ['id' => 42])
                      ->will($this->returnValue($proxyInstance));
 
         $this->_em->setProxyFactory($proxyFactory);
@@ -1040,21 +1040,21 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('p', 'p__shipping_id', 'shipping_id');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'p__id' => '1',
                 'p__name' => 'Doctrine Book',
                 'p__shipping_id' => 42
-            )
-        );
+            ]
+        ];
 
         $proxyInstance = new \Doctrine\Tests\Models\ECommerce\ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', array('getProxy'), array(), '', false, false, false);
+        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', ['getProxy'], [], '', false, false, false);
         $proxyFactory->expects($this->once())
                      ->method('getProxy')
-                     ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), array('id' => 42))
+                     ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), ['id' => 42])
                      ->will($this->returnValue($proxyInstance));
 
         $this->_em->setProxyFactory($proxyFactory);
@@ -1103,29 +1103,29 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('c', 'c__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'a__id' => null,
                 'a__topic' => null,
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'a__id' => null,
                 'a__topic' => null,
                 'c__id' => null,
                 'c__topic' => null
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1166,29 +1166,29 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('c', 'c__topic', 'topic');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'a__id' => null,
                 'a__topic' => null,
                 'c__id' => null,
                 'c__topic' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'a__id' => null,
                 'a__topic' => null,
                 'c__id' => null,
                 'c__topic' => null
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1278,20 +1278,20 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt           = new HydratorMockStatement($resultSet);
         $hydrator       = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $iterableResult = $hydrator->iterate($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $iterableResult = $hydrator->iterate($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
         $rowNum         = 0;
 
         while (($row = $iterableResult->next()) !== false) {
@@ -1322,20 +1322,20 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-            )
-        );
+            ]
+        ];
 
         $stmt           = new HydratorMockStatement($resultSet);
         $hydrator       = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $iterableResult = $hydrator->iterate($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $iterableResult = $hydrator->iterate($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
         $rowNum         = 0;
 
         while (($row = $iterableResult->next()) !== false) {
@@ -1377,96 +1377,96 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 1111,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 1111,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 2222,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 2222,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '2',
                 'g__name' => 'TestGroupA',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '4',
                 'g__name' => 'TestGroupC',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '2',
                 'g__name' => 'TestGroupA',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '4',
                 'g__name' => 'TestGroupC',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 4444,
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1500,96 +1500,96 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 1111,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 1111,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 2222,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 2222,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '2',
                 'g__name' => 'TestGroupA',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '4',
                 'g__name' => 'TestGroupC',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 3333,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '2',
                 'g__name' => 'TestGroupA',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '3',
                 'g__name' => 'TestGroupB',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '4',
                 'g__name' => 'TestGroupC',
                 'p__phonenumber' => 4444,
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage',
                 'g__id' => '5',
                 'g__name' => 'TestGroupD',
                 'p__phonenumber' => 4444,
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1621,33 +1621,33 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('sclr0', 'nameUpper');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => null,
                 'u__status' => null,
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
-            ),
-            array(
+            ],
+            [
                 'u__id' => null,
                 'u__status' => null,
                 'sclr0' => 'JWAGE',
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result), "Should hydrate four results.");
 
@@ -1687,37 +1687,37 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => null
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => null
-            )
-        );
+            ]
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1751,27 +1751,27 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('a', 'user_id', 'user_id');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
                 'a__id' => 1,
                 'a__city' => 'Berlin',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'BENJAMIN',
                 'a__id' => null,
                 'a__city' => null,
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1797,23 +1797,23 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addIndexBy('u', 'id');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'sclr0' => 'JWAGE',
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
 
@@ -1839,25 +1839,25 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addIndexByScalar('sclr0');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'sclr0' => 'ROMANB',
-            ),
-            array(
+            ],
+            [
                 'sclr0' => 'JWAGE',
-            ),
-        );
+            ],
+        ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $result   = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(
-            array(
-                'ROMANB' => array('nameUpper' => 'ROMANB'),
-                'JWAGE'  => array('nameUpper' => 'JWAGE')
-            ),
+            [
+                'ROMANB' => ['nameUpper' => 'ROMANB'],
+                'JWAGE'  => ['nameUpper' => 'JWAGE']
+            ],
             $result
         );
     }
@@ -1879,12 +1879,12 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('c', 'c__id', 'id');
         $rsm->setDiscriminatorColumn('c', 'c_discr');
 
-        $resultSet = array(
-              array(
+        $resultSet = [
+              [
                   'c__id'   => '1',
                   'c_discr' => 'fix',
-              ),
-         );
+              ],
+         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
@@ -1913,14 +1913,14 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('e ', 'e_discr', 'discr');
         $rsm->setDiscriminatorColumn('e', 'e_discr');
 
-        $resultSet = array(
-              array(
+        $resultSet = [
+              [
                   'c__id'   => '1',
                   'c_discr' => 'fix',
                   'e__id'   => '1',
                   'e__name' => 'Fabio B. Silva'
-              ),
-         );
+              ],
+         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
@@ -1944,13 +1944,13 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('p', 'discr', 'discr');
         $rsm->setDiscriminatorColumn('p', 'discr');
 
-        $resultSet = array(
-              array(
+        $resultSet = [
+              [
                   'p__id'   => '1',
                   'p__name' => 'Fabio B. Silva',
                   'discr'   => 'subworker'
-              ),
-         );
+              ],
+         ];
 
         $stmt       = new HydratorMockStatement($resultSet);
         $hydrator   = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -100,60 +100,60 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'fieldName'     => 'email',
             'targetEntity'  => 'Doctrine\Tests\Models\CMS\CmsEmail',
-            'cascade'       => array('persist'),
+            'cascade'       => ['persist'],
             'inversedBy'    => 'user',
             'orphanRemoval' => false,
-            'joinColumns'   => array(array(
+            'joinColumns'   => [[
                     'nullable' => true,
                     'referencedColumnName' => 'id',
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT u.id AS user_id, e.id AS email_id, u.name, e.email, u.id + e.id AS scalarColumn FROM cms_users u INNER JOIN cms_emails e ON e.id = u.email_id',
             'resultSetMapping'  => 'find-all',
-        ));
-        $cm->addSqlResultSetMapping(array(
+        ]);
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => '__CLASS__',
-                    'fields'        => array(
-                        array(
+                    'fields'        => [
+                        [
                             'name'  => 'id',
                             'column'=> 'user_id'
-                        ),
-                        array(
+                        ],
+                        [
                             'name'  => 'name',
                             'column'=> 'name'
-                        )
-                    )
-                ),
-                array(
+                        ]
+                    ]
+                ],
+                [
                     'entityClass'   => 'CmsEmail',
-                    'fields'        => array(
-                        array(
+                    'fields'        => [
+                        [
                             'name'  => 'id',
                             'column'=> 'email_id'
-                        ),
-                        array(
+                        ],
+                        [
                             'name'  => 'email',
                             'column'=> 'email'
-                        )
-                    )
-                )
-            ),
-            'columns'   => array(
-                array(
+                        ]
+                    ]
+                ]
+            ],
+            'columns'   => [
+                [
                     'name' => 'scalarColumn'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
         
         $queryMapping = $cm->getNamedNativeQuery('find-all');
@@ -185,24 +185,24 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT u.id AS user_id, e.id AS email_id, u.name, e.email, u.id + e.id AS scalarColumn FROM cms_users u INNER JOIN cms_emails e ON e.id = u.email_id',
             'resultSetMapping'  => 'find-all',
-        ));
-        $cm->addSqlResultSetMapping(array(
+        ]);
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => '__CLASS__',
-                )
-            ),
-            'columns'   => array(
-                array(
+                ]
+            ],
+            'columns'   => [
+                [
                     'name' => 'scalarColumn'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
 
         $queryMapping = $cm->getNamedNativeQuery('find-all');
@@ -231,11 +231,11 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'resultClass'       => '__CLASS__',
             'query'             => 'SELECT * FROM cms_users',
-        ));
+        ]);
 
         $queryMapping = $cm->getNamedNativeQuery('find-all');
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
@@ -18,16 +18,16 @@ class ScalarHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb'
-                ),
-            array(
+                ],
+            [
                 'u__id' => '2',
                 'u__name' => 'jwage'
-                )
-            );
+                ]
+            ];
 
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -53,13 +53,13 @@ class ScalarHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('bar2', 'bar');
         $rsm->addScalarResult('baz3', 'baz');
 
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'foo1' => 'A',
                 'bar2' => 'B',
                 'baz3' => 'C',
-            ),
-        );
+            ],
+        ];
 
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ScalarHydrator($this->_em);
@@ -80,16 +80,16 @@ class ScalarHydratorTest extends HydrationTestCase
         $rsm->addScalarResult('bar2', 'bar');
         $rsm->addScalarResult('baz3', 'baz');
 
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'u__id' => '1',
                 'u__name' => 'romanb',
                 'foo1' => 'A',
                 'bar2' => 'B',
                 'baz3' => 'C',
                 'foo' => 'bar', // Unknown!
-            ),
-        );
+            ],
+        ];
 
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new \Doctrine\ORM\Internal\Hydration\ScalarHydrator($this->_em);

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -21,12 +21,12 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('p', 'p__name', 'name');
         $rsm->addMetaResult('p ', 'discr', 'discr');
         $rsm->setDiscriminatorColumn('p', 'discr');
-        $resultSet = array(
-              array(
+        $resultSet = [
+              [
                   'u__id'   => '1',
                   'u__name' => 'Fabio B. Silva'
-              ),
-         );
+              ],
+         ];
 
         $stmt       = new HydratorMockStatement($resultSet);
         $hydrator   = new \Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator($this->_em);
@@ -39,13 +39,13 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $rsm->addEntityResult('Doctrine\Tests\Models\CMS\CmsAddress', 'a');
         $rsm->addFieldResult('a', 'a__id', 'id');
         $rsm->addFieldResult('a', 'a__city', 'city');
-        $resultSet = array(
-            array(
+        $resultSet = [
+            [
                 'a__id'   => '1',
                 'a__city' => 'Cracow',
                 'doctrine_rownum' => '1'
-            ),
-        );
+            ],
+        ];
 
         $expectedEntity = new \Doctrine\Tests\Models\CMS\CmsAddress();
         $expectedEntity->id = 1;
@@ -74,13 +74,13 @@ class SimpleObjectHydratorTest extends HydrationTestCase
         $rsm->addMetaResult('p', 'discr', 'discr');
         $rsm->setDiscriminatorColumn('p', 'discr');
 
-        $resultSet = array(
-              array(
+        $resultSet = [
+              [
                   'p__id'   => '1',
                   'p__name' => 'Fabio B. Silva',
                   'discr'   => 'subworker'
-              ),
-         );
+              ],
+         ];
 
         $stmt       = new HydratorMockStatement($resultSet);
         $hydrator   = new \Doctrine\ORM\Internal\Hydration\SimpleObjectHydrator($this->_em);

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -9,40 +9,40 @@ class SingleScalarHydratorTest extends HydrationTestCase
 {
     /** Result set provider for the HYDRATE_SINGLE_SCALAR tests */
     public static function singleScalarResultSetProvider() {
-        return array(
+        return [
           // valid
-          array('name' => 'result1',
-                'resultSet' => array(
-                  array(
+          ['name' => 'result1',
+                'resultSet' => [
+                  [
                       'u__name' => 'romanb'
-                  )
-               )),
+                  ]
+               ]],
           // valid
-          array('name' => 'result2',
-                'resultSet' => array(
-                  array(
+          ['name' => 'result2',
+                'resultSet' => [
+                  [
                       'u__id' => '1'
-                  )
-             )),
+                  ]
+             ]],
            // invalid
-           array('name' => 'result3',
-                'resultSet' => array(
-                  array(
+           ['name' => 'result3',
+                'resultSet' => [
+                  [
                       'u__id' => '1',
                       'u__name' => 'romanb'
-                  )
-             )),
+                  ]
+             ]],
            // invalid
-           array('name' => 'result4',
-                'resultSet' => array(
-                  array(
+           ['name' => 'result4',
+                'resultSet' => [
+                  [
                       'u__id' => '1'
-                  ),
-                  array(
+                  ],
+                  [
                       'u__id' => '2'
-                  )
-             )),
-        );
+                  ]
+             ]],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -40,13 +40,13 @@ class AssignedGeneratorTest extends \Doctrine\Tests\OrmTestCase
         $entity = new AssignedSingleIdEntity;
         $entity->myId = 1;
         $id = $this->_assignedGen->generate($this->_em, $entity);
-        $this->assertEquals(array('myId' => 1), $id);
+        $this->assertEquals(['myId' => 1], $id);
 
         $entity = new AssignedCompositeIdEntity;
         $entity->myId2 = 2;
         $entity->myId1 = 4;
         $id = $this->_assignedGen->generate($this->_em, $entity);
-        $this->assertEquals(array('myId1' => 4, 'myId2' => 2), $id);
+        $this->assertEquals(['myId1' => 4, 'myId2' => 2], $id);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -53,7 +53,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->listenersInvoker = $this->getMock('Doctrine\ORM\Event\ListenersInvoker', array(), array(), '', false);
+        $this->listenersInvoker = $this->getMock('Doctrine\ORM\Event\ListenersInvoker', [], [], '', false);
         $this->entityManager    = $this->getMock('Doctrine\ORM\EntityManagerInterface');
         $this->handler          = new HydrationCompleteHandler($this->listenersInvoker, $this->entityManager);
     }
@@ -66,7 +66,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testDefersPostLoadOfEntity($listenersFlag)
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', [], [], '', false);
         $entity        = new stdClass();
         $entityManager = $this->entityManager;
 
@@ -104,7 +104,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testDefersPostLoadOfEntityOnlyOnce($listenersFlag)
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', [], [], '', false);
         $entity   = new stdClass();
 
         $this
@@ -131,8 +131,8 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     {
         /* @var $metadata1 \Doctrine\ORM\Mapping\ClassMetadata */
         /* @var $metadata2 \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata1      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
-        $metadata2      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata1      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', [], [], '', false);
+        $metadata2      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', [], [], '', false);
         $entity1        = new stdClass();
         $entity2        = new stdClass();
         $entityManager  = $this->entityManager;
@@ -156,7 +156,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
                 Events::postLoad,
                 $this->logicalOr($entity1, $entity2),
                 $this->callback(function (LifecycleEventArgs $args) use ($entityManager, $entity1, $entity2) {
-                    return in_array($args->getEntity(), array($entity1, $entity2), true)
+                    return in_array($args->getEntity(), [$entity1, $entity2], true)
                         && $entityManager === $args->getObjectManager();
                 }),
                 $listenersFlag
@@ -168,7 +168,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testSkipsDeferredPostLoadOfMetadataWithNoInvokedListeners()
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', [], [], '', false);
         $entity   = new stdClass();
 
         $this
@@ -187,13 +187,13 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testGetValidListenerInvocationFlags()
     {
-        return array(
-            array(ListenersInvoker::INVOKE_LISTENERS),
-            array(ListenersInvoker::INVOKE_CALLBACKS),
-            array(ListenersInvoker::INVOKE_MANAGER),
-            array(ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_CALLBACKS),
-            array(ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_MANAGER),
-            array(ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_CALLBACKS | ListenersInvoker::INVOKE_MANAGER),
-        );
+        return [
+            [ListenersInvoker::INVOKE_LISTENERS],
+            [ListenersInvoker::INVOKE_CALLBACKS],
+            [ListenersInvoker::INVOKE_MANAGER],
+            [ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_CALLBACKS],
+            [ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_MANAGER],
+            [ListenersInvoker::INVOKE_LISTENERS | ListenersInvoker::INVOKE_CALLBACKS | ListenersInvoker::INVOKE_MANAGER],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -65,12 +65,12 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('loadCriteria')
             ->with($this->criteria)
-            ->will($this->returnValue(array('foo', 'bar', 'baz')));
+            ->will($this->returnValue(['foo', 'bar', 'baz']));
 
         // should never call the persister's count
         $this->persister->expects($this->never())->method('count');
 
-        $this->assertSame(array('foo', 'bar', 'baz'), $this->lazyCriteriaCollection->toArray());
+        $this->assertSame(['foo', 'bar', 'baz'], $this->lazyCriteriaCollection->toArray());
 
         $this->assertSame(3, $this->lazyCriteriaCollection->count());
     }
@@ -90,7 +90,7 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('loadCriteria')
             ->with($this->criteria)
-            ->will($this->returnValue(array($foo, $bar, $baz)));
+            ->will($this->returnValue([$foo, $bar, $baz]));
 
         $criteria = new Criteria();
 
@@ -99,8 +99,8 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
         $filtered = $this->lazyCriteriaCollection->matching($criteria);
 
         $this->assertInstanceOf('Doctrine\Common\Collections\Collection', $filtered);
-        $this->assertEquals(array($foo), $filtered->toArray());
+        $this->assertEquals([$foo], $filtered->toArray());
 
-        $this->assertEquals(array($foo), $this->lazyCriteriaCollection->matching($criteria)->toArray());
+        $this->assertEquals([$foo], $this->lazyCriteriaCollection->matching($criteria)->toArray());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -67,10 +67,10 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
     public function testEntityIndexes($class)
     {
         $this->assertArrayHasKey('indexes', $class->table, 'ClassMetadata should have indexes key in table property.');
-        $this->assertEquals(array(
-            'name_idx' => array('columns' => array('name')),
-            0 => array('columns' => array('user_email'))
-        ), $class->table['indexes']);
+        $this->assertEquals([
+            'name_idx' => ['columns' => ['name']],
+            0 => ['columns' => ['user_email']]
+        ], $class->table['indexes']);
 
         return $class;
     }
@@ -79,13 +79,13 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
     {
         $class = $this->createClassMetadata('Doctrine\Tests\ORM\Mapping\Comment');
 
-        $this->assertEquals(array(
-            0 => array(
-                'columns' => array('content'),
-                'flags' => array('fulltext'),
-                'options' => array('where' => 'content IS NOT NULL'),
-            )
-        ), $class->table['indexes']);
+        $this->assertEquals([
+            0 => [
+                'columns' => ['content'],
+                'flags' => ['fulltext'],
+                'options' => ['where' => 'content IS NOT NULL'],
+            ]
+        ], $class->table['indexes']);
     }
 
     /**
@@ -97,9 +97,9 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertArrayHasKey('uniqueConstraints', $class->table,
             'ClassMetadata should have uniqueConstraints key in table property when Unique Constraints are set.');
 
-        $this->assertEquals(array(
-            "search_idx" => array("columns" => array("name", "user_email"), 'options' => array('where' => 'name IS NOT NULL'))
-        ), $class->table['uniqueConstraints']);
+        $this->assertEquals([
+            "search_idx" => ["columns" => ["name", "user_email"], 'options' => ['where' => 'name IS NOT NULL']]
+        ], $class->table['uniqueConstraints']);
 
         return $class;
     }
@@ -112,9 +112,9 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertArrayHasKey('options', $class->table, 'ClassMetadata should have options key in table property.');
 
-        $this->assertEquals(array(
-            'foo' => 'bar', 'baz' => array('key' => 'val')
-        ), $class->table['options']);
+        $this->assertEquals([
+            'foo' => 'bar', 'baz' => ['key' => 'val']
+        ], $class->table['options']);
 
         return $class;
     }
@@ -127,11 +127,11 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertInternalType('array', $class->sequenceGeneratorDefinition, 'No Sequence Definition set on this driver.');
         $this->assertEquals(
-            array(
+            [
                 'sequenceName' => 'tablename_seq',
                 'allocationSize' => 100,
                 'initialValue' => 1,
-            ),
+            ],
             $class->sequenceGeneratorDefinition
         );
     }
@@ -143,7 +143,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_CUSTOM,
             $class->generatorType, "Generator Type");
         $this->assertEquals(
-            array("class" => "stdClass"),
+            ["class" => "stdClass"],
             $class->customGeneratorDefinition,
             "Custom Generator Definition");
     }
@@ -209,7 +209,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFieldOptions($class)
     {
-        $expected = array('foo' => 'bar', 'baz' => array('key' => 'val'));
+        $expected = ['foo' => 'bar', 'baz' => ['key' => 'val']];
         $this->assertEquals($expected, $class->fieldMappings['name']['options']);
 
         return $class;
@@ -221,7 +221,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testIdFieldOptions($class)
     {
-        $this->assertEquals(array('foo' => 'bar'), $class->fieldMappings['id']['options']);
+        $this->assertEquals(['foo' => 'bar'], $class->fieldMappings['id']['options']);
 
         return $class;
     }
@@ -232,7 +232,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testIdentifier($class)
     {
-        $this->assertEquals(array('id'), $class->identifier);
+        $this->assertEquals(['id'], $class->identifier);
         $this->assertEquals('integer', $class->fieldMappings['id']['type']);
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_AUTO, $class->generatorType, "ID-Generator is not ClassMetadata::GENERATOR_TYPE_AUTO");
 
@@ -285,7 +285,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($class->associationMappings['phonenumbers']['orphanRemoval']);
 
         // Test Order By
-        $this->assertEquals(array('number' => 'ASC'), $class->associationMappings['phonenumbers']['orderBy']);
+        $this->assertEquals(['number' => 'ASC'], $class->associationMappings['phonenumbers']['orderBy']);
 
         return $class;
     }
@@ -383,7 +383,7 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $class = $this->createClassMetadata('Doctrine\Tests\ORM\Mapping\Animal');
 
         $this->assertEquals(
-            array('name' => 'discr', 'type' => 'string', 'length' => '32', 'fieldName' => 'discr', 'columnDefinition' => null),
+            ['name' => 'discr', 'type' => 'string', 'length' => '32', 'fieldName' => 'discr', 'columnDefinition' => null],
             $class->discriminatorColumn
         );
     }
@@ -578,18 +578,18 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $findAllMapping = $class->getSqlResultSetMapping('mapping-find-all');
         $this->assertEquals('mapping-find-all', $findAllMapping['name']);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $findAllMapping['entities'][0]['entityClass']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'), $findAllMapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'city','column'=>'city'), $findAllMapping['entities'][0]['fields'][1]);
-        $this->assertEquals(array('name'=>'country','column'=>'country'), $findAllMapping['entities'][0]['fields'][2]);
+        $this->assertEquals(['name'=>'id','column'=>'id'], $findAllMapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'city','column'=>'city'], $findAllMapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'country','column'=>'country'], $findAllMapping['entities'][0]['fields'][2]);
 
         $withoutFieldsMapping = $class->getSqlResultSetMapping('mapping-without-fields');
         $this->assertEquals('mapping-without-fields', $withoutFieldsMapping['name']);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $withoutFieldsMapping['entities'][0]['entityClass']);
-        $this->assertEquals(array(), $withoutFieldsMapping['entities'][0]['fields']);
+        $this->assertEquals([], $withoutFieldsMapping['entities'][0]['fields']);
 
         $countMapping = $class->getSqlResultSetMapping('mapping-count');
         $this->assertEquals('mapping-count', $countMapping['name']);
-        $this->assertEquals(array('name'=>'count'), $countMapping['columns'][0]);
+        $this->assertEquals(['name'=>'count'], $countMapping['columns'][0]);
 
     }
 
@@ -606,61 +606,61 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertCount(4, $userMetadata->getSqlResultSetMappings());
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingJoinedAddress');
-        $this->assertEquals(array(),$mapping['columns']);
+        $this->assertEquals([],$mapping['columns']);
         $this->assertEquals('mappingJoinedAddress', $mapping['name']);
         $this->assertNull($mapping['entities'][0]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'),                     $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'name'),                 $mapping['entities'][0]['fields'][1]);
-        $this->assertEquals(array('name'=>'status','column'=>'status'),             $mapping['entities'][0]['fields'][2]);
-        $this->assertEquals(array('name'=>'address.zip','column'=>'zip'),           $mapping['entities'][0]['fields'][3]);
-        $this->assertEquals(array('name'=>'address.city','column'=>'city'),         $mapping['entities'][0]['fields'][4]);
-        $this->assertEquals(array('name'=>'address.country','column'=>'country'),   $mapping['entities'][0]['fields'][5]);
-        $this->assertEquals(array('name'=>'address.id','column'=>'a_id'),           $mapping['entities'][0]['fields'][6]);
+        $this->assertEquals(['name'=>'id','column'=>'id'],                     $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'name'],                 $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'status','column'=>'status'],             $mapping['entities'][0]['fields'][2]);
+        $this->assertEquals(['name'=>'address.zip','column'=>'zip'],           $mapping['entities'][0]['fields'][3]);
+        $this->assertEquals(['name'=>'address.city','column'=>'city'],         $mapping['entities'][0]['fields'][4]);
+        $this->assertEquals(['name'=>'address.country','column'=>'country'],   $mapping['entities'][0]['fields'][5]);
+        $this->assertEquals(['name'=>'address.id','column'=>'a_id'],           $mapping['entities'][0]['fields'][6]);
         $this->assertEquals($userMetadata->name,                                    $mapping['entities'][0]['entityClass']);
 
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingJoinedPhonenumber');
-        $this->assertEquals(array(),$mapping['columns']);
+        $this->assertEquals([],$mapping['columns']);
         $this->assertEquals('mappingJoinedPhonenumber', $mapping['name']);
         $this->assertNull($mapping['entities'][0]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'),                             $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'name'),                         $mapping['entities'][0]['fields'][1]);
-        $this->assertEquals(array('name'=>'status','column'=>'status'),                     $mapping['entities'][0]['fields'][2]);
-        $this->assertEquals(array('name'=>'phonenumbers.phonenumber','column'=>'number'),   $mapping['entities'][0]['fields'][3]);
+        $this->assertEquals(['name'=>'id','column'=>'id'],                             $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'name'],                         $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'status','column'=>'status'],                     $mapping['entities'][0]['fields'][2]);
+        $this->assertEquals(['name'=>'phonenumbers.phonenumber','column'=>'number'],   $mapping['entities'][0]['fields'][3]);
         $this->assertEquals($userMetadata->name,                                            $mapping['entities'][0]['entityClass']);
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingUserPhonenumberCount');
-        $this->assertEquals(array('name'=>'numphones'),$mapping['columns'][0]);
+        $this->assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
         $this->assertEquals('mappingUserPhonenumberCount', $mapping['name']);
         $this->assertNull($mapping['entities'][0]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'),         $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'name'),     $mapping['entities'][0]['fields'][1]);
-        $this->assertEquals(array('name'=>'status','column'=>'status'), $mapping['entities'][0]['fields'][2]);
+        $this->assertEquals(['name'=>'id','column'=>'id'],         $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'name'],     $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'status','column'=>'status'], $mapping['entities'][0]['fields'][2]);
         $this->assertEquals($userMetadata->name,                        $mapping['entities'][0]['entityClass']);
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingMultipleJoinsEntityResults');
-        $this->assertEquals(array('name'=>'numphones'),$mapping['columns'][0]);
+        $this->assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
         $this->assertEquals('mappingMultipleJoinsEntityResults', $mapping['name']);
         $this->assertNull($mapping['entities'][0]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'u_id'),           $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'u_name'),       $mapping['entities'][0]['fields'][1]);
-        $this->assertEquals(array('name'=>'status','column'=>'u_status'),   $mapping['entities'][0]['fields'][2]);
+        $this->assertEquals(['name'=>'id','column'=>'u_id'],           $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'u_name'],       $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'status','column'=>'u_status'],   $mapping['entities'][0]['fields'][2]);
         $this->assertEquals($userMetadata->name,                            $mapping['entities'][0]['entityClass']);
         $this->assertNull($mapping['entities'][1]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'a_id'),           $mapping['entities'][1]['fields'][0]);
-        $this->assertEquals(array('name'=>'zip','column'=>'a_zip'),         $mapping['entities'][1]['fields'][1]);
-        $this->assertEquals(array('name'=>'country','column'=>'a_country'), $mapping['entities'][1]['fields'][2]);
+        $this->assertEquals(['name'=>'id','column'=>'a_id'],           $mapping['entities'][1]['fields'][0]);
+        $this->assertEquals(['name'=>'zip','column'=>'a_zip'],         $mapping['entities'][1]['fields'][1]);
+        $this->assertEquals(['name'=>'country','column'=>'a_country'], $mapping['entities'][1]['fields'][2]);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress',         $mapping['entities'][1]['entityClass']);
 
         //person asserts
         $this->assertCount(1, $personMetadata->getSqlResultSetMappings());
 
         $mapping = $personMetadata->getSqlResultSetMapping('mappingFetchAll');
-        $this->assertEquals(array(),$mapping['columns']);
+        $this->assertEquals([],$mapping['columns']);
         $this->assertEquals('mappingFetchAll', $mapping['name']);
         $this->assertEquals('discriminator',                            $mapping['entities'][0]['discriminatorColumn']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'),         $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'name'),     $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'id','column'=>'id'],         $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'name'],     $mapping['entities'][0]['fields'][1]);
         $this->assertEquals($personMetadata->name,                      $mapping['entities'][0]['entityClass']);
     }
 
@@ -700,18 +700,18 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('user_id', $guestGroups['joinTable']['joinColumns'][0]['name']);
         $this->assertEquals('group_id', $guestGroups['joinTable']['inverseJoinColumns'][0]['name']);
 
-        $this->assertEquals(array('user_id'=>'id'), $guestGroups['relationToSourceKeyColumns']);
-        $this->assertEquals(array('group_id'=>'id'), $guestGroups['relationToTargetKeyColumns']);
-        $this->assertEquals(array('user_id','group_id'), $guestGroups['joinTableColumns']);
+        $this->assertEquals(['user_id'=>'id'], $guestGroups['relationToSourceKeyColumns']);
+        $this->assertEquals(['group_id'=>'id'], $guestGroups['relationToTargetKeyColumns']);
+        $this->assertEquals(['user_id','group_id'], $guestGroups['joinTableColumns']);
 
 
         $this->assertEquals('ddc964_users_admingroups', $adminGroups['joinTable']['name']);
         $this->assertEquals('adminuser_id', $adminGroups['joinTable']['joinColumns'][0]['name']);
         $this->assertEquals('admingroup_id', $adminGroups['joinTable']['inverseJoinColumns'][0]['name']);
 
-        $this->assertEquals(array('adminuser_id'=>'id'), $adminGroups['relationToSourceKeyColumns']);
-        $this->assertEquals(array('admingroup_id'=>'id'), $adminGroups['relationToTargetKeyColumns']);
-        $this->assertEquals(array('adminuser_id','admingroup_id'), $adminGroups['joinTableColumns']);
+        $this->assertEquals(['adminuser_id'=>'id'], $adminGroups['relationToSourceKeyColumns']);
+        $this->assertEquals(['admingroup_id'=>'id'], $adminGroups['relationToTargetKeyColumns']);
+        $this->assertEquals(['adminuser_id','admingroup_id'], $adminGroups['joinTableColumns']);
 
 
         // assert address association mappings
@@ -736,15 +736,15 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
 
         // assert override
         $this->assertEquals('address_id', $guestAddress['joinColumns'][0]['name']);
-        $this->assertEquals(array('address_id'=>'id'), $guestAddress['sourceToTargetKeyColumns']);
-        $this->assertEquals(array('address_id'=>'address_id'), $guestAddress['joinColumnFieldNames']);
-        $this->assertEquals(array('id'=>'address_id'), $guestAddress['targetToSourceKeyColumns']);
+        $this->assertEquals(['address_id'=>'id'], $guestAddress['sourceToTargetKeyColumns']);
+        $this->assertEquals(['address_id'=>'address_id'], $guestAddress['joinColumnFieldNames']);
+        $this->assertEquals(['id'=>'address_id'], $guestAddress['targetToSourceKeyColumns']);
 
 
         $this->assertEquals('adminaddress_id', $adminAddress['joinColumns'][0]['name']);
-        $this->assertEquals(array('adminaddress_id'=>'id'), $adminAddress['sourceToTargetKeyColumns']);
-        $this->assertEquals(array('adminaddress_id'=>'adminaddress_id'), $adminAddress['joinColumnFieldNames']);
-        $this->assertEquals(array('id'=>'adminaddress_id'), $adminAddress['targetToSourceKeyColumns']);
+        $this->assertEquals(['adminaddress_id'=>'id'], $adminAddress['sourceToTargetKeyColumns']);
+        $this->assertEquals(['adminaddress_id'=>'adminaddress_id'], $adminAddress['joinColumnFieldNames']);
+        $this->assertEquals(['id'=>'adminaddress_id'], $adminAddress['targetToSourceKeyColumns']);
     }
 
     /**
@@ -760,8 +760,8 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($adminMetadata->fieldMappings['id']['id']);
         $this->assertEquals('id', $adminMetadata->fieldMappings['id']['fieldName']);
         $this->assertEquals('user_id', $adminMetadata->fieldMappings['id']['columnName']);
-        $this->assertEquals(array('user_id'=>'id','user_name'=>'name'), $adminMetadata->fieldNames);
-        $this->assertEquals(array('id'=>'user_id','name'=>'user_name'), $adminMetadata->columnNames);
+        $this->assertEquals(['user_id'=>'id','user_name'=>'name'], $adminMetadata->fieldNames);
+        $this->assertEquals(['id'=>'user_id','name'=>'user_name'], $adminMetadata->columnNames);
         $this->assertEquals(150, $adminMetadata->fieldMappings['id']['length']);
 
 
@@ -775,8 +775,8 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($guestMetadata->fieldMappings['id']['id']);
         $this->assertEquals('guest_id', $guestMetadata->fieldMappings['id']['columnName']);
         $this->assertEquals('id', $guestMetadata->fieldMappings['id']['fieldName']);
-        $this->assertEquals(array('guest_id'=>'id','guest_name'=>'name'), $guestMetadata->fieldNames);
-        $this->assertEquals(array('id'=>'guest_id','name'=>'guest_name'), $guestMetadata->columnNames);
+        $this->assertEquals(['guest_id'=>'id','guest_name'=>'name'], $guestMetadata->fieldNames);
+        $this->assertEquals(['id'=>'guest_id','name'=>'guest_name'], $guestMetadata->columnNames);
         $this->assertEquals(140, $guestMetadata->fieldMappings['id']['length']);
 
         $this->assertEquals('name', $guestMetadata->fieldMappings['name']['fieldName']);
@@ -1045,126 +1045,126 @@ class User
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
         $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-        $metadata->setPrimaryTable(array(
+        $metadata->setPrimaryTable([
            'name' => 'cms_users',
-           'options' => array('foo' => 'bar', 'baz' => array('key' => 'val')),
-          ));
+           'options' => ['foo' => 'bar', 'baz' => ['key' => 'val']],
+          ]);
         $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
         $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
         $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
         $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id' => true,
            'fieldName' => 'id',
            'type' => 'integer',
            'columnName' => 'id',
-           'options' => array('foo' => 'bar'),
-          ));
-        $metadata->mapField(array(
+           'options' => ['foo' => 'bar'],
+          ]);
+        $metadata->mapField([
            'fieldName' => 'name',
            'type' => 'string',
            'length' => 50,
            'unique' => true,
            'nullable' => true,
            'columnName' => 'name',
-           'options' => array('foo' => 'bar', 'baz' => array('key' => 'val')),
-          ));
-        $metadata->mapField(array(
+           'options' => ['foo' => 'bar', 'baz' => ['key' => 'val']],
+          ]);
+        $metadata->mapField([
            'fieldName' => 'email',
            'type' => 'string',
            'columnName' => 'user_email',
            'columnDefinition' => 'CHAR(32) NOT NULL',
-          ));
-        $mapping = array('fieldName' => 'version', 'type' => 'integer');
+          ]);
+        $mapping = ['fieldName' => 'version', 'type' => 'integer'];
         $metadata->setVersionMapping($mapping);
         $metadata->mapField($mapping);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
-        $metadata->mapOneToOne(array(
+        $metadata->mapOneToOne([
            'fieldName' => 'address',
            'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Address',
            'cascade' =>
-           array(
+           [
            0 => 'remove',
-           ),
+           ],
            'mappedBy' => NULL,
            'inversedBy' => 'user',
            'joinColumns' =>
-           array(
+           [
            0 =>
-           array(
+           [
             'name' => 'address_id',
             'referencedColumnName' => 'id',
             'onDelete' => 'CASCADE',
-           ),
-           ),
+           ],
+           ],
            'orphanRemoval' => false,
-          ));
-        $metadata->mapOneToMany(array(
+          ]);
+        $metadata->mapOneToMany([
            'fieldName' => 'phonenumbers',
            'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Phonenumber',
            'cascade' =>
-           array(
+           [
            1 => 'persist',
-           ),
+           ],
            'mappedBy' => 'user',
            'orphanRemoval' => true,
            'orderBy' =>
-           array(
+           [
            'number' => 'ASC',
-           ),
-          ));
-        $metadata->mapManyToMany(array(
+           ],
+          ]);
+        $metadata->mapManyToMany([
            'fieldName' => 'groups',
            'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Group',
            'cascade' =>
-           array(
+           [
            0 => 'remove',
            1 => 'persist',
            2 => 'refresh',
            3 => 'merge',
            4 => 'detach',
-           ),
+           ],
            'mappedBy' => NULL,
            'joinTable' =>
-           array(
+           [
            'name' => 'cms_users_groups',
            'joinColumns' =>
-           array(
+           [
             0 =>
-            array(
+            [
             'name' => 'user_id',
             'referencedColumnName' => 'id',
             'unique' => false,
             'nullable' => false,
-            ),
-           ),
+            ],
+           ],
            'inverseJoinColumns' =>
-           array(
+           [
             0 =>
-            array(
+            [
             'name' => 'group_id',
             'referencedColumnName' => 'id',
             'columnDefinition' => 'INT NULL',
-            ),
-           ),
-           ),
+            ],
+           ],
+           ],
            'orderBy' => NULL,
-          ));
-        $metadata->table['uniqueConstraints'] = array(
-            'search_idx' => array('columns' => array('name', 'user_email'), 'options'=> array('where' => 'name IS NOT NULL')),
-        );
-        $metadata->table['indexes'] = array(
-            'name_idx' => array('columns' => array('name')), 0 => array('columns' => array('user_email'))
-        );
-        $metadata->setSequenceGeneratorDefinition(array(
+          ]);
+        $metadata->table['uniqueConstraints'] = [
+            'search_idx' => ['columns' => ['name', 'user_email'], 'options'=> ['where' => 'name IS NOT NULL']],
+        ];
+        $metadata->table['indexes'] = [
+            'name_idx' => ['columns' => ['name']], 0 => ['columns' => ['user_email']]
+        ];
+        $metadata->setSequenceGeneratorDefinition([
                 'sequenceName' => 'tablename_seq',
                 'allocationSize' => 100,
                 'initialValue' => 1,
-            ));
-        $metadata->addNamedQuery(array(
+            ]);
+        $metadata->addNamedQuery([
                 'name' => 'all',
                 'query' => 'SELECT u FROM __CLASS__ u'
-            ));
+            ]);
     }
 }
 
@@ -1185,7 +1185,7 @@ abstract class Animal
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
-        $metadata->setCustomGeneratorDefinition(array("class" => "stdClass"));
+        $metadata->setCustomGeneratorDefinition(["class" => "stdClass"]);
     }
 }
 
@@ -1252,16 +1252,16 @@ class DDC1170Entity
 
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
-        $metadata->mapField(array(
+        $metadata->mapField([
            'id'                 => true,
            'fieldName'          => 'id',
            'columnDefinition'   => 'INT unsigned NOT NULL',
-        ));
+        ]);
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             'fieldName'         => 'value',
             'columnDefinition'  => 'VARCHAR(255) NOT NULL'
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
     }
@@ -1285,16 +1285,16 @@ class DDC807Entity
 
    public static function loadMetadata(ClassMetadataInfo $metadata)
     {
-         $metadata->mapField(array(
+         $metadata->mapField([
            'id'                 => true,
            'fieldName'          => 'id',
-        ));
+        ]);
 
-        $metadata->setDiscriminatorColumn(array(
+        $metadata->setDiscriminatorColumn([
             'name'              => "dtype",
             'type'              => "string",
             'columnDefinition'  => "ENUM('ONE','TWO')"
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
     }
@@ -1322,13 +1322,13 @@ class Comment
     public static function loadMetadata(ClassMetadataInfo $metadata)
     {
         $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-        $metadata->setPrimaryTable(array(
-            'indexes' => array(
-                array('columns' => array('content'), 'flags' => array('fulltext'), 'options' => array('where' => 'content IS NOT NULL'))
-            )
-        ));
+        $metadata->setPrimaryTable([
+            'indexes' => [
+                ['columns' => ['content'], 'flags' => ['fulltext'], 'options' => ['where' => 'content IS NOT NULL']]
+            ]
+        ]);
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             'fieldName' => 'content',
             'type' => 'text',
             'scale' => 0,
@@ -1337,6 +1337,6 @@ class Comment
             'nullable' => false,
             'precision' => 0,
             'columnName' => 'content',
-        ));
+        ]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -95,7 +95,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     protected function _loadDriverForCMSModels()
     {
         $annotationDriver = $this->_loadDriver();
-        $annotationDriver->addPaths(array(__DIR__ . '/../../Models/CMS/'));
+        $annotationDriver->addPaths([__DIR__ . '/../../Models/CMS/']);
         return $annotationDriver;
     }
 
@@ -117,7 +117,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     public function testJoinTablesWithMappedSuperclassForAnnotationDriver()
     {
         $annotationDriver = $this->_loadDriver();
-        $annotationDriver->addPaths(array(__DIR__ . '/../../Models/DirectoryTree/'));
+        $annotationDriver->addPaths([__DIR__ . '/../../Models/DirectoryTree/']);
 
         $em = $this->_getTestEntityManager();
         $em->getConfiguration()->setMetadataDriverImpl($annotationDriver);
@@ -181,10 +181,10 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory->setEntityManager($em);
 
         $cm = $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\AnnotationChild');
-        $this->assertEquals(array("postLoad" => array("postLoad"), "preUpdate" => array("preUpdate")), $cm->lifecycleCallbacks);
+        $this->assertEquals(["postLoad" => ["postLoad"], "preUpdate" => ["preUpdate"]], $cm->lifecycleCallbacks);
 
         $cm = $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\AnnotationParent');
-        $this->assertEquals(array("postLoad" => array("postLoad"), "preUpdate" => array("preUpdate")), $cm->lifecycleCallbacks);
+        $this->assertEquals(["postLoad" => ["postLoad"], "preUpdate" => ["preUpdate"]], $cm->lifecycleCallbacks);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/AnsiQuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnsiQuoteStrategyTest.php
@@ -47,8 +47,8 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     public function testGetColumnName()
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $class->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
-        $class->mapField(array('fieldName' => 'id', 'columnName' => 'id', 'id' => true));
+        $class->mapField(['fieldName' => 'name', 'columnName' => 'name']);
+        $class->mapField(['fieldName' => 'id', 'columnName' => 'id', 'id' => true]);
 
         $this->assertEquals('id' ,$this->strategy->getColumnName('id', $class, $this->platform));
         $this->assertEquals('name' ,$this->strategy->getColumnName('name', $class, $this->platform));
@@ -58,7 +58,7 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $class->setPrimaryTable(array('name'=>'cms_user'));
+        $class->setPrimaryTable(['name'=>'cms_user']);
         $this->assertEquals('cms_user' ,$this->strategy->getTableName($class, $this->platform));
     }
 
@@ -66,14 +66,14 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         
-        $class->mapManyToMany(array(
+        $class->mapManyToMany([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser',
             'inversedBy'    => 'users',
-            'joinTable'     => array(
+            'joinTable'     => [
                 'name'  => 'cmsaddress_cmsuser'
-            )
-        ));
+            ]
+        ]);
         
         $this->assertEquals('cmsaddress_cmsuser', $this->strategy->getJoinTableName($class->associationMappings['user'], $class, $this->platform));
        
@@ -83,13 +83,13 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
 
-        $class->mapField(array(
+        $class->mapField([
             'id'            => true,
             'fieldName'     => 'id',
             'columnName'    => 'id',
-        ));
+        ]);
 
-        $this->assertEquals(array('id'), $this->strategy->getIdentifierColumnNames($class, $this->platform));
+        $this->assertEquals(['id'], $this->strategy->getIdentifierColumnNames($class, $this->platform));
     }
 
 
@@ -102,14 +102,14 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     {
         $class = $this->createClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
 
-        $class->mapOneToOne(array(
+        $class->mapOneToOne([
             'id'            => true,
             'fieldName'     => 'article',
             'targetEntity'  => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns'    => array(array(
+            'joinColumns'    => [[
                 'name'  => 'article'
-            )),
-        ));
+            ]],
+        ]);
 
         $joinColumn = $class->associationMappings['article']['joinColumns'][0];
         $this->assertEquals('article',$this->strategy->getJoinColumnName($joinColumn, $class, $this->platform));
@@ -119,14 +119,14 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'id'            => true,
             'fieldName'     => 'article',
             'targetEntity'  => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns'    => array(array(
+            'joinColumns'    => [[
                 'name'  => 'article'
-            )),
-        ));
+            ]],
+        ]);
 
         $joinColumn = $cm->associationMappings['article']['joinColumns'][0];
         $this->assertEquals('id',$this->strategy->getReferencedJoinColumnName($joinColumn, $cm, $this->platform));
@@ -135,11 +135,11 @@ class AnsiQuoteStrategyTest extends OrmTestCase
     public function testGetSequenceName()
     {
         $class      = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $definition = array(
+        $definition = [
             'sequenceName'      => 'user_id_seq',
             'allocationSize'    => 1,
             'initialValue'      => 2
-        );
+        ];
 
         $class->setSequenceGeneratorDefinition($definition);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -153,7 +153,7 @@ class BasicInheritanceMappingTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertInstanceOf('Doctrine\ORM\Id\SequenceGenerator', $class->idGenerator);
         $this->assertEquals(
-            array('allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'),
+            ['allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'],
             $class->sequenceGeneratorDefinition
         );
     }
@@ -169,7 +169,7 @@ class BasicInheritanceMappingTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertInstanceOf('Doctrine\ORM\Id\SequenceGenerator', $class->idGenerator);
         $this->assertEquals(
-            array('allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'),
+            ['allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'],
             $class->sequenceGeneratorDefinition
         );
     }
@@ -185,7 +185,7 @@ class BasicInheritanceMappingTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertInstanceOf('Doctrine\ORM\Id\SequenceGenerator', $class->idGenerator);
         $this->assertEquals(
-            array('allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'),
+            ['allocationSize' => 1, 'initialValue' => 10, 'sequenceName' => 'foo'],
             $class->sequenceGeneratorDefinition
         );
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -70,28 +70,28 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
 
     public function testAddIndex()
     {
-        $this->assertIsFluent($this->builder->addIndex(array('username', 'name'), 'users_idx'));
-        $this->assertEquals(array('users_idx' => array('columns' => array('username', 'name'))), $this->cm->table['indexes']);
+        $this->assertIsFluent($this->builder->addIndex(['username', 'name'], 'users_idx'));
+        $this->assertEquals(['users_idx' => ['columns' => ['username', 'name']]], $this->cm->table['indexes']);
     }
 
     public function testAddUniqueConstraint()
     {
-        $this->assertIsFluent($this->builder->addUniqueConstraint(array('username', 'name'), 'users_idx'));
-        $this->assertEquals(array('users_idx' => array('columns' => array('username', 'name'))), $this->cm->table['uniqueConstraints']);
+        $this->assertIsFluent($this->builder->addUniqueConstraint(['username', 'name'], 'users_idx'));
+        $this->assertEquals(['users_idx' => ['columns' => ['username', 'name']]], $this->cm->table['uniqueConstraints']);
     }
 
     public function testSetPrimaryTableRelated()
     {
-        $this->builder->addUniqueConstraint(array('username', 'name'), 'users_idx');
-        $this->builder->addIndex(array('username', 'name'), 'users_idx');
+        $this->builder->addUniqueConstraint(['username', 'name'], 'users_idx');
+        $this->builder->addIndex(['username', 'name'], 'users_idx');
         $this->builder->setTable('users');
 
         $this->assertEquals(
-            array(
+            [
                 'name' => 'users',
-                'indexes' => array('users_idx' => array('columns' => array('username', 'name'))),
-                'uniqueConstraints' => array('users_idx' => array('columns' => array('username', 'name'))),
-            ),
+                'indexes' => ['users_idx' => ['columns' => ['username', 'name']]],
+                'uniqueConstraints' => ['users_idx' => ['columns' => ['username', 'name']]],
+            ],
             $this->cm->table
         );
     }
@@ -111,7 +111,7 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testSetDiscriminatorColumn()
     {
         $this->assertIsFluent($this->builder->setDiscriminatorColumn('discr', 'string', '124'));
-        $this->assertEquals(array('fieldName' => 'discr', 'name' => 'discr', 'type' => 'string', 'length' => '124'), $this->cm->discriminatorColumn);
+        $this->assertEquals(['fieldName' => 'discr', 'name' => 'discr', 'type' => 'string', 'length' => '124'], $this->cm->discriminatorColumn);
     }
 
     public function testAddDiscriminatorMapClass()
@@ -119,7 +119,7 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertIsFluent($this->builder->addDiscriminatorMapClass('test', 'Doctrine\Tests\Models\CMS\CmsUser'));
         $this->assertIsFluent($this->builder->addDiscriminatorMapClass('test2', 'Doctrine\Tests\Models\CMS\CmsGroup'));
 
-        $this->assertEquals(array('test' => 'Doctrine\Tests\Models\CMS\CmsUser', 'test2' => 'Doctrine\Tests\Models\CMS\CmsGroup'), $this->cm->discriminatorMap);
+        $this->assertEquals(['test' => 'Doctrine\Tests\Models\CMS\CmsUser', 'test2' => 'Doctrine\Tests\Models\CMS\CmsGroup'], $this->cm->discriminatorMap);
         $this->assertEquals('test', $this->cm->discriminatorValue);
     }
 
@@ -138,7 +138,7 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
     public function testAddField()
     {
         $this->assertIsFluent($this->builder->addField('name', 'string'));
-        $this->assertEquals(array('columnName' => 'name', 'fieldName' => 'name', 'type' => 'string'), $this->cm->fieldMappings['name']);
+        $this->assertEquals(['columnName' => 'name', 'fieldName' => 'name', 'type' => 'string'], $this->cm->fieldMappings['name']);
     }
 
     public function testCreateField()
@@ -148,13 +148,13 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertFalse(isset($this->cm->fieldMappings['name']));
         $this->assertIsFluent($fieldBuilder->build());
-        $this->assertEquals(array('columnName' => 'name', 'fieldName' => 'name', 'type' => 'string'), $this->cm->fieldMappings['name']);
+        $this->assertEquals(['columnName' => 'name', 'fieldName' => 'name', 'type' => 'string'], $this->cm->fieldMappings['name']);
     }
 
     public function testCreateVersionedField()
     {
         $this->builder->createField('name', 'integer')->columnName('username')->length(124)->nullable()->columnDefinition('foobar')->unique()->isVersionField()->build();
-        $this->assertEquals(array(
+        $this->assertEquals([
             'columnDefinition' => 'foobar',
             'columnName' => 'username',
             'default' => 1,
@@ -163,29 +163,29 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
             'type' => 'integer',
             'nullable' => true,
             'unique' => true,
-        ), $this->cm->fieldMappings['name']);
+        ], $this->cm->fieldMappings['name']);
     }
 
     public function testCreatePrimaryField()
     {
         $this->builder->createField('id', 'integer')->isPrimaryKey()->generatedValue()->build();
 
-        $this->assertEquals(array('id'), $this->cm->identifier);
-        $this->assertEquals(array('columnName' => 'id', 'fieldName' => 'id', 'id' => true, 'type' => 'integer'), $this->cm->fieldMappings['id']);
+        $this->assertEquals(['id'], $this->cm->identifier);
+        $this->assertEquals(['columnName' => 'id', 'fieldName' => 'id', 'id' => true, 'type' => 'integer'], $this->cm->fieldMappings['id']);
     }
 
     public function testCreateUnsignedOptionField()
     {
         $this->builder->createField('state', 'integer')->option('unsigned', true)->build();
 
-        $this->assertEquals(array('fieldName' => 'state', 'type' => 'integer', 'options' => array('unsigned' => true), 'columnName' => 'state'), $this->cm->fieldMappings['state']);
+        $this->assertEquals(['fieldName' => 'state', 'type' => 'integer', 'options' => ['unsigned' => true], 'columnName' => 'state'], $this->cm->fieldMappings['state']);
     }
 
     public function testAddLifecycleEvent()
     {
         $this->builder->addLifecycleEvent('getStatus', 'postLoad');
 
-        $this->assertEquals(array('postLoad' => array('getStatus')), $this->cm->lifecycleCallbacks);
+        $this->assertEquals(['postLoad' => ['getStatus']], $this->cm->lifecycleCallbacks);
     }
 
     public function testCreateManyToOne()
@@ -198,28 +198,28 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                               ->build()
         );
 
-        $this->assertEquals(array('groups' => array (
+        $this->assertEquals(['groups' =>  [
                 'fieldName' => 'groups',
                 'targetEntity' => 'Doctrine\\Tests\\Models\\CMS\\CmsGroup',
-                'cascade' => array (
+                'cascade' =>  [
                   0 => 'remove',
                   1 => 'persist',
                   2 => 'refresh',
                   3 => 'merge',
                   4 => 'detach',
-                ),
+                ],
                 'fetch' => 4,
-                'joinColumns' => array (
+                'joinColumns' =>  [
                   0 =>
-                  array (
+                   [
                     'name' => 'group_id',
                     'referencedColumnName' => 'id',
                     'nullable' => true,
                     'unique' => false,
                     'onDelete' => 'CASCADE',
                     'columnDefinition' => NULL,
-                  ),
-                ),
+                  ],
+                ],
                 'type' => 2,
                 'mappedBy' => NULL,
                 'inversedBy' => NULL,
@@ -231,20 +231,20 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                 'isCascadeMerge' => true,
                 'isCascadeDetach' => true,
                 'sourceToTargetKeyColumns' =>
-                array (
+                 [
                   'group_id' => 'id',
-                ),
+                ],
                 'joinColumnFieldNames' =>
-                array (
+                 [
                   'group_id' => 'group_id',
-                ),
+                ],
                 'targetToSourceKeyColumns' =>
-                array (
+                 [
                   'id' => 'group_id',
-                ),
+                ],
                 'orphanRemoval' => false,
-              ),
-            ), $this->cm->associationMappings);
+              ],
+            ], $this->cm->associationMappings);
     }
 
     public function testCreateOneToOne()
@@ -257,28 +257,28 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                               ->build()
         );
 
-        $this->assertEquals(array('groups' => array (
+        $this->assertEquals(['groups' =>  [
                 'fieldName' => 'groups',
                 'targetEntity' => 'Doctrine\\Tests\\Models\\CMS\\CmsGroup',
-                'cascade' => array (
+                'cascade' =>  [
                   0 => 'remove',
                   1 => 'persist',
                   2 => 'refresh',
                   3 => 'merge',
                   4 => 'detach',
-                ),
+                ],
                 'fetch' => 4,
-                'joinColumns' => array (
+                'joinColumns' =>  [
                   0 =>
-                  array (
+                   [
                     'name' => 'group_id',
                     'referencedColumnName' => 'id',
                     'nullable' => true,
                     'unique' => true,
                     'onDelete' => 'CASCADE',
                     'columnDefinition' => NULL,
-                  ),
-                ),
+                  ],
+                ],
                 'type' => 1,
                 'mappedBy' => NULL,
                 'inversedBy' => NULL,
@@ -290,20 +290,20 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                 'isCascadeMerge' => true,
                 'isCascadeDetach' => true,
                 'sourceToTargetKeyColumns' =>
-                array (
+                 [
                   'group_id' => 'id',
-                ),
+                ],
                 'joinColumnFieldNames' =>
-                array (
+                 [
                   'group_id' => 'group_id',
-                ),
+                ],
                 'targetToSourceKeyColumns' =>
-                array (
+                 [
                   'id' => 'group_id',
-                ),
+                ],
                 'orphanRemoval' => false,
-              ),
-            ), $this->cm->associationMappings);
+              ],
+            ], $this->cm->associationMappings);
     }
 
     public function testCreateManyToMany()
@@ -318,48 +318,48 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                               ->build()
         );
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'groups' =>
-            array(
+            [
                 'fieldName' => 'groups',
                 'targetEntity' => 'Doctrine\\Tests\\Models\\CMS\\CmsGroup',
                 'cascade' =>
-                array(
+                [
                     0 => 'remove',
                     1 => 'persist',
                     2 => 'refresh',
                     3 => 'merge',
                     4 => 'detach',
-                ),
+                ],
                 'fetch' => 4,
                 'joinTable' =>
-                array(
+                [
                     'joinColumns' =>
-                    array(
+                    [
                         0 =>
-                        array(
+                        [
                             'name' => 'group_id',
                             'referencedColumnName' => 'id',
                             'nullable' => true,
                             'unique' => false,
                             'onDelete' => 'CASCADE',
                             'columnDefinition' => NULL,
-                        ),
-                    ),
+                        ],
+                    ],
                     'inverseJoinColumns' =>
-                    array(
+                    [
                         0 =>
-                        array(
+                        [
                             'name' => 'user_id',
                             'referencedColumnName' => 'id',
                             'nullable' => true,
                             'unique' => false,
                             'onDelete' => NULL,
                             'columnDefinition' => NULL,
-                        ),
-                    ),
+                        ],
+                    ],
                     'name' => 'groups_users',
-                ),
+                ],
                 'type' => 8,
                 'mappedBy' => NULL,
                 'inversedBy' => NULL,
@@ -372,21 +372,21 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                 'isCascadeDetach' => true,
                 'isOnDeleteCascade' => true,
                 'relationToSourceKeyColumns' =>
-                array(
+                [
                     'group_id' => 'id',
-                ),
+                ],
                 'joinTableColumns' =>
-                array(
+                [
                     0 => 'group_id',
                     1 => 'user_id',
-                ),
+                ],
                 'relationToTargetKeyColumns' =>
-                array(
+                [
                     'user_id' => 'id',
-                ),
+                ],
                 'orphanRemoval' => false,
-            ),
-                ), $this->cm->associationMappings);
+            ],
+                ], $this->cm->associationMappings);
     }
 
     public function testCreateOneToMany()
@@ -394,21 +394,21 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
         $this->assertIsFluent(
                 $this->builder->createOneToMany('groups', 'Doctrine\Tests\Models\CMS\CmsGroup')
                         ->mappedBy('test')
-                        ->setOrderBy(array('test'))
+                        ->setOrderBy(['test'])
                         ->setIndexBy('test')
                         ->build()
         );
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'groups' =>
-            array(
+            [
                 'fieldName' => 'groups',
                 'targetEntity' => 'Doctrine\\Tests\\Models\\CMS\\CmsGroup',
                 'mappedBy' => 'test',
                 'orderBy' =>
-                array(
+                [
                     0 => 'test',
-                ),
+                ],
                 'indexBy' => 'test',
                 'type' => 4,
                 'inversedBy' => NULL,
@@ -416,16 +416,16 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
                 'sourceEntity' => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
                 'fetch' => 2,
                 'cascade' =>
-                array(
-                ),
+                [
+                ],
                 'isCascadeRemove' => false,
                 'isCascadePersist' => false,
                 'isCascadeRefresh' => false,
                 'isCascadeMerge' => false,
                 'isCascadeDetach' => false,
                 'orphanRemoval' => false,
-            ),
-                ), $this->cm->associationMappings);
+            ],
+                ], $this->cm->associationMappings);
     }
 
     public function assertIsFluent($ret)

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -34,7 +34,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $cmf->setMetadataFor($cm1->name, $cm1);
 
         // Prechecks
-        $this->assertEquals(array(), $cm1->parentClasses);
+        $this->assertEquals([], $cm1->parentClasses);
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $cm1->inheritanceType);
         $this->assertTrue($cm1->hasField('name'));
         $this->assertEquals(2, count($cm1->associationMappings));
@@ -47,7 +47,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSame($cm1, $cmMap1);
         $this->assertEquals('group', $cmMap1->table['name']);
         $this->assertTrue($cmMap1->table['quoted']);
-        $this->assertEquals(array(), $cmMap1->parentClasses);
+        $this->assertEquals([], $cmMap1->parentClasses);
         $this->assertTrue($cmMap1->hasField('name'));
     }
 
@@ -55,8 +55,8 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm1 = $this->_createValidClassMetadata();
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
-        $cm1->customGeneratorDefinition = array(
-            "class" => "Doctrine\Tests\ORM\Mapping\CustomIdGenerator");
+        $cm1->customGeneratorDefinition = [
+            "class" => "Doctrine\Tests\ORM\Mapping\CustomIdGenerator"];
         $cmf = $this->_createTestFactory();
         $cmf->setMetadataForClass($cm1->name, $cm1);
 
@@ -72,7 +72,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm1 = $this->_createValidClassMetadata();
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
-        $cm1->customGeneratorDefinition = array("class" => "NotExistingGenerator");
+        $cm1->customGeneratorDefinition = ["class" => "NotExistingGenerator"];
         $cmf = $this->_createTestFactory();
         $cmf->setMetadataForClass($cm1->name, $cm1);
         $this->setExpectedException("Doctrine\ORM\ORMException");
@@ -95,7 +95,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         require_once __DIR__."/../../Models/Global/GlobalNamespaceModel.php";
 
-        $metadataDriver = $this->createAnnotationDriver(array(__DIR__ . '/../../Models/Global/'));
+        $metadataDriver = $this->createAnnotationDriver([__DIR__ . '/../../Models/Global/']);
 
         $entityManager = $this->_createEntityManager($metadataDriver);
 
@@ -158,7 +158,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     public function testAddDefaultDiscriminatorMap()
     {
         $cmf = new ClassMetadataFactory();
-        $driver = $this->createAnnotationDriver(array(__DIR__ . '/../../Models/JoinedInheritanceType/'));
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/JoinedInheritanceType/']);
         $em = $this->_createEntityManager($driver);
         $cmf->setEntityManager($em);
 
@@ -186,7 +186,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
 
         // ClassMetadataFactory::addDefaultDiscriminatorMap shouldn't be called again, because the
         // discriminator map is already cached
-        $cmf = $this->getMock('Doctrine\ORM\Mapping\ClassMetadataFactory', array('addDefaultDiscriminatorMap'));
+        $cmf = $this->getMock('Doctrine\ORM\Mapping\ClassMetadataFactory', ['addDefaultDiscriminatorMap']);
         $cmf->setEntityManager($em);
         $cmf->expects($this->never())
             ->method('addDefaultDiscriminatorMap');
@@ -201,7 +201,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $config->setProxyDir(__DIR__ . '/../../Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $eventManager = new EventManager();
-        $conn = new ConnectionMock(array(), $driverMock, $config, $eventManager);
+        $conn = new ConnectionMock([], $driverMock, $config, $eventManager);
         $mockDriver = new MetadataDriverMock();
         $config->setMetadataDriverImpl($metadataDriver);
 
@@ -229,18 +229,18 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         // Self-made metadata
         $cm1 = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
         $cm1->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $cm1->setPrimaryTable(array('name' => '`group`'));
+        $cm1->setPrimaryTable(['name' => '`group`']);
         // Add a mapped field
-        $cm1->mapField(array('fieldName' => 'name', 'type' => 'varchar'));
+        $cm1->mapField(['fieldName' => 'name', 'type' => 'varchar']);
         // Add a mapped field
-        $cm1->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
+        $cm1->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
         // and a mapped association
-        $cm1->mapOneToOne(array('fieldName' => 'other', 'targetEntity' => 'TestEntity1', 'mappedBy' => 'this'));
+        $cm1->mapOneToOne(['fieldName' => 'other', 'targetEntity' => 'TestEntity1', 'mappedBy' => 'this']);
         // and an association on the owning side
-        $joinColumns = array(
-            array('name' => 'other_id', 'referencedColumnName' => 'id')
-        );
-        $cm1->mapOneToOne(array('fieldName' => 'association', 'targetEntity' => 'TestEntity1', 'joinColumns' => $joinColumns));
+        $joinColumns = [
+            ['name' => 'other_id', 'referencedColumnName' => 'id']
+        ];
+        $cm1->mapOneToOne(['fieldName' => 'association', 'targetEntity' => 'TestEntity1', 'joinColumns' => $joinColumns]);
         // and an id generator type
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
         return $cm1;
@@ -252,7 +252,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     public function testQuoteMetadata()
     {
         $cmf    = new ClassMetadataFactory();
-        $driver = $this->createAnnotationDriver(array(__DIR__ . '/../../Models/Quote/'));
+        $driver = $this->createAnnotationDriver([__DIR__ . '/../../Models/Quote/']);
         $em     = $this->_createEntityManager($driver);
         $cmf->setEntityManager($em);
 
@@ -339,7 +339,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $cmf           = new ClassMetadataFactory();
         $mockDriver    = new MetadataDriverMock();
         $em = $this->_createEntityManager($mockDriver);
-        $listener      = $this->getMock('stdClass', array('onClassMetadataNotFound'));
+        $listener      = $this->getMock('stdClass', ['onClassMetadataNotFound']);
         $eventManager  = $em->getEventManager();
 
         $cmf->setEntityManager($em);
@@ -355,7 +355,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
                 $args->setFoundMetadata($metadata);
             }));
 
-        $eventManager->addEventListener(array(Events::onClassMetadataNotFound), $listener);
+        $eventManager->addEventListener([Events::onClassMetadataNotFound], $listener);
 
         $this->assertSame($metadata, $cmf->getMetadataFor('Foo'));
     }
@@ -383,11 +383,11 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         $metadata = $this->_createValidClassMetadata();
 
-        $metadata->mapEmbedded(array(
+        $metadata->mapEmbedded([
             'fieldName'    => 'embedded',
             'class'        => '',
             'columnPrefix' => false,
-        ));
+        ]);
 
         $cmf = $this->_createTestFactory();
 
@@ -405,8 +405,8 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
 /* Test subject class with overridden factory method for mocking purposes */
 class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
 {
-    private $mockMetadata = array();
-    private $requestedClasses = array();
+    private $mockMetadata = [];
+    private $requestedClasses = [];
 
     /** @override */
     protected function newClassMetadataInstance($className)

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataLoadEventTest.php
@@ -25,11 +25,11 @@ class ClassMetadataLoadEventTest extends \Doctrine\Tests\OrmTestCase
     public function loadClassMetadata(\Doctrine\ORM\Event\LoadClassMetadataEventArgs $eventArgs)
     {
         $classMetadata = $eventArgs->getClassMetadata();
-        $field = array(
+        $field = [
             'fieldName' => 'about',
             'type' => 'string',
             'length' => 255
-        );
+        ];
         $classMetadata->mapField($field);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -21,19 +21,19 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->rootEntityName);
-        $this->assertEquals(array(), $cm->subClasses);
-        $this->assertEquals(array(), $cm->parentClasses);
+        $this->assertEquals([], $cm->subClasses);
+        $this->assertEquals([], $cm->parentClasses);
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $cm->inheritanceType);
 
         // Customize state
         $cm->setInheritanceType(ClassMetadata::INHERITANCE_TYPE_SINGLE_TABLE);
-        $cm->setSubclasses(array("One", "Two", "Three"));
-        $cm->setParentClasses(array("UserParent"));
+        $cm->setSubclasses(["One", "Two", "Three"]);
+        $cm->setParentClasses(["UserParent"]);
         $cm->setCustomRepositoryClass("UserRepository");
-        $cm->setDiscriminatorColumn(array('name' => 'disc', 'type' => 'integer'));
-        $cm->mapOneToOne(array('fieldName' => 'phonenumbers', 'targetEntity' => 'CmsAddress', 'mappedBy' => 'foo'));
+        $cm->setDiscriminatorColumn(['name' => 'disc', 'type' => 'integer']);
+        $cm->mapOneToOne(['fieldName' => 'phonenumbers', 'targetEntity' => 'CmsAddress', 'mappedBy' => 'foo']);
         $cm->markReadOnly();
-        $cm->addNamedQuery(array('name' => 'dql', 'query' => 'foo'));
+        $cm->addNamedQuery(['name' => 'dql', 'query' => 'foo']);
         $this->assertEquals(1, count($cm->associationMappings));
 
         $serialized = serialize($cm);
@@ -46,10 +46,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $cm->name);
         $this->assertEquals('UserParent', $cm->rootEntityName);
-        $this->assertEquals(array('Doctrine\Tests\Models\CMS\One', 'Doctrine\Tests\Models\CMS\Two', 'Doctrine\Tests\Models\CMS\Three'), $cm->subClasses);
-        $this->assertEquals(array('UserParent'), $cm->parentClasses);
+        $this->assertEquals(['Doctrine\Tests\Models\CMS\One', 'Doctrine\Tests\Models\CMS\Two', 'Doctrine\Tests\Models\CMS\Three'], $cm->subClasses);
+        $this->assertEquals(['UserParent'], $cm->parentClasses);
         $this->assertEquals('Doctrine\Tests\Models\CMS\UserRepository', $cm->customRepositoryClassName);
-        $this->assertEquals(array('name' => 'disc', 'type' => 'integer', 'fieldName' => 'disc'), $cm->discriminatorColumn);
+        $this->assertEquals(['name' => 'disc', 'type' => 'integer', 'fieldName' => 'disc'], $cm->discriminatorColumn);
         $this->assertTrue($cm->associationMappings['phonenumbers']['type'] == ClassMetadata::ONE_TO_ONE);
         $this->assertEquals(1, count($cm->associationMappings));
         $oneOneMapping = $cm->getAssociationMapping('phonenumbers');
@@ -57,7 +57,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('phonenumbers', $oneOneMapping['fieldName']);
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsAddress', $oneOneMapping['targetEntity']);
         $this->assertTrue($cm->isReadOnly);
-        $this->assertEquals(array('dql' => array('name'=>'dql','query'=>'foo','dql'=>'foo')), $cm->namedQueries);
+        $this->assertEquals(['dql' => ['name'=>'dql','query'=>'foo','dql'=>'foo']], $cm->namedQueries);
     }
 
     public function testFieldIsNullable()
@@ -66,15 +66,15 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // Explicit Nullable
-        $cm->mapField(array('fieldName' => 'status', 'nullable' => true, 'type' => 'string', 'length' => 50));
+        $cm->mapField(['fieldName' => 'status', 'nullable' => true, 'type' => 'string', 'length' => 50]);
         $this->assertTrue($cm->isNullable('status'));
 
         // Explicit Not Nullable
-        $cm->mapField(array('fieldName' => 'username', 'nullable' => false, 'type' => 'string', 'length' => 50));
+        $cm->mapField(['fieldName' => 'username', 'nullable' => false, 'type' => 'string', 'length' => 50]);
         $this->assertFalse($cm->isNullable('username'));
 
         // Implicit Not Nullable
-        $cm->mapField(array('fieldName' => 'name', 'type' => 'string', 'length' => 50));
+        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
         $this->assertFalse($cm->isNullable('name'), "By default a field should not be nullable.");
     }
 
@@ -87,15 +87,15 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $cm = new ClassMetadata('DoctrineGlobal_Article');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapManyToMany(array(
+        $cm->mapManyToMany([
             'fieldName' => 'author',
             'targetEntity' => 'DoctrineGlobal_User',
-            'joinTable' => array(
+            'joinTable' => [
                 'name' => 'bar',
-                'joinColumns' => array(array('name' => 'bar_id', 'referencedColumnName' => 'id')),
-                'inverseJoinColumns' => array(array('name' => 'baz_id', 'referencedColumnName' => 'id')),
-            ),
-        ));
+                'joinColumns' => [['name' => 'bar_id', 'referencedColumnName' => 'id']],
+                'inverseJoinColumns' => [['name' => 'baz_id', 'referencedColumnName' => 'id']],
+            ],
+        ]);
 
         $this->assertEquals("DoctrineGlobal_User", $cm->associationMappings['author']['targetEntity']);
     }
@@ -105,18 +105,18 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
-            array(
+            [
             'fieldName' => 'groups',
             'targetEntity' => 'CmsGroup'
-        ));
+        ]);
 
         $assoc = $cm->associationMappings['groups'];
         //$this->assertInstanceOf('Doctrine\ORM\Mapping\ManyToManyMapping', $assoc);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'name' => 'cmsuser_cmsgroup',
-            'joinColumns' => array(array('name' => 'cmsuser_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE')),
-            'inverseJoinColumns' => array(array('name' => 'cmsgroup_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE'))
-        ), $assoc['joinTable']);
+            'joinColumns' => [['name' => 'cmsuser_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
+            'inverseJoinColumns' => [['name' => 'cmsgroup_id', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']]
+        ], $assoc['joinTable']);
         $this->assertTrue($assoc['isOnDeleteCascade']);
     }
 
@@ -125,10 +125,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
-            array(
+            [
             'fieldName' => 'groups',
             'targetEntity' => 'CmsGroup'
-        ));
+        ]);
 
         /* @var $assoc \Doctrine\ORM\Mapping\ManyToManyMapping */
         $assoc = $cm->associationMappings['groups'];
@@ -146,7 +146,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $cm = new ClassMetadata('DoctrineGlobal_User');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->setDiscriminatorMap(array('descr' => 'DoctrineGlobal_Article', 'foo' => 'DoctrineGlobal_User'));
+        $cm->setDiscriminatorMap(['descr' => 'DoctrineGlobal_Article', 'foo' => 'DoctrineGlobal_User']);
 
         $this->assertEquals("DoctrineGlobal_Article", $cm->discriminatorMap['descr']);
         $this->assertEquals("DoctrineGlobal_User", $cm->discriminatorMap['foo']);
@@ -161,7 +161,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $cm = new ClassMetadata('DoctrineGlobal_User');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->setSubclasses(array('DoctrineGlobal_Article'));
+        $cm->setSubclasses(['DoctrineGlobal_Article']);
 
         $this->assertEquals("DoctrineGlobal_Article", $cm->subClasses[0]);
     }
@@ -171,7 +171,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testSetInvalidVersionMapping_ThrowsException()
     {
-        $field = array();
+        $field = [];
         $field['fieldName'] = 'foo';
         $field['type'] = 'string';
 
@@ -197,8 +197,8 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $a1 = array('fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo');
-        $a2 = array('fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo');
+        $a1 = ['fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo'];
+        $a2 = ['fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo'];
 
         $cm->addInheritedAssociationMapping($a1);
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
@@ -210,10 +210,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => 'name']);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->mapField(array('fieldName' => 'username', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'username', 'columnName' => 'name']);
     }
 
     public function testDuplicateColumnName_DiscriminatorColumn_ThrowsMappingException()
@@ -221,10 +221,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => 'name']);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->setDiscriminatorColumn(array('name' => 'name'));
+        $cm->setDiscriminatorColumn(['name' => 'name']);
     }
 
     public function testDuplicateColumnName_DiscriminatorColumn2_ThrowsMappingException()
@@ -232,10 +232,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->setDiscriminatorColumn(array('name' => 'name'));
+        $cm->setDiscriminatorColumn(['name' => 'name']);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => 'name']);
     }
 
     public function testDuplicateFieldAndAssociationMapping1_ThrowsException()
@@ -243,10 +243,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => 'name']);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
+        $cm->mapOneToOne(['fieldName' => 'name', 'targetEntity' => 'CmsUser']);
     }
 
     public function testDuplicateFieldAndAssociationMapping2_ThrowsException()
@@ -254,10 +254,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
+        $cm->mapOneToOne(['fieldName' => 'name', 'targetEntity' => 'CmsUser']);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => 'name']);
     }
 
     /**
@@ -279,7 +279,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // When table's name is not given
-        $primaryTable = array();
+        $primaryTable = [];
         $cm->setPrimaryTable($primaryTable);
 
         $this->assertEquals('CmsUser', $cm->getTableName());
@@ -288,12 +288,12 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         $cm->initializeReflection(new RuntimeReflectionService());
         // When joinTable's name is not given
-        $cm->mapManyToMany(array(
+        $cm->mapManyToMany([
             'fieldName' => 'user',
             'targetEntity' => 'CmsUser',
             'inversedBy' => 'users',
-            'joinTable' => array('joinColumns' => array(array('referencedColumnName' => 'id')),
-                                 'inverseJoinColumns' => array(array('referencedColumnName' => 'id')))));
+            'joinTable' => ['joinColumns' => [['referencedColumnName' => 'id']],
+                                 'inverseJoinColumns' => [['referencedColumnName' => 'id']]]]);
         $this->assertEquals('cmsaddress_cmsuser', $cm->associationMappings['user']['joinTable']['name']);
     }
 
@@ -304,21 +304,21 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         // this is really dirty, but it's the simplest way to test whether
         // joinColumn's name will be automatically set to user_id
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'fieldName' => 'user',
             'targetEntity' => 'CmsUser',
-            'joinColumns' => array(array('referencedColumnName' => 'id'))));
+            'joinColumns' => [['referencedColumnName' => 'id']]]);
         $this->assertEquals('user_id', $cm->associationMappings['user']['joinColumns'][0]['name']);
 
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapManyToMany(array(
+        $cm->mapManyToMany([
             'fieldName' => 'user',
             'targetEntity' => 'CmsUser',
             'inversedBy' => 'users',
-            'joinTable' => array('name' => 'user_CmsUser',
-                                'joinColumns' => array(array('referencedColumnName' => 'id')),
-                                'inverseJoinColumns' => array(array('referencedColumnName' => 'id')))));
+            'joinTable' => ['name' => 'user_CmsUser',
+                                'joinColumns' => [['referencedColumnName' => 'id']],
+                                'inverseJoinColumns' => [['referencedColumnName' => 'id']]]]);
         $this->assertEquals('cmsaddress_id', $cm->associationMappings['user']['joinTable']['joinColumns'][0]['name']);
         $this->assertEquals('cmsuser_id', $cm->associationMappings['user']['joinTable']['inverseJoinColumns'][0]['name']);
     }
@@ -332,19 +332,19 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $oneToOneMetadata   = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', $namingStrategy);
         $manyToManyMetadata = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress', $namingStrategy);
 
-        $oneToOneMetadata->mapOneToOne(array(
+        $oneToOneMetadata->mapOneToOne([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser'
-        ));
+        ]);
 
-        $manyToManyMetadata->mapManyToMany(array(
+        $manyToManyMetadata->mapManyToMany([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser'
-        ));
+        ]);
 
-        $this->assertEquals(array('USER_ID'=>'ID'), $oneToOneMetadata->associationMappings['user']['sourceToTargetKeyColumns']);
-        $this->assertEquals(array('USER_ID'=>'USER_ID'), $oneToOneMetadata->associationMappings['user']['joinColumnFieldNames']);
-        $this->assertEquals(array('ID'=>'USER_ID'), $oneToOneMetadata->associationMappings['user']['targetToSourceKeyColumns']);
+        $this->assertEquals(['USER_ID'=>'ID'], $oneToOneMetadata->associationMappings['user']['sourceToTargetKeyColumns']);
+        $this->assertEquals(['USER_ID'=>'USER_ID'], $oneToOneMetadata->associationMappings['user']['joinColumnFieldNames']);
+        $this->assertEquals(['ID'=>'USER_ID'], $oneToOneMetadata->associationMappings['user']['targetToSourceKeyColumns']);
 
         $this->assertEquals('USER_ID', $oneToOneMetadata->associationMappings['user']['joinColumns'][0]['name']);
         $this->assertEquals('ID', $oneToOneMetadata->associationMappings['user']['joinColumns'][0]['referencedColumnName']);
@@ -352,9 +352,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals('CMS_ADDRESS_CMS_USER', $manyToManyMetadata->associationMappings['user']['joinTable']['name']);
 
-        $this->assertEquals(array('CMS_ADDRESS_ID','CMS_USER_ID'), $manyToManyMetadata->associationMappings['user']['joinTableColumns']);
-        $this->assertEquals(array('CMS_ADDRESS_ID'=>'ID'), $manyToManyMetadata->associationMappings['user']['relationToSourceKeyColumns']);
-        $this->assertEquals(array('CMS_USER_ID'=>'ID'), $manyToManyMetadata->associationMappings['user']['relationToTargetKeyColumns']);
+        $this->assertEquals(['CMS_ADDRESS_ID','CMS_USER_ID'], $manyToManyMetadata->associationMappings['user']['joinTableColumns']);
+        $this->assertEquals(['CMS_ADDRESS_ID'=>'ID'], $manyToManyMetadata->associationMappings['user']['relationToSourceKeyColumns']);
+        $this->assertEquals(['CMS_USER_ID'=>'ID'], $manyToManyMetadata->associationMappings['user']['relationToTargetKeyColumns']);
 
         $this->assertEquals('CMS_ADDRESS_ID', $manyToManyMetadata->associationMappings['user']['joinTable']['joinColumns'][0]['name']);
         $this->assertEquals('CMS_USER_ID', $manyToManyMetadata->associationMappings['user']['joinTable']['inverseJoinColumns'][0]['name']);
@@ -364,7 +364,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
 
         $cm = new ClassMetadata('DoctrineGlobal_Article', $namingStrategy);
-        $cm->mapManyToMany(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\Models\CMS\CmsUser'));
+        $cm->mapManyToMany(['fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\Models\CMS\CmsUser']);
         $this->assertEquals('DOCTRINE_GLOBAL_ARTICLE_CMS_USER', $cm->associationMappings['author']['joinTable']['name']);
     }
 
@@ -376,10 +376,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapField(array('fieldName' => 'name'));
-        $cm->mapField(array('fieldName' => 'username'));
+        $cm->mapField(['fieldName' => 'name']);
+        $cm->mapField(['fieldName' => 'username']);
 
-        $cm->setIdentifier(array('name', 'username'));
+        $cm->setIdentifier(['name', 'username']);
         $this->assertTrue($cm->isIdentifierComposite);
     }
 
@@ -403,7 +403,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('DoctrineGlobal_Article');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapManyToMany(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\Models\CMS\CmsUser'));
+        $cm->mapManyToMany(['fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\Models\CMS\CmsUser']);
 
         $this->assertEquals('doctrineglobal_article_cmsuser', $cm->associationMappings['author']['joinTable']['name']);
     }
@@ -416,15 +416,15 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'fieldName' => 'article',
             'id' => true,
             'targetEntity' => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns' => array(),
-        ));
+            'joinColumns' => [],
+        ]);
 
         $this->assertTrue($cm->containsForeignIdentifier, "Identifier Association should set 'containsForeignIdentifier' boolean flag.");
-        $this->assertEquals(array("article"), $cm->identifier);
+        $this->assertEquals(["article"], $cm->identifier);
     }
 
     /**
@@ -436,13 +436,13 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'The orphan removal option is not allowed on an association that');
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'fieldName' => 'article',
             'id' => true,
             'targetEntity' => 'Doctrine\Tests\Models\DDC117\DDC117Article',
             'orphanRemoval' => true,
-            'joinColumns' => array(),
-        ));
+            'joinColumns' => [],
+        ]);
     }
 
     /**
@@ -455,13 +455,13 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'An inverse association is not allowed to be identifier in');
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'fieldName' => 'article',
             'id' => true,
             'mappedBy' => 'details', // INVERSE!
             'targetEntity' => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns' => array(),
-        ));
+            'joinColumns' => [],
+        ]);
     }
 
     /**
@@ -474,12 +474,12 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'Many-to-many or one-to-many associations are not allowed to be identifier in');
-        $cm->mapManyToMany(array(
+        $cm->mapManyToMany([
             'fieldName' => 'article',
             'id' => true,
             'targetEntity' => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns' => array(),
-        ));
+            'joinColumns' => [],
+        ]);
     }
 
     /**
@@ -492,7 +492,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->mapField(array('fieldName' => ''));
+        $cm->mapField(['fieldName' => '']);
     }
 
     public function testRetrievalOfNamedQueries()
@@ -503,10 +503,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals(0, count($cm->getNamedQueries()));
 
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'name'  => 'userById',
             'query' => 'SELECT u FROM __CLASS__ u WHERE u.id = ?1'
-        ));
+        ]);
 
         $this->assertEquals(1, count($cm->getNamedQueries()));
     }
@@ -522,14 +522,14 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals(0, count($cm->getSqlResultSetMappings()));
 
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $this->assertEquals(1, count($cm->getSqlResultSetMappings()));
     }
@@ -540,10 +540,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
 
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'name'  => 'all',
             'query' => 'SELECT u FROM __CLASS__ u'
-        ));
+        ]);
 
         $this->assertTrue($cm->hasNamedQuery('all'));
         $this->assertFalse($cm->hasNamedQuery('userById'));
@@ -557,19 +557,19 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT * FROM cms_users',
             'resultSetMapping'  => 'result-mapping-name',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
-        ));
+        ]);
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-by-id',
             'query'             => 'SELECT * FROM cms_users WHERE id = ?',
             'resultClass'       => '__CLASS__',
             'resultSetMapping'  => 'result-mapping-name',
-        ));
+        ]);
 
         $mapping = $cm->getNamedNativeQuery('find-all');
         $this->assertEquals('SELECT * FROM cms_users', $mapping['query']);
@@ -590,52 +590,52 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => '__CLASS__',
-                    'fields'        => array(
-                        array(
+                    'fields'        => [
+                        [
                             'name'  => 'id',
                             'column'=> 'id'
-                        ),
-                        array(
+                        ],
+                        [
                             'name'  => 'name',
                             'column'=> 'name'
-                        )
-                    )
-                ),
-                array(
+                        ]
+                    ]
+                ],
+                [
                     'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsEmail',
-                    'fields'        => array(
-                        array(
+                    'fields'        => [
+                        [
                             'name'  => 'id',
                             'column'=> 'id'
-                        ),
-                        array(
+                        ],
+                        [
                             'name'  => 'email',
                             'column'=> 'email'
-                        )
-                    )
-                )
-            ),
-            'columns'   => array(
-                array(
+                        ]
+                    ]
+                ]
+            ],
+            'columns'   => [
+                [
                     'name' => 'scalarColumn'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
         $mapping = $cm->getSqlResultSetMapping('find-all');
 
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $mapping['entities'][0]['entityClass']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'), $mapping['entities'][0]['fields'][0]);
-        $this->assertEquals(array('name'=>'name','column'=>'name'), $mapping['entities'][0]['fields'][1]);
+        $this->assertEquals(['name'=>'id','column'=>'id'], $mapping['entities'][0]['fields'][0]);
+        $this->assertEquals(['name'=>'name','column'=>'name'], $mapping['entities'][0]['fields'][1]);
 
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsEmail', $mapping['entities'][1]['entityClass']);
-        $this->assertEquals(array('name'=>'id','column'=>'id'), $mapping['entities'][1]['fields'][0]);
-        $this->assertEquals(array('name'=>'email','column'=>'email'), $mapping['entities'][1]['fields'][1]);
+        $this->assertEquals(['name'=>'id','column'=>'id'], $mapping['entities'][1]['fields'][0]);
+        $this->assertEquals(['name'=>'email','column'=>'email'], $mapping['entities'][1]['fields'][1]);
 
         $this->assertEquals('scalarColumn', $mapping['columns'][0]['name']);
     }
@@ -648,14 +648,14 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $this->assertTrue($cm->hasSqlResultSetMapping('find-all'));
         $this->assertFalse($cm->hasSqlResultSetMapping('find-by-id'));
@@ -670,12 +670,12 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
             'resultSetMapping'  => 'result-mapping-name'
-        ));
+        ]);
 
         $this->assertTrue($cm->hasNamedNativeQuery('find-all'));
         $this->assertFalse($cm->hasNamedNativeQuery('find-by-id'));
@@ -687,10 +687,10 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
 
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'name'  => 'userById',
             'query' => 'SELECT u FROM __CLASS__ u WHERE u.id = ?1'
-        ));
+        ]);
 
         $this->assertEquals('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = ?1', $cm->getNamedQuery('userById'));
     }
@@ -705,12 +705,12 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals(0, count($cm->getNamedNativeQueries()));
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
             'resultSetMapping'  => 'result-mapping-name'
-        ));
+        ]);
 
         $this->assertEquals(1, count($cm->getNamedNativeQueries()));
     }
@@ -741,15 +741,15 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'name'  => 'userById',
             'query' => 'SELECT u FROM __CLASS__ u WHERE u.id = ?1'
-        ));
+        ]);
 
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'name'  => 'userById',
             'query' => 'SELECT u FROM __CLASS__ u WHERE u.id = ?1'
-        ));
+        ]);
     }
 
     /**
@@ -763,19 +763,19 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
             'resultSetMapping'  => 'result-mapping-name'
-        ));
+        ]);
 
-        $cm->addNamedNativeQuery(array(
+        $cm->addNamedNativeQuery([
             'name'              => 'find-all',
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
             'resultSetMapping'  => 'result-mapping-name'
-        ));
+        ]);
     }
 
     /**
@@ -789,23 +789,23 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
+            'entities'  => [
+                [
                     'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -840,7 +840,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass'));
+        $cm->mapManyToOne(['fieldName' => 'address', 'targetEntity' => 'UnknownClass']);
 
         $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "The target-entity Doctrine\Tests\Models\CMS\UnknownClass cannot be found in 'Doctrine\Tests\Models\CMS\CmsUser#address'.");
         $cm->validateAssociations();
@@ -856,9 +856,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'query' => 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u',
-        ));
+        ]);
     }
 
     /**
@@ -871,11 +871,11 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->addNamedQuery(array(
+        $cm->addNamedQuery([
             'query'             => 'SELECT * FROM cms_users',
             'resultClass'       => 'Doctrine\Tests\Models\CMS\CmsUser',
             'resultSetMapping'  => 'result-mapping-name'
-        ));
+        ]);
     }
 
     /**
@@ -888,14 +888,14 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->addSqlResultSetMapping(array(
+        $cm->addSqlResultSetMapping([
             'name'      => 'find-all',
-            'entities'  => array(
-                array(
-                    'fields' => array()
-                )
-            ),
-        ));
+            'entities'  => [
+                [
+                    'fields' => []
+                ]
+            ],
+        ]);
     }
 
     /**
@@ -906,7 +906,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->setDiscriminatorColumn(array());
+        $cm->setDiscriminatorColumn([]);
     }
 
     /**
@@ -925,15 +925,15 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $articleMetadata->initializeReflection(new RuntimeReflectionService());
         $routingMetadata->initializeReflection(new RuntimeReflectionService());
 
-        $addressMetadata->mapManyToMany(array(
+        $addressMetadata->mapManyToMany([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser'
-        ));
+        ]);
 
-        $articleMetadata->mapManyToMany(array(
+        $articleMetadata->mapManyToMany([
             'fieldName'     => 'author',
             'targetEntity'  => 'Doctrine\Tests\Models\CMS\CmsUser'
-        ));
+        ]);
 
         $this->assertEquals('routing_routingleg', $routingMetadata->table['name']);
         $this->assertEquals('cms_cmsaddress_cms_cmsuser', $addressMetadata->associationMappings['user']['joinTable']['name']);
@@ -951,13 +951,13 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $metadata->initializeReflection(new RuntimeReflectionService());
 
-        $metadata->mapField(array('fieldName'=>'country'));
-        $metadata->mapField(array('fieldName'=>'city'));
+        $metadata->mapField(['fieldName'=>'country']);
+        $metadata->mapField(['fieldName'=>'city']);
 
-        $this->assertEquals($metadata->fieldNames, array(
+        $this->assertEquals($metadata->fieldNames, [
             'cmsaddress_country'   => 'country',
             'cmsaddress_city'      => 'city'
-        ));
+        ]);
     }
 
     /**
@@ -971,7 +971,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "You have specified invalid cascade options for Doctrine\Tests\Models\CMS\CmsUser::\$address: 'invalid'; available options: 'remove', 'persist', 'refresh', 'merge', and 'detach'");
 
 
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass', 'cascade' => array('invalid')));
+        $cm->mapManyToOne(['fieldName' => 'address', 'targetEntity' => 'UnknownClass', 'cascade' => ['invalid']]);
      }
 
     /**
@@ -983,9 +983,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Admin');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'DDC964Address'));
+        $cm->mapManyToOne(['fieldName' => 'address', 'targetEntity' => 'DDC964Address']);
 
-        $cm->setAssociationOverride('invalidPropertyName', array());
+        $cm->setAssociationOverride('invalidPropertyName', []);
     }
 
     /**
@@ -997,9 +997,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Guest');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapField(array('fieldName' => 'name'));
+        $cm->mapField(['fieldName' => 'name']);
 
-        $cm->setAttributeOverride('invalidPropertyName', array());
+        $cm->setAttributeOverride('invalidPropertyName', []);
     }
 
     /**
@@ -1011,9 +1011,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC964\DDC964Guest');
         $cm->initializeReflection(new RuntimeReflectionService());
-        $cm->mapField(array('fieldName' => 'name', 'type'=>'string'));
+        $cm->mapField(['fieldName' => 'name', 'type'=>'string']);
 
-        $cm->setAttributeOverride('name', array('type'=>'date'));
+        $cm->setAttributeOverride('name', ['type'=>'date']);
     }
 
     /**
@@ -1049,23 +1049,23 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CustomType\CustomTypeParent');
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToMany(
-            array(
+            [
                 'fieldName' => 'friendsWithMe',
                 'targetEntity' => 'CustomTypeParent'
-            )
+            ]
         );
 
         $this->assertEquals(
-            array(
+            [
                 'name' => 'customtypeparent_customtypeparent',
-                'joinColumns' => array(array('name' => 'customtypeparent_source', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE')),
-                'inverseJoinColumns' => array(array('name' => 'customtypeparent_target', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE')),
-            ),
+                'joinColumns' => [['name' => 'customtypeparent_source', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
+                'inverseJoinColumns' => [['name' => 'customtypeparent_target', 'referencedColumnName' => 'id', 'onDelete' => 'CASCADE']],
+            ],
             $cm->associationMappings['friendsWithMe']['joinTable']
         );
-        $this->assertEquals(array('customtypeparent_source', 'customtypeparent_target'), $cm->associationMappings['friendsWithMe']['joinTableColumns']);
-        $this->assertEquals(array('customtypeparent_source' => 'id'), $cm->associationMappings['friendsWithMe']['relationToSourceKeyColumns']);
-        $this->assertEquals(array('customtypeparent_target' => 'id'), $cm->associationMappings['friendsWithMe']['relationToTargetKeyColumns']);
+        $this->assertEquals(['customtypeparent_source', 'customtypeparent_target'], $cm->associationMappings['friendsWithMe']['joinTableColumns']);
+        $this->assertEquals(['customtypeparent_source' => 'id'], $cm->associationMappings['friendsWithMe']['relationToSourceKeyColumns']);
+        $this->assertEquals(['customtypeparent_target' => 'id'], $cm->associationMappings['friendsWithMe']['relationToTargetKeyColumns']);
     }
 
     /**
@@ -1077,7 +1077,7 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
-        $cm->setSequenceGeneratorDefinition(array());
+        $cm->setSequenceGeneratorDefinition([]);
     }
 
     /**
@@ -1088,9 +1088,9 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->setSequenceGeneratorDefinition(array('sequenceName' => '`foo`'));
+        $cm->setSequenceGeneratorDefinition(['sequenceName' => '`foo`']);
 
-        $this->assertEquals(array('sequenceName' => 'foo', 'quoted' => true), $cm->sequenceGeneratorDefinition);
+        $this->assertEquals(['sequenceName' => 'foo', 'quoted' => true], $cm->sequenceGeneratorDefinition);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php
@@ -43,32 +43,32 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataClassToTableName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'SomeClassName',
+            [self::defaultNaming(), 'SomeClassName',
                 'SomeClassName'
-            ),
-            array(self::defaultNaming(), 'SomeClassName',
+            ],
+            [self::defaultNaming(), 'SomeClassName',
                 '\SomeClassName'
-            ),
-            array(self::defaultNaming(), 'Name',
+            ],
+            [self::defaultNaming(), 'Name',
                 '\Some\Class\Name'
-            ),
+            ],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'some_class_name',
+            [self::underscoreNamingLower(), 'some_class_name',
                 '\Name\Space\SomeClassName'
-            ),
-            array(self::underscoreNamingLower(), 'name',
+            ],
+            [self::underscoreNamingLower(), 'name',
                 '\Some\Class\Name'
-            ),
-            array(self::underscoreNamingUpper(), 'SOME_CLASS_NAME',
+            ],
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME',
                 '\Name\Space\SomeClassName'
-            ),
-            array(self::underscoreNamingUpper(), 'NAME',
+            ],
+            [self::underscoreNamingUpper(), 'NAME',
                 '\Some\Class\Name'
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -86,32 +86,32 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataPropertyToColumnName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'someProperty',
+            [self::defaultNaming(), 'someProperty',
                 'someProperty'
-            ),
-            array(self::defaultNaming(), 'SOME_PROPERTY',
+            ],
+            [self::defaultNaming(), 'SOME_PROPERTY',
                 'SOME_PROPERTY'
-            ),
-            array(self::defaultNaming(), 'some_property',
+            ],
+            [self::defaultNaming(), 'some_property',
                 'some_property'
-            ),
+            ],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'some_property',
+            [self::underscoreNamingLower(), 'some_property',
                 'someProperty'
-            ),
-            array(self::underscoreNamingUpper(), 'SOME_PROPERTY',
+            ],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY',
                 'someProperty'
-            ),
-            array(self::underscoreNamingUpper(), 'SOME_PROPERTY',
+            ],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY',
                 'some_property'
-            ),
-            array(self::underscoreNamingUpper(), 'SOME_PROPERTY',
+            ],
+            [self::underscoreNamingUpper(), 'SOME_PROPERTY',
                 'SOME_PROPERTY'
-            ),
-        );
+            ],
+        ];
     }
     
     /**
@@ -133,14 +133,14 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataReferenceColumnName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'id'),
+            [self::defaultNaming(), 'id'],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'id'),
-            array(self::underscoreNamingUpper(), 'ID'),
-        );
+            [self::underscoreNamingLower(), 'id'],
+            [self::underscoreNamingUpper(), 'ID'],
+        ];
     }
 
     /**
@@ -161,18 +161,18 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataJoinColumnName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'someColumn_id', 'someColumn', null),
-            array(self::defaultNaming(), 'some_column_id', 'some_column', null),
+            [self::defaultNaming(), 'someColumn_id', 'someColumn', null],
+            [self::defaultNaming(), 'some_column_id', 'some_column', null],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'some_column_id', 'someColumn', null),
-            array(self::underscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', null),
+            [self::underscoreNamingLower(), 'some_column_id', 'someColumn', null],
+            [self::underscoreNamingUpper(), 'SOME_COLUMN_ID', 'someColumn', null],
             // JoinColumnClassNamingStrategy
-            array(new JoinColumnClassNamingStrategy(), 'classname_someColumn_id', 'someColumn', 'Some\ClassName'),
-            array(new JoinColumnClassNamingStrategy(), 'classname_some_column_id', 'some_column', 'ClassName'),
-        );
+            [new JoinColumnClassNamingStrategy(), 'classname_someColumn_id', 'someColumn', 'Some\ClassName'],
+            [new JoinColumnClassNamingStrategy(), 'classname_some_column_id', 'some_column', 'ClassName'],
+        ];
     }
 
     /**
@@ -194,39 +194,39 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataJoinTableName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'someclassname_classname',
+            [self::defaultNaming(), 'someclassname_classname',
                 'SomeClassName', 'Some\ClassName', null,
-            ),
-            array(self::defaultNaming(), 'someclassname_classname',
+            ],
+            [self::defaultNaming(), 'someclassname_classname',
                 '\SomeClassName', 'ClassName', null,
-            ),
-            array(self::defaultNaming(), 'name_classname',
+            ],
+            [self::defaultNaming(), 'name_classname',
                 '\Some\Class\Name', 'ClassName', null,
-            ),
+            ],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'some_class_name_class_name',
+            [self::underscoreNamingLower(), 'some_class_name_class_name',
                 'SomeClassName', 'Some\ClassName', null,
-            ),
-            array(self::underscoreNamingLower(), 'some_class_name_class_name',
+            ],
+            [self::underscoreNamingLower(), 'some_class_name_class_name',
                 '\SomeClassName', 'ClassName', null,
-            ),
-            array(self::underscoreNamingLower(), 'name_class_name',
+            ],
+            [self::underscoreNamingLower(), 'name_class_name',
                 '\Some\Class\Name', 'ClassName', null,
-            ),
+            ],
 
-            array(self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME',
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME',
                 'SomeClassName', 'Some\ClassName', null,
-            ),
-            array(self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME',
+            ],
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_CLASS_NAME',
                 '\SomeClassName', 'ClassName', null,
-            ),
-            array(self::underscoreNamingUpper(), 'NAME_CLASS_NAME',
+            ],
+            [self::underscoreNamingUpper(), 'NAME_CLASS_NAME',
                 '\Some\Class\Name', 'ClassName', null,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -250,30 +250,30 @@ class NamingStrategyTest extends \Doctrine\Tests\OrmTestCase
      */
     static public function dataJoinKeyColumnName()
     {
-        return array(
+        return [
             // DefaultNamingStrategy
-            array(self::defaultNaming(), 'someclassname_id',
+            [self::defaultNaming(), 'someclassname_id',
                 'SomeClassName', null, null,
-            ),
-            array(self::defaultNaming(), 'name_identifier',
+            ],
+            [self::defaultNaming(), 'name_identifier',
                 '\Some\Class\Name', 'identifier', null,
-            ),
+            ],
 
             // UnderscoreNamingStrategy
-            array(self::underscoreNamingLower(), 'some_class_name_id',
+            [self::underscoreNamingLower(), 'some_class_name_id',
                 'SomeClassName', null, null,
-            ),
-            array(self::underscoreNamingLower(), 'class_name_identifier',
+            ],
+            [self::underscoreNamingLower(), 'class_name_identifier',
                 '\Some\Class\ClassName', 'identifier', null,
-            ),
+            ],
 
-            array(self::underscoreNamingUpper(), 'SOME_CLASS_NAME_ID',
+            [self::underscoreNamingUpper(), 'SOME_CLASS_NAME_ID',
                 'SomeClassName', null, null,
-            ),
-            array(self::underscoreNamingUpper(), 'CLASS_NAME_IDENTIFIER',
+            ],
+            [self::underscoreNamingUpper(), 'CLASS_NAME_IDENTIFIER',
                 '\Some\Class\ClassName', 'IDENTIFIER', null,
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
@@ -59,8 +59,8 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
     public function testGetColumnName()
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->mapField(array('fieldName' => 'name', 'columnName' => '`name`'));
-        $cm->mapField(array('fieldName' => 'id', 'columnName' => 'id'));
+        $cm->mapField(['fieldName' => 'name', 'columnName' => '`name`']);
+        $cm->mapField(['fieldName' => 'id', 'columnName' => 'id']);
         
         $this->assertEquals('id' ,$this->strategy->getColumnName('id', $cm, $this->platform));
         $this->assertEquals('"name"' ,$this->strategy->getColumnName('name', $cm, $this->platform));
@@ -69,12 +69,12 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
     public function testGetTableName()
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
-        $cm->setPrimaryTable(array('name'=>'`cms_user`'));
+        $cm->setPrimaryTable(['name'=>'`cms_user`']);
         $this->assertEquals('"cms_user"' ,$this->strategy->getTableName($cm, $this->platform));
 
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $cm->setPrimaryTable(array('name'=>'cms_user'));
+        $cm->setPrimaryTable(['name'=>'cms_user']);
         $this->assertEquals('cms_user' ,$this->strategy->getTableName($cm, $this->platform));
     }
     
@@ -83,23 +83,23 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
         $cm1 = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         $cm2 = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         
-        $cm1->mapManyToMany(array(
+        $cm1->mapManyToMany([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser',
             'inversedBy'    => 'users',
-            'joinTable'     => array(
+            'joinTable'     => [
                 'name'  => '`cmsaddress_cmsuser`'
-            )
-        ));
+            ]
+        ]);
         
-        $cm2->mapManyToMany(array(
+        $cm2->mapManyToMany([
             'fieldName'     => 'user',
             'targetEntity'  => 'CmsUser',
             'inversedBy'    => 'users',
-            'joinTable'     => array(
+            'joinTable'     => [
                     'name'  => 'cmsaddress_cmsuser'
-                )
-            )
+                ]
+            ]
         );
 
         $this->assertEquals('"cmsaddress_cmsuser"', $this->strategy->getJoinTableName($cm1->associationMappings['user'], $cm1, $this->platform));
@@ -112,20 +112,20 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
         $cm1 = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
         $cm2 = $this->createClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
 
-        $cm1->mapField(array(
+        $cm1->mapField([
             'id'            => true,
             'fieldName'     => 'id',
             'columnName'    => '`id`',
-        ));
+        ]);
 
-        $cm2->mapField(array(
+        $cm2->mapField([
             'id'            => true,
             'fieldName'     => 'id',
             'columnName'    => 'id',
-        ));
+        ]);
 
-        $this->assertEquals(array('"id"'), $this->strategy->getIdentifierColumnNames($cm1, $this->platform));
-        $this->assertEquals(array('id'), $this->strategy->getIdentifierColumnNames($cm2, $this->platform));
+        $this->assertEquals(['"id"'], $this->strategy->getIdentifierColumnNames($cm1, $this->platform));
+        $this->assertEquals(['id'], $this->strategy->getIdentifierColumnNames($cm2, $this->platform));
     }
 
 
@@ -142,30 +142,30 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'id'            => true,
             'fieldName'     => 'article',
             'targetEntity'  => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns'    => array(array(
+            'joinColumns'    => [[
                 'name'  => '`article`'
-            )),
-        ));
+            ]],
+        ]);
 
-        $this->assertEquals(array('"article"'), $this->strategy->getIdentifierColumnNames($cm, $this->platform));
+        $this->assertEquals(['"article"'], $this->strategy->getIdentifierColumnNames($cm, $this->platform));
     }
 
     public function testJoinColumnName()
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'id'            => true,
             'fieldName'     => 'article',
             'targetEntity'  => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns'    => array(array(
+            'joinColumns'    => [[
                 'name'  => '`article`'
-            )),
-        ));
+            ]],
+        ]);
 
         $joinColumn = $cm->associationMappings['article']['joinColumns'][0];
         $this->assertEquals('"article"',$this->strategy->getJoinColumnName($joinColumn, $cm, $this->platform));
@@ -175,14 +175,14 @@ class QuoteStrategyTest extends \Doctrine\Tests\OrmTestCase
     {
         $cm = $this->createClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
 
-        $cm->mapOneToOne(array(
+        $cm->mapOneToOne([
             'id'            => true,
             'fieldName'     => 'article',
             'targetEntity'  => 'Doctrine\Tests\Models\DDC117\DDC117Article',
-            'joinColumns'    => array(array(
+            'joinColumns'    => [[
                 'name'  => '`article`'
-            )),
-        ));
+            ]],
+        ]);
 
         $joinColumn = $cm->associationMappings['article']['joinColumns'][0];
         $this->assertEquals('"id"',$this->strategy->getReferencedJoinColumnName($joinColumn, $cm, $this->platform));

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -69,8 +69,8 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function getTestedReflectionProperties()
     {
-        return array(
-            array(
+        return [
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Generic\\BooleanModel',
                     'id'
@@ -80,9 +80,9 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'id'
                 ),
                 'Doctrine\\Tests\\Models\\Generic\\BooleanModel'
-            ),
+            ],
             // reflection on embeddables that have properties defined in abstract ancestors:
-            array(
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Generic\\BooleanModel',
                     'id'
@@ -92,8 +92,8 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'propertyInAbstractClass'
                 ),
                 'Doctrine\\Tests\\Models\\Reflection\\ConcreteEmbeddable'
-            ),
-            array(
+            ],
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Generic\\BooleanModel',
                     'id'
@@ -103,9 +103,9 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'propertyInConcreteClass'
                 ),
                 'Doctrine\\Tests\\Models\\Reflection\\ConcreteEmbeddable'
-            ),
+            ],
             // reflection on classes extending internal PHP classes:
-            array(
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass',
                     'publicProperty'
@@ -115,8 +115,8 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'privateProperty'
                 ),
                 'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass'
-            ),
-            array(
+            ],
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass',
                     'publicProperty'
@@ -126,8 +126,8 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'protectedProperty'
                 ),
                 'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass'
-            ),
-            array(
+            ],
+            [
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass',
                     'publicProperty'
@@ -137,8 +137,8 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                     'publicProperty'
                 ),
                 'Doctrine\\Tests\\Models\\Reflection\\ArrayObjectExtendingClass'
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -26,10 +26,10 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 {
     public function testFindMappingFile()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\EntityFoo' => 'foo',
             'MyNamespace\MySubnamespace\Entity' => $this->dir,
-        ));
+        ]);
 
         touch($filename = $this->dir.'/Foo'.$this->getFileExtension());
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Entity\Foo'));
@@ -37,9 +37,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testFindMappingFileInSubnamespace()
     {
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Entity' => $this->dir,
-        ));
+        ]);
 
         touch($filename = $this->dir.'/Foo.Bar'.$this->getFileExtension());
         $this->assertEquals($filename, $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Entity\Foo\Bar'));
@@ -52,9 +52,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             "No mapping file found named '".$this->dir."/Foo".$this->getFileExtension()."' for class 'MyNamespace\MySubnamespace\Entity\Foo'."
         );
 
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Entity' => $this->dir,
-        ));
+        ]);
 
         $driver->getLocator()->findMappingFile('MyNamespace\MySubnamespace\Entity\Foo');
     }
@@ -66,9 +66,9 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
             "No mapping file found named 'Foo".$this->getFileExtension()."' for class 'MyOtherNamespace\MySubnamespace\Entity\Foo'."
         );
 
-        $driver = $this->getDriver(array(
+        $driver = $this->getDriver([
             'MyNamespace\MySubnamespace\Entity' => $this->dir,
-        ));
+        ]);
 
         $driver->getLocator()->findMappingFile('MyOtherNamespace\MySubnamespace\Entity\Foo');
     }
@@ -95,7 +95,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
     }
 
     abstract protected function getFileExtension();
-    abstract protected function getDriver(array $paths = array());
+    abstract protected function getDriver(array $paths = []);
 
     private function setField($obj, $field, $value)
     {
@@ -104,7 +104,7 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
         $ref->setValue($obj, $value);
     }
 
-    private function invoke($obj, $method, array $args = array()) {
+    private function invoke($obj, $method, array $args = []) {
         $ref = new \ReflectionMethod($obj, $method);
         $ref->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/XmlDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/XmlDriverTest.php
@@ -31,7 +31,7 @@ class XmlDriverTest extends AbstractDriverTest
         return '.orm.xml';
     }
 
-    protected function getDriver(array $paths = array())
+    protected function getDriver(array $paths = [])
     {
         $driver = new SimplifiedXmlDriver(array_flip($paths));
 

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
@@ -31,7 +31,7 @@ class YamlDriverTest extends AbstractDriverTest
         return '.orm.yml';
     }
 
-    protected function getDriver(array $paths = array())
+    protected function getDriver(array $paths = [])
     {
         $driver = new SimplifiedYamlDriver(array_flip($paths));
 

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -22,11 +22,11 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $class->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
         $mappingDriver->loadMetadataForClass($className, $class);
 
-        $expectedMap = array(
+        $expectedMap = [
             'foo' => 'Doctrine\Tests\ORM\Mapping\CTIFoo',
             'bar' => 'Doctrine\Tests\ORM\Mapping\CTIBar',
             'baz' => 'Doctrine\Tests\ORM\Mapping\CTIBaz',
-        );
+        ];
 
         $this->assertEquals(3, count($class->discriminatorMap));
         $this->assertEquals($expectedMap, $class->discriminatorMap);
@@ -43,7 +43,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
         $class = $factory->getMetadataFor('Doctrine\Tests\Models\DDC117\DDC117Translation');
 
-        $this->assertEquals(array('language', 'article'), $class->identifier);
+        $this->assertEquals(['language', 'article'], $class->identifier);
         $this->assertArrayHasKey('article', $class->associationMappings);
 
         $this->assertArrayHasKey('id', $class->associationMappings['article']);
@@ -103,14 +103,14 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $class = $this->createClassMetadata('Doctrine\Tests\Models\ValueObjects\Person');
 
         $this->assertEquals(
-            array(
-                'name' => array(
+            [
+                'name' => [
                     'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
                     'columnPrefix' => 'nm_',
                     'declaredField' => null,
                     'originalField' => null,
-                )
-            ),
+                ]
+            ],
             $class->embeddedClasses
         );
     }
@@ -144,16 +144,16 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     static public function dataValidSchema()
     {
         $list    = glob(__DIR__ . '/xml/*.xml');
-        $invalid = array(
+        $invalid = [
             'Doctrine.Tests.Models.DDC889.DDC889Class.dcm'
-        );
+        ];
 
         $list = array_filter($list, function($item) use ($invalid){
             return ! in_array(pathinfo($item, PATHINFO_FILENAME), $invalid);
         });
 
         return array_map(function($item){
-            return array($item);
+            return [$item];
         }, $list);
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -25,7 +25,7 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
     public function testJoinTablesWithMappedSuperclassForYamlDriver()
     {
         $yamlDriver = $this->_loadDriver();
-        $yamlDriver->getLocator()->addPaths(array(__DIR__ . DIRECTORY_SEPARATOR . 'yaml'));
+        $yamlDriver->getLocator()->addPaths([__DIR__ . DIRECTORY_SEPARATOR . 'yaml']);
 
         $em = $this->_getTestEntityManager();
         $em->getConfiguration()->setMetadataDriverImpl($yamlDriver);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsAddress.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsAddress.php
@@ -2,92 +2,92 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
    'name' => 'company_person',
-));
+]);
 
-$metadata->mapField(array (
+$metadata->mapField( [
     'id'        => true,
     'fieldName' => 'id',
     'type'      => 'integer',
-));
+]);
 
-$metadata->mapField(array (
+$metadata->mapField( [
     'fieldName' => 'zip',
     'length'    => 50,
-));
+]);
 
-$metadata->mapField(array (
+$metadata->mapField( [
     'fieldName' => 'city',
     'length'    => 50,
-));
+]);
 
-$metadata->mapOneToOne(array(
+$metadata->mapOneToOne([
     'fieldName'     => 'user',
     'targetEntity'  => 'CmsUser',
-    'joinColumns'   => array(array('referencedColumnName' => 'id'))
-));
+    'joinColumns'   => [['referencedColumnName' => 'id']]
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'find-all',
     'query'             => 'SELECT id, country, city FROM cms_addresses',
     'resultSetMapping'  => 'mapping-find-all',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'find-by-id',
     'query'             => 'SELECT * FROM cms_addresses WHERE id = ?',
     'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsAddress',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'count',
     'query'             => 'SELECT COUNT(*) AS count FROM cms_addresses',
     'resultSetMapping'  => 'mapping-count',
-));
+]);
 
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mapping-find-all',
-    'columns'   => array(),
-    'entities'  => array ( array (
-        'fields' => array (
-          array (
+    'columns'   => [],
+    'entities'  =>  [  [
+        'fields' =>  [
+           [
             'name'      => 'id',
             'column'    => 'id',
-          ),
-          array (
+          ],
+           [
             'name'      => 'city',
             'column'    => 'city',
-          ),
-          array (
+          ],
+           [
             'name'      => 'country',
             'column'    => 'country',
-          ),
-        ),
+          ],
+        ],
         'entityClass' => 'Doctrine\Tests\Models\CMS\CmsAddress',
-      ),
-    ),
-));
+      ],
+    ],
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mapping-without-fields',
-    'columns'   => array(),
-    'entities'  => array(array (
+    'columns'   => [],
+    'entities'  => [ [
         'entityClass' => 'Doctrine\\Tests\\Models\\CMS\\CmsAddress',
-        'fields' => array()
-      )
-    )
-));
+        'fields' => []
+      ]
+    ]
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name' => 'mapping-count',
-    'columns' =>array (
-        array (
+    'columns' => [
+         [
             'name' => 'count',
-        ),
-    )
-));
+        ],
+    ]
+]);
 
 $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CmsAddressListener', 'postPersist');
 $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CmsAddressListener', 'prePersist');

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsUser.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsUser.php
@@ -2,185 +2,185 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
    'name' => 'cms_users',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchIdAndUsernameWithResultClass',
     'query'             => 'SELECT id, username FROM cms_users WHERE username = ?',
     'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchAllColumns',
     'query'             => 'SELECT * FROM cms_users WHERE username = ?',
     'resultClass'       => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchJoinedAddress',
     'query'             => 'SELECT u.id, u.name, u.status, a.id AS a_id, a.country, a.zip, a.city FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?',
     'resultSetMapping'  => 'mappingJoinedAddress',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchJoinedPhonenumber',
     'query'             => 'SELECT id, name, status, phonenumber AS number FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?',
     'resultSetMapping'  => 'mappingJoinedPhonenumber',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchUserPhonenumberCount',
     'query'             => 'SELECT id, name, status, COUNT(phonenumber) AS numphones FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username IN (?) GROUP BY id, name, status, username ORDER BY username',
     'resultSetMapping'  => 'mappingUserPhonenumberCount',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     "name"              => "fetchMultipleJoinsEntityResults",
     "resultSetMapping"  => "mappingMultipleJoinsEntityResults",
     "query"             => "SELECT u.id AS u_id, u.name AS u_name, u.status AS u_status, a.id AS a_id, a.zip AS a_zip, a.country AS a_country, COUNT(p.phonenumber) AS numphones FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id INNER JOIN cms_phonenumbers p ON u.id = p.user_id GROUP BY u.id, u.name, u.status, u.username, a.id, a.zip, a.country ORDER BY u.username"
-));
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mappingJoinedAddress',
-    'columns'   => array(),
-    'entities'  => array(array (
-        'fields'=> array (
-          array (
+    'columns'   => [],
+    'entities'  => [ [
+        'fields'=>  [
+           [
             'name'      => 'id',
             'column'    => 'id',
-          ),
-          array (
+          ],
+           [
             'name'      => 'name',
             'column'    => 'name',
-          ),
-          array (
+          ],
+           [
             'name'      => 'status',
             'column'    => 'status',
-          ),
-          array (
+          ],
+           [
             'name'      => 'address.zip',
             'column'    => 'zip',
-          ),
-          array (
+          ],
+           [
             'name'      => 'address.city',
             'column'    => 'city',
-          ),
-          array (
+          ],
+           [
             'name'      => 'address.country',
             'column'    => 'country',
-          ),
-          array (
+          ],
+           [
             'name'      => 'address.id',
             'column'    => 'a_id',
-          ),
-        ),
+          ],
+        ],
         'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsUser',
         'discriminatorColumn'   => null
-      ),
-    ),
-));
+      ],
+    ],
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mappingJoinedPhonenumber',
-    'columns'   => array(),
-    'entities'  => array(array(
-        'fields'=> array (
-          array (
+    'columns'   => [],
+    'entities'  => [[
+        'fields'=>  [
+           [
             'name'      => 'id',
             'column'    => 'id',
-          ),
-          array (
+          ],
+           [
             'name'      => 'name',
             'column'    => 'name',
-          ),
-          array (
+          ],
+           [
             'name'      => 'status',
             'column'    => 'status',
-          ),
-          array (
+          ],
+           [
             'name'      => 'phonenumbers.phonenumber',
             'column'    => 'number',
-          ),
-        ),
+          ],
+        ],
         'entityClass'   => 'Doctrine\\Tests\\Models\\CMS\\CmsUser',
         'discriminatorColumn'   => null
-      ),
-    ),
-));
+      ],
+    ],
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mappingUserPhonenumberCount',
-    'columns'   => array(),
-    'entities'  => array (
-      array(
-        'fields' => array (
-          array (
+    'columns'   => [],
+    'entities'  =>  [
+      [
+        'fields' =>  [
+           [
             'name'      => 'id',
             'column'    => 'id',
-          ),
-          array (
+          ],
+           [
             'name'      => 'name',
             'column'    => 'name',
-          ),
-          array (
+          ],
+           [
             'name'      => 'status',
             'column'    => 'status',
-          )
-        ),
+          ]
+        ],
         'entityClass'   => 'Doctrine\Tests\Models\CMS\CmsUser',
         'discriminatorColumn'   => null
-      )
-    ),
-    'columns' => array (
-          array (
+      ]
+    ],
+    'columns' =>  [
+           [
             'name' => 'numphones',
-          )
-    )
-));
+          ]
+    ]
+]);
 
-$metadata->addSqlResultSetMapping(array(
+$metadata->addSqlResultSetMapping([
     'name'      => 'mappingMultipleJoinsEntityResults',
-    'entities'  => array(array(
-            'fields' => array(
-                array(
+    'entities'  => [[
+            'fields' => [
+                [
                     'name'      => 'id',
                     'column'    => 'u_id',
-                ),
-                array(
+                ],
+                [
                     'name'      => 'name',
                     'column'    => 'u_name',
-                ),
-                array(
+                ],
+                [
                     'name'      => 'status',
                     'column'    => 'u_status',
-                )
-            ),
+                ]
+            ],
             'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsUser',
             'discriminatorColumn'   => null,
-        ),
-        array(
-            'fields' => array(
-                array(
+        ],
+        [
+            'fields' => [
+                [
                     'name'      => 'id',
                     'column'    => 'a_id',
-                ),
-                array(
+                ],
+                [
                     'name'      => 'zip',
                     'column'    => 'a_zip',
-                ),
-                array(
+                ],
+                [
                     'name'      => 'country',
                     'column'    => 'a_country',
-                ),
-            ),
+                ],
+            ],
             'entityClass'           => 'Doctrine\Tests\Models\CMS\CmsAddress',
             'discriminatorColumn'   => null,
-        ),
-    ),
-    'columns' => array(array(
+        ],
+    ],
+    'columns' => [[
             'name' => 'numphones',
-        )
-    )
-));
+        ]
+    ]
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
@@ -3,52 +3,52 @@
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-$metadata->setPrimaryTable(array('name' => 'cache_city'));
+$metadata->setPrimaryTable(['name' => 'cache_city']);
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_IDENTITY);
 $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
 
-$metadata->enableCache(array(
+$metadata->enableCache([
     'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName' => 'id',
    'type' => 'integer',
    'id' => true,
-  ));
+  ]);
 
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName' => 'name',
    'type' => 'string',
-));
+]);
 
 
-$metadata->mapOneToOne(array(
+$metadata->mapOneToOne([
    'fieldName'      => 'state',
    'targetEntity'   => 'Doctrine\\Tests\\Models\\Cache\\State',
    'inversedBy'     => 'cities',
    'joinColumns'    =>
-   array(array(
+   [[
     'name' => 'state_id',
     'referencedColumnName' => 'id',
-   ))
-));
-$metadata->enableAssociationCache('state', array(
+   ]]
+]);
+$metadata->enableAssociationCache('state', [
     'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY
-));
+]);
 
-$metadata->mapManyToMany(array(
+$metadata->mapManyToMany([
    'fieldName' => 'travels',
    'targetEntity' => 'Doctrine\\Tests\\Models\\Cache\\Travel',
    'mappedBy' => 'visitedCities',
-));
+]);
 
-$metadata->mapOneToMany(array(
+$metadata->mapOneToMany([
    'fieldName' => 'attractions',
    'targetEntity' => 'Doctrine\\Tests\\Models\\Cache\\Attraction',
    'mappedBy' => 'city',
-   'orderBy' => array('name' => 'ASC',),
-));
-$metadata->enableAssociationCache('attractions', array(
+   'orderBy' => ['name' => 'ASC',],
+]);
+$metadata->enableAssociationCache('attractions', [
     'usage' => ClassMetadataInfo::CACHE_USAGE_READ_ONLY
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
@@ -4,28 +4,28 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_JOINED);
 $metadata->setTableName( 'company_contracts');
-$metadata->setDiscriminatorColumn(array(
+$metadata->setDiscriminatorColumn([
     'name' => 'discr',
     'type' => 'string',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'id'        => true,
     'name'      => 'id',
     'fieldName' => 'id',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'type'      => 'boolean',
     'name'      => 'completed',
     'fieldName' => 'completed',
-));
+]);
 
-$metadata->setDiscriminatorMap(array(
+$metadata->setDiscriminatorMap([
     "fix"       => "CompanyFixContract",
     "flexible"  => "CompanyFlexContract",
     "flexultra" => "CompanyFlexUltraContract"
-));
+]);
 
 $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CompanyContractListener', 'postPersistHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyContractListener', 'prePersistHandler');

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFixContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFixContract.php
@@ -1,7 +1,7 @@
 <?php
 
-$metadata->mapField(array(
+$metadata->mapField([
     'type'      => 'integer',
     'name'      => 'fixPrice',
     'fieldName' => 'fixPrice',
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexContract.php
@@ -1,13 +1,13 @@
 <?php
 
-$metadata->mapField(array(
+$metadata->mapField([
     'type'      => 'integer',
     'name'      => 'hoursWorked',
     'fieldName' => 'hoursWorked',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'type'      => 'integer',
     'name'      => 'pricePerHour',
     'fieldName' => 'pricePerHour',
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.php
@@ -1,10 +1,10 @@
 <?php
 
-$metadata->mapField(array(
+$metadata->mapField([
     'type'      => 'integer',
     'name'      => 'maxPrice',
     'fieldName' => 'maxPrice',
-));
+]);
 $metadata->addEntityListener(\Doctrine\ORM\Events::postPersist, 'CompanyContractListener', 'postPersistHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyContractListener', 'prePersistHandler');
 

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyPerson.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyPerson.php
@@ -2,38 +2,38 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
    'name' => 'company_person',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchAllWithResultClass',
     'query'             => 'SELECT id, name, discr FROM company_persons ORDER BY name',
     'resultClass'       => 'Doctrine\\Tests\\Models\\Company\\CompanyPerson',
-));
+]);
 
-$metadata->addNamedNativeQuery(array (
+$metadata->addNamedNativeQuery( [
     'name'              => 'fetchAllWithSqlResultSetMapping',
     'query'             => 'SELECT id, name, discr AS discriminator FROM company_persons ORDER BY name',
     'resultSetMapping'  => 'mappingFetchAll',
-));
+]);
 
-$metadata->addSqlResultSetMapping(array (
+$metadata->addSqlResultSetMapping( [
     'name'      => 'mappingFetchAll',
-    'columns'   => array(),
-    'entities'  => array ( array (
-        'fields' => array (
-          array (
+    'columns'   => [],
+    'entities'  =>  [  [
+        'fields' =>  [
+           [
             'name'      => 'id',
             'column'    => 'id',
-          ),
-          array (
+          ],
+           [
             'name'      => 'name',
             'column'    => 'name',
-          ),
-        ),
+          ],
+        ],
         'entityClass' => 'Doctrine\Tests\Models\Company\CompanyPerson',
         'discriminatorColumn' => 'discriminator',
-      ),
-    ),
-));
+      ],
+    ],
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
@@ -2,11 +2,11 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'         => true,
    'fieldName'  => 'id',
-));
-$metadata->mapField(array(
+]);
+$metadata->mapField([
    'fieldName'  => 'name'
-));
+]);
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.ExplicitSchemaAndTable.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.ExplicitSchemaAndTable.php
@@ -4,14 +4,14 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 /* @var $metadata ClassMetadata */
 
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
     'name'   => 'explicit_table',
     'schema' => 'explicit_schema',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'id'         => true,
     'fieldName'  => 'id',
-));
+]);
 
 $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.SchemaAndTableInTableName.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.SchemaAndTableInTableName.php
@@ -4,13 +4,13 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 /* @var $metadata ClassMetadata */
 
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
     'name' => 'implicit_schema.implicit_table',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'id'         => true,
     'fieldName'  => 'id',
-));
+]);
 
 $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869ChequePayment.php
@@ -1,5 +1,5 @@
 <?php
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName'  => 'serialNumber',
    'type'       => 'string',
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869CreditCardPayment.php
@@ -1,5 +1,5 @@
 <?php
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName'  => 'creditCardNumber',
    'type'       => 'string',
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
@@ -2,16 +2,16 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'         => true,
    'fieldName'  => 'id',
    'type'       => 'integer',
    'columnName' => 'id',
-));
-$metadata->mapField(array(
+]);
+$metadata->mapField([
    'fieldName'  => 'value',
    'type'       => 'float',
-  ));
+  ]);
 $metadata->isMappedSuperclass = true;
 $metadata->setCustomRepositoryClass("Doctrine\Tests\Models\DDC869\DDC869PaymentRepository");
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889Class.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889Class.php
@@ -2,11 +2,11 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'         => true,
    'fieldName'  => 'id',
    'type'       => 'integer',
    'columnName' => 'id',
-));
+]);
 
 //$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
@@ -2,10 +2,10 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName'  => 'name',
    'type'       => 'string',
-  ));
+  ]);
 $metadata->isMappedSuperclass = true;
 $metadata->setCustomRepositoryClass("Doctrine\Tests\Models\DDC889\DDC889SuperClass");
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Admin.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Admin.php
@@ -1,21 +1,21 @@
 <?php
 
-$metadata->setAssociationOverride('address',array(
-    'joinColumns'=>array(array(
+$metadata->setAssociationOverride('address',[
+    'joinColumns'=>[[
         'name' => 'adminaddress_id',
         'referencedColumnName' => 'id',
-    ))
-));
+    ]]
+]);
 
-$metadata->setAssociationOverride('groups',array(
-    'joinTable' => array (
+$metadata->setAssociationOverride('groups',[
+    'joinTable' =>  [
         'name'      => 'ddc964_users_admingroups',
-        'joinColumns' => array(array(
+        'joinColumns' => [[
             'name' => 'adminuser_id',
-        )),
+        ]],
 
-        'inverseJoinColumns' =>array (array (
+        'inverseJoinColumns' => [ [
             'name'      => 'admingroup_id',
-        ))
-  )
-));
+        ]]
+  ]
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Guest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964Guest.php
@@ -1,13 +1,13 @@
 <?php
-$metadata->setAttributeOverride('id', array(
+$metadata->setAttributeOverride('id', [
     'columnName'    => 'guest_id',
     'type'          => 'integer',
     'length'        => 140,
-));
+]);
 
-$metadata->setAttributeOverride('name',array(
+$metadata->setAttributeOverride('name',[
     'columnName'    => 'guest_name',
     'nullable'      => false,
     'unique'        => true,
     'length'        => 240,
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
@@ -2,45 +2,45 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'         => true,
    'fieldName'  => 'id',
    'type'       => 'integer',
    'columnName' => 'user_id',
    'length'     => 150,
-));
-$metadata->mapField(array(
+]);
+$metadata->mapField([
     'fieldName' => 'name',
     'type'      => 'string',
     'columnName'=> 'user_name',
     'nullable'  => true,
     'unique'    => false,
     'length'    => 250,
-));
+]);
 
-$metadata->mapManyToOne(array(
+$metadata->mapManyToOne([
    'fieldName'      => 'address',
    'targetEntity'   => 'DDC964Address',
-   'cascade'        => array('persist','merge'),
-   'joinColumn'     => array('name'=>'address_id', 'referencedColumnMame'=>'id'),
-));
+   'cascade'        => ['persist','merge'],
+   'joinColumn'     => ['name'=>'address_id', 'referencedColumnMame'=>'id'],
+]);
 
-$metadata->mapManyToMany(array(
+$metadata->mapManyToMany([
    'fieldName'      => 'groups',
    'targetEntity'   => 'DDC964Group',
    'inversedBy'     => 'users',
-   'cascade'        => array('persist','merge','detach'),
-   'joinTable'      => array(
+   'cascade'        => ['persist','merge','detach'],
+   'joinTable'      => [
         'name'          => 'ddc964_users_groups',
-        'joinColumns'   => array(array(
+        'joinColumns'   => [[
             'name'=>'user_id',
             'referencedColumnName'=>'id',
-        )),
-        'inverseJoinColumns'=>array(array(
+        ]],
+        'inverseJoinColumns'=>[[
             'name'=>'group_id',
             'referencedColumnName'=>'id',
-        ))
-   )
-));
+        ]]
+   ]
+]);
 
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
@@ -4,18 +4,18 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /* @var $metadata ClassMetadataInfo */
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE);
-$metadata->setDiscriminatorColumn(array(
+$metadata->setDiscriminatorColumn([
    'name' => 'dtype',
    'type' => 'string',
    'length' => 255,
    'fieldName' => 'dtype',
-  ));
-$metadata->setDiscriminatorMap(array(
+  ]);
+$metadata->setDiscriminatorMap([
    'cat' => 'Doctrine\\Tests\\ORM\\Mapping\\Cat',
    'dog' => 'Doctrine\\Tests\\ORM\\Mapping\\Dog',
-  ));
+  ]);
 $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
-$metadata->mapField(array(
+$metadata->mapField([
    'fieldName' => 'id',
    'type' => 'string',
    'length' => NULL,
@@ -25,6 +25,6 @@ $metadata->mapField(array(
    'unique' => false,
    'id' => true,
    'columnName' => 'id',
-  ));
+  ]);
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM);
-$metadata->setCustomGeneratorDefinition(array("class" => "stdClass"));
+$metadata->setCustomGeneratorDefinition(["class" => "stdClass"]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Comment.php
@@ -3,13 +3,13 @@
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-$metadata->setPrimaryTable(array(
-   'indexes' => array(
-       array('columns' => array('content'), 'flags' => array('fulltext'), 'options'=> array('where' => 'content IS NOT NULL'))
-   )
-  ));
+$metadata->setPrimaryTable([
+   'indexes' => [
+       ['columns' => ['content'], 'flags' => ['fulltext'], 'options'=> ['where' => 'content IS NOT NULL']]
+   ]
+  ]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'fieldName' => 'content',
     'type' => 'text',
     'scale' => 0,
@@ -18,4 +18,4 @@ $metadata->mapField(array(
     'nullable' => false,
     'precision' => 0,
     'columnName' => 'content',
-));
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
@@ -2,15 +2,15 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'                 => true,
    'fieldName'          => 'id',
    'columnDefinition'   => 'INT unsigned NOT NULL',
-));
+]);
 
-$metadata->mapField(array(
+$metadata->mapField([
     'fieldName'         => 'value',
     'columnDefinition'  => 'VARCHAR(255) NOT NULL'
-));
+]);
 
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
@@ -2,14 +2,14 @@
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-$metadata->mapField(array(
+$metadata->mapField([
    'id'                 => true,
    'fieldName'          => 'id',
-));
+]);
 
-$metadata->setDiscriminatorColumn(array(
+$metadata->setDiscriminatorColumn([
     'name'              => "dtype",
     'columnDefinition'  => "ENUM('ONE','TWO')"
-));
+]);
 
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -3,126 +3,126 @@
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
    'name' => 'cms_users',
-  ));
+  ]);
 $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
 $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
 $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
-$metadata->addNamedQuery(array(
+$metadata->addNamedQuery([
     'name'  => 'all',
     'query' => 'SELECT u FROM __CLASS__ u'
-));
-$metadata->mapField(array(
+]);
+$metadata->mapField([
    'id' => true,
    'fieldName' => 'id',
    'type' => 'integer',
    'columnName' => 'id',
-   'options' => array('foo' => 'bar'),
-  ));
-$metadata->mapField(array(
+   'options' => ['foo' => 'bar'],
+  ]);
+$metadata->mapField([
    'fieldName' => 'name',
    'type' => 'string',
    'length' => 50,
    'unique' => true,
    'nullable' => true,
    'columnName' => 'name',
-   'options' => array('foo' => 'bar', 'baz' => array('key' => 'val')),
-  ));
-$metadata->mapField(array(
+   'options' => ['foo' => 'bar', 'baz' => ['key' => 'val']],
+  ]);
+$metadata->mapField([
    'fieldName' => 'email',
    'type' => 'string',
    'columnName' => 'user_email',
    'columnDefinition' => 'CHAR(32) NOT NULL',
-  ));
-$mapping = array('fieldName' => 'version', 'type' => 'integer');
+  ]);
+$mapping = ['fieldName' => 'version', 'type' => 'integer'];
 $metadata->setVersionMapping($mapping);
 $metadata->mapField($mapping);
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
-$metadata->mapOneToOne(array(
+$metadata->mapOneToOne([
    'fieldName' => 'address',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Address',
    'cascade' =>
-   array(
+   [
    0 => 'remove',
-   ),
+   ],
    'mappedBy' => NULL,
    'inversedBy' => 'user',
    'joinColumns' =>
-   array(
+   [
    0 =>
-   array(
+   [
     'name' => 'address_id',
     'referencedColumnName' => 'id',
     'onDelete' => 'CASCADE',
-   ),
-   ),
+   ],
+   ],
    'orphanRemoval' => false,
-  ));
-$metadata->mapOneToMany(array(
+  ]);
+$metadata->mapOneToMany([
    'fieldName' => 'phonenumbers',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Phonenumber',
    'cascade' =>
-   array(
+   [
    1 => 'persist',
-   ),
+   ],
    'mappedBy' => 'user',
    'orphanRemoval' => true,
    'orderBy' =>
-   array(
+   [
    'number' => 'ASC',
-   ),
-  ));
-$metadata->mapManyToMany(array(
+   ],
+  ]);
+$metadata->mapManyToMany([
    'fieldName' => 'groups',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Mapping\\Group',
    'cascade' =>
-   array(
+   [
    0 => 'remove',
    1 => 'persist',
    2 => 'refresh',
    3 => 'merge',
    4 => 'detach',
-   ),
+   ],
    'mappedBy' => NULL,
    'joinTable' =>
-   array(
+   [
    'name' => 'cms_users_groups',
    'joinColumns' =>
-   array(
+   [
     0 =>
-    array(
+    [
     'name' => 'user_id',
     'referencedColumnName' => 'id',
     'unique' => false,
     'nullable' => false,
-    ),
-   ),
+    ],
+   ],
    'inverseJoinColumns' =>
-   array(
+   [
     0 =>
-    array(
+    [
     'name' => 'group_id',
     'referencedColumnName' => 'id',
     'columnDefinition' => 'INT NULL',
-    ),
-   ),
-   ),
+    ],
+   ],
+   ],
    'orderBy' => NULL,
-  ));
-$metadata->table['options'] = array(
+  ]);
+$metadata->table['options'] = [
     'foo' => 'bar',
-    'baz' => array('key' => 'val')
-);
-$metadata->table['uniqueConstraints'] = array(
-    'search_idx' => array('columns' => array('name', 'user_email'), 'options' => array('where' => 'name IS NOT NULL')),
-);
-$metadata->table['indexes'] = array(
-    'name_idx' => array('columns' => array('name')), 0 => array('columns' => array('user_email'))
-);
-$metadata->setSequenceGeneratorDefinition(array(
+    'baz' => ['key' => 'val']
+];
+$metadata->table['uniqueConstraints'] = [
+    'search_idx' => ['columns' => ['name', 'user_email'], 'options' => ['where' => 'name IS NOT NULL']],
+];
+$metadata->table['indexes'] = [
+    'name_idx' => ['columns' => ['name']], 0 => ['columns' => ['user_email']]
+];
+$metadata->setSequenceGeneratorDefinition([
         'sequenceName' => 'tablename_seq',
         'allocationSize' => 100,
         'initialValue' => 1,
-    ));
+    ]);

--- a/tests/Doctrine/Tests/ORM/Performance/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Performance/DDC2602Test.php
@@ -16,12 +16,12 @@ class DDC2602Test extends \Doctrine\Tests\OrmPerformanceTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602Biography'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602BiographyField'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602BiographyFieldChoice'),
-        ));
+        ]);
 
         $this->loadFixture();
     }
@@ -30,18 +30,18 @@ class DDC2602Test extends \Doctrine\Tests\OrmPerformanceTestCase
     {
         parent::tearDown();
 
-        $this->_schemaTool->dropSchema(array(
+        $this->_schemaTool->dropSchema([
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602User'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602Biography'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602BiographyField'),
             $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2602BiographyFieldChoice'),
-        ));
+        ]);
     }
 
     public function testIssue()
     {
         $eventManager = $this->_em->getEventManager();
-        $eventManager->addEventListener(array(Events::postLoad), new DDC2602PostLoadListener());
+        $eventManager->addEventListener([Events::postLoad], new DDC2602PostLoadListener());
 
         // Set maximum seconds this can run
         $this->setMaxRunningTime(1);
@@ -231,7 +231,7 @@ class DDC2602Biography
     /**
      * @var array
      */
-    public $fieldList = array();
+    public $fieldList = [];
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Performance/HydrationPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/HydrationPerformanceTest.php
@@ -34,35 +34,35 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            )
-        );
+            ]
+        ];
 
         for ($i = 4; $i < 10000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -92,35 +92,35 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            )
-        );
+            ]
+        ];
 
         for ($i = 4; $i < 10000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -158,43 +158,43 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            )
-        );
+            ]
+        ];
 
         for ($i = 4; $i < 10000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
                 'sclr0' => 'JWAGE' . $i,
                 'p__phonenumber' => '91'
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -222,35 +222,35 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
-            )
-        );
+            ]
+        ];
 
         for ($i = 4; $i < 10000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -258,7 +258,7 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
 
         $this->setMaxRunningTime(3);
         $s = microtime(true);
-        $result = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
         $e = microtime(true);
         echo __FUNCTION__ . " - " . ($e - $s) . " seconds" . PHP_EOL;
     }
@@ -288,25 +288,25 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         //$rsm->addFieldResult('a', 'a__city', 'city');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'a__id' => '1'
-            )
-        );
+            ]
+        ];
 
         for ($i = 2; $i < 10000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
                 'a__id' => $i
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -342,43 +342,43 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('p', 'p__phonenumber', 'phonenumber');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '43',
-            ),
-            array(
+            ],
+            [
                 'u__id' => '2',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
                 'u__name' => 'Roman',
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91'
-            )
-        );
+            ]
+        ];
 
         for ($i = 4; $i < 2000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
                 'u__name' => 'Jonathan',
                 'sclr0' => 'JWAGE' . $i,
                 'p__phonenumber' => '91'
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);
@@ -386,7 +386,7 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
 
         $this->setMaxRunningTime(1);
         $s = microtime(true);
-        $result = $hydrator->hydrateAll($stmt, $rsm, array(Query::HINT_FORCE_PARTIAL_LOAD => true));
+        $result = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
         $e = microtime(true);
         echo __FUNCTION__ . " - " . ($e - $s) . " seconds" . PHP_EOL;
     }
@@ -421,9 +421,9 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
         $rsm->addFieldResult('a', 'a__id', 'id');
 
         // Faked result set
-        $resultSet = array(
+        $resultSet = [
             //row1
-            array(
+            [
                 'u__id' => '1',
                 'u__status' => 'developer',
                 'u__username' => 'romanb',
@@ -431,11 +431,11 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
                 'sclr0' => 'ROMANB',
                 'p__phonenumber' => '42',
                 'a__id' => '1'
-            )
-        );
+            ]
+        ];
 
         for ($i = 2; $i < 2000; ++$i) {
-            $resultSet[] = array(
+            $resultSet[] = [
                 'u__id' => $i,
                 'u__status' => 'developer',
                 'u__username' => 'jwage',
@@ -443,7 +443,7 @@ class HydrationPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
                 'sclr0' => 'JWAGE' . $i,
                 'p__phonenumber' => '91',
                 'a__id' => $i
-            );
+            ];
         }
 
         $stmt = new HydratorMockStatement($resultSet);

--- a/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
@@ -30,7 +30,7 @@ class PersisterPerformanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $author->username = "beberlei";
         $this->_em->persist($author);
 
-        $ids = array();
+        $ids = [];
         for ($i = 0; $i < 100; $i++) {
             $article = new CmsArticle();
             $article->text = "foo";

--- a/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/ProxyPerformanceTest.php
@@ -39,10 +39,10 @@ class ProxyPerformanceTest extends OrmPerformanceTestCase
      */
     public function entitiesProvider()
     {
-        return array(
-            array('Doctrine\Tests\Models\CMS\CmsEmployee'),
-            array('Doctrine\Tests\Models\CMS\CmsUser'),
-        );
+        return [
+            ['Doctrine\Tests\Models\CMS\CmsEmployee'],
+            ['Doctrine\Tests\Models\CMS\CmsUser'],
+        ];
     }
 
     /**
@@ -55,7 +55,7 @@ class ProxyPerformanceTest extends OrmPerformanceTestCase
         $start = microtime(true);
 
         for ($i = 0; $i < 100000; $i += 1) {
-            $user = $proxyFactory->getProxy($entityName, array('id' => $i));
+            $user = $proxyFactory->getProxy($entityName, ['id' => $i]);
         }
 
         echo __FUNCTION__ . " - " . (microtime(true) - $start) . " seconds with " . $entityName . PHP_EOL;
@@ -69,7 +69,7 @@ class ProxyPerformanceTest extends OrmPerformanceTestCase
         $em              = new MockEntityManager($this->_getEntityManager());
         $proxyFactory    = $em->getProxyFactory();
         /* @var $user \Doctrine\Common\Proxy\Proxy */
-        $user            = $proxyFactory->getProxy($entityName, array('id' => 1));
+        $user            = $proxyFactory->getProxy($entityName, ['id' => 1]);
         $initializer     = $user->__getInitializer();
 
         $this->setMaxRunningTime(5);
@@ -164,7 +164,7 @@ class PersisterMock extends BasicEntityPersister
     }
 
     /** {@inheritDoc} */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = 0, $limit = null, array $orderBy = null)
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = 0, $limit = null, array $orderBy = null)
     {
         return $entity;
     }

--- a/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
@@ -159,8 +159,8 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
     {
         $times        = 50;
         $size         = 30;
-        $states       = array();
-        $cities       = array();
+        $states       = [];
+        $cities       = [];
         $startPersist = microtime(true);
         $country      = new Country("Country");
 
@@ -218,7 +218,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
     {
         $times        = 10;
         $size         = 500;
-        $countries    = array();
+        $countries    = [];
         $startPersist = microtime(true);
 
         echo PHP_EOL . $label;

--- a/tests/Doctrine/Tests/ORM/Performance/UnitOfWorkPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/UnitOfWorkPerformanceTest.php
@@ -22,7 +22,7 @@ class UnitOfWorkPerformanceTest extends \Doctrine\Tests\OrmPerformanceTestCase
     {
         $n = 100;
 
-        $users = array();
+        $users = [];
         for ($i=1; $i<=$n; ++$i) {
             $user = new CmsUser;
             $user->status = 'user';

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -28,7 +28,7 @@ class PersistentCollectionTest extends OrmTestCase
     {
         parent::setUp();
         // SUT
-        $this->_connectionMock = new ConnectionMock(array(), new \Doctrine\Tests\Mocks\DriverMock());
+        $this->_connectionMock = new ConnectionMock([], new \Doctrine\Tests\Mocks\DriverMock());
         $this->_emMock = EntityManagerMock::create($this->_connectionMock);
     }
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -64,8 +64,8 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
         $parent->customInteger = 1;
         $parent->child = $child;
 
-        $this->_em->getUnitOfWork()->registerManaged($parent, array('id' => 1), array('customInteger' => 0, 'child' => null));
-        $this->_em->getUnitOfWork()->registerManaged($child, array('id' => 1), array());
+        $this->_em->getUnitOfWork()->registerManaged($parent, ['id' => 1], ['customInteger' => 0, 'child' => null]);
+        $this->_em->getUnitOfWork()->registerManaged($child, ['id' => 1], []);
 
         $this->_em->getUnitOfWork()->propertyChanged($parent, 'customInteger', 0, 1);
         $this->_em->getUnitOfWork()->propertyChanged($parent, 'child', null, $child);
@@ -82,7 +82,7 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
         $method = new \ReflectionMethod($this->_persister, 'getSelectConditionSQL');
         $method->setAccessible(true);
 
-        $sql = $method->invoke($this->_persister,  array('customInteger' => 1, 'child' => 1));
+        $sql = $method->invoke($this->_persister,  ['customInteger' => 1, 'child' => 1]);
 
         $this->assertEquals('t0.customInteger = ABS(?) AND t0.child_id = ?', $sql);
     }
@@ -104,19 +104,19 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testSelectConditionStatementIsNull()
     {
-        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, array(), Comparison::IS);
+        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, [], Comparison::IS);
         $this->assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementEqNull()
     {
-        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, array(), Comparison::EQ);
+        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, [], Comparison::EQ);
         $this->assertEquals('test IS NULL', $statement);
     }
 
     public function testSelectConditionStatementNeqNull()
     {
-        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, array(), Comparison::NEQ);
+        $statement = $this->_persister->getSelectConditionStatementSQL('test', null, [], Comparison::NEQ);
         $this->assertEquals('test IS NOT NULL', $statement);
     }
 
@@ -127,17 +127,17 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertEquals(
             '(t0.id IN (?) OR t0.id IS NULL)',
-            $this->_persister->getSelectConditionStatementSQL('id', array(null))
+            $this->_persister->getSelectConditionStatementSQL('id', [null])
         );
 
         $this->assertEquals(
             '(t0.id IN (?) OR t0.id IS NULL)',
-            $this->_persister->getSelectConditionStatementSQL('id', array(null, 123))
+            $this->_persister->getSelectConditionStatementSQL('id', [null, 123])
         );
 
         $this->assertEquals(
             '(t0.id IN (?) OR t0.id IS NULL)',
-            $this->_persister->getSelectConditionStatementSQL('id', array(123, null))
+            $this->_persister->getSelectConditionStatementSQL('id', [123, null])
         );
     }
 
@@ -146,7 +146,7 @@ class BasicEntityPersisterTypeValueSqlTest extends \Doctrine\Tests\OrmTestCase
         $persister = new BasicEntityPersister($this->_em, $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC1719SimpleEntity'));
 
         // Using a criteria as array
-        $statement = $persister->getCountSQL(array('value' => 'bar'));
+        $statement = $persister->getCountSQL(['value' => 'bar']);
         $this->assertEquals('SELECT COUNT(*) FROM "ddc-1719-simple-entity" t0 WHERE t0."simple-entity-value" = ?', $statement);
 
         // Using a criteria object

--- a/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/JoinedSubclassPersisterTest.php
@@ -59,6 +59,6 @@ class JoinedSubClassPersisterTest extends OrmTestCase
      */
     public function testExecuteInsertsWillReturnEmptySetWithNoQueuedInserts()
     {
-        $this->assertSame(array(), $this->persister->executeInserts());
+        $this->assertSame([], $this->persister->executeInserts());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -44,7 +44,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->connectionMock = new ConnectionMock(array(), new DriverMock());
+        $this->connectionMock = new ConnectionMock([], new DriverMock());
         $this->emMock = EntityManagerMock::create($this->connectionMock);
         $this->uowMock = new UnitOfWorkMock($this->emMock);
         $this->emMock->setUnitOfWork($this->uowMock);
@@ -53,9 +53,9 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
 
     public function testReferenceProxyDelegatesLoadingToThePersister()
     {
-        $identifier = array('id' => 42);
+        $identifier = ['id' => 42];
         $proxyClass = 'Proxies\__CG__\Doctrine\Tests\Models\ECommerce\ECommerceFeature';
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', ['load'], [], '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $identifier);
@@ -78,7 +78,7 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
         $this->assertNotNull($cm->reflClass);
 
-        $num = $this->proxyFactory->generateProxyClasses(array($cm));
+        $num = $this->proxyFactory->generateProxyClasses([$cm]);
 
         $this->assertEquals(0, $num, "No proxies generated.");
     }
@@ -88,11 +88,11 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', ['load'], [], '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */
-        $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', array('id' => 42));
+        $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', ['id' => 42]);
 
         $persister
             ->expects($this->atLeastOnce())
@@ -115,11 +115,11 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', ['load'], [], '', false);
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */
-        $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', array('id' => 42));
+        $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', ['id' => 42]);
 
         $persister
             ->expects($this->atLeastOnce())

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php
@@ -41,7 +41,7 @@ class CustomTreeWalkersJoinTest extends \Doctrine\Tests\OrmTestCase
     {
         try {
             $query = $this->em->createQuery($dqlToBeTested);
-            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Query\CustomTreeWalkerJoin'))
+            $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\Tests\ORM\Query\CustomTreeWalkerJoin'])
                   ->useQueryCache(false);
 
             $this->assertEquals($sqlToBeConfirmed, $query->getSql());
@@ -100,14 +100,14 @@ class CustomTreeWalkerJoin extends Query\TreeWalkerAdapter
         $addressMetadata = $entityManager->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
 
         $this->setQueryComponent($rangeVariableDecl->aliasIdentificationVariable . 'a',
-            array(
+            [
                 'metadata'     => $addressMetadata,
                 'parent'       => $rangeVariableDecl->aliasIdentificationVariable,
                 'relation'     => $userMetadata->getAssociationMapping('address'),
                 'map'          => null,
                 'nestingLevel' => 0,
                 'token'        => null,
-            )
+            ]
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
@@ -51,7 +51,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         return $query->getSql();
     }
 
-    public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed, $treeWalkers = array(), $outputWalker = null)
+    public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed, $treeWalkers = [], $outputWalker = null)
     {
         try {
             $this->assertEquals($sqlToBeConfirmed, $this->generateSql($dqlToBeTested, $treeWalkers, $outputWalker));
@@ -65,7 +65,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u',
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3, c0_.email_id AS email_id_4 FROM cms_users c0_ WHERE c0_.id = 1",
-            array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
+            ['Doctrine\Tests\ORM\Functional\CustomTreeWalker']
         );
     }
 
@@ -74,7 +74,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u where u.name = :name or u.name = :otherName',
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3, c0_.email_id AS email_id_4 FROM cms_users c0_ WHERE (c0_.name = ? OR c0_.name = ?) AND c0_.id = 1",
-            array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
+            ['Doctrine\Tests\ORM\Functional\CustomTreeWalker']
         );
     }
 
@@ -83,7 +83,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u where u.name = :name',
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3, c0_.email_id AS email_id_4 FROM cms_users c0_ WHERE c0_.name = ? AND c0_.id = 1",
-            array('Doctrine\Tests\ORM\Functional\CustomTreeWalker')
+            ['Doctrine\Tests\ORM\Functional\CustomTreeWalker']
         );
     }
 
@@ -92,7 +92,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         $this->setExpectedException("Doctrine\ORM\Query\QueryException", "Invalid query component given for DQL alias 'x', requires 'metadata', 'parent', 'relation', 'map', 'nestingLevel' and 'token' keys.");
         $this->generateSql(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u',
-            array(),
+            [],
             __NAMESPACE__ . '\\AddUnknownQueryComponentWalker'
         );
     }
@@ -102,7 +102,7 @@ class CustomTreeWalkersTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u',
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3, c1_.id AS id_4, c1_.country AS country_5, c1_.zip AS zip_6, c1_.city AS city_7, c0_.email_id AS email_id_8, c1_.user_id AS user_id_9 FROM cms_users c0_ LEFT JOIN cms_addresses c1_ ON c0_.id = c1_.user_id WHERE c0_.id = 1",
-            array('Doctrine\Tests\ORM\Functional\CustomTreeWalkerJoin', 'Doctrine\Tests\ORM\Functional\CustomTreeWalker')
+            ['Doctrine\Tests\ORM\Functional\CustomTreeWalkerJoin', 'Doctrine\Tests\ORM\Functional\CustomTreeWalker']
         );
     }
 }
@@ -113,7 +113,7 @@ class AddUnknownQueryComponentWalker extends Query\SqlWalker
     {
         parent::walkSelectStatement($selectStatement);
 
-        $this->setQueryComponent('x', array());
+        $this->setQueryComponent('x', []);
     }
 }
 
@@ -122,7 +122,7 @@ class CustomTreeWalker extends Query\TreeWalkerAdapter
     public function walkSelectStatement(Query\AST\SelectStatement $selectStatement)
     {
         // Get the DQL aliases of all the classes we want to modify
-        $dqlAliases = array();
+        $dqlAliases = [];
 
         foreach ($this->_getQueryComponents() as $dqlAlias => $comp) {
             // Hard-coded check just for demonstration: We want to modify the query if
@@ -133,7 +133,7 @@ class CustomTreeWalker extends Query\TreeWalkerAdapter
         }
 
         // Create our conditions for all involved classes
-        $factors = array();
+        $factors = [];
         foreach ($dqlAliases as $alias) {
             $pathExpr = new Query\AST\PathExpression(Query\AST\PathExpression::TYPE_STATE_FIELD, $alias, 'id');
             $pathExpr->type = Query\AST\PathExpression::TYPE_STATE_FIELD;
@@ -152,7 +152,7 @@ class CustomTreeWalker extends Query\TreeWalkerAdapter
 
             // Since Phase 1 AST optimizations were included, we need to re-add the ConditionalExpression
             if ( ! ($condExpr instanceof Query\AST\ConditionalExpression)) {
-                $condExpr = new Query\AST\ConditionalExpression(array($condExpr));
+                $condExpr = new Query\AST\ConditionalExpression([$condExpr]);
 
                 $whereClause->conditionalExpression = $condExpr;
             }
@@ -166,27 +166,27 @@ class CustomTreeWalker extends Query\TreeWalkerAdapter
                 $primary = new Query\AST\ConditionalPrimary;
                 $primary->conditionalExpression = new Query\AST\ConditionalExpression($existingTerms);
                 $existingFactor = new Query\AST\ConditionalFactor($primary);
-                $term = new Query\AST\ConditionalTerm(array_merge(array($existingFactor), $factors));
+                $term = new Query\AST\ConditionalTerm(array_merge([$existingFactor], $factors));
 
-                $selectStatement->whereClause->conditionalExpression->conditionalTerms = array($term);
+                $selectStatement->whereClause->conditionalExpression->conditionalTerms = [$term];
             } else {
                 // Just one term so we can simply append our factors to that term
                 $singleTerm = $selectStatement->whereClause->conditionalExpression->conditionalTerms[0];
 
                 // Since Phase 1 AST optimizations were included, we need to re-add the ConditionalExpression
                 if ( ! ($singleTerm instanceof Query\AST\ConditionalTerm)) {
-                    $singleTerm = new Query\AST\ConditionalTerm(array($singleTerm));
+                    $singleTerm = new Query\AST\ConditionalTerm([$singleTerm]);
 
                     $selectStatement->whereClause->conditionalExpression->conditionalTerms[0] = $singleTerm;
                 }
 
                 $singleTerm->conditionalFactors = array_merge($singleTerm->conditionalFactors, $factors);
-                $selectStatement->whereClause->conditionalExpression->conditionalTerms = array($singleTerm);
+                $selectStatement->whereClause->conditionalExpression->conditionalTerms = [$singleTerm];
             }
         } else {
             // Create a new WHERE clause with our factors
             $term = new Query\AST\ConditionalTerm($factors);
-            $condExpr = new Query\AST\ConditionalExpression(array($term));
+            $condExpr = new Query\AST\ConditionalExpression([$term]);
             $whereClause = new Query\AST\WhereClause($condExpr);
             $selectStatement->whereClause = $whereClause;
         }
@@ -224,14 +224,14 @@ class CustomTreeWalkerJoin extends Query\TreeWalkerAdapter
         $addressMetadata = $entityManager->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
 
         $this->setQueryComponent($rangeVariableDecl->aliasIdentificationVariable . 'a',
-            array(
+            [
                 'metadata'     => $addressMetadata,
                 'parent'       => $rangeVariableDecl->aliasIdentificationVariable,
                 'relation'     => $userMetadata->getAssociationMapping('address'),
                 'map'          => null,
                 'nestingLevel' => 0,
                 'token'        => null,
-            )
+            ]
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -284,22 +284,22 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
 
     public function testInExpr()
     {
-        $this->assertEquals('u.id IN(1, 2, 3)', (string) $this->_expr->in('u.id', array(1, 2, 3)));
+        $this->assertEquals('u.id IN(1, 2, 3)', (string) $this->_expr->in('u.id', [1, 2, 3]));
     }
 
     public function testInLiteralExpr()
     {
-        $this->assertEquals("u.type IN('foo', 'bar')", (string) $this->_expr->in('u.type', array('foo', 'bar')));
+        $this->assertEquals("u.type IN('foo', 'bar')", (string) $this->_expr->in('u.type', ['foo', 'bar']));
     }
 
     public function testNotInExpr()
     {
-        $this->assertEquals('u.id NOT IN(1, 2, 3)', (string) $this->_expr->notIn('u.id', array(1, 2, 3)));
+        $this->assertEquals('u.id NOT IN(1, 2, 3)', (string) $this->_expr->notIn('u.id', [1, 2, 3]));
     }
 
     public function testNotInLiteralExpr()
     {
-        $this->assertEquals("u.type NOT IN('foo', 'bar')", (string) $this->_expr->notIn('u.type', array('foo', 'bar')));
+        $this->assertEquals("u.type NOT IN('foo', 'bar')", (string) $this->_expr->notIn('u.type', ['foo', 'bar']));
     }
 
     public function testAndxOrxExpr()
@@ -370,8 +370,8 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     {
 
         // Andx
-        $andx = new Expr\Andx(array('1 = 1', '2 = 2'));
-        $this->assertEquals(array('1 = 1', '2 = 2'), $andx->getParts());
+        $andx = new Expr\Andx(['1 = 1', '2 = 2']);
+        $this->assertEquals(['1 = 1', '2 = 2'], $andx->getParts());
 
         // Comparison
         $comparison = new Expr\Comparison('foo', Expr\Comparison::EQ, 'bar');
@@ -386,13 +386,13 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('f.id', $from->getIndexBy());
 
         // Func
-        $func = new Expr\Func('MAX', array('f.id'));
+        $func = new Expr\Func('MAX', ['f.id']);
         $this->assertEquals('MAX', $func->getName());
-        $this->assertEquals(array('f.id'), $func->getArguments());
+        $this->assertEquals(['f.id'], $func->getArguments());
 
         // GroupBy
-        $group = new Expr\GroupBy(array('foo DESC', 'bar ASC'));
-        $this->assertEquals(array('foo DESC', 'bar ASC'), $group->getParts());
+        $group = new Expr\GroupBy(['foo DESC', 'bar ASC']);
+        $this->assertEquals(['foo DESC', 'bar ASC'], $group->getParts());
 
         // Join
         $join = new Expr\Join(Expr\Join::INNER_JOIN, 'f.bar', 'b', Expr\Join::ON, 'b.bar_id = 1', 'b.bar_id');
@@ -404,8 +404,8 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('b', $join->getAlias());
 
         // Literal
-        $literal = new Expr\Literal(array('foo'));
-        $this->assertEquals(array('foo'), $literal->getParts());
+        $literal = new Expr\Literal(['foo']);
+        $this->assertEquals(['foo'], $literal->getParts());
 
         // Math
         $math = new Expr\Math(10, '+', 20);
@@ -415,15 +415,15 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
 
         // OrderBy
         $order = new Expr\OrderBy('foo', 'DESC');
-        $this->assertEquals(array('foo DESC'), $order->getParts());
+        $this->assertEquals(['foo DESC'], $order->getParts());
 
         // Andx
-        $orx = new Expr\Orx(array('foo = 1', 'bar = 2'));
-        $this->assertEquals(array('foo = 1', 'bar = 2'), $orx->getParts());
+        $orx = new Expr\Orx(['foo = 1', 'bar = 2']);
+        $this->assertEquals(['foo = 1', 'bar = 2'], $orx->getParts());
 
         // Select
-        $select = new Expr\Select(array('foo', 'bar'));
-        $this->assertEquals(array('foo', 'bar'), $select->getParts());
+        $select = new Expr\Select(['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar'], $select->getParts());
     }
 
     public function testAddEmpty() {

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -40,7 +40,7 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
         }
     }
 
-    public function parseDql($dql, $hints = array())
+    public function parseDql($dql, $hints = [])
     {
         $query = $this->_em->createQuery($dql);
         $query->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true);

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -170,63 +170,63 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
         $dql = "SELECT u FROM My\Namespace\User u WHERE u.name = 'Jack O''Neil'";
         $lexer = new Lexer($dql);
 
-        $tokens = array(
-            array(
+        $tokens = [
+            [
                 'value' => 'SELECT',
                 'type'  => Lexer::T_SELECT,
                 'position' => 0
-            ),
-            array(
+            ],
+            [
                 'value' => 'u',
                 'type'  => Lexer::T_IDENTIFIER,
                 'position' => 7
-            ),
-            array(
+            ],
+            [
                 'value' => 'FROM',
                 'type'  => Lexer::T_FROM,
                 'position' => 9
-            ),
-            array(
+            ],
+            [
                 'value' => 'My\Namespace\User',
                 'type'  => Lexer::T_IDENTIFIER,
                 'position' => 14
-            ),
-            array(
+            ],
+            [
                 'value' => 'u',
                 'type'  => Lexer::T_IDENTIFIER,
                 'position' => 32
-            ),
-            array(
+            ],
+            [
                 'value' => 'WHERE',
                 'type'  => Lexer::T_WHERE,
                 'position' => 34
-            ),
-            array(
+            ],
+            [
                 'value' => 'u',
                 'type'  => Lexer::T_IDENTIFIER,
                 'position' => 40
-            ),
-            array(
+            ],
+            [
                 'value' => '.',
                 'type'  => Lexer::T_DOT,
                 'position' => 41
-            ),
-            array(
+            ],
+            [
                 'value' => 'name',
                 'type'  => Lexer::T_IDENTIFIER,
                 'position' => 42
-            ),
-            array(
+            ],
+            [
                 'value' => '=',
                 'type'  => Lexer::T_EQUALS,
                 'position' => 47
-            ),
-            array(
+            ],
+            [
                 'value' => "Jack O'Neil",
                 'type'  => Lexer::T_STRING,
                 'position' => 49
-            )
-        );
+            ]
+        ];
 
         foreach ($tokens as $expected) {
             $lexer->moveNext();

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -28,17 +28,17 @@ class ParameterTypeInfererTest extends \Doctrine\Tests\OrmTestCase
 
     public function providerParameterTypeInferer()
     {
-         return array(
-            array(1,                 Type::INTEGER),
-            array("bar",             PDO::PARAM_STR),
-            array("1",               PDO::PARAM_STR),
-            array(new \DateTime,     Type::DATETIME),
-            array(array(2),          Connection::PARAM_INT_ARRAY),
-            array(array("foo"),      Connection::PARAM_STR_ARRAY),
-            array(array("1","2"),    Connection::PARAM_STR_ARRAY),
-            array(array(),           Connection::PARAM_STR_ARRAY),
-            array(true,              Type::BOOLEAN),
-        );
+         return [
+            [1,                 Type::INTEGER],
+            ["bar",             PDO::PARAM_STR],
+            ["1",               PDO::PARAM_STR],
+            [new \DateTime,     Type::DATETIME],
+            [[2],          Connection::PARAM_INT_ARRAY],
+            [["foo"],      Connection::PARAM_STR_ARRAY],
+            [["1","2"],    Connection::PARAM_STR_ARRAY],
+            [[],           Connection::PARAM_STR_ARRAY],
+            [true,              Type::BOOLEAN],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
@@ -25,7 +25,7 @@ class ParserResultTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNull($this->parserResult->getSqlExecutor());
 
-        $executor = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', array('execute'));
+        $executor = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', ['execute']);
         $this->parserResult->setSqlExecutor($executor);
         $this->assertSame($executor, $this->parserResult->getSqlExecutor());
     }
@@ -34,7 +34,7 @@ class ParserResultTest extends \PHPUnit_Framework_TestCase
     {
         $this->parserResult->addParameterMapping(1, 1);
         $this->parserResult->addParameterMapping(1, 2);
-        $this->assertEquals(array(1, 2), $this->parserResult->getSqlParameterPositions(1));
+        $this->assertEquals([1, 2], $this->parserResult->getSqlParameterPositions(1));
     }
 
     public function testGetParameterMappings()
@@ -43,6 +43,6 @@ class ParserResultTest extends \PHPUnit_Framework_TestCase
 
         $this->parserResult->addParameterMapping(1, 1);
         $this->parserResult->addParameterMapping(1, 2);
-        $this->assertEquals(array(1 => array(1, 2)), $this->parserResult->getParameterMappings());
+        $this->assertEquals([1 => [1, 2]], $this->parserResult->getParameterMappings());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -47,7 +47,7 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->visitor = new QueryExpressionVisitor(array('o','p'));
+        $this->visitor = new QueryExpressionVisitor(['o','p']);
     }
 
     /**
@@ -61,7 +61,7 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals($queryExpr, $this->visitor->walkComparison($criteriaExpr));
         if ($parameter) {
-            $this->assertEquals(new ArrayCollection(array($parameter)), $this->visitor->getParameters());
+            $this->assertEquals(new ArrayCollection([$parameter]), $this->visitor->getParameters());
         }
     }
 
@@ -70,30 +70,30 @@ class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
         $cb = new CriteriaBuilder();
         $qb = new QueryBuilder();
 
-        return array(
-            array($cb->eq('field', 'value'), $qb->eq('o.field', ':field'), new Parameter('field', 'value')),
-            array($cb->neq('field', 'value'), $qb->neq('o.field', ':field'), new Parameter('field', 'value')),
-            array($cb->eq('field', null), $qb->isNull('o.field')),
-            array($cb->neq('field', null), $qb->isNotNull('o.field')),
-            array($cb->isNull('field'), $qb->isNull('o.field')),
+        return [
+            [$cb->eq('field', 'value'), $qb->eq('o.field', ':field'), new Parameter('field', 'value')],
+            [$cb->neq('field', 'value'), $qb->neq('o.field', ':field'), new Parameter('field', 'value')],
+            [$cb->eq('field', null), $qb->isNull('o.field')],
+            [$cb->neq('field', null), $qb->isNotNull('o.field')],
+            [$cb->isNull('field'), $qb->isNull('o.field')],
 
-            array($cb->gt('field', 'value'), $qb->gt('o.field', ':field'), new Parameter('field', 'value')),
-            array($cb->gte('field', 'value'), $qb->gte('o.field', ':field'), new Parameter('field', 'value')),
-            array($cb->lt('field', 'value'), $qb->lt('o.field', ':field'), new Parameter('field', 'value')),
-            array($cb->lte('field', 'value'), $qb->lte('o.field', ':field'), new Parameter('field', 'value')),
+            [$cb->gt('field', 'value'), $qb->gt('o.field', ':field'), new Parameter('field', 'value')],
+            [$cb->gte('field', 'value'), $qb->gte('o.field', ':field'), new Parameter('field', 'value')],
+            [$cb->lt('field', 'value'), $qb->lt('o.field', ':field'), new Parameter('field', 'value')],
+            [$cb->lte('field', 'value'), $qb->lte('o.field', ':field'), new Parameter('field', 'value')],
 
-            array($cb->in('field', array('value')), $qb->in('o.field', ':field'), new Parameter('field', array('value'))),
-            array($cb->notIn('field', array('value')), $qb->notIn('o.field', ':field'), new Parameter('field', array('value'))),
+            [$cb->in('field', ['value']), $qb->in('o.field', ':field'), new Parameter('field', ['value'])],
+            [$cb->notIn('field', ['value']), $qb->notIn('o.field', ':field'), new Parameter('field', ['value'])],
 
-            array($cb->contains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')),
+            [$cb->contains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')],
 
             // Test parameter conversion
-            array($cb->eq('object.field', 'value'), $qb->eq('o.object.field', ':object_field'), new Parameter('object_field', 'value')),
+            [$cb->eq('object.field', 'value'), $qb->eq('o.object.field', ':object_field'), new Parameter('object_field', 'value')],
 
             // Test alternative rootAlias
-            array($cb->eq('p.field', 'value'), $qb->eq('p.field', ':p_field'), new Parameter('p_field', 'value')),
-            array($cb->eq('p.object.field', 'value'), $qb->eq('p.object.field', ':p_object_field'), new Parameter('p_object_field', 'value')),
-        );
+            [$cb->eq('p.field', 'value'), $qb->eq('p.field', ':p_field'), new Parameter('p_field', 'value')],
+            [$cb->eq('p.object.field', 'value'), $qb->eq('p.object.field', ':p_object_field'), new Parameter('p_object_field', 'value')],
+        ];
     }
 
     public function testWalkAndCompositeExpression()

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -86,7 +86,7 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
           ->setHint('foo', 'bar')
           ->setHint('bar', 'baz')
           ->setParameter(1, 'bar')
-          ->setParameters(new ArrayCollection(array(new Parameter(2, 'baz'))))
+          ->setParameters(new ArrayCollection([new Parameter(2, 'baz')]))
           ->setResultCacheDriver(null)
           ->setResultCacheId('foo')
           ->setDql('foo')
@@ -106,7 +106,7 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals('bar', $q->getHint('foo'));
         $this->assertEquals('baz', $q->getHint('bar'));
-        $this->assertEquals(array('foo' => 'bar', 'bar' => 'baz'), $q->getHints());
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $q->getHints());
         $this->assertTrue($q->hasHint('foo'));
         $this->assertFalse($q->hasHint('barFooBaz'));
     }
@@ -151,11 +151,11 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testCollectionParameters()
     {
-        $cities = array(
+        $cities = [
             0 => "Paris",
             3 => "Canne",
             9 => "St Julien"
-        );
+        ];
 
         $query  = $this->_em
                 ->createQuery("SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.city IN (:cities)")
@@ -183,11 +183,11 @@ class QueryTest extends \Doctrine\Tests\OrmTestCase
     public function testDefaultQueryHints()
     {
         $config = $this->_em->getConfiguration();
-        $defaultHints = array(
+        $defaultHints = [
             'hint_name_1' => 'hint_value_1',
             'hint_name_2' => 'hint_value_2',
             'hint_name_3' => 'hint_value_3',
-        );
+        ];
 
         $config->setDefaultQueryHints($defaultHints);
         $query = $this->_em->createQuery();

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -22,7 +22,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
      * @param array $queryHints
      * @param array $queryParams
      */
-    public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed, array $queryHints = array(), array $queryParams = array())
+    public function assertSqlGeneration($dqlToBeTested, $sqlToBeConfirmed, array $queryHints = [], array $queryParams = [])
     {
         try {
             $query = $this->_em->createQuery($dqlToBeTested);
@@ -60,7 +60,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
      * @param array $queryHints
      * @param array $queryParams
      */
-    public function assertInvalidSqlGeneration($dqlToBeTested, $expectedException, array $queryHints = array(), array $queryParams = array())
+    public function assertInvalidSqlGeneration($dqlToBeTested, $expectedException, array $queryHints = [], array $queryParams = [])
     {
         $this->setExpectedException($expectedException);
 
@@ -510,7 +510,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF ?1",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN (?)",
-            array(), array(1 => $this->_em->getClassMetadata('Doctrine\Tests\Models\Company\CompanyEmployee'))
+            [], [1 => $this->_em->getClassMetadata('Doctrine\Tests\Models\Company\CompanyEmployee')]
         );
     }
 
@@ -655,7 +655,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $group->id = 101;
         $group2 = new \Doctrine\Tests\Models\CMS\CmsGroup;
         $group2->id = 105;
-        $q->setParameter('param', array($group, $group2));
+        $q->setParameter('param', [$group, $group2]);
 
         $this->assertEquals(
             'SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE EXISTS (SELECT 1 FROM cms_users_groups c1_ INNER JOIN cms_groups c2_ ON c1_.group_id = c2_.id WHERE c1_.user_id = c0_.id AND c2_.id IN (?))',
@@ -669,7 +669,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         // Tough one: Many-many self-referencing ("friends") with class table inheritance
         $q = $this->_em->createQuery('SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p WHERE :param MEMBER OF p.friends');
         $person = new \Doctrine\Tests\Models\Company\CompanyPerson;
-        $this->_em->getClassMetadata(get_class($person))->setIdentifierValues($person, array('id' => 101));
+        $this->_em->getClassMetadata(get_class($person))->setIdentifierValues($person, ['id' => 101]);
         $q->setParameter('param', $person);
         $this->assertEquals(
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.title AS title_2, c2_.salary AS salary_3, c2_.department AS department_4, c2_.startDate AS startDate_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c1_.car_id AS car_id_8 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id WHERE EXISTS (SELECT 1 FROM company_persons_friends c3_ INNER JOIN company_persons c4_ ON c3_.friend_id = c4_.id WHERE c3_.person_id = c0_.id AND c4_.id IN (?))',
@@ -1003,7 +1003,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 ".
             "FROM cms_users c0_ WHERE c0_.username = 'gblanco' FOR UPDATE",
-            array(Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE)
+            [Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_WRITE]
         );
     }
 
@@ -1019,7 +1019,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 ".
             "FROM cms_users c0_ WHERE c0_.username = 'gblanco' FOR SHARE",
-            array(Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ)
+            [Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ]
                 );
     }
 
@@ -1033,7 +1033,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 ".
             "FROM cms_users c0_ WHERE c0_.username = 'gblanco'",
-            array(Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::NONE)
+            [Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::NONE]
                 );
     }
 
@@ -1060,7 +1060,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
             "SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 ".
             "FROM cms_users c0_ WHERE c0_.username = 'gblanco' LOCK IN SHARE MODE",
-            array(Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ)
+            [Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ]
         );
     }
 
@@ -1076,7 +1076,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
             "SELECT c0_.id AS ID_0, c0_.status AS STATUS_1, c0_.username AS USERNAME_2, c0_.name AS NAME_3 ".
             "FROM cms_users c0_ WHERE c0_.username = 'gblanco' FOR UPDATE",
-            array(Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ)
+            [Query::HINT_LOCK_MODE => \Doctrine\DBAL\LockMode::PESSIMISTIC_READ]
         );
     }
 
@@ -1093,7 +1093,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             'SELECT ABS(c0_.phonenumber) AS sclr_0 FROM cms_phonenumbers c0_'
         );
 
-        $config->setCustomNumericFunctions(array());
+        $config->setCustomNumericFunctions([]);
     }
 
     /**
@@ -1397,7 +1397,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.title AS title_2, c2_.salary AS salary_3, c2_.department AS department_4, c2_.startDate AS startDate_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c1_.car_id AS car_id_8 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1409,7 +1409,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1421,7 +1421,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c2_.car_id AS car_id_8 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ ON c1_.id = c2_.id',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1433,7 +1433,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1445,7 +1445,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT m FROM Doctrine\Tests\Models\Company\CompanyManager m',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6, c0_.spouse_id AS spouse_id_7, c2_.car_id AS car_id_8 FROM company_managers c2_ INNER JOIN company_employees c1_ ON c2_.id = c1_.id INNER JOIN company_persons c0_ ON c2_.id = c0_.id',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1457,7 +1457,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT m FROM Doctrine\Tests\Models\Company\CompanyManager m',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c2_.title AS title_5, c0_.discr AS discr_6 FROM company_managers c2_ INNER JOIN company_employees c1_ ON c2_.id = c1_.id INNER JOIN company_persons c0_ ON c2_.id = c0_.id',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1469,7 +1469,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6, c0_.salesPerson_id AS salesPerson_id_7 FROM company_contracts c0_ WHERE c0_.discr IN ('fix', 'flexible', 'flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1481,7 +1481,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ WHERE c0_.discr IN ('fix', 'flexible', 'flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1493,7 +1493,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT fc FROM Doctrine\Tests\Models\Company\CompanyFlexContract fc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5, c0_.salesPerson_id AS salesPerson_id_6 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1505,7 +1505,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT fc FROM Doctrine\Tests\Models\Company\CompanyFlexContract fc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5 FROM company_contracts c0_ WHERE c0_.discr IN ('flexible', 'flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1517,7 +1517,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT fuc FROM Doctrine\Tests\Models\Company\CompanyFlexUltraContract fuc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5, c0_.salesPerson_id AS salesPerson_id_6 FROM company_contracts c0_ WHERE c0_.discr IN ('flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -1529,7 +1529,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT fuc FROM Doctrine\Tests\Models\Company\CompanyFlexUltraContract fuc',
             "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.hoursWorked AS hoursWorked_2, c0_.pricePerHour AS pricePerHour_3, c0_.maxPrice AS maxPrice_4, c0_.discr AS discr_5 FROM company_contracts c0_ WHERE c0_.discr IN ('flexultra')",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
         );
     }
 
@@ -1541,7 +1541,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT p, pp FROM Doctrine\Tests\Models\Company\CompanyPerson p JOIN p.spouse pp',
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.title AS title_2, c2_.salary AS salary_3, c2_.department AS department_4, c2_.startDate AS startDate_5, c3_.id AS id_6, c3_.name AS name_7, c4_.title AS title_8, c5_.salary AS salary_9, c5_.department AS department_10, c5_.startDate AS startDate_11, c0_.discr AS discr_12, c0_.spouse_id AS spouse_id_13, c1_.car_id AS car_id_14, c3_.discr AS discr_15, c3_.spouse_id AS spouse_id_16, c4_.car_id AS car_id_17 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id INNER JOIN company_persons c3_ ON c0_.spouse_id = c3_.id LEFT JOIN company_managers c4_ ON c3_.id = c4_.id LEFT JOIN company_employees c5_ ON c3_.id = c5_.id",
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -2116,7 +2116,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT e.id FROM Doctrine\Tests\Models\Company\CompanyOrganization o JOIN o.events e WITH e.id = ?1',
             'SELECT c0_.id AS id_0 FROM company_organizations c1_ INNER JOIN (company_events c0_ LEFT JOIN company_auctions c2_ ON c0_.id = c2_.id LEFT JOIN company_raffles c3_ ON c0_.id = c3_.id) ON c1_.id = c0_.org_id AND (c0_.id = ?)',
-            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+            [Query::HINT_FORCE_PARTIAL_LOAD => false]
         );
     }
 
@@ -2194,8 +2194,8 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSqlGeneration(
             'SELECT e, COUNT(c) FROM Doctrine\Tests\Models\Company\CompanyEmployee e JOIN e.contracts c WHERE e.department = :department',
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, COUNT(c2_.id) AS sclr_5, c0_.discr AS discr_6 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id INNER JOIN company_contract_employees c3_ ON c1_.id = c3_.employee_id INNER JOIN company_contracts c2_ ON c2_.id = c3_.contract_id AND c2_.discr IN ('fix', 'flexible', 'flexultra') WHERE c1_.department = ?",
-            array(),
-            array('department' => 'foobar')
+            [],
+            ['department' => 'foobar']
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/SqlWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SqlWalkerTest.php
@@ -24,7 +24,7 @@ class SqlWalkerTest extends OrmTestCase
      */
     protected function setUp()
     {
-        $this->sqlWalker = new SqlWalker(new Query($this->_getTestEntityManager()), new ParserResult(), array());
+        $this->sqlWalker = new SqlWalker(new Query($this->_getTestEntityManager()), new ParserResult(), []);
     }
 
     /**
@@ -53,10 +53,10 @@ class SqlWalkerTest extends OrmTestCase
      */
     public function getColumnNamesAndSqlAliases()
     {
-        return array(
-            array('aaaaa', 'a0_'),
-            array('table', 't0_'),
-            array('çtable', 't0_'),
-        );
+        return [
+            ['aaaaa', 'a0_'],
+            ['table', 't0_'],
+            ['çtable', 't0_'],
+        ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -271,7 +271,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
            ->where('u.id = :uid')
-           ->andWhere($qb->expr()->in('u.id', array(1, 2, 3)));
+           ->andWhere($qb->expr()->in('u.id', [1, 2, 3]));
 
         $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid AND u.id IN(1, 2, 3)');
     }
@@ -282,7 +282,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
            ->where('u.id = :uid')
-           ->orWhere($qb->expr()->in('u.id', array(1, 2, 3)));
+           ->orWhere($qb->expr()->in('u.id', [1, 2, 3]));
 
         $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid OR u.id IN(1, 2, 3)');
     }
@@ -293,7 +293,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
            ->where('u.id = :uid')
-           ->andWhere($qb->expr()->notIn('u.id', array(1, 2, 3)));
+           ->andWhere($qb->expr()->notIn('u.id', [1, 2, 3]));
 
         $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid AND u.id NOT IN(1, 2, 3)');
     }
@@ -304,7 +304,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
            ->where('u.id = :uid')
-           ->orWhere($qb->expr()->notIn('u.id', array(1, 2, 3)));
+           ->orWhere($qb->expr()->notIn('u.id', [1, 2, 3]));
 
         $this->assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = :uid OR u.id NOT IN(1, 2, 3)');
     }
@@ -514,7 +514,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
 
         $criteria = new Criteria();
-        $criteria->orderBy(array('field' => Criteria::DESC));
+        $criteria->orderBy(['field' => Criteria::DESC]);
 
         $qb->addCriteria($criteria);
 
@@ -533,7 +533,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->join('u.article','a');
 
         $criteria = new Criteria();
-        $criteria->orderBy(array('a.field' => Criteria::DESC));
+        $criteria->orderBy(['a.field' => Criteria::DESC]);
 
         $qb->addCriteria($criteria);
 
@@ -678,7 +678,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb = $this->_em->createQueryBuilder();
         $orExpr = $qb->expr()->orX();
         $orExpr->add($qb->expr()->eq('u.id', ':uid3'));
-        $orExpr->add($qb->expr()->in('u.id', array(1)));
+        $orExpr->add($qb->expr()->in('u.id', [1]));
 
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
@@ -692,11 +692,11 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb = $this->_em->createQueryBuilder();
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
-           ->where($qb->expr()->in('u.name', array('one', 'two', 'three')));
+           ->where($qb->expr()->in('u.name', ['one', 'two', 'three']));
 
         $this->assertValidQueryBuilder($qb, "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name IN('one', 'two', 'three')");
 
-        $qb->where($qb->expr()->in('u.name', array("O'Reilly", "O'Neil", 'Smith')));
+        $qb->where($qb->expr()->in('u.name', ["O'Reilly", "O'Neil", 'Smith']));
 
         $this->assertValidQueryBuilder($qb, "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name IN('O''Reilly', 'O''Neil', 'Smith')");
     }
@@ -707,11 +707,11 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $expr = $this->_em->getExpressionBuilder();
         $qb->select('u')
            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
-           ->where($expr->in('u.name', array($expr->literal('one'), $expr->literal('two'), $expr->literal('three'))));
+           ->where($expr->in('u.name', [$expr->literal('one'), $expr->literal('two'), $expr->literal('three')]));
 
         $this->assertValidQueryBuilder($qb, "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name IN('one', 'two', 'three')");
 
-        $qb->where($expr->in('u.name', array($expr->literal("O'Reilly"), $expr->literal("O'Neil"), $expr->literal('Smith'))));
+        $qb->where($expr->in('u.name', [$expr->literal("O'Reilly"), $expr->literal("O'Neil"), $expr->literal('Smith')]));
 
         $this->assertValidQueryBuilder($qb, "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name IN('O''Reilly', 'O''Neil', 'Smith')");
     }
@@ -721,7 +721,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $expr = $this->_em->getExpressionBuilder();
         $orExpr = $expr->orX();
         $orExpr->add($expr->eq('u.id', ':uid3'));
-        $orExpr->add($expr->not($expr->in('u.id', array(1))));
+        $orExpr->add($expr->not($expr->in('u.id', [1])));
 
         $qb = $this->_em->createQueryBuilder();
         $qb->select('u')
@@ -825,7 +825,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
             ->where('u.username = ?1')->orderBy('u.username');
 
-        $qb->resetDQLParts(array('where', 'orderBy'));
+        $qb->resetDQLParts(['where', 'orderBy']);
 
         $this->assertEquals(1, count($qb->getDQLPart('select')));
         $this->assertNull($qb->getDQLPart('where'));
@@ -961,7 +961,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->select('u')
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
 
-        $this->assertEquals(array('u'), $qb->getRootAliases());
+        $this->assertEquals(['u'], $qb->getRootAliases());
     }
 
     public function testGetRootEntities()
@@ -970,7 +970,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->select('u')
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
 
-        $this->assertEquals(array('Doctrine\Tests\Models\CMS\CmsUser'), $qb->getRootEntities());
+        $this->assertEquals(['Doctrine\Tests\Models\CMS\CmsUser'], $qb->getRootEntities());
     }
 
     public function testGetSeveralRootAliases()
@@ -980,7 +980,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u2');
 
-        $this->assertEquals(array('u', 'u2'), $qb->getRootAliases());
+        $this->assertEquals(['u', 'u2'], $qb->getRootAliases());
         $this->assertEquals('u', $qb->getRootAlias());
     }
 
@@ -989,7 +989,7 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
         $qb = $this->_em->createQueryBuilder()
             ->select('u')
             ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
-            ->add('join', array('INNER JOIN u.groups g'), true);
+            ->add('join', ['INNER JOIN u.groups g'], true);
 
         $this->assertEquals('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.groups g', $qb->getDQL());
     }

--- a/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -49,7 +49,7 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
             ->entityManager
             ->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnCallback(array($this, 'buildClassMetadata')));
+            ->will($this->returnCallback([$this, 'buildClassMetadata']));
 
         $this->assertInstanceOf(
             'Doctrine\\Tests\\Models\\DDC869\\DDC869PaymentRepository',
@@ -63,7 +63,7 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
             ->entityManager
             ->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnCallback(array($this, 'buildClassMetadata')));
+            ->will($this->returnCallback([$this, 'buildClassMetadata']));
 
         $this->assertSame(
             $this->repositoryFactory->getRepository($this->entityManager, __CLASS__),
@@ -97,11 +97,11 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
         $em1
             ->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnCallback(array($this, 'buildClassMetadata')));
+            ->will($this->returnCallback([$this, 'buildClassMetadata']));
         $em2
             ->expects($this->any())
             ->method('getClassMetadata')
-            ->will($this->returnCallback(array($this, 'buildClassMetadata')));
+            ->will($this->returnCallback([$this, 'buildClassMetadata']));
 
         $repo1 = $this->repositoryFactory->getRepository($em1, __CLASS__);
         $repo2 = $this->repositoryFactory->getRepository($em2, __CLASS__);

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
@@ -32,9 +32,9 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $this->command     = new CollectionRegionCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($this->command);
     }
@@ -43,10 +43,10 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:collection');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ]);
 
         $this->assertEquals('Clearing all second-level cache collection regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -55,11 +55,11 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:collection');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache for collection "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }
@@ -68,12 +68,12 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:collection');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
             'owner-id'      => 1,
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache entry for collection "Doctrine\Tests\Models\Cache\State#cities" owner entity identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
@@ -82,12 +82,12 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:collection');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
             '--flush'       => true,
-        ));
+        ]);
 
         $this->assertEquals('Flushing cache provider configured for "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
@@ -32,9 +32,9 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $this->command     = new EntityRegionCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($this->command);
     }
@@ -43,10 +43,10 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:entity');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ]);
 
         $this->assertEquals('Clearing all second-level cache entity regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -55,10 +55,10 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:entity');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache for entity "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }
@@ -67,11 +67,11 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:entity');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
             'entity-id'     => 1,
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
@@ -80,11 +80,11 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:entity');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
             '--flush'       => true,
-        ));
+        ]);
 
         $this->assertEquals('Flushing cache provider configured for entity named "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
@@ -32,9 +32,9 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $this->command     = new QueryRegionCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($this->command);
     }
@@ -43,10 +43,10 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:query');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ]);
 
         $this->assertEquals('Clearing all second-level cache query regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -55,10 +55,10 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:query');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'region-name'   => null,
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache query region named "query_cache_region"' . PHP_EOL, $tester->getDisplay());
     }
@@ -67,10 +67,10 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:query');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'region-name'   => 'my_region',
-        ));
+        ]);
 
         $this->assertEquals('Clearing second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }
@@ -79,11 +79,11 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
     {
         $command    = $this->application->find('orm:clear-cache:region:query');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'       => $command->getName(),
             'region-name'   => 'my_region',
             '--flush'       => true,
-        ));
+        ]);
 
         $this->assertEquals('Flushing cache provider configured for second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
@@ -17,6 +17,6 @@ class ConvertDoctrine1SchemaCommandTest extends \Doctrine\Tests\OrmTestCase
                ->method('writeln')
                ->with($this->equalTo('No Metadata Classes to process.'));
 
-        $command->convertDoctrine1Schema(array(), sys_get_temp_dir(), 'annotation', 4, null, $output);
+        $command->convertDoctrine1Schema([], sys_get_temp_dir(), 'annotation', 4, null, $output);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
@@ -35,15 +35,15 @@ class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
 
         $metadataDriver = $this->_em->getConfiguration()->getMetadataDriverImpl();
 
-        $metadataDriver->addPaths(array(
+        $metadataDriver->addPaths([
             __DIR__ . '/../../../../Models/DDC3231/'
-        ));
+        ]);
         
         $this->application = new Application();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add(new GenerateRepositoriesCommand());
 
@@ -54,7 +54,7 @@ class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
      */
     public function tearDown()
     {
-        $dirs = array();
+        $dirs = [];
 
         $ri = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->path));
         foreach ($ri AS $file) {
@@ -133,11 +133,11 @@ class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
 
         $command    = $this->application->find('orm:generate-repositories');
         $tester     = new CommandTester($command);
-        $tester->execute(array(
+        $tester->execute([
             'command'   => $command->getName(),
             'dest-path' => $this->path,
             '--filter'  => $filter,
-        ));
+        ]);
     }
 
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php
@@ -34,9 +34,9 @@ class InfoCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $command           = new InfoCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($command);
 
@@ -46,9 +46,9 @@ class InfoCommandTest extends OrmFunctionalTestCase
 
     public function testListAllClasses()
     {
-        $this->tester->execute(array(
+        $this->tester->execute([
             'command' => $this->command->getName(),
-        ));
+        ]);
 
         $this->assertContains('Doctrine\Tests\Models\Cache\AttractionInfo', $this->tester->getDisplay());
         $this->assertContains('Doctrine\Tests\Models\Cache\City', $this->tester->getDisplay());

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -38,9 +38,9 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $command = new MappingDescribeCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($command);
 
@@ -50,10 +50,10 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
 
     public function testShowSpecificFuzzySingle()
     {
-        $this->tester->execute(array(
+        $this->tester->execute([
             'command' => $this->command->getName(),
             'entityName' => 'AttractionInfo',
-        ));
+        ]);
 
         $display = $this->tester->getDisplay();
         $this->assertContains('Doctrine\Tests\Models\Cache\AttractionInfo', $display);
@@ -66,10 +66,10 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
      */
     public function testShowSpecificFuzzyAmbiguous()
     {
-        $this->tester->execute(array(
+        $this->tester->execute([
             'command' => $this->command->getName(),
             'entityName' => 'Attraction',
-        ));
+        ]);
     }
 
     /**
@@ -78,10 +78,10 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
      */
     public function testShowSpecificNotFound()
     {
-        $this->tester->execute(array(
+        $this->tester->execute([
             'command' => $this->command->getName(),
             'entityName' => 'AttractionFooBar'
-        ));
+        ]);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
@@ -41,9 +41,9 @@ class RunDqlCommandTest extends OrmFunctionalTestCase
         $this->application = new Application();
         $this->command     = new RunDqlCommand();
 
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => new EntityManagerHelper($this->_em)
-        )));
+        ]));
 
         $this->application->add($this->command);
 
@@ -62,10 +62,10 @@ class RunDqlCommandTest extends OrmFunctionalTestCase
 
         $this->assertSame(
             0,
-            $this->tester->execute(array(
+            $this->tester->execute([
                 'command' => $this->command->getName(),
                 'dql'     => 'SELECT e FROM ' . DateTimeModel::CLASSNAME . ' e',
-            ))
+            ])
         );
 
         $this->assertContains(DateTimeModel::CLASSNAME, $this->tester->getDisplay());
@@ -78,11 +78,11 @@ class RunDqlCommandTest extends OrmFunctionalTestCase
 
         $this->assertSame(
             0,
-            $this->tester->execute(array(
+            $this->tester->execute([
                 'command'    => $this->command->getName(),
                 'dql'        => 'SELECT e FROM ' . DateTimeModel::CLASSNAME . ' e',
                 '--show-sql' => 'true'
-            ))
+            ])
         );
 
         $this->assertStringMatchesFormat('string%sSELECT %a', $this->tester->getDisplay());

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -50,7 +50,7 @@ class ConvertDoctrine1SchemaTest extends \Doctrine\Tests\OrmTestCase
         $config->setProxyDir(__DIR__ . '/../../Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $eventManager = new EventManager();
-        $conn = new ConnectionMock(array(), $driverMock, $config, $eventManager);
+        $conn = new ConnectionMock([], $driverMock, $config, $eventManager);
         $mockDriver = new MetadataDriverMock();
         $config->setMetadataDriverImpl($metadataDriver);
 

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -54,32 +54,32 @@ class EntityGeneratorTest extends OrmTestCase
      *
      * @return ClassMetadataInfo
      */
-    public function generateBookEntityFixture(array $embeddedClasses = array())
+    public function generateBookEntityFixture(array $embeddedClasses = [])
     {
         $metadata = new ClassMetadataInfo($this->_namespace . '\EntityGeneratorBook');
         $metadata->namespace = $this->_namespace;
         $metadata->customRepositoryClassName = $this->_namespace  . '\EntityGeneratorBookRepository';
 
         $metadata->table['name'] = 'book';
-        $metadata->table['uniqueConstraints']['name_uniq'] = array('columns' => array('name'));
-        $metadata->table['indexes']['status_idx'] = array('columns' => array('status'));
-        $metadata->mapField(array('fieldName' => 'name', 'type' => 'string'));
-        $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'default' => 'published'));
-        $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
-        $metadata->mapOneToOne(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor', 'mappedBy' => 'book'));
-        $joinColumns = array(
-            array('name' => 'author_id', 'referencedColumnName' => 'id')
-        );
-        $metadata->mapManyToMany(array(
+        $metadata->table['uniqueConstraints']['name_uniq'] = ['columns' => ['name']];
+        $metadata->table['indexes']['status_idx'] = ['columns' => ['status']];
+        $metadata->mapField(['fieldName' => 'name', 'type' => 'string']);
+        $metadata->mapField(['fieldName' => 'status', 'type' => 'string', 'default' => 'published']);
+        $metadata->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
+        $metadata->mapOneToOne(['fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor', 'mappedBy' => 'book']);
+        $joinColumns = [
+            ['name' => 'author_id', 'referencedColumnName' => 'id']
+        ];
+        $metadata->mapManyToMany([
             'fieldName' => 'comments',
             'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorComment',
             'fetch' => ClassMetadataInfo::FETCH_EXTRA_LAZY,
-            'joinTable' => array(
+            'joinTable' => [
                 'name' => 'book_comment',
-                'joinColumns' => array(array('name' => 'book_id', 'referencedColumnName' => 'id')),
-                'inverseJoinColumns' => array(array('name' => 'comment_id', 'referencedColumnName' => 'id')),
-            ),
-        ));
+                'joinColumns' => [['name' => 'book_id', 'referencedColumnName' => 'id']],
+                'inverseJoinColumns' => [['name' => 'comment_id', 'referencedColumnName' => 'id']],
+            ],
+        ]);
         $metadata->addLifecycleCallback('loading', 'postLoad');
         $metadata->addLifecycleCallback('willBeRemoved', 'preRemove');
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
@@ -100,12 +100,12 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata->namespace = $this->_namespace;
 
         $metadata->table['name'] = 'entity_type';
-        $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
+        $metadata->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
 
         $name  = $field['fieldName'];
         $type  = $field['dbType'];
-        $metadata->mapField(array('fieldName' => $name, 'type' => $type));
+        $metadata->mapField(['fieldName' => $name, 'type' => $type]);
 
         $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
 
@@ -115,16 +115,16 @@ class EntityGeneratorTest extends OrmTestCase
     /**
      * @return ClassMetadataInfo
      */
-    private function generateIsbnEmbeddableFixture(array $embeddedClasses = array())
+    private function generateIsbnEmbeddableFixture(array $embeddedClasses = [])
     {
         $metadata = new ClassMetadataInfo($this->_namespace . '\EntityGeneratorIsbn');
         $metadata->namespace = $this->_namespace;
         $metadata->isEmbeddedClass = true;
-        $metadata->mapField(array('fieldName' => 'prefix', 'type' => 'integer'));
-        $metadata->mapField(array('fieldName' => 'groupNumber', 'type' => 'integer'));
-        $metadata->mapField(array('fieldName' => 'publisherNumber', 'type' => 'integer'));
-        $metadata->mapField(array('fieldName' => 'titleNumber', 'type' => 'integer'));
-        $metadata->mapField(array('fieldName' => 'checkDigit', 'type' => 'integer'));
+        $metadata->mapField(['fieldName' => 'prefix', 'type' => 'integer']);
+        $metadata->mapField(['fieldName' => 'groupNumber', 'type' => 'integer']);
+        $metadata->mapField(['fieldName' => 'publisherNumber', 'type' => 'integer']);
+        $metadata->mapField(['fieldName' => 'titleNumber', 'type' => 'integer']);
+        $metadata->mapField(['fieldName' => 'checkDigit', 'type' => 'integer']);
 
         foreach ($embeddedClasses as $fieldName => $embeddedClass) {
             $this->mapEmbedded($fieldName, $metadata, $embeddedClass);
@@ -143,10 +143,10 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata = new ClassMetadataInfo($this->_namespace . '\EntityGeneratorTestEmbeddable');
         $metadata->namespace = $this->_namespace;
         $metadata->isEmbeddedClass = true;
-        $metadata->mapField(array('fieldName' => 'field1', 'type' => 'integer'));
-        $metadata->mapField(array('fieldName' => 'field2', 'type' => 'integer', 'nullable' => true));
-        $metadata->mapField(array('fieldName' => 'field3', 'type' => 'datetime'));
-        $metadata->mapField(array('fieldName' => 'field4', 'type' => 'datetime', 'nullable' => true));
+        $metadata->mapField(['fieldName' => 'field1', 'type' => 'integer']);
+        $metadata->mapField(['fieldName' => 'field2', 'type' => 'integer', 'nullable' => true]);
+        $metadata->mapField(['fieldName' => 'field3', 'type' => 'datetime']);
+        $metadata->mapField(['fieldName' => 'field4', 'type' => 'datetime', 'nullable' => true]);
 
         $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
 
@@ -166,7 +166,7 @@ class EntityGeneratorTest extends OrmTestCase
         $columnPrefix = false
     ) {
         $classMetadata->mapEmbedded(
-            array('fieldName' => $fieldName, 'class' => $embeddableMetadata->name, 'columnPrefix' => $columnPrefix)
+            ['fieldName' => $fieldName, 'class' => $embeddableMetadata->name, 'columnPrefix' => $columnPrefix]
         );
     }
 
@@ -181,7 +181,7 @@ class EntityGeneratorTest extends OrmTestCase
         ClassMetadataInfo $embeddableMetadata
     ) {
         foreach ($embeddableMetadata->embeddedClasses as $property => $embeddableClass) {
-            $classMetadata->mapEmbedded(array(
+            $classMetadata->mapEmbedded([
                 'fieldName' => $fieldName . '.' . $property,
                 'class' => $embeddableClass['class'],
                 'columnPrefix' => $embeddableClass['columnPrefix'],
@@ -189,7 +189,7 @@ class EntityGeneratorTest extends OrmTestCase
                         ? $fieldName . '.' . $embeddableClass['declaredField']
                         : $fieldName,
                 'originalField' => $embeddableClass['originalField'] ?: $property,
-            ));
+            ]);
         }
     }
 
@@ -221,8 +221,8 @@ class EntityGeneratorTest extends OrmTestCase
     public function testGeneratedEntityClass()
     {
         $testMetadata = $this->generateTestEmbeddableFixture();
-        $isbnMetadata = $this->generateIsbnEmbeddableFixture(array('test' => $testMetadata));
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $isbnMetadata));
+        $isbnMetadata = $this->generateIsbnEmbeddableFixture(['test' => $testMetadata]);
+        $metadata = $this->generateBookEntityFixture(['isbn' => $isbnMetadata]);
 
         $book = $this->newInstance($metadata);
         $this->assertTrue(class_exists($metadata->name), "Class does not exist.");
@@ -265,9 +265,9 @@ class EntityGeneratorTest extends OrmTestCase
         $comment = new EntityGeneratorComment();
         $book->addComment($comment);
         $this->assertInstanceOf('Doctrine\Common\Collections\ArrayCollection', $book->getComments());
-        $this->assertEquals(new \Doctrine\Common\Collections\ArrayCollection(array($comment)), $book->getComments());
+        $this->assertEquals(new \Doctrine\Common\Collections\ArrayCollection([$comment]), $book->getComments());
         $book->removeComment($comment);
-        $this->assertEquals(new \Doctrine\Common\Collections\ArrayCollection(array()), $book->getComments());
+        $this->assertEquals(new \Doctrine\Common\Collections\ArrayCollection([]), $book->getComments());
 
         $this->newInstance($isbnMetadata);
         $isbn = new $isbnMetadata->name();
@@ -282,9 +282,9 @@ class EntityGeneratorTest extends OrmTestCase
 
     public function testEntityUpdatingWorks()
     {
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $this->generateIsbnEmbeddableFixture()));
+        $metadata = $this->generateBookEntityFixture(['isbn' => $this->generateIsbnEmbeddableFixture()]);
 
-        $metadata->mapField(array('fieldName' => 'test', 'type' => 'string'));
+        $metadata->mapField(['fieldName' => 'test', 'type' => 'string']);
 
         $testEmbeddableMetadata = $this->generateTestEmbeddableFixture();
         $this->mapEmbedded('testEmbedded', $metadata, $testEmbeddableMetadata);
@@ -326,7 +326,7 @@ class EntityGeneratorTest extends OrmTestCase
      */
     public function testDoesNotRegenerateExistingMethodsWithDifferentCase()
     {
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $this->generateIsbnEmbeddableFixture()));
+        $metadata = $this->generateBookEntityFixture(['isbn' => $this->generateIsbnEmbeddableFixture()]);
 
         // Workaround to change existing fields case (just to simulate the use case)
         $metadata->fieldMappings['status']['fieldName'] = 'STATUS';
@@ -357,7 +357,7 @@ class EntityGeneratorTest extends OrmTestCase
     public function testMethodDocBlockShouldStartWithBackSlash()
     {
         $embeddedMetadata = $this->generateIsbnEmbeddableFixture();
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $embeddedMetadata));
+        $metadata = $this->generateBookEntityFixture(['isbn' => $embeddedMetadata]);
         $book     = $this->newInstance($metadata);
 
         $this->assertPhpDocVarType('\Doctrine\Common\Collections\Collection', new \ReflectionProperty($book, 'comments'));
@@ -402,7 +402,7 @@ class EntityGeneratorTest extends OrmTestCase
     public function testLoadMetadata()
     {
         $embeddedMetadata = $this->generateIsbnEmbeddableFixture();
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $embeddedMetadata));
+        $metadata = $this->generateBookEntityFixture(['isbn' => $embeddedMetadata]);
 
         $book = $this->newInstance($metadata);
 
@@ -441,10 +441,10 @@ class EntityGeneratorTest extends OrmTestCase
     {
         $this->_generator->setAnnotationPrefix('ORM\\');
         $embeddedMetadata = $this->generateIsbnEmbeddableFixture();
-        $metadata = $this->generateBookEntityFixture(array('isbn' => $embeddedMetadata));
+        $metadata = $this->generateBookEntityFixture(['isbn' => $embeddedMetadata]);
 
         $reader = new AnnotationReader();
-        $driver = new AnnotationDriver($reader, array());
+        $driver = new AnnotationDriver($reader, []);
 
         $book = $this->newInstance($metadata);
 
@@ -487,7 +487,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
         $this->newInstance($metadata); // force instantiation (causes autoloading to kick in)
 
-        $driver = new AnnotationDriver(new AnnotationReader(), array());
+        $driver = new AnnotationDriver(new AnnotationReader(), []);
         $cm     = new ClassMetadata($metadata->name);
 
         $cm->initializeReflection(new RuntimeReflectionService);
@@ -519,13 +519,13 @@ class EntityGeneratorTest extends OrmTestCase
     {
         $metadata               = new ClassMetadataInfo($this->_namespace . '\DDC1784Entity');
         $metadata->namespace    = $this->_namespace;
-        $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
+        $metadata->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
-        $metadata->setSequenceGeneratorDefinition(array(
+        $metadata->setSequenceGeneratorDefinition([
             'sequenceName'      => 'DDC1784_ID_SEQ',
             'allocationSize'    => 1,
             'initialValue'      => 2
-        ));
+        ]);
         $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
 
         $filename = $this->_tmpDir . DIRECTORY_SEPARATOR
@@ -551,23 +551,23 @@ class EntityGeneratorTest extends OrmTestCase
     {
         $metadata               = new ClassMetadataInfo($this->_namespace . '\DDC2079Entity');
         $metadata->namespace    = $this->_namespace;
-        $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
+        $metadata->mapField(['fieldName' => 'id', 'type' => 'integer', 'id' => true]);
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
-        $metadata->mapManyToMany(array(
+        $metadata->mapManyToMany([
             'fieldName'     => 'centroCustos',
             'targetEntity'  => 'DDC2079CentroCusto',
-            'joinTable'     => array(
+            'joinTable'     => [
                 'name'                  => 'unidade_centro_custo',
-                'joinColumns'           => array(
-                    array('name' => 'idorcamento',      'referencedColumnName' => 'idorcamento'),
-                    array('name' => 'idunidade',        'referencedColumnName' => 'idunidade')
-                ),
-                'inverseJoinColumns'    => array(
-                    array('name' => 'idcentrocusto',    'referencedColumnName' => 'idcentrocusto'),
-                    array('name' => 'idpais',           'referencedColumnName' => 'idpais'),
-                ),
-            ),
-        ));
+                'joinColumns'           => [
+                    ['name' => 'idorcamento',      'referencedColumnName' => 'idorcamento'],
+                    ['name' => 'idunidade',        'referencedColumnName' => 'idunidade']
+                ],
+                'inverseJoinColumns'    => [
+                    ['name' => 'idcentrocusto',    'referencedColumnName' => 'idcentrocusto'],
+                    ['name' => 'idpais',           'referencedColumnName' => 'idpais'],
+                ],
+            ],
+        ]);
         $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
 
         $filename = $this->_tmpDir . DIRECTORY_SEPARATOR
@@ -830,7 +830,7 @@ class EntityGeneratorTest extends OrmTestCase
     public function testGeneratedMutableEmbeddablesClass()
     {
         $embeddedMetadata = $this->generateTestEmbeddableFixture();
-        $metadata = $this->generateIsbnEmbeddableFixture(array('test' => $embeddedMetadata));
+        $metadata = $this->generateIsbnEmbeddableFixture(['test' => $embeddedMetadata]);
 
         $isbn = $this->newInstance($metadata);
 
@@ -870,7 +870,7 @@ class EntityGeneratorTest extends OrmTestCase
     {
         $this->_generator->setEmbeddablesImmutable(true);
         $embeddedMetadata = $this->generateTestEmbeddableFixture();
-        $metadata = $this->generateIsbnEmbeddableFixture(array('test' => $embeddedMetadata));
+        $metadata = $this->generateIsbnEmbeddableFixture(['test' => $embeddedMetadata]);
 
         $this->loadEntityClass($embeddedMetadata);
         $this->loadEntityClass($metadata);
@@ -942,86 +942,86 @@ class EntityGeneratorTest extends OrmTestCase
      */
     public function getEntityTypeAliasDataProvider()
     {
-        return array(
-            array(array(
+        return [
+            [[
                 'fieldName' => 'datetimetz',
                 'phpType' => '\\DateTime',
                 'dbType' => 'datetimetz',
                 'value' => new \DateTime
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'datetime',
                 'phpType' => '\\DateTime',
                 'dbType' => 'datetime',
                 'value' => new \DateTime
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'date',
                 'phpType' => '\\DateTime',
                 'dbType' => 'date',
                 'value' => new \DateTime
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'time',
                 'phpType' => '\DateTime',
                 'dbType' => 'time',
                 'value' => new \DateTime
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'object',
                 'phpType' => '\stdClass',
                 'dbType' => 'object',
                 'value' => new \stdClass()
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'bigint',
                 'phpType' => 'integer',
                 'dbType' => 'bigint',
                 'value' => 11
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'smallint',
                 'phpType' => 'integer',
                 'dbType' => 'smallint',
                 'value' => 22
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'text',
                 'phpType' => 'string',
                 'dbType' => 'text',
                 'value' => 'text'
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'blob',
                 'phpType' => 'string',
                 'dbType' => 'blob',
                 'value' => 'blob'
-            )),
-            array(array(
+            ]],
+            [[
                 'fieldName' => 'decimal',
                 'phpType' => 'string',
                 'dbType' => 'decimal',
                 'value' => '12.34'
-            ),
-        ));
+            ],
+        ]];
     }
 
     public function getParseTokensInEntityFileData()
     {
-        return array(
-            array(
+        return [
+            [
                 '<?php namespace Foo\Bar; class Baz {}',
-                array('Foo\Bar\Baz'),
-            ),
-            array(
+                ['Foo\Bar\Baz'],
+            ],
+            [
                 '<?php namespace Foo\Bar; use Foo; class Baz {}',
-                array('Foo\Bar\Baz'),
-            ),
-            array(
+                ['Foo\Bar\Baz'],
+            ],
+            [
                 '<?php namespace /*Comment*/ Foo\Bar; /** Foo */class /* Comment */ Baz {}',
-                array('Foo\Bar\Baz'),
-            ),
-            array(
+                ['Foo\Bar\Baz'],
+            ],
+            [
                 '
 <?php namespace
 /*Comment*/
@@ -1033,9 +1033,9 @@ class
 /* Comment */
  Baz {}
      ',
-                array('Foo\Bar\Baz'),
-            ),
-            array(
+                ['Foo\Bar\Baz'],
+            ],
+            [
                 '
 <?php namespace Foo\Bar; class Baz {
     public static function someMethod(){
@@ -1043,9 +1043,9 @@ class
     }
 }
 ',
-                array('Foo\Bar\Baz'),
-            ),
-        );
+                ['Foo\Bar\Baz'],
+            ],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
@@ -46,7 +46,7 @@ class EntityRepositoryGeneratorTest extends \Doctrine\Tests\OrmTestCase
      */
     public function tearDown()
     {
-        $dirs = array();
+        $dirs = [];
 
         $ri = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->_tmpDir));
         foreach ($ri AS $file) {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -56,7 +56,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         $config->setProxyDir(__DIR__ . '/../../Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $eventManager = new EventManager();
-        $conn = new ConnectionMock(array(), $driverMock, $config, $eventManager);
+        $conn = new ConnectionMock([], $driverMock, $config, $eventManager);
         $mockDriver = new MetadataDriverMock();
         $config->setMetadataDriverImpl($metadataDriver);
 
@@ -65,17 +65,17 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
 
     protected function _createMetadataDriver($type, $path)
     {
-        $mappingDriver = array(
+        $mappingDriver = [
             'php'        => 'Doctrine\Common\Persistence\Mapping\Driver\PHPDriver',
             'annotation' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
             'xml'        => 'Doctrine\ORM\Mapping\Driver\XmlDriver',
             'yaml'       => 'Doctrine\ORM\Mapping\Driver\YamlDriver',
-        );
+        ];
         $this->assertArrayHasKey($type, $mappingDriver, "There is no metadata driver for the type '" . $type . "'.");
         $class = $mappingDriver[$type];
 
         if ($type === 'annotation') {
-            $driver = $this->createAnnotationDriver(array($path));
+            $driver = $this->createAnnotationDriver([$path]);
         } else {
             $driver = new $class($path);
         }
@@ -155,7 +155,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
     public function testTableIsExported($class)
     {
         $this->assertEquals('cms_users', $class->table['name']);
-        $this->assertEquals(array('engine' => 'MyISAM', 'foo' => array('bar' => 'baz')),
+        $this->assertEquals(['engine' => 'MyISAM', 'foo' => ['bar' => 'baz']],
             $class->table['options']);
 
         return $class;
@@ -179,7 +179,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
     public function testIdentifierIsExported($class)
     {
         $this->assertEquals(ClassMetadataInfo::GENERATOR_TYPE_IDENTITY, $class->generatorType, "Generator Type wrong");
-        $this->assertEquals(array('id'), $class->identifier);
+        $this->assertEquals(['id'], $class->identifier);
         $this->assertTrue(isset($class->fieldMappings['id']['id']) && $class->fieldMappings['id']['id'] === true);
 
         return $class;
@@ -272,7 +272,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
         //$this->assertInstanceOf('Doctrine\ORM\Mapping\OneToManyMapping', $class->associationMappings['phonenumbers']);
         $this->assertEquals('Doctrine\Tests\ORM\Tools\Export\Phonenumber', $class->associationMappings['phonenumbers']['targetEntity']);
         $this->assertEquals('user', $class->associationMappings['phonenumbers']['mappedBy']);
-        $this->assertEquals(array('number' => 'ASC'), $class->associationMappings['phonenumbers']['orderBy']);
+        $this->assertEquals(['number' => 'ASC'], $class->associationMappings['phonenumbers']['orderBy']);
 
         $this->assertTrue($class->associationMappings['phonenumbers']['isCascadeRemove']);
         $this->assertTrue($class->associationMappings['phonenumbers']['isCascadePersist']);

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -48,19 +48,19 @@ class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
         $exporter = new XmlExporter();
         $metadata = new ClassMetadata('entityTest');
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             "fieldName" => 'id',
             "type" => 'integer',
             "columnName" => 'id',
             "id" => true,
-        ));
+        ]);
 
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
-        $metadata->setSequenceGeneratorDefinition(array(
+        $metadata->setSequenceGeneratorDefinition([
             'sequenceName' => 'seq_entity_test_id',
             'allocationSize' => 5,
             'initialValue' => 1
-        ));
+        ]);
 
         $expectedFileContent = <<<'XML'
 <?xml version="1.0" encoding="utf-8"?>
@@ -90,15 +90,15 @@ XML;
         $exporter = new XmlExporter();
         $metadata = new ClassMetadata('entityTest');
 
-        $metadata->mapField(array(
+        $metadata->mapField([
             "fieldName" => 'myField',
             "type" => 'string',
             "columnName" => 'my_field',
-            "options" => array(
+            "options" => [
                 "default" => "default_string",
                 "comment" => "The comment for the field",
-            ),
-        ));
+            ],
+        ]);
 
         $expectedFileContent = <<<'XML'
 <?xml version="1.0" encoding="utf-8"?>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -3,111 +3,111 @@
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
-$metadata->setPrimaryTable(array(
+$metadata->setPrimaryTable([
    'name' => 'cms_users',
-   'options' => array('engine' => 'MyISAM', 'foo' => array('bar' => 'baz')),
-  ));
+   'options' => ['engine' => 'MyISAM', 'foo' => ['bar' => 'baz']],
+  ]);
 $metadata->setChangeTrackingPolicy(ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT);
 $metadata->addLifecycleCallback('doStuffOnPrePersist', 'prePersist');
 $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
 $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
-$metadata->mapField(array(
+$metadata->mapField([
    'id' => true,
    'fieldName' => 'id',
    'type' => 'integer',
    'columnName' => 'id',
-  ));
-$metadata->mapField(array(
+  ]);
+$metadata->mapField([
    'fieldName' => 'name',
    'type' => 'string',
    'length' => 50,
    'unique' => true,
    'nullable' => true,
    'columnName' => 'name',
-  ));
-$metadata->mapField(array(
+  ]);
+$metadata->mapField([
    'fieldName' => 'email',
    'type' => 'string',
    'columnName' => 'user_email',
    'columnDefinition' => 'CHAR(32) NOT NULL',
-  ));
+  ]);
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
-$metadata->mapManyToOne(array(
+$metadata->mapManyToOne([
     'fieldName' => 'mainGroup',
     'targetEntity' => 'Doctrine\\Tests\\ORM\Tools\\Export\\Group',
-));
-$metadata->mapOneToOne(array(
+]);
+$metadata->mapOneToOne([
    'fieldName' => 'address',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Address',
    'inversedBy' => 'user',
    'cascade' =>
-   array(
+   [
    0 => 'persist',
-   ),
+   ],
    'mappedBy' => NULL,
    'joinColumns' =>
-   array(
+   [
    0 =>
-   array(
+   [
     'name' => 'address_id',
     'referencedColumnName' => 'id',
     'onDelete' => 'CASCADE',
-   ),
-   ),
+   ],
+   ],
    'orphanRemoval' => true,
    'fetch' => ClassMetadataInfo::FETCH_EAGER,
-  ));
-$metadata->mapOneToMany(array(
+  ]);
+$metadata->mapOneToMany([
    'fieldName' => 'phonenumbers',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Phonenumber',
    'cascade' =>
-   array(
+   [
    1 => 'persist',
    2 => 'merge',
-   ),
+   ],
    'mappedBy' => 'user',
    'orphanRemoval' => true,
    'fetch' => ClassMetadataInfo::FETCH_LAZY,
    'orderBy' =>
-   array(
+   [
    'number' => 'ASC',
-   ),
-  ));
-$metadata->mapManyToMany(array(
+   ],
+  ]);
+$metadata->mapManyToMany([
    'fieldName' => 'groups',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Group',
    'fetch' => ClassMetadataInfo::FETCH_EXTRA_LAZY,
    'cascade' =>
-   array(
+   [
    0 => 'remove',
    1 => 'persist',
    2 => 'refresh',
    3 => 'merge',
    4 => 'detach',
-   ),
+   ],
    'mappedBy' => NULL,
    'joinTable' =>
-   array(
+   [
    'name' => 'cms_users_groups',
    'joinColumns' =>
-   array(
+   [
     0 =>
-    array(
+    [
     'name' => 'user_id',
     'referencedColumnName' => 'id',
     'unique' => false,
     'nullable' => false,
-    ),
-   ),
+    ],
+   ],
    'inverseJoinColumns' =>
-   array(
+   [
     0 =>
-    array(
+    [
     'name' => 'group_id',
     'referencedColumnName' => 'id',
     'columnDefinition' => 'INT NULL',
-    ),
-   ),
-   ),
+    ],
+   ],
+   ],
    'orderBy' => NULL,
-  ));
+  ]);

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
@@ -14,7 +14,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN p.category c JOIN p.author a');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 
@@ -27,7 +27,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT a, sum(a.name) as foo FROM Doctrine\Tests\ORM\Tools\Pagination\Author a');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 
@@ -40,7 +40,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b GROUP BY b.id');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 
@@ -53,7 +53,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN p.category c JOIN p.author a ORDER BY a.name');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 
@@ -66,7 +66,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN p.category c JOIN p.author a');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 
@@ -80,7 +80,7 @@ class CountWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g.id HAVING userCount > 0"
         );
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setFirstResult(null)->setMaxResults(null);
 
         $this->setExpectedException(
@@ -98,7 +98,7 @@ class CountWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery(
             'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p LEFT JOIN Doctrine\Tests\ORM\Tools\Pagination\Category c WITH p.category = c');
-        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
+        $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\CountWalker']);
         $query->setHint(CountWalker::HINT_DISTINCT, true);
         $query->setFirstResult(null)->setMaxResults(null);
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -15,7 +15,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT m0_.id AS id_0 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id", 
@@ -29,7 +29,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT m0_.id AS id_0, m0_.title AS title_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id ORDER BY m0_.title ASC", 
@@ -43,7 +43,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT a0_.id AS id_0, sum(a0_.name) AS sclr_1 FROM Author a0_", 
@@ -60,7 +60,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT m0_.id AS id_0, m0_.author_id AS sclr_1 FROM MyBlogPost m0_ ORDER BY m0_.author_id ASC", 
@@ -77,7 +77,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT m0_.id AS id_0 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON (m0_.category_id = c1_.id)", 
@@ -91,7 +91,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $query      = $this->entityManager->createQuery($dql);
         $limitQuery = clone $query;
         
-        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker'));
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker']);
 
         $this->assertEquals(
             "SELECT DISTINCT m0_.id AS id_0, m0_.title AS title_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON (m0_.category_id = c1_.id) ORDER BY m0_.title ASC", 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -16,7 +16,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -30,7 +30,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT a, sum(a.name) as foo FROM Doctrine\Tests\ORM\Tools\Pagination\Author a'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -44,7 +44,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE 1 = 1'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -58,7 +58,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE 1 = 1 AND 2 = 2'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -72,7 +72,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE 1 = 1 OR 2 = 2'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -86,7 +86,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE (1 = 1 OR 2 = 2) AND 3 = 3'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -100,7 +100,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE 1 = 1 AND 2 = 2 OR 3 = 3'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -114,7 +114,7 @@ class WhereInWalkerTest extends PaginationTestCase
             'SELECT u, g FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g WHERE NOT 1 = 2'
         );
         $whereInQuery = clone $query;
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -130,7 +130,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery  = $this->entityManager->createQuery(
             'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN Doctrine\Tests\ORM\Tools\Pagination\Category c WITH p.category = c'
         );
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
@@ -143,7 +143,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery = $this->entityManager->createQuery(
             'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost p JOIN Doctrine\Tests\ORM\Tools\Pagination\Category c WITH p.category = c WHERE 1 = 1'
         );
-        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\WhereInWalker'));
+        $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, ['Doctrine\ORM\Tools\Pagination\WhereInWalker']);
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -42,12 +42,12 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->listener->addResolveTargetEntity(
             'Doctrine\Tests\ORM\Tools\ResolveTargetInterface',
             'Doctrine\Tests\ORM\Tools\ResolveTargetEntity',
-            array()
+            []
         );
         $this->listener->addResolveTargetEntity(
             'Doctrine\Tests\ORM\Tools\TargetInterface',
             'Doctrine\Tests\ORM\Tools\TargetEntity',
-            array()
+            []
         );
         $evm->addEventSubscriber($this->listener);
 
@@ -72,7 +72,7 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->listener->addResolveTargetEntity(
             'Doctrine\Tests\ORM\Tools\ResolveTargetInterface',
             'Doctrine\Tests\ORM\Tools\ResolveTargetEntity',
-            array()
+            []
         );
 
         $this->em->getEventManager()->addEventSubscriber($this->listener);
@@ -91,12 +91,12 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->listener->addResolveTargetEntity(
             'Doctrine\Tests\ORM\Tools\ResolveTargetInterface',
             'Doctrine\Tests\ORM\Tools\ResolveTargetEntity',
-            array()
+            []
         );
         $this->listener->addResolveTargetEntity(
             'Doctrine\Tests\ORM\Tools\TargetInterface',
             'Doctrine\Tests\ORM\Tools\TargetEntity',
-            array()
+            []
         );
 
         $evm->addEventListener(Events::loadClassMetadata, $this->listener);
@@ -104,7 +104,7 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $meta = $cm->associationMappings['manyToMany'];
 
         $this->assertSame('Doctrine\Tests\ORM\Tools\TargetEntity', $meta['targetEntity']);
-        $this->assertEquals(array('resolvetargetentity_id', 'targetinterface_id'), $meta['joinTableColumns']);
+        $this->assertEquals(['resolvetargetentity_id', 'targetinterface_id'], $meta['joinTableColumns']);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -14,7 +14,7 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $em = $this->_getTestEntityManager();
         $schemaTool = new SchemaTool($em);
 
-        $classes = array(
+        $classes = [
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsComment'),
@@ -22,12 +22,12 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
-        );
+        ];
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
         $this->assertTrue($schema->hasTable('cms_users'), "Table cms_users should exist.");
-        $this->assertTrue($schema->getTable('cms_users')->columnsAreIndexed(array('username')), "username column should be indexed.");
+        $this->assertTrue($schema->getTable('cms_users')->columnsAreIndexed(['username']), "username column should be indexed.");
     }
 
     public function testAnnotationOptionsAttribute()
@@ -35,13 +35,13 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $em = $this->_getTestEntityManager();
         $schemaTool = new SchemaTool($em);
 
-        $classes = array(
+        $classes = [
             $em->getClassMetadata(__NAMESPACE__ . '\\TestEntityWithAnnotationOptionsAttribute'),
-        );
+        ];
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
-        $expected = array('foo' => 'bar', 'baz' => array('key' => 'val'));
+        $expected = ['foo' => 'bar', 'baz' => ['key' => 'val']];
 
         $this->assertEquals($expected, $schema->getTable('TestEntityWithAnnotationOptionsAttribute')->getOptions(), "options annotation are passed to the tables options");
         $this->assertEquals($expected, $schema->getTable('TestEntityWithAnnotationOptionsAttribute')->getColumn('test')->getCustomSchemaOptions(), "options annotation are passed to the columns customSchemaOptions");
@@ -61,7 +61,7 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $avatar->fieldMappings['id']['columnDefinition'] = $customColumnDef;
         $user = $em->getClassMetadata('Doctrine\Tests\Models\Forum\ForumUser');
 
-        $classes = array($avatar, $user);
+        $classes = [$avatar, $user];
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
@@ -80,11 +80,11 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
 
         $em = $this->_getTestEntityManager();
         $em->getEventManager()->addEventListener(
-            array(ToolEvents::postGenerateSchemaTable, ToolEvents::postGenerateSchema), $listener
+            [ToolEvents::postGenerateSchemaTable, ToolEvents::postGenerateSchema], $listener
         );
         $schemaTool = new SchemaTool($em);
 
-        $classes = array(
+        $classes = [
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsArticle'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsComment'),
@@ -92,7 +92,7 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsGroup'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsPhonenumber'),
             $em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser'),
-        );
+        ];
 
         $schema = $schemaTool->getSchemaFromMetadata($classes);
 
@@ -105,16 +105,16 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $em = $this->_getTestEntityManager();
         $schemaTool = new SchemaTool($em);
 
-        $classes = array(
+        $classes = [
             $em->getClassMetadata('Doctrine\Tests\Models\NullDefault\NullDefaultColumn'),
-        );
+        ];
 
         $customSchemaOptions = $schemaTool->getSchemaFromMetadata($classes)
             ->getTable('NullDefaultColumn')
             ->getColumn('nullDefault')
             ->getCustomSchemaOptions();
 
-        $this->assertSame(array(), $customSchemaOptions);
+        $this->assertSame([], $customSchemaOptions);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -24,49 +24,49 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
 
     public function testCmsModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/CMS"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
     public function testCompanyModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/Company"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
     public function testECommerceModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/ECommerce"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
     public function testForumModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/Forum"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
     public function testNavigationModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/Navigation"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
     public function testRoutingModelSet()
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(array(
+        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths([
             __DIR__ . "/../../Models/Routing"
-        ));
+        ]);
         $this->validator->validateMapping();
     }
 
@@ -81,10 +81,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class1);
 
         $this->assertEquals(
-            array(
+            [
                 "The inverse join columns of the many-to-many table 'Entity1Entity2' have to contain to ALL identifier columns of the target entity 'Doctrine\Tests\ORM\Tools\InvalidEntity2', however 'key4' are missing.",
                 "The join columns of the many-to-many table 'Entity1Entity2' have to contain to ALL identifier columns of the source entity 'Doctrine\Tests\ORM\Tools\InvalidEntity1', however 'key2' are missing."
-            ),
+            ],
             $ce
         );
     }
@@ -100,10 +100,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class2);
 
         $this->assertEquals(
-            array(
+            [
                 "The referenced column name 'id' has to be a primary key column on the target entity class 'Doctrine\Tests\ORM\Tools\InvalidEntity1'.",
                 "The join columns of the association 'assoc' have to match to ALL identifier columns of the target entity 'Doctrine\Tests\ORM\Tools\InvalidEntity1', however 'key1, key2' are missing."
-            ),
+            ],
             $ce
         );
     }
@@ -118,7 +118,7 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
 
         $ce = $this->validator->validateClass($class1);
 
-        $this->assertEquals(array(), $ce);
+        $this->assertEquals([], $ce);
     }
 
     /**
@@ -129,10 +129,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $classThree = $this->em->getClassMetadata(__NAMESPACE__ . '\DDC1649Three');
         $ce = $this->validator->validateClass($classThree);
 
-        $this->assertEquals(Array(
+        $this->assertEquals([
             "Cannot map association 'Doctrine\Tests\ORM\Tools\DDC1649Three#two as identifier, because the target entity 'Doctrine\Tests\ORM\Tools\DDC1649Two' also maps an association as identifier.",
             "The referenced column name 'id' has to be a primary key column on the target entity class 'Doctrine\Tests\ORM\Tools\DDC1649Two'."
-        ), $ce);
+        ], $ce);
     }
 
     /**
@@ -144,11 +144,11 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class);
 
         $this->assertEquals(
-            array(
+            [
                 "The field Doctrine\Tests\ORM\Tools\DDC3274One#two is on the inverse side of a bi-directional " .
                 "relationship, but the specified mappedBy association on the target-entity " .
                 "Doctrine\Tests\ORM\Tools\DDC3274Two#one does not contain the required 'inversedBy=\"two\"' attribute."
-            ),
+            ],
             $ce
         );
     }
@@ -162,10 +162,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class);
 
         $this->assertEquals(
-            array(
+            [
                 "The association Doctrine\Tests\ORM\Tools\DDC3322One#invalidAssoc is ordered by a foreign field " .
                 "invalidField that is not a field on the target entity Doctrine\Tests\ORM\Tools\DDC3322ValidEntity1."
-            ),
+            ],
             $ce
         );
     }
@@ -179,10 +179,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class);
 
         $this->assertEquals(
-            array(
+            [
                 "The association Doctrine\Tests\ORM\Tools\DDC3322Two#invalidAssoc is ordered by a field oneToMany " .
                 "on Doctrine\Tests\ORM\Tools\DDC3322ValidEntity1 that is a collection-valued association."
-            ),
+            ],
             $ce
         );
     }
@@ -196,10 +196,10 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
         $ce = $this->validator->validateClass($class);
 
         $this->assertEquals(
-            array(
+            [
                 "The association Doctrine\Tests\ORM\Tools\DDC3322Three#invalidAssoc is ordered by a field oneToOneInverse " .
                 "on Doctrine\Tests\ORM\Tools\DDC3322ValidEntity1 that is the inverse side of an association."
-            ),
+            ],
             $ce
         );
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -44,7 +44,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
 
     public function testAnnotationConfiguration()
     {
-        $config = Setup::createAnnotationMetadataConfiguration(array(), true);
+        $config = Setup::createAnnotationMetadataConfiguration([], true);
 
         $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
         $this->assertEquals(sys_get_temp_dir(), $config->getProxyDir());
@@ -54,7 +54,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
 
     public function testXMLConfiguration()
     {
-        $config = Setup::createXMLMetadataConfiguration(array(), true);
+        $config = Setup::createXMLMetadataConfiguration([], true);
 
         $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
         $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\XmlDriver', $config->getMetadataDriverImpl());
@@ -62,7 +62,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
 
     public function testYAMLConfiguration()
     {
-        $config = Setup::createYAMLMetadataConfiguration(array(), true);
+        $config = Setup::createYAMLMetadataConfiguration([], true);
 
         $this->assertInstanceOf('Doctrine\ORM\Configuration', $config);
         $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\YamlDriver', $config->getMetadataDriverImpl());
@@ -73,7 +73,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testConfigureProxyDir()
     {
-        $config = Setup::createAnnotationMetadataConfiguration(array(), true, "/foo");
+        $config = Setup::createAnnotationMetadataConfiguration([], true, "/foo");
         $this->assertEquals('/foo', $config->getProxyDir());
     }
 
@@ -83,7 +83,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
     public function testConfigureCache()
     {
         $cache = new ArrayCache();
-        $config = Setup::createAnnotationMetadataConfiguration(array(), true, null, $cache);
+        $config = Setup::createAnnotationMetadataConfiguration([], true, null, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());
         $this->assertSame($cache, $config->getMetadataCacheImpl());
@@ -98,7 +98,7 @@ class SetupTest extends \Doctrine\Tests\OrmTestCase
         $cache = $this->getMock('Doctrine\Common\Cache\Cache');
         $cache->expects($this->never())->method('setNamespace');
 
-        $config = Setup::createConfiguration(array(), true, $cache);
+        $config = Setup::createConfiguration([], true, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());
         $this->assertSame($cache, $config->getMetadataCacheImpl());

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -44,7 +44,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
 
     protected function setUp() {
         parent::setUp();
-        $this->_connectionMock = new ConnectionMock(array(), new DriverMock());
+        $this->_connectionMock = new ConnectionMock([], new DriverMock());
         $this->_emMock = EntityManagerMock::create($this->_connectionMock);
         // SUT
         $this->_unitOfWork = new UnitOfWorkMock($this->_emMock);
@@ -160,7 +160,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertTrue($this->_unitOfWork->isScheduledForDirtyCheck($entity));
 
-        $this->assertEquals(array('data' => array('thedata', 'newdata')), $this->_unitOfWork->getEntityChangeSet($entity));
+        $this->assertEquals(['data' => ['thedata', 'newdata']], $this->_unitOfWork->getEntityChangeSet($entity));
 
         $item = new NotifyChangedRelatedItem();
         $entity->getItems()->add($item);
@@ -207,7 +207,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $persister->reset();
 
         // if the entity is already managed the exists() check should be skipped
-        $this->_unitOfWork->registerManaged($ph, array('phonenumber' => '12345'), array());
+        $this->_unitOfWork->registerManaged($ph, ['phonenumber' => '12345'], []);
         $this->assertEquals(UnitOfWork::STATE_MANAGED, $this->_unitOfWork->getEntityState($ph));
         $this->assertFalse($persister->isExistsCalled());
         $ph2 = new \Doctrine\Tests\Models\CMS\CmsPhonenumber();
@@ -325,7 +325,7 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
  */
 class NotifyChangedEntity implements NotifyPropertyChanged
 {
-    private $_listeners = array();
+    private $_listeners = [];
     /**
      * @Id
      * @Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerTest.php
@@ -35,12 +35,12 @@ class IdentifierFlattenerTest extends OrmFunctionalTestCase
 
         try {
             $this->_schemaTool->createSchema(
-                array(
+                [
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity'),
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToOne\SecondRelatedEntity'),
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\Cache\Flight'),
                     $this->_em->getClassMetadata('Doctrine\Tests\Models\Cache\City')
-                )
+                ]
             );
         } catch (ORMException $e) {
         }
@@ -65,7 +65,7 @@ class IdentifierFlattenerTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $firstEntity = $this->_em->getRepository('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity')
-            ->findOneBy(array('name' => 'Fred'));
+            ->findOneBy(['name' => 'Fred']);
 
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity');
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -55,29 +55,29 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      *
      * @var array
      */
-    protected $_usedModelSets = array();
+    protected $_usedModelSets = [];
 
     /**
      * Whether the database schema has already been created.
      *
      * @var array
      */
-    protected static $_tablesCreated = array();
+    protected static $_tablesCreated = [];
 
     /**
      * Array of entity class name to their tables that were created.
      *
      * @var array
      */
-    protected static $_entityTablesCreated = array();
+    protected static $_entityTablesCreated = [];
 
     /**
      * List of model sets and their classes.
      *
      * @var array
      */
-    protected static $_modelSets = array(
-        'cms' => array(
+    protected static $_modelSets = [
+        'cms' => [
             'Doctrine\Tests\Models\CMS\CmsUser',
             'Doctrine\Tests\Models\CMS\CmsPhonenumber',
             'Doctrine\Tests\Models\CMS\CmsAddress',
@@ -85,9 +85,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\CMS\CmsGroup',
             'Doctrine\Tests\Models\CMS\CmsArticle',
             'Doctrine\Tests\Models\CMS\CmsComment',
-        ),
-        'forum' => array(),
-        'company' => array(
+        ],
+        'forum' => [],
+        'company' => [
             'Doctrine\Tests\Models\Company\CompanyPerson',
             'Doctrine\Tests\Models\Company\CompanyEmployee',
             'Doctrine\Tests\Models\Company\CompanyManager',
@@ -97,40 +97,40 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Company\CompanyRaffle',
             'Doctrine\Tests\Models\Company\CompanyCar',
             'Doctrine\Tests\Models\Company\CompanyContract',
-        ),
-        'ecommerce' => array(
+        ],
+        'ecommerce' => [
             'Doctrine\Tests\Models\ECommerce\ECommerceCart',
             'Doctrine\Tests\Models\ECommerce\ECommerceCustomer',
             'Doctrine\Tests\Models\ECommerce\ECommerceProduct',
             'Doctrine\Tests\Models\ECommerce\ECommerceShipping',
             'Doctrine\Tests\Models\ECommerce\ECommerceFeature',
             'Doctrine\Tests\Models\ECommerce\ECommerceCategory'
-        ),
-        'generic' => array(
+        ],
+        'generic' => [
             'Doctrine\Tests\Models\Generic\BooleanModel',
             'Doctrine\Tests\Models\Generic\DateTimeModel',
             'Doctrine\Tests\Models\Generic\DecimalModel',
             'Doctrine\Tests\Models\Generic\SerializationModel',
-        ),
-        'routing' => array(
+        ],
+        'routing' => [
             'Doctrine\Tests\Models\Routing\RoutingLeg',
             'Doctrine\Tests\Models\Routing\RoutingLocation',
             'Doctrine\Tests\Models\Routing\RoutingRoute',
             'Doctrine\Tests\Models\Routing\RoutingRouteBooking',
-        ),
-        'navigation' => array(
+        ],
+        'navigation' => [
             'Doctrine\Tests\Models\Navigation\NavUser',
             'Doctrine\Tests\Models\Navigation\NavCountry',
             'Doctrine\Tests\Models\Navigation\NavPhotos',
             'Doctrine\Tests\Models\Navigation\NavTour',
             'Doctrine\Tests\Models\Navigation\NavPointOfInterest',
-        ),
-        'directorytree' => array(
+        ],
+        'directorytree' => [
             'Doctrine\Tests\Models\DirectoryTree\AbstractContentItem',
             'Doctrine\Tests\Models\DirectoryTree\File',
             'Doctrine\Tests\Models\DirectoryTree\Directory',
-        ),
-        'ddc117' => array(
+        ],
+        'ddc117' => [
             'Doctrine\Tests\Models\DDC117\DDC117Article',
             'Doctrine\Tests\Models\DDC117\DDC117Reference',
             'Doctrine\Tests\Models\DDC117\DDC117Translation',
@@ -138,36 +138,36 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\DDC117\DDC117ApproveChanges',
             'Doctrine\Tests\Models\DDC117\DDC117Editor',
             'Doctrine\Tests\Models\DDC117\DDC117Link',
-        ),
-        'stockexchange' => array(
+        ],
+        'stockexchange' => [
             'Doctrine\Tests\Models\StockExchange\Bond',
             'Doctrine\Tests\Models\StockExchange\Stock',
             'Doctrine\Tests\Models\StockExchange\Market',
-        ),
-        'legacy' => array(
+        ],
+        'legacy' => [
             'Doctrine\Tests\Models\Legacy\LegacyUser',
             'Doctrine\Tests\Models\Legacy\LegacyUserReference',
             'Doctrine\Tests\Models\Legacy\LegacyArticle',
             'Doctrine\Tests\Models\Legacy\LegacyCar',
-        ),
-        'customtype' => array(
+        ],
+        'customtype' => [
             'Doctrine\Tests\Models\CustomType\CustomTypeChild',
             'Doctrine\Tests\Models\CustomType\CustomTypeParent',
             'Doctrine\Tests\Models\CustomType\CustomTypeUpperCase',
-        ),
-        'compositekeyinheritance' => array(
+        ],
+        'compositekeyinheritance' => [
             'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedRootClass',
             'Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass',
             'Doctrine\Tests\Models\CompositeKeyInheritance\SingleRootClass',
             'Doctrine\Tests\Models\CompositeKeyInheritance\SingleChildClass',
-        ),
-        'taxi' => array(
+        ],
+        'taxi' => [
             'Doctrine\Tests\Models\Taxi\PaidRide',
             'Doctrine\Tests\Models\Taxi\Ride',
             'Doctrine\Tests\Models\Taxi\Car',
             'Doctrine\Tests\Models\Taxi\Driver',
-        ),
-        'cache' => array(
+        ],
+        'cache' => [
             'Doctrine\Tests\Models\Cache\Country',
             'Doctrine\Tests\Models\Cache\State',
             'Doctrine\Tests\Models\Cache\City',
@@ -183,76 +183,76 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Cache\AttractionInfo',
             'Doctrine\Tests\Models\Cache\AttractionContactInfo',
             'Doctrine\Tests\Models\Cache\AttractionLocationInfo'
-        ),
-        'tweet' => array(
+        ],
+        'tweet' => [
             'Doctrine\Tests\Models\Tweet\User',
             'Doctrine\Tests\Models\Tweet\Tweet',
             'Doctrine\Tests\Models\Tweet\UserList',
-        ),
-        'ddc2504' => array(
+        ],
+        'ddc2504' => [
             'Doctrine\Tests\Models\DDC2504\DDC2504RootClass',
             'Doctrine\Tests\Models\DDC2504\DDC2504ChildClass',
             'Doctrine\Tests\Models\DDC2504\DDC2504OtherClass',
-        ),
-        'ddc3346' => array(
+        ],
+        'ddc3346' => [
             'Doctrine\Tests\Models\DDC3346\DDC3346Author',
             'Doctrine\Tests\Models\DDC3346\DDC3346Article',
-        ),
-        'quote' => array(
+        ],
+        'quote' => [
             'Doctrine\Tests\Models\Quote\Address',
             'Doctrine\Tests\Models\Quote\Group',
             'Doctrine\Tests\Models\Quote\NumericEntity',
             'Doctrine\Tests\Models\Quote\Phone',
             'Doctrine\Tests\Models\Quote\User'
-        ),
-        'vct_onetoone' => array(
+        ],
+        'vct_onetoone' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneEntity'
-        ),
-        'vct_onetoone_compositeid' => array(
+        ],
+        'vct_onetoone_compositeid' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdEntity'
-        ),
-        'vct_onetoone_compositeid_foreignkey' => array(
+        ],
+        'vct_onetoone_compositeid_foreignkey' => [
             'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToOneCompositeIdForeignKeyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningOneToOneCompositeIdForeignKeyEntity'
-        ),
-        'vct_onetomany' => array(
+        ],
+        'vct_onetomany' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneEntity'
-        ),
-        'vct_onetomany_compositeid' => array(
+        ],
+        'vct_onetomany_compositeid' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdEntity'
-        ),
-        'vct_onetomany_compositeid_foreignkey' => array(
+        ],
+        'vct_onetomany_compositeid_foreignkey' => [
             'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyCompositeIdForeignKeyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneCompositeIdForeignKeyEntity'
-        ),
-        'vct_onetomany_extralazy' => array(
+        ],
+        'vct_onetomany_extralazy' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedOneToManyExtraLazyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToOneExtraLazyEntity'
-        ),
-        'vct_manytomany' => array(
+        ],
+        'vct_manytomany' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyEntity'
-        ),
-        'vct_manytomany_compositeid' => array(
+        ],
+        'vct_manytomany_compositeid' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdEntity'
-        ),
-        'vct_manytomany_compositeid_foreignkey' => array(
+        ],
+        'vct_manytomany_compositeid_foreignkey' => [
             'Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity',
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyCompositeIdForeignKeyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyCompositeIdForeignKeyEntity'
-        ),
-        'vct_manytomany_extralazy' => array(
+        ],
+        'vct_manytomany_extralazy' => [
             'Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity',
             'Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity'
-        ),
-    );
+        ],
+    ];
 
     /**
      * @param string $setName
@@ -500,7 +500,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             throw new \RuntimeException("EntityManager not set, you have to call parent::setUp() before invoking this method.");
         }
 
-        $classes = array();
+        $classes = [];
         foreach ($classNames as $className) {
             if ( ! isset(static::$_entityTablesCreated[$className])) {
                 static::$_entityTablesCreated[$className] = true;
@@ -534,7 +534,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($GLOBALS['DOCTRINE_MARK_SQL_LOGS'])) {
-            if (in_array(static::$_sharedConn->getDatabasePlatform()->getName(), array("mysql", "postgresql"))) {
+            if (in_array(static::$_sharedConn->getDatabasePlatform()->getName(), ["mysql", "postgresql"])) {
                 static::$_sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/');
             } else if (static::$_sharedConn->getDatabasePlatform()->getName() == "oracle") {
                 static::$_sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/ FROM dual');
@@ -546,7 +546,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $this->_schemaTool = new \Doctrine\ORM\Tools\SchemaTool($this->_em);
         }
 
-        $classes = array();
+        $classes = [];
 
         foreach ($this->_usedModelSets as $setName => $bool) {
             if ( ! isset(static::$_tablesCreated[$setName])/* || $forceCreateTables*/) {
@@ -622,9 +622,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $this->isSecondLevelCacheEnabled = true;
         }
 
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache')
-        ), true));
+        ], true));
 
         $conn = static::$_sharedConn;
         $conn->getConfiguration()->setSQLLogger($this->_sqlLoggerStack);
@@ -633,7 +633,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         $evm = $conn->getEventManager();
         foreach ($evm->getListeners() AS $event => $listeners) {
             foreach ($listeners AS $listener) {
-                $evm->removeEventListener(array($event), $listener);
+                $evm->removeEventListener([$event], $listener);
             }
         }
 
@@ -649,7 +649,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($GLOBALS['debug_uow_listener'])) {
-            $evm->addEventListener(array('onFlush'), new \Doctrine\ORM\Tools\DebugUnitOfWorkListener());
+            $evm->addEventListener(['onFlush'], new \Doctrine\ORM\Tools\DebugUnitOfWorkListener());
         }
 
         return \Doctrine\ORM\EntityManager::create($conn, $config);
@@ -672,7 +672,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $queries = "";
             for($i = count($this->_sqlLoggerStack->queries)-1; $i > max(count($this->_sqlLoggerStack->queries)-25, 0) && isset($this->_sqlLoggerStack->queries[$i]); $i--) {
                 $query = $this->_sqlLoggerStack->queries[$i];
-                $params = array_map(function($p) { if (is_object($p)) return get_class($p); else return "'".$p."'"; }, $query['params'] ?: array());
+                $params = array_map(function($p) { if (is_object($p)) return get_class($p); else return "'".$p."'"; }, $query['params'] ?: []);
                 $queries .= ($i+1).". SQL: '".$query['sql']."' Params: ".implode(", ", $params).PHP_EOL;
             }
 

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -55,7 +55,7 @@ abstract class OrmTestCase extends DoctrineTestCase
      *
      * @return \Doctrine\ORM\Mapping\Driver\AnnotationDriver
      */
-    protected function createAnnotationDriver($paths = array(), $alias = null)
+    protected function createAnnotationDriver($paths = [], $alias = null)
     {
         if (version_compare(\Doctrine\Common\Version::VERSION, '3.0.0', '>=')) {
             $reader = new \Doctrine\Common\Annotations\CachedReader(
@@ -117,13 +117,13 @@ abstract class OrmTestCase extends DoctrineTestCase
         $config = new \Doctrine\ORM\Configuration();
 
         $config->setMetadataCacheImpl($metadataCache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], true));
         $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([
             realpath(__DIR__ . '/Models/Cache')
-        ), true));
+        ], true));
 
         if ($this->isSecondLevelCacheEnabled) {
 
@@ -139,12 +139,12 @@ abstract class OrmTestCase extends DoctrineTestCase
         }
 
         if ($conn === null) {
-            $conn = array(
+            $conn = [
                 'driverClass'  => 'Doctrine\Tests\Mocks\DriverMock',
                 'wrapperClass' => 'Doctrine\Tests\Mocks\ConnectionMock',
                 'user'         => 'john',
                 'password'     => 'wayne'
-            );
+            ];
         }
 
         if (is_array($conn)) {

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -125,10 +125,10 @@ class TestUtil
 
     private static function getFallbackConnectionParams()
     {
-        $params = array(
+        $params = [
             'driver' => 'pdo_sqlite',
             'memory' => true
-        );
+        ];
 
         if (isset($GLOBALS['db_path'])) {
             $params['path'] = $GLOBALS['db_path'];
@@ -151,14 +151,14 @@ class TestUtil
 
     private static function getParamsForTemporaryConnection()
     {
-        $connectionParams = array(
+        $connectionParams = [
             'driver' => $GLOBALS['tmpdb_type'],
             'user' => $GLOBALS['tmpdb_username'],
             'password' => $GLOBALS['tmpdb_password'],
             'host' => $GLOBALS['tmpdb_host'],
             'dbname' => null,
             'port' => $GLOBALS['tmpdb_port']
-        );
+        ];
 
         if (isset($GLOBALS['tmpdb_name'])) {
             $connectionParams['dbname'] = $GLOBALS['tmpdb_name'];
@@ -177,14 +177,14 @@ class TestUtil
 
     private static function getParamsForMainConnection()
     {
-        $connectionParams = array(
+        $connectionParams = [
             'driver' => $GLOBALS['db_type'],
             'user' => $GLOBALS['db_username'],
             'password' => $GLOBALS['db_password'],
             'host' => $GLOBALS['db_host'],
             'dbname' => $GLOBALS['db_name'],
             'port' => $GLOBALS['db_port']
-        );
+        ];
 
         if (isset($GLOBALS['db_server'])) {
             $connectionParams['server'] = $GLOBALS['db_server'];

--- a/tools/sandbox/bootstrap.php
+++ b/tools/sandbox/bootstrap.php
@@ -19,7 +19,7 @@ $debug = true;
 $config = new \Doctrine\ORM\Configuration();
 
 // Set up Metadata Drivers
-$driverImpl = $config->newDefaultAnnotationDriver(array(__DIR__ . "/Entities"));
+$driverImpl = $config->newDefaultAnnotationDriver([__DIR__ . "/Entities"]);
 $config->setMetadataDriverImpl($driverImpl);
 
 // Set up caches, depending on $debug variable.
@@ -33,10 +33,10 @@ $config->setProxyDir(__DIR__ . '/Proxies');
 $config->setProxyNamespace('Proxies');
 
 // Database connection information
-$connectionOptions = array(
+$connectionOptions = [
     'driver' => 'pdo_sqlite',
     'path'   => 'database.sqlite'
-);
+];
 
 // Enable second-level cache
 $cacheConfig    = new \Doctrine\ORM\Cache\CacheConfiguration();

--- a/tools/sandbox/doctrine.php
+++ b/tools/sandbox/doctrine.php
@@ -5,12 +5,12 @@ $em = require_once __DIR__.'/bootstrap.php';
 $cli = new \Symfony\Component\Console\Application('Doctrine Command Line Interface', Doctrine\Common\Version::VERSION);
 $cli->setCatchExceptions(true);
 
-$cli->setHelperSet(new Symfony\Component\Console\Helper\HelperSet(array(
+$cli->setHelperSet(new Symfony\Component\Console\Helper\HelperSet([
     'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($em->getConnection()),
     'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($em)
-)));
+]));
 
-$cli->addCommands(array(
+$cli->addCommands([
     // DBAL Commands
     new \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand(),
     new \Doctrine\DBAL\Tools\Console\Command\ImportCommand(),
@@ -34,5 +34,5 @@ $cli->addCommands(array(
     new \Doctrine\ORM\Tools\Console\Command\RunDqlCommand(),
     new \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand(),
 
-));
+]);
 $cli->run();


### PR DESCRIPTION
Now that the minimum PHP version is 5.4, it would be good to encourage the use of the short array syntax `[]`.
Converting the existing codebase to this syntax will promote this good practice and encourage everyone to follow it.

I have converted the codebase with [a tool](https://gist.github.com/BenMorel/6994483) I wrote for personal projects:

```
find doctrine2 -type f -name '*.php' -exec php short-array-syntax-converter.php {} \;
```

The number of changes is quite large, but I'm confident that nothing is broken, and the passing tests confirm this.
