### PR TITLE
Allow custom id generators to handle composite keys

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1005,8 +1005,9 @@ class ClassMetadataInfo implements ClassMetadata
             throw MappingException::identifierRequired($this->name);
         }
 
-        if ($this->usesIdGenerator() && $this->isIdentifierComposite) {
-            throw MappingException::compositeKeyAssignedIdGeneratorRequired($this->name);
+        // Composite keys require either id assignation or a custom id generator which handles them
+        if ($this->usesIdGenerator() && $this->isIdentifierComposite && !$this->isIdGeneratorCustom()) {
+            throw MappingException::compositeKeyAssignedOrCustomIdGeneratorRequired($this->name);
         }
     }
 
@@ -1974,6 +1975,16 @@ class ClassMetadataInfo implements ClassMetadata
     public function isIdGeneratorTable()
     {
         return $this->generatorType == self::GENERATOR_TYPE_TABLE;
+    }
+
+    /**
+     * Checks whether the class uses a custom id generator.
+     *
+     * @return boolean TRUE if the class uses a CUSTOM generator, false otherwise.
+     */
+    public function isIdGeneratorCustom()
+    {
+        return $this->generatorType == self::GENERATOR_TYPE_CUSTOM;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -745,9 +745,9 @@ class MappingException extends \Doctrine\ORM\ORMException
      *
      * @return MappingException
      */
-    public static function compositeKeyAssignedIdGeneratorRequired($className)
+    public static function compositeKeyAssignedOrCustomIdGeneratorRequired($className)
     {
-        return new self("Entity '". $className . "' has a composite identifier but uses an ID generator other than manually assigning (Identity, Sequence). This is not supported.");
+        return new self("Entity '". $className . "' has a composite identifier but uses an ID generation strategy other than custom or manually assigning (Identity, Sequence). This is not supported.");
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1150,6 +1150,59 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals(array('test' => null, 'test.embeddedProperty' => null), $classMetadata->getReflectionProperties());
     }
+
+    /**
+     * Test if it works to use the CUSTOM id generation strategy for composite keys
+     *
+     * @group DDC-3853
+     */
+    public function testItAllowsCustomIdGenerationStrategyForCompositeKeys()
+    {
+        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
+        $cm->setIdentifier(array(
+            'username', 'email'
+        ));
+
+        $cm->validateIdentifier();
+    }
+
+    /**
+     * Test if it works to use the NONE id generation strategy for composite keys
+     *
+     * @group DDC-3853
+     */
+    public function testItAllowsNoneIdGenerationStrategyForCompositeKeys()
+    {
+        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+        $cm->setIdentifier(array(
+            'username', 'email'
+        ));
+
+        $cm->validateIdentifier();
+    }
+
+    /**
+     * Test if an exception is thrown if a unsupported id generation strategy is used for composite keys
+     *
+     * @group DDC-3853
+     */
+    public function testItDoesNotAllowUnsupportedIdGenerationStrategiesForCompositeKeys()
+    {
+        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $cm->initializeReflection(new RuntimeReflectionService());
+        $cm->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+        $cm->setIdentifier(array(
+            'username', 'email'
+        ));
+
+        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+
+        $cm->validateIdentifier();
+    }
 }
 
 /**


### PR DESCRIPTION
Currently when using composite keys, any other id generation strategy than
NONE (assigned identifiers) is triggering an exception in ClassMetadataInfo.

This commit allows to use the CUSTOM strategy with composite keys, therefore
to allow a custom id generator to handle the composite key identifier
generation.
