### PR TITLE
Allow DateTimeImmutable as parameter value

### DIFF
--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -53,7 +53,7 @@ class ParameterTypeInferer
             return Type::BOOLEAN;
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
             return Type::DATETIME;
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -28,7 +28,7 @@ class ParameterTypeInfererTest extends \Doctrine\Tests\OrmTestCase
 
     public function providerParameterTypeInferer()
     {
-         return array(
+         $data = array(
             array(1,                 Type::INTEGER),
             array("bar",             PDO::PARAM_STR),
             array("1",               PDO::PARAM_STR),
@@ -39,6 +39,10 @@ class ParameterTypeInfererTest extends \Doctrine\Tests\OrmTestCase
             array(array(),           Connection::PARAM_STR_ARRAY),
             array(true,              Type::BOOLEAN),
         );
+        if(PHP_VERSION_ID >= 50500) {
+            $data[] = array(new \DateTimeImmutable(), Type::DATETIME);
+        }
+        return $data;
     }
 
     /**


### PR DESCRIPTION
This pull request allows passing instance of DateTimeImmutable as value to `setParameter` and its correct formating in query.
