### PR TITLE
Paginator functional tests

### DIFF
--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Company.php
+ * Created by William Schaller
+ * Date: 3/19/2015
+ * Time: 9:39 PM
+ */
+namespace Doctrine\Tests\Models\Pagination;
+
+/**
+ * Company
+ *
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity
+ * @Table(name="pagination_company")
+ */
+class Company
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @OneToOne(targetEntity="Logo", mappedBy="company", cascade={"persist"}, orphanRemoval=true)
+     */
+    public $logo;
+}

--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Company.php
- * Created by William Schaller
- * Date: 3/19/2015
- * Time: 9:39 PM
- */
 namespace Doctrine\Tests\Models\Pagination;
 
 /**
@@ -12,6 +6,7 @@ namespace Doctrine\Tests\Models\Pagination;
  *
  * @package Doctrine\Tests\Models\Pagination
  *
+ * @author Bill Schaller
  * @Entity
  * @Table(name="pagination_company")
  */

--- a/tests/Doctrine/Tests/Models/Pagination/Logo.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Logo.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Logo.php
+ * Created by William Schaller
+ * Date: 3/19/2015
+ * Time: 9:44 PM
+ */
+namespace Doctrine\Tests\Models\Pagination;
+
+/**
+ * Logo
+ *
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity
+ * @Table(name="pagination_logo")
+ */
+class Logo
+{
+    /**
+     * @Column(type="integer") @Id
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $image;
+
+    /**
+     * @Column(type="integer")
+     */
+    public $image_height;
+
+    /**
+     * @Column(type="integer")
+     */
+    public $image_width;
+
+    /**
+     * @OneToOne(targetEntity="Company", inversedBy="logo", cascade={"persist"})
+     * @JoinColumn(name="company_id")
+     */
+    public $company;
+}

--- a/tests/Doctrine/Tests/Models/Pagination/Logo.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Logo.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Logo.php
- * Created by William Schaller
- * Date: 3/19/2015
- * Time: 9:44 PM
- */
 namespace Doctrine\Tests\Models\Pagination;
 
 /**
@@ -12,6 +6,7 @@ namespace Doctrine\Tests\Models\Pagination;
  *
  * @package Doctrine\Tests\Models\Pagination
  *
+ * @Author Bill Schaller
  * @Entity
  * @Table(name="pagination_logo")
  */

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -29,7 +29,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testCountSimpleWithoutJoin($useOutputWalkers)
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -42,7 +42,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testCountWithFetchJoin($useOutputWalkers)
     {
-        $dql = "SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g";
+        $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -52,7 +52,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testCountComplexWithOutputWalker()
     {
-        $dql = "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0";
+        $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -60,12 +60,9 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(3, $paginator);
     }
 
-    /**
-     * @expectedException
-     */
     public function testCountComplexWithoutOutputWalker()
     {
-        $dql = "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0";
+        $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -96,7 +93,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testIterateSimpleWithoutJoin($useOutputWalkers, $fetchJoinCollection)
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query, $fetchJoinCollection);
@@ -116,8 +113,9 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(3, $paginator->getIterator());
     }
 
-    private function iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    private function iterateWithOrderAsc($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
     {
+
         // Ascending
         $dql = "$baseDql ASC";
         $query = $this->_em->createQuery($dql);
@@ -128,6 +126,14 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(9, $iter);
         $result = iterator_to_array($iter);
         $this->assertEquals($checkField . "0", $result[0]->$checkField);
+    }
+
+    private function iterateWithOrderAscWithLimit($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    {
+
+        // Ascending
+        $dql = "$baseDql ASC";
+        $query = $this->_em->createQuery($dql);
 
         // With limit
         $query->setMaxResults(3);
@@ -137,6 +143,13 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(3, $iter);
         $result = iterator_to_array($iter);
         $this->assertEquals($checkField . "0", $result[0]->$checkField);
+    }
+
+    private function iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    {
+        // Ascending
+        $dql = "$baseDql ASC";
+        $query = $this->_em->createQuery($dql);
 
         // With offset
         $query->setMaxResults(3)->setFirstResult(3);
@@ -146,8 +159,10 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(3, $iter);
         $result = iterator_to_array($iter);
         $this->assertEquals($checkField . "3", $result[0]->$checkField);
+    }
 
-        // Descending
+    private function iterateWithOrderDesc($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    {
         $dql = "$baseDql DESC";
         $query = $this->_em->createQuery($dql);
 
@@ -157,6 +172,12 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(9, $iter);
         $result = iterator_to_array($iter);
         $this->assertEquals($checkField . "8", $result[0]->$checkField);
+    }
+
+    private function iterateWithOrderDescWithLimit($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    {
+        $dql = "$baseDql DESC";
+        $query = $this->_em->createQuery($dql);
 
         // With limit
         $query->setMaxResults(3);
@@ -166,6 +187,12 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(3, $iter);
         $result = iterator_to_array($iter);
         $this->assertEquals($checkField . "8", $result[0]->$checkField);
+    }
+
+    private function iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
+    {
+        $dql = "$baseDql DESC";
+        $query = $this->_em->createQuery($dql);
 
         // With offset
         $query->setMaxResults(3)->setFirstResult(3);
@@ -183,8 +210,31 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIterateSimpleWithoutJoinWithOrder($useOutputWalkers, $fetchJoinCollection)
     {
         // Ascending
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.username";
-        $this->iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.username';
+        $this->iterateWithOrderAsc($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDesc($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateSimpleWithoutJoinWithOrderAndLimit($useOutputWalkers, $fetchJoinCollection)
+    {
+        // Ascending
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.username';
+        $this->iterateWithOrderAscWithLimit($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDescWithLimit($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateSimpleWithoutJoinWithOrderAndLimitAndOffset($useOutputWalkers, $fetchJoinCollection)
+    {
+        // Ascending
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.username';
+        $this->iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $dql, "username");
     }
 
     /**
@@ -193,8 +243,31 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIterateSimpleWithOutputWalkerWithoutJoinWithComplexOrder($fetchJoinCollection)
     {
         // Ascending
-        $dql = "SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height";
-        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "image");
+        $dql = 'SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAsc(true, $fetchJoinCollection, $dql, "image");
+        $this->iterateWithOrderDesc(true, $fetchJoinCollection, $dql, "image");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateSimpleWithOutputWalkerWithoutJoinWithComplexOrderAndLimit($fetchJoinCollection)
+    {
+        // Ascending
+        $dql = 'SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAscWithLimit(true, $fetchJoinCollection, $dql, "image");
+        $this->iterateWithOrderDescWithLimit(true, $fetchJoinCollection, $dql, "image");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateSimpleWithOutputWalkerWithoutJoinWithComplexOrderAndLimitAndOffset($fetchJoinCollection)
+    {
+        // Ascending
+        $dql = 'SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAscWithLimitAndOffset(true, $fetchJoinCollection, $dql, "image");
+        $this->iterateWithOrderDescWithLimitAndOffset(true, $fetchJoinCollection, $dql, "image");
     }
 
     /**
@@ -202,7 +275,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testIterateWithFetchJoin($useOutputWalkers)
     {
-        $dql = "SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g";
+        $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query, true);
@@ -216,7 +289,28 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIterateWithFetchJoinWithOrder($useOutputWalkers)
     {
         $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g ORDER BY u.username';
-        $this->iterateWithOrder($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderAsc($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDesc($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrderAndLimit($useOutputWalkers)
+    {
+        $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g ORDER BY u.username';
+        $this->iterateWithOrderAscWithLimit($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDescWithLimit($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrderAndLimitAndOffset($useOutputWalkers)
+    {
+        $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g ORDER BY u.username';
+        $this->iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, true, $dql, "username");
     }
 
     /**
@@ -225,7 +319,28 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIterateWithRegularJoinWithOrderByColumnFromJoined($useOutputWalkers, $fetchJoinCollection)
     {
         $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e ORDER BY e.email';
-        $this->iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderAsc($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDesc($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateWithRegularJoinWithOrderByColumnFromJoinedWithLimit($useOutputWalkers, $fetchJoinCollection)
+    {
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrderAscWithLimit($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDescWithLimit($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateWithRegularJoinWithOrderByColumnFromJoinedWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection)
+    {
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+        $this->iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $dql, "username");
     }
 
     /**
@@ -235,8 +350,33 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         // long function name is loooooooooooong
 
-        $dql = "SELECT c FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_height * l.image_width";
-        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "name");
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_height * l.image_width';
+        $this->iterateWithOrderAsc(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDesc(true, $fetchJoinCollection, $dql, "name");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithRegularJoinWithComplexOrderByReferencingJoinedWithLimit($fetchJoinCollection)
+    {
+        // long function name is loooooooooooong
+
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_height * l.image_width';
+        $this->iterateWithOrderAscWithLimit(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimit(true, $fetchJoinCollection, $dql, "name");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithRegularJoinWithComplexOrderByReferencingJoinedWithLimitAndOffset($fetchJoinCollection)
+    {
+        // long function name is loooooooooooong
+
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_height * l.image_width';
+        $this->iterateWithOrderAscWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
     }
 
     /**
@@ -244,8 +384,29 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testIterateWithFetchJoinWithOrderByColumnFromJoined($useOutputWalkers)
     {
-        $dql = "SELECT u,g,e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g JOIN u.email e ORDER BY e.email";
-        $this->iterateWithOrder($useOutputWalkers, true, $dql, "username");
+        $dql = 'SELECT u,g,e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrderAsc($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDesc($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrderByColumnFromJoinedWithLimit($useOutputWalkers)
+    {
+        $dql = 'SELECT u,g,e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrderAscWithLimit($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDescWithLimit($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrderByColumnFromJoinedWithLimitAndOffset($useOutputWalkers)
+    {
+        $dql = 'SELECT u,g,e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, true, $dql, "username");
+        $this->iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, true, $dql, "username");
     }
 
     /**
@@ -253,13 +414,34 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoined($fetchJoinCollection)
     {
-        $dql = "SELECT c,l FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_width * l.image_height";
-        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "name");
+        $dql = 'SELECT c,l FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAsc(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDesc(true, $fetchJoinCollection, $dql, "name");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoinedWithLimit($fetchJoinCollection)
+    {
+        $dql = 'SELECT c,l FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAscWithLimit(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimit(true, $fetchJoinCollection, $dql, "name");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoinedWithLimitAndOffset($fetchJoinCollection)
+    {
+        $dql = 'SELECT c,l FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_width * l.image_height';
+        $this->iterateWithOrderAscWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
     }
 
     public function testIterateComplexWithOutputWalker()
     {
-        $dql = "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0";
+        $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -270,7 +452,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testDetectOutputWalker()
     {
         // This query works using the output walkers but causes an exception using the TreeWalker
-        $dql = "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0";
+        $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
         $query = $this->_em->createQuery($dql);
 
         // If the Paginator detects the custom output walker it should fall back to using the
@@ -288,7 +470,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testCloneQuery()
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';
         $query = $this->_em->createQuery($dql);
 
         $paginator = new Paginator($query);
@@ -299,7 +481,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testQueryWalkerIsKept()
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';
         $query = $this->_em->createQuery($dql);
         $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\Tests\ORM\Functional\CustomPaginationTestTreeWalker'));
 
@@ -341,7 +523,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function populate()
     {
-        $groups = [];
+        $groups = array();
         for ($j = 0; $j < 3; $j++) {;
             $group = new CmsGroup();
             $group->name = "group$j";

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -2,15 +2,13 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
-use Doctrine\Tests\Models\CMS\CmsPhonenumber;
-use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsGroup;
-use Doctrine\Tests\Models\CMS\CmsArticle;
-use Doctrine\Tests\Models\CMS\CmsComment;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\Pagination\Company;
+use Doctrine\Tests\Models\Pagination\Logo;
 use ReflectionMethod;
 
 /**
@@ -21,6 +19,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('cms');
+        $this->useModelSet('pagination');
         parent::setUp();
         $this->populate();
     }
@@ -35,7 +34,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers($useOutputWalkers);
-        $this->assertCount(3, $paginator);
+        $this->assertCount(9, $paginator);
     }
 
     /**
@@ -48,7 +47,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers($useOutputWalkers);
-        $this->assertCount(3, $paginator);
+        $this->assertCount(9, $paginator);
     }
 
     public function testCountComplexWithOutputWalker()
@@ -58,33 +57,144 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers(true);
+        $this->assertCount(3, $paginator);
+    }
+
+    /**
+     * @expectedException
+     */
+    public function testCountComplexWithoutOutputWalker()
+    {
+        $dql = "SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0";
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $paginator->setUseOutputWalkers(false);
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'Cannot count query that uses a HAVING clause. Use the output walkers for pagination'
+        );
+        $this->assertCount(3, $paginator);
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testCountWithComplexScalarOrderBy($useOutputWalkers)
+    {
+        $dql = 'SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height DESC';
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
         $this->assertCount(9, $paginator);
     }
 
     /**
-     * @dataProvider useOutputWalkers
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
      */
-    public function testIterateSimpleWithoutJoinFetchJoinHandlingOff($useOutputWalkers)
+    public function testIterateSimpleWithoutJoin($useOutputWalkers, $fetchJoinCollection)
     {
         $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $query = $this->_em->createQuery($dql);
 
-        $paginator = new Paginator($query, false);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $this->assertCount(9, $paginator->getIterator());
+
+        // Test with limit
+        $query->setMaxResults(3);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $this->assertCount(3, $paginator->getIterator());
+
+        // Test with limit and offset
+        $query->setMaxResults(3)->setFirstResult(4);
+        $paginator = new Paginator($query, $fetchJoinCollection);
         $paginator->setUseOutputWalkers($useOutputWalkers);
         $this->assertCount(3, $paginator->getIterator());
     }
 
-    /**
-     * @dataProvider useOutputWalkers
-     */
-    public function testIterateSimpleWithoutJoinFetchJoinHandlingOn($useOutputWalkers)
+    private function iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        // Ascending
+        $dql = "$baseDql ASC";
         $query = $this->_em->createQuery($dql);
 
-        $paginator = new Paginator($query, true);
+        $paginator = new Paginator($query, $fetchJoinCollection);
         $paginator->setUseOutputWalkers($useOutputWalkers);
-        $this->assertCount(3, $paginator->getIterator());
+        $iter = $paginator->getIterator();
+        $this->assertCount(9, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "0", $result[0]->$checkField);
+
+        // With limit
+        $query->setMaxResults(3);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $iter = $paginator->getIterator();
+        $this->assertCount(3, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "0", $result[0]->$checkField);
+
+        // With offset
+        $query->setMaxResults(3)->setFirstResult(3);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $iter = $paginator->getIterator();
+        $this->assertCount(3, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "3", $result[0]->$checkField);
+
+        // Descending
+        $dql = "$baseDql DESC";
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $iter = $paginator->getIterator();
+        $this->assertCount(9, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "8", $result[0]->$checkField);
+
+        // With limit
+        $query->setMaxResults(3);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $iter = $paginator->getIterator();
+        $this->assertCount(3, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "8", $result[0]->$checkField);
+
+        // With offset
+        $query->setMaxResults(3)->setFirstResult(3);
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalkers);
+        $iter = $paginator->getIterator();
+        $this->assertCount(3, $iter);
+        $result = iterator_to_array($iter);
+        $this->assertEquals($checkField . "5", $result[0]->$checkField);
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateSimpleWithoutJoinWithOrder($useOutputWalkers, $fetchJoinCollection)
+    {
+        // Ascending
+        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u ORDER BY u.username";
+        $this->iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateSimpleWithOutputWalkerWithoutJoinWithComplexOrder($fetchJoinCollection)
+    {
+        // Ascending
+        $dql = "SELECT l FROM Doctrine\Tests\Models\Pagination\Logo l ORDER BY l.image_width * l.image_height";
+        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "image");
     }
 
     /**
@@ -97,7 +207,54 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $paginator = new Paginator($query, true);
         $paginator->setUseOutputWalkers($useOutputWalkers);
-        $this->assertCount(3, $paginator->getIterator());
+        $this->assertCount(9, $paginator->getIterator());
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrder($useOutputWalkers)
+    {
+        $dql = 'SELECT u,g FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g ORDER BY u.username';
+        $this->iterateWithOrder($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testIterateWithRegularJoinWithOrderByColumnFromJoined($useOutputWalkers, $fetchJoinCollection)
+    {
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.email e ORDER BY e.email';
+        $this->iterateWithOrder($useOutputWalkers, $fetchJoinCollection, $dql, "username");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithRegularJoinWithComplexOrderByReferencingJoined($fetchJoinCollection)
+    {
+        // long function name is loooooooooooong
+
+        $dql = "SELECT c FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_height * l.image_width";
+        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "name");
+    }
+
+    /**
+     * @dataProvider useOutputWalkers
+     */
+    public function testIterateWithFetchJoinWithOrderByColumnFromJoined($useOutputWalkers)
+    {
+        $dql = "SELECT u,g,e FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.groups g JOIN u.email e ORDER BY e.email";
+        $this->iterateWithOrder($useOutputWalkers, true, $dql, "username");
+    }
+
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoined($fetchJoinCollection)
+    {
+        $dql = "SELECT c,l FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.logo l ORDER BY l.image_width * l.image_height";
+        $this->iterateWithOrder(true, $fetchJoinCollection, $dql, "name");
     }
 
     public function testIterateComplexWithOutputWalker()
@@ -107,7 +264,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers(true);
-        $this->assertCount(9, $paginator->getIterator());
+        $this->assertCount(3, $paginator->getIterator());
     }
 
     public function testDetectOutputWalker()
@@ -170,7 +327,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $getCountQuery->setAccessible(true);
 
         $this->assertCount(2, $getCountQuery->invoke($paginator)->getParameters());
-        $this->assertCount(3, $paginator);
+        $this->assertCount(9, $paginator);
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Query\SqlWalker');
 
@@ -179,25 +336,44 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         // if select part of query is replaced with count(...) paginator should remove
         // parameters from query object not used in new query.
         $this->assertCount(1, $getCountQuery->invoke($paginator)->getParameters());
-        $this->assertCount(3, $paginator);
+        $this->assertCount(9, $paginator);
     }
 
     public function populate()
     {
-        for ($i = 0; $i < 3; $i++) {
+        $groups = [];
+        for ($j = 0; $j < 3; $j++) {;
+            $group = new CmsGroup();
+            $group->name = "group$j";
+            $groups[] = $group;
+            $this->_em->persist($group);
+        }
+
+        for ($i = 0; $i < 9; $i++) {
             $user = new CmsUser();
             $user->name = "Name$i";
             $user->username = "username$i";
             $user->status = "active";
-            $this->_em->persist($user);
-
-            for ($j = 0; $j < 3; $j++) {;
-                $group = new CmsGroup();
-                $group->name = "group$j";
-                $user->addGroup($group);
-                $this->_em->persist($group);
+            $user->email = new CmsEmail();
+            $user->email->user = $user;
+            $user->email->email = "email$i";
+            for ($j = 0; $j < 3; $j++) {
+                $user->addGroup($groups[$j]);
             }
+            $this->_em->persist($user);
         }
+
+        for ($i = 0; $i < 9; $i++) {
+            $company = new Company();
+            $company->name = "name$i";
+            $company->logo = new Logo();
+            $company->logo->image = "image$i";
+            $company->logo->image_width = 100 + $i;
+            $company->logo->image_height = 100 + $i;
+            $company->logo->company = $company;
+            $this->_em->persist($company);
+        }
+
         $this->_em->flush();
     }
 
@@ -206,6 +382,24 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         return array(
             array(true),
             array(false),
+        );
+    }
+
+    public function fetchJoinCollection()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
+    }
+
+    public function useOutputWalkersAndFetchJoinCollection()
+    {
+        return array(
+            array(true, false),
+            array(true, true),
+            array(false, false),
+            array(false, true),
         );
     }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -267,6 +267,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\CustomType\CustomIdObjectTypeParent',
             'Doctrine\Tests\Models\CustomType\CustomIdObjectTypeChild',
         ),
+        'pagination' => array(
+            'Doctrine\Tests\Models\Pagination\Company',
+            'Doctrine\Tests\Models\Pagination\Logo',
+        ),
     );
 
     /**
@@ -513,6 +517,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['custom_id_object_type'])) {
             $conn->executeUpdate('DELETE FROM custom_id_type_child');
             $conn->executeUpdate('DELETE FROM custom_id_type_parent');
+        }
+
+        if (isset($this->_usedModelSets['pagination'])) {
+            $conn->executeUpdate('DELETE FROM pagination_logo');
+            $conn->executeUpdate('DELETE FROM pagination_company');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
PaginationTest has been expanded and now covers ordering and limiting rather thoroughly.

4 tests fail on PostgreSQL and MySQL, 14 tests fail on SQL Server, and I didn't try any other DBMS.
