### PR TITLE
Remove (useless?) call to parser::getLexer()

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -719,8 +719,6 @@ classes have to implement the base class :
 
         public function parse(\Doctrine\ORM\Query\Parser $parser)
         {
-            $lexer = $parser->getLexer();
-
             $parser->match(Lexer::T_IDENTIFIER);
             $parser->match(Lexer::T_OPEN_PARENTHESIS);
 


### PR DESCRIPTION
The `$lexer` variable is not used, the method `parser::getLexer()` is just a dumb getter and do nothing, so in my opinion, the call to `parser::getLexer()` is useless in this context.

Can you confirm?
