### PR TITLE
Pass orderings, maxRresults and firstResult when call getHash

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -508,9 +508,12 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     public function loadCriteria(Criteria $criteria)
     {
+        $orderBy     = $criteria->getOrderings();
+        $limit       = $criteria->getMaxResults();
+        $offset      = $criteria->getFirstResult();
         $query       = $this->persister->getSelectSQL($criteria);
         $timestamp   = $this->timestampRegion->get($this->timestampKey);
-        $hash        = $this->getHash($query, $criteria, null, null, null, $timestamp ? $timestamp->time : null);
+        $hash        = $this->getHash($query, $criteria, $orderBy, $limit, $offset, $timestamp ? $timestamp->time : null);
         $rsm         = $this->getResultSetMapping();
         $querykey    = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL);
         $queryCache  = $this->cache->getQueryCache($this->regionName);


### PR DESCRIPTION
When you call getHash method in loadCriteria, you don't pass order, limit and offset parameters and it causes a problem when you want use second level cache
