### PR TITLE
Add EAGER_BATCHED fetchmode to OneToMany association

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -161,6 +161,11 @@ class ClassMetadataInfo implements ClassMetadata
      */
     const FETCH_EXTRA_LAZY = 4;
 
+	/**
+	 * Specifies that an association is to be fetched eagerly, but loaded though a single query.
+	 */
+	const FETCH_EAGER_BATCHED = 5;
+
     /**
      * Identifies a one-to-one association.
      */

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -161,10 +161,10 @@ class ClassMetadataInfo implements ClassMetadata
      */
     const FETCH_EXTRA_LAZY = 4;
 
-	/**
-	 * Specifies that an association is to be fetched eagerly, but loaded though a single query.
-	 */
-	const FETCH_EAGER_BATCHED = 5;
+    /**
+     * Specifies that an association is to be fetched eagerly, but loaded though a single query.
+     */
+    const FETCH_EAGER_BATCHED = 5;
 
     /**
      * Identifies a one-to-one association.

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -45,7 +45,7 @@ final class OneToMany implements Annotation
      *
      * @var string
      *
-     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
+     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY","EAGER_BATCHED"})
      */
     public $fetch = 'LAZY';
 

--- a/tests/Doctrine/Tests/Models/EagerBatched/Article.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Article.php
@@ -16,7 +16,8 @@ use Doctrine\ORM\Mapping\Table;
  * @Entity()
  * @Table(name="eager_batched_article")
  */
-class Article {
+class Article
+{
 
 	/**
 	 * @Id @Column(type="integer", name="id") @GeneratedValue

--- a/tests/Doctrine/Tests/Models/EagerBatched/Article.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Article.php
@@ -7,7 +7,10 @@
  */
 
 namespace Doctrine\Tests\Models\EagerBatched;
+
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\Tests\Models\EagerBatched\Tag;
 
 /**
  * Class Article
@@ -19,82 +22,91 @@ use Doctrine\ORM\Mapping\Table;
 class Article
 {
 
-	/**
-	 * @Id @Column(type="integer", name="id") @GeneratedValue
-	 */
-	protected $id;
+    /**
+     * @Id @Column(type="integer", name="id") @GeneratedValue
+     * @var int
+     */
+    protected $id;
 
-	/**
-	 * @Column(type="string")
-	 */
-	protected $title;
+    /**
+     * @Column(type="string")
+     * @var string|null
+     */
+    protected $title;
 
-	/**
-	 * @OneToMany(targetEntity="Tag",mappedBy="article",cascade={"persist"},fetch="EAGER_BATCHED")
-	 */
-	protected $tags;
+    /**
+     * @OneToMany(targetEntity="Tag",mappedBy="article",cascade={"persist"},fetch="EAGER_BATCHED")
+     * @var Tag[]|Collection
+     */
+    protected $tags;
 
-	/**
-	 * Get id
-	 *
-	 * @return mixed
-	 */
-	public function getId() {
-		return $this->id;
-	}
+    /**
+     * Get id
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
 
-	/**
-	 * Set id
-	 *
-	 * @param mixed $id
-	 * @return $this
-	 */
-	public function setId($id) {
-		$this->id = $id;
+    /**
+     * Set id
+     *
+     * @param integer $id
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get title
-	 *
-	 * @return mixed
-	 */
-	public function getTitle() {
-		return $this->title;
-	}
+    /**
+     * Get title
+     *
+     * @return string|null
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
 
-	/**
-	 * Set title
-	 *
-	 * @param mixed $title
-	 * @return $this
-	 */
-	public function setTitle($title) {
-		$this->title = $title;
+    /**
+     * Set title
+     *
+     * @param string $title
+     * @return $this
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get tags
-	 *
-	 * @return mixed
-	 */
-	public function getTags() {
-		return $this->tags;
-	}
+    /**
+     * Get tags
+     *
+     * @return Collection|Tag[]
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
 
-	/**
-	 * Set tags
-	 *
-	 * @param mixed $tags
-	 * @return $this
-	 */
-	public function setTags($tags) {
-		$this->tags = $tags;
+    /**
+     * Set tags
+     *
+     * @param Collection|Tag[] $tags
+     * @return $this
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
 
-		return $this;
-	}
+        return $this;
+    }
 
 }

--- a/tests/Doctrine/Tests/Models/EagerBatched/Article.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Article.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: wouter
+ * Date: 11/18/15
+ * Time: 1:00 PM
+ */
+
+namespace Doctrine\Tests\Models\EagerBatched;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * Class Article
+ * @package Doctrine\Tests\Models\EagerBatched
+ *
+ * @Entity()
+ * @Table(name="eager_batched_article")
+ */
+class Article {
+
+	/**
+	 * @Id @Column(type="integer", name="id") @GeneratedValue
+	 */
+	protected $id;
+
+	/**
+	 * @Column(type="string")
+	 */
+	protected $title;
+
+	/**
+	 * @OneToMany(targetEntity="Tag",mappedBy="article",cascade={"persist"},fetch="EAGER_BATCHED")
+	 */
+	protected $tags;
+
+	/**
+	 * Get id
+	 *
+	 * @return mixed
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * Set id
+	 *
+	 * @param mixed $id
+	 * @return $this
+	 */
+	public function setId($id) {
+		$this->id = $id;
+
+		return $this;
+	}
+
+	/**
+	 * Get title
+	 *
+	 * @return mixed
+	 */
+	public function getTitle() {
+		return $this->title;
+	}
+
+	/**
+	 * Set title
+	 *
+	 * @param mixed $title
+	 * @return $this
+	 */
+	public function setTitle($title) {
+		$this->title = $title;
+
+		return $this;
+	}
+
+	/**
+	 * Get tags
+	 *
+	 * @return mixed
+	 */
+	public function getTags() {
+		return $this->tags;
+	}
+
+	/**
+	 * Set tags
+	 *
+	 * @param mixed $tags
+	 * @return $this
+	 */
+	public function setTags($tags) {
+		$this->tags = $tags;
+
+		return $this;
+	}
+
+}

--- a/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
@@ -15,7 +15,8 @@ namespace Doctrine\Tests\Models\EagerBatched;
  * @Entity()
  * @Table(name="eager_batched_tag")
  */
-class Tag {
+class Tag
+{
 
 	/**
 	 * @Column(type="string")

--- a/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
@@ -18,70 +18,86 @@ namespace Doctrine\Tests\Models\EagerBatched;
 class Tag
 {
 
-	/**
-	 * @Column(type="string")
-	 * @Id()
-	 */
-	protected $name;
+    /**
+     * @Column(type="string")
+     * @Id()
+     * @var string
+     */
+    protected $name;
 
-	public static function factory(Article $a, $tag) {
-		$me = new static();
-		$me->setArticle($a);
-		$me->setName($tag);
-		return $me;
-	}
+    /**
+     * @ManyToOne(targetEntity="Article",cascade={"persist"},fetch="LAZY",inversedBy="tags")
+     * @Id()
+     * @var Article
+     */
+    protected $article;
 
-	/**
-	 * @ManyToOne(targetEntity="Article",cascade={"persist"},fetch="LAZY",inversedBy="tags")
-	 * @Id()
-	 */
-	protected $article;
+    /**
+     * Factor a tag for an article
+     *
+     * @param Article $a
+     * @param $tag
+     *
+     * @return static
+     */
+    public static function factory(Article $a, $tag)
+    {
+        $me = new static();
+        $me->setArticle($a);
+        $me->setName($tag);
+        return $me;
+    }
 
-	public function __toString() {
-		return $this->name;
-	}
+    public function __toString()
+    {
+        return $this->name;
+    }
 
-	/**
-	 * Get name
-	 *
-	 * @return mixed
-	 */
-	public function getName() {
-		return $this->name;
-	}
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
-	/**
-	 * Set name
-	 *
-	 * @param mixed $name
-	 * @return $this
-	 */
-	public function setName($name) {
-		$this->name = $name;
+    /**
+     * Set name
+     *
+     * @param mixed $name
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get article
-	 *
-	 * @return Article
-	 */
-	public function getArticle() {
-		return $this->article;
-	}
+    /**
+     * Get article
+     *
+     * @return Article
+     */
+    public function getArticle()
+    {
+        return $this->article;
+    }
 
-	/**
-	 * Set article
-	 *
-	 * @param mixed $article
-	 * @return $this
-	 */
-	public function setArticle($article) {
-		$this->article = $article;
+    /**
+     * Set article
+     *
+     * @param mixed $article
+     * @return $this
+     */
+    public function setArticle($article)
+    {
+        $this->article = $article;
 
-		return $this;
-	}
+        return $this;
+    }
 
 
 }

--- a/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
+++ b/tests/Doctrine/Tests/Models/EagerBatched/Tag.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: wouter
+ * Date: 11/18/15
+ * Time: 1:00 PM
+ */
+
+namespace Doctrine\Tests\Models\EagerBatched;
+
+/**
+ * Class Tag
+ * @package Doctrine\Tests\Models\EagerBatched
+ *
+ * @Entity()
+ * @Table(name="eager_batched_tag")
+ */
+class Tag {
+
+	/**
+	 * @Column(type="string")
+	 * @Id()
+	 */
+	protected $name;
+
+	public static function factory(Article $a, $tag) {
+		$me = new static();
+		$me->setArticle($a);
+		$me->setName($tag);
+		return $me;
+	}
+
+	/**
+	 * @ManyToOne(targetEntity="Article",cascade={"persist"},fetch="LAZY",inversedBy="tags")
+	 * @Id()
+	 */
+	protected $article;
+
+	public function __toString() {
+		return $this->name;
+	}
+
+	/**
+	 * Get name
+	 *
+	 * @return mixed
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * Set name
+	 *
+	 * @param mixed $name
+	 * @return $this
+	 */
+	public function setName($name) {
+		$this->name = $name;
+
+		return $this;
+	}
+
+	/**
+	 * Get article
+	 *
+	 * @return Article
+	 */
+	public function getArticle() {
+		return $this->article;
+	}
+
+	/**
+	 * Set article
+	 *
+	 * @param mixed $article
+	 * @return $this
+	 */
+	public function setArticle($article) {
+		$this->article = $article;
+
+		return $this;
+	}
+
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
@@ -14,10 +14,8 @@ use Doctrine\Tests\Models\EagerBatched\Article;
 use Doctrine\Tests\Models\EagerBatched\Tag;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-class OneToManyEagerBatchedLoading extends OrmFunctionalTestCase {
-
-	private $lazyLoadingTime;
-	private $batchedLoadingTime;
+class OneToManyEagerBatchedLoading extends OrmFunctionalTestCase
+{
 
 	protected function setUp() {
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
@@ -17,102 +17,105 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 class OneToManyEagerBatchedLoading extends OrmFunctionalTestCase
 {
 
-	protected function setUp() {
+    protected function setUp()
+    {
 
-		$this->useModelSet('eager_batched');
-		parent::setUp();
+        $this->useModelSet('eager_batched');
+        parent::setUp();
 
-		$tags = explode(' ', 'professionally fabricate initiatives before expanded array practices');
+        $tags = explode(' ', 'professionally fabricate initiatives before expanded array practices');
 
-		for($i = 0; $i < 100; $i++) {
+        for($i = 0; $i < 100; $i++) {
 
-			$article = new Article();
-			$article->setTitle('Test article '.$i);
-			$article->setTags(array_map(function($word) use ($article) {
-				return Tag::factory($article, $word);
-			}, $tags));
+            $article = new Article();
+            $article->setTitle('Test article '.$i);
+            $article->setTags(array_map(function($word) use ($article) {
+                return Tag::factory($article, $word);
+            }, $tags));
 
-			$this->_em->persist($article);
-		}
+            $this->_em->persist($article);
+        }
 
-		$this->_em->flush();
-		$this->_em->clear();
-	}
+        $this->_em->flush();
+        $this->_em->clear();
+    }
 
-	public function testEagerBatchedLoading() {
+    public function testEagerBatchedLoading()
+    {
 
-		$start = microtime(true);
+        $start = microtime(true);
 
-		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+        $currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
 
-		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+        $all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
 
-		/** @var Article $article */
-		foreach($all as $article) {
-			$this->assertEquals(7, count($article->getTags()));
-		}
+        /** @var Article $article */
+        foreach($all as $article) {
+            $this->assertEquals(7, count($article->getTags()));
+        }
 
-		// the EAGER_BATCHED mode will trigger two queries. One to select from Articles, and one to select all
-		// tags that are linked to the articles we've loaded
-		$this->assertEquals(2, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+        // the EAGER_BATCHED mode will trigger two queries. One to select from Articles, and one to select all
+        // tags that are linked to the articles we've loaded
+        $this->assertEquals(2, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
 
-		return microtime(true) - $start;
-	}
+        return microtime(true) - $start;
+    }
 
 
-	/**
-	 * @depends testEagerBatchedLoading
-	 * @param $batchedLoadingTime
-	 */
-	public function testLazyLoading($batchedLoadingTime) {
+    /**
+     * @depends testEagerBatchedLoading
+     * @param $batchedLoadingTime
+     */
+    public function testLazyLoading($batchedLoadingTime)
+    {
 
-		$start = microtime(true);
+        $start = microtime(true);
 
-		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
-		$class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
-		$class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_LAZY;
+        $currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+        $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
+        $class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_LAZY;
 
-		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+        $all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
 
-		/** @var Article $article */
-		foreach($all as $article) {
-			$this->assertEquals(7, count($article->getTags()));
-		}
+        /** @var Article $article */
+        foreach($all as $article) {
+            $this->assertEquals(7, count($article->getTags()));
+        }
 
-		// Check that what we're improving is indeed behaving as we don't want
-		$this->assertEquals(101, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+        // Check that what we're improving is indeed behaving as we don't want
+        $this->assertEquals(101, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
 
-		$lazyLoadingTime = microtime(true) - $start;
+        $lazyLoadingTime = microtime(true) - $start;
 
-		$this->assertGreaterThan($batchedLoadingTime, $lazyLoadingTime, 'Make sure the improvement improves');
-	}
+        $this->assertGreaterThan($batchedLoadingTime, $lazyLoadingTime, 'Make sure the improvement improves');
+    }
 
-	/**
-	 * @depends testEagerBatchedLoading
-	 * @param $batchedLoadingTime
-	 */
-	public function testEagerLoading($batchedLoadingTime) {
+    /**
+     * @depends testEagerBatchedLoading
+     * @param $batchedLoadingTime
+     */
+    public function testEagerLoading($batchedLoadingTime)
+    {
+        $start = microtime(true);
 
-		$start = microtime(true);
+        $currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+        $class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
+        $class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_EAGER;
 
-		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
-		$class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
-		$class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_EAGER;
+        $all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
 
-		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+        /** @var Article $article */
+        foreach($all as $article) {
+            $this->assertEquals(7, count($article->getTags()));
+        }
 
-		/** @var Article $article */
-		foreach($all as $article) {
-			$this->assertEquals(7, count($article->getTags()));
-		}
+        // Check that what we're improving is indeed behaving as we don't want
+        $this->assertEquals(1, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
 
-		// Check that what we're improving is indeed behaving as we don't want
-		$this->assertEquals(1, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+        $time = microtime(true) - $start;
 
-		$time = microtime(true) - $start;
-
-		$this->assertGreaterThan($batchedLoadingTime, $time, 'Make sure the improvement improves');
-	}
+        $this->assertGreaterThan($batchedLoadingTime, $time, 'Make sure the improvement improves');
+    }
 
 
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyEagerBatchedLoading.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: wouter
+ * Date: 11/18/15
+ * Time: 12:54 PM
+ */
+
+namespace Doctrine\Tests\ORM\Functional;
+
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Tests\Models\EagerBatched\Article;
+use Doctrine\Tests\Models\EagerBatched\Tag;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class OneToManyEagerBatchedLoading extends OrmFunctionalTestCase {
+
+	private $lazyLoadingTime;
+	private $batchedLoadingTime;
+
+	protected function setUp() {
+
+		$this->useModelSet('eager_batched');
+		parent::setUp();
+
+		$tags = explode(' ', 'professionally fabricate initiatives before expanded array practices');
+
+		for($i = 0; $i < 100; $i++) {
+
+			$article = new Article();
+			$article->setTitle('Test article '.$i);
+			$article->setTags(array_map(function($word) use ($article) {
+				return Tag::factory($article, $word);
+			}, $tags));
+
+			$this->_em->persist($article);
+		}
+
+		$this->_em->flush();
+		$this->_em->clear();
+	}
+
+	public function testEagerBatchedLoading() {
+
+		$start = microtime(true);
+
+		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+
+		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+
+		/** @var Article $article */
+		foreach($all as $article) {
+			$this->assertEquals(7, count($article->getTags()));
+		}
+
+		// the EAGER_BATCHED mode will trigger two queries. One to select from Articles, and one to select all
+		// tags that are linked to the articles we've loaded
+		$this->assertEquals(2, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+
+		return microtime(true) - $start;
+	}
+
+
+	/**
+	 * @depends testEagerBatchedLoading
+	 * @param $batchedLoadingTime
+	 */
+	public function testLazyLoading($batchedLoadingTime) {
+
+		$start = microtime(true);
+
+		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+		$class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
+		$class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_LAZY;
+
+		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+
+		/** @var Article $article */
+		foreach($all as $article) {
+			$this->assertEquals(7, count($article->getTags()));
+		}
+
+		// Check that what we're improving is indeed behaving as we don't want
+		$this->assertEquals(101, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+
+		$lazyLoadingTime = microtime(true) - $start;
+
+		$this->assertGreaterThan($batchedLoadingTime, $lazyLoadingTime, 'Make sure the improvement improves');
+	}
+
+	/**
+	 * @depends testEagerBatchedLoading
+	 * @param $batchedLoadingTime
+	 */
+	public function testEagerLoading($batchedLoadingTime) {
+
+		$start = microtime(true);
+
+		$currentQueryBefore = $this->_sqlLoggerStack->currentQuery;
+		$class = $this->_em->getClassMetadata('Doctrine\Tests\Models\EagerBatched\Article');
+		$class->associationMappings['tags']['fetch'] = ClassMetadata::FETCH_EAGER;
+
+		$all = $this->_em->getRepository('Doctrine\Tests\Models\EagerBatched\Article')->findAll();
+
+		/** @var Article $article */
+		foreach($all as $article) {
+			$this->assertEquals(7, count($article->getTags()));
+		}
+
+		// Check that what we're improving is indeed behaving as we don't want
+		$this->assertEquals(1, $this->_sqlLoggerStack->currentQuery - $currentQueryBefore);
+
+		$time = microtime(true) - $start;
+
+		$this->assertGreaterThan($batchedLoadingTime, $time, 'Make sure the improvement improves');
+	}
+
+
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -225,7 +225,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory->setEntityManager($em);
 
         $this->setExpectedException('Doctrine\Common\Annotations\AnnotationException',
-            '[Enum Error] Attribute "fetch" of @Doctrine\ORM\Mapping\OneToMany declared on property Doctrine\Tests\ORM\Mapping\InvalidFetchOption::$collection accept only [LAZY, EAGER, EXTRA_LAZY], but got eager.');
+            '[Enum Error] Attribute "fetch" of @Doctrine\ORM\Mapping\OneToMany declared on property Doctrine\Tests\ORM\Mapping\InvalidFetchOption::$collection accept only [LAZY, EAGER, EXTRA_LAZY, EAGER_BATCHED], but got eager.');
         $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\InvalidFetchOption');
     }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -282,6 +282,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Pagination\User',
             'Doctrine\Tests\Models\Pagination\User1',
         ),
+        'eager_batched' => Array(
+            'Doctrine\Tests\Models\EagerBatched\Article',
+            'Doctrine\Tests\Models\EagerBatched\Tag'
+        )
     );
 
     /**
@@ -543,6 +547,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM pagination_user');
         }
 
+        if (isset($this->_usedModelSets['eager_batched'])) {
+            $conn->executeUpdate('DELETE FROM eager_batched_tag');
+            $conn->executeUpdate('DELETE FROM eager_batched_article');
+        }
         $this->_em->clear();
     }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -282,7 +282,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Pagination\User',
             'Doctrine\Tests\Models\Pagination\User1',
         ),
-        'eager_batched' => Array(
+        'eager_batched' => array(
             'Doctrine\Tests\Models\EagerBatched\Article',
             'Doctrine\Tests\Models\EagerBatched\Tag'
         )


### PR DESCRIPTION
In regular EAGER mode, doctrine adds a JOIN for a OneToMany association
forcing the database to load more data in memory than essentially
needed. In a classic Article => Tag concept, each article would be
loaded one extra time for every addition tag.

LAZY mode issues a query for every article to load all associated tags,
also adding more overhead to the database than needed.

This new fetchmode addreses this issue by loading all tags associated to
an article into one additional query.
