### PR TITLE
Also export default value for fieldMapping

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1661,6 +1661,10 @@ public function __construct(<params>)
                 $options[] = '"unsigned"=true';
             }
 
+            if (isset($fieldMapping['options']['default'])) {
+                $options[] = '"default"="'.$fieldMapping['options']['default'].'"';
+            }
+
             if ($options) {
                 $column[] = 'options={'.implode(',', $options).'}';
             }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -211,6 +211,7 @@ abstract class AbstractClassMetadataExporterTest extends \Doctrine\Tests\OrmTest
 
         $this->assertEquals(true, $class->fieldMappings['age']['options']['unsigned']);
 
+        $this->assertEquals(array('default' => '0'), $class->fieldMappings['deleted']['options']);
         return $class;
     }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -55,6 +55,12 @@ class User
     public $groups;
 
     /**
+     * @Column(type="integer", options={"default":"0"})
+     */
+    public $deleted = 0;
+
+
+    /**
      * @PrePersist
      */
     public function doStuffOnPrePersist()

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -36,6 +36,11 @@ $metadata->mapField(array(
    'type' => 'integer',
    'options' => array("unsigned"=>true),
   ));
+$metadata->mapField(array(
+   'fieldName' => 'deleted',
+   'type' => 'integer',
+   'options' => array('default' => '0')
+  ));
 $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
 $metadata->mapManyToOne(array(
     'fieldName' => 'mainGroup',

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
@@ -29,6 +29,11 @@
                 <option name="unsigned">1</option>
             </options>
         </field>
+        <field name="deleted" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
 
         <one-to-one field="address" target-entity="Doctrine\Tests\ORM\Tools\Export\Address" inversed-by="user" orphan-removal="true" fetch="EAGER">
             <cascade><cascade-persist /></cascade>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -23,6 +23,10 @@ Doctrine\Tests\ORM\Tools\Export\User:
       type: integer
       options:
         unsigned: true
+    deleted:
+      type: integer
+      options:
+        default: 0
   oneToOne:
     address:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Address


### PR DESCRIPTION
The default value is only exported as a default value for the PHP entity, not as an annotation.

Without this annotation doctrine migration wants to remove the default value in the database.
