### PR TITLE
Link annotation ref to locking explanation

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -1212,12 +1212,13 @@ Example with partial indexes:
 .. _annref_version:
 
 @Version
-~~~~~~~~~~~~~~
+~~~~~~~~
 
-Marker annotation that defines a specified column as version
-attribute used in an optimistic locking scenario. It only works on
-:ref:`@Column <annref_column>` annotations that have the type integer or
-datetime. Combining @Version with :ref:`@Id <annref_id>` is not supported.
+Marker annotation that defines a specified column as version attribute used in
+an :ref:`optimistic locking <transactions-and-concurrency_optimistic-locking>`
+scenario. It only works on :ref:`@Column <annref_column>` annotations that have
+the type ``integer`` or ``datetime``. Combining ``@Version`` with
+:ref:`@Id <annref_id>` is not supported.
 
 Example:
 

--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -1,6 +1,8 @@
 Transactions and Concurrency
 ============================
 
+.. _transactions-and-concurrency_transaction-demarcation:
+
 Transaction Demarcation
 -----------------------
 
@@ -26,6 +28,8 @@ and control transaction demarcation yourself.
 These are two ways to deal with transactions when using the
 Doctrine ORM and are now described in more detail.
 
+.. _transactions-and-concurrency_approach-implicitly:
+
 Approach 1: Implicitly
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -48,6 +52,8 @@ transaction. This behavior is made possible by the aggregation of
 the DML operations by the Doctrine ORM and is sufficient if all the
 data manipulation that is part of a unit of work happens through
 the domain model and thus the ORM.
+
+.. _transactions-and-concurrency_approach-explicitly:
 
 Approach 2: Explicitly
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -104,6 +110,8 @@ abstraction flushes the ``EntityManager`` prior to transaction
 commit and rolls back the transaction when an
 exception occurs.
 
+.. _transactions-and-concurrency_exception-handling:
+
 Exception Handling
 ~~~~~~~~~~~~~~~~~~
 
@@ -134,6 +142,8 @@ knowing that their state is potentially no longer accurate.
 If you intend to start another unit of work after an exception has
 occurred you should do that with a new ``EntityManager``.
 
+.. _transactions-and-concurrency_locking-support:
+
 Locking Support
 ---------------
 
@@ -141,6 +151,8 @@ Doctrine 2 offers support for Pessimistic- and Optimistic-locking
 strategies natively. This allows to take very fine-grained control
 over what kind of locking is required for your Entities in your
 application.
+
+.. _transactions-and-concurrency_optimistic-locking:
 
 Optimistic Locking
 ~~~~~~~~~~~~~~~~~~
@@ -304,6 +316,8 @@ And the change headline action (POST Request):
     $postVersion = (int)$_GET['version'];
     
     $post = $em->find('BlogPost', $postId, \Doctrine\DBAL\LockMode::OPTIMISTIC, $postVersion);
+
+.. _transactions-and-concurrency_pessimistic-locking:
 
 Pessimistic Locking
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The annotation reference contained no cross reference to the great
transaction and concurrency page. But this might be very useful for the
reader.
