### PR TITLE
Changed references from PHP6 to PHP7

### DIFF
--- a/docs/en/reference/best-practices.rst
+++ b/docs/en/reference/best-practices.rst
@@ -54,7 +54,7 @@ Don't use special characters
 
 Avoid using any non-ASCII characters in class, field, table or
 column names. Doctrine itself is not unicode-safe in many places
-and will not be until PHP itself is fully unicode-aware (PHP6).
+and will not be until PHP itself is fully unicode-aware.
 
 Don't use identifier quoting
 ----------------------------

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -634,7 +634,7 @@ class ArrayHydratorTest extends HydrationTestCase
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
-                'a__topic' => 'PHP6'
+                'a__topic' => 'PHP7'
             ),
         );
 
@@ -662,7 +662,7 @@ class ArrayHydratorTest extends HydrationTestCase
         $this->assertEquals('Getting things done!', $result[0][0]['articles'][0]['topic']);
         $this->assertEquals('ZendCon', $result[0][0]['articles'][1]['topic']);
         $this->assertEquals('LINQ', $result[1][0]['articles'][0]['topic']);
-        $this->assertEquals('PHP6', $result[1][0]['articles'][1]['topic']);
+        $this->assertEquals('PHP7', $result[1][0]['articles'][1]['topic']);
     }
 
     /**
@@ -771,7 +771,7 @@ class ArrayHydratorTest extends HydrationTestCase
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
-                'a__topic' => 'PHP6',
+                'a__topic' => 'PHP7',
                 'c__id' => null,
                 'c__topic' => null
             ),
@@ -803,7 +803,7 @@ class ArrayHydratorTest extends HydrationTestCase
         $this->assertEquals('Getting things done!', $result[0][0]['articles'][0]['topic']);
         $this->assertEquals('ZendCon', $result[0][0]['articles'][1]['topic']);
         $this->assertEquals('LINQ', $result[1][0]['articles'][0]['topic']);
-        $this->assertEquals('PHP6', $result[1][0]['articles'][1]['topic']);
+        $this->assertEquals('PHP7', $result[1][0]['articles'][1]['topic']);
 
         $this->assertEquals('First!', $result[0][0]['articles'][0]['comments'][0]['topic']);
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -645,7 +645,7 @@ class ObjectHydratorTest extends HydrationTestCase
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
-                'a__topic' => 'PHP6'
+                'a__topic' => 'PHP7'
             ),
         );
 
@@ -773,7 +773,7 @@ class ObjectHydratorTest extends HydrationTestCase
                 'sclr0' => 'JWAGE',
                 'p__phonenumber' => '91',
                 'a__id' => '4',
-                'a__topic' => 'PHP6',
+                'a__topic' => 'PHP7',
                 'c__id' => null,
                 'c__topic' => null
             ),


### PR DESCRIPTION
Found a reference to PHP6 while reading the best practices docs.

While doing this tiny change, I also found a couple more references to it in the tests which I changed too.

If this is a funny reference to it, I'm happy for you to leave it as is. Otherwise, this PR replaces the existing references to PHP6 for PHP7 instead.
