### PR TITLE
AbstractCommand: use name of helper, do not require alias

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -51,7 +51,7 @@ abstract class AbstractCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $emHelper = $this->getHelper('em');
+        $emHelper = $this->getHelper('entityManager');
 
         /* @var $em \Doctrine\ORM\EntityManager */
         $em = $emHelper->getEntityManager();


### PR DESCRIPTION
Name for the helper is "entityManager", see https://github.com/doctrine/doctrine2/blob/330f88e44ba0e5e6f932a92ae63b64cdd5cdc046/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php#L70

Using "em" forces creating an alias, while adding helper.

Seems like some forgotten name change.
