### PR TITLE
Target entity resolver for DQL

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -965,7 +965,7 @@ class Parser
             $schemaName = $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
         }
 
-        $exists = class_exists($schemaName, true);
+        $exists = class_exists($schemaName, true) || interface_exists($schemaName, true);
 
         if ( ! $exists) {
             $this->semanticalError("Class '$schemaName' is not defined.", $this->lexer->token);


### PR DESCRIPTION
Since we have target entity resolver in doctrine this class check is not enought.
To gain interface resolution it is better to add interface check in addition to class_check here.
