### PR TITLE
[DDC-4006] Inherit ID generator strategy mapping from embeddables

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -157,19 +157,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         // However this is only true if the hierarchy of parents contains the root entity,
         // if it consists of mapped superclasses these don't necessarily include the id field.
         if ($parent && $rootEntityFound) {
-            if ($parent->isIdGeneratorSequence()) {
-                $class->setSequenceGeneratorDefinition($parent->sequenceGeneratorDefinition);
-            } else if ($parent->isIdGeneratorTable()) {
-                $class->tableGeneratorDefinition = $parent->tableGeneratorDefinition;
-            }
-
-            if ($parent->generatorType) {
-                $class->setIdGeneratorType($parent->generatorType);
-            }
-
-            if ($parent->idGenerator) {
-                $class->setIdGenerator($parent->idGenerator);
-            }
+            $this->inheritIdGeneratorMapping($class, $parent);
         } else {
             $this->completeIdGeneratorMapping($class);
         }
@@ -195,6 +183,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 if ($embeddableMetadata->isEmbeddedClass) {
                     $this->addNestedEmbeddedClasses($embeddableMetadata, $class, $property);
+                }
+
+                if (! empty($embeddableMetadata->getIdentifier())) {
+                    $this->inheritIdGeneratorMapping($class, $embeddableMetadata);
                 }
 
                 $class->inlineEmbeddable($property, $embeddableMetadata);
@@ -709,6 +701,29 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
             default:
                 throw new ORMException("Unknown generator type: " . $class->generatorType);
+        }
+    }
+
+    /**
+     * Inherits the ID generator mapping from a parent class.
+     *
+     * @param ClassMetadataInfo $class
+     * @param ClassMetadataInfo $parent
+     */
+    private function inheritIdGeneratorMapping(ClassMetadataInfo $class, ClassMetadataInfo $parent)
+    {
+        if ($parent->isIdGeneratorSequence()) {
+            $class->setSequenceGeneratorDefinition($parent->sequenceGeneratorDefinition);
+        } elseif ($parent->isIdGeneratorTable()) {
+            $class->tableGeneratorDefinition = $parent->tableGeneratorDefinition;
+        }
+
+        if ($parent->generatorType) {
+            $class->setIdGeneratorType($parent->generatorType);
+        }
+
+        if ($parent->idGenerator) {
+            $class->setIdGenerator($parent->idGenerator);
         }
     }
 

--- a/tests/Doctrine/Tests/Models/DDC4006/DDC4006User.php
+++ b/tests/Doctrine/Tests/Models/DDC4006/DDC4006User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC4006;
+
+/**
+ * @Entity
+ */
+class DDC4006User
+{
+    /**
+     * @Embedded(class="DDC4006UserId")
+     */
+    private $id;
+}

--- a/tests/Doctrine/Tests/Models/DDC4006/DDC4006UserId.php
+++ b/tests/Doctrine/Tests/Models/DDC4006/DDC4006UserId.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC4006;
+
+/**
+ * @Embeddable
+ */
+class DDC4006UserId
+{
+    /**
+     * @Id
+     * @GeneratedValue("IDENTITY")
+     * @Column(type="integer")
+     */
+    private $id;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -309,7 +309,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('parent-id', $user['joinColumns'][0]['name']);
         $this->assertEquals('group-id', $user['joinColumns'][0]['referencedColumnName']);
 
-        
+
         // Address Class Metadata
         $this->assertTrue($addressMetadata->fieldMappings['id']['quoted']);
         $this->assertTrue($addressMetadata->fieldMappings['zip']['quoted']);
@@ -327,11 +327,11 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         // User Class Metadata
         $this->assertTrue($userMetadata->fieldMappings['id']['quoted']);
         $this->assertTrue($userMetadata->fieldMappings['name']['quoted']);
-        
+
         $this->assertEquals('user-id', $userMetadata->fieldMappings['id']['columnName']);
         $this->assertEquals('user-name', $userMetadata->fieldMappings['name']['columnName']);
 
-        
+
         $address = $userMetadata->associationMappings['address'];
         $this->assertTrue($address['joinColumns'][0]['quoted']);
         $this->assertEquals('address-id', $address['joinColumns'][0]['name']);
@@ -422,6 +422,21 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
         );
 
         $cmf->getMetadataFor($metadata->name);
+    }
+
+    /**
+     * @group DDC-4006
+     */
+    public function testInheritsIdGeneratorMappingFromEmbeddable()
+    {
+        $cmf = new ClassMetadataFactory();
+        $driver = $this->createAnnotationDriver(array(__DIR__ . '/../../Models/DDC4006/'));
+        $em = $this->_createEntityManager($driver);
+        $cmf->setEntityManager($em);
+
+        $userMetadata = $cmf->getMetadataFor('Doctrine\Tests\Models\DDC4006\DDC4006User');
+
+        $this->assertTrue($userMetadata->isIdGeneratorIdentity());
     }
 }
 


### PR DESCRIPTION
Setting the ID generator strategy mapping when using embeddables as identifiers in entities has no effect and always results in the "NONE" strategy.

This is due to the ID generator strategy not being inherited to its parent entity when declared in an embeddable (ClassMetadataFactory).
