### PR TITLE
Fix DDC767Test failing on php7 + pg94

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
@@ -49,7 +49,7 @@ class DDC767Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertNotNull($pUser, "User not retrieved from database.");
 
-        $groups = array(2, 3);
+        $groups = array($group2->id, $group3->id);
 
         try {
             $this->_em->beginTransaction();


### PR DESCRIPTION
The failure happens when running the full suite or even just:

```
phpunit tests/Doctrine/Tests/ORM/Functional/Ticket
```

see: https://revive.beccati.com/bamboo/browse/PHP-DOCPG-MAS-164/log

For reference:

```
05-Apr-2015 04:39:42    ...S......................................................... 1342 / 2921 ( 45%)
05-Apr-2015 04:39:43    ........SSS...........................................SS
05-Apr-2015 04:39:43    Fatal error: Argument 1 passed to Doctrine\Tests\Models\CMS\CmsUser::addGroup() must be an instance of Doctrine\Tests\Models\CMS\CmsGroup, null given, called in /home/atlassian/bamboo/xml-data/build-dir/PHP-DOCPG-MAS/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php on line 63 and defined in /home/atlassian/bamboo/xml-data/build-dir/PHP-DOCPG-MAS/tests/Doctrine/Tests/Models/CMS/CmsUser.php on line 211
```

I wasn't able to replicate with other PHP versions. On PHP7, running `tests/Doctrine/Tests/ORM/Functional/Ticket` yields 20, 21 and 22 as group IDs, rather than 1, 2, 3. Maybe some cleanup isn't run?

Removing hardocoded IDs seems a sensible thing to do anyway.
