### PR TITLE
Paginator fixes take3

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -344,6 +344,14 @@ class LimitSubqueryOutputWalker extends SqlWalker
         // Generate search patterns for each field's path expression in the order by clause
         foreach($this->rsm->fieldMappings as $fieldAlias => $columnName) {
             $dqlAliasForFieldAlias = $this->rsm->columnOwnerMap[$fieldAlias];
+            $class = $dqlAliasToClassMap[$dqlAliasForFieldAlias];
+
+            // If the field is from a joined child table, we won't be ordering
+            // on it.
+            if (!isset($class->fieldMappings[$columnName])) {
+                continue;
+            }
+
             $columnName = $this->quoteStrategy->getColumnName(
                 $columnName,
                 $dqlAliasToClassMap[$dqlAliasForFieldAlias],

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -88,6 +88,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     private $orderByPathExpressions = [];
 
+    /** @var bool $inSubselect */
+    private $inSubselect = false;
+
     /**
      * Constructor.
      *
@@ -443,18 +446,6 @@ class LimitSubqueryOutputWalker extends SqlWalker
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function walkPathExpression($pathExpr)
-    {
-        if (!$this->platformSupportsRowNumber() && !in_array($pathExpr, $this->orderByPathExpressions)) {
-            $this->orderByPathExpressions[] = $pathExpr;
-        }
-
-        return parent::walkPathExpression($pathExpr);
-    }
-
-    /**
      * getter for $orderByPathExpressions
      *
      * @return array
@@ -548,5 +539,32 @@ class LimitSubqueryOutputWalker extends SqlWalker
         }
 
         return $sqlIdentifier;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkPathExpression($pathExpr)
+    {
+        if (!$this->inSubselect && !$this->platformSupportsRowNumber() && !in_array($pathExpr, $this->orderByPathExpressions)) {
+            $this->orderByPathExpressions[] = $pathExpr;
+        }
+
+        return parent::walkPathExpression($pathExpr);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function walkSubSelect($subselect)
+    {
+        // We don't want to add path expressions from subselects into the select clause of the containing query.
+        $this->inSubselect = true;
+
+        $sql = parent::walkSubselect($subselect);
+
+        $this->inSubselect = false;
+
+        return $sql;
     }
 }

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -121,7 +121,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
      *
      * @return bool
      */
-    private function platformSupportsRowNumber() {
+    private function platformSupportsRowNumber()
+    {
         return $this->_platform instanceof PostgreSqlPlatform
             || $this->_platform instanceof SQLServerPlatform
             || $this->_platform instanceof OraclePlatform
@@ -137,13 +138,17 @@ class LimitSubqueryOutputWalker extends SqlWalker
      *
      * @param SelectStatement $AST
      */
-    private function rebuildOrderByForRowNumber(SelectStatement $AST) {
+    private function rebuildOrderByForRowNumber(SelectStatement $AST)
+    {
         $orderByClause = $AST->orderByClause;
         $selectAliasToExpressionMap = [];
-        foreach($AST->selectClause->selectExpressions as $selectExpression) {
+        // Get any aliases that are available for select expressions.
+        foreach ($AST->selectClause->selectExpressions as $selectExpression) {
             $selectAliasToExpressionMap[$selectExpression->fieldIdentificationVariable] = $selectExpression->expression;
         }
-        foreach($orderByClause->orderByItems as $orderByItem) {
+
+        // Rebuild string orderby expressions to use the select expression they're referencing
+        foreach ($orderByClause->orderByItems as $orderByItem) {
             if (is_string($orderByItem->expression) && isset($selectAliasToExpressionMap[$orderByItem->expression])) {
                 $orderByItem->expression = $selectAliasToExpressionMap[$orderByItem->expression];
             }
@@ -203,8 +208,11 @@ class LimitSubqueryOutputWalker extends SqlWalker
         }
 
         // Build the counter query
-        $sql = sprintf('SELECT DISTINCT %s FROM (%s) dctrn_result',
-            implode(', ', $sqlIdentifier), $innerSql);
+        $sql = sprintf(
+            'SELECT DISTINCT %s FROM (%s) dctrn_result',
+            implode(', ', $sqlIdentifier),
+            $innerSql
+        );
 
         if ($hasOrderBy) {
             $sql .= $orderGroupBy . $outerOrderBy;
@@ -212,7 +220,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
         // Apply the limit and offset.
         $sql = $this->_platform->modifyLimitQuery(
-            $sql, $this->maxResults, $this->firstResult
+            $sql,
+            $this->maxResults,
+            $this->firstResult
         );
 
         // Add the columns to the ResultSetMapping. It's not really nice but

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -410,27 +410,27 @@ class LimitSubqueryOutputWalker extends SqlWalker
         $fieldSearchPattern = '/(?<![a-z0-9_])%s\.%s(?![a-z0-9_])/i';
 
         // Generate search patterns for each field's path expression in the order by clause
-        foreach($this->rsm->fieldMappings as $fieldAlias => $columnName) {
+        foreach($this->rsm->fieldMappings as $fieldAlias => $fieldName) {
             $dqlAliasForFieldAlias = $this->rsm->columnOwnerMap[$fieldAlias];
             $class = $dqlAliasToClassMap[$dqlAliasForFieldAlias];
 
             // If the field is from a joined child table, we won't be ordering
             // on it.
-            if (!isset($class->fieldMappings[$columnName])) {
+            if (!isset($class->fieldMappings[$fieldName])) {
                 continue;
             }
 
+            $fieldMapping = $class->fieldMappings[$fieldName];
+
             // Get the proper column name as will appear in the select list
             $columnName = $this->quoteStrategy->getColumnName(
-                $columnName,
+                $fieldName,
                 $dqlAliasToClassMap[$dqlAliasForFieldAlias],
                 $this->em->getConnection()->getDatabasePlatform()
             );
 
             // Get the SQL table alias for the entity and field
             $sqlTableAliasForFieldAlias = $dqlAliasToSqlTableAliasMap[$dqlAliasForFieldAlias];
-
-            $fieldMapping = $class->fieldMappings[$columnName];
             if (isset($fieldMapping['declared']) && $fieldMapping['declared'] !== $class->name) {
                 // Field was declared in a parent class, so we need to get the proper SQL table alias
                 // for the joined parent table.

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -1,15 +1,37 @@
 <?php
-/**
- * RowNumberOverFunction.php
- * Created by William Schaller
- * Date: 3/27/2015
- * Time: 11:31 AM
+
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
  */
+
 namespace Doctrine\ORM\Tools\Pagination;
 
-
+use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 
+
+/**
+ * RowNumberOverFunction
+ *
+ * Provides ROW_NUMBER() OVER(ORDER BY...) construct for use in LimitSubqueryOutputWalker
+ *
+ * @since   2.5
+ * @author  Bill Schaller <bill@zeroedin.com>
+ */
 class RowNumberOverFunction extends FunctionNode
 {
     /**
@@ -29,7 +51,11 @@ class RowNumberOverFunction extends FunctionNode
 
     /**
      * @override
+     *
+     * @throws ORMException
      */
     public function parse(\Doctrine\ORM\Query\Parser $parser)
-    {}
+    {
+        throw new ORMException("The RowNumberOverFunction is not intended for, nor is it enabled for use in DQL.");
+    }
 }

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * RowNumberOverFunction.php
+ * Created by William Schaller
+ * Date: 3/27/2015
+ * Time: 11:31 AM
+ */
+namespace Doctrine\ORM\Tools\Pagination;
+
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+
+class RowNumberOverFunction extends FunctionNode
+{
+    /**
+     * @var \Doctrine\ORM\Query\AST\OrderByClause
+     */
+    public $orderByClause;
+
+    /**
+     * @override
+     */
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        return 'ROW_NUMBER() OVER(' . trim($sqlWalker->walkOrderByClause(
+            $this->orderByClause
+        )) . ')';
+    }
+
+    /**
+     * @override
+     */
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {}
+}

--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -27,4 +27,9 @@ class Company
      * @OneToOne(targetEntity="Logo", mappedBy="company", cascade={"persist"}, orphanRemoval=true)
      */
     public $logo;
+
+    /**
+     * @OneToMany(targetEntity="Department", mappedBy="company", cascade={"persist"}, orphanRemoval=true)
+     */
+    public $departments;
 }

--- a/tests/Doctrine/Tests/Models/Pagination/Company.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Company.php
@@ -24,6 +24,11 @@ class Company
     public $name;
 
     /**
+     * @Column(type="string", name="jurisdiction_code", nullable=true)
+     */
+    public $jurisdiction;
+
+    /**
      * @OneToOne(targetEntity="Logo", mappedBy="company", cascade={"persist"}, orphanRemoval=true)
      */
     public $logo;

--- a/tests/Doctrine/Tests/Models/Pagination/Department.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Department.php
@@ -1,0 +1,30 @@
+<?php
+namespace Doctrine\Tests\Models\Pagination;
+
+/**
+ * Department
+ *
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @author Bill Schaller
+ * @Entity
+ * @Table(name="pagination_department")
+ */
+class Department
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @ManyToOne(targetEntity="Company", inversedBy="departments", cascade={"persist"})
+     */
+    public $company;
+}

--- a/tests/Doctrine/Tests/Models/Pagination/User.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\Pagination;
+
+
+/**
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity
+ * @Table(name="pagination_user")
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="type", type="string")
+ * @DiscriminatorMap({"user1"="User1"})
+ */
+abstract class User
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/Models/Pagination/User1.php
+++ b/tests/Doctrine/Tests/Models/Pagination/User1.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Doctrine\Tests\Models\Pagination;
+
+/**
+ * Class User1
+ * @package Doctrine\Tests\Models\Pagination
+ *
+ * @Entity()
+ */
+class User1 extends User
+{
+    /**
+     * @Column(type="string")
+     */
+    public $email;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -8,6 +8,7 @@ use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\Company\CompanyManager;
 use Doctrine\Tests\Models\Pagination\Company;
 use Doctrine\Tests\Models\Pagination\Department;
 use Doctrine\Tests\Models\Pagination\Logo;
@@ -724,6 +725,14 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $user->email = "email$i";
             $this->_em->persist($user);
         }
+
+        $manager = new CompanyManager();
+        $manager->setName('Roman B.');
+        $manager->setTitle('Foo');
+        $manager->setDepartment('IT');
+        $manager->setSalary(100000);
+
+        $this->_em->persist($manager);
 
         $this->_em->flush();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -120,7 +120,6 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     private function iterateWithOrderAsc($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
     {
-
         // Ascending
         $dql = "$baseDql ASC";
         $query = $this->_em->createQuery($dql);
@@ -135,7 +134,6 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     private function iterateWithOrderAscWithLimit($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
     {
-
         // Ascending
         $dql = "$baseDql ASC";
         $query = $this->_em->createQuery($dql);
@@ -487,18 +485,12 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIterateWithFetchJoinOneToManyWithOrderByColumnFromBothWithLimitWithoutOutputWalker()
     {
-        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a joined entity. Use output walkers.");
-
-        $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY c.name ASC';
-        // Ascending
-        $query = $this->_em->createQuery($dql);
-
-        // With limit
-        $query->setMaxResults(3);
-        $paginator = new Paginator($query, true);
-        $paginator->setUseOutputWalkers(false);
-        $iter = $paginator->getIterator();
-        iterator_to_array($iter);
+        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.");
+        $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY c.name';
+        $dqlAsc = $dql . " ASC, d.name";
+        $dqlDesc = $dql . " DESC, d.name";
+        $this->iterateWithOrderAscWithLimit(false, true, $dqlAsc, "name");
+        $this->iterateWithOrderDescWithLimit(false, true, $dqlDesc, "name");
     }
 
     /**
@@ -550,18 +542,11 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIterateWithFetchJoinOneToManyWithOrderByColumnFromJoinedWithLimitWithoutOutputWalker()
     {
-        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a joined entity. Use output walkers.");
-        $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY d.name ASC';
+        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.");
+        $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY d.name';
 
-        // Ascending
-        $query = $this->_em->createQuery($dql);
-
-        // With limit
-        $query->setMaxResults(3);
-        $paginator = new Paginator($query, true);
-        $paginator->setUseOutputWalkers(false);
-        $iter = $paginator->getIterator();
-        iterator_to_array($iter);
+        $this->iterateWithOrderAscWithLimit(false, true, $dql, "name");
+        $this->iterateWithOrderDescWithLimit(false, true, $dql, "name");
     }
 
     public function testCountWithCountSubqueryInWhereClauseWithOutputWalker()

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
@@ -561,6 +562,31 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         iterator_to_array($iter);
     }
 
+    public function testCountWithCountSubqueryInWhereClauseWithOutputWalker()
+    {
+        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE ((SELECT COUNT(s.id) FROM Doctrine\Tests\Models\CMS\CmsUser s) = 9) ORDER BY u.id desc";
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(true);
+        $this->assertCount(9, $paginator);
+    }
+
+    public function testIterateWithCountSubqueryInWhereClause()
+    {
+        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE ((SELECT COUNT(s.id) FROM Doctrine\Tests\Models\CMS\CmsUser s) = 9) ORDER BY u.id desc";
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(true);
+
+        $users = iterator_to_array($paginator->getIterator());
+        $this->assertCount(9, $users);
+        foreach ($users as $i => $user) {
+            $this->assertEquals("username" . (8 - $i), $user->username);
+        }
+    }
+
     public function testDetectOutputWalker()
     {
         // This query works using the output walkers but causes an exception using the TreeWalker
@@ -655,6 +681,14 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 $user->addGroup($groups[$j]);
             }
             $this->_em->persist($user);
+            for ($j = 0; $j < $i + 1; $j++) {
+                $article = new CmsArticle();
+                $article->topic = "topic$i$j";
+                $article->text = "text$i$j";
+                $article->setAuthor($user);
+                $article->version = 0;
+                $this->_em->persist($article);
+            }
         }
 
         for ($i = 0; $i < 9; $i++) {

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Models\Pagination\Company;
 use Doctrine\Tests\Models\Pagination\Department;
 use Doctrine\Tests\Models\Pagination\Logo;
+use Doctrine\Tests\Models\Pagination\User1;
 use ReflectionMethod;
 
 /**
@@ -440,6 +441,16 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->iterateWithOrderDescWithLimitAndOffset(true, $fetchJoinCollection, $dql, "name");
     }
 
+    /**
+     * @dataProvider fetchJoinCollection
+     */
+    public function testIterateWithOutputWalkersWithFetchJoinWithComplexOrderByReferencingJoinedWithLimitAndOffsetWithInheritanceType($fetchJoinCollection)
+    {
+        $dql = 'SELECT u FROM Doctrine\Tests\Models\Pagination\User u ORDER BY u.id';
+        $this->iterateWithOrderAscWithLimit(true, $fetchJoinCollection, $dql, "name");
+        $this->iterateWithOrderDescWithLimit(true, $fetchJoinCollection, $dql, "name");
+    }
+
     public function testIterateComplexWithOutputWalker()
     {
         $dql = 'SELECT g, COUNT(u.id) AS userCount FROM Doctrine\Tests\Models\CMS\CmsGroup g LEFT JOIN g.users u GROUP BY g HAVING COUNT(u.id) > 0';
@@ -661,6 +672,13 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 $company->departments[] = $department;
             }
             $this->_em->persist($company);
+        }
+
+        for ($i = 0; $i < 9; $i++) {
+            $user = new User1();
+            $user->name = "name$i";
+            $user->email = "email$i";
+            $this->_em->persist($user);
         }
 
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -20,6 +20,7 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->useModelSet('cms');
         $this->useModelSet('pagination');
+        $this->useModelSet('company');
         parent::setUp();
         $this->populate();
     }
@@ -447,6 +448,15 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers(true);
         $this->assertCount(3, $paginator->getIterator());
+    }
+
+    public function testJoinedClassTableInheritance()
+    {
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Company\CompanyManager c ORDER BY c.startDate';
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $this->assertCount(1, $paginator->getIterator());
     }
 
     public function testDetectOutputWalker()

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -602,6 +602,20 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         count($paginator);
     }
 
+    /**
+     * Test using a paginator when the entity attribute name and corresponding column name are not the same.
+     */
+    public function testPaginationWithColumnAttributeNameDifference()
+    {
+        $dql = 'SELECT c FROM Doctrine\Tests\Models\Pagination\Company c ORDER BY c.id';
+        $query = $this->_em->createQuery($dql);
+
+        $paginator = new Paginator($query);
+        $paginator->getIterator();
+
+        $this->assertCount(9, $paginator->getIterator());
+    }
+
     public function testCloneQuery()
     {
         $dql = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u';

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -318,5 +318,37 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
             $query->getSQL()
         );
     }
+
+    public function testLimitSubqueryWithOrderByAndSubSelectInWhereClauseMySql()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $query = $this->entityManager->createQuery(
+            'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b
+WHERE  ((SELECT COUNT(simple.id) FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost simple) = 1)
+ORDER BY b.id DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0 FROM (SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS dctrn__1 FROM BlogPost b1_) = 1)) dctrn_result ORDER BY id_0 DESC',
+            $query->getSQL()
+        );
+    }
+
+    public function testLimitSubqueryWithOrderByAndSubSelectInWhereClausePgSql()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $query = $this->entityManager->createQuery(
+            'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b
+WHERE  ((SELECT COUNT(simple.id) FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost simple) = 1)
+ORDER BY b.id DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0, MIN(sclr_1) AS dctrn_minrownum FROM (SELECT b0_.id AS id_0, ROW_NUMBER() OVER(ORDER BY b0_.id DESC) AS sclr_1, b0_.author_id AS author_id_2, b0_.category_id AS category_id_3 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS dctrn__1 FROM BlogPost b1_) = 1)) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
+            $query->getSQL()
+        );
+    }
 }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -34,7 +34,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT id_0, title_1 FROM (SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id) dctrn_result ORDER BY title_1 ASC", $limitQuery->getSql()
+            "SELECT DISTINCT id_0, MIN(sclr_5) AS dctrn_minrownum FROM (SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, ROW_NUMBER() OVER(ORDER BY m0_.title ASC) AS sclr_5, m0_.author_id AS author_id_6, m0_.category_id AS category_id_7 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC", $limitQuery->getSql()
         );
 
         $this->entityManager->getConnection()->setDatabasePlatform($odp);
@@ -52,7 +52,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT id_1, sclr_0 FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result ORDER BY sclr_0 ASC",
+            "SELECT DISTINCT id_1, MIN(sclr_3) AS dctrn_minrownum FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2, ROW_NUMBER() OVER(ORDER BY COUNT(g0_.id) ASC) AS sclr_3 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result GROUP BY id_1 ORDER BY dctrn_minrownum ASC",
             $limitQuery->getSql()
         );
 
@@ -71,7 +71,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT id_1, sclr_0 FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result ORDER BY sclr_0 ASC, id_1 DESC",
+            "SELECT DISTINCT id_1, MIN(sclr_3) AS dctrn_minrownum FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2, ROW_NUMBER() OVER(ORDER BY COUNT(g0_.id) ASC, u1_.id DESC) AS sclr_3 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result GROUP BY id_1 ORDER BY dctrn_minrownum ASC",
             $limitQuery->getSql()
         );
 
@@ -90,7 +90,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT id_1, sclr_0 FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result ORDER BY sclr_0 ASC, id_1 DESC",
+            "SELECT DISTINCT id_1, MIN(sclr_3) AS dctrn_minrownum FROM (SELECT COUNT(g0_.id) AS sclr_0, u1_.id AS id_1, g0_.id AS id_2, ROW_NUMBER() OVER(ORDER BY COUNT(g0_.id) ASC, u1_.id DESC) AS sclr_3 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result GROUP BY id_1 ORDER BY dctrn_minrownum ASC",
             $limitQuery->getSql()
         );
 
@@ -119,7 +119,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT ID_0, TITLE_1 FROM (SELECT m0_.id AS ID_0, m0_.title AS TITLE_1, c1_.id AS ID_2, a2_.id AS ID_3, a2_.name AS NAME_4, m0_.author_id AS AUTHOR_ID_5, m0_.category_id AS CATEGORY_ID_6 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id) dctrn_result ORDER BY TITLE_1 ASC", $limitQuery->getSql()
+            "SELECT DISTINCT ID_0, MIN(SCLR_5) AS dctrn_minrownum FROM (SELECT m0_.id AS ID_0, m0_.title AS TITLE_1, c1_.id AS ID_2, a2_.id AS ID_3, a2_.name AS NAME_4, ROW_NUMBER() OVER(ORDER BY m0_.title ASC) AS SCLR_5, m0_.author_id AS AUTHOR_ID_6, m0_.category_id AS CATEGORY_ID_7 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id INNER JOIN Author a2_ ON m0_.author_id = a2_.id) dctrn_result GROUP BY ID_0 ORDER BY dctrn_minrownum ASC", $limitQuery->getSql()
         );
 
         $this->entityManager->getConnection()->setDatabasePlatform($odp);
@@ -138,7 +138,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT ID_1, SCLR_0 FROM (SELECT COUNT(g0_.id) AS SCLR_0, u1_.id AS ID_1, g0_.id AS ID_2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result ORDER BY SCLR_0 ASC",
+            "SELECT DISTINCT ID_1, MIN(SCLR_3) AS dctrn_minrownum FROM (SELECT COUNT(g0_.id) AS SCLR_0, u1_.id AS ID_1, g0_.id AS ID_2, ROW_NUMBER() OVER(ORDER BY COUNT(g0_.id) ASC) AS SCLR_3 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result GROUP BY ID_1 ORDER BY dctrn_minrownum ASC",
             $limitQuery->getSql()
         );
 
@@ -158,7 +158,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            "SELECT DISTINCT ID_1, SCLR_0 FROM (SELECT COUNT(g0_.id) AS SCLR_0, u1_.id AS ID_1, g0_.id AS ID_2 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result ORDER BY SCLR_0 ASC, ID_1 DESC",
+            "SELECT DISTINCT ID_1, MIN(SCLR_3) AS dctrn_minrownum FROM (SELECT COUNT(g0_.id) AS SCLR_0, u1_.id AS ID_1, g0_.id AS ID_2, ROW_NUMBER() OVER(ORDER BY COUNT(g0_.id) ASC, u1_.id DESC) AS SCLR_3 FROM User u1_ INNER JOIN user_group u2_ ON u1_.id = u2_.user_id INNER JOIN groups g0_ ON g0_.id = u2_.group_id) dctrn_result GROUP BY ID_1 ORDER BY dctrn_minrownum ASC",
             $limitQuery->getSql()
         );
 
@@ -208,7 +208,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT id_0, (1 - 1000) * 1 AS ordr_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1 FROM Author a0_) dctrn_result ORDER BY ordr_0 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1 FROM Author a0_) dctrn_result ORDER BY (1 - 1000) * 1 DESC',
             $query->getSQL()
         );
     }
@@ -223,7 +223,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT id_0, image_height_2 * image_width_3 AS ordr_0 FROM (SELECT a0_.id AS id_0, a0_.image AS image_1, a0_.image_height AS image_height_2, a0_.image_width AS image_width_3, a0_.image_alt_desc AS image_alt_desc_4, a0_.user_id AS user_id_5 FROM Avatar a0_) dctrn_result ORDER BY ordr_0 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.image AS image_1, a0_.image_height AS image_height_2, a0_.image_width AS image_width_3, a0_.image_alt_desc AS image_alt_desc_4, a0_.user_id AS user_id_5 FROM Avatar a0_) dctrn_result ORDER BY image_height_2 * image_width_3 DESC',
             $query->getSQL()
         );
     }
@@ -238,7 +238,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT id_0, image_height_1 * image_width_2 AS ordr_0 FROM (SELECT u0_.id AS id_0, a1_.image_height AS image_height_1, a1_.image_width AS image_width_2, a1_.user_id AS user_id_3 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result ORDER BY ordr_0 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT u0_.id AS id_0, a1_.image_height AS image_height_1, a1_.image_width AS image_width_2, a1_.user_id AS user_id_3 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result ORDER BY image_height_1 * image_width_2 DESC',
             $query->getSQL()
         );
     }
@@ -253,7 +253,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT id_0, image_height_3 * image_width_4 AS ordr_0 FROM (SELECT u0_.id AS id_0, a1_.id AS id_1, a1_.image_alt_desc AS image_alt_desc_2, a1_.image_height AS image_height_3, a1_.image_width AS image_width_4, a1_.user_id AS user_id_5 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result ORDER BY ordr_0 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT u0_.id AS id_0, a1_.id AS id_1, a1_.image_alt_desc AS image_alt_desc_2, a1_.image_height AS image_height_3, a1_.image_width AS image_width_4, a1_.user_id AS user_id_5 FROM User u0_ INNER JOIN Avatar a1_ ON u0_.id = a1_.user_id) dctrn_result ORDER BY image_height_3 * image_width_4 DESC',
             $query->getSQL()
         );
     }
@@ -268,7 +268,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT ID_0, IMAGE_HEIGHT_2 * IMAGE_WIDTH_3 AS ordr_0 FROM (SELECT a0_.id AS ID_0, a0_.image AS IMAGE_1, a0_.image_height AS IMAGE_HEIGHT_2, a0_.image_width AS IMAGE_WIDTH_3, a0_.image_alt_desc AS IMAGE_ALT_DESC_4, a0_.user_id AS USER_ID_5 FROM Avatar a0_) dctrn_result ORDER BY ordr_0 DESC',
+            'SELECT DISTINCT ID_0, MIN(SCLR_5) AS dctrn_minrownum FROM (SELECT a0_.id AS ID_0, a0_.image AS IMAGE_1, a0_.image_height AS IMAGE_HEIGHT_2, a0_.image_width AS IMAGE_WIDTH_3, a0_.image_alt_desc AS IMAGE_ALT_DESC_4, ROW_NUMBER() OVER(ORDER BY a0_.image_height * a0_.image_width DESC) AS SCLR_5, a0_.user_id AS USER_ID_6 FROM Avatar a0_) dctrn_result GROUP BY ID_0 ORDER BY dctrn_minrownum ASC',
             $query->getSQL()
         );
     }
@@ -285,7 +285,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0, name_2 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, a0_.name AS name_2 FROM Author a0_) dctrn_result ORDER BY name_2 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, a0_.name AS name_2 FROM Author a0_) dctrn_result ORDER BY name_2 DESC',
             $query->getSql()
         );
     }
@@ -300,7 +300,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertSame(
-            'SELECT DISTINCT id_0, image_alt_desc_4 FROM (SELECT a0_.id AS id_0, a0_.image AS image_1, a0_.image_height AS image_height_2, a0_.image_width AS image_width_3, a0_.image_alt_desc AS image_alt_desc_4, a0_.user_id AS user_id_5 FROM Avatar a0_) dctrn_result ORDER BY image_alt_desc_4 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.image AS image_1, a0_.image_height AS image_height_2, a0_.image_width AS image_width_3, a0_.image_alt_desc AS image_alt_desc_4, a0_.user_id AS user_id_5 FROM Avatar a0_) dctrn_result ORDER BY image_alt_desc_4 DESC',
             $query->getSQL()
         );
     }
@@ -314,7 +314,7 @@ class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0, name_1 FROM (SELECT b0_.id AS id_0, a1_.name AS name_1, b0_.author_id AS author_id_2, b0_.category_id AS category_id_3 FROM BlogPost b0_ INNER JOIN Author a1_ ON b0_.author_id = a1_.id) dctrn_result ORDER BY name_1 ASC',
+            'SELECT DISTINCT id_0 FROM (SELECT b0_.id AS id_0, a1_.name AS name_1, b0_.author_id AS author_id_2, b0_.category_id AS category_id_3 FROM BlogPost b0_ INNER JOIN Author a1_ ON b0_.author_id = a1_.id) dctrn_result ORDER BY name_1 ASC',
             $query->getSQL()
         );
     }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -270,6 +270,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         'pagination' => array(
             'Doctrine\Tests\Models\Pagination\Company',
             'Doctrine\Tests\Models\Pagination\Logo',
+            'Doctrine\Tests\Models\Pagination\Department',
         ),
     );
 
@@ -521,6 +522,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
 
         if (isset($this->_usedModelSets['pagination'])) {
             $conn->executeUpdate('DELETE FROM pagination_logo');
+            $conn->executeUpdate('DELETE FROM pagination_department');
             $conn->executeUpdate('DELETE FROM pagination_company');
         }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -271,6 +271,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Pagination\Company',
             'Doctrine\Tests\Models\Pagination\Logo',
             'Doctrine\Tests\Models\Pagination\Department',
+            'Doctrine\Tests\Models\Pagination\User',
+            'Doctrine\Tests\Models\Pagination\User1',
         ),
     );
 
@@ -524,6 +526,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM pagination_logo');
             $conn->executeUpdate('DELETE FROM pagination_department');
             $conn->executeUpdate('DELETE FROM pagination_company');
+            $conn->executeUpdate('DELETE FROM pagination_user');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
This PR fixes issues reported in #1347 and #1351.
- Ordering a query by a column from an association which uses SINGLE_TABLE inheritance no longer throws an error.
- Limiting a query which is ordered by fields from a joined -To-Many association now works as expected.

This patch converts LimitSubqueryOutputWalker to use the ROW_NUMBER window function for queries on platforms that support it. Other platforms use a modified version of the previous method. The modification is to not select the ORDER BY columns in the wrapping query. The reason those columns were selected like that in the first place is that ORDER BY on columns not in the select list is unsupported on many platforms. MySQL and SQLite are fine with it, and don't support ROW_NUMBER.

The ROW_NUMBER solution is actually much simpler.

LimitSubqueryOutputWalker SQL generation tests for PG and Oracle have been changed.

**There are 2 failing expectedException tests right now.** The LimitSubqueryWalker needs to be modified to throw an exception when it detects a query that does the following things together:
- Joins a -To-Many association
- Orders by a column from the associated entity
- Limits the result

As with the previous patch, this depends on changes to SQLServerPlatform2008 that have not yet been merged. SQLServerPlatform2008 in DBAL/master currently mangles the generated queries when trying to apply LIMIT/OFFSET.
