### PR TITLE
[DDC-3382] Allow orphan removal to be cancelled

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -470,6 +470,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         parent::set($key, $value);
 
         $this->changed();
+
+        if ($this->em) {
+            $this->em->getUnitOfWork()->cancelOrphanRemoval($value);
+        }
     }
 
     /**
@@ -480,6 +484,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $this->collection->add($value);
 
         $this->changed();
+
+        if ($this->em) {
+            $this->em->getUnitOfWork()->cancelOrphanRemoval($value);
+        }
 
         return true;
     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2432,6 +2432,21 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * INTERNAL:
+     * Cancels a previously scheduled orphan removal.
+     *
+     * @ignore
+     *
+     * @param object $entity
+     *
+     * @return void
+     */
+    public function cancelOrphanRemoval($entity)
+    {
+        unset($this->orphanRemovals[spl_object_hash($entity)]);
+    }
+
+    /**
+     * INTERNAL:
      * Schedules a complete collection for removal when this UnitOfWork commits.
      *
      * @param PersistentCollection $coll

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyOrphanRemovalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyOrphanRemovalTest.php
@@ -24,10 +24,14 @@ class OneToManyOrphanRemovalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $user->username = 'romanb';
         $user->name = 'Roman B.';
 
-        $phone = new CmsPhonenumber;
-        $phone->phonenumber = '123456';
+        $phone1 = new CmsPhonenumber;
+        $phone1->phonenumber = '123456';
 
-        $user->addPhonenumber($phone);
+        $phone2 = new CmsPhonenumber;
+        $phone2->phonenumber = '234567';
+
+        $user->addPhonenumber($phone1);
+        $user->addPhonenumber($phone2);
 
         $this->_em->persist($user);
         $this->_em->flush();
@@ -53,6 +57,44 @@ class OneToManyOrphanRemovalTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $result = $query->getResult();
 
         $this->assertEquals(0, count($result), 'CmsPhonenumber should be removed by orphanRemoval');
+    }
+
+    /**
+     * @group DDC-3382
+     */
+    public function testOrphanRemovalRemoveFromCollection()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+
+        $phonenumber = $user->getPhonenumbers()->remove(0);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query  = $this->_em->createQuery('SELECT p FROM Doctrine\Tests\Models\CMS\CmsPhonenumber p');
+        $result = $query->getResult();
+
+        $this->assertEquals(1, count($result), 'CmsPhonenumber should be removed by orphanRemoval');
+    }
+
+    /**
+     * @group DDC-3382
+     */
+    public function testOrphanRemovalClearCollectionAndReAdd()
+    {
+        $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
+
+        $phone1 = $user->getPhonenumbers()->first();
+
+        $user->getPhonenumbers()->clear();
+        $user->addPhonenumber($phone1);
+
+        $this->_em->flush();
+
+        $query  = $this->_em->createQuery('SELECT p FROM Doctrine\Tests\Models\CMS\CmsPhonenumber p');
+        $result = $query->getResult();
+
+        $this->assertEquals(1, count($result), 'CmsPhonenumber should be removed by orphanRemoval');
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
@@ -16,6 +16,14 @@ class DDC1654Test extends \Doctrine\Tests\OrmFunctionalTestCase
         ));
     }
 
+    public function tearDown()
+    {
+        $conn = static::$_sharedConn;
+        $conn->executeUpdate('DELETE FROM ddc1654post_ddc1654comment');
+        $conn->executeUpdate('DELETE FROM DDC1654Comment');
+        $conn->executeUpdate('DELETE FROM DDC1654Post');
+    }
+
     public function testManyToManyRemoveFromCollectionOrphanRemoval()
     {
         $post = new DDC1654Post();
@@ -54,6 +62,29 @@ class DDC1654Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(0, count($comments));
     }
 
+    /**
+     * @group DDC-3382
+     */
+    public function testManyToManyRemoveElementFromReAddToCollectionOrphanRemoval()
+    {
+        $post = new DDC1654Post();
+        $post->comments[] = new DDC1654Comment();
+        $post->comments[] = new DDC1654Comment();
+
+        $this->_em->persist($post);
+        $this->_em->flush();
+
+        $comment = $post->comments[0];
+        $post->comments->removeElement($comment);
+        $post->comments->add($comment);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $comments = $this->_em->getRepository(__NAMESPACE__ . '\\DDC1654Comment')->findAll();
+        $this->assertEquals(2, count($comments));
+    }
+
     public function testManyToManyClearCollectionOrphanRemoval()
     {
         $post = new DDC1654Post();
@@ -71,6 +102,29 @@ class DDC1654Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $comments = $this->_em->getRepository(__NAMESPACE__ . '\\DDC1654Comment')->findAll();
         $this->assertEquals(0, count($comments));
 
+    }
+
+    /**
+     * @group DDC-3382
+     */
+    public function testManyToManyClearCollectionReAddOrphanRemoval()
+    {
+        $post = new DDC1654Post();
+        $post->comments[] = new DDC1654Comment();
+        $post->comments[] = new DDC1654Comment();
+
+        $this->_em->persist($post);
+        $this->_em->flush();
+
+        $comment = $post->comments[0];
+        $post->comments->clear();
+        $post->comments->add($comment);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $comments = $this->_em->getRepository(__NAMESPACE__ . '\\DDC1654Comment')->findAll();
+        $this->assertEquals(1, count($comments));
     }
 }
 


### PR DESCRIPTION
I have a one-to-many relation with orphanRemoval=true.
If I remove an entity from the related collection and add it back, the entity is removed from the database.

``` PHP
$employee = $company->getEmployees()->first();
$company->getEmployees()->removeElement($employee);
$company->getEmployees()->add($employee);

$em->persist($company);
$em->flush();
// Now $employee is deleted from the database.
```

The expected behaviour is to leave the entity in the database, because it was present in the PersistentCollection when $em->persist() was called.

This has previously been suggested in [DDC-3382](http://www.doctrine-project.org/jira/browse/DDC-3382), but it was rejected. This PR shows how small a change it is, so I hope the suggestion will be reconsidered in the light of this.
