### PR TITLE
Fix for DDC-3697 and DDC-3701

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1409,7 +1409,9 @@ Terminals
 ~~~~~~~~~
 
 
--  identifier (name, email, ...)
+-  identifier (name, email, ...) must match ``[a-z_][a-z0-9_]*``
+-  fully_qualified_name (Doctrine\Tests\Models\CMS\CmsUser) matches PHP's fully qualified class names
+-  aliased_name (CMS:CmsUser) uses two identifiers, one for the namespace alias and one for the class inside it
 -  string ('foo', 'bar''s house', '%ninja%', ...)
 -  char ('/', '\\', ' ', ...)
 -  integer (-1, 0, 1, 34, ...)
@@ -1443,8 +1445,8 @@ Identifiers
     /* Alias Identification declaration (the "u" of "FROM User u") */
     AliasIdentificationVariable :: = identifier
 
-    /* identifier that must be a class name (the "User" of "FROM User u") */
-    AbstractSchemaName ::= identifier
+    /* identifier that must be a class name (the "User" of "FROM User u"), possibly as a fully qualified class name or namespace-aliased */
+    AbstractSchemaName ::= fully_qualified_name | aliased_name | identifier
 
     /* Alias ResultVariable declaration (the "total" of "COUNT(*) AS total") */
     AliasResultVariable = identifier
@@ -1543,7 +1545,7 @@ Select Expressions
     SimpleSelectExpression  ::= (StateFieldPathExpression | IdentificationVariable | FunctionDeclaration | AggregateExpression | "(" Subselect ")" | ScalarExpression) [["AS"] AliasResultVariable]
     PartialObjectExpression ::= "PARTIAL" IdentificationVariable "." PartialFieldSet
     PartialFieldSet         ::= "{" SimpleStateField {"," SimpleStateField}* "}"
-    NewObjectExpression     ::= "NEW" IdentificationVariable "(" NewObjectArg {"," NewObjectArg}* ")"
+    NewObjectExpression     ::= "NEW" AbstractSchemaName "(" NewObjectArg {"," NewObjectArg}* ")"
     NewObjectArg            ::= ScalarExpression | "(" Subselect ")"
 
 Conditional Expressions

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -30,27 +30,27 @@ namespace Doctrine\ORM\Query;
 class Lexer extends \Doctrine\Common\Lexer
 {
     // All tokens that are not valid identifiers must be < 100
-    const T_NONE                = 1;
-    const T_INTEGER             = 2;
-    const T_STRING              = 3;
-    const T_INPUT_PARAMETER     = 4;
-    const T_FLOAT               = 5;
-    const T_CLOSE_PARENTHESIS   = 6;
-    const T_OPEN_PARENTHESIS    = 7;
-    const T_COMMA               = 8;
-    const T_DIVIDE              = 9;
-    const T_DOT                 = 10;
-    const T_EQUALS              = 11;
-    const T_GREATER_THAN        = 12;
-    const T_LOWER_THAN          = 13;
-    const T_MINUS               = 14;
-    const T_MULTIPLY            = 15;
-    const T_NEGATE              = 16;
-    const T_PLUS                = 17;
-    const T_OPEN_CURLY_BRACE    = 18;
-    const T_CLOSE_CURLY_BRACE   = 19;
-    const T_ALIASED_NAME        = 20;
-    const T_QUALIFIED_NAME      = 21;
+    const T_NONE                 = 1;
+    const T_INTEGER              = 2;
+    const T_STRING               = 3;
+    const T_INPUT_PARAMETER      = 4;
+    const T_FLOAT                = 5;
+    const T_CLOSE_PARENTHESIS    = 6;
+    const T_OPEN_PARENTHESIS     = 7;
+    const T_COMMA                = 8;
+    const T_DIVIDE               = 9;
+    const T_DOT                  = 10;
+    const T_EQUALS               = 11;
+    const T_GREATER_THAN         = 12;
+    const T_LOWER_THAN           = 13;
+    const T_MINUS                = 14;
+    const T_MULTIPLY             = 15;
+    const T_NEGATE               = 16;
+    const T_PLUS                 = 17;
+    const T_OPEN_CURLY_BRACE     = 18;
+    const T_CLOSE_CURLY_BRACE    = 19;
+    const T_ALIASED_NAME         = 20;
+    const T_FULLY_QUALIFIED_NAME = 21;
 
     // All tokens that are also identifiers should be >= 100
     const T_IDENTIFIER          = 100;
@@ -179,7 +179,7 @@ class Lexer extends \Doctrine\Common\Lexer
                 }
 
                 if (strpos($value, '\\') !== false) {
-                    return self::T_QUALIFIED_NAME;
+                    return self::T_FULLY_QUALIFIED_NAME;
                 }
                 if (strpos($value, ':') !== false) {
                     return self::T_ALIASED_NAME;

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -129,7 +129,7 @@ class Lexer extends \Doctrine\Common\Lexer
     {
         return array(
             '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // aliased name
-            '\\\?[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
+            '[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
             '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?', // numbers
             "'(?:[^']|'')*'", // quoted strings
             '\?[0-9]*|:[a-z_][a-z0-9_]*' // parameters
@@ -167,7 +167,7 @@ class Lexer extends \Doctrine\Common\Lexer
                 return self::T_STRING;
 
             // Recognize identifiers, aliased or qualified names
-            case (ctype_alpha($value[0]) || $value[0] === '_' || $value[0] === '\\'):
+            case (ctype_alpha($value[0]) || $value[0] === '_'):
                 $name = 'Doctrine\ORM\Query\Lexer::T_' . strtoupper($value);
 
                 if (defined($name)) {

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -180,11 +180,11 @@ class Lexer extends \Doctrine\Common\Lexer
 
                 if (strpos($value, '\\') !== false) {
                     return self::T_QUALIFIED_NAME;
-                } else if (strpos($value, ':') !== false) {
-                    return self::T_ALIASED_NAME;
-                } else {
-                    return self::T_IDENTIFIER;
                 }
+                if (strpos($value, ':') !== false) {
+                    return self::T_ALIASED_NAME;
+                }
+                return self::T_IDENTIFIER;
 
             // Recognize input parameters
             case ($value[0] === '?' || $value[0] === ':'):

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -164,7 +164,7 @@ class Lexer extends \Doctrine\Common\Lexer
                 return self::T_STRING;
 
             // Recognize identifiers
-            case (ctype_alpha($value[0]) || $value[0] === '_'):
+            case (ctype_alpha($value[0]) || $value[0] === '_' || $value[0] === '\\'):
                 $name = 'Doctrine\ORM\Query\Lexer::T_' . strtoupper($value);
 
                 if (defined($name)) {

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -128,7 +128,7 @@ class Lexer extends \Doctrine\Common\Lexer
     protected function getCatchablePatterns()
     {
         return array(
-            '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*', // aliased name
+            '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // aliased name
             '\\\?[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
             '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?', // numbers
             "'(?:[^']|'')*'", // quoted strings
@@ -178,11 +178,11 @@ class Lexer extends \Doctrine\Common\Lexer
                     }
                 }
 
-                if (strpos($value, '\\') !== false) {
-                    return self::T_FULLY_QUALIFIED_NAME;
-                }
                 if (strpos($value, ':') !== false) {
                     return self::T_ALIASED_NAME;
+                }
+                if (strpos($value, '\\') !== false) {
+                    return self::T_FULLY_QUALIFIED_NAME;
                 }
                 return self::T_IDENTIFIER;
 

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -49,6 +49,8 @@ class Lexer extends \Doctrine\Common\Lexer
     const T_PLUS                = 17;
     const T_OPEN_CURLY_BRACE    = 18;
     const T_CLOSE_CURLY_BRACE   = 19;
+    const T_ALIASED_NAME        = 20;
+    const T_QUALIFIED_NAME      = 21;
 
     // All tokens that are also identifiers should be >= 100
     const T_IDENTIFIER          = 100;
@@ -126,10 +128,11 @@ class Lexer extends \Doctrine\Common\Lexer
     protected function getCatchablePatterns()
     {
         return array(
-            '[a-z_\\\][a-z0-9_\:\\\]*[a-z0-9_]{1}',
-            '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?',
-            "'(?:[^']|'')*'",
-            '\?[0-9]*|:[a-z_][a-z0-9_]*'
+            '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*', // aliased name
+            '\\\?[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
+            '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?', // numbers
+            "'(?:[^']|'')*'", // quoted strings
+            '\?[0-9]*|:[a-z_][a-z0-9_]*' // parameters
         );
     }
 
@@ -163,7 +166,7 @@ class Lexer extends \Doctrine\Common\Lexer
 
                 return self::T_STRING;
 
-            // Recognize identifiers
+            // Recognize identifiers, aliased or qualified names
             case (ctype_alpha($value[0]) || $value[0] === '_' || $value[0] === '\\'):
                 $name = 'Doctrine\ORM\Query\Lexer::T_' . strtoupper($value);
 
@@ -175,7 +178,13 @@ class Lexer extends \Doctrine\Common\Lexer
                     }
                 }
 
-                return self::T_IDENTIFIER;
+                if (strpos($value, '\\') !== false) {
+                    return self::T_QUALIFIED_NAME;
+                } else if (strpos($value, ':') !== false) {
+                    return self::T_ALIASED_NAME;
+                } else {
+                    return self::T_IDENTIFIER;
+                }
 
             // Recognize input parameters
             case ($value[0] === '?' || $value[0] === ':'):
@@ -196,6 +205,9 @@ class Lexer extends \Doctrine\Common\Lexer
             case ($value === '!'): return self::T_NEGATE;
             case ($value === '{'): return self::T_OPEN_CURLY_BRACE;
             case ($value === '}'): return self::T_CLOSE_CURLY_BRACE;
+
+            case (strrpos($value, ':') !== false):
+                return self::T_ALIASED_NAME;
 
             // Default
             default:

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -320,6 +320,7 @@ class Parser
         if ($lookaheadType !== $token && ($token !== Lexer::T_IDENTIFIER || $lookaheadType <= Lexer::T_IDENTIFIER)) {
             $this->syntaxError($this->lexer->getLiteral($token));
         }
+
         $this->lexer->moveNext();
     }
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -962,16 +962,14 @@ class Parser
     {
         if ($this->lexer->isNextToken(Lexer::T_FULLY_QUALIFIED_NAME)) {
             $this->match(Lexer::T_FULLY_QUALIFIED_NAME);
-            $schemaName = ltrim($this->lexer->token['value'], '\\');
+            $schemaName = $this->lexer->token['value'];
+        } else if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+            $this->match(Lexer::T_IDENTIFIER);
+            $schemaName = $this->lexer->token['value'];
         } else {
-            if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-                $this->match(Lexer::T_IDENTIFIER);
-                $schemaName = $this->lexer->token['value'];
-            } else {
-                $this->match(Lexer::T_ALIASED_NAME);
-                list($namespaceAlias, $simpleClassName) = explode(':', $this->lexer->token['value']);
-                $schemaName = $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
-            }
+            $this->match(Lexer::T_ALIASED_NAME);
+            list($namespaceAlias, $simpleClassName) = explode(':', $this->lexer->token['value']);
+            $schemaName = $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
         }
 
         return $schemaName;

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -962,8 +962,8 @@ class Parser
      */
     public function AbstractSchemaName($validateName = true)
     {
-        if ($this->lexer->isNextToken(Lexer::T_QUALIFIED_NAME)) {
-            $this->match(Lexer::T_QUALIFIED_NAME);
+        if ($this->lexer->isNextToken(Lexer::T_FULLY_QUALIFIED_NAME)) {
+            $this->match(Lexer::T_FULLY_QUALIFIED_NAME);
             $schemaName = ltrim($this->lexer->token['value'], '\\');
         } else {
             if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -311,7 +311,12 @@ class Parser
     {
         $lookaheadType = $this->lexer->lookahead['type'];
 
-        // short-circuit on first condition, usually types match
+        /*
+         * The following condition means:
+         * - If next token matches expectation -> ok.
+         * - If expectation is to get T_IDENTIFIER and we find one of the tokens that are reserved words *but* would work as identifiers as well (e. g. "FROM", DDC-505) -> ok.
+         * - Else fail.
+         */
         if ($lookaheadType !== $token && ($token !== Lexer::T_IDENTIFIER || $lookaheadType <= Lexer::T_IDENTIFIER)) {
             $this->syntaxError($this->lexer->getLiteral($token));
         }

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -954,7 +954,7 @@ class Parser
     }
 
     /**
-     * AbstractSchemaName ::= qualified_name | aliased_name | identifier
+     * AbstractSchemaName ::= fully_qualified_name | aliased_name | identifier
      *
      * @param bool $validateName Whether to validate that the parsed name refers to an existing class.
      *

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -312,10 +312,9 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
 
         // short-circuit on first condition, usually types match
-        if ($lookaheadType !== $token && $token !== Lexer::T_IDENTIFIER && $lookaheadType <= Lexer::T_IDENTIFIER) {
+        if ($lookaheadType !== $token && ($token !== Lexer::T_IDENTIFIER || $lookaheadType <= Lexer::T_IDENTIFIER)) {
             $this->syntaxError($this->lexer->getLiteral($token));
         }
-
         $this->lexer->moveNext();
     }
 
@@ -1678,8 +1677,6 @@ class Parser
         // Describe non-root join declaration
         if ($joinDeclaration instanceof AST\RangeVariableDeclaration) {
             $joinDeclaration->isRoot = false;
-
-            $adhocConditions = true;
         }
 
         // Check for ad-hoc Join conditions

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1125,7 +1125,7 @@ class SqlWalker implements TreeWalker
                 $class      = $this->em->getClassMetadata($joinDeclaration->abstractSchemaName);
                 $dqlAlias   = $joinDeclaration->aliasIdentificationVariable;
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
-                $conditions = array();
+                $conditions = [];
 
                 if ($join->conditionalExpression) {
                     $conditions[] = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1125,14 +1125,16 @@ class SqlWalker implements TreeWalker
                 $class      = $this->em->getClassMetadata($joinDeclaration->abstractSchemaName);
                 $dqlAlias   = $joinDeclaration->aliasIdentificationVariable;
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
-                $condition = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
+                $conditions = array();
+
+                if ($join->conditionalExpression) {
+                    $conditions[] = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
+                }
                 $condExprConjunction = ($class->isInheritanceTypeJoined() && $joinType != AST\Join::JOIN_TYPE_LEFT && $joinType != AST\Join::JOIN_TYPE_LEFTOUTER)
                     ? ' AND '
                     : ' ON ';
 
                 $sql .= $this->walkRangeVariableDeclaration($joinDeclaration);
-
-                $conditions = array($condition);
 
                 // Apply remaining inheritance restrictions
                 $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($dqlAlias));
@@ -1148,7 +1150,10 @@ class SqlWalker implements TreeWalker
                     $conditions[] = $filterExpr;
                 }
 
-                $sql .= $condExprConjunction . implode(' AND ', $conditions);
+                if ($conditions) {
+                    $sql .= $condExprConjunction . implode(' AND ', $conditions);
+                }
+
                 break;
 
             case ($joinDeclaration instanceof \Doctrine\ORM\Query\AST\JoinAssociationDeclaration):

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1130,6 +1130,7 @@ class SqlWalker implements TreeWalker
                 if ($join->conditionalExpression) {
                     $conditions[] = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
                 }
+
                 $condExprConjunction = ($class->isInheritanceTypeJoined() && $joinType != AST\Join::JOIN_TYPE_LEFT && $joinType != AST\Join::JOIN_TYPE_LEFTOUTER)
                     ? ' AND '
                     : ' ON ';

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -129,7 +129,7 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $user2 = $this->_em->createQuery('select u from \Doctrine\Tests\Models\CMS\CmsUser u where u.id=?1')
+        $user2 = $this->_em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.id=?1')
                 ->setParameter(1, $userId)
                 ->getSingleResult();
 

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -1046,21 +1046,21 @@ class NewOperatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\InvalidClass(u.name)': Error: Class "InvalidClass" is not defined.
+     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near 'InvalidClass(u.name)': Error: Class "InvalidClass" is not defined.
      */
     public function testInvalidClassException()
     {
-        $dql = "SELECT new \InvalidClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = "SELECT new InvalidClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\stdClass(u.name)': Error: Class "stdClass" has not a valid constructor.
+     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near 'stdClass(u.name)': Error: Class "stdClass" has not a valid constructor.
      */
     public function testInvalidClassConstructorException()
     {
-        $dql = "SELECT new \stdClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
+        $dql = "SELECT new stdClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -1046,7 +1046,7 @@ class NewOperatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\InvalidClass(u.name)': Error: Class "\InvalidClass" is not defined.
+     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\InvalidClass(u.name)': Error: Class "InvalidClass" is not defined.
      */
     public function testInvalidClassException()
     {
@@ -1056,7 +1056,7 @@ class NewOperatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\stdClass(u.name)': Error: Class "\stdClass" has not a valid constructor.
+     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\stdClass(u.name)': Error: Class "stdClass" has not a valid constructor.
      */
     public function testInvalidClassConstructorException()
     {

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -78,14 +78,6 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
     }
 
     /**
-     * @group DDC-675, also see https://github.com/doctrine/doctrine2/commit/0424d870999c9fb0a044a8b5773f250376d2368f
-     */
-    public function testAbstractSchemaNameWithLeadingBackslash()
-    {
-        $this->assertValidDQL('SELECT u FROM \Doctrine\Tests\Models\CMS\CmsUser u');
-    }
-
-    /**
      * @dataProvider invalidDQL
      */
     public function testRejectsInvalidDQL($dql)
@@ -132,11 +124,6 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
             array('SELECT \'foo\' AS foo: FROM Doctrine\Tests\Models\CMS\CmsUser u'),
             array('SELECT \'foo\' AS foo:bar FROM Doctrine\Tests\Models\CMS\CmsUser u'),
         );
-    }
-
-    public function testSelectSingleComponentWithLeadingBackslashOnFQCN()
-    {
-        $this->assertValidDQL('SELECT u FROM \Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
     public function testSelectSingleComponentWithMultipleColumns()

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -73,6 +73,11 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
+    public function testSelectSingleComponentWithLeadingBackslashOnFQCN()
+    {
+        $this->assertValidDQL('SELECT u FROM \Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testSelectSingleComponentWithMultipleColumns()
     {
         $this->assertValidDQL('SELECT u.name, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
@@ -209,9 +214,25 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
         $this->assertValidDQL('SELECT u.name, a.topic, p.phonenumber FROM Doctrine\Tests\Models\CMS\CmsUser u INNER JOIN u.articles a LEFT JOIN u.phonenumbers p');
     }
 
-    public function testJoinClassPath()
+    public function testJoinClassPathUsingWITH()
     {
         $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a WITH a.user = u.id');
+    }
+
+    /**
+     * @group DDC-3701
+     */
+    public function testJoinClassPathUsingWHERE()
+    {
+        $this->assertValidDQL('SELECT u.name FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN Doctrine\Tests\Models\CMS\CmsArticle a WHERE a.user = u.id');
+    }
+
+    /**
+     * @group DDC-3701
+     */
+    public function testDDC3701WHEREIsNotWITH()
+    {
+        $this->assertInvalidDQL('SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c JOIN Doctrine\Tests\Models\Company\CompanyEmployee e WHERE e.id = c.salesPerson WHERE c.completed = true');
     }
 
     public function testOrderBySingleColumn()

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -1,11 +1,15 @@
 <?php
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query,
     Doctrine\ORM\Query\QueryException;
 
 class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
 {
+    /**
+     * @var EntityManagerInterface
+     */
     private $_em;
 
     protected function setUp()
@@ -71,6 +75,63 @@ class LanguageRecognitionTest extends \Doctrine\Tests\OrmTestCase
     public function testSelectSingleComponentWithAsterisk()
     {
         $this->assertValidDQL('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    /**
+     * @group DDC-675, also see https://github.com/doctrine/doctrine2/commit/0424d870999c9fb0a044a8b5773f250376d2368f
+     */
+    public function testAbstractSchemaNameWithLeadingBackslash()
+    {
+        $this->assertValidDQL('SELECT u FROM \Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
+    /**
+     * @dataProvider invalidDQL
+     */
+    public function testRejectsInvalidDQL($dql)
+    {
+        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+
+        $this->_em->getConfiguration()->setEntityNamespaces(array('Unknown' => 'Unknown', 'CMS' => 'Doctrine\Tests\Models\CMS'));
+        $this->parseDql($dql);
+    }
+
+    public function invalidDQL()
+    {
+        return array(
+
+            /* Checks for invalid IdentificationVariables and AliasIdentificationVariables */
+            array('SELECT \foo FROM Doctrine\Tests\Models\CMS\CmsUser \foo'),
+            array('SELECT foo\ FROM Doctrine\Tests\Models\CMS\CmsUser foo\\'),
+            array('SELECT foo\bar FROM Doctrine\Tests\Models\CMS\CmsUser foo\bar'),
+            array('SELECT foo:bar FROM Doctrine\Tests\Models\CMS\CmsUser foo:bar'),
+            array('SELECT foo: FROM Doctrine\Tests\Models\CMS\CmsUser foo:'),
+
+            /* Checks for invalid AbstractSchemaName */
+            array('SELECT u FROM UnknownClass u'),  // unknown
+            array('SELECT u FROM Unknown\Class u'), // unknown with namespace
+            array('SELECT u FROM \Unknown\Class u'), // unknown, leading backslash
+            array('SELECT u FROM Unknown\\\\Class u'), // unknown, syntactically bogus (duplicate \\)
+            array('SELECT u FROM Unknown\Class\ u'), // unknown, syntactically bogus (trailing \)
+            array('SELECT u FROM Unknown:Class u'), // unknown, with namespace alias
+            array('SELECT u FROM Unknown::Class u'), // unknown, with PAAMAYIM_NEKUDOTAYIM
+            array('SELECT u FROM Unknown:Class:Name u'), // unknown, with invalid namespace alias
+            array('SELECT u FROM UnknownClass: u'), // unknown, with invalid namespace alias
+            array('SELECT u FROM Unknown:Class: u'), // unknown, with invalid namespace alias
+            array('SELECT u FROM Doctrine\Tests\Models\CMS\\\\CmsUser u'), // syntactically bogus (duplicate \\)array('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser\ u'), // syntactically bogus (trailing \)
+            array('SELECT u FROM CMS::User u'),
+            array('SELECT u FROM CMS:User: u'),
+            array('SELECT u FROM CMS:User:Foo u'),
+
+            /* Checks for invalid AliasResultVariable */
+            array('SELECT \'foo\' AS \foo FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS \foo\bar FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS foo\bar FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS foo\ FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS foo\\\\bar FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS foo: FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+            array('SELECT \'foo\' AS foo:bar FROM Doctrine\Tests\Models\CMS\CmsUser u'),
+        );
     }
 
     public function testSelectSingleComponentWithLeadingBackslashOnFQCN()

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -239,7 +239,6 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
             array(Lexer::T_IDENTIFIER, '_some_identifier'), // starts with underscore
             array(Lexer::T_IDENTIFIER, 'comma'), // name of a token class with value < 100 (whitebox test)
             array(Lexer::T_FULLY_QUALIFIED_NAME, 'Some\Class'), // DQL class reference
-            array(Lexer::T_FULLY_QUALIFIED_NAME, '\Some\Class'), // DQL class reference with leading \
             array(Lexer::T_ALIASED_NAME, 'Some:Name'),
             array(Lexer::T_ALIASED_NAME, 'Some:Subclassed\Name')
         );

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -12,16 +12,16 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
     }
 
     /**
-     * @dataProvider validIdentifiers
+     * @dataProvider provideTokens
      */
-    public function testScannerRecognizesIdentifier($value)
+    public function testScannerRecognizesTokens($type, $value)
     {
         $lexer = new Lexer($value);
 
         $lexer->moveNext();
         $token = $lexer->lookahead;
 
-        $this->assertEquals(Lexer::T_IDENTIFIER, $token['type']);
+        $this->assertEquals($type, $token['type']);
         $this->assertEquals($value, $token['value']);
     }
 
@@ -178,7 +178,7 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
             ),
             array(
                 'value' => 'My\Namespace\User',
-                'type'  => Lexer::T_IDENTIFIER,
+                'type'  => Lexer::T_QUALIFIED_NAME,
                 'position' => 14
             ),
             array(
@@ -229,17 +229,18 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
         $this->assertFalse($lexer->moveNext());
     }
 
-    public function validIdentifiers()
+    public function provideTokens()
     {
         return array(
-            array('u'), // one char
-            array('someIdentifier'),
-            array('s0m31d3nt1f13r'), // including digits
-            array('some_identifier'), // including underscore
-            array('_some_identifier'), // starts with underscore
-            array('Some\Class'), // DQL class reference
-            array('\Some\Class'), // DQL class reference with leading \
-            array('comma') // name of a token class with value < 100 (whitebox test)
+            array(Lexer::T_IDENTIFIER, 'u'), // one char
+            array(Lexer::T_IDENTIFIER, 'someIdentifier'),
+            array(Lexer::T_IDENTIFIER, 's0m31d3nt1f13r'), // including digits
+            array(Lexer::T_IDENTIFIER, 'some_identifier'), // including underscore
+            array(Lexer::T_IDENTIFIER, '_some_identifier'), // starts with underscore
+            array(Lexer::T_IDENTIFIER, 'comma'), // name of a token class with value < 100 (whitebox test)
+            array(Lexer::T_QUALIFIED_NAME, 'Some\Class'), // DQL class reference
+            array(Lexer::T_QUALIFIED_NAME, '\Some\Class'), // DQL class reference with leading \
+            array(Lexer::T_ALIASED_NAME, 'Some:Name')
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -240,7 +240,8 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
             array(Lexer::T_IDENTIFIER, 'comma'), // name of a token class with value < 100 (whitebox test)
             array(Lexer::T_FULLY_QUALIFIED_NAME, 'Some\Class'), // DQL class reference
             array(Lexer::T_FULLY_QUALIFIED_NAME, '\Some\Class'), // DQL class reference with leading \
-            array(Lexer::T_ALIASED_NAME, 'Some:Name')
+            array(Lexer::T_ALIASED_NAME, 'Some:Name'),
+            array(Lexer::T_ALIASED_NAME, 'Some:Subclassed\Name')
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -178,7 +178,7 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
             ),
             array(
                 'value' => 'My\Namespace\User',
-                'type'  => Lexer::T_QUALIFIED_NAME,
+                'type'  => Lexer::T_FULLY_QUALIFIED_NAME,
                 'position' => 14
             ),
             array(
@@ -238,8 +238,8 @@ class LexerTest extends \Doctrine\Tests\OrmTestCase
             array(Lexer::T_IDENTIFIER, 'some_identifier'), // including underscore
             array(Lexer::T_IDENTIFIER, '_some_identifier'), // starts with underscore
             array(Lexer::T_IDENTIFIER, 'comma'), // name of a token class with value < 100 (whitebox test)
-            array(Lexer::T_QUALIFIED_NAME, 'Some\Class'), // DQL class reference
-            array(Lexer::T_QUALIFIED_NAME, '\Some\Class'), // DQL class reference with leading \
+            array(Lexer::T_FULLY_QUALIFIED_NAME, 'Some\Class'), // DQL class reference
+            array(Lexer::T_FULLY_QUALIFIED_NAME, '\Some\Class'), // DQL class reference with leading \
             array(Lexer::T_ALIASED_NAME, 'Some:Name')
         );
     }

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -53,27 +53,6 @@ class ParserTest extends \Doctrine\Tests\OrmTestCase
     }
 
     /**
-     * @covers \Doctrine\ORM\Query\Parser::AbstractSchemaName
-     * @group DDC-3715
-     */
-    public function testAbstractSchemaNameFailsIfClassDoesNotExist()
-    {
-        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
-        $parser = $this->createParser('Foo\Bar');
-        $parser->AbstractSchemaName();
-    }
-
-    /**
-     * @covers \Doctrine\ORM\Query\Parser::AbstractSchemaName
-     * @group DDC-3715
-     */
-    public function testAbstractSchemaNameCanSkipClassCheck()
-    {
-        $parser = $this->createParser('Foo\Bar');
-        $this->assertEquals('Foo\Bar', $parser->AbstractSchemaName(false));
-    }
-
-    /**
      * @dataProvider validMatches
      * @covers Doctrine\ORM\Query\Parser::match
      * @group DDC-3701

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -24,10 +24,12 @@ class ParserTest extends \Doctrine\Tests\OrmTestCase
      * @covers Doctrine\ORM\Query\Parser::AbstractSchemaName
      * @group DDC-3715
      */
-    public function testAbstractSchemaNameTrimsLeadingBackslash()
+    public function testAbstractSchemaNameFailsOnClassnamesWithLeadingBackslash()
     {
+        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+
         $parser = $this->createParser('\Doctrine\Tests\Models\CMS\CmsUser');
-        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
+        $parser->AbstractSchemaName();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -53,6 +53,18 @@ class ParserTest extends \Doctrine\Tests\OrmTestCase
     }
 
     /**
+     * @covers \Doctrine\ORM\Query\Parser::AbstractSchemaName
+     * @group DDC-3715
+     */
+    public function testAbstractSchemaNameSupportsNamespaceAliasWithRelativeClassname()
+    {
+        $parser = $this->createParser('Model:CMS\CmsUser');
+        $parser->getEntityManager()->getConfiguration()->addEntityNamespace('Model', 'Doctrine\Tests\Models');
+
+        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
+    }
+
+    /**
      * @dataProvider validMatches
      * @covers Doctrine\ORM\Query\Parser::match
      * @group DDC-3701

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -3,10 +3,16 @@
 namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 
 class ParserTest extends \Doctrine\Tests\OrmTestCase
 {
+
+    /**
+     * @covers \Doctrine\ORM\Query\Parser::AbstractSchemaName
+     * @group DDC-3715
+     */
     public function testAbstractSchemaName()
     {
         $parser = $this->createParser('Doctrine\Tests\Models\CMS\CmsUser');
@@ -14,10 +20,66 @@ class ParserTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
     }
 
+    /**
+     * @covers Doctrine\ORM\Query\Parser::AbstractSchemaName
+     * @group DDC-3715
+     */
     public function testAbstractSchemaNameTrimsLeadingBackslash()
     {
         $parser = $this->createParser('\Doctrine\Tests\Models\CMS\CmsUser');
         $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
+    }
+
+    /**
+     * @dataProvider validMatches
+     * @covers Doctrine\ORM\Query\Parser::match
+     * @group DDC-3701
+     */
+    public function testMatch($expectedToken, $inputString)
+    {
+        $parser = $this->createParser($inputString);
+        $parser->match($expectedToken); // throws exception if not matched
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider invalidMatches
+     * @covers Doctrine\ORM\Query\Parser::match
+     * @group DDC-3701
+     */
+    public function testMatchFailure($expectedToken, $inputString)
+    {
+        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+
+        $parser = $this->createParser($inputString);
+        $parser->match($expectedToken);
+    }
+
+    public function validMatches()
+    {
+        return array(
+            array(Lexer::T_WHERE, 'where'), // keyword
+            array(Lexer::T_DOT, '.'), // token that cannot be an identifier
+            array(Lexer::T_IDENTIFIER, 'u'), // one char
+            array(Lexer::T_IDENTIFIER, 'someIdentifier'),
+            array(Lexer::T_IDENTIFIER, 's0m31d3nt1f13r'), // including digits
+            array(Lexer::T_IDENTIFIER, 'some_identifier'), // including underscore
+            array(Lexer::T_IDENTIFIER, '_some_identifier'), // starts with underscore
+            array(Lexer::T_IDENTIFIER, 'Some\Class'), // DQL class reference
+            array(Lexer::T_IDENTIFIER, '\Some\Class'), // DQL class reference with leading \
+            array(Lexer::T_IDENTIFIER, 'from'), // also a terminal string (the "FROM" keyword) as in DDC-505
+            array(Lexer::T_IDENTIFIER, 'comma') // not even a terminal string, but the name of a constant in the Lexer (whitebox test)
+        );
+    }
+
+    public function invalidMatches()
+    {
+        return array(
+            array(Lexer::T_DOT, 'ALL'), // ALL is a terminal string (reserved keyword) and also possibly an identifier
+            array(Lexer::T_DOT, ','), // "," is a token on its own, but cannot be used as identifier
+            array(Lexer::T_WHERE, 'WITH'), // as in DDC-3697
+            array(Lexer::T_WHERE, '.')
+        );
     }
 
     private function createParser($dql)

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Query;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\Parser;
+
+class ParserTest extends \Doctrine\Tests\OrmTestCase
+{
+    public function testAbstractSchemaName()
+    {
+        $parser = $this->createParser('Doctrine\Tests\Models\CMS\CmsUser');
+
+        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
+    }
+
+    public function testAbstractSchemaNameTrimsLeadingBackslash()
+    {
+        $parser = $this->createParser('\Doctrine\Tests\Models\CMS\CmsUser');
+        $this->assertEquals('Doctrine\Tests\Models\CMS\CmsUser', $parser->AbstractSchemaName());
+    }
+
+    private function createParser($dql)
+    {
+        $query = new Query($this->_getTestEntityManager());
+        $query->setDQL($dql);
+
+        $parser = new Parser($query);
+        $parser->getLexer()->moveNext();
+
+        return $parser;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -84,6 +84,23 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->fail($sql);
     }
 
+    public function testDDC3697WithPartialLoad()
+    {
+        $this->assertSqlGeneration(
+            'SELECT c.id FROM \Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
+            'SELECT c0_.id AS id_0 FROM company_persons c0_ INNER JOIN company_persons c1_ WHERE c0_.spouse_id = c1_.id AND c1_.id = 42',
+            array(Query::HINT_FORCE_PARTIAL_LOAD => true)
+        );
+    }
+
+    public function testDDC3697WithoutPartialLoad()
+    {
+        $this->assertSqlGeneration(
+            'SELECT c.id FROM \Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
+            'SELECT c0_.id AS id_0 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id INNER JOIN company_persons c3_ LEFT JOIN company_managers c4_ ON c3_.id = c4_.id LEFT JOIN company_employees c5_ ON c3_.id = c5_.id WHERE c0_.spouse_id = c3_.id AND c3_.id = 42',
+            array(Query::HINT_FORCE_PARTIAL_LOAD => false)
+        );
+    }
 
     public function testSupportsSelectForAllFields()
     {

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2259,6 +2259,43 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             'SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING sclr_0 IS NULL'
         );
     }
+
+    /**
+     * @group DDC-3701
+     */
+    public function testFROMClauseAcceptsFQCNWithLeadingBackslash()
+    {
+        $this->_em->createQuery(
+            'SELECT c FROM \Doctrine\Tests\Models\Company\CompanyContract c'
+        )->getSQL();
+    }
+
+    /**
+     * @group DDC-3701
+     * @expectedException \Doctrine\ORM\Query\QueryException
+     */
+    public function testParserDoesNotAcceptWHEREWhenWITHIsExpected()
+    {
+        $this->_em->createQuery('
+            SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
+            JOIN Doctrine\Tests\Models\Company\CompanyEmployee e
+            WHERE e.id = c.salesPerson
+            WHERE c.completed = true
+        ')->getSQL();
+    }
+
+    /**
+     * @group DDC-3701
+     */
+    public function testParserAcceptsJoinWithRangeVariableDeclatationAndNoWITHClause()
+    {
+        $this->_em->createQuery('
+            SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
+            JOIN Doctrine\Tests\Models\Company\CompanyEmployee e
+            WHERE e.id = c.salesPerson
+        ')->getSQL();
+    }
+
 }
 
 class MyAbsFunction extends \Doctrine\ORM\Query\AST\Functions\FunctionNode

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -84,7 +84,10 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         $this->fail($sql);
     }
 
-    public function testDDC3697WithPartialLoad()
+    /**
+     * @group DDC-3697
+     */
+    public function testJoinWithRangeVariablePutsConditionIntoSqlWhereClause()
     {
         $this->assertSqlGeneration(
             'SELECT c.id FROM Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
@@ -93,8 +96,16 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         );
     }
 
-    public function testDDC3697WithoutPartialLoad()
+    /**
+     * @group DDC-3697
+     */
+    public function testJoinWithRangeVariableAndInheritancePutsConditionIntoSqlWhereClause()
     {
+        /*
+         * Basically like the previous test, but this time load data for the inherited objects as well.
+         * The important thing is that the ON clauses in LEFT JOINs only contain the conditions necessary to join the appropriate inheritance table
+         * whereas the filtering condition must remain in the SQL WHERE clause.
+         */
         $this->assertSqlGeneration(
             'SELECT c.id FROM Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
             'SELECT c0_.id AS id_0 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id INNER JOIN company_persons c3_ LEFT JOIN company_managers c4_ ON c3_.id = c4_.id LEFT JOIN company_employees c5_ ON c3_.id = c5_.id WHERE c0_.spouse_id = c3_.id AND c3_.id = 42',

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2289,11 +2289,13 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testParserAcceptsJoinWithRangeVariableDeclatationAndNoWITHClause()
     {
-        $this->_em->createQuery('
+        $sql = $this->_em->createQuery('
             SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
             JOIN Doctrine\Tests\Models\Company\CompanyEmployee e
             WHERE e.id = c.salesPerson
         ')->getSQL();
+
+        $this->assertInternalType('string', $sql);
     }
 
 }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -491,19 +491,8 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     {
         // This also uses FQCNs starting with or without a backslash in the INSTANCE OF parameter
         $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, \Doctrine\Tests\Models\Company\CompanyManager)",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, Doctrine\Tests\Models\Company\CompanyManager)",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee', 'manager')"
-        );
-    }
-
-    /**
-     * @group DDC-1194
-     */
-    public function testSupportsInstanceOfExpressionsInWherePartPrefixedSlash()
-    {
-        $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF \Doctrine\Tests\Models\Company\CompanyEmployee",
-            "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee')"
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -489,8 +489,9 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 
     public function testSupportsInstanceOfExpressionInWherePartWithMultipleValues()
     {
+        // This also uses FQCNs starting with or without a backslash in the INSTANCE OF parameter
         $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, Doctrine\Tests\Models\Company\CompanyManager)",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, \Doctrine\Tests\Models\Company\CompanyManager)",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee', 'manager')"
         );
     }
@@ -501,7 +502,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSupportsInstanceOfExpressionsInWherePartPrefixedSlash()
     {
         $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF Doctrine\Tests\Models\Company\CompanyEmployee",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF \Doctrine\Tests\Models\Company\CompanyEmployee",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee')"
         );
     }
@@ -512,7 +513,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSupportsInstanceOfExpressionsInWherePartWithUnrelatedClass()
     {
         $this->assertInvalidSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF Doctrine\Tests\Models\CMS\CmsUser",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF \Doctrine\Tests\Models\CMS\CmsUser",
             "Doctrine\ORM\Query\QueryException"
         );
     }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2259,46 +2259,6 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             'SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING sclr_0 IS NULL'
         );
     }
-
-    /**
-     * @group DDC-3701
-     */
-    public function testFROMClauseAcceptsFQCNWithLeadingBackslash()
-    {
-        $this->_em->createQuery(
-            'SELECT c FROM \Doctrine\Tests\Models\Company\CompanyContract c'
-        )->getSQL();
-    }
-
-    /**
-     * @group DDC-3701
-     */
-    public function testParserDoesNotAcceptWHEREWhenWITHIsExpected()
-    {
-        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
-
-        $this->_em->createQuery('
-            SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
-            JOIN Doctrine\Tests\Models\Company\CompanyEmployee e
-            WHERE e.id = c.salesPerson
-            WHERE c.completed = true
-        ')->getSQL();
-    }
-
-    /**
-     * @group DDC-3701
-     */
-    public function testParserAcceptsJoinWithRangeVariableDeclatationAndNoWITHClause()
-    {
-        $sql = $this->_em->createQuery('
-            SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
-            JOIN Doctrine\Tests\Models\Company\CompanyEmployee e
-            WHERE e.id = c.salesPerson
-        ')->getSQL();
-
-        $this->assertInternalType('string', $sql);
-    }
-
 }
 
 class MyAbsFunction extends \Doctrine\ORM\Query\AST\Functions\FunctionNode

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2272,10 +2272,11 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 
     /**
      * @group DDC-3701
-     * @expectedException \Doctrine\ORM\Query\QueryException
      */
     public function testParserDoesNotAcceptWHEREWhenWITHIsExpected()
     {
+        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+
         $this->_em->createQuery('
             SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c
             JOIN Doctrine\Tests\Models\Company\CompanyEmployee e

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -87,7 +87,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testDDC3697WithPartialLoad()
     {
         $this->assertSqlGeneration(
-            'SELECT c.id FROM \Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
+            'SELECT c.id FROM Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
             'SELECT c0_.id AS id_0 FROM company_persons c0_ INNER JOIN company_persons c1_ WHERE c0_.spouse_id = c1_.id AND c1_.id = 42',
             array(Query::HINT_FORCE_PARTIAL_LOAD => true)
         );
@@ -96,7 +96,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testDDC3697WithoutPartialLoad()
     {
         $this->assertSqlGeneration(
-            'SELECT c.id FROM \Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
+            'SELECT c.id FROM Doctrine\Tests\Models\Company\CompanyPerson c JOIN Doctrine\Tests\Models\Company\CompanyPerson r WHERE c.spouse = r AND r.id = 42',
             'SELECT c0_.id AS id_0 FROM company_persons c0_ LEFT JOIN company_managers c1_ ON c0_.id = c1_.id LEFT JOIN company_employees c2_ ON c0_.id = c2_.id INNER JOIN company_persons c3_ LEFT JOIN company_managers c4_ ON c3_.id = c4_.id LEFT JOIN company_employees c5_ ON c3_.id = c5_.id WHERE c0_.spouse_id = c3_.id AND c3_.id = 42',
             array(Query::HINT_FORCE_PARTIAL_LOAD => false)
         );
@@ -479,7 +479,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSupportsInstanceOfExpressionInWherePartWithMultipleValues()
     {
         $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, \Doctrine\Tests\Models\Company\CompanyManager)",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF (Doctrine\Tests\Models\Company\CompanyEmployee, Doctrine\Tests\Models\Company\CompanyManager)",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee', 'manager')"
         );
     }
@@ -490,7 +490,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSupportsInstanceOfExpressionsInWherePartPrefixedSlash()
     {
         $this->assertSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF \Doctrine\Tests\Models\Company\CompanyEmployee",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF Doctrine\Tests\Models\Company\CompanyEmployee",
             "SELECT c0_.id AS id_0, c0_.name AS name_1, c0_.discr AS discr_2 FROM company_persons c0_ WHERE c0_.discr IN ('employee')"
         );
     }
@@ -501,7 +501,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
     public function testSupportsInstanceOfExpressionsInWherePartWithUnrelatedClass()
     {
         $this->assertInvalidSqlGeneration(
-            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF \Doctrine\Tests\Models\CMS\CmsUser",
+            "SELECT u FROM Doctrine\Tests\Models\Company\CompanyPerson u WHERE u INSTANCE OF Doctrine\Tests\Models\CMS\CmsUser",
             "Doctrine\ORM\Query\QueryException"
         );
     }


### PR DESCRIPTION
This is about the DQL parser generating wrong SQL because conditions may end in the "ON" clause of a LEFT JOIN instead of the WHERE clause (http://www.doctrine-project.org/jira/browse/DDC-3697).

It also fixes that the parser may be too sloppy on expected tokens, for example accepting a WHERE instead of WITH (http://www.doctrine-project.org/jira/browse/DDC-3701) or `identifier`s with backslashes like in `SELECT \foo.bar\baz FROM...`. The first problem probably would have surfaced earlier with this strict check in place.
