### PR TITLE
Added: A public SQLFilter Hash Function

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -152,7 +152,7 @@ abstract class SQLFilter
      */
     public function getHash()
     {
-    	return $this->__toString();
+        return $this->__toString();
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -142,6 +142,18 @@ abstract class SQLFilter
     {
         return $this->em->getConnection();
     }
+    
+    /**
+     * Return a hash representation of this instance for e.g. caching id purposes.
+     * Defaults to __toString(). Can be overridden in case a custom SQLFilter
+     * needs to manipulate its caching behaviour.
+     *
+     * @return string A string representation as hash id
+     */
+    public function getHash()
+    {
+    	return $this->__toString();
+    }
 
     /**
      * Gets the SQL query part to add to a query.

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -209,7 +209,7 @@ class FilterCollection
         $filterHash = '';
 
         foreach ($this->enabledFilters as $name => $filter) {
-            $filterHash .= $name . $filter;
+            $filterHash .= $name . $filter->getHash();
         }
 
         return $filterHash;


### PR DESCRIPTION
Hi

To be more flexible from a custom SQLFilter perspective, a dedicated hash function was added, which is not final and can be used by any implementing class to manipulate their e.g. caching behaviour.

The idea came from the event of having a query cache running and a filter, requiring to add actual current timestamps to the queries for comparison purposes (i.e. SoftDeleteable). As the old timestamps are cached too and the parser not fired again, old entities were returned. 

As the cache id is based also on the filters hash, a quick and I think good, slick solution would be to add a Hash Function that can be manipulated by an owning filter, to handle its behaviour on its own.

It defaults back to __toString and therefore nothing changes in basics but it could be.

Cheers

Changes:
- Added: A public SQLFilter Hash Function (defaults to __toString)
- Changed: FilterCollection to use the newly added SQLFilter Hash Function
