### PR TITLE
Make exception message configurable for NoResultException

### DIFF
--- a/lib/Doctrine/ORM/NoResultException.php
+++ b/lib/Doctrine/ORM/NoResultException.php
@@ -29,15 +29,16 @@ class NoResultException extends UnexpectedResultException
 {
     /**
      * Constructor.
+     *
      * @param string     $message  [optional] The Exception message to throw.
      * @param integer    $code     [optional] The Exception code.
      * @param \Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
-    {
-        if (empty($message)) {
-            $message = 'No result was found for query although at least one row was expected.';
-        }
+    public function __construct(
+        $message = 'No result was found for query although at least one row was expected.',
+        $code = 0,
+        \Exception $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
     }
 }

--- a/lib/Doctrine/ORM/NoResultException.php
+++ b/lib/Doctrine/ORM/NoResultException.php
@@ -29,9 +29,15 @@ class NoResultException extends UnexpectedResultException
 {
     /**
      * Constructor.
+     * @param string     $message  [optional] The Exception message to throw.
+     * @param integer    $code     [optional] The Exception code.
+     * @param \Exception $previous [optional] The previous exception used for the exception chaining. Since 5.3.0
      */
-    public function __construct()
+    public function __construct($message = '', $code = 0, \Exception $previous = null)
     {
-        parent::__construct('No result was found for query although at least one row was expected.');
+        if (empty($message)) {
+            $message = 'No result was found for query although at least one row was expected.';
+        }
+        parent::__construct($message, $code, $previous);
     }
 }


### PR DESCRIPTION
Currently it's not possible to use a custom exception message for the NoResultException. It would be great to use a custom one. For example you can define what specific result was expected or with what query it was executed, let's say you want to find members with a select query. Then it would be great if the message could be 'No members found for query.', instead of the default message.

This change is backward compatible, because it uses the current message as default value for message. Furthermore it's now possible to loop the parameters $code and $prevision exception throw this NoResultException.

Thanks for the hint Koc.
