### PR TITLE
[RFC] remove indexes overruled by primary key

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -122,10 +122,9 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
      */
     public function testSchemaHasProperIndexesFromUniqueConstraintAnnotation()
     {
-        $em = $this->_getTestEntityManager();
+        $em         = $this->_getTestEntityManager();
         $schemaTool = new SchemaTool($em);
-
-        $classes = [
+        $classes    = [
             $em->getClassMetadata(__NAMESPACE__ . '\\UniqueConstraintAnnotationModel'),
         ];
 
@@ -137,6 +136,25 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(2, count($table->getIndexes()));
         $this->assertTrue($table->hasIndex('primary'));
         $this->assertTrue($table->hasIndex('uniq_hash'));
+    }
+
+    public function testRemoveUniqueIndexOverruledByPrimaryKey()
+    {
+        $em         = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+        $classes    = [
+            $em->getClassMetadata(__NAMESPACE__ . '\\FirstEntity'),
+            $em->getClassMetadata(__NAMESPACE__ . '\\SecondEntity')
+        ];
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        $this->assertTrue($schema->hasTable('first_entity'), "Table first_entity should exist.");
+
+        $indexes = $schema->getTable('first_entity')->getIndexes();
+
+        $this->assertCount(1, $indexes, "there should be only one index");
+        $this->assertTrue(current($indexes)->isPrimary(), "index should be primary");
     }
 }
 
@@ -186,4 +204,46 @@ class UniqueConstraintAnnotationModel
      * @Column(name="hash", type="string", length=8, nullable=false, unique=true)
      */
     private $hash;
+}
+
+/**
+ * @Entity
+ * @Table(name="first_entity")
+ */
+class FirstEntity
+{
+    /**
+     * @Id
+     * @Column(name="id")
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="SecondEntity")
+     * @JoinColumn(name="id", referencedColumnName="fist_entity_id")
+     */
+    public $secondEntity;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
+}
+
+/**
+ * @Entity
+ * @Table(name="second_entity")
+ */
+class SecondEntity
+{
+    /**
+     * @Id
+     * @Column(name="fist_entity_id")
+     */
+    public $fist_entity_id;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
 }


### PR DESCRIPTION
Fixes #1522 

There can be unique indexes automatically created for join column.
If join column is also primary key we should keep only primary key on this column.

Oracle does not allow having both unique index and primary key on the same column, it is useless for mysql too.
(Previously it was done by DBAL, but now it allows duplicate indexes)
