### PR TITLE
transactional() wrapper corrupts return values

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -235,7 +235,7 @@ use Doctrine\Common\Util\ClassUtils;
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
+            return $return;
         } catch (Exception $e) {
             $this->close();
             $this->conn->rollback();


### PR DESCRIPTION
The EntityManager::transactional() method has undocumented behavior, which unexpectedly rewrites all `false`-ish return values into `true` before passing them on:

```
$result = $this->_em->transactional(function (){
    return array();
}
assert(is_array($result)); // Fails
```

I think there's a very strong case to be made that this is undesirable, **however** it's been in existence for a few years now (since DDC-1125) and it's very likely at least a few users have code that _relies_ on the undocumented behavior.

This PR represents the most direct fix, but as a practical matter we may want to improve the documentation instead. If that is the decision, I'd be happy to create a separate PR for documentation changes.
