### PR TITLE
EntityManager#getReference throw ORMException for unrecognized id

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -482,6 +482,11 @@ use Doctrine\Common\Util\ClassUtils;
             }
 
             $sortedId[$identifier] = $id[$identifier];
+            unset($id[$identifier]);
+        }
+
+        if ($id) {
+            throw ORMException::unrecognizedIdentifierFields($class->name, array_keys($id));
         }
 
         // Check identity map first, if its already in there just return it.
@@ -491,10 +496,6 @@ use Doctrine\Common\Util\ClassUtils;
 
         if ($class->subClasses) {
             return $this->find($entityName, $sortedId);
-        }
-
-        if ( ! is_array($sortedId)) {
-            $sortedId = array($class->identifier[0] => $sortedId);
         }
 
         $entity = $this->proxyFactory->getProxy($class->name, $sortedId);

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -296,7 +296,7 @@ class ORMException extends Exception
 
     /**
      * @param string $className
-     * @param string $fieldName
+     * @param string[] $fieldNames
      *
      * @return ORMException
      */

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -136,6 +136,12 @@ class CompositePrimaryKeyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('key1' => 100));
     }
 
+    public function testUnrecognizedIdentifierFieldsOnGetReference()
+    {
+        $this->setExpectedException('Doctrine\ORM\ORMException', "Unrecognized identifier fields: 'key1'");
+        $poi = $this->_em->getReference('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 10, 'long' => 20, 'key1' => 100));
+    }
+
     /**
      * @group DDC-1939
      */


### PR DESCRIPTION
- Unreachable statements have been removed
- Throw ORMException for unrecognized identifier field (same
  behavior as EntityManager#find)
