### PR TITLE
Changed some wrong usage of the @internal phpdoc

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -42,8 +42,9 @@ use Doctrine\ORM\Repository\RepositoryFactory;
  * Configuration container for all configuration options of Doctrine.
  * It combines all configuration options from DBAL & ORM.
  *
+ * Internal note: When adding a new configuration option just write a getter/setter pair.
+ *
  * @since 2.0
- * @internal When adding a new configuration option just write a getter/setter pair.
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -270,11 +270,11 @@ use Doctrine\Common\Util\ClassUtils;
      * MyProject\Domain\User
      * sales:PriceRequest
      *
+     * Internal note: Performance-sensitive method.
+     *
      * @param string $className
      *
      * @return \Doctrine\ORM\Mapping\ClassMetadata
-     *
-     * @internal Performance-sensitive method.
      */
     public function getClassMetadata($className)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -33,12 +33,12 @@ use Doctrine\ORM\Proxy\Proxy;
 /**
  * The ObjectHydrator constructs an object graph out of an SQL result set.
  *
+ * Internal note: Highly performance-sensitive code.
+ *
  * @since  2.0
  * @author Roman Borschel <roman@code-factory.org>
  * @author Guilherme Blanco <guilhermeblanoc@hotmail.com>
  * @author Fabio B. Silva <fabio.bat.silva@gmail.com>
- *
- * @internal Highly performance-sensitive code.
  */
 class ObjectHydrator extends AbstractHydrator
 {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -707,10 +707,10 @@ final class PersistentCollection implements Collection, Selectable
      * Called by PHP when this collection is serialized. Ensures that only the
      * elements are properly serialized.
      *
-     * @return array
+     * Internal note: Tried to implement Serializable first but that did not work well
+     *                with circular references. This solution seems simpler and works well.
      *
-     * @internal Tried to implement Serializable first but that did not work well
-     *           with circular references. This solution seems simpler and works well.
+     * @return array
      */
     public function __sleep()
     {

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -376,9 +376,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
     /**
      * {@inheritdoc}
      *
+     * Internal note: Order of the parameters must be the same as the order of the columns in getDeleteSql.
      * @override
-     *
-     * @internal Order of the parameters must be the same as the order of the columns in getDeleteSql.
      */
     protected function getDeleteSQLParameters(PersistentCollection $collection)
     {
@@ -440,7 +439,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * Gets the SQL parameters for the corresponding SQL statement to delete the given
      * element from the given collection.
      *
-     * @internal Order of the parameters must be the same as the order of the columns in getDeleteRowSql.
+     * Internal note: Order of the parameters must be the same as the order of the columns in getDeleteRowSql.
      *
      * @param \Doctrine\ORM\PersistentCollection $collection
      * @param mixed                              $element
@@ -491,7 +490,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * Gets the SQL parameters for the corresponding SQL statement to insert the given
      * element of the given collection into the database.
      *
-     * @internal Order of the parameters must be the same as the order of the columns in getInsertRowSql.
+     * Internal note: Order of the parameters must be the same as the order of the columns in getInsertRowSql.
      *
      * @param \Doctrine\ORM\PersistentCollection $collection
      * @param mixed                              $element

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -51,11 +51,11 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
     /**
      * Initializes a new <tt>MultiTableDeleteExecutor</tt>.
      *
+     * Internal note: Any SQL construction and preparation takes place in the constructor for
+     *                best performance. With a query cache the executor will be cached.
+     *
      * @param \Doctrine\ORM\Query\AST\Node  $AST       The root AST node of the DQL query.
      * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker The walker used for SQL generation from the AST.
-     *
-     * @internal Any SQL construction and preparation takes place in the constructor for
-     *           best performance. With a query cache the executor will be cached.
      */
     public function __construct(AST\Node $AST, $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -62,11 +62,11 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
     /**
      * Initializes a new <tt>MultiTableUpdateExecutor</tt>.
      *
+     * Internal note: Any SQL construction and preparation takes place in the constructor for
+     *                best performance. With a query cache the executor will be cached.
+     *
      * @param \Doctrine\ORM\Query\AST\Node  $AST The root AST node of the DQL query.
      * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker The walker used for SQL generation from the AST.
-     *
-     * @internal Any SQL construction and preparation takes place in the constructor for
-     *           best performance. With a query cache the executor will be cached.
      */
     public function __construct(AST\Node $AST, $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1578,7 +1578,7 @@ class Parser
      *
      * SubselectIdentificationVariableDeclaration ::= IdentificationVariableDeclaration
      *
-     * {@internal WARNING: Solution is harder than a bare implementation.
+     * {Internal note: WARNING: Solution is harder than a bare implementation.
      * Desired EBNF support:
      *
      * SubselectIdentificationVariableDeclaration ::= IdentificationVariableDeclaration | (AssociationPathExpression ["AS"] AliasIdentificationVariable)

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -56,13 +56,14 @@ use Doctrine\ORM\Cache\AssociationCacheEntry;
  * "object-level" transaction and for writing out changes to the database
  * in the correct order.
  *
+ * Internal note: This class contains highly performance-sensitive code.
+ *
  * @since       2.0
  * @author      Benjamin Eberlei <kontakt@beberlei.de>
  * @author      Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author      Jonathan Wage <jonwage@gmail.com>
  * @author      Roman Borschel <roman@code-factory.org>
  * @author      Rob Caiger <rob@clocal.co.uk>
- * @internal    This class contains highly performance-sensitive code.
  */
 class UnitOfWork implements PropertyChangedListener
 {
@@ -120,10 +121,11 @@ class UnitOfWork implements PropertyChangedListener
      * Keys are object ids (spl_object_hash). This is used for calculating changesets
      * at commit time.
      *
+     * Internal note: Note that PHPs "copy-on-write" behavior helps a lot with memory usage.
+     *                A value will only really be copied if the value in the entity is modified
+     *                by the user.
+     *
      * @var array
-     * @internal Note that PHPs "copy-on-write" behavior helps a lot with memory usage.
-     *           A value will only really be copied if the value in the entity is modified
-     *           by the user.
      */
     private $originalEntityData = array();
 
@@ -2474,6 +2476,8 @@ class UnitOfWork implements PropertyChangedListener
      * INTERNAL:
      * Creates an entity. Used for reconstitution of persistent entities.
      *
+     * Internal note: Highly performance-sensitive method.
+     *
      * @ignore
      *
      * @param string $className The name of the entity class.
@@ -2481,8 +2485,6 @@ class UnitOfWork implements PropertyChangedListener
      * @param array  $hints     Any hints to account for during reconstitution/lookup of the entity.
      *
      * @return object The managed entity instance.
-     *
-     * @internal Highly performance-sensitive method.
      *
      * @todo Rename: getOrCreateEntity
      */


### PR DESCRIPTION
With this PR I removed/moved some @internal phpdocs as they weren't "real" internal tags, but more like internal info which ocramius and beberlei pointed out to me on the IRC channel. 
The use of the @internal phpdoc shows in IDE's as if the method/class should not be used and that's not true is most of the cases
