### PR TITLE
Fix for inconsistent use of getSQLDeclaration

### DIFF
--- a/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
+++ b/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
@@ -150,7 +150,7 @@ Now we're going to create the ``point`` type and implement all required methods.
             return self::POINT;
         }
 
-        public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+        public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             return 'POINT';
         }

--- a/docs/en/cookbook/custom-mapping-types.rst
+++ b/docs/en/cookbook/custom-mapping-types.rst
@@ -24,7 +24,7 @@ you wish. Here is an example skeleton of such a custom type class:
     {
         const MYTYPE = 'mytype'; // modify to match your type name
     
-        public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+        public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             // return the SQL used to create your column type. To create a portable column type, use the $platform.
         }

--- a/docs/en/cookbook/mysql-enums.rst
+++ b/docs/en/cookbook/mysql-enums.rst
@@ -148,7 +148,7 @@ You can generalize this approach easily to create a base class for enums:
         protected $name;
         protected $values = array();
 
-        public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+        public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             $values = array_map(function($val) { return "'".$val."'"; }, $this->values);
 

--- a/docs/en/cookbook/mysql-enums.rst
+++ b/docs/en/cookbook/mysql-enums.rst
@@ -96,7 +96,7 @@ For example for the previous enum type:
         const STATUS_VISIBLE = 'visible';
         const STATUS_INVISIBLE = 'invisible';
 
-        public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+        public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
             return "ENUM('visible', 'invisible') COMMENT '(DC2Type:enumvisibility)'";
         }


### PR DESCRIPTION
I found an inconsistency in naming of the getSQLDeclaration method
I changed in 5 files `getSqlDeclaration` -> `getSQLDeclaration`

Pull request is related to: https://github.com/doctrine/dbal/pull/815
