### PR TITLE
Travis: Enable cache for composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.6' && $DB = 'sqlite' ]]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; else PHPUNIT_FLAGS=""; fi
   - if [[ $TRAVIS_PHP_VERSION != '5.6' && $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
-  - composer install --prefer-source --dev
+  - composer install --dev
 
 script:
   - ENABLE_SECOND_LEVEL_CACHE=0 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml $PHPUNIT_FLAGS
@@ -33,3 +33,7 @@ matrix:
     - php: 7.0
 
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache


### PR DESCRIPTION
Travis is now able to persist caches and reuse them in future builds. This could avoid re-downloading of stable packages (5 atm).
As @stof suggested in #1466, after removing `--prefer-source`, stable versions will be downloaded as an archive while dev versions will be still cloned by git directly.
More info in [Caching Dependencies and Directories](http://docs.travis-ci.com/user/caching/).
