### PR TITLE
[WIP] Generator: Associations annotations improvement

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -410,7 +410,7 @@ public function __construct(<params>)
 
         $replacements = array(
             $this->generateEntityNamespace($metadata),
-            $this->generateEntityUse(),
+            $this->generateEntityUse($metadata),
             $this->generateEntityDocBlock($metadata),
             $this->generateEntityClassName($metadata),
             $this->generateEntityBody($metadata)
@@ -603,13 +603,19 @@ public function __construct(<params>)
         }
     }
 
-    protected function generateEntityUse()
+    protected function generateEntityUse(ClassMetadataInfo $metadataInfo)
     {
-        if ($this->generateAnnotations) {
-            return "\n".'use Doctrine\ORM\Mapping as ORM;'."\n";
-        } else {
-            return "";
+        $entityUse = '';
+
+        if (count($metadataInfo->associationMappings)) {
+            $entityUse .= "\n".'use Doctrine\Common\Collections\ArrayCollection;'."\n";
         }
+
+        if ($this->generateAnnotations) {
+            $entityUse .= "\n".'use Doctrine\ORM\Mapping as ORM;'."\n";
+        }
+
+        return $entityUse;
     }
 
     /**
@@ -682,7 +688,7 @@ public function __construct(<params>)
 
         foreach ($metadata->associationMappings as $mapping) {
             if ($mapping['type'] & ClassMetadataInfo::TO_MANY) {
-                $collections[] = '$this->'.$mapping['fieldName'].' = new \Doctrine\Common\Collections\ArrayCollection();';
+                $collections[] = '$this->'.$mapping['fieldName'].' = new ArrayCollection();';
             }
         }
 
@@ -1208,7 +1214,7 @@ public function __construct(<params>)
                 if ($code = $this->generateEntityStubMethod($metadata, 'remove', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
                     $methods[] = $code;
                 }
-                $getAssociationType = sprintf('%s[]|\Doctrine\Common\Collections\ArrayCollection', $associationMapping['targetEntity']);
+                $getAssociationType = sprintf('%s[]|ArrayCollection', $associationMapping['targetEntity']);
                 if ($code = $this->generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $getAssociationType)) {
                     $methods[] = $code;
                 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1208,7 +1208,8 @@ public function __construct(<params>)
                 if ($code = $this->generateEntityStubMethod($metadata, 'remove', $associationMapping['fieldName'], $associationMapping['targetEntity'])) {
                     $methods[] = $code;
                 }
-                if ($code = $this->generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], 'Doctrine\Common\Collections\Collection')) {
+                $getAssociationType = sprintf('%s[]|\Doctrine\Common\Collections\ArrayCollection', $associationMapping['targetEntity']);
+                if ($code = $this->generateEntityStubMethod($metadata, 'get', $associationMapping['fieldName'], $getAssociationType)) {
                     $methods[] = $code;
                 }
             }


### PR DESCRIPTION
- [x] Replace `Doctrine\Common\Collections\Collection` by `RelatedEntity[]|\Doctrine\Common\Collections\ArrayCollection`
- [x] Add `use` statement for `ArrayCollection`
- [ ] Add `use` statement for related entities
- [ ] Remove FQN annotation usage

This is a proposal for association mapping annotations improvement.

In a nutshell, I replaced `Collection` by `ArrayCollection` on getter annotation because `ArrayCollection` is used on constructor. I also add `RelatedEntity[]` annotation which is more IDE friendly.

I'm planning to add `use` statement too for FQN usage avoiding.

If you this made some regressions, we could maybe introduce it as an option.

Regards
