### PR TITLE
Update Upgrade.md after minor bc break in 2.5.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,9 @@
+# Upgrade to 2.5.1
+
+## Minor BC BREAK: added second parameter $indexBy in EntityRepository#createQueryBuilder method signature
+
+Added way to access the underlying QueryBuilder#from() method's 'indexBy' parameter when using EntityRepository#createQueryBuilder()
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: discriminator map must now include all non-transient classes

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,9 +1,3 @@
-# Upgrade to 2.5.1
-
-## Minor BC BREAK: added second parameter $indexBy in EntityRepository#createQueryBuilder method signature
-
-Added way to access the underlying QueryBuilder#from() method's 'indexBy' parameter when using EntityRepository#createQueryBuilder()
-
 # Upgrade to 2.5
 
 ## Minor BC BREAK: discriminator map must now include all non-transient classes
@@ -143,6 +137,10 @@ From now on, the resultset will look like this:
         ),
         ...
     )
+
+## Minor BC BREAK: added second parameter $indexBy in EntityRepository#createQueryBuilder method signature
+
+Added way to access the underlying QueryBuilder#from() method's 'indexBy' parameter when using EntityRepository#createQueryBuilder()
 
 # Upgrade to 2.4
 


### PR DESCRIPTION
The introduction of the second parameter in EntityRepository#createQueryBuilder generates a runtime notice if you have a sub-class of EntityRepository that has a second parameter in the createQueryBuilder method

The parameter was introduced in https://github.com/doctrine/doctrine2/commit/b0513a75173326016e39800c0f513f3f5e9e908f
