### PR TITLE
[DDC-3661] Fix count in Doctrine\ORM\LazyCriteriaCollection

### DIFF
--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -70,16 +70,16 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
      */
     public function count()
     {
-        if ($this->isInitialized()) {
-            return $this->collection->count();
-        }
-
         // Return cached result in case count query was already executed
         if ($this->count !== null) {
             return $this->count;
         }
 
-        return $this->count = $this->entityPersister->count($this->criteria);
+        $maxResults  = $this->criteria->getMaxResults();
+        $total       = $this->entityPersister->count($this->criteria);
+        $this->count = $maxResults === null ? $total : min($maxResults, $total);
+
+        return $this->count;
     }
 
     /**


### PR DESCRIPTION
Fix Doctrine\ORM\LazyCriteriaCollection::count() when Criteria::$maxResults defined

ps. I have no idea how to write test for it :speak_no_evil: 
