### PR TITLE
Ignore non-objects

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -467,6 +467,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function set($key, $value)
     {
+        if (!is_object($value)) {
+            return true;
+        }
+
         parent::set($key, $value);
 
         $this->changed();
@@ -481,6 +485,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function add($value)
     {
+        if (!is_object($value)) {
+            return true;
+        }
+
         $this->collection->add($value);
 
         $this->changed();

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -9,6 +9,7 @@ use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
+use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\OrmTestCase;
 
 /**
@@ -83,4 +84,30 @@ class PersistentCollectionTest extends OrmTestCase
         $this->collection->next();
         $this->assertTrue($this->collection->isInitialized());
     }
+
+    /**
+     * Test that PersistentCollection::add() and ::set() ignores non-objects.
+     *
+     * @group DDC-3382
+     */
+    public function testNonObjects()
+    {
+        $this->setUpPersistentCollection();
+        $this->assertEmpty($this->collection);
+
+        $this->collection->add("dummy");
+        $this->assertEmpty($this->collection);
+
+        $this->collection->add(null);
+        $this->assertEmpty($this->collection);
+
+        $product = new ECommerceProduct();
+        $this->collection->set(1, $product);
+
+        // Trying to overwrite the element will not work.
+        $this->collection->set(1, "dummy");
+        $this->collection->set(1, null);
+        $this->assertSame($product, $this->collection->get(1));
+    }
 }
+


### PR DESCRIPTION
PR #1419 introduced a BC break. Apparently some code rely on the ability to invoke PersistentCollection::set() with a null value.

This PR adds a simple check that makes add() and set() silently ignore non-object values.
