### PR TITLE
check if collection is empty without loading it

### DIFF
--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -93,7 +93,7 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
             return $this->collection->isEmpty();
         }
 
-        return $this->count() == 0;
+        return !$this->count();
     }
 
     /**

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -83,6 +83,20 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
     }
 
     /**
+     * check if collection is empty without loading it
+     *
+     * @return boolean TRUE if the collection is empty, FALSE otherwise.
+     */
+    public function isEmpty()
+    {
+        if ($this->isInitialized()) {
+            return $this->collection->isEmpty();
+        }
+
+        return $this->count() == 0;
+    }
+
+    /**
      * Do an optimized search of an element
      *
      * @param  object $element

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -111,6 +111,13 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->lazyCriteriaCollection->isEmpty());
     }
 
+    public function testIsEmptyIsFalseIfCountIsNotZero()
+    {
+        $this->persister->expects($this->once())->method('count')->with($this->criteria)->will($this->returnValue(1));
+
+        $this->assertFalse($this->lazyCriteriaCollection->isEmpty());
+    }
+
     public function testIsEmptyUsesWrappedCollectionWhenInitialized()
     {
         $this

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -103,4 +103,28 @@ class LazyCriteriaCollectionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(array($foo), $this->lazyCriteriaCollection->matching($criteria)->toArray());
     }
+
+    public function testIsEmptyUsesCountWhenNotInitialized()
+    {
+        $this->persister->expects($this->once())->method('count')->with($this->criteria)->will($this->returnValue(0));
+
+        $this->assertTrue($this->lazyCriteriaCollection->isEmpty());
+    }
+
+    public function testIsEmptyUsesWrappedCollectionWhenInitialized()
+    {
+        $this
+            ->persister
+            ->expects($this->once())
+            ->method('loadCriteria')
+            ->with($this->criteria)
+            ->will($this->returnValue(array('foo', 'bar', 'baz')));
+
+        // should never call the persister's count
+        $this->persister->expects($this->never())->method('count');
+
+        $this->assertSame(array('foo', 'bar', 'baz'), $this->lazyCriteriaCollection->toArray());
+
+        $this->assertFalse($this->lazyCriteriaCollection->isEmpty());
+    }
 }


### PR DESCRIPTION
Actually isEmpty() is always loading the collection in LazyCriteriaCollection.
A lazy version should use the existing functionality of count() to check if there are no elements if the collection is not initialized.
