### PR TITLE
Fix: generated IDs are converted to integer

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -35,10 +35,10 @@ use Doctrine\ORM\Cache\EntityCacheKey;
 class ReadWriteCachedEntityPersister extends AbstractEntityPersister
 {
     /**
-     * @param \Doctrine\ORM\Persister\Entity\EntityPersister $persister The entity persister to cache.
-     * @param \Doctrine\ORM\Cache\ConcurrentRegion           $region    The entity cache region.
-     * @param \Doctrine\ORM\EntityManagerInterface           $em        The entity manager.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata            $class     The entity metadata.
+     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister The entity persister to cache.
+     * @param \Doctrine\ORM\Cache\ConcurrentRegion            $region    The entity cache region.
+     * @param \Doctrine\ORM\EntityManagerInterface            $em        The entity manager.
+     * @param \Doctrine\ORM\Mapping\ClassMetadata             $class     The entity metadata.
      */
     public function __construct(EntityPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, ClassMetadata $class)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -285,7 +285,10 @@ class BasicEntityPersister implements EntityPersister
                 $id = array(
                     $this->class->identifier[0] => $generatedId
                 );
-                $postInsertIds[$generatedId] = $entity;
+                $postInsertIds[] = array(
+                    'generatedId' => $generatedId,
+                    'entity' => $entity,
+                );
             } else {
                 $id = $this->class->getIdentifierValues($entity);
             }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -180,7 +180,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $id = array(
                     $this->class->identifier[0] => $generatedId
                 );
-                $postInsertIds[$generatedId] = $entity;
+                $postInsertIds[] = array(
+                    'generatedId' => $generatedId,
+                    'entity' => $entity,
+                );
             } else {
                 $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
             }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1019,7 +1019,9 @@ class UnitOfWork implements PropertyChangedListener
 
         if ($postInsertIds) {
             // Persister returned post-insert IDs
-            foreach ($postInsertIds as $id => $entity) {
+            foreach ($postInsertIds as $postInsertId) {
+                $id      = $postInsertId['generatedId'];
+                $entity  = $postInsertId['entity'];
                 $oid     = spl_object_hash($entity);
                 $idField = $class->identifier[0];
 

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -55,7 +55,10 @@ class EntityPersisterMock extends \Doctrine\ORM\Persisters\Entity\BasicEntityPer
         if ( ! is_null($this->mockIdGeneratorType) && $this->mockIdGeneratorType == \Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_IDENTITY
                 || $this->class->isIdGeneratorIdentity()) {
             $id = $this->identityColumnValueCounter++;
-            $this->postInsertIds[$id] = $entity;
+            $this->postInsertIds[] = array(
+                'generatedId' => $id,
+                'entity' => $entity,
+            );
             return $id;
         }
         return null;


### PR DESCRIPTION
When I try to use type `bigint` and `@GeneratedValue` together, generated value is converted to integer.

See PHP documentation http://php.net/manual/en/language.types.array.php

> Strings containing valid integers will be cast to the integer type. E.g. the key "8" will actually be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer.
