### PR TITLE
Composite key id used in nullable relations

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -666,6 +666,12 @@ class BasicEntityPersister implements EntityPersister
 
                 $this->quotedColumns[$sourceColumn]  = $quotedColumn;
                 $this->columnTypes[$sourceColumn]    = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
+
+                // Skip the null aissgnment for Id fields, to prevent overwriting a composite key.
+                if ( ! isset($newValId) && isset($this->class->fieldMappings[$sourceColumn]['id']) && $this->class->fieldMappings[$sourceColumn]['id']) {
+                    continue;
+                }
+
                 $result[$owningTable][$sourceColumn] = $newValId
                     ? $newValId[$targetClass->getFieldForColumn($targetColumn)]
                     : null;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2645,7 +2645,7 @@ class UnitOfWork implements PropertyChangedListener
                         }
                     }
 
-                    if ( ! $associatedId) {
+                    if ( ! $associatedId || count($assoc['targetToSourceKeyColumns']) != count($associatedId)) {
                         // Foreign key is NULL
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;

--- a/tests/Doctrine/Tests/Models/PriceRegions/PriceRegion.php
+++ b/tests/Doctrine/Tests/Models/PriceRegions/PriceRegion.php
@@ -1,0 +1,57 @@
+<?php
+namespace Doctrine\Tests\Models\PriceRegions;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\JoinColumns;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\Cache;
+
+/**
+ * @Entity
+ * @Table(name="price_regions")
+ * @Cache
+ */
+class PriceRegion
+{
+    /**
+     * @Id
+     * @Column(type="string", length=25)
+     */
+
+    public $id;
+
+    /**
+     * @Id
+     * @Column(type="string", length=25)
+     */
+
+    public $master_user_id;
+
+    /**
+     * @ManyToOne(targetEntity="VatRate")
+     * @JoinColumns({
+     *    @JoinColumn(name="default_vat_rate_id", referencedColumnName="id"),
+     *    @JoinColumn(name="master_user_id", referencedColumnName="master_user_id")
+     * })
+     * @Cache
+     */
+
+    public $default_vat_rate_id;
+
+    /**
+     * @Column(type="string", length=255);
+     */
+
+    public $name;
+
+    public function __construct($id, $master_user_id, $name)
+    {
+        $this->id             = $id;
+        $this->name           = $name;
+        $this->master_user_id = $master_user_id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/PriceRegions/VatRate.php
+++ b/tests/Doctrine/Tests/Models/PriceRegions/VatRate.php
@@ -1,0 +1,46 @@
+<?php
+namespace Doctrine\Tests\Models\PriceRegions;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\JoinColumns;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\Cache;
+
+/**
+ * @Entity
+ * @Table(name="vat_rates")
+ * @Cache
+ */
+class VatRate
+{
+    /**
+     * @Id
+     * @Column(type="string", length=25)
+     */
+
+    public $id;
+
+    /**
+     * @Id
+     * @Column(type="string", length=25)
+     */
+
+    public $master_user_id;
+
+    /**
+     * @Column(type="string", length=255);
+     */
+
+    public $name;
+
+    public function __construct($id, $master_user_id, $name)
+    {
+        $this->id             = $id;
+        $this->name           = $name;
+        $this->master_user_id = $master_user_id;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyWithAssociationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyWithAssociationsTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\Models\GeoNames\Country;
 use Doctrine\Tests\Models\GeoNames\Admin1;
 use Doctrine\Tests\Models\GeoNames\Admin1AlternateName;
+use Doctrine\Tests\Models\PriceRegions\PriceRegion;
 
 class CompositePrimaryKeyWithAssociationsTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -56,5 +57,19 @@ class CompositePrimaryKeyWithAssociationsTest extends \Doctrine\Tests\OrmFunctio
 
         $this->assertEquals(2, $name2->id);
         $this->assertEquals("Rome", $name2->name);
+    }
+
+    public function testFindByAbleToGetCompositeEntitiesWithMixedNullableRelation()
+    {
+        $priceRegion = $this->_em->getRepository('Doctrine\Tests\Models\PriceRegions\PriceRegion');
+        $pr          = new PriceRegion("dk-pr-1", "mu-1", "Denmark");
+
+        $this->_em->persist($pr);
+        $this->_em->flush();
+
+        $region = $priceRegion->findOneBy(array('id' => 'dk-pr-1'));
+
+        $this->assertEquals($region->id, "dk-pr-1");
+        $this->assertEquals($region->name, "Denmark");
     }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -261,7 +261,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\GeoNames\Country',
             'Doctrine\Tests\Models\GeoNames\Admin1',
             'Doctrine\Tests\Models\GeoNames\Admin1AlternateName',
-            'Doctrine\Tests\Models\GeoNames\City'
+            'Doctrine\Tests\Models\GeoNames\City',
+            'Doctrine\Tests\Models\PriceRegions\PriceRegion',
+            'Doctrine\Tests\Models\PriceRegions\VatRate',
         ),
         'custom_id_object_type' => array(
             'Doctrine\Tests\Models\CustomType\CustomIdObjectTypeParent',


### PR DESCRIPTION
This provides a fix, when you're using a composite primary key, and using part of the composite key as a join column, that will make sure you don't overwrite the composite id key.

Also the fix to Unit of Work needed to consider if part of a composite key was null, it should not try to map the entity.
