### PR TITLE
Fix DDC-3818 - Paginator fails to retrieve entities linked with One-To-Many

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -150,7 +150,7 @@ class Paginator implements \Countable, \IteratorAggregate
 
             $ids = array_map('current', $subQuery->getScalarResult());
 
-            $whereInQuery = $this->cloneQuery($this->query);
+            $whereInQuery = $this->cloneQuery($this->query, false);
             // don't do this for an empty id array
             if (count($ids) === 0) {
                 return new \ArrayIterator(array());
@@ -179,15 +179,18 @@ class Paginator implements \Countable, \IteratorAggregate
      * Clones a query.
      *
      * @param Query $query The query.
+     * @param bool  $cloneParameters whether we need to clone parameters too
      *
      * @return Query The cloned query.
      */
-    private function cloneQuery(Query $query)
+    private function cloneQuery(Query $query, $cloneParameters = true)
     {
         /* @var $cloneQuery Query */
         $cloneQuery = clone $query;
 
-        $cloneQuery->setParameters(clone $query->getParameters());
+        if ($cloneParameters === true) {
+            $cloneQuery->setParameters(clone $query->getParameters());
+        }
         $cloneQuery->setCacheable(false);
 
         foreach ($query->getHints() as $name => $value) {

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -109,34 +109,12 @@ class WhereInWalker extends TreeWalkerAdapter
 
         $conditionalPrimary = new ConditionalPrimary;
         $conditionalPrimary->simpleConditionalExpression = $expression;
-        if ($AST->whereClause) {
-            if ($AST->whereClause->conditionalExpression instanceof ConditionalTerm) {
-                $AST->whereClause->conditionalExpression->conditionalFactors[] = $conditionalPrimary;
-            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalPrimary) {
-                $AST->whereClause->conditionalExpression = new ConditionalExpression(array(
-                    new ConditionalTerm(array(
-                        $AST->whereClause->conditionalExpression,
-                        $conditionalPrimary
-                    ))
-                ));
-            } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
-                || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
-            ) {
-                $tmpPrimary = new ConditionalPrimary;
-                $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
-                $AST->whereClause->conditionalExpression = new ConditionalTerm(array(
-                    $tmpPrimary,
+        $AST->whereClause = new WhereClause(
+            new ConditionalExpression(array(
+                new ConditionalTerm(array(
                     $conditionalPrimary
-                ));
-            }
-        } else {
-            $AST->whereClause = new WhereClause(
-                new ConditionalExpression(array(
-                    new ConditionalTerm(array(
-                        $conditionalPrimary
-                    ))
                 ))
-            );
-        }
+            ))
+        );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -68,8 +68,8 @@ class PaginatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $query = $this->_em->createQuery(
             'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d '.
-            ' WHERE c.name = \'name0\''
-        )->setFirstResult(0)->setMaxResults(1);
+            ' WHERE c.name = :name'
+        )->setParameter('name', 'name0')->setFirstResult(0)->setMaxResults(1);
 
         $paginator = new Paginator($query, true);
         $this->assertEquals(1, count($paginator), 'Expecting one row to match in Paginator');
@@ -84,8 +84,8 @@ class PaginatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $query = $this->_em->createQuery(
             'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d '.
-            ' WHERE d.name = \'namedep5-0\''
-        )->setFirstResult(0)->setMaxResults(1);
+            ' WHERE d.name = :name'
+        )->setParameter('name', 'namedep5-0')->setFirstResult(0)->setMaxResults(1);
         
         $paginator = new Paginator($query, true);
         $this->assertEquals(1, count($paginator), 'Expecting one row to match in Paginator');

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -46,7 +46,7 @@ class PaginatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         // Test simple test
         $query = $this->_em->createQuery(
-            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d'
+            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d ORDER BY c.id ASC'
         )->setFirstResult(5)->setMaxResults(2);
 
         $paginator = new Paginator($query, true);

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -90,9 +90,9 @@ class PaginatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $paginator = new Paginator($query, true);
         $this->assertEquals(1, count($paginator), 'Expecting one row to match in Paginator');
 
-        //xdebug_start_trace('/tmp/test');
         $results = $paginator->getIterator()->getArrayCopy();
-        //xdebug_stop_trace();
+
+        // If bug #DDC-3818 is present, next call will fail and will find only one department in object (instead of 3)
         $this->checkCompany($results[0]);
 
         $this->assertEquals('name5', $results[0]->name, 'expecting company returned to be named "name0"');

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\Pagination\Company;
+use Doctrine\Tests\Models\Pagination\Department;
+use Doctrine\Tests\Models\Pagination\Logo;
+
+class PaginatorTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->useModelSet('pagination');
+        parent::setUp();
+        $this->populate();
+
+        // we don't want cache to break tests / hide bug.
+        $this->_em->clear();
+    }
+
+    public function testSimpleUse()
+    {
+        // Test simple test
+        $query = $this->_em->createQuery(
+            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d'
+        );
+
+        $results = $query->getResult();
+        $this->assertEquals(9, count($results), 'Expecting nine rows to be returned');
+
+        // reset
+        unset($results);
+
+        $paginator = new Paginator($query, true);
+        $this->assertEquals(9, count($paginator), 'Expecting nine rows to count in Paginator');
+
+
+        foreach ($paginator as $company) {
+            $this->checkCompany($company);
+        }
+    }
+
+    public function testLimitAndOffset()
+    {
+        // Test simple test
+        $query = $this->_em->createQuery(
+            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d'
+        )->setFirstResult(5)->setMaxResults(2);
+
+        $paginator = new Paginator($query, true);
+        $this->assertEquals(9, count($paginator), 'Expecting nine rows to count in Paginator');
+        $this->assertEquals(9, $paginator->count(), 'Expecting nine rows to count in Paginator');
+
+        $results = $paginator->getIterator()->getArrayCopy();
+        $this->assertEquals(2, count($results), 'Expecting to retrieve two rows only');
+        foreach ($results as $company) {
+            $this->checkCompany($company);
+        }
+
+        // expect companies 'name5' and 'name6' to be returned
+        $this->assertEquals('name5', $results[0]->name, 'first company retrieved should be "name5"');
+        $this->assertEquals('name6', $results[1]->name, 'second company retrieved should be "name6"');
+    }
+
+    public function testWhereInMainObject()
+    {
+        $query = $this->_em->createQuery(
+            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d '.
+            ' WHERE c.name = \'name0\''
+        )->setFirstResult(0)->setMaxResults(1);
+
+        $paginator = new Paginator($query, true);
+        $this->assertEquals(1, count($paginator), 'Expecting one row to match in Paginator');
+
+        $results = $paginator->getIterator()->getArrayCopy();
+        $this->checkCompany($results[0]);
+
+        $this->assertEquals('name0', $results[0]->name, 'expecting company returned to be named "name0"');
+    }
+
+    public function testDDC3818()
+    {
+        $query = $this->_em->createQuery(
+            'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c LEFT JOIN c.departments d '.
+            ' WHERE d.name = \'namedep5-0\''
+        )->setFirstResult(0)->setMaxResults(1);
+        
+        $paginator = new Paginator($query, true);
+        $this->assertEquals(1, count($paginator), 'Expecting one row to match in Paginator');
+
+        //xdebug_start_trace('/tmp/test');
+        $results = $paginator->getIterator()->getArrayCopy();
+        //xdebug_stop_trace();
+        $this->checkCompany($results[0]);
+
+        $this->assertEquals('name5', $results[0]->name, 'expecting company returned to be named "name0"');
+        foreach ($results[0]->departments as $dep) {
+            $this->assertContains('namedep5-', $dep->name);
+        }
+
+    }
+
+    protected function checkCompany($company)
+    {
+        $this->assertTrue($company instanceof Company, 'result is a Company object');
+        $this->assertTrue($company->logo instanceof Logo, 'logo is a Logo object');
+        $this->assertEquals(3, count($company->departments), 'expect 3 departments per Company');
+        foreach ($company->departments as $dep) {
+            $this->assertTrue($dep instanceof Department, 'Department object expected');
+        }
+    }
+
+    public function populate()
+    {
+        for ($i = 0; $i < 9; $i++) {
+            $company = new Company();
+            $company->name = "name$i";
+            $company->logo = new Logo();
+            $company->logo->image = "image$i";
+            $company->logo->image_width = 100 + $i;
+            $company->logo->image_height = 100 + $i;
+            $company->logo->company = $company;
+            for ($j=0; $j<3; $j++) {
+                $department = new Department();
+                $department->name = "namedep$i-$j";
+                $department->company = $company;
+                $company->departments[] = $department;
+            }
+            $this->_em->persist($company);
+        }
+        $this->_em->flush();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -48,7 +48,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE 1 = 1 AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 
@@ -62,7 +62,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE 1 = 1 AND 2 = 2 AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 
@@ -76,7 +76,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (1 = 1 OR 2 = 2) AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 
@@ -90,7 +90,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (1 = 1 OR 2 = 2) AND 3 = 3 AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 
@@ -104,7 +104,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (1 = 1 AND 2 = 2 OR 3 = 3) AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 
@@ -118,7 +118,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE (NOT 1 = 2) AND u0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT u0_.id AS id_0, g1_.id AS id_1 FROM User u0_ INNER JOIN user_group u2_ ON u0_.id = u2_.user_id INNER JOIN groups g1_ ON g1_.id = u2_.group_id WHERE u0_.id IN (?)", $whereInQuery->getSql()
         );
     }
     
@@ -147,7 +147,7 @@ class WhereInWalkerTest extends PaginationTestCase
         $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
 
         $this->assertEquals(
-            "SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ INNER JOIN Category c1_ ON (b0_.category_id = c1_.id) WHERE 1 = 1 AND b0_.id IN (?)", $whereInQuery->getSql()
+            "SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ INNER JOIN Category c1_ ON (b0_.category_id = c1_.id) WHERE b0_.id IN (?)", $whereInQuery->getSql()
         );
     }
 }


### PR DESCRIPTION
Please see http://www.doctrine-project.org/jira/browse/DDC-3818

Reminder : using a DQL query with WHERE on a One-To-Many relationship fails to retrieve full object.

This went unseen in previous tests because cache is used to retrieve the originating object.
