### PR TITLE
add flush() to EntityManagerInterface

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -293,4 +293,12 @@ interface EntityManagerInterface extends ObjectManager
      * @return boolean True, if the EM has a filter collection.
      */
     public function hasFilters();
+    
+    /**
+     * Flushes all changes scheduled in the UnitOfWork in the database.
+     * If an entity is passed as argument, only this entity and its cascades will be flushed.
+     * 
+     * @param null|object|array $entity
+     */
+    public function flush($entity = null);
 }


### PR DESCRIPTION
the custom flush has the $entity argument.
This argument stops IDEs from complaining that the $entity argument shouldn't be passed into the EntityManager#flush since the ObjectManager does not contain the $entity argument.
In implementations such as the PHPCR-ODM the issue is already fixed: https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/DocumentManagerInterface.php#L492-L508
