### PR TITLE
Allow null to be passed to setHydrationCacheProfile

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -502,7 +502,7 @@ abstract class AbstractQuery
      */
     public function setHydrationCacheProfile(QueryCacheProfile $profile = null)
     {
-        if ( ! $profile->getResultCacheDriver()) {
+        if ($profile !== null && ! $profile->getResultCacheDriver()) {
             $resultCacheDriver = $this->_em->getConfiguration()->getHydrationCacheImpl();
             $profile = $profile->setResultCacheDriver($resultCacheDriver);
         }


### PR DESCRIPTION
Currently null can be passed and is set as default, however if you do this you get an exception. This allows null to be passed and set. 

There is an if statement later on to see if $this->_hydrationCacheProfile is null so it seems logical you can set it to be null.
