### PR TITLE
Fixed broken url for implementing Serializable interface

### DIFF
--- a/docs/en/reference/architecture.rst
+++ b/docs/en/reference/architecture.rst
@@ -83,7 +83,7 @@ be any regular PHP class observing the following restrictions:
 -  An entity class must not implement ``__wakeup`` or
    :doc:`do so safely <../cookbook/implementing-wakeup-or-clone>`.
    Also consider implementing
-   `Serializable <http://de3.php.net/manual/en/class.serializable.php>`_
+   `Serializable <http://php.net/manual/en/class.serializable.php>`_
    instead.
 -  Any two entity classes in a class hierarchy that inherit
    directly or indirectly from one another must not have a mapped


### PR DESCRIPTION
Fixed a broken url for implementing the Serializable interface. The link was pointing to an outdated German version of php.net manual.
