### PR TITLE
Backport of "LimitSubqueryOutputWalker: fix aliasing of property in OrderBy from MappedSuperclass"

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -438,7 +438,10 @@ class LimitSubqueryOutputWalker extends SqlWalker
                 // Field was declared in a parent class, so we need to get the proper SQL table alias
                 // for the joined parent table.
                 $otherClassMetadata = $this->em->getClassMetadata($fieldMapping['declared']);
-                $sqlTableAliasForFieldAlias = $this->getSQLTableAlias($otherClassMetadata->getTableName(), $dqlAliasForFieldAlias);
+                if (!$otherClassMetadata->isMappedSuperclass) {
+                    $sqlTableAliasForFieldAlias = $this->getSQLTableAlias($otherClassMetadata->getTableName(), $dqlAliasForFieldAlias);
+                    
+                }
             }
 
             // Compose search/replace patterns

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -350,7 +350,26 @@ ORDER BY b.id DESC'
             $query->getSQL()
         );
     }
+    
+    /**
+     * This tests ordering by property that has the 'declared' field.
+     */
+    public function testLimitSubqueryOrderByFieldFromMappedSuperclass()
+    {
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
 
+        // now use the third one in query
+        $query = $this->entityManager->createQuery(
+            'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\Banner b ORDER BY b.id DESC'
+        );
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker');
+
+        $this->assertEquals(
+            'SELECT DISTINCT id_0 FROM (SELECT b0_.id AS id_0, b0_.name AS name_1 FROM Banner b0_) dctrn_result ORDER BY id_0 DESC',
+            $query->getSQL()
+        );
+    }
+    
     /**
      * Tests order by on a subselect expression (mysql).
      */

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginationTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginationTestCase.php
@@ -169,3 +169,21 @@ class Avatar
     /** @Column(type="string", length=255) */
     public $image_alt_desc;
 }
+
+/** @MappedSuperclass */
+abstract class Identified
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    private $id;
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
+/** @Entity */
+class Banner extends Identified
+{
+    /** @Column(type="string") */
+    public $name;
+}


### PR DESCRIPTION
Backport of "LimitSubqueryOutputWalker: fix aliasing of property in OrderBy from MappedSuperclass" ( e501137 )
See my comment on neoglez@a3ece3b
