### PR TITLE
Break on autoloader selected

### DIFF
--- a/bin/doctrine.php
+++ b/bin/doctrine.php
@@ -26,6 +26,7 @@ $autoloadFiles = array(__DIR__ . '/../vendor/autoload.php',
 foreach ($autoloadFiles as $autoloadFile) {
     if (file_exists($autoloadFile)) {
         require_once $autoloadFile;
+        break;
     }
 }
 
@@ -63,4 +64,4 @@ if ( ! ($helperSet instanceof HelperSet)) {
     }
 }
 
-\Doctrine\ORM\Tools\Console\ConsoleRunner::run($helperSet, $commands);
+ConsoleRunner::run($helperSet, $commands);


### PR DESCRIPTION
No need to check all autoloader files if one is already found.
