### PR TITLE
Allow interface in dql

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -996,7 +996,7 @@ class Parser
      */
     private function validateAbstractSchemaName($schemaName)
     {
-        $exists = class_exists($schemaName, true);
+        $exists = class_exists($schemaName, true) || interface_exists($schemaName, true);
 
         if (! $exists) {
             $this->semanticalError("Class '$schemaName' is not defined.", $this->lexer->token);

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -106,6 +106,22 @@ class ResolveTargetEntityListenerTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSame('Doctrine\Tests\ORM\Tools\TargetEntity', $meta['targetEntity']);
         $this->assertEquals(array('resolvetargetentity_id', 'targetinterface_id'), $meta['joinTableColumns']);
     }
+    
+    /**
+     * @group DDC-4015
+     */
+    public function testInterfaceInDQL(){
+        $this->listener->addResolveTargetEntity(
+            'Doctrine\Tests\ORM\Tools\TargetInterface',
+            'Doctrine\Tests\ORM\Tools\TargetEntity',
+            array()
+        );
+        
+        $this->em->getEventManager()->addEventSubscriber($this->listener);
+                                                                                  
+        $query = $this->em->createQuery('SELECT rti FROM Doctrine\Tests\ORM\Tools\TargetInterface rti');
+        $this->assertEquals('SELECT t0_.id AS id_0 FROM TargetEntity t0_', $query->getSQL());
+    }
 }
 
 interface ResolveTargetInterface


### PR DESCRIPTION
When I used Target Entity Resolver, I couldn't use Entity Interface in DQL. 

I had to call entityRepository::getClassName() like this:

``` php
$this->em->createQuery('SELECT a FROM ' . $this->em->getRepository(IArticle::class)->getClassName() . ' a ORDER BY a.id DESC')
```

Now this should work: 

``` php
$this->em->createQuery('SELECT a FROM ' . IArticle::class . ' a ORDER BY a.id DESC')
```
