### PR TITLE
"INSTANCE OF" example doesn't match description.

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -601,5 +601,5 @@ Querying for the staffs without getting any technicians can be achieved by this 
 .. code-block:: php
 
     <?php
-    $query = $em->createQuery("SELECT staff FROM MyProject\Model\Staff staff WHERE staff INSTANCE OF MyProject\Model\Staff");
+    $query = $em->createQuery("SELECT staff FROM MyProject\Model\Staff staff WHERE staff NOT INSTANCE OF MyProject\Model\Technician");
     $staffs = $query->getResult();


### PR DESCRIPTION
Just did a small change. The DQL is supposed to

> [Query] for the staffs without getting any technicians

As it's currently written, it would select all `Staff` and the `INSTANCE OF` check would only test if they're `Staff`.
