### PR TITLE
Fixed typo in QueryBuilder->where() docblock

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1055,7 +1055,7 @@ class QueryBuilder
      *         ->from('User', 'u')
      *         ->where('u.id = ?');
      *
-     *     // You can optionally programatically build and/or expressions
+     *     // You can optionally programmatically build and/or expressions
      *     $qb = $em->createQueryBuilder();
      *
      *     $or = $qb->expr()->orX();


### PR DESCRIPTION
Just found this while reading the doc-block, thought I'd send you guys a PR.
