### PR TITLE
[DDC-2763] Inheritance. Improve lazy load associated entitities

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -70,6 +70,8 @@ abstract class AbstractQuery
      */
     const HYDRATE_SIMPLEOBJECT = 5;
 
+    const HYDRATE_PROXY = 6;
+
     /**
      * The parameter map of this query.
      *

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -787,6 +787,9 @@ use Doctrine\Common\Util\ClassUtils;
             case Query::HYDRATE_SIMPLEOBJECT:
                 return new Internal\Hydration\SimpleObjectHydrator($this);
 
+            case Query::HYDRATE_PROXY:
+                return new Internal\Hydration\ProxyHydrator($this);
+
             default:
                 if (($class = $this->config->getCustomHydrationMode($hydrationMode)) !== null) {
                     return new $class($this);

--- a/lib/Doctrine/ORM/Internal/Hydration/ProxyHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ProxyHydrator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+class ProxyHydrator extends SimpleObjectHydrator
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function hydrateRowData(array $sqlResult, array &$result)
+    {
+        $entityName = $this->getEntityName($sqlResult);
+        $identifier = array();
+
+        foreach ($sqlResult as $column => $value) {
+            // An ObjectHydrator should be used instead of SimpleObjectHydrator
+            if (isset($this->_rsm->relationMap[$column])) {
+                throw new \Exception(sprintf('Unable to retrieve association information for column "%s"', $column));
+            }
+
+            $cacheKeyInfo = $this->hydrateColumnInfo($column);
+
+            if ( ! $cacheKeyInfo || ! $cacheKeyInfo['isIdentifier']) {
+                continue;
+            }
+
+            // Convert field to a valid PHP value
+            if (isset($cacheKeyInfo['type'])) {
+                $type  = $cacheKeyInfo['type'];
+                $value = $type->convertToPHPValue($value, $this->_platform);
+            }
+
+            $fieldName = $cacheKeyInfo['fieldName'];
+
+            // Prevent overwrite in case of inherit classes using same property name (See AbstractHydrator)
+            if ( ! isset($identifier[$fieldName]) || $value !== null) {
+                $identifier[$fieldName] = $value;
+            }
+        }
+
+        $result[] = $this->_em->getProxyFactory()->getProxy($entityName, $identifier);
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -160,6 +160,8 @@ class ClassMetadataInfo implements ClassMetadata
      */
     const FETCH_EXTRA_LAZY = 4;
 
+    const FETCH_USE_PROXY = 5;
+
     /**
      * Identifies a one-to-one association.
      */

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -40,7 +40,7 @@ final class ManyToOne implements Annotation
      *
      * @var string
      *
-     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
+     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY", "USE_PROXY"})
      */
     public $fetch = 'LAZY';
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -716,7 +716,18 @@ class BasicEntityPersister implements EntityPersister
             $hints[Query::HINT_REFRESH_ENTITY]  = $entity;
         }
 
-        $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
+        $hydrationMode = $this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT;
+        if (
+            $assoc
+            && ClassMetadata::FETCH_USE_PROXY === $assoc['fetch']
+            && $assoc['isOwningSide']
+            && $this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE
+            && ! $this->currentPersisterContext->selectJoinSql
+        ) {
+            $hydrationMode = Query::HYDRATE_PROXY;
+        }
+
+        $hydrator = $this->em->newHydrator($hydrationMode);
         $entities = $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
 
         return $entities ? $entities[0] : null;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2763Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2763Test.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class DDC2763Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2763MainTable'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2763SubTable'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2763TableWithAssoc'),
+        ));
+    }
+
+    public function testIssue()
+    {
+        $sub = new DDC2763SubTable('value', 'foobar');
+        $assoc = new DDC2763TableWithAssoc();
+        $assoc->setReference($sub);
+
+        $this->_em->persist($sub);
+        $this->_em->persist($assoc);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $entity = $this->_em->find(__NAMESPACE__ . '\DDC2763TableWithAssoc', 1);
+        $reference = $entity->getReference();
+
+        $this->assertInstanceOf(__NAMESPACE__ . '\DDC2763SubTable', $reference);
+        $this->assertInstanceOf('Doctrine\ORM\Proxy\Proxy', $reference);
+        $this->assertEquals('foobar', $reference->getSubField());
+    }
+}
+
+/**
+ * @Entity
+ * @Table
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="smallint")
+ * @DiscriminatorMap({
+ *     "0" = "DDC2763MainTable",
+ *     "1" = "DDC2763SubTable"
+ * })
+ */
+class DDC2763MainTable
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @Column(type="string")
+     */
+    private $mainField;
+
+    public function __construct($mainField)
+    {
+        $this->mainField = $mainField;
+    }
+}
+
+/**
+ * @Entity
+ * @Table
+ */
+class DDC2763SubTable extends DDC2763MainTable
+{
+    /**
+     * @Column(type="string")
+     */
+    private $subField;
+
+    public function __construct($mainField, $subField)
+    {
+        parent::__construct($mainField);
+        $this->subField = $subField;
+    }
+
+    public function getSubField()
+    {
+        return $this->subField;
+    }
+}
+
+/**
+ * @Entity
+ * @Table
+ */
+class DDC2763TableWithAssoc
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @ManyToOne(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\DDC2763MainTable", fetch="USE_PROXY")
+     * @JoinColumn(referencedColumnName="id")
+     */
+    private $reference;
+
+    public function setReference($reference)
+    {
+        $this->reference = $reference;
+    }
+
+    public function getReference()
+    {
+        return $this->reference;
+    }
+}
+
+


### PR DESCRIPTION
[DDC-2763 92c1a8f] [DDC-2763] Inheritance. CTI & STI. Improve lazy load associated entity, when target entity in association mapping is not last leaf in class hierarchy.

Issue fixed by adding class "ProxyHydrator" and new fetch mode for associations "FETCH_USE_PROXY".
Users need to mark the associations with "fetch=USE_PROXY" to trigger new lazy loading behaviour.
This PR is not intended to be final. It still lacks of tests.
