### PR TITLE
remove indexes overruled by primary key

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -262,6 +262,16 @@ class SchemaTool
                 $table->setPrimaryKey($pkColumns);
             }
 
+            // there can be unique indexes automatically created for join column
+            // if join column is also primary key we should keep only primary key on this column
+            // so, remove indexes overruled by primary key
+            $primaryKey = $table->getIndex('primary');
+            foreach ($table->getIndexes() as $idxKey => $existingIndex) {
+                if ($primaryKey->overrules($existingIndex)) {
+                    $table->dropIndex($idxKey);
+                }
+            }
+
             if (isset($class->table['indexes'])) {
                 foreach ($class->table['indexes'] as $indexName => $indexData) {
                     if( ! isset($indexData['flags'])) {

--- a/tests/Doctrine/Tests/Models/OneToOne/FirstEntity.php
+++ b/tests/Doctrine/Tests/Models/OneToOne/FirstEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\Models\OneToOne;
+
+/**
+ *
+ * @Entity
+ * @Table(name="first_entity")
+ */
+class FirstEntity
+{
+    /**
+     * @Id
+     * @Column(name="id")
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="SecondEntity")
+     * @JoinColumn(name="id", referencedColumnName="fist_entity_id")
+     */
+    public $secondEntity;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
+
+}

--- a/tests/Doctrine/Tests/Models/OneToOne/SecondEntity.php
+++ b/tests/Doctrine/Tests/Models/OneToOne/SecondEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\Models\OneToOne;
+
+/**
+ *
+ * @Entity
+ * @Table(name="second_entity")
+ */
+class SecondEntity
+{
+    /**
+     * @Id
+     * @Column(name="fist_entity_id")
+     */
+    public $fist_entity_id;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
+
+}

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -116,6 +116,24 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertSame(array(), $customSchemaOptions);
     }
+
+    public function testRemoveUniqueIndexOverruledByPrimaryKey()
+    {
+        $em = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $classes = array(
+            $em->getClassMetadata('Doctrine\Tests\Models\OneToOne\FirstEntity'),
+            $em->getClassMetadata('Doctrine\Tests\Models\OneToOne\SecondEntity')
+        );
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('first_entity'), "Table first_entity should exist.");
+        $indexes = $schema->getTable('first_entity')->getIndexes();
+        self::assertCount(1, $indexes, "there should be only one index");
+        self::assertTrue(current($indexes)->isPrimary(), "index should be primary");
+    }
 }
 
 /**


### PR DESCRIPTION
There can be unique indexes automatically created for join column.
If join column is also primary key we should keep only primary key on this column.

Oracle does not allow having both unique index and primary key on the same column, it is useless for mysql too.
(Previously it was done by DBAL, but now it allows duplicate indexes)
