### PR TITLE
Second Level Cache key 

### DIFF
--- a/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
@@ -61,6 +61,6 @@ class CollectionCacheKey extends CacheKey
         $this->ownerIdentifier  = $ownerIdentifier;
         $this->entityClass      = (string) $entityClass;
         $this->association      = (string) $association;
-        $this->hash             = str_replace('\\', '.', strtolower($entityClass)) . '_' . implode(' ', $ownerIdentifier) . '__' .  $association;
+        $this->hash             = str_replace('\\', '.', strtolower($entityClass)) . '_' . implode('.', $ownerIdentifier) . '__' .  $association;
     }
 }

--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -52,6 +52,6 @@ class EntityCacheKey extends CacheKey
 
         $this->identifier  = $identifier;
         $this->entityClass = $entityClass;
-        $this->hash        = str_replace('\\', '.', strtolower($entityClass) . '_' . implode(' ', $identifier));
+        $this->hash        = str_replace('\\', '.', strtolower($entityClass) . '_' . implode('.', $identifier));
     }
 }


### PR DESCRIPTION
Various cache engines may not support spaces in key, like memcached, this will result in cache miss since cache component will return false on persisting data to cache 
