### PR TITLE
Merge entity associated to versioned entity

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1866,7 +1866,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
             }
 
-            if ($class->isVersioned) {
+            if ($class->isVersioned && !($this->isNotInitializedProxy($managedCopy) || $this->isNotInitializedProxy($entity))) {
                 $reflField          = $class->reflFields[$class->versionField];
                 $managedCopyVersion = $reflField->getValue($managedCopy);
                 $entityVersion      = $reflField->getValue($entity);
@@ -1902,6 +1902,18 @@ class UnitOfWork implements PropertyChangedListener
         $this->cascadeMerge($entity, $managedCopy, $visited);
 
         return $managedCopy;
+    }
+
+    /**
+     * Tests if an entity is a non initialized proxy class
+     *
+     * @param $entity
+     *
+     * @return bool
+     */
+    private function isNotInitializedProxy($entity)
+    {
+        return $entity instanceof Proxy && !$entity->__isInitialized();
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1866,7 +1866,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
             }
 
-            if ($class->isVersioned && !($this->isNotInitializedProxy($managedCopy) || $this->isNotInitializedProxy($entity))) {
+            if ($class->isVersioned && $this->isLoaded($managedCopy) && $this->isLoaded($entity)) {
                 $reflField          = $class->reflFields[$class->versionField];
                 $managedCopyVersion = $reflField->getValue($managedCopy);
                 $entityVersion      = $reflField->getValue($entity);
@@ -1879,7 +1879,7 @@ class UnitOfWork implements PropertyChangedListener
 
             $visited[$oid] = $managedCopy; // mark visited
 
-            if (!($entity instanceof Proxy && ! $entity->__isInitialized())) {
+            if ($this->isLoaded($entity)) {
                 if ($managedCopy instanceof Proxy && ! $managedCopy->__isInitialized()) {
                     $managedCopy->__load();
                 }
@@ -1905,15 +1905,15 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * Tests if an entity is a non initialized proxy class
+     * Tests if an entity is loaded (Not a proxy or a non initialized proxy)
      *
      * @param $entity
      *
      * @return bool
      */
-    private function isNotInitializedProxy($entity)
+    private function isLoaded($entity)
     {
-        return $entity instanceof Proxy && !$entity->__isInitialized();
+        return !($entity instanceof Proxy) || $entity->__isInitialized();
     }
 
     /**

--- a/tests/Doctrine/Tests/Models/VersionedOneToMany/Article.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToMany/Article.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\Models\VersionedOneToMany;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- *
  * @Entity
  * @Table(name="article")
  */
@@ -38,7 +37,6 @@ class Article
 
     /**
      * Category constructor.
-     *
      */
     public function __construct()
     {

--- a/tests/Doctrine/Tests/Models/VersionedOneToMany/Article.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToMany/Article.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\Tests\Models\VersionedOneToMany;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ *
+ * @Entity
+ * @Table(name="article")
+ */
+class Article
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
+
+    /**
+     * @ManyToOne(targetEntity="Category", inversedBy="category", cascade={"merge", "persist"})
+     */
+    public $category;
+
+    /**
+     * Version column
+     *
+     * @Column(type="integer", name="version")
+     * @Version
+     */
+    public $version;
+
+    /**
+     * Category constructor.
+     *
+     */
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/VersionedOneToMany/Category.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToMany/Category.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Doctrine\Tests\Models\VersionedOneToMany;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ *
+ * @Entity
+ * @Table(name="category")
+ */
+class Category
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity="Article", mappedBy="category", cascade={"merge", "persist"})
+     */
+    public $articles;
+
+    /**
+     * @Column(name="name")
+     */
+    public $name;
+
+    /**
+     * Version column
+     *
+     * @Column(type="integer", name="version")
+     * @Version
+     */
+    public $version;
+
+    /**
+     * Category constructor.
+     *
+     */
+    public function __construct()
+    {
+        $this->articles = new ArrayCollection();
+    }
+
+
+}

--- a/tests/Doctrine/Tests/Models/VersionedOneToMany/Category.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToMany/Category.php
@@ -5,7 +5,6 @@ namespace Doctrine\Tests\Models\VersionedOneToMany;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- *
  * @Entity
  * @Table(name="category")
  */
@@ -38,12 +37,9 @@ class Category
 
     /**
      * Category constructor.
-     *
      */
     public function __construct()
     {
         $this->articles = new ArrayCollection();
     }
-
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\Tests\Models\VersionedOneToMany\Article;
+use Doctrine\Tests\Models\VersionedOneToMany\Category;
+use Doctrine\Tests\Models\VersionedOneToMany\Tag;
+
+/**
+ *
+ * @group MergeVersionedOneToMany
+ */
+class MergeVersionedOneToManyTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try {
+            $this->_schemaTool->createSchema(
+                [
+                    $this->_em->getClassMetadata(Category::class),
+                    $this->_em->getClassMetadata(Article::class),
+                ]
+            );
+        } catch (ORMException $e) {
+        }
+    }
+
+    /**
+     * This test case tests that a versionable entity, that has a oneToOne relationship as it's id can be created
+     *  without this bug fix (DDC-3318), you could not do this
+     */
+    public function testSetVersionOnCreate()
+    {
+        $category = new Category();
+        $category->name = 'Category';
+
+        $article = new Article();
+        $article->name = 'Article';
+        $article->category = $category;
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $mergeSucceed = false;
+        try {
+            $articleMerged = $this->_em->merge($article);
+            $mergeSucceed = true;
+        } catch (OptimisticLockException $e) {
+        }
+        $this->assertTrue($mergeSucceed);
+
+        $articleMerged->name = 'Article Merged';
+
+        $flushSucceed = false;
+        try {
+            $this->_em->flush();
+            $flushSucceed = true;
+        } catch (OptimisticLockException $e) {
+        }
+        $this->assertTrue($flushSucceed);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
@@ -29,8 +29,8 @@ class MergeVersionedOneToManyTest extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 
     /**
-     * This test case tests that a versionable entity, that has a oneToOne relationship as it's id can be created
-     *  without this bug fix (DDC-3318), you could not do this
+     * This test case asserts that a detached and unmodified entity could be merge without firing
+     * OptimisticLockException.
      */
     public function testSetVersionOnCreate()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeVersionedOneToManyTest.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
 use Doctrine\Tests\Models\VersionedOneToMany\Article;
 use Doctrine\Tests\Models\VersionedOneToMany\Category;
-use Doctrine\Tests\Models\VersionedOneToMany\Tag;
 
 /**
  *
@@ -21,8 +20,8 @@ class MergeVersionedOneToManyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                    $this->_em->getClassMetadata(Category::class),
-                    $this->_em->getClassMetadata(Article::class),
+                    $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToMany\Category'),
+                    $this->_em->getClassMetadata('Doctrine\Tests\Models\VersionedOneToMany\Article'),
                 ]
             );
         } catch (ORMException $e) {
@@ -46,22 +45,11 @@ class MergeVersionedOneToManyTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $mergeSucceed = false;
-        try {
-            $articleMerged = $this->_em->merge($article);
-            $mergeSucceed = true;
-        } catch (OptimisticLockException $e) {
-        }
-        $this->assertTrue($mergeSucceed);
+        $articleMerged = $this->_em->merge($article);
 
         $articleMerged->name = 'Article Merged';
 
-        $flushSucceed = false;
-        try {
-            $this->_em->flush();
-            $flushSucceed = true;
-        } catch (OptimisticLockException $e) {
-        }
-        $this->assertTrue($flushSucceed);
+        $this->_em->flush();
+        $this->assertEquals(2, $articleMerged->version);
     }
 }


### PR DESCRIPTION
I wrote a unit test that reveal the bug and a fix.

If I merge an entity which is associated to a versioned entity this fire a OptimisticLockException as the managedCopy is a Proxy so the version attribute is always null.

I think when we compare version attribute, we should skip it when one of the entity or the managed copy is a Proxy not initialized.
