### PR TITLE
Identifier is cached with wrong type

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -73,7 +73,7 @@ class DefaultEntityHydrator implements EntityHydrator
     public function buildCacheEntry(ClassMetadata $metadata, EntityCacheKey $key, $entity)
     {
         $data = $this->uow->getOriginalEntityData($entity);
-        $data = array_merge($data, $key->identifier); // why update has no identifier values ?
+        $data = array_merge($data, $metadata->getIdentifierValues($entity)); // why update has no identifier values ?
 
         foreach ($metadata->associationMappings as $name => $assoc) {
             if ( ! isset($data[$name])) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3967Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3967Test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Cache\Country;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+
+class DDC3967Test extends SecondLevelCacheAbstractTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->loadFixturesCountries();
+        $this->_em->getCache()->evictEntityRegion(Country::CLASSNAME);
+        $this->_em->clear();
+    }
+
+    public function testIdentifierCachedWithProperType()
+    {
+        $country = array_pop($this->countries);
+        $id = $country->getId();
+
+        // First time, loaded from database
+        $this->_em->find(Country::CLASSNAME, "$id");
+        $this->_em->clear();
+
+        // Second time, loaded from cache
+        /** @var Country $country */
+        $country = $this->_em->find(Country::CLASSNAME, "$id");
+
+        // Identifier type should be integer
+        $this->assertSame($country->getId(), $id);
+    }
+}


### PR DESCRIPTION
Based on #1556, just added a functional test that reflects what was described on the original ticket.
