### PR TITLE
make QueryBuilder::getAllAliases public

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -473,7 +473,7 @@ class QueryBuilder
      * </code>
      * @return array
      */
-    private function getAllAliases() {
+    public function getAllAliases() {
         return array_merge($this->getRootAliases(),array_keys($this->joinRootAliases));
     }
 

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1120,4 +1120,26 @@ class QueryBuilderTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals($dql, $dql2);
     }
+
+    public function testGetAllAliasesWithNoJoins()
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('u')->from('Doctrine\Tests\Models\CMS\CmsUser', 'u');
+
+        $aliases = $qb->getAllAliases();
+
+        $this->assertEquals(['u'], $aliases);
+    }
+
+    public function testGetAllAliasesWithJoins()
+    {
+        $qb = $this->_em->createQueryBuilder()
+            ->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->join('u.groups', 'g');
+
+        $aliases = $qb->getAllAliases();
+
+        $this->assertEquals(['u', 'g'], $aliases);
+    }
 }


### PR DESCRIPTION
Being able to get all already defined aliases in the QueryBuilder can be helpful when dynamically joining.

Funny, the DocBlock makes it seem as if this method was already public.
