### PR TITLE
[2.4] #1169 DDC-3343 one-to-omany persister deletes only on EXTRA_LAZY plus orphanRemoval

### DIFF
--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -19,7 +19,6 @@
 
 namespace Doctrine\ORM\Persisters;
 
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -249,16 +249,6 @@ class OneToManyPersister extends AbstractCollectionPersister
         $sql   = 'DELETE FROM ' . $this->quoteStrategy->getTableName($class, $this->platform)
             . ' WHERE ' . implode('= ? AND ', $class->getIdentifierColumnNames()) . ' = ?';
 
-        if ($element instanceof Proxy && ! $element->__isInitialized()) {
-            $element->__load();
-        }
-
-        // clearing owning side value
-        $targetMetadata->reflFields[$mapping['mappedBy']]->setValue($element, null);
-
-        $this->uow->computeChangeSet($targetMetadata, $element);
-        $persister->update($element);
-
-        return true;
+        return (bool) $this->conn->executeUpdate($sql, $this->getDeleteRowSQLParameters($coll, $element));
     }
 }

--- a/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/OneToManyPersister.php
@@ -244,10 +244,11 @@ class OneToManyPersister extends AbstractCollectionPersister
             return false;
         }
 
-        $class = $this->em->getClassMetadata($mapping['targetEntity']);
-        $sql   = 'DELETE FROM ' . $this->quoteStrategy->getTableName($class, $this->platform)
-            . ' WHERE ' . implode('= ? AND ', $class->getIdentifierColumnNames()) . ' = ?';
+        $this
+            ->uow
+            ->getEntityPersister($mapping['targetEntity'])
+            ->delete($element);
 
-        return (bool) $this->conn->executeUpdate($sql, $this->getDeleteRowSQLParameters($coll, $element));
+        return true;
     }
 }

--- a/tests/Doctrine/Tests/Models/Tweet/Tweet.php
+++ b/tests/Doctrine/Tests/Models/Tweet/Tweet.php
@@ -32,6 +32,6 @@ class Tweet
      */
     public function setAuthor(User $author)
     {
-        $this->user = $author;
+        $this->author = $author;
     }
 }

--- a/tests/Doctrine/Tests/Models/Tweet/Tweet.php
+++ b/tests/Doctrine/Tests/Models/Tweet/Tweet.php
@@ -18,17 +18,20 @@ class Tweet
     public $id;
 
     /**
-     * @Column(type="string")
+     * @Column(type="string", length=140)
      */
-    public $content;
+    public $content = '';
 
     /**
-     * @ManyToOne(targetEntity="User", inversedBy="tweets")
+     * @ManyToOne(targetEntity="User", inversedBy="tweets", cascade={"persist"}, fetch="EXTRA_LAZY")
      */
     public $author;
 
-    public function setAuthor(User $user)
+    /**
+     * @param User $author
+     */
+    public function setAuthor(User $author)
     {
-        $this->author = $user;
+        $this->user = $author;
     }
 }

--- a/tests/Doctrine/Tests/Models/Tweet/User.php
+++ b/tests/Doctrine/Tests/Models/Tweet/User.php
@@ -29,14 +29,26 @@ class User
      */
     public $tweets;
 
+    /**
+     * @OneToMany(targetEntity="UserList", mappedBy="owner", fetch="EXTRA_LAZY", orphanRemoval=true)
+     */
+    public $userLists;
+
     public function __construct()
     {
-        $this->tweets = new ArrayCollection();
+        $this->tweets    = new ArrayCollection();
+        $this->userLists = new ArrayCollection();
     }
 
     public function addTweet(Tweet $tweet)
     {
         $tweet->setAuthor($this);
         $this->tweets->add($tweet);
+    }
+
+    public function addUserList(UserList $userList)
+    {
+        $userList->owner = $this;
+        $this->userLists->add($userList);
     }
 }

--- a/tests/Doctrine/Tests/Models/Tweet/UserList.php
+++ b/tests/Doctrine/Tests/Models/Tweet/UserList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\Models\Tweet;
+
+/**
+ * @Entity
+ * @Table(name="tweet_user_list")
+ */
+class UserList
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $listName;
+
+    /**
+     * @ManyToOne(targetEntity="User", inversedBy="userLists")
+     */
+    public $owner;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -5,6 +5,8 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Tests\Models\Tweet\Tweet;
 use Doctrine\Tests\Models\Tweet\User;
+use Doctrine\Tests\Models\Tweet\UserList;
+use Doctrine\Tests\OrmFunctionalTestCase;
 
 require_once __DIR__ . '/../../TestInit.php';
 
@@ -685,10 +687,9 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         /* @var $user User */
         $user  = $this->_em->find(User::CLASSNAME, $userId);
+        $tweet = $this->_em->find(Tweet::CLASSNAME, $tweetId);
 
-        $e = $this->_em->find(Tweet::CLASSNAME, $tweetId);
-
-        $user->tweets->removeElement($e);
+        $user->tweets->removeElement($tweet);
 
         $this->_em->clear();
 
@@ -836,6 +837,83 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 
     /**
+     * @group DDC-3343
+     */
+    public function testRemoveOrphanedManagedElementFromOneToManyExtraLazyCollection()
+    {
+        list($userId, $userListId) = $this->loadUserListFixture();
+
+        /* @var $user User */
+        $user = $this->_em->find(User::CLASSNAME, $userId);
+
+        $user->tweets->removeElement($this->_em->find(UserList::CLASSNAME, $userListId));
+
+        $this->_em->clear();
+
+        /* @var $user User */
+        $user = $this->_em->find(User::CLASSNAME, $userId);
+
+        $this->assertCount(0, $user->userLists, 'Element was removed from association due to orphan removal');
+        $this->assertNull(
+            $this->_em->find(UserList::CLASSNAME, $userListId),
+            'Element was deleted due to orphan removal'
+        );
+    }
+
+    /**
+     * @group DDC-3343
+     */
+    public function testRemoveOrphanedUnManagedElementFromOneToManyExtraLazyCollection()
+    {
+        list($userId, $userListId) = $this->loadUserListFixture();
+
+        /* @var $user User */
+        $user = $this->_em->find(User::CLASSNAME, $userId);
+
+        $user->userLists->removeElement(new UserList());
+
+        $this->_em->clear();
+
+        /* @var $userList UserList */
+        $userList = $this->_em->find(UserList::CLASSNAME, $userListId);
+        $this->assertInstanceOf(
+            UserList::CLASSNAME,
+            $userList,
+            'Even though the collection is extra lazy + orphan removal, the user list should not have been deleted'
+        );
+
+        $this->assertInstanceOf(
+            User::CLASSNAME,
+            $userList->owner,
+            'User list to owner link has not been removed'
+        );
+    }
+
+    /**
+     * @group DDC-3343
+     */
+    public function testRemoveOrphanedManagedLazyProxyFromExtraLazyOneToMany()
+    {
+        list($userId, $userListId) = $this->loadUserListFixture();
+
+        /* @var $user User */
+        $user = $this->_em->find(User::CLASSNAME, $userId);
+
+        $user->tweets->removeElement($this->_em->getReference(UserList::CLASSNAME, $userListId));
+
+        $this->_em->clear();
+
+        /* @var $user User */
+        $user = $this->_em->find(User::CLASSNAME, $userId);
+
+        $this->assertCount(0, $user->userLists, 'Element was removed from association due to orphan removal');
+        $this->assertNull(
+            $this->_em->find(UserList::CLASSNAME, $userListId),
+            'Element was deleted due to orphan removal'
+        );
+    }
+
+    /**
      * @return int[] ordered tuple: user id and tweet id
      */
     private function loadTweetFixture()
@@ -854,5 +932,26 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->clear();
 
         return array($user->id, $tweet->id);
+    }
+
+    /**
+     * @return int[] ordered tuple: user id and user list id
+     */
+    private function loadUserListFixture()
+    {
+        $user     = new User();
+        $userList = new UserList();
+
+        $user->name     = 'ocramius';
+        $userList->listName = 'PHP Developers to follow closely';
+
+        $user->addUserList($userList);
+
+        $this->_em->persist($user);
+        $this->_em->persist($userList);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return array($user->id, $userList->id);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Tests\Models\Tweet\Tweet;
 use Doctrine\Tests\Models\Tweet\User;
 use Doctrine\Tests\Models\Tweet\UserList;
-use Doctrine\Tests\OrmFunctionalTestCase;
 
 require_once __DIR__ . '/../../TestInit.php';
 
@@ -29,6 +28,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->useModelSet('tweet');
         $this->useModelSet('cms');
         $this->useModelSet('tweet');
+
         parent::setUp();
 
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
@@ -655,7 +655,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->topic = $article1->topic;
         $this->phonenumber = $phonenumber1->phonenumber;
-
     }
 
     /**
@@ -740,27 +739,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 
     /**
-     * @return int[] ordered tuple: user id and tweet id
-     */
-    private function loadTweetFixture()
-    {
-        $user  = new User();
-        $tweet = new Tweet();
-
-        $user->name     = 'ocramius';
-        $tweet->content = 'The cat is on the table';
-
-        $user->addTweet($tweet);
-
-        $this->_em->persist($user);
-        $this->_em->persist($tweet);
-        $this->_em->flush();
-        $this->_em->clear();
-
-        return array($user->id, $tweet->id);
-    }
-
-    /**
      * @group DDC-3343
      */
     public function testRemovesManagedElementFromOneToManyExtraLazyCollection()
@@ -803,37 +781,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         );
 
         $this->assertNull($tweet->author, 'Tweet author link has been removed');
-    }
-
-    /**
-     * @group DDC-3343
-     */
-    public function testRemovingManagedLazyProxyFromExtraLazyOneToManyDoesRemoveTheAssociationButNotTheEntity()
-    {
-        list($userId, $tweetId) = $this->loadTweetFixture();
-
-        /* @var $user User */
-        $user  = $this->_em->find(User::CLASSNAME, $userId);
-        $tweet = $this->_em->getReference(Tweet::CLASSNAME, $tweetId);
-
-        $user->tweets->removeElement($this->_em->getReference(Tweet::CLASSNAME, $tweetId));
-
-        $this->_em->clear();
-
-        /* @var $tweet Tweet */
-        $tweet = $this->_em->find(Tweet::CLASSNAME, $tweet->id);
-        $this->assertInstanceOf(
-            Tweet::CLASSNAME,
-            $tweet,
-            'Even though the collection is extra lazy, the tweet should not have been deleted'
-        );
-
-        $this->assertNull($tweet->author);
-
-        /* @var $user User */
-        $user = $this->_em->find(User::CLASSNAME, $userId);
-
-        $this->assertCount(0, $user->tweets);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -730,7 +730,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
             'Even though the collection is extra lazy, the tweet should not have been deleted'
         );
 
-        $this->assertNull($tweet->author);
+        $this->assertInstanceOf(User::CLASSNAME, $tweet->author);
 
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -369,8 +369,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user->articles->removeElement($article);
 
         $this->assertFalse($user->articles->isInitialized(), "Post-Condition: Collection is not initialized.");
-        // NOTE: +2 queries because CmsArticle is a versioned entity, and that needs to be handled accordingly
-        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
 
         // Test One to Many removal with Entity state as new
         $article = new \Doctrine\Tests\Models\CMS\CmsArticle();
@@ -391,7 +390,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $user->articles->removeElement($article);
 
-        $this->assertEquals($queryCount, $this->getCurrentQueryCount(), "Removing a persisted entity will not cause queries when the owning side doesn't actually change.");
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount(), "Removing a persisted entity should cause one query to be executed.");
         $this->assertFalse($user->articles->isInitialized(), "Post-Condition: Collection is not initialized.");
 
         // Test One to Many removal with Entity state as managed
@@ -847,7 +846,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);
 
-        $user->tweets->removeElement($this->_em->find(UserList::CLASSNAME, $userListId));
+        $user->userLists->removeElement($this->_em->find(UserList::CLASSNAME, $userListId));
 
         $this->_em->clear();
 
@@ -900,7 +899,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /* @var $user User */
         $user = $this->_em->find(User::CLASSNAME, $userId);
 
-        $user->tweets->removeElement($this->_em->getReference(UserList::CLASSNAME, $userListId));
+        $user->userLists->removeElement($this->_em->getReference(UserList::CLASSNAME, $userListId));
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -741,51 +741,6 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     /**
      * @group DDC-3343
      */
-    public function testRemovesManagedElementFromOneToManyExtraLazyCollection()
-    {
-        list($userId, $tweetId) = $this->loadTweetFixture();
-
-        /* @var $user User */
-        $user = $this->_em->find(User::CLASSNAME, $userId);
-
-        $user->tweets->removeElement($this->_em->find(Tweet::CLASSNAME, $tweetId));
-
-        $this->_em->clear();
-
-        /* @var $user User */
-        $user = $this->_em->find(User::CLASSNAME, $userId);
-
-        $this->assertCount(0, $user->tweets);
-    }
-
-    /**
-     * @group DDC-3343
-     */
-    public function testRemovesManagedElementFromOneToManyExtraLazyCollectionWithoutDeletingTheTargetEntityEntry()
-    {
-        list($userId, $tweetId) = $this->loadTweetFixture();
-
-        /* @var $user User */
-        $user  = $this->_em->find(User::CLASSNAME, $userId);
-
-        $user->tweets->removeElement($this->_em->find(Tweet::CLASSNAME, $tweetId));
-
-        $this->_em->clear();
-
-        /* @var $tweet Tweet */
-        $tweet = $this->_em->find(Tweet::CLASSNAME, $tweetId);
-        $this->assertInstanceOf(
-            Tweet::CLASSNAME,
-            $tweet,
-            'Even though the collection is extra lazy, the tweet should not have been deleted'
-        );
-
-        $this->assertNull($tweet->author, 'Tweet author link has been removed');
-    }
-
-    /**
-     * @group DDC-3343
-     */
     public function testRemoveOrphanedManagedElementFromOneToManyExtraLazyCollection()
     {
         list($userId, $userListId) = $this->loadUserListFixture();

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -28,6 +28,7 @@ class ExtraLazyCollectionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->useModelSet('tweet');
         $this->useModelSet('cms');
+        $this->useModelSet('tweet');
         parent::setUp();
 
         $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -280,6 +280,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
         if (isset($this->_usedModelSets['tweet'])) {
             $conn->executeUpdate('DELETE FROM tweet_tweet');
+            $conn->executeUpdate('DELETE FROM tweet_user_list');
             $conn->executeUpdate('DELETE FROM tweet_user');
         }
         if (isset($this->_usedModelSets['legacy'])) {

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -166,6 +166,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Taxi\Car',
             'Doctrine\Tests\Models\Taxi\Driver',
         ),
+        'tweet' => array(
+            'Doctrine\Tests\Models\Tweet\User',
+            'Doctrine\Tests\Models\Tweet\Tweet',
+            'Doctrine\Tests\Models\Tweet\UserList',
+        ),
     );
 
     /**
@@ -303,6 +308,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM taxi_ride');
             $conn->executeUpdate('DELETE FROM taxi_car');
             $conn->executeUpdate('DELETE FROM taxi_driver');
+        }
+
+        if (isset($this->_usedModelSets['tweet'])) {
+            $conn->executeUpdate('DELETE FROM tweet_tweet');
+            $conn->executeUpdate('DELETE FROM tweet_user_list');
+            $conn->executeUpdate('DELETE FROM tweet_user');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
As per #1169 and DDC-3343 ( http://www.doctrine-project.org/jira/browse/DDC-3343 ), `EXTRA_LAZY` `PersistentCollection#removeElement()` calls should only affect the database if `orphanRemoval=true` is specified in the mappings.

Otherwise, being the `one-to-many` the inverse side, no action should be performed.
