### PR TITLE
Fix proxy erased by hydratation

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/NotRelatedProxyHydration.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotRelatedProxyHydration.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;
+
+/**
+ * Tests a ManyToOne reated hydration does not remove proxy
+ */
+class NotRelatedProxyHydration extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected $customerId;
+    protected $mentor1Id;
+    protected $mentor2Id;
+
+    protected function setUp()
+    {
+        $this->useModelSet('ecommerce');
+        parent::setUp();
+
+        $mentor1 = new ECommerceCustomer();
+        $mentor1->setName('John Doe');
+        $this->_em->persist($mentor1);
+        $mentor2 = new ECommerceCustomer();
+        $mentor2->setName('Jane Doe');
+        $this->_em->persist($mentor2);
+
+        $customer = new ECommerceCustomer();
+        $customer->setName('Jean Dupont');
+        $customer->setMentor($mentor1);
+
+        $this->_em->persist($customer);
+        $this->_em->flush();
+
+        $this->customerId = $customer->getId();
+        $this->mentor1Id = $mentor1->getId();
+        $this->mentor2Id = $mentor2->getId();
+
+        $this->_em->clear();
+    }
+
+    public function testHydrationDoesNotResetProxy()
+    {
+        $repos = $this->_em->getRepository('Doctrine\Tests\Models\ECommerce\ECommerceCustomer');
+
+        $customer = $repos->find($this->customerId);
+        $this->assertSame($this->mentor1Id, $customer->getMentor()->getId());
+
+        $customer->setMentor($this->_em->getReference('Doctrine\Tests\Models\ECommerce\ECommerceCustomer', $this->mentor2Id));
+        $repos->findOneByName('Jean Dupont');
+
+        $this->assertSame($this->mentor2Id, $customer->getMentor()->getId());
+    }
+}


### PR DESCRIPTION
This PR fixe a edge case when hydrating an existing object which already has a proxy to différente entity.

Imagine the entity

```
/** @ORM\Entity() */
class User
{
    //...

    /** @ORM\ManyToOne(targetEntity="Address", fetch="EAGER") */
    private $address;

    //...
}

/** @ORM\Entity() */
class Address
{
}
```

When a instance of `User` has an address created with a `Proxy`, then, the hydratation of an other instance of the same `User` will replace the content of the field `address` in this instance.

Such situation append with a PUT call with the [DunglasApiBundle](https://github.com/dunglas/DunglasApiBundle) and the validator [UniqueEntity](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php) from Symfony which trigger a `$repository->find` on the object.
- First the entity is loaded from the entityManager (which store the reference in the `identityMap` of the `uow`
- Then the serializer overrwrite the entity, and may create reference for the related properties
- Then the object is validated before flushing which trigger the UniqueEntityValidator

How to reproduce:

```
$user = $repository->find($id);
var_dump($user->getAddress()->getId());
// 1337

$user->setAddress($em->getReference('Address', 42));
var_dump($user->getAddress()->getId());
// 42

$somethingElse = $repository->find($id);
var_dump($user->getAddress()->getId());
// 1337
```
