### PR TITLE
No-frills support for Entity version bumping

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -654,7 +654,8 @@ preUpdate
 PreUpdate is the most restrictive to use event, since it is called
 right before an update statement is called for an entity inside the
 ``EntityManager#flush()`` method. Note that this event is not
-triggered when the computed changeset is empty.
+normally triggered if the computed changeset is empty. (One
+exception is when a version-column is being forcibly updated.)
 
 Changes to associations of the updated entity are never allowed in
 this event, since Doctrine cannot guarantee to correctly handle

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -576,6 +576,7 @@ entities and their associations have been computed. This means, the
 
 -  Entities scheduled for insert
 -  Entities scheduled for update
+-  Entities scheduled for version-bumping
 -  Entities scheduled for removal
 -  Collections scheduled for update
 -  Collections scheduled for removal
@@ -599,6 +600,10 @@ mentioned sets. See this example:
             }
 
             foreach ($uow->getScheduledEntityUpdates() as $entity) {
+
+            }
+
+            foreach ($uow->getScheduledEntityVersionBumps() as $entity){
 
             }
 

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -659,8 +659,10 @@ preUpdate
 PreUpdate is the most restrictive to use event, since it is called
 right before an update statement is called for an entity inside the
 ``EntityManager#flush()`` method. Note that this event is not
-normally triggered if the computed changeset is empty. (One
-exception is when a version-column is being forcibly updated.)
+normally triggered if the computed changeset is empty. One
+exception is when using ``EntityManager#lock()`` with
+``LockMode::OPTIMISTIC_FORCE_INCREMENT``, which will fire the event
+with an empty changeset for the affected entities.
 
 Changes to associations of the updated entity are never allowed in
 this event, since Doctrine cannot guarantee to correctly handle

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -421,7 +421,7 @@ use Doctrine\Common\Util\ClassUtils;
 
             switch (true) {
                 case LockMode::OPTIMISTIC === $lockMode:
-                case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
+                case LockMode::OPTIMISTIC_FORCE_INCREMENT === $lockMode:
                     $this->lock($entity, $lockMode, $lockVersion);
                     break;
 
@@ -440,7 +440,7 @@ use Doctrine\Common\Util\ClassUtils;
 
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
-            case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
+            case LockMode::OPTIMISTIC_FORCE_INCREMENT === $lockMode:
                 if ( ! $class->isVersioned) {
                     throw OptimisticLockException::notVersioned($class->name);
                 }

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -421,6 +421,7 @@ use Doctrine\Common\Util\ClassUtils;
 
             switch (true) {
                 case LockMode::OPTIMISTIC === $lockMode:
+                case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
                     $this->lock($entity, $lockMode, $lockVersion);
                     break;
 
@@ -439,6 +440,7 @@ use Doctrine\Common\Util\ClassUtils;
 
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
+            case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
                 if ( ! $class->isVersioned) {
                     throw OptimisticLockException::notVersioned($class->name);
                 }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -239,12 +239,12 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return;
         }
 
-        $versionedClass  = $this->getVersionedClassMetadata();
-        $versionedTable  = $versionedClass->getTableName();
-
         if ( !$updateData && (!$isVersioned || !$this->em->getUnitOfWork()->isScheduledForVersionBump($entity)) ) {
             return;
         }
+
+        $versionedClass  = $this->getVersionedClassMetadata();
+        $versionedTable  = $versionedClass->getTableName();
 
         foreach ($updateData as $tableName => $data) {
             $tableName = $this->quotedTableMap[$tableName];

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -554,7 +554,7 @@ class SqlWalker implements TreeWalker
             return $sql . ' ' . $this->platform->getWriteLockSQL();
         }
 
-        if ($lockMode !== LockMode::OPTIMISTIC && $lockMode !== LockMode::OPTIMISTIC_FORCE_UPDATE) {
+        if ($lockMode !== LockMode::OPTIMISTIC && $lockMode !== LockMode::OPTIMISTIC_FORCE_INCREMENT) {
             throw QueryException::invalidLockMode();
         }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -554,7 +554,7 @@ class SqlWalker implements TreeWalker
             return $sql . ' ' . $this->platform->getWriteLockSQL();
         }
 
-        if ($lockMode !== LockMode::OPTIMISTIC) {
+        if ($lockMode !== LockMode::OPTIMISTIC && $lockMode !== LockMode::OPTIMISTIC_FORCE_UPDATE) {
             throw QueryException::invalidLockMode();
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1354,9 +1354,13 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * INTERNAL:
      * Schedules (or de-schedules) an entity for a "forced" version bump, which
      * should occur even if no other update/insert activity is needed. If such
      * activity is also present, the version will only be bumped once.
+     *
+     * User-level code that needs to increment a version number should instead
+     * use lock($entity,LockMode::OPTIMISTIC_FORCE_INCREMENT)
      *
      * @param object $entity
      * @param boolean $enable Defaults to true, false will remove from schedule if present
@@ -2396,8 +2400,13 @@ class UnitOfWork implements PropertyChangedListener
 
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
+            case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
                 if ( ! $class->isVersioned) {
                     throw OptimisticLockException::notVersioned($class->name);
+                }
+
+                if(LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode){
+                    $this->scheduleForVersionBump($entity);
                 }
 
                 if ($lockVersion === null) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2400,12 +2400,12 @@ class UnitOfWork implements PropertyChangedListener
 
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
-            case LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode:
+            case LockMode::OPTIMISTIC_FORCE_INCREMENT === $lockMode:
                 if ( ! $class->isVersioned) {
                     throw OptimisticLockException::notVersioned($class->name);
                 }
 
-                if(LockMode::OPTIMISTIC_FORCE_UPDATE === $lockMode){
+                if(LockMode::OPTIMISTIC_FORCE_INCREMENT === $lockMode){
                     $this->scheduleForVersionBump($entity);
                 }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1157,11 +1157,9 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            //TODO ensure any entities already given a "real" update/insert don't get bumped again from being on both lists
-
             if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
-                $blankArray = array(); //TODO document that "no-change" events are a new thing
-                $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $blankArray), $preUpdateInvoke);
+                $blankChangeSet = array();
+                $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $blankChangeSet), $preUpdateInvoke);
                 $this->recomputeSingleEntityChangeSet($class, $entity);
             }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3257,6 +3257,15 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * Gets the currently scheduled entity version-bumps in this UnitOfWork.
+     *
+     * @return array
+     */
+    public function getScheduledEntityVersionBumps(){
+        return $this->entityUpdateVersions;
+    }
+
+    /**
      * Gets the currently scheduled entity deletions in this UnitOfWork.
      *
      * @return array

--- a/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
@@ -9,7 +9,7 @@ namespace Doctrine\Tests\Models\Company;
  * @DiscriminatorMap({"auction"="CompanyAuction", "raffle"="CompanyRaffle"})
  */
 abstract class CompanyEvent {
-   /**
+    /**
      * @Id @Column(type="integer")
      * @GeneratedValue
      */
@@ -21,16 +21,26 @@ abstract class CompanyEvent {
      */
      private $organization;
 
-     public function getId() {
-         return $this->id;
-     }
+    /**
+     * @Version @Column(type="integer")
+     * @var int
+     */
+    protected $version;
 
-     public function getOrganization() {
-         return $this->organization;
-     }
+    public function getId() {
+        return $this->id;
+    }
 
-     public function setOrganization(CompanyOrganization $org) {
-         $this->organization = $org;
-     }
+    public function getOrganization() {
+        return $this->organization;
+    }
+
+    public function setOrganization(CompanyOrganization $org) {
+        $this->organization = $org;
+    }
+
+    public function getVersion() {
+        return $this->version;
+    }
 
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -500,6 +500,12 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $raffle = new CompanyRaffle();
         $raffle->setData("foo");
 
+        /*
+         * Accessing UOW is ugly on an API level, but it's the only way to
+         * test the core-behavior until DDC-3781 provides another mechanism.
+         */
+        $uow = $this->_em->getUnitOfWork();
+
 
         $this->_em->persist($raffle);
         $this->_em->flush();
@@ -523,24 +529,24 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /*
          * Check that forcing a version increase works in the absence of other changes
          */
-        $this->_em->getUnitOfWork()->scheduleForVersionBump($raffle);
+        $uow->scheduleForVersionBump($raffle);
 
-        $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForVersionBump($raffle));
+        $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();
         $this->assertEquals(3,$raffle->getVersion());
-        $this->assertFalse($this->_em->getUnitOfWork()->isScheduledForVersionBump($raffle));
+        $this->assertFalse($uow->isScheduledForVersionBump($raffle));
 
         /*
          * Check that versions are not double-incremented when both situations demand
          * a version change.
          */
         $raffle->setData("baz");
-        $this->_em->getUnitOfWork()->scheduleForVersionBump($raffle);
+        $uow->scheduleForVersionBump($raffle);
 
-        $this->assertTrue($this->_em->getUnitOfWork()->isScheduledForVersionBump($raffle));
+        $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();
         $this->assertEquals(4,$raffle->getVersion());
-        $this->assertFalse($this->_em->getUnitOfWork()->isScheduledForVersionBump($raffle));
+        $this->assertFalse($uow->isScheduledForVersionBump($raffle));
 
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\LockMode;
 use Doctrine\Tests\Models\Company\CompanyPerson,
     Doctrine\Tests\Models\Company\CompanyEmployee,
     Doctrine\Tests\Models\Company\CompanyManager,
@@ -501,8 +502,8 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $raffle->setData("foo");
 
         /*
-         * Accessing UOW is ugly on an API level, but it's the only way to
-         * test the core-behavior until DDC-3781 provides another mechanism.
+         * Accessing UOW like this is ugly on an API level, but we're only
+         * doing it to verify some state
          */
         $uow = $this->_em->getUnitOfWork();
 
@@ -529,7 +530,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /*
          * Check that forcing a version increase works in the absence of other changes
          */
-        $uow->scheduleForVersionBump($raffle);
+        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_UPDATE);
 
         $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();
@@ -541,7 +542,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
          * a version change.
          */
         $raffle->setData("baz");
-        $uow->scheduleForVersionBump($raffle);
+        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_UPDATE);
 
         $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -530,7 +530,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /*
          * Check that forcing a version increase works in the absence of other changes
          */
-        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_UPDATE);
+        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_INCREMENT);
 
         $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();
@@ -542,7 +542,7 @@ class ClassTableInheritanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
          * a version change.
          */
         $raffle->setData("baz");
-        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_UPDATE);
+        $this->_em->lock($raffle,LockMode::OPTIMISTIC_FORCE_INCREMENT);
 
         $this->assertTrue($uow->isScheduledForVersionBump($raffle));
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -138,7 +138,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /*
          * Check that our flag forces an update and resets the flag
          */
-        $uow->scheduleForVersionBump($test);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
         $this->_em->flush();
         $this->assertEquals(2, $test->getVersion());
         $this->assertFalse($uow->isScheduledForVersionBump($test));
@@ -156,7 +156,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
          * Check that using the flag AND making a change still results in only
          * a single increment to the version.
          */
-        $uow->scheduleForVersionBump($test);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
         $test->name = "test2";
         $this->_em->flush();
         $this->assertEquals(3, $test->getVersion());
@@ -170,7 +170,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $test2 = new OptimisticStandard();
         $test2->name = 'insert_checks';
-        $uow->scheduleForVersionBump($test);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
         $this->_em->persist($test2);
         $this->_em->flush();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -138,7 +138,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
         /*
          * Check that our flag forces an update and resets the flag
          */
-        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_INCREMENT);
         $this->_em->flush();
         $this->assertEquals(2, $test->getVersion());
         $this->assertFalse($uow->isScheduledForVersionBump($test));
@@ -156,7 +156,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
          * Check that using the flag AND making a change still results in only
          * a single increment to the version.
          */
-        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_INCREMENT);
         $test->name = "test2";
         $this->_em->flush();
         $this->assertEquals(3, $test->getVersion());
@@ -170,7 +170,7 @@ class OptimisticTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $test2 = new OptimisticStandard();
         $test2->name = 'insert_checks';
-        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_UPDATE);
+        $this->_em->lock($test,LockMode::OPTIMISTIC_FORCE_INCREMENT);
         $this->_em->persist($test2);
         $this->_em->flush();
 


### PR DESCRIPTION
A cut-down version of DDC-3640 / PR #1378

This PR focuses on the "support code", and does not contain any annotations or other mechanisms for knowing _when_ an entity's version should be bumped in the absence of "direct" modifications. Instead, it mimics other insert/update features with the methods:

```
$em->lock($entity,LockMode::OPTIMISTIC_FORCE_INCREMENT); // Preferred usage

$unitOfWork->lock($entity,LockMode::OPTIMISTIC_FORCE_INCREMENT); 
$unitOfWork->scheduleForVersionBump($entity,$enable); // For internal usage
$unitOfWork->isScheduledForVersionBump($entity);      // For internal usage
$unitOfWork->getScheduledEntityVersionBumps();        // For internal usage
```

These simple calls will allow users to solve tricky use-cases right now with their own custom event-listener code, and serve as a foundation for when DDC-3781 eventually defines an officially-sanctioned method.

Depends on doctrine/dbal#905
