### PR TITLE
Add test for MariaDB 5.5 and 10.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,48 @@ after_script:
   - php vendor/bin/coveralls -v
 
 matrix:
+  include:
+    - php: 5.4
+      env: DB=mariadb
+      addons:
+        mariadb: 5.5
+    - php: 5.5
+      env: DB=mariadb
+      addons:
+        mariadb: 5.5
+    - php: 5.6
+      env: DB=mariadb
+      addons:
+        mariadb: 5.5
+    - php: 7.0
+      env: DB=mariadb
+      addons:
+        mariadb: 5.5
+    - php: hhvm
+      env: DB=mariadb
+      addons:
+        mariadb: 5.5
+
+    - php: 5.4
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 5.5
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 5.6
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 7.0
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: hhvm
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
   exclude:
     - php: hhvm
       env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency

--- a/tests/travis/mariadb.travis.xml
+++ b/tests/travis/mariadb.travis.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit bootstrap="../Doctrine/Tests/TestInit.php" colors="true">
+    <php>
+        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_host" value="localhost" />
+        <var name="db_username" value="travis" />
+        <var name="db_password" value="" />
+        <var name="db_name" value="doctrine_tests" />
+        <var name="db_port" value="3306"/>
+
+        <var name="tmpdb_type" value="pdo_mysql"/>
+        <var name="tmpdb_host" value="localhost" />
+        <var name="tmpdb_username" value="travis" />
+        <var name="tmpdb_password" value="" />
+        <var name="tmpdb_port" value="3306"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Doctrine ORM Test Suite">
+            <directory>./../Doctrine/Tests/ORM</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./../../lib/Doctrine</directory>
+        </whitelist>
+    </filter>
+    <groups>
+        <exclude>
+            <group>performance</group>
+            <group>locking_functional</group>
+        </exclude>
+    </groups>
+
+</phpunit>
+


### PR DESCRIPTION
This use the brand new supported addon mariadb (not yet officially announced).
This is unfortunately a bit verbose, but I don't think there is any
alternative because we cannot install the addon when testing against mysql
otherwise it would overwrite mysql install.
