### PR TITLE
Patch second level cache association hydration

### DIFF
--- a/lib/Doctrine/ORM/Cache/MultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/MultiGetRegion.php
@@ -23,7 +23,7 @@ namespace Doctrine\ORM\Cache;
 /**
  * Defines a region that supports multi-get reading.
  *
- * With one method call we can get multipe items.
+ * With one method call we can get multiple items.
  *
  * @since   2.5
  * @author  Asmir Mustafic
@@ -31,7 +31,7 @@ namespace Doctrine\ORM\Cache;
 interface MultiGetRegion
 {
     /**
-     * Get all items from the cache indentifed by $keys.
+     * Get all items from the cache identified by $keys.
      * It returns NULL if some elements can not be found.
      *
      * @param CollectionCacheEntry $collection The collection of the items to be retrieved.

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -57,8 +57,9 @@ class DefaultMultiGetRegion extends DefaultRegion
     public function getMultiple(CollectionCacheEntry $collection)
     {
         $keysToRetrieve = array();
+
         foreach ($collection->identifiers as $index => $key) {
-            $keysToRetrieve[$index] = $this->name . '_' . $key->hash;
+            $keysToRetrieve[$index] = $this->getCacheEntryKey($key);
         }
 
         $items = $this->cache->fetchMultiple($keysToRetrieve);
@@ -70,6 +71,7 @@ class DefaultMultiGetRegion extends DefaultRegion
         foreach ($keysToRetrieve as $index => $key) {
             $returnableItems[$index] = $items[$key];
         }
+
         return $returnableItems;
     }
 }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -120,7 +120,7 @@ class DefaultRegion implements Region
         $returnableItems = array();
 
         foreach ($keysToRetrieve as $index => $key) {
-            $returnableItems[$index] = $items[$key];
+            $returnableItems[$index] = $items[$index];
         }
 
         return $returnableItems;

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -36,6 +36,8 @@ use Doctrine\ORM\Cache\Region;
  */
 class DefaultRegion implements Region
 {
+    const REGION_KEY_SEPARATOR = '_';
+
     /**
      * @var CacheAdapter
      */
@@ -84,7 +86,7 @@ class DefaultRegion implements Region
      */
     public function contains(CacheKey $key)
     {
-        return $this->cache->contains($this->name . '_' . $key->hash);
+        return $this->cache->contains($this->getCacheEntryKey($key));
     }
 
     /**
@@ -92,7 +94,7 @@ class DefaultRegion implements Region
      */
     public function get(CacheKey $key)
     {
-        return $this->cache->fetch($this->name . '_' . $key->hash) ?: null;
+        return $this->cache->fetch($this->getCacheEntryKey($key)) ?: null;
     }
 
     /**
@@ -103,7 +105,7 @@ class DefaultRegion implements Region
         $result = array();
 
         foreach ($collection->identifiers as $key) {
-            $entry = $this->cache->fetch($this->name . '_' . $key->hash);
+            $entry = $this->cache->fetch($this->getCacheEntryKey($key));
             if ($entry === false) {
                 $result = null;
                 break;
@@ -116,11 +118,20 @@ class DefaultRegion implements Region
     }
 
     /**
+     * @param CacheKey $key
+     * @return string
+     */
+    protected function getCacheEntryKey(CacheKey $key)
+    {
+        return $this->name . self::REGION_KEY_SEPARATOR . $key->hash;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function put(CacheKey $key, CacheEntry $entry, Lock $lock = null)
     {
-        return $this->cache->save($this->name . '_' . $key->hash, $entry, $this->lifetime);
+        return $this->cache->save($this->getCacheEntryKey($key), $entry, $this->lifetime);
     }
 
     /**
@@ -128,7 +139,7 @@ class DefaultRegion implements Region
      */
     public function evict(CacheKey $key)
     {
-        return $this->cache->delete($this->name . '_' . $key->hash);
+        return $this->cache->delete($this->getCacheEntryKey($key));
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -105,13 +105,14 @@ class DefaultRegion implements Region
         $result = array();
 
         foreach ($collection->identifiers as $key) {
-            $entry = $this->cache->fetch($this->getCacheEntryKey($key));
-            if ($entry === false) {
-                $result = null;
-                break;
-            } else {
-                $result[] = $entry;
+            $entryKey   = $this->getCacheEntryKey($key);
+            $entryValue = $this->cache->fetch($entryKey);
+
+            if ($entryValue === false) {
+                return null;
             }
+
+            $result[] = $entryValue;
         }
 
         return $result;

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -100,30 +100,19 @@ class DefaultRegion implements Region
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $keysToRetrieve = array();
+        $result = array();
 
-        foreach ($collection->identifiers as $index => $key) {
-            $keysToRetrieve[$index] = $this->name . '_' . $key->hash;
-        }
-
-        $items = array_filter(
-            array_map([$this->cache, 'fetch'], $keysToRetrieve),
-            function ($retrieved) {
-                return false !== $retrieved;
+        foreach ($collection->identifiers as $key) {
+            $entry = $this->cache->fetch($this->name . '_' . $key->hash);
+            if ($entry === false) {
+                $result = null;
+                break;
+            } else {
+                $result[] = $entry;
             }
-        );
-
-        if (count($items) !== count($keysToRetrieve)) {
-            return null;
         }
 
-        $returnableItems = array();
-
-        foreach ($keysToRetrieve as $index => $key) {
-            $returnableItems[$index] = $items[$index];
-        }
-
-        return $returnableItems;
+        return $result;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -3,9 +3,11 @@
 namespace Doctrine\Tests\ORM\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
+
 
 /**
  * @group DDC-2183
@@ -71,5 +73,28 @@ class DefaultRegionTest extends AbstractRegionTest
         $this->setExpectedException('BadMethodCallException');
 
         $region->evictAll();
+    }
+
+    public function testGetMulti()
+    {
+        $key1 = new CacheKeyMock('key.1');
+        $value1 = new CacheEntryMock(array('id' => 1, 'name' => 'bar'));
+
+        $key2 = new CacheKeyMock('key.2');
+        $value2 = new CacheEntryMock(array('id' => 2, 'name' => 'bar'));
+
+        $this->assertFalse($this->region->contains($key1));
+        $this->assertFalse($this->region->contains($key2));
+
+        $this->region->put($key1, $value1);
+        $this->region->put($key2, $value2);
+
+        $this->assertTrue($this->region->contains($key1));
+        $this->assertTrue($this->region->contains($key2));
+
+        $actual = $this->region->getMultiple(new CollectionCacheEntry(array($key1, $key2)));
+
+        $this->assertEquals($value1, $actual[0]);
+        $this->assertEquals($value2, $actual[1]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
@@ -22,16 +22,19 @@ class MultiGetRegionTest extends AbstractRegionTest
     public function testGetMulti()
     {
         $key1 = new CacheKeyMock('key.1');
-        $value1 = new CacheEntryMock(array('id'=>1, 'name' => 'bar'));
+        $value1 = new CacheEntryMock(array('id' => 1, 'name' => 'bar'));
 
         $key2 = new CacheKeyMock('key.2');
-        $value2 = new CacheEntryMock(array('id'=>2, 'name' => 'bar'));
+        $value2 = new CacheEntryMock(array('id' => 2, 'name' => 'bar'));
 
         $this->assertFalse($this->region->contains($key1));
         $this->assertFalse($this->region->contains($key2));
 
         $this->region->put($key1, $value1);
         $this->region->put($key2, $value2);
+
+        $this->assertTrue($this->region->contains($key1));
+        $this->assertTrue($this->region->contains($key2));
 
         $actual = $this->region->getMultiple(new CollectionCacheEntry(array($key1, $key2)));
 


### PR DESCRIPTION
Fixed incorrect use of keys in DefaultRegion::getMultiple() and simplified overall mechanism
