### PR TITLE
[RFC] Parse trait class annotations

### DIFF
--- a/tests/Doctrine/Tests/Models/Timestampable/Timestampable.php
+++ b/tests/Doctrine/Tests/Models/Timestampable/Timestampable.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Doctrine\Tests\Models\Timestampable;
+
+/**
+ * Trait Timestampable
+ *
+ * @MappedSuperclass()
+ * @HasLifecycleCallbacks()
+ */
+trait Timestampable
+{
+    /**
+     * @Column(type="datetime")
+     *
+     * @var \DateTime
+     */
+    protected $created;
+
+    /**
+     * @Column(type="datetime")
+     *
+     * @var \DateTime
+     */
+    protected $updated;
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreated()
+    {
+        return $this->created;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * @PrePersist
+     */
+    public function onCreate()
+    {
+        $this->created = $this->updated = new \DateTime('now');
+    }
+
+    /**
+     * @PreUpdate
+     */
+    public function onUpdate()
+    {
+        $this->updated = new \DateTime('now');
+    }
+}

--- a/tests/Doctrine/Tests/Models/Timestampable/User.php
+++ b/tests/Doctrine/Tests/Models/Timestampable/User.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Models\Timestampable;
+
+/**
+ * @Entity
+ * @Table(name="timestampable_user")
+ */
+class User
+{
+    use Timestampable;
+
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string", nullable=true)
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleEventsTraitTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleEventsTraitTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use Doctrine\ORM\Mapping\ClassMetaData;
+use Doctrine\Common\Cache\ArrayCache;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\Models\CMS\CmsPhonenumber;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\Models\CMS\CmsComment;
+
+use Doctrine\Tests\Models\Company\CompanyPerson;
+use Doctrine\Tests\Models\Company\CompanyManager;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\Models\Company\CompanyOrganization;
+use Doctrine\Tests\Models\Company\CompanyAuction;
+
+use Doctrine\Tests\Models\Company\CompanyFlexContract;
+use Doctrine\Tests\Models\Company\CompanyFlexUltraContract;
+use Doctrine\Tests\Models\Timestampable\User;
+
+/**
+ * Tests Lifecycle events from traits.
+ *
+ * @author Kinn Coelho Julião <kinncj@php.net>
+ *
+ * @group non-cacheable
+ */
+class LifecycleEventsTraitTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    private $userId, $userId2, $articleId, $articleId2;
+    private $groupId, $groupId2;
+    private $managerId, $managerId2, $contractId1, $contractId2;
+    private $organizationId, $eventId1, $eventId2;
+
+    public function setUp()
+    {
+        $this->useModelSet('timestampable_user');
+        parent::setUp();
+    }
+
+    public function testShouldExecuteOnCreate()
+    {
+        $user = new User();
+
+        $user->name = 'Joao';
+
+        $this->_em->persist($user);
+
+        $createDate = new \DateTime('now');
+
+        $this->_em->flush();
+
+        $this->assertEquals($user->getCreated(), $createDate);
+
+        $user->name = 'Maria';
+
+        $this->_em->persist($user);
+
+        $updatedDate = new \DateTime('now');
+
+        $this->_em->flush();
+
+        $this->assertEquals($user->getUpdated(), $updatedDate);
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -280,6 +280,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Pagination\User',
             'Doctrine\Tests\Models\Pagination\User1',
         ),
+        'timestampable_user' => array(
+            'Doctrine\Tests\Models\Timestampable\User',
+        ),
     );
 
     /**


### PR DESCRIPTION
The parser isn't parsing `trait` class annotations.
Fixed by doctrine/annotations#63
