### PR TITLE
convertToDatabaseValueSQL with $columnName

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -403,7 +403,7 @@ class BasicEntityPersister implements EntityPersister
 
                     if (isset($this->class->fieldMappings[$fieldName]['requireSQLConversion'])) {
                         $type        = Type::getType($this->columnTypes[$columnName]);
-                        $placeholder = $type->convertToDatabaseValueSQL('?', $this->platform);
+                        $placeholder = $type->convertToDatabaseValueSQL('?', $this->platform, $column);
                     }
 
                     break;


### PR DESCRIPTION
## Goal:

I want to be able to atomically increment a property such that `$stock->setQuantityDelta(2);` will render into an SQL such as `UPDATE stock SET quantity = quantity+? WHERE id = ?;`.

I would like to accomplish this without using `DQL` every time it is necessary hence I implemented a custom Doctrine2 type which can accomplish this -- with support from this PR.
## Changes:

`\Doctrine\ORM\Persisters\BasicEntityPersister::updateTable` now passes the column name to `\Doctrine\DBAL\Types\Type::convertToDatabaseValueSQL` ([PR](https://github.com/doctrine/dbal/pull/874))  to be used by the concrete type instance (ex.: **@mihai-stancu/doctrine-types-extra**:`\MS\Doctrine\DBAL\Types\DeltaType`).
