### PR TITLE
Allow symfony 3.0 components on 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": ">=2.5-dev,<2.6-dev",
         "doctrine/cache": "~1.4",
-        "symfony/console": "~2.5"
+        "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.1",
+        "symfony/yaml": "~2.3|~3.0",
         "phpunit/phpunit": "~4.0",
         "satooshi/php-coveralls": "dev-master"
     },


### PR DESCRIPTION
So that doctrine 2.5 can be used with symfony 3.0.
