### PR TITLE
[DDC-3619] Update identityMap when entity gets managed again

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1682,6 +1682,7 @@ class UnitOfWork implements PropertyChangedListener
             case self::STATE_REMOVED:
                 // Entity becomes managed again
                 unset($this->entityDeletions[$oid]);
+                $this->addToIdentityMap($entity);
 
                 $this->entityStates[$oid] = self::STATE_MANAGED;
                 break;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3619Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3619Test.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class DDC3619Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setup()
+    {
+        parent::setup();
+
+        $this->_schemaTool->createSchema(
+            array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3619Entity'),
+            )
+        );
+    }
+
+    public function testIssue()
+    {
+        $uow = $this->_em->getUnitOfWork();
+
+        $entity = new DDC3619Entity();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->assertTrue($uow->isInIdentityMap($entity));
+
+        $this->_em->remove($entity);
+        $this->assertFalse($uow->isInIdentityMap($entity));
+
+        $this->_em->persist($entity);
+        $this->assertTrue($uow->isInIdentityMap($entity));
+    }
+}
+
+/**
+ * @Entity()
+ */
+class DDC3619Entity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+}


### PR DESCRIPTION
http://www.doctrine-project.org/jira/browse/DDC-3619

When using SoftDeleteable doctrine extension, an entity can be scheduled
for deletion, then persisted before flushing. In such a case, the entity
was removed from the unit of work identity map and no reference was
hold. This could lead to spl_object_hash collisions, and prevent
another, new entity to be persisted later.

This fix makes sure the unit of work identity map holds a reference to
the entity after it has been soft-deleted.
