### PR TITLE
Collection cache key is built differently on read than on write

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -553,7 +553,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
         if ($hasCache) {
             $ownerId = $this->uow->getEntityIdentifier($coll->getOwner());
-            $key     = new CollectionCacheKey($assoc['sourceEntity'], $assoc['fieldName'], $ownerId);
+            $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
             $list    = $persister->loadCollectionCache($coll, $key);
 
             if ($list !== null) {
@@ -588,7 +588,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
         if ($hasCache) {
             $ownerId = $this->uow->getEntityIdentifier($coll->getOwner());
-            $key     = new CollectionCacheKey($assoc['sourceEntity'], $assoc['fieldName'], $ownerId);
+            $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
             $list    = $persister->loadCollectionCache($coll, $key);
 
             if ($list !== null) {
@@ -637,4 +637,17 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $this->persister->refresh($id, $entity, $lockMode);
     }
 
+    /**
+     * @param array $association
+     * @param array $ownerId
+     *
+     * @return CollectionCacheKey
+     */
+    protected function buildCollectionCacheKey(array $association, $ownerId)
+    {
+        /** @var ClassMetadata $metadata */
+        $metadata = $this->metadataFactory->getMetadataFor($association['sourceEntity']);
+
+        return new CollectionCacheKey($metadata->rootEntityName, $association['fieldName'], $ownerId);
+    }
 }


### PR DESCRIPTION
This one's a quick bugfix that would be better if we could refactor key building logic inside the `\Doctrine\ORM\Cache` implementations, but that would be a (albeit small) BC break in its current API.

I intentionally named the refactored protected method exactly as its named in `\Doctrine\ORM\DefaultCache`.

Testing this proved harder than what it's worth. I'm actually patching this in userland, and you'll find the bug and correction pretty obvious if you look at both the modified class and `\Doctrine\ORM\DefaultCache`, so I hope we can merge this one and maybe work on a full test suite for all of the Persister strategies.

Cheers!
