### PR TITLE
Skip generate lifecycle methods if they already generated

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1806,6 +1806,8 @@ public function __construct(<params>)
      * Exports (nested) option elements.
      *
      * @param array $options
+     *
+     * @return string
      */
     private function exportTableOptions(array $options)
     {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -82,6 +82,8 @@ class EntityGeneratorTest extends OrmTestCase
         ));
         $metadata->addLifecycleCallback('loading', 'postLoad');
         $metadata->addLifecycleCallback('willBeRemoved', 'preRemove');
+        $metadata->addLifecycleCallback('updateDate', 'preUpdate');
+        $metadata->addLifecycleCallback('updateDate', 'prePersist');
         $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
 
         foreach ($embeddedClasses as $fieldName => $embeddedClass) {
@@ -243,7 +245,7 @@ class EntityGeneratorTest extends OrmTestCase
         $reflClass = new \ReflectionClass($metadata->name);
 
         $this->assertCount(6, $reflClass->getProperties());
-        $this->assertCount(15, $reflClass->getMethods());
+        $this->assertCount(16, $reflClass->getMethods());
 
         $this->assertEquals('published', $book->getStatus());
 

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -23,7 +23,7 @@ class EntityGeneratorTest extends OrmTestCase
     private $_tmpDir;
     private $_namespace;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->_namespace = uniqid("doctrine_");
         $this->_tmpDir = \sys_get_temp_dir();
@@ -37,7 +37,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $ri = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->_tmpDir . '/' . $this->_namespace));
         foreach ($ri AS $file) {
@@ -67,9 +67,6 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'options' => array('default' => 'published')));
         $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $metadata->mapOneToOne(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor', 'mappedBy' => 'book'));
-        $joinColumns = array(
-            array('name' => 'author_id', 'referencedColumnName' => 'id')
-        );
         $metadata->mapManyToMany(array(
             'fieldName' => 'comments',
             'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorComment',


### PR DESCRIPTION
This happens when I use one lifecycle method in prePersist and preUpdate together. Like

``` yml
    lifecycleCallbacks:
        prePersist: [setCreatedAtValue, setUpdatedAtValue]
        preUpdate: [setUpdatedAtValue]
```

Generator generate two methods with the same names.

@Ocramius, what do you think what is better way to write test for this?
Should I test generateEntityLifecycleCallbackMethods directly?
