### PR TITLE
[DDC-3582] Fix hydration of nested embeddables

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -91,7 +91,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
         if (null === $embeddedObject) {
             $this->instantiator = $this->instantiator ?: new Instantiator();
 
-            $embeddedObject = $this->instantiator->instantiate($this->embeddedClass);
+            $embeddedObject = $this->instantiator->instantiate($this->class);
 
             $this->parentProperty->setValue($object, $embeddedObject);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3582Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3582Test.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class DDC3582Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    function testNestedEmbeddablesAreHydratedWithProperClass()
+    {
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC3582Entity::CLASSNAME),
+            $this->_em->getClassMetadata(DDC3582Embeddable1::CLASSNAME),
+            $this->_em->getClassMetadata(DDC3582Embeddable2::CLASSNAME),
+        ]);
+
+        $this->_em->persist(new DDC3582Entity('foo'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var DDC3582Entity $entity */
+        $entity = $this->_em->find(DDC3582Entity::CLASSNAME, 'foo');
+
+        $this->assertInstanceOf(DDC3582Embeddable1::CLASSNAME, $entity->embeddable1);
+        $this->assertInstanceOf(DDC3582Embeddable2::CLASSNAME, $entity->embeddable1->embeddable2);
+    }
+}
+
+/** @Entity */
+class DDC3582Entity
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column */
+    private $id;
+
+    /** @Embedded(class="DDC3582Embeddable1") @var DDC3582Embeddable1 */
+    public $embeddable1;
+
+    function __construct($id)
+    {
+        $this->id = $id;
+        $this->embeddable1 = new DDC3582Embeddable1();
+    }
+}
+
+/** @Embeddable */
+class DDC3582Embeddable1
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Column */
+    public $embeddedValue1 = 'foo';
+
+    /** @Embedded(class="DDC3582Embeddable2") @var DDC3582Embeddable2 */
+    public $embeddable2;
+    public function __construct() { $this->embeddable2 = new DDC3582Embeddable2(); }
+}
+
+/** @Embeddable */
+class DDC3582Embeddable2
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Column */
+    public $embeddedValue2 = 'foo';
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -81,18 +81,6 @@ class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
                 ),
                 'Doctrine\\Tests\\Models\\Generic\\BooleanModel'
             ),
-            // reflection on embeddables that have properties defined in abstract ancestors:
-            array(
-                $this->getReflectionProperty(
-                    'Doctrine\\Tests\\Models\\Generic\\BooleanModel',
-                    'id'
-                ),
-                $this->getReflectionProperty(
-                    'Doctrine\\Tests\\Models\\Reflection\\AbstractEmbeddable',
-                    'propertyInAbstractClass'
-                ),
-                'Doctrine\\Tests\\Models\\Reflection\\ConcreteEmbeddable'
-            ),
             array(
                 $this->getReflectionProperty(
                     'Doctrine\\Tests\\Models\\Generic\\BooleanModel',


### PR DESCRIPTION
The wrong class is chosen when hydrating embeddables that are part of a nested structure. See `DDC3582Test` for a demonstration. The fix is to use `class` instead of `embeddedClass` to instantiate the embeddable in ReflectionEmbeddedProperty.

The test I removed from ReflectionEmbeddedPropertyTest was failing because you cannot instantiate an abstract class (and rightfully so). However, as this would not be possible in practice anyway (you always end up extending the abstract class), I think this test can be removed safely. 
