### PR TITLE
[DDC-2922] Error when new entities are reachable through multiple paths but not all of them are marked cascade-persist

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -183,6 +183,19 @@ class UnitOfWork implements PropertyChangedListener
     private $entityDeletions = array();
 
     /**
+     * New entities that were discovered through relationships that were not
+     * marked as cascade-persist. During flush, this array is populated and
+     * then pruned of any entities that were discovered through a valid
+     * cascade-persist path. (Leftovers cause an error.)
+     *
+     * Keys are OIDs, payload is a two-item array describing the association
+     * and the entity.
+     *
+     * @var array
+     */
+    private $newEntitiesWithoutCascade = array();
+
+    /**
      * All pending collection deletions.
      *
      * @var array
@@ -433,6 +446,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->extraUpdates =
         $this->entityChangeSets =
         $this->collectionUpdates =
+        $this->newEntitiesWithoutCascade =
         $this->collectionDeletions =
         $this->visitedCollections =
         $this->scheduledForSynchronization =
@@ -804,6 +818,16 @@ class UnitOfWork implements PropertyChangedListener
                 }
             }
         }
+
+        /**
+         * Filter out any entities that we (successfully) managed to schedule
+         * for insertion.
+         */
+        $entitiesNeedingCascadePersist = array_diff_key($this->newEntitiesWithoutCascade, $this->entityInsertions);
+        if(count($entitiesNeedingCascadePersist) > 0){
+            list($assoc,$entity) = array_values($entitiesNeedingCascadePersist)[0];
+            throw ORMInvalidArgumentException::newEntityFoundThroughRelationship($assoc, $entity);
+        }
     }
 
     /**
@@ -853,11 +877,17 @@ class UnitOfWork implements PropertyChangedListener
             switch ($state) {
                 case self::STATE_NEW:
                     if ( ! $assoc['isCascadePersist']) {
-                        throw ORMInvalidArgumentException::newEntityFoundThroughRelationship($assoc, $entry);
+                        /*
+                         * For now just record the details, because this may
+                         * not be an issue if we later discover another pathway
+                         * through the object-graph where cascade-persistence
+                         * is enabled for this object.
+                         */
+                        $this->newEntitiesWithoutCascade[spl_object_hash($entry)] = array($assoc,$entry);
+                    }else {
+                        $this->persistNew($targetClass, $entry);
+                        $this->computeChangeSet($targetClass, $entry);
                     }
-
-                    $this->persistNew($targetClass, $entry);
-                    $this->computeChangeSet($targetClass, $entry);
                     break;
 
                 case self::STATE_REMOVED:
@@ -2384,6 +2414,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->entityInsertions =
             $this->entityUpdates =
             $this->entityDeletions =
+            $this->newEntitiesWithoutCascade =
             $this->collectionDeletions =
             $this->collectionUpdates =
             $this->extraUpdates =

--- a/tests/Doctrine/Tests/Models/CMS/CmsEmail.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsEmail.php
@@ -22,7 +22,7 @@ class CmsEmail
     public $email;
 
     /**
-     * @OneToOne(targetEntity="CmsUser", mappedBy="email")
+     * @OneToOne(targetEntity="CmsUser", mappedBy="email", cascade={"persist"})
      */
     public $user;
 

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Query;
-use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -807,50 +806,6 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->_em->flush(); // should raise an exception
             $this->fail();
         } catch (\InvalidArgumentException $expected) {}
-    }
-
-    /**
-     * @group DDC-2922
-     */
-    public function testNewAssociatedEntityWorksWithJustOnePath()
-    {
-
-        /**
-         * First we persist and flush an e-mail with no user. This seems
-         * Save an un-owned email with no user. This seems to
-         * matter for reproducing the bug
-         */
-        $mail = new CmsEmail();
-        $mail->email = "nobody@example.com";
-        $mail->user = null;
-
-        $this->_em->persist($mail);
-        $this->_em->flush();
-
-        $user = new CmsUser();
-        $user->username = "beberlei";
-        $user->name = "Benjamin E.";
-        $user->status = 'active';
-
-        $mail->user = $user;
-
-        /**
-         * Note that we have NOT directly persisted the CmsUser, and CmsAddress
-         * does NOT have cascade-persist.
-         *
-         * However, CmsEmail *does* have a cascade-persist, which ought to
-         * allow us to save the CmsUser anyway through that connection.
-         */
-        $address = new CmsAddress();
-        $address->city = "Bonn";
-        $address->zip = "12354";
-        $address->country = "Germany";
-        $address->street = "somestreet";
-        $address->user = $user;
-
-        $this->_em->persist($address);
-        $this->_em->flush();
-
     }
 
     public function testOneToOneOrphanRemoval()

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -806,6 +807,50 @@ class BasicFunctionalTest extends \Doctrine\Tests\OrmFunctionalTestCase
             $this->_em->flush(); // should raise an exception
             $this->fail();
         } catch (\InvalidArgumentException $expected) {}
+    }
+
+    /**
+     * @group DDC-2922
+     */
+    public function testNewAssociatedEntityWorksWithJustOnePath()
+    {
+
+        /**
+         * First we persist and flush an e-mail with no user. This seems
+         * Save an un-owned email with no user. This seems to
+         * matter for reproducing the bug
+         */
+        $mail = new CmsEmail();
+        $mail->email = "nobody@example.com";
+        $mail->user = null;
+
+        $this->_em->persist($mail);
+        $this->_em->flush();
+
+        $user = new CmsUser();
+        $user->username = "beberlei";
+        $user->name = "Benjamin E.";
+        $user->status = 'active';
+
+        $mail->user = $user;
+
+        /**
+         * Note that we have NOT directly persisted the CmsUser, and CmsAddress
+         * does NOT have cascade-persist.
+         *
+         * However, CmsEmail *does* have a cascade-persist, which ought to
+         * allow us to save the CmsUser anyway through that connection.
+         */
+        $address = new CmsAddress();
+        $address->city = "Bonn";
+        $address->zip = "12354";
+        $address->country = "Germany";
+        $address->street = "somestreet";
+        $address->user = $user;
+
+        $this->_em->persist($address);
+        $this->_em->flush();
+
     }
 
     public function testOneToOneOrphanRemoval()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2922Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2922Test.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+
+use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsEmail;
+use Doctrine\Tests\Models\CMS\CmsUser;
+
+class DDC2922Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    /**
+     * @group DDC-2922
+     */
+    public function testNewAssociatedEntityWorksWithJustOnePath()
+    {
+
+        /**
+         * First we persist and flush an e-mail with no user. This seems
+         * Save an un-owned email with no user. This seems to
+         * matter for reproducing the bug
+         */
+        $mail = new CmsEmail();
+        $mail->email = "nobody@example.com";
+        $mail->user = null;
+
+        $this->_em->persist($mail);
+        $this->_em->flush();
+
+        $user = new CmsUser();
+        $user->username = "beberlei";
+        $user->name = "Benjamin E.";
+        $user->status = 'active';
+
+        $mail->user = $user;
+
+        /**
+         * Note that we have NOT directly persisted the CmsUser, and CmsAddress
+         * does NOT have cascade-persist.
+         *
+         * However, CmsEmail *does* have a cascade-persist, which ought to
+         * allow us to save the CmsUser anyway through that connection.
+         */
+        $address = new CmsAddress();
+        $address->city = "Bonn";
+        $address->zip = "12354";
+        $address->country = "Germany";
+        $address->street = "somestreet";
+        $address->user = $user;
+
+        $this->_em->persist($address);
+        try{
+            $this->_em->flush();
+        }catch(ORMInvalidArgumentException $e){
+            if(strpos($e->getMessage(),'not configured to cascade persist operations') !== FALSE) {
+                $this->fail($e);
+            }
+            throw $e;
+        }
+
+
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2922Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2922Test.php
@@ -48,6 +48,11 @@ class DDC2922Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->flush();
 
+        // Verify the flush succeeded
+        $this->assertEquals($email, $this->_em->find(get_class($email),$email->id));
+        $this->assertEquals($address, $this->_em->find(get_class($address),$address->id));
+        $this->assertEquals($user, $this->_em->find(get_class($user),$user->id));
+
     }
 
     /**
@@ -101,5 +106,11 @@ class DDC2922Test extends \Doctrine\Tests\OrmFunctionalTestCase
             }
             throw $e;
         }
+
+        // Verify the flushes succeeded
+        $this->assertEquals($email, $this->_em->find(get_class($email),$email->id));
+        $this->assertEquals($address, $this->_em->find(get_class($address),$address->id));
+        $this->assertEquals($user, $this->_em->find(get_class($user),$user->id));
+
     }
 }


### PR DESCRIPTION
Issue first-reported in [DDC-2922](http://www.doctrine-project.org/jira/browse/DDC-2922).
- [x] Uninteresting test to issue doesn't surface when all entities are new
- [x] Reproduction test showing error
- [x] Rough fix for error
- [x] Analyze why simple-test doesn't repro it

As explained in the test-case, it seems to hinge on the "valid path" stemming a non-new object, so it's important that `CmsEmail` is flushed before the other things happen. If everything occurs together, the problem doesn't surface. 

Note that I've made a small but essential cascade-persist change to `CmsEmail` in order to show the problem, but this change to the fixtures may or may not be desirable in the long-run.
