### PR TITLE
Type annotation correction in `ResultSetMappingBuilder#addJoinedEntityFromClassMetadata()` `$relation` (should be `string`)

### DIFF
--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -110,7 +110,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param string   $class          The class name of the joined entity.
      * @param string   $alias          The unique alias to use for the joined entity.
      * @param string   $parentAlias    The alias of the entity result that is the parent of this joined result.
-     * @param object   $relation       The association field that connects the parent entity result
+     * @param string   $relation       The association field that connects the parent entity result
      *                                 with the joined entity result.
      * @param array    $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).


### PR DESCRIPTION
The documentation for the method ‘addJoinedEntityFromClassMetadata’ is a little bit wrong. As we can currently see it says you need to pass an object instead of a string. The $relation variable is passed to ‘addJoinedEntityResult’ which is using it as a string.
