### PR TITLE
switch/case with colon instead of semicolon

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1412,7 +1412,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         switch (true) {
-            case ($class->isIdentifierNatural());
+            case ($class->isIdentifierNatural()):
                 // Check for a version field, if available, to avoid a db lookup.
                 if ($class->isVersioned) {
                     return ($class->getFieldValue($entity, $class->versionField))


### PR DESCRIPTION
A semicolon is also correct ( http://php.net/manual/en/control-structures.switch.php "It's possible to use a semicolon instead of a colon after a case like: ") but there are colons on the other cases.
