### PR TITLE
Missing opening tags added in one of the tutorials

### DIFF
--- a/docs/en/tutorials/override-field-association-mappings-in-subclasses.rst
+++ b/docs/en/tutorials/override-field-association-mappings-in-subclasses.rst
@@ -58,6 +58,7 @@ which has mapping metadata that is overridden by the annotation above:
 
 .. code-block:: php
 
+    <?php
     /**
      * Trait class
      */
@@ -82,6 +83,7 @@ The case for just extending a class would be just the same but:
 
 .. code-block:: php
 
+    <?php
     class ExampleEntityWithOverride extends BaseEntityWithSomeMapping
     {
         // ...


### PR DESCRIPTION
This commit adds opening tags to one of the tutorials, so code can be properly highlighted on http://doctrine-orm.readthedocs.org/en/latest/tutorials/override-field-association-mappings-in-subclasses.html
