### PR TITLE
Travis: Switch to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ matrix:
       env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
   allow_failures:
     - php: 7.0
+
+sudo: false


### PR DESCRIPTION
This PR migrates Travis builds to the new container-based infrastructure.
See [Using container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) for details.
