### PR TITLE
Fix variable reference in phpdoc of ClassMetadataInfo

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -225,7 +225,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * READ-ONLY: The name of the entity class that is at the root of the mapped entity inheritance
      * hierarchy. If the entity is not part of a mapped inheritance hierarchy this is the same
-     * as {@link $entityName}.
+     * as {@link $name}.
      *
      * @var string
      */


### PR DESCRIPTION
`$entityName` does not exist. The property is called `$name`
