### PR TITLE
Fix issue with second-level-cache tests and versioned entities

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -180,13 +180,7 @@ class DefaultCacheFactory implements CacheFactory
      */
     public function buildCollectionHydrator(EntityManagerInterface $em, array $mapping)
     {
-        /* @var $targetPersister \Doctrine\ORM\Cache\Persister\CachedPersister */
-        $targetPersister = $em->getUnitOfWork()->getEntityPersister($mapping['targetEntity']);
-
-        return new DefaultCollectionHydrator(
-            $em,
-            $targetPersister->getCacheRegion()
-        );
+        return new DefaultCollectionHydrator($em);
     }
 
     /**

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -20,6 +20,8 @@
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
@@ -30,12 +32,40 @@ use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClas
 class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
 {
     /**
+     * @param ClassMetadata $classMetadata
+     * @param EntityManager $entityManager
+     */
+    function __construct(ClassMetadata $classMetadata, EntityManager $entityManager)
+    {
+        /*
+        We use our own constructor here to enforce type-hinting requirements,
+        since both inputs are specialized subclasses compared to what the super-
+        class is willing to accept.
+
+        In particular, we want to have EntityManager rather than ObjectManager.
+        */
+        parent::__construct($classMetadata, $entityManager);
+    }
+
+    /**
      * Retrieve associated EntityManager.
      *
      * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {
-        return $this->getObjectManager();
+        $em = $this->getObjectManager();
+        assert($em instanceof EntityManager);
+        return $em;
+    }
+
+    /**
+     * Retrieves the associated ClassMetadata.
+     *
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    public function getClassMetadata()
+    {
+        return parent::getClassMetadata();
     }
 }

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -54,9 +54,11 @@ class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
      */
     public function getEntityManager()
     {
-        $em = $this->getObjectManager();
-        assert($em instanceof EntityManager);
-        return $em;
+        /*
+        We can safely assume our ObjectManager is also an EventManager due to
+        our restrictions in the constructor.
+        */
+        return $this->getObjectManager();
     }
 
     /**

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -30,10 +30,6 @@ class CacheMetadataListener
             return;
         }
 
-        if( ! $em instanceof EntityManager){
-            return;
-        }
-
         $this->enableCaching($metadata, $em);
     }
 

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -3,24 +3,53 @@
 namespace Doctrine\Tests\EventListener;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 class CacheMetadataListener
 {
+
+    /**
+     * Tracks which entities we have already forced caching enabled on. This is
+     * important to avoid some potential infinite-recursion issues.
+     * @var array
+     */
+    protected $enabledItems = array();
+
     /**
      * @param \Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs $event
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
         $metadata = $event->getClassMetadata();
-        $cache    = array(
-            'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
-        );
+        $em = $event->getObjectManager();
 
         /** @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
         if (strstr($metadata->name, 'Doctrine\Tests\Models\Cache')) {
             return;
         }
+
+        if( ! $em instanceof EntityManager){
+            return;
+        }
+
+        $this->enableCaching($metadata, $em);
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     * @param EntityManager $em
+     */
+    protected function enableCaching(ClassMetadata $metadata, EntityManager $em){
+
+        if(array_key_exists($metadata->getName(), $this->enabledItems)){
+            return; // Already handled in the past
+        }
+
+        $cache    = array(
+            'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
+        );
 
         if ($metadata->isVersioned) {
             return;
@@ -28,8 +57,20 @@ class CacheMetadataListener
 
         $metadata->enableCache($cache);
 
+        $this->enabledItems[$metadata->getName()] = $metadata;
+
+        /*
+         * Only enable association-caching when the target has already been
+         * given caching settings
+         */
         foreach ($metadata->associationMappings as $mapping) {
-            $metadata->enableAssociationCache($mapping['fieldName'], $cache);
+
+            $targetMeta = $em->getClassMetadata($mapping['targetEntity']);
+            $this->enableCaching($targetMeta, $em);
+
+            if(array_key_exists($targetMeta->getName(), $this->enabledItems)){
+                $metadata->enableAssociationCache($mapping['fieldName'], $cache);
+            }
         }
     }
 }

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -37,13 +37,13 @@ class CacheMetadataListener
      * @param ClassMetadata $metadata
      * @param EntityManager $em
      */
-    protected function enableCaching(ClassMetadata $metadata, EntityManager $em){
+    protected function enableCaching(ClassMetadata $metadata, EntityManager $em) {
 
-        if(array_key_exists($metadata->getName(), $this->enabledItems)){
+        if (array_key_exists($metadata->getName(), $this->enabledItems)) {
             return; // Already handled in the past
         }
 
-        $cache    = array(
+        $cache = array(
             'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
         );
 
@@ -64,7 +64,7 @@ class CacheMetadataListener
             $targetMeta = $em->getClassMetadata($mapping['targetEntity']);
             $this->enableCaching($targetMeta, $em);
 
-            if(array_key_exists($targetMeta->getName(), $this->enabledItems)){
+            if (array_key_exists($targetMeta->getName(), $this->enabledItems)) {
                 $metadata->enableAssociationCache($mapping['fieldName'], $cache);
             }
         }


### PR DESCRIPTION
I'm not sure why this bug doesn't show normally within `master`, but I ran across it with pull-request build [3930.1](https://travis-ci.org/doctrine/doctrine2/jobs/57975906), where it complained since `$targetPersister` was not an instance of `CachedPersister`. 

The immediate fix seems straightforward, because `DefaultCollectionHydrator` doesn't even accept the second argument.

@FabioBatSilva : Please let me know if you see some better resolution to this, or if it indicates some edge-case in the second-level-cache logic that requires a new test.
