### PR TITLE
Fix empty expression on PHP 5.4

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -185,7 +185,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $this->addNestedEmbeddedClasses($embeddableMetadata, $class, $property);
                 }
 
-                if (! empty($embeddableMetadata->getIdentifier())) {
+                $identifier = $embeddableMetadata->getIdentifier();
+
+                if (! empty($identifier)) {
                     $this->inheritIdGeneratorMapping($class, $embeddableMetadata);
                 }
 


### PR DESCRIPTION
Sorry my last PR introduced an invalid `empty` expression on PHP 5.4.
