### PR TITLE
Added custom ID generator definition to the FieldBuilder

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -55,6 +55,11 @@ class FieldBuilder
     private $sequenceDef;
 
     /**
+     * @var string|null
+     */
+    private $customIdGenerator;
+
+    /**
      * @param ClassMetadataBuilder $builder
      * @param array                $mapping
      */
@@ -233,6 +238,21 @@ class FieldBuilder
     }
 
     /**
+     * Set the FQCN of the custom ID generator.
+     * This class must extend \Doctrine\ORM\Id\AbstractIdGenerator.
+     *
+     * @param string $customIdGenerator
+     *
+     * @return $this
+     */
+    public function setCustomIdGenerator($customIdGenerator)
+    {
+        $this->customIdGenerator = (string) $customIdGenerator;
+
+        return $this;
+    }
+
+    /**
      * Finalizes this field and attach it to the ClassMetadata.
      *
      * Without this call a FieldBuilder has no effect on the ClassMetadata.
@@ -245,13 +265,20 @@ class FieldBuilder
         if ($this->generatedValue) {
             $cm->setIdGeneratorType(constant('Doctrine\ORM\Mapping\ClassMetadata::GENERATOR_TYPE_' . $this->generatedValue));
         }
+
         if ($this->version) {
             $cm->setVersionMapping($this->mapping);
         }
+
         $cm->mapField($this->mapping);
         if ($this->sequenceDef) {
             $cm->setSequenceGeneratorDefinition($this->sequenceDef);
         }
+        
+        if ($this->customIdGenerator) {
+            $cm->setCustomGeneratorDefinition(['class' => $this->customIdGenerator]);
+        }
+
         return $this->builder;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldBuilderTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+class FieldBuilderTest extends \Doctrine\Tests\OrmTestCase
+{
+    public function testCustomIdGeneratorCanBeSet()
+    {
+        $cmBuilder = new ClassMetadataBuilder(new ClassMetadataInfo('Doctrine\Tests\Models\CMS\CmsUser'));
+
+        $fieldBuilder = $cmBuilder->createField('aField', 'string');
+
+        $fieldBuilder->generatedValue('CUSTOM');
+        $fieldBuilder->setCustomIdGenerator('stdClass');
+
+        $fieldBuilder->build();
+
+        $this->assertEquals(ClassMetadataInfo::GENERATOR_TYPE_CUSTOM, $cmBuilder->getClassMetadata()->generatorType);
+        $this->assertEquals(['class' => 'stdClass'], $cmBuilder->getClassMetadata()->customGeneratorDefinition);
+    }
+}


### PR DESCRIPTION
The @CustomIdGenerator annotation does not have a FieldBuilder (php driver) counterpart.
