### PR TITLE
One to one unique index mapping bug

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1598,7 +1598,17 @@ class ClassMetadataInfo implements ClassMetadata
                 if ( ! $this->table) {
                     throw new RuntimeException("ClassMetadataInfo::setTable() has to be called before defining a one to one relationship.");
                 }
+                /*
+                 * Mapping via the field name causes issues if unrelated tables use the same fieldName in their independent mappings
+                 * Note: The hack below of prepending the table name probably exceeds length constraints of some databases
+                 * e.g. Oracle.
+                 * Naming should really be delegated to the NamingStrategy but there is no API in the interface to support this yet.
+
                 $this->table['uniqueConstraints'][$mapping['fieldName']."_uniq"] = array(
+                    'columns' => $uniqueConstraintColumns
+                );
+                 */
+                $this->table['uniqueConstraints'][$this->table['name'].$mapping['fieldName']."_uniq"] = array(
                     'columns' => $uniqueConstraintColumns
                 );
             }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/UpdateSchemaSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/UpdateSchemaSqlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\SchemaTool;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\Tools\SchemaTool;
+
+/**
+ * Functional tests for the Class Table Inheritance mapping strategy.
+ *
+ * @author Barrie Treloar <baerrach@gmail.com>
+ */
+class UpdateSchemaSqlTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+  protected function setUp()
+  {
+    $setName = 'company';
+    $this->useModelSet($setName);
+    parent::setUp();
+    $this->classnamesToClassmetaData = $this->getClassnamesToClassMetadata(static::$_modelSets[$setName]);
+  }
+
+  public function testEmpty() {
+  }
+
+  /**
+   *
+   */
+  public function testUpdateSchemaSql()
+  {
+    $tool = new SchemaTool($this->_em);
+
+    $sql = $tool->getUpdateSchemaSql(array_values($this->classnamesToClassmetaData));
+#    var_dump($sql);
+  }
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -44,16 +44,6 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -39,15 +39,6 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
@@ -53,15 +53,6 @@ class ManyToManyExtraLazyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_extralazy');
-    }
-
     public function testThatTheExtraLazyCollectionFromOwningToInversedIsCounted()
     {
         $owning = $this->_em->find(

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
@@ -38,15 +38,6 @@ class ManyToManyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -45,15 +45,6 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -40,14 +40,6 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
@@ -50,14 +50,6 @@ class OneToManyExtraLazyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_extralazy');
-    }
-
     public function testThatExtraLazyCollectionIsCounted()
     {
         $inversed = $this->_em->find(

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -39,14 +39,6 @@ class OneToManyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -44,15 +44,6 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -39,14 +39,6 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
@@ -39,14 +39,6 @@ class OneToOneTest extends OrmFunctionalTestCase
         $this->_em->clear();
     }
 
-    public static function tearDownAfterClass()
-    {
-        $conn = static::$_sharedConn;
-
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone');
-    }
-
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase()
     {
         $conn = $this->_em->getConnection();


### PR DESCRIPTION
As per request on google groups.

My original problem was that schema:validate is telling me the database is not up to date and the only SQL it wants to run is DROP INDEX and CREATE INDEX on what is already there.

To write some tests to see why,  I started hacking OrmFunctionalTestCase to give me back the class metadata for the model set in use. And while I was doing that I DRYed up the test setup to avoid duplication. But the ValueConversionType stopped working because they DROP TABLES when no other tests do. I think the drop tables was necessary because they use the same entities across some of the different test classes so when the entites were setup the would fail because the table already existed - which is the problem I bumped into.

I've got the code working by sharing the schema creation setup and not dropping tables, but because of this OneToOne mapping issue the tests fail because the unique index name already exists in the name space.

I've pushed the code changes to https://github.com/baerrach/doctrine2/tree/one-to-one-unique-index-mapping-bug so you can see what I am talking about.

Its done in three stages:

b0ce47d Remove tearDownAfterClass() and DROP TABLES

4b5cd37 DRY test setup for entities and modelSets

f7efac6 Fix OneToOne unique constraint mapping

You can run the ValueConversionType to see the failures, and resolution, in action.

phpunit -d memory_limit=-1 tests/Doctrine/Tests/ORM/Functional/ValueConversionType/
