### PR TITLE
Fix crashes in ConvertMappingCommand and GenerateEntitiesCommand...

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -311,6 +311,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($metadata->discriminatorValue
             || ! $metadata->discriminatorMap
             || $metadata->isMappedSuperclass
+            || ! $metadata->reflClass
             || $metadata->reflClass->isAbstract()
         ) {
             return;


### PR DESCRIPTION
 ... when using entities with joined table inheritance

ConvertMappingCommand and GenerateEntitiesCommand both use the DisconnectedClassMetadataFactory, which allows metadata manipulation without loading the associated classes. Commit a36bea broke these two commands by adding a bailout condition in ClassMetadataFactory::populateDiscriminatorValue which checks $metadata->reflClass->isAbstract(). If the DisconnectedClassMetadataFactory is being used, $metadata->reflClass will always be null, causing a fatal error, "Fatal error: Call to a member function isAbstract() on null".

This commit adds a check to see if $metadata->reflClass is set before checking isAbstract.
