### PR TITLE
Update ExprTest.php

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -71,6 +71,11 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     {
         $this->assertEquals('COUNT(DISTINCT u.id)', (string) $this->_expr->countDistinct('u.id'));
     }
+    
+    public function testCountDistinctExprMulti()
+    {
+        $this->assertEquals('COUNT(DISTINCT u.id, u.name)', (string) $this->_expr->countDistinct('u.id', 'u.name'));
+    }
 
     public function testExistsExpr()
     {


### PR DESCRIPTION
expr()->countDistinct allows to create COUNT(DISTINCT) expression with mulltiple fields but parser requires only one field.

\Doctrine\ORM\Query\Parser::AggregateExpression

some body, please, fix this problem
