### PR TITLE
Add Expr::concat support for multiple arguments

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -526,13 +526,13 @@ class Expr
      * Creates a CONCAT() function expression with the given arguments.
      *
      * @param mixed $x First argument to be used in CONCAT() function.
-     * @param mixed $y Second argument to be used in CONCAT() function.
+     * @param mixed $y,... Other arguments to be used in CONCAT() function.
      *
      * @return Expr\Func
      */
     public function concat($x, $y)
     {
-        return new Expr\Func('CONCAT', array($x, $y));
+        return new Expr\Func('CONCAT', func_get_args());
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -3464,7 +3464,7 @@ class Parser
 
     /**
      * FunctionsReturningStrings ::=
-     *   "CONCAT" "(" StringPrimary "," StringPrimary ")" |
+     *   "CONCAT" "(" StringPrimary "," StringPrimary {"," StringPrimary}* ")" |
      *   "SUBSTRING" "(" StringPrimary "," SimpleArithmeticExpression "," SimpleArithmeticExpression ")" |
      *   "TRIM" "(" [["LEADING" | "TRAILING" | "BOTH"] [char] "FROM"] StringPrimary ")" |
      *   "LOWER" "(" StringPrimary ")" |

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -184,6 +184,7 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     public function testConcatExpr()
     {
         $this->assertEquals('CONCAT(u.first_name, u.last_name)', (string) $this->_expr->concat('u.first_name', 'u.last_name'));
+        $this->assertEquals('CONCAT(u.first_name, u.middle_name, u.last_name)', (string) $this->_expr->concat('u.first_name', 'u.middle_name', 'u.last_name'));
     }
 
     public function testSubstringExpr()


### PR DESCRIPTION
DQL CONCAT function support variable number of arguments (2+) since version `2.4.0`.

The `Expr` class, on the other hand, is still limited to 2 arguments, and require multiple call to achive a similar result (see [this SO question](http://stackoverflow.com/questions/22169324/concat-three-or-more-fields-in-doctrine/29913780)). I've improved `Expr` implementation to support variable number of arguments in a backward compatible way.

Please, consider backporting to `2.4` branch if you plan to release other versions, since `2.5` introduce many features and may not be possible to easily upgrade. I may be wrong, though.
