### PR TITLE
Remove HHVM-nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 env:
   - DB=mysql
@@ -15,7 +14,7 @@ env:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.6' && $DB = 'sqlite' ]]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; else PHPUNIT_FLAGS=""; fi
-  - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != 'hhvm-nightly' && $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer install --prefer-source --dev
 
@@ -32,10 +31,5 @@ matrix:
       env: DB=pgsql  # driver currently unsupported by HHVM
     - php: hhvm
       env: DB=mysqli # driver currently unsupported by HHVM
-    - php: hhvm-nightly
-      env: DB=pgsql  # driver currently unsupported by HHVM
-    - php: hhvm-nightly
-      env: DB=mysqli # driver currently unsupported by HHVM
   allow_failures:
     - php: 7.0
-    - php: hhvm-nightly # hhvm-nightly currently chokes on composer installation


### PR DESCRIPTION
hhvm-nightly is not available anymore on Travis because HHVM dropped support for Ubuntu Precise, which is still used by Travis.

This avoids creating useless jobs in the matrix which are killed by Travis from the start.
