### PR TITLE
Add failing test with ToOne SL2 association

### DIFF
--- a/tests/Doctrine/Tests/Models/Cache/Client.php
+++ b/tests/Doctrine/Tests/Models/Cache/Client.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Doctrine\Tests\Models\Cache;
+
+/**
+ * @Entity
+ * @Table("cache_client")
+ */
+class Client
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @Column(unique=true)
+     */
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($nae)
+    {
+        $this->name = $nae;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Cache/Token.php
+++ b/tests/Doctrine/Tests/Models/Cache/Token.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Doctrine\Tests\Models\Cache;
+
+/**
+ * @Entity
+ * @Cache("READ_ONLY")
+ * @Table("cache_token")
+ */
+class Token
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="string")
+     */
+    protected $token;
+
+    /**
+     * @Column(type="date")
+     */
+    protected $expiresAt;
+
+    /**
+     * @OneToOne(targetEntity="Client")
+     */
+    protected $client;
+
+    public function __construct($token, Client $client = null)
+    {
+        $this->token     = $token;
+        $this->client    = $client;
+        $this->expiresAt = new \DateTime(date('Y-m-d H:i:s', strtotime("+7 day")));
+    }
+
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
+    }
+
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    public function setToken($token)
+    {
+        $this->token = $token;
+    }
+
+    public function setExpiresAt(DateTime $expiresAt)
+    {
+        $this->expiresAt = $expiresAt;
+    }
+
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Tests\Models\Cache\Client;
+use Doctrine\Tests\Models\Cache\Token;
 use Doctrine\Tests\Models\Cache\Traveler;
 use Doctrine\Tests\Models\Cache\TravelerProfile;
 use Doctrine\Tests\Models\Cache\TravelerProfileInfo;
@@ -187,4 +189,32 @@ class SecondLevelCacheOneToOneTest extends SecondLevelCacheAbstractTest
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
     }
 
+    public function testPutAndLoadNonCacheableOneToOne()
+    {
+        $this->assertNull($this->cache->getEntityCacheRegion(Client::CLASSNAME));
+        $this->assertInstanceOf('Doctrine\ORM\Cache\Region', $this->cache->getEntityCacheRegion(Token::CLASSNAME));
+
+        $client = new Client('FabioBatSilva');
+        $token  = new Token('token-hash', $client);
+
+        $this->_em->persist($client);
+        $this->_em->persist($token);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+
+        $this->assertTrue($this->cache->containsEntity(Token::CLASSNAME, $token->getToken()));
+        $this->assertFalse($this->cache->containsEntity(Client::CLASSNAME, $client->getId()));
+
+        $entity = $this->_em->find(Token::CLASSNAME, $token->getToken());
+
+        $this->assertInstanceOf(Token::CLASSNAME, $entity);
+        $this->assertInstanceOf(Client::CLASSNAME, $entity->getClient());
+        $this->assertEquals('token-hash', $entity->getToken());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
+
+        $this->assertEquals('FabioBatSilva', $entity->getClient()->getName());
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+    }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -180,6 +180,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Cache\Beach',
             'Doctrine\Tests\Models\Cache\Bar',
             'Doctrine\Tests\Models\Cache\Flight',
+            'Doctrine\Tests\Models\Cache\Token',
+            'Doctrine\Tests\Models\Cache\Client',
             'Doctrine\Tests\Models\Cache\AttractionInfo',
             'Doctrine\Tests\Models\Cache\AttractionContactInfo',
             'Doctrine\Tests\Models\Cache\AttractionLocationInfo'
@@ -408,6 +410,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM cache_city');
             $conn->executeUpdate('DELETE FROM cache_state');
             $conn->executeUpdate('DELETE FROM cache_country');
+            $conn->executeUpdate('DELETE FROM cache_token');
+            $conn->executeUpdate('DELETE FROM cache_client');
         }
 
         if (isset($this->_usedModelSets['ddc3346'])) {


### PR DESCRIPTION
Hi,

This failing test is based on @FabioBatSilva tests here (https://github.com/FabioBatSilva/doctrine2/blob/4f7e71963f5197235fce9f87a56b02bbbba46026/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php).

I've changed the test so that on Token association, there is no @Cache annotation.

The default behaviour would be to Doctrine set a proxy on non-cached association. Instead, it basically creates a "partial" object where any associations without the @Cache is set to null. I'm pretty sure it works the same ManyToOne association too.
