### PR TITLE
Move dispatchPostFlushEvent method below

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -424,8 +424,6 @@ class UnitOfWork implements PropertyChangedListener
             $coll->takeSnapshot();
         }
 
-        $this->dispatchPostFlushEvent();
-
         // Clear up
         $this->entityInsertions =
         $this->entityUpdates =
@@ -437,6 +435,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections =
         $this->scheduledForSynchronization =
         $this->orphanRemovals = array();
+        
+        $this->dispatchPostFlushEvent();
     }
 
     /**


### PR DESCRIPTION
This related with https://github.com/doctrine/doctrine2/commit/b6c3fc5b1ab8f97ba3a47b5a667ef8986c48059e

This PR fix possible issues with `flush` call inside `postFlush` event.

I fully understand this is **not good idea** to call `flush` inside `postFlush` event, but this change makes this unsafe code to more safe.

Current implementation has some issues: collections `collectionUpdates`, `collectionDeletions` not cleared after works and stay `dirty` in the second `flush`.
