### PR TITLE
wrong or wrong created source results in wrong default variable assignment

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1311,6 +1311,19 @@ public function __construct(<params>)
             }
 
             $lines[] = $this->generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
+            switch($fieldMapping['type']){
+                case 'boolean':
+                    $fieldMapping['options']['default'] = (boolean) $fieldMapping['options']['default'];
+                    break;
+                case 'integer':
+                    $fieldMapping['options']['default'] = (integer) $fieldMapping['options']['default'];
+                    break;
+                case 'text':
+                case 'string':
+                default:
+                    $fieldMapping['options']['default'] = (string) $fieldMapping['options']['default'];
+                    break;
+            }
             $lines[] = $this->spaces . $this->fieldVisibility . ' $' . $fieldMapping['fieldName']
                      . (isset($fieldMapping['options']['default']) ? ' = ' . var_export($fieldMapping['options']['default'], true) : null) . ";\n";
         }


### PR DESCRIPTION
This is a bit tricky, since the problem occures only in rare circumstances.

I rely heavily on the "database reverse engineering" function in symphony. So during development we modell our database and deploy it to the database server (debian/madiadb). Then I do an automated ORM descriptor creation and a automated entity file creation provided by this tool. DB -> table.orm.yml -> table.php
A default integer (1) value, defined in the database becomes a: default: '1'
Than the EntityGenerator reads the default: '1' in quotes from the yaml-definition and var_dumps it into the .php entity. As a result the default value becomes a wrong type and doctrine tells me it can't use this default value.
As a workaround I extra type cast the value depending on the defined type.
Would like to see this problem solved in a futher version. Anyways, I am happy with the way these processes work.
