### PR TITLE
Avoid Connection error when calling ClassMetadataFactor::getAllMetadata()

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -753,6 +753,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         return isset($class->isMappedSuperclass) && $class->isMappedSuperclass === false;
     }
 
+    /**
+     * @return Platforms\AbstractPlatform
+     */
     private function getTargetPlatform()
     {
         if (!$this->targetPlatform) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -755,7 +755,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     private function getTargetPlatform()
     {
-        if ($this->targetPlatform === null) {
+        if (!$this->targetPlatform) {
             $this->targetPlatform = $this->em->getConnection()->getDatabasePlatform();
         }
 


### PR DESCRIPTION
Hi guys!

When you pair the ORM with DBAL 2.5.0, then getting the `targetPlatform` means that a connection will be made to the database. For that reason, it's really important to _not_ get the `targetPlatform` unless it's absolutely needed. Currently, if you call `ClassMetadataFactor::getAllMetadata()`, it will try to determine `targetPlatform` (in `initialize()`), which will make a connection. And if that connection fails (e.g. no db yet), it will blow up - even though `getAllMetadata()` doesn't need the `targetPlatform`.

This fixes that, and in an absolutely BC way, since `targetPlatform` is private (yay!). This should fix a number of issues in userland, like symfony/symfony-standard#748 and symfony/symfony-standard#774.

This is a PR to master (per the guidelines), but the real target is 2.4, since it's the latest stable. The patch won't apply cleanly, but it's simple: remove from initialize, then replace all references to the new private method.

Thanks in advance! More details are on the commit message.
