### PR TITLE
deduplication of internal UnitOfWork methods

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3287,7 +3287,7 @@ class UnitOfWork implements PropertyChangedListener
 
         foreach (array_merge($this->persisters, $this->collectionPersisters) as $persister) {
             if ($persister instanceof CachedPersister) {
-                call_user_func($callback, $persister);
+                $callback($persister);
             }
         }
     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3273,16 +3273,18 @@ class UnitOfWork implements PropertyChangedListener
             $persister->afterTransactionRolledBack();
         });
     }
-    
+
     /**
      * Performs an action after the transaction.
+     *
+     * @param callable $callback
      */
     private function doAfterTransaction(callable $callback)
     {
-        if (!$this->hasCache) {
+        if ( ! $this->hasCache) {
             return;
         }
-        
+
         foreach (array_merge($this->persisters, $this->collectionPersisters) as $persister) {
             if ($persister instanceof CachedPersister) {
                 call_user_func($callback, $persister);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3259,7 +3259,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function afterTransactionComplete()
     {
-        $this->doAfterTransaction(function (CachedPersister $persister) {
+        $this->performCallbackOnCachedPersister(function (CachedPersister $persister) {
             $persister->afterTransactionComplete();
         });
     }
@@ -3269,7 +3269,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function afterTransactionRolledBack()
     {
-        $this->doAfterTransaction(function (CachedPersister $persister) {
+        $this->performCallbackOnCachedPersister(function (CachedPersister $persister) {
             $persister->afterTransactionRolledBack();
         });
     }
@@ -3279,7 +3279,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param callable $callback
      */
-    private function doAfterTransaction(callable $callback)
+    private function performCallbackOnCachedPersister(callable $callback)
     {
         if ( ! $this->hasCache) {
             return;


### PR DESCRIPTION
the methods UnitOfWork#afterTransactionRolledBack() and UnitOfWork#afterTransactionComplete do almost the same, so it can be abstracted into another private method.
