### PR TITLE
minor: removed useless line breaks

### DIFF
--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -90,7 +90,6 @@ class TreeWalkerChainIterator implements \Iterator, \ArrayAccess
         return key($this->walkers) !== null;
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -22,7 +22,6 @@ namespace Doctrine\ORM\Tools\Console\Helper;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Helper\Helper;
 
-
 /**
  * Doctrine CLI Connection Helper.
  *

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -23,7 +23,6 @@ namespace Doctrine\ORM\Tools\Pagination;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 
-
 /**
  * RowNumberOverFunction
  *

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -17,7 +17,6 @@
  * <http://www.doctrine-project.org>.
  */
 
-
 namespace Doctrine\ORM\Utility;
 
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\Mocks;
 
-
 use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\LockException;

--- a/tests/Doctrine/Tests/Models/DirectoryTree/File.php
+++ b/tests/Doctrine/Tests/Models/DirectoryTree/File.php
@@ -17,7 +17,6 @@
  * <http://www.doctrine-project.org>.
  */
 
-
 namespace Doctrine\Tests\Models\DirectoryTree;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
 
-
 /**
  * @group DDC-2183
  */

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php
@@ -73,5 +73,3 @@ class PostUpdateListener
         $this->wasNotified = true;
     }
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Doctrine\Tests\ORM\Functional;
-
 
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Logging\DebugStack;

--- a/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php
@@ -92,5 +92,3 @@ class PostFlushListener
         $this->receivedArgs = $args;
     }
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -87,5 +87,3 @@ class DDC1193Account {
     public $id;
 
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -58,5 +58,3 @@ class DDC144Operand extends DDC144Expression {
     public $operandProperty;
     function method() {}
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1515Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1515Test.php
@@ -60,5 +60,3 @@ class DDC1515Bar
      */
     public $foo;
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -59,5 +59,3 @@ class DDC2692Listener implements EventSubscriber {
     public function preFlush(PreFlushEventArgs $args) {
     }
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php
@@ -71,5 +71,3 @@ class DDC444User
      */
     public $name;
 }
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
@@ -65,7 +65,3 @@ class DDC493Contact
     /** @Column(type="string") */
     public $data;
 }
-
-
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
@@ -86,7 +86,3 @@ class DDC512Item
      */
     public $id;
 }
-
-
-
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
@@ -67,7 +67,3 @@ class DDC513Price {
     /** @Column(type="string") */
     public $data;
 }
-
-
-
-

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -17,7 +17,6 @@
  * <http://www.doctrine-project.org>.
  */
 
-
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/PersisterPerformanceTest.php
@@ -114,6 +114,3 @@ class PersisterPerformanceTest extends \Doctrine\Tests\OrmFunctionalTestCase
         echo "100 CmsUser: " . number_format(microtime(true) - $start, 6) . "\n";
     }
 }
-
-
-


### PR DESCRIPTION
As follows:
- Before `namespace` declaration
- After `use` declaration
- EOF

Also, between methods of `TreeWalkerChainIterator`. It is useless, isn't it?:
https://github.com/doctrine/doctrine2/compare/master...issei-m:patch-2#diff-1a49328b1dad26b38988b57df28ff10cL93
