### PR TITLE
Fix for many-to-many ignoring "order by" in Criteria

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -259,6 +259,15 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
+        if ($criteria->getOrderings()) {
+            $orderBy = [];
+            foreach ($criteria->getOrderings() as $field => $direction) {
+                $orderBy[] = $field . ' ' . $direction;
+            }
+
+            $sql .= ' ORDER BY ' . implode(', ', $orderBy);
+        }
+
         $stmt = $this->conn->executeQuery($sql, $params);
 
         return $this

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -259,9 +259,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
-        if ($criteria->getOrderings()) {
+        $orderings = $criteria->getOrderings();
+        if ($orderings) {
             $orderBy = [];
-            foreach ($criteria->getOrderings() as $field => $direction) {
+            foreach ($orderings as $field => $direction) {
                 $orderBy[] = $field . ' ' . $direction;
             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -377,6 +377,44 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         $this->assertEquals(0, count($user->groups));
     }
 
+    /**
+     * @group DDC-3952
+     */
+    public function testManyToManyOrderByIsNotIgnored()
+    {
+        $user = $this->addCmsUserGblancoWithGroups(1);
+
+        $group = new CmsGroup;
+        $group->name = 'C';
+        $user->addGroup($group);
+
+        $group = new CmsGroup;
+        $group->name = 'A';
+        $user->addGroup($group);
+
+        $group = new CmsGroup;
+        $group->name = 'B';
+        $user->addGroup($group);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $criteria = Criteria::create()
+            ->orderBy(['name' => Criteria::ASC]);
+        $groups   = $user->getGroups()->matching($criteria);
+
+        $existingOrder = [];
+        foreach ($groups as $group) {
+            $existingOrder[] = $group->getName();
+        }
+
+        $this->assertEquals(['A', 'B', 'C', 'Developers_0'], $existingOrder);
+    }
+
     public function testMatching()
     {
         $user = $this->addCmsUserGblancoWithGroups(2);


### PR DESCRIPTION
The matching of a `Criteria` in a many-to-many association will ignore the "order by" clause.

``` php
use Doctrine\Common\Collections\Criteria;

/**
 * @Entity @Table(name="hospitals")
 **/
class Hospital
{
    // . . . 

    /**
     * @ManyToMany(targetEntity="User")
     * @JoinTable(name="foo_join_table",
     *      joinColumns={@JoinColumn(name="hospital_id", referencedColumnName="id")},
     *      inverseJoinColumns={@JoinColumn(name="user_id", referencedColumnName="id")}
     *      )
     **/
    protected $users;

    public function getUsers()
    {
        $criteria = Criteria::create()
            // . . .
            ->orderBy(array("name" => Criteria::ASC));

        return $this->users->matching($criteria);
    }
}

// . . .

$users = $entityManager->find(Hospital::class, $hospital_id)->getUsers();

// $users will not be sorted by "name"
```

This is a very crude fix. I just stated using doctrine this week so I'm sure there's a better/more secure way to fix it. But this hot fix got it working on my local installation. :)
