### PR TITLE
DefaultEntityHydrator: Undefined index: targetToSourceKeyColumns

### DIFF
--- a/tests/Doctrine/Tests/Models/Cache/TravelerProfile.php
+++ b/tests/Doctrine/Tests/Models/Cache/TravelerProfile.php
@@ -25,7 +25,6 @@ class TravelerProfile
 
     /**
      * @OneToOne(targetEntity="TravelerProfileInfo", mappedBy="profile")
-     * @Cache()
      */
     private $info;
 


### PR DESCRIPTION
I'm experiencing an issue while configuring the SecondLevelCache. I still have to figure out correctly how it works (the docs are not very verbose on the topic), so actually I have messed up with many parameters.

I found a bug while caching entities which have non-owning OneToOne relationship: in these case, if the relation is not marked as `@Cache`able, i got the message `Undefined index: targetToSourceKeyColumns`. This issue never happens on the owning side.

I was able to track down the issue, and the commit here just expose the issue in some existing tests.

I'm sorry I cannot give you a proper patch, but I don't know if the problem reside in the Hydrator logic, in the association class (since targetToSourceKeyColumns and sourceToTargetKeyColumns are unset) or in the configuration validation.
