### PR TITLE
Properly generate default value from yml & xml mapping

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1312,7 +1312,7 @@ public function __construct(<params>)
 
             $lines[] = $this->generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
             $lines[] = $this->spaces . $this->fieldVisibility . ' $' . $fieldMapping['fieldName']
-                     . (isset($fieldMapping['default']) ? ' = ' . var_export($fieldMapping['default'], true) : null) . ";\n";
+                     . (isset($fieldMapping['options']['default']) ? ' = ' . var_export($fieldMapping['options']['default'], true) : null) . ";\n";
         }
 
         return implode("\n", $lines);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -64,7 +64,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata->table['uniqueConstraints']['name_uniq'] = array('columns' => array('name'));
         $metadata->table['indexes']['status_idx'] = array('columns' => array('status'));
         $metadata->mapField(array('fieldName' => 'name', 'type' => 'string'));
-        $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'default' => 'published'));
+        $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'options' => array('default' => 'published')));
         $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $metadata->mapOneToOne(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor', 'mappedBy' => 'book'));
         $joinColumns = array(


### PR DESCRIPTION
Yaml & Xml mapping which define default value for a field aren't properly generated in the entity class by the `EntityGenerator`.

This is how the documentation says to define a default value in [xml](http://doctrine-orm.readthedocs.org/en/latest/reference/xml-mapping.html):

``` xml
<field name="login_count" type="integer" nullable="false">
    <options>
        <option name="default">0</option>
    </options>
</field>
```

and in [yml](http://doctrine-orm.readthedocs.org/en/latest/reference/yaml-mapping.html):

``` yaml
    loginCount:
      type: integer
      column: login_count
      nullable: false
      options:
        default: 0
```

Both generates this field mapping (aka `$fieldMapping`):

``` php
array(5) {
  'fieldName' =>
  string(11) "login_count"
  'type' =>
  string(7) "integer"
  'nullable' =>
  bool(false)
  'options' =>
  array(1) {
    'default' =>
    string(1) "0"
  }
  'columnName' =>
  string(11) "login_count"
}
```

But the `EntityGenerator` check the default value in the wrong place, in `$fieldMapping['default']` instead of `$fieldMapping['options']['default']`.

This is related to :
- this JIRA ticket: http://www.doctrine-project.org/jira/browse/DDC-2809
- this PR https://github.com/doctrine/doctrine2/pull/853
