### PR TITLE
Added to_char function to convert other types to chars (/strings).

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/ToCharFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ToCharFunction.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* This software consists of voluntary contributions made by many individuals
+* and is licensed under the MIT license. For more information, see
+* <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Lexer;
+
+/**
+ * "TO_CHAR" "(" StringPrimary ")"
+ * @link    www.doctrine-project.org
+ * @since   2.5
+ * @author  Andreas Hümmerich
+*/
+class ToCharFunction extends FunctionNode
+{
+    public $stringPrimary;
+
+    /**
+     * @override
+     */
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        return $sqlWalker->getConnection()->getDatabasePlatform()->getToCharExpression(
+               $sqlWalker->walkSimpleArithmeticExpression($this->stringPrimary)
+        );
+    }
+
+    /**
+     * @override
+     */
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        $this->stringPrimary = $parser->StringPrimary();
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+}

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -47,6 +47,7 @@ class Parser
         'lower'     => 'Doctrine\ORM\Query\AST\Functions\LowerFunction',
         'upper'     => 'Doctrine\ORM\Query\AST\Functions\UpperFunction',
         'identity'  => 'Doctrine\ORM\Query\AST\Functions\IdentityFunction',
+	'to_char'   => 'Doctrine\ORM\Query\AST\Functions\ToCharFunction',
     );
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -381,6 +381,14 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(($result[3][0]['salary']/100000) & 2, $result[3]['salary_bit_and']);
     }
 
+    public function testToChar()
+    {
+        $arg = $this->_em->createQuery("SELECT TO_CHAR(m.salary) AS value FROM Doctrine\Tests\Models\Company\CompanyManager m")
+                ->getArrayResult();
+
+        $this->assertTrue(is_string($arg[0]['value']));
+    }
+
     protected function generateFixture()
     {
         $manager1 = new CompanyManager();


### PR DESCRIPTION
Been missing the TO_CHAR function, which - under some circumstances - is needed in platforms like Oracle, e. g. to compare char and non-char fields. Have added it - hope, it is OK this way!
