### PR TITLE
Second level cache stores identifier with correct type even if findById is called with wrong identifier type

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -73,7 +73,7 @@ class DefaultEntityHydrator implements EntityHydrator
     public function buildCacheEntry(ClassMetadata $metadata, EntityCacheKey $key, $entity)
     {
         $data = $this->uow->getOriginalEntityData($entity);
-        $data = array_merge($data, $key->identifier); // why update has no identifier values ?
+        $data = array_merge($data, $metadata->getIdentifierValues($entity)); // why update has no identifier values ?
 
         foreach ($metadata->associationMappings as $name => $assoc) {
             if ( ! isset($data[$name])) {


### PR DESCRIPTION
Fixes http://www.doctrine-project.org/jira/browse/DDC-3967
