### PR TITLE
Fix @Column options sections in documentation

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -129,8 +129,7 @@ Optional attributes:
    -  ``comment``: The comment of the column in the schema (might not
       be supported by all vendors).
 
-   -  ``customSchemaOptions``: Array of additional schema options
-      which are mostly vendor specific.
+   -  ``collation``: The collation of the column (only supported by Drizzle, Mysql, PostgreSQL>=9.1, Sqlite and SQLServer).
 
 -  **columnDefinition**: DDL SQL snippet that starts after the column
    name and specifies the complete (non-portable!) column definition.


### PR DESCRIPTION
I lose hours to find out how to make column collation works, mostly because of incorrect docs.

Annotations options is the equivalent of customSchemaOptions in https://github.com/doctrine/dbal/blob/master/docs/en/reference/schema-representation.rst

See https://github.com/doctrine/doctrine2/blob/d1e5034659e7beeb11830417a4a38de6586fe960/lib/Doctrine/ORM/Tools/SchemaTool.php#L443
