### PR TITLE
Fix result cache setting query caching

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -294,6 +294,8 @@ final class Query extends AbstractQuery
 
         if ($this->_queryCacheProfile) {
             $executor->setQueryCacheProfile($this->_queryCacheProfile);
+        } else {
+            $executor->removeQueryCacheProfile();
         }
 
         if ($this->_resultSetMapping === null) {

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -64,6 +64,16 @@ abstract class AbstractSqlExecutor
     }
 
     /**
+     * Do not use query cache
+     *
+     * @return void
+     */
+    public function removeQueryCacheProfile()
+    {
+        $this->queryCacheProfile = null;
+    }
+
+    /**
      * Executes all sql statements.
      *
      * @param Connection $conn   The database connection that is used to execute the queries.

--- a/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverConnectionMock.php
@@ -8,11 +8,32 @@ namespace Doctrine\Tests\Mocks;
 class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
 {
     /**
+     * @var \Doctrine\DBAL\Driver\Statement
+     */
+    private $statementMock;
+
+    /**
+     * @return \Doctrine\DBAL\Driver\Statement
+     */
+    public function getStatementMock()
+    {
+        return $this->statementMock;
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Driver\Statement $statementMock
+     */
+    public function setStatementMock($statementMock)
+    {
+        $this->statementMock = $statementMock;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function prepare($prepareString)
     {
-        return new StatementMock();
+        return $this->statementMock ?: new StatementMock();
     }
 
     /**
@@ -20,7 +41,7 @@ class DriverConnectionMock implements \Doctrine\DBAL\Driver\Connection
      */
     public function query()
     {
-        return new StatementMock;
+        return $this->statementMock ?: new StatementMock();
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: avasilenko
+ * Date: 24/04/15
+ * Time: 19:01
+ */
+
+namespace Doctrine\Tests\Mocks;
+
+
+/**
+ * Simple statement mock that returns result based on array.
+ * Doesn't support fetch modes
+ */
+class StatementArrayMock extends StatementMock
+{
+    /**
+     * @var array
+     */
+    private $_result;
+
+    public function __construct($result)
+    {
+        $this->_result = $result;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->_result);
+    }
+
+    public function columnCount()
+    {
+        $row = reset($this->_result);
+        if ($row) {
+            return count($row);
+        } else {
+            return 0;
+        }
+    }
+
+    public function fetchAll($fetchStyle = null)
+    {
+        return $this->_result;
+    }
+
+    public function fetch($fetchStyle = null)
+    {
+        $current = current($this->_result);
+        next($this->_result);
+
+        return $current;
+    }
+
+    public function fetchColumn($columnIndex = 0)
+    {
+        $current = current($this->_result);
+        if ($current) {
+            next($this->_result);
+            return reset($current);
+        } else {
+            return false;
+        }
+    }
+
+    public function rowCount()
+    {
+        return count($this->_result);
+    }
+}


### PR DESCRIPTION
Hello!

This PR fixes the issue with result caching option when query caching is on. 

Reproduce is pretty easy. Call same query twice: first time with `Query::useResultCache(true)`, second time with `Query::useResultCache(false)`. If query cache is on - `useResultCache()` setting will be cached along with query itself. 

Use case is when you want to keep query cache always on but want sometimes to bypass result cache (e.g. you're sure that underlying data was updated).

P.S. Is it possible to backport fix to 2.4? I can provide another PR for it

Alex
