### PR TITLE
Fix skipping properties if they are listed after a not loaded relation.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3378,7 +3378,7 @@ class UnitOfWork implements PropertyChangedListener
                     } else {
                         if ($other instanceof Proxy && !$other->__isInitialized()) {
                             // do not merge fields marked lazy that have not been fetched.
-                            return;
+                            continue;
                         }
 
                         if ( ! $assoc2['isCascadeMerge']) {
@@ -3406,7 +3406,7 @@ class UnitOfWork implements PropertyChangedListener
                     if ($mergeCol instanceof PersistentCollection && ! $mergeCol->isInitialized()) {
                         // do not merge fields marked lazy that have not been fetched.
                         // keep the lazy persistent collection of the managed copy.
-                        return;
+                        continue;
                     }
 
                     $managedCol = $prop->getValue($managedCopy);

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_child")
+ */
+class DDC3699Child extends DDC3699Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $childField;
+
+    /**
+     * @OneToOne(targetEntity="DDC3699RelationOne", inversedBy="child")
+     */
+    protected $oneRelation;
+
+    /**
+     * @OneToMany(targetEntity="DDC3699RelationMany", mappedBy="child")
+     */
+    protected $relations;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChildField()
+    {
+        return $this->childField;
+    }
+
+    public function setChildField($childField)
+    {
+        $this->childField = $childField;
+    }
+
+    public function getOneRelation()
+    {
+        return $this->oneRelation;
+    }
+
+    public function setOneRelation($oneRelation)
+    {
+        $this->oneRelation = $oneRelation;
+    }
+
+    public function hasRelation($relation)
+    {
+        return $this->relations && $this->relations->contains($relation);
+    }
+
+    public function addRelation($relation)
+    {
+        if (!$this->hasRelation($relation)) {
+            $this->relations[] = $relation;
+        }
+
+        return $this;
+    }
+
+    public function removeRelation($relation)
+    {
+        $this->relations->removeElement($relation);
+
+        return $this;
+    }
+
+    public function getRelations()
+    {
+        return $this->relations;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class DDC3699Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $parentField;
+
+    public function getParentField()
+    {
+        return $this->parentField;
+    }
+
+    public function setParentField($parentField)
+    {
+        $this->parentField = $parentField;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_relation_many")
+ */
+class DDC3699RelationMany
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @ManyToOne(targetEntity="DDC3699Child", inversedBy="relations")
+     * @JoinColumn(name="child", referencedColumnName="id")
+     */
+    protected $child;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    public function setChild($child)
+    {
+        $this->child = $child;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_relation_one")
+ */
+class DDC3699RelationOne
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @OneToOne(targetEntity="DDC3699Child", mappedBy="oneRelation")
+     */
+    protected $child;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    public function setChild($child)
+    {
+        $this->child = $child;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
@@ -1,0 +1,96 @@
+<?php
+
+use Doctrine\Tests\Models\DDC3699\DDC3699Parent;
+use Doctrine\Tests\Models\DDC3699\DDC3699RelationOne;
+use Doctrine\Tests\Models\DDC3699\DDC3699RelationMany;
+use Doctrine\Tests\Models\DDC3699\DDC3699Child;
+
+/**
+ * @group DDC-3699
+ */
+class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(DDC3699Parent::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699RelationOne::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699RelationMany::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699Child::CLASSNAME),
+            ));
+        } catch (\Exception $e) {
+            // should throw error on second because schema is already created
+        }
+    }
+
+    private function createChild($id, $relationClass, $relationMethod)
+    {
+        // element in DB
+        $child = new DDC3699Child();
+        $child->setId($id);
+        $child->setChildField('childValue');
+        $child->setParentField('parentValue');
+
+        $relation = new $relationClass();
+        $relation->setId($id);
+        $relation->setChild($child);
+        $child->$relationMethod($relation);
+
+        $this->_em->persist($relation);
+        $this->_em->persist($child);
+        $this->_em->flush();
+
+        // detach
+        $this->_em->detach($relation);
+        $this->_em->detach($child);
+    }
+
+    /**
+     * @group DDC-3699
+     */
+    public function testMergeParentEntityFieldsOne()
+    {
+        $id = 1;
+        $this->createChild($id, DDC3699RelationOne::CLASSNAME, 'setOneRelation');
+
+        $unmanagedChild = $this->_em->find(DDC3699Child::CLASSNAME, $id);
+        $this->_em->detach($unmanagedChild);
+
+        // make it managed again
+        $this->_em->find(DDC3699Child::CLASSNAME, $id);
+
+        $unmanagedChild->setChildField('modifiedChildValue');
+        $unmanagedChild->setParentField('modifiedParentValue');
+
+        $mergedChild = $this->_em->merge($unmanagedChild);
+
+        $this->assertEquals($mergedChild->getChildField(), 'modifiedChildValue');
+        $this->assertEquals($mergedChild->getParentField(), 'modifiedParentValue');
+    }
+
+    /**
+     * @group DDC-3699
+     */
+    public function testMergeParentEntityFieldsMany()
+    {
+        $id = 2;
+        $this->createChild($id, DDC3699RelationMany::CLASSNAME, 'addRelation');
+
+        $unmanagedChild = $this->_em->find(DDC3699Child::CLASSNAME, $id);
+        $this->_em->detach($unmanagedChild);
+
+        // make it managed again
+        $this->_em->find(DDC3699Child::CLASSNAME, $id);
+
+        $unmanagedChild->setChildField('modifiedChildValue');
+        $unmanagedChild->setParentField('modifiedParentValue');
+
+        $mergedChild = $this->_em->merge($unmanagedChild);
+
+        $this->assertEquals($mergedChild->getChildField(), 'modifiedChildValue');
+        $this->assertEquals($mergedChild->getParentField(), 'modifiedParentValue');
+    }
+}


### PR DESCRIPTION
This issue fixes an issue that occurs when merging entites, when the entity that is being merged has some other properties after a association type field.

Fixes the following scenario : 
Your entity extends a parent entity and when it is merged by the entity manager first its fields are computed, this is done correctly bby `ReflectionPropertiesGetter::getProperties()`, but in the `mergeEntityStateIntoManagedCopy` method the iteration is stopped when it gets to a field that is a relationship and it is Proxy and was not loaded yet. 
The order in which the fields are computed is : current class properties and then the parent properties, so if the current class has a lazy loaded relationship then the properties of the parent are not merged.

So the fix doesn't stop the iteration it just skips the current property that is not loaded yet and goes to the next property.
