### PR TITLE
Fixed typo in 9.6.7 of docs

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -740,7 +740,7 @@ The three post events are called inside ``EntityManager#flush()``.
 Changes in here are not relevant to the persistence in the
 database, but you can use these events to alter non-persistable items,
 like non-mapped fields, logging or even associated classes that are
-directly mapped by Doctrine.
+not directly mapped by Doctrine.
 
 postLoad
 ~~~~~~~~


### PR DESCRIPTION
Fixed typo according to this tweet:
https://twitter.com/Ocramius/status/651072509748580352
