### PR TITLE
Fixes ClassMetadata wakeupReflection with embeddable and StaticReflectio...

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -945,7 +945,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         foreach ($this->fieldMappings as $field => $mapping) {
-            if (isset($mapping['declaredField'])) {
+            if (isset($mapping['declaredField']) && isset($parentReflFields[$mapping['declaredField']])) {
                 $this->reflFields[$field] = new ReflectionEmbeddedProperty(
                     $parentReflFields[$mapping['declaredField']],
                     $reflService->getAccessibleProperty($mapping['originalClass'], $mapping['originalField']),

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\Common\Persistence\Mapping\StaticReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
@@ -1124,6 +1125,30 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $classMetadata->wakeupReflection(new RuntimeReflectionService());
 
         $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+    }
+
+    public function testWakeupReflectionWithEmbeddableAndStaticReflectionService()
+    {
+        $classMetadata = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
+
+        $classMetadata->mapEmbedded(array(
+            'fieldName'    => 'test',
+            'class'        => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'columnPrefix' => false,
+        ));
+
+        $field = array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'originalClass' => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'declaredField' => 'test',
+            'originalField' => 'embeddedProperty'
+        );
+
+        $classMetadata->mapField($field);
+        $classMetadata->wakeupReflection(new StaticReflectionService());
+
+        $this->assertEquals(array('test' => null, 'test.embeddedProperty' => null), $classMetadata->getReflectionProperties());
     }
 }
 


### PR DESCRIPTION
...nService

When the `StaticReflectionService` is used, then the wakeupReflection will cause an error with embedded properties. This is because the `getAccessibleProperty` method of the `StaticReflectionService` will always return null, so the parentReflFields will only have null values.

I found this problem when I was generating a Symfony form based on an entity with embedded properties.
