### PR TITLE
[DDC-3944] Add removeLifecycleCallback method in ClassMetadataInfo.php

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2660,6 +2660,23 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->lifecycleCallbacks = $callbacks;
     }
+    
+    /**
+     * Removes a lifecycle callback for entities of this class.
+     *
+     * @param string $callback
+     * @param string $lifecycleEvent
+     *
+     * @return void
+     */
+    public function removeLifecycleCallback($callback, $lifecycleEvent)
+    {
+        if (isset($this->lifecycleCallbacks[$lifecycleEvent])) {
+            if($key = array_search($callback, $this->lifecycleCallbacks[$lifecycleEvent]) !== false) {
+                unset($this->lifecycleCallbacks[$lifecycleEvent][$key]);
+            }
+        }
+    }
 
     /**
      * Adds a entity listener for entities of this class.

--- a/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
@@ -24,22 +24,22 @@ class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
     
     
     /**
- * @ORM\Entity()
- * @ORM\HasLifecycleCallbacks()
- */
-class Product
-{
-    protected $id;
-    protected $name;
-    protacted $updatedAt;
-    
-  /**
-   * @ORM\PrePersist
-   */
-  public function setUpdatedAtValue()
-  {
-      $this->updatedAt = new \DateTime();
-  }
+     * @ORM\Entity()
+     * @ORM\HasLifecycleCallbacks()
+     */
+    class Product
+    {
+        protected $id;
+        protected $name;
+        protacted $updatedAt;
+        
+      /**
+       * @ORM\PrePersist
+       */
+      public function setUpdatedAtValue()
+      {
+          $this->updatedAt = new \DateTime();
+    }
 }
 
 

--- a/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
@@ -6,13 +6,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
 {
-    private $product;
 
-    public function setUp()
-    {
-        $this->product = new Product();
-    }
-    
     /**
      * @group DDC-3944
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/MetaDataInfoTest.php
@@ -1,0 +1,53 @@
+namespace Doctrine\Tests\ORM\Mapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * @group DDC-3944
+ */
+class ClassMetadataBuilderTest extends \Doctrine\Tests\OrmTestCase
+{
+    private $product;
+
+    public function setUp()
+    {
+        $this->product = new Product();
+    }
+    
+    /**
+     * @group DDC-3944
+     */
+    public function testRemoveLifecycleCallbackNotFound()
+    {
+        $productMd = new ClassMetadata('Product');
+        $productMd->initializeReflection(new RuntimeReflectionService());
+        
+        $callBacks = $productMd->getLifecycleCallbacks('PrePersist');
+        
+        $this->assertTrue( in_array('setUpdatedAtValue', $callBacks) );
+        $product->removeLifecycleCallback('setUpdatedAtValue', 'PrePersist');
+        $this->assertFalse( in_array('setUpdatedAtValue', $callBacks) );
+    }
+    
+    
+    /**
+ * @ORM\Entity()
+ * @ORM\HasLifecycleCallbacks()
+ */
+class Product
+{
+    protected $id;
+    protected $name;
+    protacted $updatedAt;
+    
+  /**
+   * @ORM\PrePersist
+   */
+  public function setUpdatedAtValue()
+  {
+      $this->updatedAt = new \DateTime();
+  }
+}
+
+
+    
+    


### PR DESCRIPTION
Ability to remove a lifecycle callback.
This is useful in order to disable a callback method on specific case.

Example with TimeStampable and updateTimestamps callback method: 

When a user connect to the website, some attributes get updated automatically like last_logged_time...etc.
The object will see it's updated_at changed which is correct from the object point of view.
But it is not correct from the functional point of view, because none updated that user object.

Example of a method that update the object but the updated_at update is not desired:

```
public function updateLoggedInDateTime(User $user)
{
    $user->setLastLoggedAt(new \DateTime());
    ...        
    // remove lifecycle methodes to not update updated_at field
    //         array:2 [▼
    //             "prePersist" => array:1 [▼
    //                 0 => "updateTimestamps"
    //             ]
    //             "preUpdate" => array:1 [▼
    //                 0 => "updateTimestamps"
    //             ]
    //         ]        
    $this->entityManager->getClassMetadata(get_class($user))->removeLifecycleCallback('updateTimestamps', 'prePersist');
    $this->entityManager->getClassMetadata(get_class($user))->removeLifecycleCallback('updateTimestamps', 'preUpdate');  


    $this->entityManager->transactional(function($em) use ($user) {
    $em->persist($user);
    });
}
```

So in this particular situation, there will be no date time updating  in updated_at.
