### PR TITLE
Added PHPDoc return type false of next method in Hydration/IterableResult

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -74,7 +74,7 @@ class IterableResult implements \Iterator
     /**
      * Gets the next set of results.
      *
-     * @return array
+     * @return array|false
      */
     public function next()
     {


### PR DESCRIPTION
Because hydrateRow can return false, too. The PHPDoc return type of the next method has return false in addition to array.
