### PR TITLE
Fix cache storage related test issues (due to doctrine/cache 1.5.0 changes)

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -45,12 +45,12 @@ class QueryCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query->setQueryCacheDriver($cache);
 
         $query->getResult();
-        $this->assertEquals(2, $this->getCacheSize($cache));
+        $this->assertEquals(1, $this->getCacheSize($cache));
 
         $query->setHint('foo', 'bar');
 
         $query->getResult();
-        $this->assertEquals(3, $this->getCacheSize($cache));
+        $this->assertEquals(2, $this->getCacheSize($cache));
 
         return $query;
     }
@@ -112,7 +112,7 @@ class QueryCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $users = $query->getResult();
 
         $data = $this->cacheDataReflection->getValue($cache);
-        $this->assertEquals(2, count($data));
+        $this->assertEquals(1, count($data));
 
         $this->assertInstanceOf('Doctrine\ORM\Query\ParserResult', array_pop($data));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -141,7 +141,7 @@ class ResultCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertEquals(0, $this->getCacheSize($cache));
         $query->getResult();
-        $this->assertEquals(2, $this->getCacheSize($cache));
+        $this->assertEquals(1, $this->getCacheSize($cache));
 
         return $query;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -343,18 +343,18 @@ class SQLFilterTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $query->setQueryCacheDriver($cache);
 
         $query->getResult();
-        $this->assertEquals(2, sizeof($cacheDataReflection->getValue($cache)));
+        $this->assertEquals(1, sizeof($cacheDataReflection->getValue($cache)));
 
         $conf = $this->_em->getConfiguration();
         $conf->addFilter("locale", "\Doctrine\Tests\ORM\Functional\MyLocaleFilter");
         $this->_em->getFilters()->enable("locale");
 
         $query->getResult();
-        $this->assertEquals(3, sizeof($cacheDataReflection->getValue($cache)));
+        $this->assertEquals(2, sizeof($cacheDataReflection->getValue($cache)));
 
         // Another time doesn't add another cache entry
         $query->getResult();
-        $this->assertEquals(3, sizeof($cacheDataReflection->getValue($cache)));
+        $this->assertEquals(2, sizeof($cacheDataReflection->getValue($cache)));
     }
 
     public function testQueryGeneration_DependsOnFilters()


### PR DESCRIPTION
https://github.com/doctrine/cache/commit/dd47003641aa5425820c0ec8a6f4a85e7412ffcd removes the `DoctrineNamespaceCacheKey[]` entry from the cache. Thus, all tests counting cache entries were off by one.
