### PR TITLE
load all many to many join columns

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -514,9 +514,9 @@ class YamlDriver extends FileDriver
                             if ( ! isset($joinColumnElement['name'])) {
                                 $joinColumnElement['name'] = $joinColumnName;
                             }
+                            
+                            $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumnElement);
                         }
-
-                        $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumnElement);
                     }
 
                     if (isset($joinTableElement['inverseJoinColumns'])) {
@@ -524,9 +524,9 @@ class YamlDriver extends FileDriver
                             if ( ! isset($joinColumnElement['name'])) {
                                 $joinColumnElement['name'] = $joinColumnName;
                             }
+                            
+                            $joinTable['inverseJoinColumns'][] = $this->joinColumnToArray($joinColumnElement);
                         }
-
-                        $joinTable['inverseJoinColumns'][] = $this->joinColumnToArray($joinColumnElement);
                     }
 
                     $mapping['joinTable'] = $joinTable;


### PR DESCRIPTION
the `$joinColumnElement` variable is created inside the foreach loop, and used only after it finishes, causing only the last join column to be loaded.
