### PR TITLE
[CS] Added PHP-CS-Fixer and ruleset

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,44 @@
+<?php
+
+$header = <<<'EOF'
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software consists of voluntary contributions made by many individuals
+and is licensed under the MIT license. For more information, see
+<http://www.doctrine-project.org>.
+EOF;
+
+Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
+
+$finder = Symfony\CS\Finder::create()
+    ->in(__DIR__.'/lib/')
+    ->in(__DIR__.'/tests/')
+    ->in(__DIR__.'/tools/')
+;
+
+return Symfony\CS\Config::create()
+    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->fixers([
+        'header_comment',
+        'align_double_arrow',
+        'align_equals',
+        'concat_with_spaces',
+    ])
+    ->finder(
+        Symfony\CS\Finder::create()
+            ->in(__DIR__.'/lib/')
+            ->in(__DIR__.'/tests/')
+            ->in(__DIR__.'/tools/')
+    )
+;
+

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "fabpot/php-cs-fixer": "^1.9"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Added dependency for PHP-CS-Fixer and ruleset based on
https://github.com/doctrine/coding-standard/blob/96b3e19c9a151760e0246687a7143f77c0aff3a0/Docs/README.md
