### PR TITLE
Chained selectable matching

### DIFF
--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -116,9 +116,27 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
      */
     public function matching(Criteria $criteria)
     {
-        $this->initialize();
+        if ($this->isInitialized()) {
+            return $this->collection->matching($criteria);
+        }
 
-        return $this->collection->matching($criteria);
+        $mergedCriteria = clone $this->criteria;
+
+        if (null !== $criteria->getWhereExpression()) {
+            $mergedCriteria->andWhere($criteria->getWhereExpression());
+        }
+
+        if (null !== $criteria->getFirstResult()) {
+            $mergedCriteria->setFirstResult($criteria->getFirstResult());
+        }
+
+        if (null !== $criteria->getMaxResults()) {
+            $mergedCriteria->setMaxResults($criteria->getMaxResults());
+        }
+
+        $mergedCriteria->orderBy($criteria->getOrderings());
+
+        return new self($this->entityPersister, $mergedCriteria);
     }
 
     /**

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -134,7 +134,10 @@ class LazyCriteriaCollection extends AbstractLazyCollection implements Selectabl
             $mergedCriteria->setMaxResults($criteria->getMaxResults());
         }
 
-        $mergedCriteria->orderBy($criteria->getOrderings());
+        $mergedCriteria->orderBy(array_merge(
+            $this->criteria->getOrderings(),
+            $criteria->getOrderings()
+        ));
 
         return new self($this->entityPersister, $mergedCriteria);
     }


### PR DESCRIPTION
The purpose is to make it possible to do selectable matching keeping the **_lazy behavior**_, aggregating the criterias until the collection is initialized(used)

``` php
$selectable->matching(Criteria::create())->matching(Criteria::create())->matching(Criteria::create());
```

The current behavior get the results as soon as you call the matching, and it forces us to build the full criteria before calling matching, however, if this change is approved it will do the query only when the selectable is in fact used (any other method)

PS: I ended up in this solution because the second call to matching (which should filter it on ArrayCollection) was giving me a collection with results I didn't expect to see, and that probably means that there is some sort of issue with ArrayCollection matching, but maybe I am missing something.

_I also would like some advice in the `$this->any()` on the tests. I did it  to make sure that the cloned mock will receive the same value provided in the original one, but I couldn't use `$this->once()`, because it would fail in the original mock._
