### PR TITLE
Fix tests for SLC console commands failing due to console output decoration

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
@@ -46,7 +46,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing all second-level cache collection regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -59,7 +59,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             'command'       => $command->getName(),
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache for collection "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }
@@ -73,7 +73,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
             'owner-id'      => 1,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache entry for collection "Doctrine\Tests\Models\Cache\State#cities" owner entity identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
@@ -87,7 +87,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             'owner-class'   => 'Doctrine\Tests\Models\Cache\State',
             'association'   => 'cities',
             '--flush'       => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Flushing cache provider configured for "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
@@ -46,7 +46,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing all second-level cache entity regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -58,7 +58,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache for entity "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }
@@ -71,7 +71,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
             'entity-id'     => 1,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
@@ -84,7 +84,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             'command'       => $command->getName(),
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
             '--flush'       => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Flushing cache provider configured for entity named "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
@@ -46,7 +46,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command' => $command->getName(),
             '--all'   => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing all second-level cache query regions' . PHP_EOL, $tester->getDisplay());
     }
@@ -58,7 +58,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command'       => $command->getName(),
             'region-name'   => null,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache query region named "query_cache_region"' . PHP_EOL, $tester->getDisplay());
     }
@@ -70,7 +70,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
         $tester->execute(array(
             'command'       => $command->getName(),
             'region-name'   => 'my_region',
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Clearing second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }
@@ -83,7 +83,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
             'command'       => $command->getName(),
             'region-name'   => 'my_region',
             '--flush'       => true,
-        ));
+        ), array('decorated' => false));
 
         $this->assertEquals('Flushing cache provider configured for second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }


### PR DESCRIPTION
The tests for the SLC console commands were failing on my box because the console output was being decorated with ANSI color codes, while the test assertions were using undecorated strings.

This PR turns off output decoration when these console commands are executed in the tests.
