### PR TITLE
Add simple CSV text field comparison expression.

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -670,4 +670,25 @@ class Expr
     {
         return new Expr\Comparison($x, 'INSTANCE OF', $y);
     }
+
+    /**
+     * Creates an ORX composite of LIKE comparison expressions matching the
+     * given arguments as a value within a CSV list with a given separator.
+     *
+     * @param string $x Field in string format to be inspected by LIKE() comparisons.
+     * @param string $y Argument to be used in LIKE() comparisons.
+     * @param string $z Separator used in list field.
+     *
+     * @return Expr\Orx
+     */
+    public function inList($x, $y, $z = ',')
+    {
+        $y = (string) $y;
+        return new Expr\Orx(array(
+            new Expr\Comparison($x, 'LIKE', $this->literal($y)), // only
+            new Expr\Comparison($x, 'LIKE', $this->literal($y . $z . '%')), // first
+            new Expr\Comparison($x, 'LIKE', $this->literal('%' . $z . $y)), // last
+            new Expr\Comparison($x, 'LIKE', $this->literal('%' . $z . $y . $z . '%')), // middle
+        ));
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -302,6 +302,16 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals("u.type NOT IN('foo', 'bar')", (string) $this->_expr->notIn('u.type', array('foo', 'bar')));
     }
 
+    public function testInListExpr()
+    {
+        $this->assertEquals("u.types LIKE 'foo' OR u.types LIKE 'foo,%' OR u.types LIKE '%,foo' OR u.types LIKE '%,foo,%'", (string) $this->_expr->inList('u.types', 'foo'));
+    }
+
+    public function testInListExprWithSeparator()
+    {
+        $this->assertEquals("u.types LIKE 'foo' OR u.types LIKE 'foo %' OR u.types LIKE '% foo' OR u.types LIKE '% foo %'", (string) $this->_expr->inList('u.types', 'foo', ' '));
+    }
+
     public function testAndxOrxExpr()
     {
         $andExpr = $this->_expr->andx();
@@ -429,14 +439,14 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
     public function testAddEmpty() {
         $andExpr = $this->_expr->andx();
         $andExpr->add($this->_expr->andx());
-        
+
         $this->assertEquals(0, $andExpr->count());
     }
 
     public function testAddNull() {
         $andExpr = $this->_expr->andx();
         $andExpr->add(null);
-        
+
         $this->assertEquals(0, $andExpr->count());
     }
 }


### PR DESCRIPTION
Comparison expression added for matching a value found within a CSV list type of field, such as the `simple_array` Doctrine column mapping.  Other bundles make use of this type of field but with a different value separator, such as [FOSOAuthServerBundle](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle)'s `Token::$scope` column, so the default separator value can be overridden.
