### PR TITLE
[DDC-3609] Syntax error in class table inheritance join when WITH is used in DQL query #1328

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1122,9 +1122,7 @@ class SqlWalker implements TreeWalker
                 $dqlAlias   = $joinDeclaration->aliasIdentificationVariable;
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
                 $condition = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
-                $condExprConjunction = ($class->isInheritanceTypeJoined() && $joinType != AST\Join::JOIN_TYPE_LEFT && $joinType != AST\Join::JOIN_TYPE_LEFTOUTER)
-                    ? ' AND '
-                    : ' ON ';
+                $condExprConjunction = $class->isInheritanceTypeJoined() ? ' AND ' : ' ON ';
 
                 $sql .= $this->walkRangeVariableDeclaration($joinDeclaration);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3609Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3609Test.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @group DDC-3609
+ */
+class DDC3609Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setup()
+    {
+        parent::setup();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609Order'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609SimpleOrder'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609ComplexOrder'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609DeliveryLocation'),
+        ));
+    }
+
+    /**
+     * Verifies that class table inheritance joins work correctly when additional
+     * restrictions are placed on the joins for child tables.
+     */
+    public function testIssue()
+    {
+        $simpleOrder = new DDC3609SimpleOrder();
+        $simpleOrder->fulfiller = 'FulfillerUser';
+
+        $complexOrder = new DDC3609ComplexOrder();
+        $deliverTo1 = new DDC3609DeliveryLocation($complexOrder);
+        $deliverTo1->location = 'Room 100';
+        $deliverTo1->fulfiller = 'FulfillerUser';
+
+        $shouldNotAppear = new DDC3609SimpleOrder();
+
+        $this->_em->persist($simpleOrder);
+        $this->_em->persist($shouldNotAppear);
+        $this->_em->persist($complexOrder);
+        $this->_em->flush();
+
+        $dql = "
+        SELECT
+          BaseOrder
+
+        FROM
+          \Doctrine\Tests\ORM\Functional\Ticket\DDC3609Order BaseOrder
+          LEFT JOIN \Doctrine\Tests\ORM\Functional\Ticket\DDC3609SimpleOrder SimpleOrder WITH SimpleOrder.id = BaseOrder.id
+          LEFT JOIN \Doctrine\Tests\ORM\Functional\Ticket\DDC3609ComplexOrder ComplexOrder WITH ComplexOrder.id = BaseOrder.id
+
+          LEFT JOIN ComplexOrder.deliveryLocations ComplexDeliveryLocation
+
+        WHERE
+          (
+            BaseOrder INSTANCE OF \Doctrine\Tests\ORM\Functional\Ticket\DDC3609SimpleOrder
+            AND
+            SimpleOrder.fulfiller = 'FulfillerUser'
+          )
+          OR
+          (
+            BaseOrder INSTANCE OF \Doctrine\Tests\ORM\Functional\Ticket\DDC3609ComplexOrder
+            AND
+            ComplexDeliveryLocation.fulfiller = 'FulfillerUser'
+          )
+        ";
+
+        $query = $this->_em->createQuery($dql);
+        $results = $query->execute();
+
+        $foundSimple = false;
+        $foundComplex = false;
+        foreach ($results as $result) {
+            if ($result->id == $shouldNotAppear->id) {
+                $this->fail('Order was present in results when it should not have been');
+            }
+            if ($result->id == $simpleOrder->id) {
+                $foundSimple = true;
+            }
+            if ($result->id == $complexOrder->id) {
+                $foundComplex = true;
+            }
+        }
+
+        $this->assertTrue($foundSimple, 'Simple order was not found in search results');
+        $this->assertTrue($foundComplex, 'Complex order was not found in search results');
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *  "BaseOrder" = "DDC3609Order",
+ *  "SimpleOrder" = "DDC3609SimpleOrder",
+ *  "ComplexOrder" = "DDC3609ComplexOrder"
+ * })
+ */
+class DDC3609Order
+{
+    /** @Id @Column(type="integer") @GeneratedValue(strategy="AUTO") */
+    public $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $requester;
+}
+
+/**
+ * @Entity
+ */
+class DDC3609SimpleOrder extends DDC3609Order
+{
+    /**
+     * @Column(type="string", nullable=true)
+     */
+    public $fulfiller;
+}
+
+/**
+ * @Entity
+ */
+class DDC3609ComplexOrder extends DDC3609Order
+{
+    /**
+     * @var DDC2306UserAddress[]|\Doctrine\Common\Collections\Collection
+     *
+     * @OneToMany(targetEntity="DDC3609DeliveryLocation", mappedBy="order", cascade={"persist"})
+     */
+    public $deliveryLocations;
+
+    public function __construct() {
+        $this->deliveryLocations = new ArrayCollection();
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC3609DeliveryLocation
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @ManyToOne(targetEntity="DDC3609ComplexOrder") */
+    public $order;
+
+    /** @Column(type="string", nullable=true) */
+    public $location;
+
+    /** @Column(type="string", nullable=true) */
+    public $fulfiller;
+
+    public function __construct(DDC3609ComplexOrder $order)
+    {
+        $this->order = $order;
+        $order->deliveryLocations->add($this);
+    }
+}
+
+

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3609Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3609Test.php
@@ -25,6 +25,21 @@ class DDC3609Test extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 
     /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        $this->_schemaTool->dropSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609Order'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609SimpleOrder'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609ComplexOrder'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC3609DeliveryLocation'),
+        ));
+
+        parent::tearDown();
+    }
+
+    /**
      * Verifies that class table inheritance joins work correctly when additional
      * restrictions are placed on the joins for child tables.
      *

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -158,7 +158,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyManager m WITH e.id = m.id',
-            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id ON (c0_.id = c3_.id)'
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id AND (c0_.id = c3_.id)'
         );
     }
 
@@ -2165,7 +2165,7 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
         // the where clause when not joining onto that table
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c LEFT JOIN Doctrine\Tests\Models\Company\CompanyEmployee e WITH e.id = c.salesPerson WHERE c.completed = true',
-            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ LEFT JOIN company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id ON (c2_.id = c0_.salesPerson_id) WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ LEFT JOIN company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id AND (c2_.id = c0_.salesPerson_id) WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
         );
     }
 


### PR DESCRIPTION
I found that in SqlWalker::walkJoin(), it is using ON if the join type is LEFT or LEFT OUTER. That seems weird, because SqlWalker::walkRangeVariableDeclaration() always adds a JOIN with ON, even in the case of LEFT or LEFT OUTER join. Furthermore, the tests in SelectSqlGenerationTest seem to incorrectly check for the second ON to be present.

However, this change only fixes one of the tests by @adeanzan, the other two are still failing. So I don't know if my fix is correct.
