### PR TITLE
Mark getSelectConditionStatementColumnSQL method as private

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1611,7 +1611,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    protected function getSelectConditionStatementColumnSQL($field, $assoc = null)
+    private function getSelectConditionStatementColumnSQL($field, $assoc = null)
     {
         if (isset($this->class->columnNames[$field])) {
             $className = (isset($this->class->fieldMappings[$field]['inherited']))


### PR DESCRIPTION
The `Doctrine/\ORM\Persisters\BasicEntityPersister::getSelectConditionStatementColumnSQL` method has been marked as `private`.

The current `protected` mark is a bit unuseful since everything is already handled into the public method `getSelectConditionStatementSQL`.
