### PR TITLE
Support embeddables in partial object query expression [DDC-3621]

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1784,8 +1784,16 @@ class Parser
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
             $this->match(Lexer::T_IDENTIFIER);
-
-            $partialFieldSet[] = $this->lexer->token['value'];
+    
+            $field = $this->lexer->token['value'];
+    
+            while ($this->lexer->isNextToken(Lexer::T_DOT)) {
+                $this->match(Lexer::T_DOT);
+                $this->match(Lexer::T_IDENTIFIER);
+                $field .= '.'.$this->lexer->token['value'];
+            }
+    
+            $partialFieldSet[] = $field;
         }
 
         $this->match(Lexer::T_CLOSE_CURLY_BRACE);


### PR DESCRIPTION
I don't see any tests covering this class, but all existing tests pass with this change.
