### PR TITLE
fixed outdated entity

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2344,6 +2344,7 @@ class UnitOfWork implements PropertyChangedListener
                     array_combine($class->getIdentifierFieldNames(), $this->entityIdentifiers[$oid]),
                     $lockMode
                 );
+                $this->refresh($entity);
                 break;
 
             default:


### PR DESCRIPTION
I found an issue with outdated entities. If you have following code which will be called by your request:

```
$em->beginTransaction();
try {
    $repository = $em->getRepository(Entity::class);
    /** @var Entity $entity */
    $entity = $repository->findOneBy(['tyef' => 'foo']);
    $em->lock($entity, LockMode::PESSIMISTIC_WRITE);
    $entity->increase(1); //increase field 'bar'

    sleep(2);

    $em->persist($entity);

    $em->flush();
    $em->commit();
} catch (\Exception $e) {
    $em->rollback();
    throw $e;
}
```

This will happen:
1. Before requests: Number is 30 (in field`bar`)
2. Request 1 is fired
3. Request 2 is fired
4. Request 1 finished. Number is 31
5. Request 2 finished. Number is **31**

Since we have a write lock inside of a transaction I expect to have **32**. The entity is not up to date and has do be refreshed. If you use the `EntityRepository::find()` method with the write lock it works fine. It only occurs if you add the lock afterwards.
