### PR TITLE
[Docs] TablePrefix example - Check for being the owning side

### DIFF
--- a/docs/en/cookbook/sql-table-prefixes.rst
+++ b/docs/en/cookbook/sql-table-prefixes.rst
@@ -45,8 +45,8 @@ appropriate autoloaders.
             }
 
             foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
-                if ($mapping['type'] == \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY) {
-                    $mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
+                if ($mapping['type'] == \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY && $mapping['isOwningSide']) {
+                    $mappedTableName = $mapping['joinTable']['name'];
                     $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
                 }
             }


### PR DESCRIPTION
- Small fix do get rid of notice `undefined index 'joinTable'` as the inverse side does not declare `joinTable` at all.
- Shortened access to `$classMetadata->associationMappings[$fieldName]` for read accesses to increase readability
