### PR TITLE
Fix second level caching for queries with multiple joins

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -259,7 +259,8 @@ class DefaultQueryCache implements QueryCache
             }
 
             // @TODO - move to cache hydration components
-            foreach ($rsm->relationMap as $name) {
+            foreach ($rsm->relationMap as $alias => $name) {
+                $metadata = $this->em->getClassMetadata($rsm->aliasMap[$rsm->parentAliasMap[$alias]]);
                 $assoc = $metadata->associationMappings[$name];
 
                 if (($assocValue = $metadata->getFieldValue($entity, $name)) === null || $assocValue instanceof Proxy) {


### PR DESCRIPTION
The $metadata of the main entity is not always the metadata you need here, for example when you do join A with B and then B with C. For the second join it was using the metadata from A.
