### PR TITLE
Allow access to Query#getResultSetMapping

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -456,7 +456,7 @@ abstract class AbstractQuery
      *
      * @return \Doctrine\ORM\Query\ResultSetMapping
      */
-    protected function getResultSetMapping()
+    public function getResultSetMapping()
     {
         return $this->_resultSetMapping;
     }

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -222,7 +222,7 @@ final class Query extends AbstractQuery
     /**
      * {@inheritdoc}
      */
-    protected function getResultSetMapping()
+    public function getResultSetMapping()
     {
         // parse query or load from cache
         if ($this->_resultSetMapping === null) {


### PR DESCRIPTION
Hi,

I've recently came across an issue which would require modifying the result set mapping of a query made with query builder.

I would like to SUM a field with a **custom type**, which is stored as an int, but normally converted to a custom value object.

When using an aggregation function, the returned result is a simple int.

Is there any reason the `Query#getResultSetMapping` has to be protected?

Is there any danger if I do this? (works fine at first glance)

``` php
$rsm = $query->getResultSetMapping();
$rsm->addScalarResult(
    array_search('custom_field', $rsm->scalarMappings),
    'custom_field',
    'custom_type'
);

$query->setResultSetMapping($rsm);
```

Related: https://github.com/doctrine/doctrine2/commit/ea14bcff4a2a78bf774e8847b6645dca112f9757

Thanks!
