### PR TITLE
Updated syntax for "integer" and "boolean" types

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -157,13 +157,15 @@ class EntityGenerator
         Type::DATE          => '\DateTime',
         Type::TIME          => '\DateTime',
         Type::OBJECT        => '\stdClass',
-        Type::BIGINT        => 'integer',
-        Type::SMALLINT      => 'integer',
+        Type::INTEGER       => 'int',
+        Type::BIGINT        => 'int',
+        Type::SMALLINT      => 'int',
         Type::TEXT          => 'string',
         Type::BLOB          => 'string',
         Type::DECIMAL       => 'string',
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
+        Type::BOOLEAN       => 'bool',
     );
 
     /**

--- a/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
@@ -37,7 +37,7 @@ class DDC1476EntityWithDefaultFieldType
     protected $name;
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
@@ -23,7 +23,7 @@ abstract class DDC1590Entity
     /**
      * Get id
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
@@ -49,7 +49,7 @@ class DDC964Address
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -51,7 +51,7 @@ class DDC964User
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -137,7 +137,7 @@ class DDC1657Screen
 {
     /**
      * Identifier
-     * @var integer
+     * @var int
      *
      * @Id
      * @GeneratedValue(strategy="IDENTITY")
@@ -187,7 +187,7 @@ class DDC1657Avatar
 {
     /**
      * Identifier
-     * @var integer
+     * @var int
      *
      * @Id
      * @GeneratedValue(strategy="IDENTITY")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -240,7 +240,7 @@ class DDC1080FooBar
      */
     protected $_bar = null;
     /**
-     * @var integer orderNr
+     * @var int orderNr
      * @Column(name="orderNr", type="integer", nullable=false)
      */
     protected $_orderNr = null;
@@ -292,7 +292,7 @@ class DDC1080FooBar
     /**
      * Retrieve the orderNr property
      *
-     * @return integer|null
+     * @return int|null
      */
     public function getOrderNr()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -45,7 +45,7 @@ class DDC1300Test extends \Doctrine\Tests\OrmFunctionalTestCase
 class DDC1300Foo
 {
     /**
-     * @var integer fooID
+     * @var int fooID
      * @Column(name="fooID", type="integer", nullable=false)
      * @GeneratedValue(strategy="AUTO")
      * @Id

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
@@ -75,7 +75,7 @@ class DDC1404ParentEntity
     protected $id;
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -163,7 +163,7 @@ class DDC1430Order
     private $products;
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -253,7 +253,7 @@ class DDC1430OrderProduct
     }
 
      /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -41,7 +41,7 @@ class DDC144Test extends \Doctrine\Tests\OrmFunctionalTestCase
 class DDC144FlowElement {
     /**
      * @Id @Column(type="integer") @GeneratedValue
-     * @var integer
+     * @var int
      */
     public $id;
     /** @Column */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
@@ -77,7 +77,7 @@ abstract class DDC1595BaseInheritance
      * @Id @GeneratedValue
      * @Column(type="integer")
      *
-     * @var integer
+     * @var int
      */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
@@ -29,7 +29,7 @@ class DDC1695Test extends \Doctrine\Tests\OrmFunctionalTestCase
 class DDC1695News
 {
     /**
-     * @var integer $idNews
+     * @var int $idNews
      *
      * @Column(name="`IdNews`", type="integer", nullable=false)
      * @Id
@@ -45,42 +45,42 @@ class DDC1695News
     private $idUser;
 
     /**
-     * @var integer $idLanguage
+     * @var int $idLanguage
      *
      * @Column(name="`IdLanguage`", type="integer", nullable=false)
      */
     private $idLanguage;
 
     /**
-     * @var integer $idCondition
+     * @var int $idCondition
      *
      * @Column(name="`IdCondition`", type="integer", nullable=true)
      */
     private $idCondition;
 
     /**
-     * @var integer $idHealthProvider
+     * @var int $idHealthProvider
      *
      * @Column(name="`IdHealthProvider`", type="integer", nullable=true)
      */
     private $idHealthProvider;
 
     /**
-     * @var integer $idSpeciality
+     * @var int $idSpeciality
      *
      * @Column(name="`IdSpeciality`", type="integer", nullable=true)
      */
     private $idSpeciality;
 
     /**
-     * @var integer $idMedicineType
+     * @var int $idMedicineType
      *
      * @Column(name="`IdMedicineType`", type="integer", nullable=true)
      */
     private $idMedicineType;
 
     /**
-     * @var integer $idTreatment
+     * @var int $idTreatment
      *
      * @Column(name="`IdTreatment`", type="integer", nullable=true)
      */
@@ -122,35 +122,35 @@ class DDC1695News
     private $idxNews;
 
     /**
-     * @var boolean $highlight
+     * @var bool $highlight
      *
      * @Column(name="`Highlight`", type="boolean", nullable=false)
      */
     private $highlight;
 
     /**
-     * @var integer $order
+     * @var int $order
      *
      * @Column(name="`Order`", type="integer", nullable=false)
      */
     private $order;
 
     /**
-     * @var boolean $deleted
+     * @var bool $deleted
      *
      * @Column(name="`Deleted`", type="boolean", nullable=false)
      */
     private $deleted;
 
     /**
-     * @var boolean $active
+     * @var bool $active
      *
      * @Column(name="`Active`", type="boolean", nullable=false)
      */
     private $active;
 
     /**
-     * @var boolean $updateToHighlighted
+     * @var bool $updateToHighlighted
      *
      * @Column(name="`UpdateToHighlighted`", type="boolean", nullable=true)
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -42,7 +42,7 @@ class DDC1925Test extends \Doctrine\Tests\OrmFunctionalTestCase
 class DDC1925Product
 {
     /**
-     * @var integer $id
+     * @var int $id
      *
      * @Column(name="id", type="integer")
      * @Id
@@ -76,7 +76,7 @@ class DDC1925Product
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {
@@ -133,7 +133,7 @@ class DDC1925Product
 class DDC1925User
 {
     /**
-     * @var integer
+     * @var int
      *
      * @Column(name="id", type="integer")
      * @Id
@@ -151,7 +151,7 @@ class DDC1925User
     /**
      * Get id
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
@@ -75,7 +75,7 @@ class DDC2138Structure
 abstract class DDC2138UserFollowedObject
 {
     /**
-     * @var integer $id
+     * @var int $id
      *
      * @Column(name="id", type="integer")
      * @Id
@@ -86,7 +86,7 @@ abstract class DDC2138UserFollowedObject
     /**
      * Get id
      *
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php
@@ -103,7 +103,7 @@ class DDC2931User
     /**
      * Return Rank recursively
      * My rank is 1 + rank of my parent
-     * @return integer
+     * @return int
      */
     public function getRank()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php
@@ -58,7 +58,7 @@ class DDC3033Product
     public $changeSet = array();
 
     /**
-     * @var integer $id
+     * @var int $id
      *
      * @Column(name="id", type="integer")
      * @Id
@@ -120,7 +120,7 @@ class DDC3033Product
 class DDC3033User
 {
     /**
-     * @var integer
+     * @var int
      *
      * @Column(name="id", type="integer")
      * @Id

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -81,7 +81,7 @@ class DDC742User
      * @Id
      * @GeneratedValue(strategy="AUTO")
      * @Column(type="integer")
-     * @var integer
+     * @var int
      */
     public $id;
     /**
@@ -114,7 +114,7 @@ class DDC742Comment
      * @Id
      * @GeneratedValue(strategy="AUTO")
      * @Column(type="integer")
-     * @var integer
+     * @var int
      */
     public $id;
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1235,7 +1235,7 @@ class DDC1170Entity
     private $value;
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2312,7 +2312,7 @@ class DDC1474Entity
     }
 
     /**
-     * @return integer
+     * @return int
      */
     public function getId()
     {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -993,13 +993,13 @@ class EntityGeneratorTest extends OrmTestCase
             )),
             array(array(
                 'fieldName' => 'bigint',
-                'phpType' => 'integer',
+                'phpType' => 'int',
                 'dbType' => 'bigint',
                 'value' => 11
             )),
             array(array(
                 'fieldName' => 'smallint',
-                'phpType' => 'integer',
+                'phpType' => 'int',
                 'dbType' => 'smallint',
                 'value' => 22
             )),

--- a/tests/Doctrine/Tests/OrmPerformanceTestCase.php
+++ b/tests/Doctrine/Tests/OrmPerformanceTestCase.php
@@ -10,7 +10,7 @@ namespace Doctrine\Tests;
 class OrmPerformanceTestCase extends OrmFunctionalTestCase
 {
     /**
-     * @var integer
+     * @var int
      */
     protected $maxRunningTime = 0;
 
@@ -54,7 +54,7 @@ class OrmPerformanceTestCase extends OrmFunctionalTestCase
     }
 
     /**
-     * @return integer
+     * @return int
      *
      * @since Method available since Release 2.3.0
      */

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -25,12 +25,12 @@ abstract class OrmTestCase extends DoctrineTestCase
     private static $_queryCacheImpl = null;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $isSecondLevelCacheEnabled = false;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $isSecondLevelCacheLogEnabled = false;
 

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -13,7 +13,7 @@ use Doctrine\DBAL\DriverManager;
 class TestUtil
 {
     /**
-     * @var boolean Whether the database schema is initialized.
+     * @var bool Whether the database schema is initialized.
      */
     private static $initialized = false;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Used short syntax for `integer` and `boolean` types.

**Before**

``` php
/**
 * @var integer
 *
 * @ORM\Column(name="some_integer_field", type="integer")
 */
private $someIntegerField;

/**
 * @var boolean
 *
 * @ORM\Column(name="some_boolean_field", type="boolean")
 */
private $someBooleanField;
```

**After**

``` php
/**
 * @var int
 *
 * @ORM\Column(name="some_integer_field", type="integer")
 */
private $someIntegerField;

/**
 * @var bool
 *
 * @ORM\Column(name="some_boolean_field", type="boolean")
 */
private $someBooleanField;
```
