### PR TITLE
[Small Enhancement] Make scalar field separator overwritable

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -336,7 +336,7 @@ abstract class AbstractHydrator
             if ( ! isset($cacheKeyInfo['isScalar'])) {
                 $dqlAlias  = $cacheKeyInfo['dqlAlias'];
                 $type      = $cacheKeyInfo['type'];
-                $fieldName = $dqlAlias . '_' . $fieldName;
+                $fieldName = $dqlAlias . $this->getScalarFieldSeparator() . $fieldName;
                 $value     = $type
                     ? $type->convertToPHPValue($value, $this->_platform)
                     : $value;
@@ -346,6 +346,15 @@ abstract class AbstractHydrator
         }
 
         return $rowData;
+    }
+    
+    /**
+     * Return separation string used to generate scalar result keys
+     * @return string
+     */
+    protected function getScalarFieldSeparator()
+    {
+        return '_';
     }
 
     /**


### PR DESCRIPTION
I would like to have a custom Hydrator extending ScalarHydrator just to change field separator ('_'), but I dont want to overwrite all method.
It's not very risky to make it extensible.
