### PR TITLE
Docs: Remove empty pages from TOC

### DIFF
--- a/docs/en/toc.rst
+++ b/docs/en/toc.rst
@@ -26,7 +26,6 @@ Reference Guide
    :numbered:
 
    reference/architecture
-   reference/installation
    reference/configuration.rst
    reference/faq
    reference/basic-mapping
@@ -57,7 +56,6 @@ Reference Guide
    tutorials/pagination
    reference/filters
    reference/namingstrategy
-   reference/installation
    reference/advanced-configuration
    reference/second-level-cache
    reference/security


### PR DESCRIPTION
Remove Installation page from TOC as it was moved to "Installation and Configuration"
