### PR TITLE
problem with LimitSubqueryOutputWalker when use InheritanceType

### DIFF
--- a/tests/Doctrine/Tests/Models/Pagination/User.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\Pagination;
+
+
+/**
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity
+ * @Table(name="pagination_user")
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="type", type="string")
+ * @DiscriminatorMap({"user1"="User1"})
+ */
+abstract class User
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/Models/Pagination/User1.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User1.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Models\Pagination;
+
+/**
+ * Class User1
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity()
+ */
+class User1 extends User
+{
+    /**
+     * @Column(type="string")
+     */
+    public $email;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -9,6 +9,7 @@ use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Models\Pagination\Company;
 use Doctrine\Tests\Models\Pagination\Logo;
+use Doctrine\Tests\Models\Pagination\User1;
 use ReflectionMethod;
 
 /**
@@ -439,6 +440,16 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->iterateWithOrderDescWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
     }
 
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoinedWithLimitAndOffsetWithInheritanceType($fetchJoinCollection)
+    {
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\Pagination\User u ORDER BY u.id';
+        $this->iterateWithOrderAscWithLimit(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimit(true, $fetchJoinCollection, $dql, "name");
+    }
+
     public function testIterateComplexWithOutputWalker()
     {
         $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
@@ -554,6 +565,13 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $company->logo->image_height = 100 + $i;
             $company->logo->company = $company;
             $this->_em->persist($company);
+        }
+
+        for ($i = 0; $i < 9; $i++) {
+            $user = new User1();
+            $user->name = "name$i";
+            $user->email = "email$i";
+            $this->_em->persist($user);
         }
 
         $this->_em->flush();

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -270,6 +270,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'pagination' => array(
             'Doctrine\Tests\Models\Pagination\Company',
             'Doctrine\Tests\Models\Pagination\Logo',
+            'Doctrine\Tests\Models\Pagination\User',
+            'Doctrine\Tests\Models\Pagination\User1',
         ),
     );
 
@@ -522,6 +524,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['pagination'])) {
             $conn->executeUpdate('DELETE FROM pagination_logo');
             $conn->executeUpdate('DELETE FROM pagination_company');
+            $conn->executeUpdate('DELETE FROM pagination_user');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
When we use InheritanceType ("SINGLE_TABLE") catch exception that field in joined class does not exist in base class.
