### PR TITLE
Check if identityMap contains entity in UnitOfWork::getEntityIdentifier() to prevent "Undefined index" notice

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2914,10 +2914,18 @@ class UnitOfWork implements PropertyChangedListener
      * @param object $entity
      *
      * @return array The identifier values.
+     *
+     * @throws \Doctrine\ORM\ORMInvalidArgumentException
      */
     public function getEntityIdentifier($entity)
     {
-        return $this->entityIdentifiers[spl_object_hash($entity)];
+        $oid = spl_object_hash($entity);
+
+        if ( ! isset($this->entityIdentifiers[$oid])) {
+            throw ORMInvalidArgumentException::entityNotManaged($entity);
+        }
+
+        return $this->entityIdentifiers[$oid];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -216,6 +216,12 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $this->assertFalse($persister->isExistsCalled());
     }
 
+    public function testNoUndefinedIndexNoticeInGetEntityIdentifier()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->_unitOfWork->getEntityIdentifier(new \stdClass());
+    }
+
     /**
      * DDC-2086 [GH-484] Prevented 'Undefined index' notice when updating.
      */


### PR DESCRIPTION
Some people use UnitOfWork directly and could run into this issue. Seems nicer to throw an exception with an explanation, so they could find an error in their code faster without necessity to look through library code for the source of notice.
Also, if notices are disabled in php.ini (in production enviroment, for example), this method will return null and probably lead to undefined behavior.
