### PR TITLE
Fix AbstractQuery::getParameter() documented return type

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -320,7 +320,7 @@ abstract class AbstractQuery
      *
      * @param mixed $key The key (index or name) of the bound parameter.
      *
-     * @return mixed The value of the bound parameter.
+     * @return Query\Parameter|null The value of the bound parameter, or NULL if not available.
      */
     public function getParameter($key)
     {


### PR DESCRIPTION
[As documented](https://github.com/doctrine/doctrine2/blob/master/UPGRADE.md#query-querybuilder-and-nativequery-parameters-bc-break), `getParameter()` always returns a `Query\Parameter` (or `NULL`).
