### PR TITLE
Quoted field - yaml driver

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -601,5 +601,5 @@ Querying for the staffs without getting any technicians can be achieved by this 
 .. code-block:: php
 
     <?php
-    $query = $em->createQuery("SELECT staff FROM MyProject\Model\Staff staff WHERE staff INSTANCE OF MyProject\Model\Staff");
+    $query = $em->createQuery("SELECT staff FROM MyProject\Model\Staff staff WHERE staff NOT INSTANCE OF MyProject\Model\Technician");
     $staffs = $query->getResult();

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -180,13 +180,7 @@ class DefaultCacheFactory implements CacheFactory
      */
     public function buildCollectionHydrator(EntityManagerInterface $em, array $mapping)
     {
-        /* @var $targetPersister \Doctrine\ORM\Cache\Persister\CachedPersister */
-        $targetPersister = $em->getUnitOfWork()->getEntityPersister($mapping['targetEntity']);
-
-        return new DefaultCollectionHydrator(
-            $em,
-            $targetPersister->getCacheRegion()
-        );
+        return new DefaultCollectionHydrator($em);
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/MultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/MultiGetRegion.php
@@ -23,7 +23,7 @@ namespace Doctrine\ORM\Cache;
 /**
  * Defines a region that supports multi-get reading.
  *
- * With one method call we can get multipe items.
+ * With one method call we can get multiple items.
  *
  * @since   2.5
  * @author  Asmir Mustafic
@@ -31,7 +31,7 @@ namespace Doctrine\ORM\Cache;
 interface MultiGetRegion
 {
     /**
-     * Get all items from the cache indentifed by $keys.
+     * Get all items from the cache identified by $keys.
      * It returns NULL if some elements can not be found.
      *
      * @param CollectionCacheEntry $collection The collection of the items to be retrieved.

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -57,8 +57,9 @@ class DefaultMultiGetRegion extends DefaultRegion
     public function getMultiple(CollectionCacheEntry $collection)
     {
         $keysToRetrieve = array();
+
         foreach ($collection->identifiers as $index => $key) {
-            $keysToRetrieve[$index] = $this->name . '_' . $key->hash;
+            $keysToRetrieve[$index] = $this->getCacheEntryKey($key);
         }
 
         $items = $this->cache->fetchMultiple($keysToRetrieve);
@@ -70,6 +71,7 @@ class DefaultMultiGetRegion extends DefaultRegion
         foreach ($keysToRetrieve as $index => $key) {
             $returnableItems[$index] = $items[$key];
         }
+
         return $returnableItems;
     }
 }

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -61,7 +61,7 @@ class FileLockRegion implements ConcurrentRegion
      */
     public function __construct(Region $region, $directory, $lockLifetime)
     {
-        if ( ! is_dir($directory) && ! @mkdir($directory, 0777, true)) {
+        if ( ! is_dir($directory) && ! @mkdir($directory, 0775, true)) {
             throw new \InvalidArgumentException(sprintf('The directory "%s" does not exist and could not be created.', $directory));
         }
 
@@ -242,6 +242,7 @@ class FileLockRegion implements ConcurrentRegion
         if ( ! @file_put_contents($filename, $lock->value, LOCK_EX)) {
             return null;
         }
+        chmod($filename, 0664);
 
         return $lock;
     }

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -20,6 +20,8 @@
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
@@ -30,12 +32,40 @@ use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClas
 class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
 {
     /**
+     * @param ClassMetadata $classMetadata
+     * @param EntityManager $entityManager
+     */
+    function __construct(ClassMetadata $classMetadata, EntityManager $entityManager)
+    {
+        /*
+        We use our own constructor here to enforce type-hinting requirements,
+        since both inputs are specialized subclasses compared to what the super-
+        class is willing to accept.
+
+        In particular, we want to have EntityManager rather than ObjectManager.
+        */
+        parent::__construct($classMetadata, $entityManager);
+    }
+
+    /**
      * Retrieve associated EntityManager.
      *
      * @return \Doctrine\ORM\EntityManager
      */
     public function getEntityManager()
     {
-        return $this->getObjectManager();
+        $em = $this->getObjectManager();
+        assert($em instanceof EntityManager);
+        return $em;
+    }
+
+    /**
+     * Retrieves the associated ClassMetadata.
+     *
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    public function getClassMetadata()
+    {
+        return parent::getClassMetadata();
     }
 }

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -54,9 +54,11 @@ class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
      */
     public function getEntityManager()
     {
-        $em = $this->getObjectManager();
-        assert($em instanceof EntityManager);
-        return $em;
+        /*
+        We can safely assume our ObjectManager is also an EventManager due to
+        our restrictions in the constructor.
+        */
+        return $this->getObjectManager();
     }
 
     /**

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -20,33 +20,20 @@
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs as BaseLoadClassMetadataEventArgs;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\EntityManager;
 
 /**
  * Class that holds event arguments for a loadMetadata event.
  *
  * @author Jonathan H. Wage <jonwage@gmail.com>
  * @since  2.0
+ *
+ * Note: method annotations are used instead of method overrides (due to BC policy)
+ *
+ * @method __construct(\Doctrine\ORM\Mapping\ClassMetadata $classMetadata, \Doctrine\ORM\EntityManager $objectManager)
+ * @method \Doctrine\ORM\EntityManager getClassMetadata()
  */
 class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
 {
-    /**
-     * @param ClassMetadata $classMetadata
-     * @param EntityManager $entityManager
-     */
-    function __construct(ClassMetadata $classMetadata, EntityManager $entityManager)
-    {
-        /*
-        We use our own constructor here to enforce type-hinting requirements,
-        since both inputs are specialized subclasses compared to what the super-
-        class is willing to accept.
-
-        In particular, we want to have EntityManager rather than ObjectManager.
-        */
-        parent::__construct($classMetadata, $entityManager);
-    }
-
     /**
      * Retrieve associated EntityManager.
      *
@@ -54,20 +41,6 @@ class LoadClassMetadataEventArgs extends BaseLoadClassMetadataEventArgs
      */
     public function getEntityManager()
     {
-        /*
-        We can safely assume our ObjectManager is also an EventManager due to
-        our restrictions in the constructor.
-        */
         return $this->getObjectManager();
-    }
-
-    /**
-     * Retrieves the associated ClassMetadata.
-     *
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
-     */
-    public function getClassMetadata()
-    {
-        return parent::getClassMetadata();
     }
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -189,8 +189,8 @@ class ObjectHydrator extends AbstractHydrator
         $relation = $class->associationMappings[$fieldName];
         $value    = $class->reflFields[$fieldName]->getValue($entity);
 
-        if ($value === null) {
-            $value = new ArrayCollection;
+        if ($value === null || is_array($value)) {
+            $value = new ArrayCollection((array) $value);
         }
 
         if ( ! $value instanceof PersistentCollection) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -945,7 +945,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         foreach ($this->fieldMappings as $field => $mapping) {
-            if (isset($mapping['declaredField'])) {
+            if (isset($mapping['declaredField']) && isset($parentReflFields[$mapping['declaredField']])) {
                 $this->reflFields[$field] = new ReflectionEmbeddedProperty(
                     $parentReflFields[$mapping['declaredField']],
                     $reflService->getAccessibleProperty($mapping['originalClass'], $mapping['originalField']),

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -682,6 +682,10 @@ class YamlDriver extends FileDriver
             $joinColumn['nullable'] = (bool) $joinColumnElement['nullable'];
         }
 
+        if (isset($joinColumnElement['quoted'])) {
+            $joinColumn['quoted'] = (bool) $joinColumnElement['quoted'];
+        }
+
         if (isset($joinColumnElement['onDelete'])) {
             $joinColumn['onDelete'] = $joinColumnElement['onDelete'];
         }
@@ -742,7 +746,12 @@ class YamlDriver extends FileDriver
         }
 
         if (isset($column['nullable'])) {
-            $mapping['nullable'] = $column['nullable'];
+
+            $mapping['nullable'] = (bool) $column['nullable'];
+        }
+
+        if (isset($column['quoted'])) {
+            $mapping['quoted'] = (bool) $column['quoted'];
         }
 
         if (isset($column['version']) && $column['version']) {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -103,16 +103,14 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @param EntityManagerInterface $em         The EntityManager the collection will be associated with.
      * @param ClassMetadata          $class      The class descriptor of the entity type of this collection.
-     * @param Collection|array|null  $collection The collection elements.
+     * @param Collection             $collection The collection elements.
      */
-    public function __construct(EntityManagerInterface $em, $class, $collection)
+    public function __construct(EntityManagerInterface $em, $class, Collection $collection)
     {
+        $this->collection  = $collection;
         $this->em          = $em;
         $this->typeClass   = $class;
         $this->initialized = true;
-        $this->collection  = $collection instanceof Collection
-            ? $collection
-            : new ArrayCollection((array) $collection);
     }
 
     /**

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -101,16 +101,18 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * Creates a new persistent collection.
      *
-     * @param EntityManagerInterface $em    The EntityManager the collection will be associated with.
-     * @param ClassMetadata          $class The class descriptor of the entity type of this collection.
-     * @param Collection             $coll  The collection elements.
+     * @param EntityManagerInterface $em         The EntityManager the collection will be associated with.
+     * @param ClassMetadata          $class      The class descriptor of the entity type of this collection.
+     * @param Collection|array|null  $collection The collection elements.
      */
-    public function __construct(EntityManagerInterface $em, $class, $coll)
+    public function __construct(EntityManagerInterface $em, $class, $collection)
     {
-        $this->collection  = $coll;
         $this->em          = $em;
         $this->typeClass   = $class;
         $this->initialized = true;
+        $this->collection  = $collection instanceof Collection
+            ? $collection
+            : new ArrayCollection((array) $collection);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -347,7 +347,7 @@ class ResultSetMapping
      * @param string $class       The class name of the joined entity.
      * @param string $alias       The unique alias to use for the joined entity.
      * @param string $parentAlias The alias of the entity result that is the parent of this joined result.
-     * @param object $relation    The association field that connects the parent entity result
+     * @param string $relation    The association field that connects the parent entity result
      *                            with the joined entity result.
      *
      * @return ResultSetMapping This ResultSetMapping instance.

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1093,6 +1093,10 @@ class SqlWalker implements TreeWalker
 
         $this->orderedColumnsMap[$sql] = $type;
 
+        if ($expr instanceof AST\Subselect) {
+            return '(' . $sql . ') ' . $type;
+        }
+
         return $sql . ' ' . $type;
     }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -137,7 +137,7 @@ EOT
 
         // Process destination directory
         if ( ! is_dir($destPath = $input->getArgument('dest-path'))) {
-            mkdir($destPath, 0777, true);
+            mkdir($destPath, 0775, true);
         }
         $destPath = realpath($destPath);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -79,7 +79,7 @@ EOT
         }
 
         if ( ! is_dir($destPath)) {
-            mkdir($destPath, 0777, true);
+            mkdir($destPath, 0775, true);
         }
 
         $destPath = realpath($destPath);

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -80,7 +80,7 @@ class ConvertDoctrine1Schema
                     $schema = array_merge($schema, (array) Yaml::parse(file_get_contents($file)));
                 }
             } else {
-                $schema = array_merge($schema, (array) Yaml::parse(file_get_contents($file)));
+                $schema = array_merge($schema, (array) Yaml::parse(file_get_contents($path)));
             }
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -364,7 +364,7 @@ public function __construct(<params>)
         $dir = dirname($path);
 
         if ( ! is_dir($dir)) {
-            mkdir($dir, 0777, true);
+            mkdir($dir, 0775, true);
         }
 
         $this->isNew = !file_exists($path) || (file_exists($path) && $this->regenerateEntityIfExists);
@@ -389,6 +389,7 @@ public function __construct(<params>)
         } elseif ( ! $this->isNew && $this->updateEntityIfExists) {
             file_put_contents($path, $this->generateUpdatedEntityClass($metadata, $path));
         }
+        chmod($path, 0664);
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -147,11 +147,12 @@ class <className> extends <repositoryName>
         $dir = dirname($path);
 
         if ( ! is_dir($dir)) {
-            mkdir($dir, 0777, true);
+            mkdir($dir, 0775, true);
         }
 
         if ( ! file_exists($path)) {
             file_put_contents($path, $code);
+            chmod($path, 0664);
         }
     }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -130,7 +130,7 @@ abstract class AbstractExporter
     public function export()
     {
         if ( ! is_dir($this->_outputDir)) {
-            mkdir($this->_outputDir, 0777, true);
+            mkdir($this->_outputDir, 0775, true);
         }
 
         foreach ($this->_metadata as $metadata) {
@@ -139,12 +139,13 @@ abstract class AbstractExporter
                 $path = $this->_generateOutputPath($metadata);
                 $dir = dirname($path);
                 if ( ! is_dir($dir)) {
-                    mkdir($dir, 0777, true);
+                    mkdir($dir, 0775, true);
                 }
                 if (file_exists($path) && !$this->_overwriteExistingFiles) {
                     throw ExportException::attemptOverwriteExistingFile($path);
                 }
                 file_put_contents($path, $output);
+                chmod($path, 0664);
             }
         }
     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3378,7 +3378,7 @@ class UnitOfWork implements PropertyChangedListener
                     } else {
                         if ($other instanceof Proxy && !$other->__isInitialized()) {
                             // do not merge fields marked lazy that have not been fetched.
-                            return;
+                            continue;
                         }
 
                         if ( ! $assoc2['isCascadeMerge']) {
@@ -3406,7 +3406,7 @@ class UnitOfWork implements PropertyChangedListener
                     if ($mergeCol instanceof PersistentCollection && ! $mergeCol->isInitialized()) {
                         // do not merge fields marked lazy that have not been fetched.
                         // keep the lazy persistent collection of the managed copy.
-                        return;
+                        continue;
                     }
 
                     $managedCol = $prop->getValue($managedCopy);

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -36,7 +36,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.5.1-DEV';
+    const VERSION = '2.5.1';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -36,7 +36,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.6.0-DEV';
+    const VERSION = '2.5.1-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -36,7 +36,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.5.1';
+    const VERSION = '2.5.2-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -30,10 +30,6 @@ class CacheMetadataListener
             return;
         }
 
-        if( ! $em instanceof EntityManager){
-            return;
-        }
-
         $this->enableCaching($metadata, $em);
     }
 

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\EventListener;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
@@ -38,16 +37,19 @@ class CacheMetadataListener
 
     /**
      * @param ClassMetadata $metadata
+     *
      * @return bool
      */
-    private function isVisited(ClassMetaData $metadata) {
+    private function isVisited(ClassMetaData $metadata)
+    {
         return isset($this->enabledItems[$metadata->getName()]);
     }
 
     /**
      * @param ClassMetadata $metadata
      */
-    private function recordVisit(ClassMetaData $metadata) {
+    private function recordVisit(ClassMetaData $metadata)
+    {
         $this->enabledItems[$metadata->getName()] = true;
     }
 
@@ -55,8 +57,8 @@ class CacheMetadataListener
      * @param ClassMetadata $metadata
      * @param EntityManager $em
      */
-    protected function enableCaching(ClassMetadata $metadata, EntityManager $em) {
-
+    protected function enableCaching(ClassMetadata $metadata, EntityManager $em)
+    {
         if ($this->isVisited($metadata)) {
             return; // Already handled in the past
         }
@@ -73,12 +75,9 @@ class CacheMetadataListener
 
         $this->recordVisit($metadata);
 
-        /*
-         * Only enable association-caching when the target has already been
-         * given caching settings
-         */
+        // only enable association-caching when the target has already been
+        // given caching settings
         foreach ($metadata->associationMappings as $mapping) {
-
             $targetMeta = $em->getClassMetadata($mapping['targetEntity']);
             $this->enableCaching($targetMeta, $em);
 

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -3,24 +3,53 @@
 namespace Doctrine\Tests\EventListener;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 
 class CacheMetadataListener
 {
+
+    /**
+     * Tracks which entities we have already forced caching enabled on. This is
+     * important to avoid some potential infinite-recursion issues.
+     * @var array
+     */
+    protected $enabledItems = array();
+
     /**
      * @param \Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs $event
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
         $metadata = $event->getClassMetadata();
-        $cache    = array(
-            'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
-        );
+        $em = $event->getObjectManager();
 
         /** @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
         if (strstr($metadata->name, 'Doctrine\Tests\Models\Cache')) {
             return;
         }
+
+        if( ! $em instanceof EntityManager){
+            return;
+        }
+
+        $this->enableCaching($metadata, $em);
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     * @param EntityManager $em
+     */
+    protected function enableCaching(ClassMetadata $metadata, EntityManager $em){
+
+        if(array_key_exists($metadata->getName(), $this->enabledItems)){
+            return; // Already handled in the past
+        }
+
+        $cache    = array(
+            'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
+        );
 
         if ($metadata->isVersioned) {
             return;
@@ -28,8 +57,20 @@ class CacheMetadataListener
 
         $metadata->enableCache($cache);
 
+        $this->enabledItems[$metadata->getName()] = $metadata;
+
+        /*
+         * Only enable association-caching when the target has already been
+         * given caching settings
+         */
         foreach ($metadata->associationMappings as $mapping) {
-            $metadata->enableAssociationCache($mapping['fieldName'], $cache);
+
+            $targetMeta = $em->getClassMetadata($mapping['targetEntity']);
+            $this->enableCaching($targetMeta, $em);
+
+            if(array_key_exists($targetMeta->getName(), $this->enabledItems)){
+                $metadata->enableAssociationCache($mapping['fieldName'], $cache);
+            }
         }
     }
 }

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -37,13 +37,13 @@ class CacheMetadataListener
      * @param ClassMetadata $metadata
      * @param EntityManager $em
      */
-    protected function enableCaching(ClassMetadata $metadata, EntityManager $em){
+    protected function enableCaching(ClassMetadata $metadata, EntityManager $em) {
 
-        if(array_key_exists($metadata->getName(), $this->enabledItems)){
+        if (array_key_exists($metadata->getName(), $this->enabledItems)) {
             return; // Already handled in the past
         }
 
-        $cache    = array(
+        $cache = array(
             'usage' => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
         );
 
@@ -64,7 +64,7 @@ class CacheMetadataListener
             $targetMeta = $em->getClassMetadata($mapping['targetEntity']);
             $this->enableCaching($targetMeta, $em);
 
-            if(array_key_exists($targetMeta->getName(), $this->enabledItems)){
+            if (array_key_exists($targetMeta->getName(), $this->enabledItems)) {
                 $metadata->enableAssociationCache($mapping['fieldName'], $cache);
             }
         }

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_child")
+ */
+class DDC3699Child extends DDC3699Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $childField;
+
+    /**
+     * @OneToOne(targetEntity="DDC3699RelationOne", inversedBy="child")
+     */
+    protected $oneRelation;
+
+    /**
+     * @OneToMany(targetEntity="DDC3699RelationMany", mappedBy="child")
+     */
+    protected $relations;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChildField()
+    {
+        return $this->childField;
+    }
+
+    public function setChildField($childField)
+    {
+        $this->childField = $childField;
+    }
+
+    public function getOneRelation()
+    {
+        return $this->oneRelation;
+    }
+
+    public function setOneRelation($oneRelation)
+    {
+        $this->oneRelation = $oneRelation;
+    }
+
+    public function hasRelation($relation)
+    {
+        return $this->relations && $this->relations->contains($relation);
+    }
+
+    public function addRelation($relation)
+    {
+        if (!$this->hasRelation($relation)) {
+            $this->relations[] = $relation;
+        }
+
+        return $this;
+    }
+
+    public function removeRelation($relation)
+    {
+        $this->relations->removeElement($relation);
+
+        return $this;
+    }
+
+    public function getRelations()
+    {
+        return $this->relations;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Child.php
@@ -2,90 +2,20 @@
 
 namespace Doctrine\Tests\Models\DDC3699;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
-/**
- * @Entity
- * @Table(name="ddc3699_child")
- */
+/** @Entity @Table(name="ddc3699_child") */
 class DDC3699Child extends DDC3699Parent
 {
     const CLASSNAME = __CLASS__;
 
-    /**
-     * @Id
-     * @Column(type="integer")
-     */
-    protected $id;
+    /** @Id @Column(type="integer") */
+    public $id;
 
-    /**
-     * @Column(type="string")
-     */
-    protected $childField;
+    /** @Column(type="string") */
+    public $childField;
 
-    /**
-     * @OneToOne(targetEntity="DDC3699RelationOne", inversedBy="child")
-     */
-    protected $oneRelation;
+    /** @OneToOne(targetEntity="DDC3699RelationOne", inversedBy="child") */
+    public $oneRelation;
 
-    /**
-     * @OneToMany(targetEntity="DDC3699RelationMany", mappedBy="child")
-     */
-    protected $relations;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
-    public function getChildField()
-    {
-        return $this->childField;
-    }
-
-    public function setChildField($childField)
-    {
-        $this->childField = $childField;
-    }
-
-    public function getOneRelation()
-    {
-        return $this->oneRelation;
-    }
-
-    public function setOneRelation($oneRelation)
-    {
-        $this->oneRelation = $oneRelation;
-    }
-
-    public function hasRelation($relation)
-    {
-        return $this->relations && $this->relations->contains($relation);
-    }
-
-    public function addRelation($relation)
-    {
-        if (!$this->hasRelation($relation)) {
-            $this->relations[] = $relation;
-        }
-
-        return $this;
-    }
-
-    public function removeRelation($relation)
-    {
-        $this->relations->removeElement($relation);
-
-        return $this;
-    }
-
-    public function getRelations()
-    {
-        return $this->relations;
-    }
+    /** @OneToMany(targetEntity="DDC3699RelationMany", mappedBy="child") */
+    public $relations;
 }

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class DDC3699Parent
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Column(type="string")
+     */
+    protected $parentField;
+
+    public function getParentField()
+    {
+        return $this->parentField;
+    }
+
+    public function setParentField($parentField)
+    {
+        $this->parentField = $parentField;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699Parent.php
@@ -2,25 +2,11 @@
 
 namespace Doctrine\Tests\Models\DDC3699;
 
-/**
- * @MappedSuperclass
- */
+/** @MappedSuperclass */
 abstract class DDC3699Parent
 {
     const CLASSNAME = __CLASS__;
 
-    /**
-     * @Column(type="string")
-     */
-    protected $parentField;
-
-    public function getParentField()
-    {
-        return $this->parentField;
-    }
-
-    public function setParentField($parentField)
-    {
-        $this->parentField = $parentField;
-    }
+    /** @Column(type="string") */
+    public $parentField;
 }

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
@@ -10,35 +10,9 @@ class DDC3699RelationMany
 {
     const CLASSNAME = __CLASS__;
 
-    /**
-     * @Id
-     * @Column(type="integer")
-     */
-    protected $id;
+    /** @Id @Column(type="integer") */
+    public $id;
 
-    /**
-     * @ManyToOne(targetEntity="DDC3699Child", inversedBy="relations")
-     * @JoinColumn(name="child", referencedColumnName="id")
-     */
-    protected $child;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
-    public function getChild()
-    {
-        return $this->child;
-    }
-
-    public function setChild($child)
-    {
-        $this->child = $child;
-    }
+    /** @ManyToOne(targetEntity="DDC3699Child", inversedBy="relations") */
+    public $child;
 }

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationMany.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_relation_many")
+ */
+class DDC3699RelationMany
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @ManyToOne(targetEntity="DDC3699Child", inversedBy="relations")
+     * @JoinColumn(name="child", referencedColumnName="id")
+     */
+    protected $child;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    public function setChild($child)
+    {
+        $this->child = $child;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
@@ -10,34 +10,9 @@ class DDC3699RelationOne
 {
     const CLASSNAME = __CLASS__;
 
-    /**
-     * @Id
-     * @Column(type="integer")
-     */
-    protected $id;
+    /** @Id @Column(type="integer") */
+    public $id;
 
-    /**
-     * @OneToOne(targetEntity="DDC3699Child", mappedBy="oneRelation")
-     */
-    protected $child;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
-    public function getChild()
-    {
-        return $this->child;
-    }
-
-    public function setChild($child)
-    {
-        $this->child = $child;
-    }
+    /** @OneToOne(targetEntity="DDC3699Child", mappedBy="oneRelation") */
+    public $child;
 }

--- a/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
+++ b/tests/Doctrine/Tests/Models/DDC3699/DDC3699RelationOne.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3699;
+
+/**
+ * @Entity
+ * @Table(name="ddc3699_relation_one")
+ */
+class DDC3699RelationOne
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    protected $id;
+
+    /**
+     * @OneToOne(targetEntity="DDC3699Child", mappedBy="oneRelation")
+     */
+    protected $child;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+
+    public function setChild($child)
+    {
+        $this->child = $child;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Hydration/EntityWithArrayDefaultArrayValueM2M.php
+++ b/tests/Doctrine/Tests/Models/Hydration/EntityWithArrayDefaultArrayValueM2M.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Tests\Models\Hydration;
+
+/** @Entity */
+class EntityWithArrayDefaultArrayValueM2M
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") @GeneratedValue(strategy="AUTO") */
+    public $id;
+
+    /** @ManyToMany(targetEntity=SimpleEntity::class) */
+    public $collection = [];
+}

--- a/tests/Doctrine/Tests/Models/Hydration/SimpleEntity.php
+++ b/tests/Doctrine/Tests/Models/Hydration/SimpleEntity.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Doctrine\Tests\Models\Hydration;
+
+/** @Entity */
+class SimpleEntity
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") @GeneratedValue(strategy="AUTO") */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -3,9 +3,11 @@
 namespace Doctrine\Tests\ORM\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
+
 
 /**
  * @group DDC-2183
@@ -71,5 +73,28 @@ class DefaultRegionTest extends AbstractRegionTest
         $this->setExpectedException('BadMethodCallException');
 
         $region->evictAll();
+    }
+
+    public function testGetMulti()
+    {
+        $key1 = new CacheKeyMock('key.1');
+        $value1 = new CacheEntryMock(array('id' => 1, 'name' => 'bar'));
+
+        $key2 = new CacheKeyMock('key.2');
+        $value2 = new CacheEntryMock(array('id' => 2, 'name' => 'bar'));
+
+        $this->assertFalse($this->region->contains($key1));
+        $this->assertFalse($this->region->contains($key2));
+
+        $this->region->put($key1, $value1);
+        $this->region->put($key2, $value2);
+
+        $this->assertTrue($this->region->contains($key1));
+        $this->assertTrue($this->region->contains($key2));
+
+        $actual = $this->region->getMultiple(new CollectionCacheEntry(array($key1, $key2)));
+
+        $this->assertEquals($value1, $actual[0]);
+        $this->assertEquals($value2, $actual[1]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php
@@ -22,16 +22,19 @@ class MultiGetRegionTest extends AbstractRegionTest
     public function testGetMulti()
     {
         $key1 = new CacheKeyMock('key.1');
-        $value1 = new CacheEntryMock(array('id'=>1, 'name' => 'bar'));
+        $value1 = new CacheEntryMock(array('id' => 1, 'name' => 'bar'));
 
         $key2 = new CacheKeyMock('key.2');
-        $value2 = new CacheEntryMock(array('id'=>2, 'name' => 'bar'));
+        $value2 = new CacheEntryMock(array('id' => 2, 'name' => 'bar'));
 
         $this->assertFalse($this->region->contains($key1));
         $this->assertFalse($this->region->contains($key2));
 
         $this->region->put($key1, $value1);
         $this->region->put($key2, $value2);
+
+        $this->assertTrue($this->region->contains($key1));
+        $this->assertTrue($this->region->contains($key2));
 
         $actual = $this->region->getMultiple(new CollectionCacheEntry(array($key1, $key2)));
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\PersistentCollection;
 
@@ -390,7 +391,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     {
         $mapping   = $this->em->getClassMetadata('Doctrine\Tests\Models\Cache\Country');
         $assoc     = array('type' => 1);
-        $coll      = new PersistentCollection($this->em, $mapping, null);
+        $coll      = new PersistentCollection($this->em, $mapping, new ArrayCollection());
         $persister = $this->createPersisterDefault();
         $entity    = new Country("Foo");
 
@@ -406,7 +407,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     {
         $mapping   = $this->em->getClassMetadata('Doctrine\Tests\Models\Cache\Country');
         $assoc     = array('type' => 1);
-        $coll      = new PersistentCollection($this->em, $mapping, null);
+        $coll      = new PersistentCollection($this->em, $mapping, new ArrayCollection());
         $persister = $this->createPersisterDefault();
         $entity    = new Country("Foo");
 

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -669,6 +669,28 @@ class PaginationTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertCount(9, $paginator);
     }
 
+    /**
+     * @dataProvider useOutputWalkersAndFetchJoinCollection
+     */
+    public function testPaginationWithSubSelectOrderByExpression($useOutputWalker, $fetchJoinCollection)
+    {
+        $query = $this->_em->createQuery(
+            "SELECT u, 
+                (
+                    SELECT MAX(a.version)
+                    FROM Doctrine\\Tests\\Models\\CMS\\CmsArticle a
+                    WHERE a.user = u
+                ) AS HIDDEN max_version
+            FROM Doctrine\\Tests\\Models\\CMS\\CmsUser u
+            ORDER BY max_version DESC"
+        );
+
+        $paginator = new Paginator($query, $fetchJoinCollection);
+        $paginator->setUseOutputWalkers($useOutputWalker);
+
+        $this->assertCount(9, $paginator->getIterator());
+    }
+
     public function populate()
     {
         $groups = array();

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -61,7 +61,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionAbs()
     {
-        $result = $this->_em->createQuery('SELECT m, ABS(m.salary * -1) AS abs FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, ABS(m.salary * -1) AS abs FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                          ->getResult();
 
         $this->assertEquals(4, count($result));
@@ -73,7 +73,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionConcat()
     {
-        $arg = $this->_em->createQuery('SELECT m, CONCAT(m.name, m.department) AS namedep FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $arg = $this->_em->createQuery('SELECT m, CONCAT(m.name, m.department) AS namedep FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                          ->getArrayResult();
 
         $this->assertEquals(4, count($arg));
@@ -85,7 +85,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionLength()
     {
-        $result = $this->_em->createQuery('SELECT m, LENGTH(CONCAT(m.name, m.department)) AS namedeplength FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, LENGTH(CONCAT(m.name, m.department)) AS namedeplength FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
@@ -98,7 +98,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testFunctionLocate()
     {
         $dql = "SELECT m, LOCATE('e', LOWER(m.name)) AS loc, LOCATE('e', LOWER(m.name), 7) AS loc2 ".
-               "FROM Doctrine\Tests\Models\Company\CompanyManager m";
+               "FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC";
 
         $result = $this->_em->createQuery($dql)
                          ->getArrayResult();
@@ -116,7 +116,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionLower()
     {
-        $result = $this->_em->createQuery("SELECT m, LOWER(m.name) AS lowername FROM Doctrine\Tests\Models\Company\CompanyManager m")
+        $result = $this->_em->createQuery("SELECT m, LOWER(m.name) AS lowername FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC")
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
@@ -128,7 +128,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionMod()
     {
-        $result = $this->_em->createQuery("SELECT m, MOD(m.salary, 3500) AS amod FROM Doctrine\Tests\Models\Company\CompanyManager m")
+        $result = $this->_em->createQuery("SELECT m, MOD(m.salary, 3500) AS amod FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC")
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
@@ -140,7 +140,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionSqrt()
     {
-        $result = $this->_em->createQuery("SELECT m, SQRT(m.salary) AS sqrtsalary FROM Doctrine\Tests\Models\Company\CompanyManager m")
+        $result = $this->_em->createQuery("SELECT m, SQRT(m.salary) AS sqrtsalary FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC")
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
@@ -152,7 +152,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testFunctionUpper()
     {
-        $result = $this->_em->createQuery("SELECT m, UPPER(m.name) AS uppername FROM Doctrine\Tests\Models\Company\CompanyManager m")
+        $result = $this->_em->createQuery("SELECT m, UPPER(m.name) AS uppername FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC")
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
@@ -186,7 +186,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $dql = "SELECT m, TRIM(TRAILING '.' FROM m.name) AS str1, ".
                " TRIM(LEADING '.' FROM m.name) AS str2, TRIM(CONCAT(' ', CONCAT(m.name, ' '))) AS str3 ".
-               "FROM Doctrine\Tests\Models\Company\CompanyManager m";
+               "FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC";
 
         $result = $this->_em->createQuery($dql)->getArrayResult();
 
@@ -207,7 +207,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testOperatorAdd()
     {
-        $result = $this->_em->createQuery('SELECT m, m.salary+2500 AS add FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, m.salary+2500 AS add FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                 ->getResult();
 
         $this->assertEquals(4, count($result));
@@ -219,7 +219,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testOperatorSub()
     {
-        $result = $this->_em->createQuery('SELECT m, m.salary-2500 AS sub FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, m.salary-2500 AS sub FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                 ->getResult();
 
         $this->assertEquals(4, count($result));
@@ -231,7 +231,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testOperatorMultiply()
     {
-        $result = $this->_em->createQuery('SELECT m, m.salary*2 AS op FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, m.salary*2 AS op FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                 ->getResult();
 
         $this->assertEquals(4, count($result));
@@ -246,7 +246,7 @@ class QueryDqlFunctionTest extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testOperatorDiv()
     {
-        $result = $this->_em->createQuery('SELECT m, (m.salary/0.5) AS op FROM Doctrine\Tests\Models\Company\CompanyManager m')
+        $result = $this->_em->createQuery('SELECT m, (m.salary/0.5) AS op FROM Doctrine\Tests\Models\Company\CompanyManager m ORDER BY m.salary ASC')
                 ->getResult();
 
         $this->assertEquals(4, count($result));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
@@ -13,18 +13,9 @@ class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected function setUp()
     {
-        parent::setUp();
+        $this->useModelSet('ddc3699');
 
-        try {
-            $this->_schemaTool->createSchema(array(
-                $this->_em->getClassMetadata(DDC3699Parent::CLASSNAME),
-                $this->_em->getClassMetadata(DDC3699RelationOne::CLASSNAME),
-                $this->_em->getClassMetadata(DDC3699RelationMany::CLASSNAME),
-                $this->_em->getClassMetadata(DDC3699Child::CLASSNAME),
-            ));
-        } catch (SchemaException $e) {
-            // should throw error on second because schema is already created
-        }
+        parent::setUp();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\Tests\Models\DDC3699\DDC3699Parent;
 use Doctrine\Tests\Models\DDC3699\DDC3699RelationOne;
 use Doctrine\Tests\Models\DDC3699\DDC3699RelationMany;
@@ -21,7 +22,7 @@ class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->_em->getClassMetadata(DDC3699RelationMany::CLASSNAME),
                 $this->_em->getClassMetadata(DDC3699Child::CLASSNAME),
             ));
-        } catch (\Exception $e) {
+        } catch (SchemaException $e) {
             // should throw error on second because schema is already created
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
@@ -1,0 +1,96 @@
+<?php
+
+use Doctrine\Tests\Models\DDC3699\DDC3699Parent;
+use Doctrine\Tests\Models\DDC3699\DDC3699RelationOne;
+use Doctrine\Tests\Models\DDC3699\DDC3699RelationMany;
+use Doctrine\Tests\Models\DDC3699\DDC3699Child;
+
+/**
+ * @group DDC-3699
+ */
+class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(DDC3699Parent::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699RelationOne::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699RelationMany::CLASSNAME),
+                $this->_em->getClassMetadata(DDC3699Child::CLASSNAME),
+            ));
+        } catch (\Exception $e) {
+            // should throw error on second because schema is already created
+        }
+    }
+
+    private function createChild($id, $relationClass, $relationMethod)
+    {
+        // element in DB
+        $child = new DDC3699Child();
+        $child->setId($id);
+        $child->setChildField('childValue');
+        $child->setParentField('parentValue');
+
+        $relation = new $relationClass();
+        $relation->setId($id);
+        $relation->setChild($child);
+        $child->$relationMethod($relation);
+
+        $this->_em->persist($relation);
+        $this->_em->persist($child);
+        $this->_em->flush();
+
+        // detach
+        $this->_em->detach($relation);
+        $this->_em->detach($child);
+    }
+
+    /**
+     * @group DDC-3699
+     */
+    public function testMergeParentEntityFieldsOne()
+    {
+        $id = 1;
+        $this->createChild($id, DDC3699RelationOne::CLASSNAME, 'setOneRelation');
+
+        $unmanagedChild = $this->_em->find(DDC3699Child::CLASSNAME, $id);
+        $this->_em->detach($unmanagedChild);
+
+        // make it managed again
+        $this->_em->find(DDC3699Child::CLASSNAME, $id);
+
+        $unmanagedChild->setChildField('modifiedChildValue');
+        $unmanagedChild->setParentField('modifiedParentValue');
+
+        $mergedChild = $this->_em->merge($unmanagedChild);
+
+        $this->assertEquals($mergedChild->getChildField(), 'modifiedChildValue');
+        $this->assertEquals($mergedChild->getParentField(), 'modifiedParentValue');
+    }
+
+    /**
+     * @group DDC-3699
+     */
+    public function testMergeParentEntityFieldsMany()
+    {
+        $id = 2;
+        $this->createChild($id, DDC3699RelationMany::CLASSNAME, 'addRelation');
+
+        $unmanagedChild = $this->_em->find(DDC3699Child::CLASSNAME, $id);
+        $this->_em->detach($unmanagedChild);
+
+        // make it managed again
+        $this->_em->find(DDC3699Child::CLASSNAME, $id);
+
+        $unmanagedChild->setChildField('modifiedChildValue');
+        $unmanagedChild->setParentField('modifiedParentValue');
+
+        $mergedChild = $this->_em->merge($unmanagedChild);
+
+        $this->assertEquals($mergedChild->getChildField(), 'modifiedChildValue');
+        $this->assertEquals($mergedChild->getParentField(), 'modifiedParentValue');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
@@ -49,7 +49,7 @@ class DDC767Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertNotNull($pUser, "User not retrieved from database.");
 
-        $groups = array(2, 3);
+        $groups = array($group2->id, $group3->id);
 
         try {
             $this->_em->beginTransaction();

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1968,7 +1968,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('e1', 'a1__id', 'id');
         $rsm->addFieldResult('e2', 'e2__id', 'id');
 
-        $result = (new ObjectHydrator($this->_em))
+        $result = (new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em))
             ->hydrateAll(
                 new HydratorMockStatement([[
                     'a1__id' => '1',

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\Common\Persistence\Mapping\StaticReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
@@ -1124,6 +1125,30 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
         $classMetadata->wakeupReflection(new RuntimeReflectionService());
 
         $this->assertInstanceOf(__NAMESPACE__ . '\\MyArrayObjectEntity', $classMetadata->newInstance());
+    }
+
+    public function testWakeupReflectionWithEmbeddableAndStaticReflectionService()
+    {
+        $classMetadata = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
+
+        $classMetadata->mapEmbedded(array(
+            'fieldName'    => 'test',
+            'class'        => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'columnPrefix' => false,
+        ));
+
+        $field = array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'originalClass' => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'declaredField' => 'test',
+            'originalField' => 'embeddedProperty'
+        );
+
+        $classMetadata->mapField($field);
+        $classMetadata->wakeupReflection(new StaticReflectionService());
+
+        $this->assertEquals(array('test' => null, 'test.embeddedProperty' => null), $classMetadata->getReflectionProperties());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -83,39 +83,4 @@ class PersistentCollectionTest extends OrmTestCase
         $this->collection->next();
         $this->assertTrue($this->collection->isInitialized());
     }
-
-    public function testAcceptsArrayAsConstructorArgument()
-    {
-        $metadata = $this->_emMock->getClassMetadata('Doctrine\Tests\Models\ECommerce\ECommerceCart');
-
-        $collection = new PersistentCollection($this->_emMock, $metadata, []);
-
-        $this->assertEmpty($collection);
-        $this->tryGenericCollectionOperations($collection);
-    }
-
-    public function testAcceptsNullAsConstructorArgument()
-    {
-        $metadata = $this->_emMock->getClassMetadata('Doctrine\Tests\Models\ECommerce\ECommerceCart');
-
-        $collection = new PersistentCollection($this->_emMock, $metadata, null);
-
-        $this->assertEmpty($collection);
-        $this->tryGenericCollectionOperations($collection);
-    }
-
-    private function tryGenericCollectionOperations(Collection $collection)
-    {
-        $count  = count($collection);
-        $object = new \stdClass();
-
-        $collection->add($object);
-
-        $this->assertTrue($collection->contains($object));
-        $this->assertCount($count + 1, $collection);
-
-        $collection->removeElement($object);
-
-        $this->assertCount($count, $collection);
-    }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -350,5 +350,80 @@ ORDER BY b.id DESC'
             $query->getSQL()
         );
     }
+
+    /**
+     * Tests order by on a subselect expression (mysql).
+     */
+    public function testLimitSubqueryOrderBySubSelectOrderByExpression()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new MysqlPlatform());
+
+        $query = $this->entityManager->createQuery(
+            'SELECT a,
+                (
+                    SELECT MIN(bp.title)
+                    FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost bp
+                    WHERE bp.author = a
+                ) AS HIDDEN first_blog_post
+            FROM Doctrine\Tests\ORM\Tools\Pagination\Author a
+            ORDER BY first_blog_post DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2 FROM Author a0_) dctrn_result ORDER BY sclr_2 DESC',
+            $query->getSQL()
+        );
+    }
+
+    /**
+     * Tests order by on a subselect expression invoking RowNumberOverFunction (postgres).
+     */
+    public function testLimitSubqueryOrderBySubSelectOrderByExpressionPg()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+
+        $query = $this->entityManager->createQuery(
+            'SELECT a,
+                (
+                    SELECT MIN(bp.title)
+                    FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost bp
+                    WHERE bp.author = a
+                ) AS HIDDEN first_blog_post
+            FROM Doctrine\Tests\ORM\Tools\Pagination\Author a
+            ORDER BY first_blog_post DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0, MIN(sclr_3) AS dctrn_minrownum FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS dctrn__2 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS sclr_3 FROM Author a0_) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
+            $query->getSQL()
+        );
+    }
+
+    /**
+     * Tests order by on a subselect expression invoking RowNumberOverFunction (oracle).
+     */
+    public function testLimitSubqueryOrderBySubSelectOrderByExpressionOracle()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new OraclePlatform());
+
+        $query = $this->entityManager->createQuery(
+            'SELECT a,
+                (
+                    SELECT MIN(bp.title)
+                    FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost bp
+                    WHERE bp.author = a
+                ) AS HIDDEN first_blog_post
+            FROM Doctrine\Tests\ORM\Tools\Pagination\Author a
+            ORDER BY first_blog_post DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT ID_0, MIN(SCLR_3) AS dctrn_minrownum FROM (SELECT a0_.id AS ID_0, a0_.name AS NAME_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS SCLR_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS dctrn__2 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS SCLR_3 FROM Author a0_) dctrn_result GROUP BY ID_0 ORDER BY dctrn_minrownum ASC',
+            $query->getSQL()
+        );
+    }
 }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -139,6 +139,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\DDC117\DDC117Editor',
             'Doctrine\Tests\Models\DDC117\DDC117Link',
         ),
+        'ddc3699' => array(
+            'Doctrine\Tests\Models\DDC3699\DDC3699Parent',
+            'Doctrine\Tests\Models\DDC3699\DDC3699RelationOne',
+            'Doctrine\Tests\Models\DDC3699\DDC3699RelationMany',
+            'Doctrine\Tests\Models\DDC3699\DDC3699Child',
+        ),
         'stockexchange' => array(
             'Doctrine\Tests\Models\StockExchange\Bond',
             'Doctrine\Tests\Models\StockExchange\Stock',


### PR DESCRIPTION
Allow the usage of `quoted` field mapping option in yaml mappings

Example:

```
MyModel:
    type: entity
    fields:
        values:
            type: string
            quoted: true
```
