### PR TITLE
Fixed issue with entity manager when using LockMode::NONE

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -449,7 +449,6 @@ use Doctrine\Common\Util\ClassUtils;
 
                 return $entity;
 
-            case LockMode::NONE === $lockMode:
             case LockMode::PESSIMISTIC_READ === $lockMode:
             case LockMode::PESSIMISTIC_WRITE === $lockMode:
                 if ( ! $this->getConnection()->isTransactionActive()) {


### PR DESCRIPTION
There is an issue in the Entity Manager find method when using LockMode::None, it currently forces to open a transaction only when the entity is not "cached" by the unitOfWork. I'm not sure why is the code forcing to start the transaction for a read with no lock mode, it's causing complex problems when using doctrine with concurrency and deamon processes at the same time. I can provide specific examples of when it's causing problems if required.
