### PR TITLE
Assigned default value to array

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -56,6 +56,7 @@ abstract class SQLFilter
     final public function __construct(EntityManager $em)
     {
         $this->em = $em;
+        $this->parameters = array();
     }
 
     /**


### PR DESCRIPTION
- For strict configurations of PHP, we were accessing to a non-array element
