### PR TITLE
Add proper pluralization into UpdateCommand

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -131,7 +131,10 @@ EOT
         	}
             $output->writeln('Updating database schema...');
             $schemaTool->updateSchema($metadatas, $saveMode);
-            $output->writeln(sprintf('Database schema updated successfully! "<info>%s</info>" queries were executed', count($sqls)));
+
+            $pluralization = (1 === count($sqls)) ? 'query was' : 'queries were';
+
+            $output->writeln(sprintf('Database schema updated successfully! "<info>%s</info>" %s executed', count($sqls), $pluralization));
         }
 
         if ($dumpSql || $force) {


### PR DESCRIPTION
This alters the UpdateCommand so that if only 1 query is was executed, it will say so.

Rather than "1 queries were executed"
