### PR TITLE
[CI] Added dev requirement for "doctrine/coding-standard"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 install: travis_retry composer update --prefer-dist
 
 script:
+  - ./vendor/bin/phpcs --standard=./vendor/doctrine/coding-standard/Doctrine/ --extensions=php . -v
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "CREATE SCHEMA doctrine_tests; GRANT ALL PRIVILEGES ON doctrine_tests.* to travis@'%'"; fi
   - ENABLE_SECOND_LEVEL_CACHE=0 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml
   - ENABLE_SECOND_LEVEL_CACHE=1 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml --exclude-group performance,non-cacheable,locking_functional

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require-dev": {
         "symfony/yaml": "~3.4|~4.0",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "doctrine/coding-standard": "^0.1"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
- Added dev requirement for `doctrine/coding-standard`.
- Updated Travis config in order to use the new requirement within
  `before_script` lifecycle.
