### PR TITLE
Fix a documentation error in the EntityManagerInterface#transactional() return value

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -101,7 +101,7 @@ functionally equivalent to the previously shown code looks as follows:
 .. warning::
 
     For historical reasons, ``EntityManager#transactional($func)`` will return
-    ``false`` whenever the return value of ``$func`` is loosely false.
+    ``true`` whenever the return value of ``$func`` is loosely false.
     Some examples of this include ``array()``, ``"0"``, ``""``, ``0``, and
     ``null``.
 


### PR DESCRIPTION
This is a fix for #1462  @DHager 

By the documentation

> For historical reasons, EntityManager#transactional($func) will return false whenever the return value of $func is loosely false. Some examples of this include array(), "0", "", 0, and null.

No! It's ``true'' ! 
Returning false whenever a user function returns false is just a natural behaviour, isn't it?
