### PR TITLE
Switch to PHP 5.4+ array syntax

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -96,7 +96,7 @@ abstract class AbstractQuery
      *
      * @var array
      */
-    protected $_hints = array();
+    protected $_hints = [];
 
     /**
      * The hydration mode.
@@ -956,7 +956,7 @@ abstract class AbstractQuery
             }
 
             if ( ! $result) {
-                $result = array();
+                $result = [];
             }
 
             $setCacheEntry = function($data) use ($cache, $result, $cacheKey, $realCacheKey, $queryCacheProfile) {
@@ -1028,7 +1028,7 @@ abstract class AbstractQuery
      */
     protected function getHydrationCacheId()
     {
-        $parameters = array();
+        $parameters = [];
 
         foreach ($this->getParameters() as $parameter) {
             $parameters[$parameter->getName()] = $this->processParameterValue($parameter->getValue());
@@ -1090,7 +1090,7 @@ abstract class AbstractQuery
     {
         $this->parameters = new ArrayCollection();
 
-        $this->_hints = array();
+        $this->_hints = [];
         $this->_hints = $this->_em->getConfiguration()->getDefaultQueryHints();
     }
 

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -53,7 +53,7 @@ class DefaultCache implements Cache
     /**
      * @var \Doctrine\ORM\Cache\QueryCache[]
      */
-    private $queryCaches = array();
+    private $queryCaches = [];
 
     /**
      * @var \Doctrine\ORM\Cache\QueryCache
@@ -336,7 +336,7 @@ class DefaultCache implements Cache
             }
         }
 
-        return array($metadata->identifier[0] => $identifier);
+        return [$metadata->identifier[0] => $identifier];
     }
 
 }

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -64,7 +64,7 @@ class DefaultCacheFactory implements CacheFactory
     /**
      * @var \Doctrine\ORM\Cache\Region[]
      */
-    private $regions = array();
+    private $regions = [];
 
     /**
      * @var string|null
@@ -167,10 +167,10 @@ class DefaultCacheFactory implements CacheFactory
         return new DefaultQueryCache(
             $em,
             $this->getRegion(
-                array(
+                [
                     'region' => $regionName ?: Cache::DEFAULT_QUERY_REGION_NAME,
                     'usage'  => ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE
-                )
+                ]
             )
         );
     }

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -46,7 +46,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
@@ -62,7 +62,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
      */
     public function buildCacheEntry(ClassMetadata $metadata, CollectionCacheKey $key, $collection)
     {
-        $data = array();
+        $data = [];
 
         foreach ($collection as $index => $entity) {
             $data[$index] = new EntityCacheKey($metadata->name, $this->uow->getEntityIdentifier($entity));
@@ -79,7 +79,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
         /* @var $targetPersister \Doctrine\ORM\Cache\Persister\CachedPersister */
         $targetPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
         $targetRegion    = $targetPersister->getCacheRegion();
-        $list            = array();
+        $list            = [];
 
         $entityEntries = $targetRegion->getMultiple($entry);
 

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -55,7 +55,7 @@ class DefaultEntityHydrator implements EntityHydrator
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
@@ -138,7 +138,7 @@ class DefaultEntityHydrator implements EntityHydrator
                 $data[reset($assoc['joinColumnFieldNames'])] = $targetId;
 
                 $targetEntity = $this->em->getClassMetadata($assoc['targetEntity']);
-                $targetId     = array($targetEntity->identifier[0] => $targetId);
+                $targetId     = [$targetEntity->identifier[0] => $targetId];
             }
 
             $data[$name] = new AssociationCacheEntry($assoc['targetEntity'], $targetId);

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -66,7 +66,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * @var array
      */
-    private static $hints = array(Query::HINT_CACHE_ENABLED => true);
+    private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em     The entity manager.
@@ -86,7 +86,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * {@inheritdoc}
      */
-    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = array())
+    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = [])
     {
         if ( ! ($key->cacheMode & Cache::MODE_GET)) {
             return null;
@@ -104,7 +104,7 @@ class DefaultQueryCache implements QueryCache
             return null;
         }
 
-        $result      = array();
+        $result      = [];
         $entityName  = reset($rsm->aliasMap);
         $hasRelation = ( ! empty($rsm->relationMap));
         $persister   = $this->uow->getEntityPersister($entityName);
@@ -209,7 +209,7 @@ class DefaultQueryCache implements QueryCache
     /**
      * {@inheritdoc}
      */
-    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = array())
+    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = [])
     {
         if ($rsm->scalarMappings) {
             throw new CacheException("Second level cache does not support scalar results.");
@@ -231,7 +231,7 @@ class DefaultQueryCache implements QueryCache
             return false;
         }
 
-        $data        = array();
+        $data        = [];
         $entityName  = reset($rsm->aliasMap);
         $hasRelation = ( ! empty($rsm->relationMap));
         $metadata    = $this->em->getClassMetadata($entityName);
@@ -246,7 +246,7 @@ class DefaultQueryCache implements QueryCache
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
             $data[$index]['identifier']     = $identifier;
-            $data[$index]['associations']   = array();
+            $data[$index]['associations']   = [];
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey = new EntityCacheKey($entityName, $identifier))) {
                 // Cancel put result if entity put fail
@@ -285,17 +285,17 @@ class DefaultQueryCache implements QueryCache
                         }
                     }
 
-                    $data[$index]['associations'][$name] = array(
+                    $data[$index]['associations'][$name] = [
                         'targetEntity'  => $assocMetadata->rootEntityName,
                         'identifier'    => $assocIdentifier,
                         'type'          => $assoc['type']
-                    );
+                    ];
 
                     continue;
                 }
 
                 // Handle *-to-many associations
-                $list = array();
+                $list = [];
 
                 foreach ($assocValue as $assocItemIndex => $assocItem) {
                     $assocIdentifier = $this->uow->getEntityIdentifier($assocItem);
@@ -311,11 +311,11 @@ class DefaultQueryCache implements QueryCache
                     $list[$assocItemIndex] = $assocIdentifier;
                 }
 
-                $data[$index]['associations'][$name] = array(
+                $data[$index]['associations'][$name] = [
                     'targetEntity'  => $assocMetadata->rootEntityName,
                     'type'          => $assoc['type'],
                     'list'          => $list,
-                );
+                ];
             }
         }
 

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -35,7 +35,7 @@ class CacheLoggerChain implements CacheLogger
     /**
      * @var array<\Doctrine\ORM\Cache\Logging\CacheLogger>
      */
-    private $loggers = array();
+    private $loggers = [];
 
     /**
      * @param string                                  $name

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -35,17 +35,17 @@ class StatisticsCacheLogger implements CacheLogger
     /**
      * @var array
      */
-    private $cacheMissCountMap = array();
+    private $cacheMissCountMap = [];
 
     /**
      * @var array
      */
-    private $cacheHitCountMap = array();
+    private $cacheHitCountMap = [];
 
     /**
      * @var array
      */
-    private $cachePutCountMap = array();
+    private $cachePutCountMap = [];
 
     /**
      * {@inheritdoc}
@@ -214,9 +214,9 @@ class StatisticsCacheLogger implements CacheLogger
      */
     public function clearStats()
     {
-        $this->cachePutCountMap  = array();
-        $this->cacheHitCountMap  = array();
-        $this->cacheMissCountMap = array();
+        $this->cachePutCountMap  = [];
+        $this->cacheHitCountMap  = [];
+        $this->cacheMissCountMap = [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -70,7 +70,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      /**
      * @var array
      */
-    protected $queuedCache = array();
+    protected $queuedCache = [];
 
     /**
      * @var \Doctrine\ORM\Cache\Region

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -46,7 +46,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -54,7 +54,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
      */
     public function afterTransactionRolledBack()
     {
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -96,9 +96,9 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
 
         $this->persister->update($collection);
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = array(
+        $this->queuedCache['update'][spl_object_hash($collection)] = [
             'key'   => $key,
             'list'  => $collection
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -60,7 +60,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -80,7 +80,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -98,10 +98,10 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = array(
+        $this->queuedCache['delete'][spl_object_hash($collection)] = [
             'key'   => $key,
             'lock'  => $lock
-        );
+        ];
     }
 
     /**
@@ -126,9 +126,9 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = array(
+        $this->queuedCache['update'][spl_object_hash($collection)] = [
             'key'   => $key,
             'lock'  => $lock
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -64,7 +64,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      /**
      * @var array
      */
-    protected $queuedCache = array();
+    protected $queuedCache = [];
 
     /**
      * @var \Doctrine\ORM\Cache\Region
@@ -160,7 +160,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         return $this->persister->getCountSQL($criteria);
     }
@@ -249,7 +249,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     private function storeJoinedAssociations($entity)
     {
         if ($this->joinedAssociations === null) {
-            $associations = array();
+            $associations = [];
 
             foreach ($this->class->associationMappings as $name => $assoc) {
                 if (isset($assoc['cache']) &&
@@ -361,7 +361,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null)
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null)
     {
         if ($entity !== null || $assoc !== null || ! empty($hints) || $lockMode !== null) {
             return $this->persister->load($criteria, $entity, $assoc, $hints, $lockMode, $limit, $orderBy);
@@ -388,7 +388,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             return null;
         }
 
-        $cached = $queryCache->put($querykey, $rsm, array($result));
+        $cached = $queryCache->put($querykey, $rsm, [$result]);
 
         if ($this->cacheLogger) {
             if ($result) {
@@ -406,7 +406,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null)
     {
         $timestamp  = $this->timestampRegion->get($this->timestampKey);
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
@@ -497,7 +497,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritDoc}
      */
-    public function count($criteria = array())
+    public function count($criteria = [])
     {
         return $this->persister->count($criteria);
     }
@@ -616,7 +616,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array())
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = [])
     {
         return $this->persister->loadOneToOneEntity($assoc, $sourceEntity, $identifier);
     }

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -62,7 +62,7 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
             $this->timestampRegion->update($this->timestampKey);
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -70,7 +70,7 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
      */
     public function afterTransactionRolledBack()
     {
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -73,7 +73,7 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             $this->timestampRegion->update($this->timestampKey);
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -93,7 +93,7 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             }
         }
 
-        $this->queuedCache = array();
+        $this->queuedCache = [];
     }
 
     /**
@@ -113,10 +113,10 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             return $deleted;
         }
 
-        $this->queuedCache['delete'][] = array(
+        $this->queuedCache['delete'][] = [
             'lock'   => $lock,
             'key'    => $key
-        );
+        ];
 
         return $deleted;
     }
@@ -135,9 +135,9 @@ class ReadWriteCachedEntityPersister extends AbstractEntityPersister
             return;
         }
 
-        $this->queuedCache['update'][] = array(
+        $this->queuedCache['update'][] = [
             'lock'   => $lock,
             'key'    => $key
-        );
+        ];
     }
 }

--- a/lib/Doctrine/ORM/Cache/QueryCache.php
+++ b/lib/Doctrine/ORM/Cache/QueryCache.php
@@ -44,7 +44,7 @@ interface QueryCache
      *
      * @return boolean
      */
-    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = array());
+    public function put(QueryCacheKey $key, ResultSetMapping $rsm, $result, array $hints = []);
 
     /**
      * @param \Doctrine\ORM\Cache\QueryCacheKey     $key
@@ -53,7 +53,7 @@ interface QueryCache
      *
      * @return array|null
      */
-    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = array());
+    public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = []);
 
     /**
      * @return \Doctrine\ORM\Cache\Region

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -56,7 +56,7 @@ class DefaultMultiGetRegion extends DefaultRegion
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $keysToRetrieve = array();
+        $keysToRetrieve = [];
 
         foreach ($collection->identifiers as $index => $key) {
             $keysToRetrieve[$index] = $this->getCacheEntryKey($key);
@@ -67,7 +67,7 @@ class DefaultMultiGetRegion extends DefaultRegion
             return null;
         }
 
-        $returnableItems = array();
+        $returnableItems = [];
         foreach ($keysToRetrieve as $index => $key) {
             $returnableItems[$index] = $items[$key];
         }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -102,7 +102,7 @@ class DefaultRegion implements Region
      */
     public function getMultiple(CollectionCacheEntry $collection)
     {
-        $result = array();
+        $result = [];
 
         foreach ($collection->identifiers as $key) {
             $entryKey   = $this->getCacheEntryKey($key);

--- a/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
@@ -31,12 +31,12 @@ class RegionsConfiguration
     /**
      * @var array
      */
-    private $lifetimes = array();
+    private $lifetimes = [];
 
     /**
      * @var array
      */
-    private $lockLifetimes = array();
+    private $lockLifetimes = [];
 
     /**
      * @var integer

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -149,7 +149,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @return AnnotationDriver
      */
-    public function newDefaultAnnotationDriver($paths = array(), $useSimpleAnnotationReader = true)
+    public function newDefaultAnnotationDriver($paths = [], $useSimpleAnnotationReader = true)
     {
         AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');
 
@@ -349,7 +349,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addNamedNativeQuery($name, $sql, Query\ResultSetMapping $rsm)
     {
-        $this->_attributes['namedNativeQueries'][$name] = array($sql, $rsm);
+        $this->_attributes['namedNativeQueries'][$name] = [$sql, $rsm];
     }
 
     /**
@@ -590,7 +590,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function setCustomHydrationModes($modes)
     {
-        $this->_attributes['customHydrationModes'] = array();
+        $this->_attributes['customHydrationModes'] = [];
 
         foreach ($modes as $modeName => $hydrator) {
             $this->addCustomHydrationMode($modeName, $hydrator);
@@ -881,7 +881,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getDefaultQueryHints()
     {
-        return isset($this->_attributes['defaultQueryHints']) ? $this->_attributes['defaultQueryHints'] : array();
+        return isset($this->_attributes['defaultQueryHints']) ? $this->_attributes['defaultQueryHints'] : [];
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -383,7 +383,7 @@ use Doctrine\Common\Util\ClassUtils;
                 throw ORMInvalidArgumentException::invalidCompositeIdentifier();
             }
 
-            $id = array($class->identifier[0] => $id);
+            $id = [$class->identifier[0] => $id];
         }
 
         foreach ($id as $i => $value) {
@@ -396,7 +396,7 @@ use Doctrine\Common\Util\ClassUtils;
             }
         }
 
-        $sortedId = array();
+        $sortedId = [];
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
@@ -455,7 +455,7 @@ use Doctrine\Common\Util\ClassUtils;
                     throw TransactionRequiredException::transactionRequired();
                 }
 
-                return $persister->load($sortedId, null, null, array(), $lockMode);
+                return $persister->load($sortedId, null, null, [], $lockMode);
 
             default:
                 return $persister->loadById($sortedId);
@@ -470,10 +470,10 @@ use Doctrine\Common\Util\ClassUtils;
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
         if ( ! is_array($id)) {
-            $id = array($class->identifier[0] => $id);
+            $id = [$class->identifier[0] => $id];
         }
 
-        $sortedId = array();
+        $sortedId = [];
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
@@ -499,7 +499,7 @@ use Doctrine\Common\Util\ClassUtils;
 
         $entity = $this->proxyFactory->getProxy($class->name, $sortedId);
 
-        $this->unitOfWork->registerManaged($entity, $sortedId, array());
+        $this->unitOfWork->registerManaged($entity, $sortedId, []);
 
         return $entity;
     }
@@ -517,14 +517,14 @@ use Doctrine\Common\Util\ClassUtils;
         }
 
         if ( ! is_array($identifier)) {
-            $identifier = array($class->identifier[0] => $identifier);
+            $identifier = [$class->identifier[0] => $identifier];
         }
 
         $entity = $class->newInstance();
 
         $class->setIdentifierValues($entity, $identifier);
 
-        $this->unitOfWork->registerManaged($entity, $identifier, array());
+        $this->unitOfWork->registerManaged($entity, $identifier, []);
         $this->unitOfWork->markReadOnly($entity);
 
         return $entity;

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -37,7 +37,7 @@ class EntityNotFoundException extends ORMException
      */
     public static function fromClassNameAndIdentifier($className, array $id)
     {
-        $ids = array();
+        $ids = [];
 
         foreach ($id as $key => $value) {
             $ids[] = $key . '(' . $value . ')';

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -162,7 +162,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function findAll()
     {
-        return $this->findBy(array());
+        return $this->findBy([]);
     }
 
     /**
@@ -194,7 +194,7 @@ class EntityRepository implements ObjectRepository, Selectable
     {
         $persister = $this->_em->getUnitOfWork()->getEntityPersister($this->_entityName);
 
-        return $persister->load($criteria, null, null, array(), null, 1, $orderBy);
+        return $persister->load($criteria, null, null, [], null, 1, $orderBy);
     }
 
     /**
@@ -239,16 +239,16 @@ class EntityRepository implements ObjectRepository, Selectable
         if ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName)) {
             switch (count($arguments)) {
                 case 1:
-                    return $this->$method(array($fieldName => $arguments[0]));
+                    return $this->$method([$fieldName => $arguments[0]]);
 
                 case 2:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1]);
 
                 case 3:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1], $arguments[2]);
 
                 case 4:
-                    return $this->$method(array($fieldName => $arguments[0]), $arguments[1], $arguments[2], $arguments[3]);
+                    return $this->$method([$fieldName => $arguments[0]], $arguments[1], $arguments[2], $arguments[3]);
 
                 default:
                     // Do nothing

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -44,7 +44,7 @@ class AssignedGenerator extends AbstractIdGenerator
     {
         $class      = $em->getClassMetadata(get_class($entity));
         $idFields   = $class->getIdentifierFieldNames();
-        $identifier = array();
+        $identifier = [];
 
         foreach ($idFields as $idField) {
             $value = $class->getFieldValue($entity, $idField);

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -108,10 +108,10 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
      */
     public function serialize()
     {
-        return serialize(array(
+        return serialize([
             'allocationSize' => $this->_allocationSize,
             'sequenceName'   => $this->_sequenceName
-        ));
+        ]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -92,7 +92,7 @@ class TableGenerator extends AbstractIdGenerator
                         $this->_tableName, $this->_sequenceName, $this->_allocationSize
                     );
 
-                    if ($conn->executeUpdate($updateSql, array(1 => $currentLevel, 2 => $currentLevel+1)) !== 1) {
+                    if ($conn->executeUpdate($updateSql, [1 => $currentLevel, 2 => $currentLevel+1]) !== 1) {
                         // no affected rows, concurrency issue, throw exception
                     }
                 } else {

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -54,14 +54,14 @@ class CommitOrderCalculator
      *
      * @var array<stdClass>
      */
-    private $nodeList = array();
+    private $nodeList = [];
 
     /**
      * Volatile variable holding calculated nodes during sorting process.
      *
      * @var array
      */
-    private $sortedNodeList = array();
+    private $sortedNodeList = [];
 
     /**
      * Checks for node (vertex) existence in graph.
@@ -90,7 +90,7 @@ class CommitOrderCalculator
         $vertex->hash           = $hash;
         $vertex->state          = self::NOT_VISITED;
         $vertex->value          = $node;
-        $vertex->dependencyList = array();
+        $vertex->dependencyList = [];
 
         $this->nodeList[$hash] = $vertex;
     }
@@ -136,8 +136,8 @@ class CommitOrderCalculator
 
         $sortedList = $this->sortedNodeList;
 
-        $this->nodeList       = array();
-        $this->sortedNodeList = array();
+        $this->nodeList       = [];
+        $this->sortedNodeList = [];
 
         return array_reverse($sortedList);
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -69,14 +69,14 @@ abstract class AbstractHydrator
      *
      * @var array
      */
-    protected $_metadataCache = array();
+    protected $_metadataCache = [];
 
     /**
      * The cache used during row-by-row hydration.
      *
      * @var array
      */
-    protected $_cache = array();
+    protected $_cache = [];
 
     /**
      * The statement that provides the data to hydrate.
@@ -113,7 +113,7 @@ abstract class AbstractHydrator
      *
      * @return IterableResult
      */
-    public function iterate($stmt, $resultSetMapping, array $hints = array())
+    public function iterate($stmt, $resultSetMapping, array $hints = [])
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;
@@ -121,7 +121,7 @@ abstract class AbstractHydrator
 
         $evm = $this->_em->getEventManager();
 
-        $evm->addEventListener(array(Events::onClear), $this);
+        $evm->addEventListener([Events::onClear], $this);
 
         $this->prepare();
 
@@ -137,7 +137,7 @@ abstract class AbstractHydrator
      *
      * @return array
      */
-    public function hydrateAll($stmt, $resultSetMapping, array $hints = array())
+    public function hydrateAll($stmt, $resultSetMapping, array $hints = [])
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;
@@ -168,7 +168,7 @@ abstract class AbstractHydrator
             return false;
         }
 
-        $result = array();
+        $result = [];
 
         $this->hydrateRowData($row, $result);
 
@@ -209,8 +209,8 @@ abstract class AbstractHydrator
 
         $this->_stmt          = null;
         $this->_rsm           = null;
-        $this->_cache         = array();
-        $this->_metadataCache = array();
+        $this->_cache         = [];
+        $this->_metadataCache = [];
     }
 
     /**
@@ -255,7 +255,7 @@ abstract class AbstractHydrator
      */
     protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents)
     {
-        $rowData = array('data' => array());
+        $rowData = ['data' => []];
 
         foreach ($data as $key => $value) {
             if (($cacheKeyInfo = $this->hydrateColumnInfo($key)) === null) {
@@ -323,7 +323,7 @@ abstract class AbstractHydrator
      */
     protected function gatherScalarRowData(&$data)
     {
-        $rowData = array();
+        $rowData = [];
 
         foreach ($data as $key => $value) {
             if (($cacheKeyInfo = $this->hydrateColumnInfo($key)) === null) {
@@ -369,18 +369,18 @@ abstract class AbstractHydrator
                 $fieldName     = $this->_rsm->fieldMappings[$key];
                 $fieldMapping  = $classMetadata->fieldMappings[$fieldName];
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isIdentifier' => in_array($fieldName, $classMetadata->identifier),
                     'fieldName'    => $fieldName,
                     'type'         => Type::getType($fieldMapping['type']),
                     'dqlAlias'     => $this->_rsm->columnOwnerMap[$key],
-                );
+                ];
 
             case (isset($this->_rsm->newObjectMappings[$key])):
                 // WARNING: A NEW object is also a scalar, so it must be declared before!
                 $mapping = $this->_rsm->newObjectMappings[$key];
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isScalar'             => true,
                     'isNewObjectParameter' => true,
                     'fieldName'            => $this->_rsm->scalarMappings[$key],
@@ -388,14 +388,14 @@ abstract class AbstractHydrator
                     'argIndex'             => $mapping['argIndex'],
                     'objIndex'             => $mapping['objIndex'],
                     'class'                => new \ReflectionClass($mapping['className']),
-                );
+                ];
 
             case (isset($this->_rsm->scalarMappings[$key])):
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isScalar'  => true,
                     'fieldName' => $this->_rsm->scalarMappings[$key],
                     'type'      => Type::getType($this->_rsm->typeMappings[$key]),
-                );
+                ];
 
             case (isset($this->_rsm->metaMappings[$key])):
                 // Meta column (has meaning in relational schema only, i.e. foreign keys or discriminator columns).
@@ -408,13 +408,13 @@ abstract class AbstractHydrator
                 // Cache metadata fetch
                 $this->getClassMetadata($this->_rsm->aliasMap[$dqlAlias]);
 
-                return $this->_cache[$key] = array(
+                return $this->_cache[$key] = [
                     'isIdentifier' => isset($this->_rsm->isIdentifierColumn[$dqlAlias][$key]),
                     'isMetaColumn' => true,
                     'fieldName'    => $fieldName,
                     'type'         => $type,
                     'dqlAlias'     => $dqlAlias,
-                );
+                ];
         }
 
         // this column is a left over, maybe from a LIMIT query hack for example in Oracle or DB2
@@ -452,7 +452,7 @@ abstract class AbstractHydrator
     protected function registerManaged(ClassMetadata $class, $entity, array $data)
     {
         if ($class->isIdentifierComposite) {
-            $id = array();
+            $id = [];
 
             foreach ($class->identifier as $fieldName) {
                 $id[$fieldName] = isset($class->associationMappings[$fieldName])
@@ -461,11 +461,11 @@ abstract class AbstractHydrator
             }
         } else {
             $fieldName = $class->identifier[0];
-            $id        = array(
+            $id        = [
                 $fieldName => isset($class->associationMappings[$fieldName])
                     ? $data[$class->associationMappings[$fieldName]['joinColumns'][0]['name']]
                     : $data[$fieldName]
-            );
+            ];
         }
 
         $this->_em->getUnitOfWork()->registerManaged($entity, $id, $data);

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -35,7 +35,7 @@ class ArrayHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $_rootAliases = array();
+    private $_rootAliases = [];
 
     /**
      * @var bool
@@ -45,17 +45,17 @@ class ArrayHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $_identifierMap = array();
+    private $_identifierMap = [];
 
     /**
      * @var array
      */
-    private $_resultPointers = array();
+    private $_resultPointers = [];
 
     /**
      * @var array
      */
-    private $_idTemplate = array();
+    private $_idTemplate = [];
 
     /**
      * @var int
@@ -70,8 +70,8 @@ class ArrayHydrator extends AbstractHydrator
         $this->_isSimpleQuery = count($this->_rsm->aliasMap) <= 1;
 
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
-            $this->_identifierMap[$dqlAlias]  = array();
-            $this->_resultPointers[$dqlAlias] = array();
+            $this->_identifierMap[$dqlAlias]  = [];
+            $this->_resultPointers[$dqlAlias] = [];
             $this->_idTemplate[$dqlAlias]     = '';
         }
     }
@@ -81,7 +81,7 @@ class ArrayHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($data = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($data, $result);
@@ -97,7 +97,7 @@ class ArrayHydrator extends AbstractHydrator
     {
         // 1) Initialize
         $id = $this->_idTemplate; // initialize the id-memory
-        $nonemptyComponents = array();
+        $nonemptyComponents = [];
         $rowData = $this->gatherRowData($row, $id, $nonemptyComponents);
 
         // 2) Now hydrate the data found in the current row.
@@ -138,7 +138,7 @@ class ArrayHydrator extends AbstractHydrator
                     $oneToOne = false;
 
                     if ( ! isset($baseElement[$relationAlias])) {
-                        $baseElement[$relationAlias] = array();
+                        $baseElement[$relationAlias] = [];
                     }
 
                     if (isset($nonemptyComponents[$dqlAlias])) {
@@ -187,7 +187,7 @@ class ArrayHydrator extends AbstractHydrator
                 // if this row has a NULL value for the root result id then make it a null result.
                 if ( ! isset($nonemptyComponents[$dqlAlias]) ) {
                     $result[] = $this->_rsm->isMixed
-                        ? array($entityKey => null)
+                        ? [$entityKey => null]
                         : null;
 
                     $resultKey = $this->_resultCounter;
@@ -199,7 +199,7 @@ class ArrayHydrator extends AbstractHydrator
                 // Check for an existing element
                 if ($this->_isSimpleQuery || ! isset($this->_identifierMap[$dqlAlias][$id[$dqlAlias]])) {
                     $element = $this->_rsm->isMixed
-                        ? array($entityKey => $data)
+                        ? [$entityKey => $data]
                         : $data;
 
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -45,17 +45,17 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $identifierMap = array();
+    private $identifierMap = [];
 
     /**
      * @var array
      */
-    private $resultPointers = array();
+    private $resultPointers = [];
 
     /**
      * @var array
      */
-    private $idTemplate = array();
+    private $idTemplate = [];
 
     /**
      * @var integer
@@ -65,17 +65,17 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * @var array
      */
-    private $rootAliases = array();
+    private $rootAliases = [];
 
     /**
      * @var array
      */
-    private $initializedCollections = array();
+    private $initializedCollections = [];
 
     /**
      * @var array
      */
-    private $existingCollections = array();
+    private $existingCollections = [];
 
     /**
      * {@inheritdoc}
@@ -87,7 +87,7 @@ class ObjectHydrator extends AbstractHydrator
         }
 
         foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
-            $this->identifierMap[$dqlAlias] = array();
+            $this->identifierMap[$dqlAlias] = [];
             $this->idTemplate[$dqlAlias]    = '';
 
             // Remember which associations are "fetch joined", so that we know where to inject
@@ -145,7 +145,7 @@ class ObjectHydrator extends AbstractHydrator
         $this->identifierMap =
         $this->initializedCollections =
         $this->existingCollections =
-        $this->resultPointers = array();
+        $this->resultPointers = [];
 
         if ($eagerLoad) {
             $this->_uow->triggerEagerLoads();
@@ -159,7 +159,7 @@ class ObjectHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($row = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($row, $result);
@@ -328,7 +328,7 @@ class ObjectHydrator extends AbstractHydrator
     {
         // Initialize
         $id = $this->idTemplate; // initialize the id-memory
-        $nonemptyComponents = array();
+        $nonemptyComponents = [];
         // Split the row data into chunks of class data.
         $rowData = $this->gatherRowData($row, $id, $nonemptyComponents);
 
@@ -477,7 +477,7 @@ class ObjectHydrator extends AbstractHydrator
                 // if this row has a NULL value for the root result id then make it a null result.
                 if ( ! isset($nonemptyComponents[$dqlAlias]) ) {
                     if ($this->_rsm->isMixed) {
-                        $result[] = array($entityKey => null);
+                        $result[] = [$entityKey => null];
                     } else {
                         $result[] = null;
                     }
@@ -491,7 +491,7 @@ class ObjectHydrator extends AbstractHydrator
                     $element = $this->getEntity($data, $dqlAlias);
 
                     if ($this->_rsm->isMixed) {
-                        $element = array($entityKey => $element);
+                        $element = [$entityKey => $element];
                     }
 
                     if (isset($this->_rsm->indexByMap[$dqlAlias])) {
@@ -586,10 +586,10 @@ class ObjectHydrator extends AbstractHydrator
         parent::onClear($eventArgs);
 
         $aliases             = array_keys($this->identifierMap);
-        $this->identifierMap = array();
+        $this->identifierMap = [];
 
         foreach ($aliases as $alias) {
-            $this->identifierMap[$alias] = array();
+            $this->identifierMap[$alias] = [];
         }
     }
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
@@ -35,7 +35,7 @@ class ScalarHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($data = $this->_stmt->fetch(\PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($data, $result);

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -63,7 +63,7 @@ class SimpleObjectHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $result = array();
+        $result = [];
 
         while ($row = $this->_stmt->fetch(PDO::FETCH_ASSOC)) {
             $this->hydrateRowData($row, $result);
@@ -80,7 +80,7 @@ class SimpleObjectHydrator extends AbstractHydrator
     protected function hydrateRowData(array $sqlResult, array &$result)
     {
         $entityName = $this->class->name;
-        $data       = array();
+        $data       = [];
 
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -47,7 +47,7 @@ final class HydrationCompleteHandler
     /**
      * @var array[]
      */
-    private $deferredPostLoadInvocations = array();
+    private $deferredPostLoadInvocations = [];
 
     /**
      * Constructor for this object
@@ -75,7 +75,7 @@ final class HydrationCompleteHandler
             return;
         }
 
-        $this->deferredPostLoadInvocations[] = array($class, $invoke, $entity);
+        $this->deferredPostLoadInvocations[] = [$class, $invoke, $entity];
     }
 
     /**
@@ -86,7 +86,7 @@ final class HydrationCompleteHandler
     public function hydrationComplete()
     {
         $toInvoke                          = $this->deferredPostLoadInvocations;
-        $this->deferredPostLoadInvocations = array();
+        $this->deferredPostLoadInvocations = [];
 
         foreach ($toInvoke as $classAndEntity) {
             list($class, $invoke, $entity) = $classAndEntity;

--- a/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
@@ -82,7 +82,7 @@ class AssociationBuilder
      */
     public function cascadeAll()
     {
-        $this->mapping['cascade'] = array("ALL");
+        $this->mapping['cascade'] = ["ALL"];
         return $this;
     }
 
@@ -172,14 +172,14 @@ class AssociationBuilder
      */
     public function addJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
-        $this->joinColumns[] = array(
+        $this->joinColumns[] = [
             'name' => $columnName,
             'referencedColumnName' => $referencedColumnName,
             'nullable' => $nullable,
             'unique' => $unique,
             'onDelete' => $onDelete,
             'columnDefinition' => $columnDef,
-        );
+        ];
         return $this;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -91,11 +91,11 @@ class ClassMetadataBuilder
      */
     public function addEmbedded($fieldName, $class, $columnPrefix = null)
     {
-        $this->cm->mapEmbedded(array(
+        $this->cm->mapEmbedded([
             'fieldName'    => $fieldName,
             'class'        => $class,
             'columnPrefix' => $columnPrefix
-        ));
+        ]);
 
         return $this;
     }
@@ -135,7 +135,7 @@ class ClassMetadataBuilder
      */
     public function setTable($name)
     {
-        $this->cm->setPrimaryTable(array('name' => $name));
+        $this->cm->setPrimaryTable(['name' => $name]);
 
         return $this;
     }
@@ -151,10 +151,10 @@ class ClassMetadataBuilder
     public function addIndex(array $columns, $name)
     {
         if (!isset($this->cm->table['indexes'])) {
-            $this->cm->table['indexes'] = array();
+            $this->cm->table['indexes'] = [];
         }
 
-        $this->cm->table['indexes'][$name] = array('columns' => $columns);
+        $this->cm->table['indexes'][$name] = ['columns' => $columns];
 
         return $this;
     }
@@ -170,10 +170,10 @@ class ClassMetadataBuilder
     public function addUniqueConstraint(array $columns, $name)
     {
         if ( ! isset($this->cm->table['uniqueConstraints'])) {
-            $this->cm->table['uniqueConstraints'] = array();
+            $this->cm->table['uniqueConstraints'] = [];
         }
 
-        $this->cm->table['uniqueConstraints'][$name] = array('columns' => $columns);
+        $this->cm->table['uniqueConstraints'][$name] = ['columns' => $columns];
 
         return $this;
     }
@@ -188,10 +188,10 @@ class ClassMetadataBuilder
      */
     public function addNamedQuery($name, $dqlQuery)
     {
-        $this->cm->addNamedQuery(array(
+        $this->cm->addNamedQuery([
             'name' => $name,
             'query' => $dqlQuery,
-        ));
+        ]);
 
         return $this;
     }
@@ -231,11 +231,11 @@ class ClassMetadataBuilder
      */
     public function setDiscriminatorColumn($name, $type = 'string', $length = 255)
     {
-        $this->cm->setDiscriminatorColumn(array(
+        $this->cm->setDiscriminatorColumn([
             'name' => $name,
             'type' => $type,
             'length' => $length,
-        ));
+        ]);
 
         return $this;
     }
@@ -303,7 +303,7 @@ class ClassMetadataBuilder
      *
      * @return ClassMetadataBuilder
      */
-    public function addField($name, $type, array $mapping = array())
+    public function addField($name, $type, array $mapping = [])
     {
         $mapping['fieldName'] = $name;
         $mapping['type'] = $type;
@@ -325,10 +325,10 @@ class ClassMetadataBuilder
     {
         return new FieldBuilder(
             $this,
-            array(
+            [
                 'fieldName' => $name,
                 'type'      => $type
-            )
+            ]
         );
     }
 
@@ -344,11 +344,11 @@ class ClassMetadataBuilder
     {
         return new EmbeddedBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $fieldName,
                 'class'        => $class,
                 'columnPrefix' => null
-            )
+            ]
         );
     }
 
@@ -386,10 +386,10 @@ class ClassMetadataBuilder
     {
         return new AssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::MANY_TO_ONE
         );
     }
@@ -406,10 +406,10 @@ class ClassMetadataBuilder
     {
         return new AssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::ONE_TO_ONE
         );
     }
@@ -463,10 +463,10 @@ class ClassMetadataBuilder
     {
         return new ManyToManyAssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::MANY_TO_MANY
         );
     }
@@ -520,10 +520,10 @@ class ClassMetadataBuilder
     {
         return new OneToManyAssociationBuilder(
             $this,
-            array(
+            [
                 'fieldName'    => $name,
                 'targetEntity' => $targetEntity
-            ),
+            ],
             ClassMetadata::ONE_TO_MANY
         );
     }

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -34,7 +34,7 @@ class EntityListenerBuilder
     /**
      * @var array Hash-map to handle event names.
      */
-    static private $events = array(
+    static private $events = [
         Events::preRemove   => true,
         Events::postRemove  => true,
         Events::prePersist  => true,
@@ -43,7 +43,7 @@ class EntityListenerBuilder
         Events::postUpdate  => true,
         Events::postLoad    => true,
         Events::preFlush    => true
-    );
+    ];
 
     /**
      * Lookup the entity class to find methods that match to event lifecycle names

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -216,11 +216,11 @@ class FieldBuilder
      */
     public function setSequenceGenerator($sequenceName, $allocationSize = 1, $initialValue = 1)
     {
-        $this->sequenceDef = array(
+        $this->sequenceDef = [
             'sequenceName' => $sequenceName,
             'allocationSize' => $allocationSize,
             'initialValue' => $initialValue,
-        );
+        ];
         return $this;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -37,7 +37,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     /**
      * @var array
      */
-    private $inverseJoinColumns = array();
+    private $inverseJoinColumns = [];
 
     /**
      * @param string $name
@@ -64,14 +64,14 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
      */
     public function addInverseJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
-        $this->inverseJoinColumns[] = array(
+        $this->inverseJoinColumns[] = [
             'name' => $columnName,
             'referencedColumnName' => $referencedColumnName,
             'nullable' => $nullable,
             'unique' => $unique,
             'onDelete' => $onDelete,
             'columnDefinition' => $columnDef,
-        );
+        ];
         return $this;
     }
 
@@ -81,7 +81,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     public function build()
     {
         $mapping = $this->mapping;
-        $mapping['joinTable'] = array();
+        $mapping['joinTable'] = [];
         if ($this->joinColumns) {
             $mapping['joinTable']['joinColumns'] = $this->joinColumns;
         }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -68,7 +68,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * @var array
      */
-    private $embeddablesActiveNesting = array();
+    private $embeddablesActiveNesting = [];
 
     /**
      * {@inheritDoc}
@@ -350,9 +350,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         $allClasses = $this->driver->getAllClassNames();
         $fqcn = $class->getName();
-        $map = array($this->getShortName($class->name) => $fqcn);
+        $map = [$this->getShortName($class->name) => $fqcn];
 
-        $duplicates = array();
+        $duplicates = [];
         foreach ($allClasses as $subClassCandidate) {
             if (is_subclass_of($subClassCandidate, $fqcn)) {
                 $shortName = $this->getShortName($subClassCandidate);
@@ -474,7 +474,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
             $embeddableMetadata = $this->getMetadataFor($embeddableClass['class']);
 
-            $parentClass->mapEmbedded(array(
+            $parentClass->mapEmbedded([
                 'fieldName' => $prefix . '.' . $property,
                 'class' => $embeddableMetadata->name,
                 'columnPrefix' => $embeddableClass['columnPrefix'],
@@ -482,7 +482,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         ? $prefix . '.' . $embeddableClass['declaredField']
                         : $prefix,
                 'originalField' => $embeddableClass['originalField'] ?: $property,
-            ));
+            ]);
         }
     }
 
@@ -500,7 +500,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             return;
         }
 
-        foreach (array('uniqueConstraints', 'indexes') as $indexType) {
+        foreach (['uniqueConstraints', 'indexes'] as $indexType) {
             if (isset($parentClass->table[$indexType])) {
                 foreach ($parentClass->table[$indexType] as $indexName => $index) {
                     if (isset($subClass->table[$indexType][$indexName])) {
@@ -527,10 +527,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedQueries as $name => $query) {
             if ( ! isset ($subClass->namedQueries[$name])) {
-                $subClass->addNamedQuery(array(
+                $subClass->addNamedQuery([
                     'name'  => $query['name'],
                     'query' => $query['query']
-                ));
+                ]);
             }
         }
     }
@@ -549,13 +549,13 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->namedNativeQueries as $name => $query) {
             if ( ! isset ($subClass->namedNativeQueries[$name])) {
-                $subClass->addNamedNativeQuery(array(
+                $subClass->addNamedNativeQuery([
                     'name'              => $query['name'],
                     'query'             => $query['query'],
                     'isSelfClass'       => $query['isSelfClass'],
                     'resultSetMapping'  => $query['resultSetMapping'],
                     'resultClass'       => $query['isSelfClass'] ? $subClass->name : $query['resultClass'],
-                ));
+                ]);
             }
         }
     }
@@ -574,21 +574,21 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->sqlResultSetMappings as $name => $mapping) {
             if ( ! isset ($subClass->sqlResultSetMappings[$name])) {
-                $entities = array();
+                $entities = [];
                 foreach ($mapping['entities'] as $entity) {
-                    $entities[] = array(
+                    $entities[] = [
                         'fields'                => $entity['fields'],
                         'isSelfClass'           => $entity['isSelfClass'],
                         'discriminatorColumn'   => $entity['discriminatorColumn'],
                         'entityClass'           => $entity['isSelfClass'] ? $subClass->name : $entity['entityClass'],
-                    );
+                    ];
                 }
 
-                $subClass->addSqlResultSetMapping(array(
+                $subClass->addSqlResultSetMapping([
                     'name'          => $mapping['name'],
                     'columns'       => $mapping['columns'],
                     'entities'      => $entities,
-                ));
+                ]);
             }
         }
     }
@@ -628,9 +628,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
                     $sequencePrefix = $class->getSequencePrefix($this->getTargetPlatform());
                     $sequenceName   = $this->getTargetPlatform()->getIdentitySequenceName($sequencePrefix, $columnName);
-                    $definition     = array(
+                    $definition     = [
                         'sequenceName' => $this->getTargetPlatform()->fixSchemaElementName($sequenceName)
-                    );
+                    ];
 
                     if ($quoted) {
                         $definition['quoted'] = true;
@@ -660,11 +660,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $sequenceName   = $class->getSequenceName($this->getTargetPlatform());
                     $quoted         = isset($class->fieldMappings[$fieldName]['quoted']) || isset($class->table['quoted']);
 
-                    $definition = array(
+                    $definition = [
                         'sequenceName'      => $this->getTargetPlatform()->fixSchemaElementName($sequenceName),
                         'allocationSize'    => 1,
                         'initialValue'      => 1,
-                    );
+                    ];
 
                     if ($quoted) {
                         $definition['quoted'] = true;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -275,28 +275,28 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $parentClasses = array();
+    public $parentClasses = [];
 
     /**
      * READ-ONLY: The names of all subclasses (descendants).
      *
      * @var array
      */
-    public $subClasses = array();
+    public $subClasses = [];
 
     /**
      * READ-ONLY: The names of all embedded classes based on properties.
      *
      * @var array
      */
-    public $embeddedClasses = array();
+    public $embeddedClasses = [];
 
     /**
      * READ-ONLY: The named queries allowed to be called directly from Repository.
      *
      * @var array
      */
-    public $namedQueries = array();
+    public $namedQueries = [];
 
     /**
      * READ-ONLY: The named native queries allowed to be called directly from Repository.
@@ -313,7 +313,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $namedNativeQueries = array();
+    public $namedNativeQueries = [];
 
     /**
      * READ-ONLY: The mappings of the results of native SQL queries.
@@ -329,7 +329,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $sqlResultSetMappings = array();
+    public $sqlResultSetMappings = [];
 
     /**
      * READ-ONLY: The field names of all fields that are part of the identifier/primary key
@@ -337,7 +337,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $identifier = array();
+    public $identifier = [];
 
     /**
      * READ-ONLY: The inheritance mapping type used by the class.
@@ -394,7 +394,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $fieldMappings = array();
+    public $fieldMappings = [];
 
     /**
      * READ-ONLY: An array of field names. Used to look up field names from column names.
@@ -402,7 +402,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $fieldNames = array();
+    public $fieldNames = [];
 
     /**
      * READ-ONLY: A map of field names to column names. Keys are field names and values column names.
@@ -413,7 +413,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @deprecated 3.0 Remove this.
      */
-    public $columnNames = array();
+    public $columnNames = [];
 
     /**
      * READ-ONLY: The discriminator value of this class.
@@ -437,7 +437,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see discriminatorColumn
      */
-    public $discriminatorMap = array();
+    public $discriminatorMap = [];
 
     /**
      * READ-ONLY: The definition of the discriminator column used in JOINED and SINGLE_TABLE
@@ -465,14 +465,14 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $lifecycleCallbacks = array();
+    public $lifecycleCallbacks = [];
 
     /**
      * READ-ONLY: The registered entity listeners.
      *
      * @var array
      */
-    public $entityListeners = array();
+    public $entityListeners = [];
 
     /**
      * READ-ONLY: The association mappings of this class.
@@ -529,7 +529,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var array
      */
-    public $associationMappings = array();
+    public $associationMappings = [];
 
     /**
      * READ-ONLY: Flag indicating whether the identifier/primary key of the class is composite.
@@ -642,7 +642,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @var \ReflectionProperty[]
      */
-    public $reflFields = array();
+    public $reflFields = [];
 
     /**
      * @var \Doctrine\Instantiator\InstantiatorInterface|null
@@ -714,7 +714,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function getIdentifierValues($entity)
     {
         if ($this->isIdentifierComposite) {
-            $id = array();
+            $id = [];
 
             foreach ($this->identifier as $idField) {
                 $value = $this->reflFields[$idField]->getValue($entity);
@@ -731,10 +731,10 @@ class ClassMetadataInfo implements ClassMetadata
         $value = $this->reflFields[$id]->getValue($entity);
 
         if (null === $value) {
-            return array();
+            return [];
         }
 
-        return array($id => $value);
+        return [$id => $value];
     }
 
     /**
@@ -809,7 +809,7 @@ class ClassMetadataInfo implements ClassMetadata
     public function __sleep()
     {
         // This metadata is always serialized/cached.
-        $serialized = array(
+        $serialized = [
             'associationMappings',
             'columnNames', //TODO: 3.0 Remove this. Can use fieldMappings[$fieldName]['columnName']
             'fieldMappings',
@@ -822,7 +822,7 @@ class ClassMetadataInfo implements ClassMetadata
             'table',
             'rootEntityName',
             'idGenerator', //TODO: Does not really need to be serialized. Could be moved to runtime.
-        );
+        ];
 
         // The rest of the metadata is only serialized if necessary.
         if ($this->changeTrackingPolicy != self::CHANGETRACKING_DEFERRED_IMPLICIT) {
@@ -924,7 +924,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->reflClass    = $reflService->getClass($this->name);
         $this->instantiator = $this->instantiator ?: new Instantiator();
 
-        $parentReflFields = array();
+        $parentReflFields = [];
 
         foreach ($this->embeddedClasses as $property => $embeddedClass) {
             if (isset($embeddedClass['declaredField'])) {
@@ -1536,15 +1536,15 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         // Cascades
-        $cascades = isset($mapping['cascade']) ? array_map('strtolower', $mapping['cascade']) : array();
+        $cascades = isset($mapping['cascade']) ? array_map('strtolower', $mapping['cascade']) : [];
 
         if (in_array('all', $cascades)) {
-            $cascades = array('remove', 'persist', 'refresh', 'merge', 'detach');
+            $cascades = ['remove', 'persist', 'refresh', 'merge', 'detach'];
         }
 
-        if (count($cascades) !== count(array_intersect($cascades, array('remove', 'persist', 'refresh', 'merge', 'detach')))) {
+        if (count($cascades) !== count(array_intersect($cascades, ['remove', 'persist', 'refresh', 'merge', 'detach']))) {
             throw MappingException::invalidCascadeOption(
-                array_diff($cascades, array_intersect($cascades, array('remove', 'persist', 'refresh', 'merge', 'detach'))),
+                array_diff($cascades, array_intersect($cascades, ['remove', 'persist', 'refresh', 'merge', 'detach'])),
                 $this->name,
                 $mapping['fieldName']
             );
@@ -1581,15 +1581,15 @@ class ClassMetadataInfo implements ClassMetadata
         if ($mapping['isOwningSide']) {
             if ( ! isset($mapping['joinColumns']) || ! $mapping['joinColumns']) {
                 // Apply default join column
-                $mapping['joinColumns'] = array(
-                    array(
+                $mapping['joinColumns'] = [
+                    [
                         'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName()
-                    )
-                );
+                    ]
+                ];
             }
 
-            $uniqueConstraintColumns = array();
+            $uniqueConstraintColumns = [];
 
             foreach ($mapping['joinColumns'] as &$joinColumn) {
                 if ($mapping['type'] === self::ONE_TO_ONE && ! $this->isInheritanceTypeSingleTable()) {
@@ -1631,9 +1631,9 @@ class ClassMetadataInfo implements ClassMetadata
                     throw new RuntimeException("ClassMetadataInfo::setTable() has to be called before defining a one to one relationship.");
                 }
 
-                $this->table['uniqueConstraints'][$mapping['fieldName'] . "_uniq"] = array(
+                $this->table['uniqueConstraints'][$mapping['fieldName'] . "_uniq"] = [
                     'columns' => $uniqueConstraintColumns
-                );
+                ];
             }
 
             $mapping['targetToSourceKeyColumns'] = array_flip($mapping['sourceToTargetKeyColumns']);
@@ -1707,26 +1707,26 @@ class ClassMetadataInfo implements ClassMetadata
                 && (! (isset($mapping['joinTable']['joinColumns']) || isset($mapping['joinTable']['inverseJoinColumns'])));
 
             if ( ! isset($mapping['joinTable']['joinColumns'])) {
-                $mapping['joinTable']['joinColumns'] = array(
-                    array(
+                $mapping['joinTable']['joinColumns'] = [
+                    [
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['sourceEntity'], $selfReferencingEntityWithoutJoinColumns ? 'source' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
                         'onDelete' => 'CASCADE'
-                    )
-                );
+                    ]
+                ];
             }
 
             if ( ! isset($mapping['joinTable']['inverseJoinColumns'])) {
-                $mapping['joinTable']['inverseJoinColumns'] = array(
-                    array(
+                $mapping['joinTable']['inverseJoinColumns'] = [
+                    [
                         'name' => $this->namingStrategy->joinKeyColumnName($mapping['targetEntity'], $selfReferencingEntityWithoutJoinColumns ? 'target' : null),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
                         'onDelete' => 'CASCADE'
-                    )
-                );
+                    ]
+                ];
             }
 
-            $mapping['joinTableColumns'] = array();
+            $mapping['joinTableColumns'] = [];
 
             foreach ($mapping['joinTable']['joinColumns'] as &$joinColumn) {
                 if (empty($joinColumn['name'])) {
@@ -1876,7 +1876,7 @@ class ClassMetadataInfo implements ClassMetadata
             return array_keys($this->fieldNames);
         }
 
-        $columnNames = array();
+        $columnNames = [];
 
         foreach ($fieldNames as $fieldName) {
             $columnNames[] = $this->getColumnName($fieldName);
@@ -1892,7 +1892,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getIdentifierColumnNames()
     {
-        $columnNames = array();
+        $columnNames = [];
 
         foreach ($this->identifier as $idProperty) {
             if (isset($this->fieldMappings[$idProperty])) {
@@ -2429,11 +2429,11 @@ class ClassMetadataInfo implements ClassMetadata
         $query  = $queryMapping['query'];
         $dql    = str_replace('__CLASS__', $this->name, $query);
 
-        $this->namedQueries[$name] = array(
+        $this->namedQueries[$name] = [
             'name'  => $name,
             'query' => $query,
             'dql'   => $dql,
-        );
+        ];
     }
 
     /**
@@ -2675,7 +2675,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getLifecycleCallbacks($event)
     {
-        return isset($this->lifecycleCallbacks[$event]) ? $this->lifecycleCallbacks[$event] : array();
+        return isset($this->lifecycleCallbacks[$event]) ? $this->lifecycleCallbacks[$event] : [];
     }
 
     /**
@@ -2721,10 +2721,10 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $class    = $this->fullyQualifiedClassName($class);
 
-        $listener = array(
+        $listener = [
             'class'  => $class,
             'method' => $method,
-        );
+        ];
 
         if ( ! class_exists($class)) {
             throw MappingException::entityListenerClassNotFound($class, $this->name);
@@ -2771,7 +2771,7 @@ class ClassMetadataInfo implements ClassMetadata
                 $columnDef['type'] = "string";
             }
 
-            if (in_array($columnDef['type'], array("boolean", "array", "object", "datetime", "time", "date"))) {
+            if (in_array($columnDef['type'], ["boolean", "array", "object", "datetime", "time", "date"])) {
                 throw MappingException::invalidDiscriminatorColumnType($this->name, $columnDef['type']);
             }
 
@@ -3039,7 +3039,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->versionField = $mapping['fieldName'];
 
         if ( ! isset($mapping['default'])) {
-            if (in_array($mapping['type'], array('integer', 'bigint', 'smallint'))) {
+            if (in_array($mapping['type'], ['integer', 'bigint', 'smallint'])) {
                 $mapping['default'] = 1;
             } else if ($mapping['type'] == 'datetime') {
                 $mapping['default'] = 'CURRENT_TIMESTAMP';
@@ -3133,7 +3133,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getQuotedIdentifierColumnNames($platform)
     {
-        $quotedColumnNames = array();
+        $quotedColumnNames = [];
 
         foreach ($this->identifier as $idProperty) {
             if (isset($this->fieldMappings[$idProperty])) {
@@ -3235,7 +3235,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getAssociationsByTargetClass($targetClass)
     {
-        $relations = array();
+        $relations = [];
 
         foreach ($this->associationMappings as $mapping) {
             if ($mapping['targetEntity'] == $targetClass) {
@@ -3288,12 +3288,12 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $this->assertFieldNotMapped($mapping['fieldName']);
 
-        $this->embeddedClasses[$mapping['fieldName']] = array(
+        $this->embeddedClasses[$mapping['fieldName']] = [
             'class' => $this->fullyQualifiedClassName($mapping['class']),
             'columnPrefix' => $mapping['columnPrefix'],
             'declaredField' => isset($mapping['declaredField']) ? $mapping['declaredField'] : null,
             'originalField' => isset($mapping['originalField']) ? $mapping['originalField'] : null,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -67,7 +67,7 @@ final class Column implements Annotation
     /**
      * @var array
      */
-    public $options = array();
+    public $options = [];
 
     /**
      * @var string

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -31,7 +31,7 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
     /**
      * @var array Map to store entity listener instances.
      */
-    private $instances = array();
+    private $instances = [];
 
     /**
      * {@inheritdoc}
@@ -39,7 +39,7 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
     public function clear($className = null)
     {
         if ($className === null) {
-            $this->instances = array();
+            $this->instances = [];
 
             return;
         }

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -116,7 +116,7 @@ class DefaultQuoteStrategy implements QuoteStrategy
      */
     public function getIdentifierColumnNames(ClassMetadata $class, AbstractPlatform $platform)
     {
-        $quotedColumnNames = array();
+        $quotedColumnNames = [];
 
         foreach ($class->identifier as $fieldName) {
             if (isset($class->fieldMappings[$fieldName])) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -42,10 +42,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
     /**
      * {@inheritDoc}
      */
-    protected $entityAnnotationClasses = array(
+    protected $entityAnnotationClasses = [
         'Doctrine\ORM\Mapping\Entity' => 1,
         'Doctrine\ORM\Mapping\MappedSuperclass' => 2,
-    );
+    ];
 
     /**
      * {@inheritDoc}
@@ -97,14 +97,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
         // Evaluate Table annotation
         if (isset($classAnnotations['Doctrine\ORM\Mapping\Table'])) {
             $tableAnnot   = $classAnnotations['Doctrine\ORM\Mapping\Table'];
-            $primaryTable = array(
+            $primaryTable = [
                 'name'   => $tableAnnot->name,
                 'schema' => $tableAnnot->schema
-            );
+            ];
 
             if ($tableAnnot->indexes !== null) {
                 foreach ($tableAnnot->indexes as $indexAnnot) {
-                    $index = array('columns' => $indexAnnot->columns);
+                    $index = ['columns' => $indexAnnot->columns];
 
                     if ( ! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
@@ -124,7 +124,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             if ($tableAnnot->uniqueConstraints !== null) {
                 foreach ($tableAnnot->uniqueConstraints as $uniqueConstraintAnnot) {
-                    $uniqueConstraint = array('columns' => $uniqueConstraintAnnot->columns);
+                    $uniqueConstraint = ['columns' => $uniqueConstraintAnnot->columns];
 
                     if ( ! empty($uniqueConstraintAnnot->options)) {
                         $uniqueConstraint['options'] = $uniqueConstraintAnnot->options;
@@ -148,10 +148,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
         // Evaluate @Cache annotation
         if (isset($classAnnotations['Doctrine\ORM\Mapping\Cache'])) {
             $cacheAnnot = $classAnnotations['Doctrine\ORM\Mapping\Cache'];
-            $cacheMap   = array(
+            $cacheMap   = [
                 'region' => $cacheAnnot->region,
                 'usage'  => constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $cacheAnnot->usage),
-            );
+            ];
 
             $metadata->enableCache($cacheMap);
         }
@@ -161,12 +161,12 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $namedNativeQueriesAnnot = $classAnnotations['Doctrine\ORM\Mapping\NamedNativeQueries'];
 
             foreach ($namedNativeQueriesAnnot->value as $namedNativeQuery) {
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => $namedNativeQuery->name,
                     'query'             => $namedNativeQuery->query,
                     'resultClass'       => $namedNativeQuery->resultClass,
                     'resultSetMapping'  => $namedNativeQuery->resultSetMapping,
-                ));
+                ]);
             }
         }
 
@@ -175,36 +175,36 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $sqlResultSetMappingsAnnot = $classAnnotations['Doctrine\ORM\Mapping\SqlResultSetMappings'];
 
             foreach ($sqlResultSetMappingsAnnot->value as $resultSetMapping) {
-                $entities = array();
-                $columns  = array();
+                $entities = [];
+                $columns  = [];
                 foreach ($resultSetMapping->entities as $entityResultAnnot) {
-                    $entityResult = array(
-                        'fields'                => array(),
+                    $entityResult = [
+                        'fields'                => [],
                         'entityClass'           => $entityResultAnnot->entityClass,
                         'discriminatorColumn'   => $entityResultAnnot->discriminatorColumn,
-                    );
+                    ];
 
                     foreach ($entityResultAnnot->fields as $fieldResultAnnot) {
-                        $entityResult['fields'][] = array(
+                        $entityResult['fields'][] = [
                             'name'      => $fieldResultAnnot->name,
                             'column'    => $fieldResultAnnot->column
-                        );
+                        ];
                     }
 
                     $entities[] = $entityResult;
                 }
 
                 foreach ($resultSetMapping->columns as $columnResultAnnot) {
-                    $columns[] = array(
+                    $columns[] = [
                         'name' => $columnResultAnnot->name,
-                    );
+                    ];
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => $resultSetMapping->name,
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -220,10 +220,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 if ( ! ($namedQuery instanceof \Doctrine\ORM\Mapping\NamedQuery)) {
                     throw new \UnexpectedValueException("@NamedQueries should contain an array of @NamedQuery annotations.");
                 }
-                $metadata->addNamedQuery(array(
+                $metadata->addNamedQuery([
                     'name'  => $namedQuery->name,
                     'query' => $namedQuery->query
-                ));
+                ]);
             }
         }
 
@@ -240,14 +240,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 if (isset($classAnnotations['Doctrine\ORM\Mapping\DiscriminatorColumn'])) {
                     $discrColumnAnnot = $classAnnotations['Doctrine\ORM\Mapping\DiscriminatorColumn'];
 
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name'             => $discrColumnAnnot->name,
                         'type'             => $discrColumnAnnot->type,
                         'length'           => $discrColumnAnnot->length,
                         'columnDefinition' => $discrColumnAnnot->columnDefinition,
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate DiscriminatorMap annotation
@@ -278,18 +278,18 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 continue;
             }
 
-            $mapping = array();
+            $mapping = [];
             $mapping['fieldName'] = $property->getName();
 
             // Evaluate @Cache annotation
             if (($cacheAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Cache')) !== null) {
-                $mapping['cache'] = $metadata->getAssociationCacheDefaults($mapping['fieldName'], array(
+                $mapping['cache'] = $metadata->getAssociationCacheDefaults($mapping['fieldName'], [
                         'usage'         => constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $cacheAnnot->usage),
                         'region'        => $cacheAnnot->region,
-                ));
+                ]);
             }
             // Check for JoinColumn/JoinColumns annotations
-            $joinColumns = array();
+            $joinColumns = [];
 
             if ($joinColumnAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinColumn')) {
                 $joinColumns[] = $this->joinColumnToArray($joinColumnAnnot);
@@ -324,17 +324,17 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 // Check for SequenceGenerator/TableGenerator definition
                 if ($seqGeneratorAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\SequenceGenerator')) {
-                    $metadata->setSequenceGeneratorDefinition(array(
+                    $metadata->setSequenceGeneratorDefinition([
                         'sequenceName' => $seqGeneratorAnnot->sequenceName,
                         'allocationSize' => $seqGeneratorAnnot->allocationSize,
                         'initialValue' => $seqGeneratorAnnot->initialValue
-                    ));
+                    ]);
                 } else if ($this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\TableGenerator')) {
                     throw MappingException::tableIdGeneratorNotImplemented($className);
                 } else if ($customGeneratorAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\CustomIdGenerator')) {
-                    $metadata->setCustomGeneratorDefinition(array(
+                    $metadata->setCustomGeneratorDefinition([
                         'class' => $customGeneratorAnnot->class
-                    ));
+                    ]);
                 }
             } else if ($oneToOneAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\OneToOne')) {
                 if ($idAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Id')) {
@@ -374,13 +374,13 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $mapping['fetch'] = $this->getFetchMode($className, $manyToOneAnnot->fetch);
                 $metadata->mapManyToOne($mapping);
             } else if ($manyToManyAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\ManyToMany')) {
-                $joinTable = array();
+                $joinTable = [];
 
                 if ($joinTableAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\JoinTable')) {
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => $joinTableAnnot->name,
                         'schema' => $joinTableAnnot->schema
-                    );
+                    ];
 
                     foreach ($joinTableAnnot->joinColumns as $joinColumn) {
                         $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumn);
@@ -418,12 +418,12 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $associationOverridesAnnot = $classAnnotations['Doctrine\ORM\Mapping\AssociationOverrides'];
 
             foreach ($associationOverridesAnnot->value as $associationOverride) {
-                $override   = array();
+                $override   = [];
                 $fieldName  = $associationOverride->name;
 
                 // Check for JoinColumn/JoinColumns annotations
                 if ($associationOverride->joinColumns) {
-                    $joinColumns = array();
+                    $joinColumns = [];
 
                     foreach ($associationOverride->joinColumns as $joinColumn) {
                         $joinColumns[] = $this->joinColumnToArray($joinColumn);
@@ -435,10 +435,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 // Check for JoinTable annotations
                 if ($associationOverride->joinTable) {
                     $joinTableAnnot = $associationOverride->joinTable;
-                    $joinTable      = array(
+                    $joinTable      = [
                         'name'      => $joinTableAnnot->name,
                         'schema'    => $joinTableAnnot->schema
-                    );
+                    ];
 
                     foreach ($joinTableAnnot->joinColumns as $joinColumn) {
                         $joinTable['joinColumns'][] = $this->joinColumnToArray($joinColumn);
@@ -542,40 +542,40 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function getMethodCallbacks(\ReflectionMethod $method)
     {
-        $callbacks   = array();
+        $callbacks   = [];
         $annotations = $this->reader->getMethodAnnotations($method);
 
         foreach ($annotations as $annot) {
             if ($annot instanceof \Doctrine\ORM\Mapping\PrePersist) {
-                $callbacks[] = array($method->name, Events::prePersist);
+                $callbacks[] = [$method->name, Events::prePersist];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostPersist) {
-                $callbacks[] = array($method->name, Events::postPersist);
+                $callbacks[] = [$method->name, Events::postPersist];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreUpdate) {
-                $callbacks[] = array($method->name, Events::preUpdate);
+                $callbacks[] = [$method->name, Events::preUpdate];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostUpdate) {
-                $callbacks[] = array($method->name, Events::postUpdate);
+                $callbacks[] = [$method->name, Events::postUpdate];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreRemove) {
-                $callbacks[] = array($method->name, Events::preRemove);
+                $callbacks[] = [$method->name, Events::preRemove];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostRemove) {
-                $callbacks[] = array($method->name, Events::postRemove);
+                $callbacks[] = [$method->name, Events::postRemove];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PostLoad) {
-                $callbacks[] = array($method->name, Events::postLoad);
+                $callbacks[] = [$method->name, Events::postLoad];
             }
 
             if ($annot instanceof \Doctrine\ORM\Mapping\PreFlush) {
-                $callbacks[] = array($method->name, Events::preFlush);
+                $callbacks[] = [$method->name, Events::preFlush];
             }
         }
 
@@ -590,14 +590,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function joinColumnToArray(JoinColumn $joinColumn)
     {
-        return array(
+        return [
             'name' => $joinColumn->name,
             'unique' => $joinColumn->unique,
             'nullable' => $joinColumn->nullable,
             'onDelete' => $joinColumn->onDelete,
             'columnDefinition' => $joinColumn->columnDefinition,
             'referencedColumnName' => $joinColumn->referencedColumnName,
-        );
+        ];
     }
 
     /**
@@ -610,7 +610,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      */
     private function columnToArray($fieldName, Column $column)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => $fieldName,
             'type'      => $column->type,
             'scale'     => $column->scale,
@@ -618,7 +618,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             'unique'    => $column->unique,
             'nullable'  => $column->nullable,
             'precision' => $column->precision
-        );
+        ];
 
         if ($column->options) {
             $mapping['options'] = $column->options;
@@ -643,7 +643,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *
      * @return AnnotationDriver
      */
-    static public function create($paths = array(), AnnotationReader $reader = null)
+    static public function create($paths = [], AnnotationReader $reader = null)
     {
         if ($reader == null) {
             $reader = new AnnotationReader();

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -54,22 +54,22 @@ class DatabaseDriver implements MappingDriver
     /**
      * @var array
      */
-    private $classToTableNames = array();
+    private $classToTableNames = [];
 
     /**
      * @var array
      */
-    private $manyToManyTables = array();
+    private $manyToManyTables = [];
 
     /**
      * @var array
      */
-    private $classNamesForTables = array();
+    private $classNamesForTables = [];
 
     /**
      * @var array
      */
-    private $fieldNamesForColumns = array();
+    private $fieldNamesForColumns = [];
 
     /**
      * The namespace for the generated entities.
@@ -153,7 +153,7 @@ class DatabaseDriver implements MappingDriver
      */
     public function setTables($entityTables, $manyToManyTables)
     {
-        $this->tables = $this->manyToManyTables = $this->classToTableNames = array();
+        $this->tables = $this->manyToManyTables = $this->classToTableNames = [];
 
         foreach ($entityTables as $table) {
             $className = $this->getClassNameForTable($table->getName());
@@ -212,36 +212,36 @@ class DatabaseDriver implements MappingDriver
 
                 $localColumn = current($myFk->getColumns());
 
-                $associationMapping = array();
+                $associationMapping = [];
                 $associationMapping['fieldName'] = $this->getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
                 $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
 
                 if (current($manyTable->getColumns())->getName() == $localColumn) {
                     $associationMapping['inversedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
-                    $associationMapping['joinTable'] = array(
+                    $associationMapping['joinTable'] = [
                         'name' => strtolower($manyTable->getName()),
-                        'joinColumns' => array(),
-                        'inverseJoinColumns' => array(),
-                    );
+                        'joinColumns' => [],
+                        'inverseJoinColumns' => [],
+                    ];
 
                     $fkCols = $myFk->getForeignColumns();
                     $cols = $myFk->getColumns();
 
                     for ($i = 0; $i < count($cols); $i++) {
-                        $associationMapping['joinTable']['joinColumns'][] = array(
+                        $associationMapping['joinTable']['joinColumns'][] = [
                             'name' => $cols[$i],
                             'referencedColumnName' => $fkCols[$i],
-                        );
+                        ];
                     }
 
                     $fkCols = $otherFk->getForeignColumns();
                     $cols = $otherFk->getColumns();
 
                     for ($i = 0; $i < count($cols); $i++) {
-                        $associationMapping['joinTable']['inverseJoinColumns'][] = array(
+                        $associationMapping['joinTable']['inverseJoinColumns'][] = [
                             'name' => $cols[$i],
                             'referencedColumnName' => $fkCols[$i],
-                        );
+                        ];
                     }
                 } else {
                     $associationMapping['mappedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
@@ -265,20 +265,20 @@ class DatabaseDriver implements MappingDriver
             return;
         }
 
-        $tables = array();
+        $tables = [];
 
         foreach ($this->_sm->listTableNames() as $tableName) {
             $tables[$tableName] = $this->_sm->listTableDetails($tableName);
         }
 
-        $this->tables = $this->manyToManyTables = $this->classToTableNames = array();
+        $this->tables = $this->manyToManyTables = $this->classToTableNames = [];
 
         foreach ($tables as $tableName => $table) {
             $foreignKeys = ($this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints())
                 ? $table->getForeignKeys()
-                : array();
+                : [];
 
-            $allForeignKeyColumns = array();
+            $allForeignKeyColumns = [];
 
             foreach ($foreignKeys as $foreignKey) {
                 $allForeignKeyColumns = array_merge($allForeignKeyColumns, $foreignKey->getLocalColumns());
@@ -345,14 +345,14 @@ class DatabaseDriver implements MappingDriver
         $columns        = $this->tables[$tableName]->getColumns();
         $primaryKeys    = $this->getTablePrimaryKeys($this->tables[$tableName]);
         $foreignKeys    = $this->getTableForeignKeys($this->tables[$tableName]);
-        $allForeignKeys = array();
+        $allForeignKeys = [];
 
         foreach ($foreignKeys as $foreignKey) {
             $allForeignKeys = array_merge($allForeignKeys, $foreignKey->getLocalColumns());
         }
 
-        $ids           = array();
-        $fieldMappings = array();
+        $ids           = [];
+        $fieldMappings = [];
 
         foreach ($columns as $column) {
             if (in_array($column->getName(), $allForeignKeys)) {
@@ -389,12 +389,12 @@ class DatabaseDriver implements MappingDriver
      */
     private function buildFieldMapping($tableName, Column $column)
     {
-        $fieldMapping = array(
+        $fieldMapping = [
             'fieldName'  => $this->getFieldNameForColumn($tableName, $column->getName(), false),
             'columnName' => $column->getName(),
             'type'       => $column->getType()->getName(),
             'nullable'   => ( ! $column->getNotNull()),
-        );
+        ];
 
         // Type specific elements
         switch ($fieldMapping['type']) {
@@ -452,10 +452,10 @@ class DatabaseDriver implements MappingDriver
             $fkColumns          = $foreignKey->getColumns();
             $fkForeignColumns   = $foreignKey->getForeignColumns();
             $localColumn        = current($fkColumns);
-            $associationMapping = array(
+            $associationMapping = [
                 'fieldName'    => $this->getFieldNameForColumn($tableName, $localColumn, true),
                 'targetEntity' => $this->getClassNameForTable($foreignTableName),
-            );
+            ];
 
             if (isset($metadata->fieldMappings[$associationMapping['fieldName']])) {
                 $associationMapping['fieldName'] .= '2'; // "foo" => "foo2"
@@ -466,10 +466,10 @@ class DatabaseDriver implements MappingDriver
             }
 
             for ($i = 0; $i < count($fkColumns); $i++) {
-                $associationMapping['joinColumns'][] = array(
+                $associationMapping['joinColumns'][] = [
                     'name'                 => $fkColumns[$i],
                     'referencedColumnName' => $fkForeignColumns[$i],
-                );
+                ];
             }
 
             // Here we need to check if $fkColumns are the same as $primaryKeys
@@ -492,7 +492,7 @@ class DatabaseDriver implements MappingDriver
     {
         return ($this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints())
             ? $table->getForeignKeys()
-            : array();
+            : [];
     }
 
     /**
@@ -510,7 +510,7 @@ class DatabaseDriver implements MappingDriver
             // Do nothing
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -76,7 +76,7 @@ class XmlDriver extends FileDriver
         }
 
         // Evaluate <entity...> attributes
-        $primaryTable = array();
+        $primaryTable = [];
 
         if (isset($xmlRoot['table'])) {
             $primaryTable['name'] = (string) $xmlRoot['table'];
@@ -96,44 +96,44 @@ class XmlDriver extends FileDriver
         // Evaluate named queries
         if (isset($xmlRoot->{'named-queries'})) {
             foreach ($xmlRoot->{'named-queries'}->{'named-query'} as $namedQueryElement) {
-                $metadata->addNamedQuery(array(
+                $metadata->addNamedQuery([
                     'name'  => (string)$namedQueryElement['name'],
                     'query' => (string)$namedQueryElement['query']
-                ));
+                ]);
             }
         }
 
         // Evaluate native named queries
         if (isset($xmlRoot->{'named-native-queries'})) {
             foreach ($xmlRoot->{'named-native-queries'}->{'named-native-query'} as $nativeQueryElement) {
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => isset($nativeQueryElement['name']) ? (string)$nativeQueryElement['name'] : null,
                     'query'             => isset($nativeQueryElement->query) ? (string)$nativeQueryElement->query : null,
                     'resultClass'       => isset($nativeQueryElement['result-class']) ? (string)$nativeQueryElement['result-class'] : null,
                     'resultSetMapping'  => isset($nativeQueryElement['result-set-mapping']) ? (string)$nativeQueryElement['result-set-mapping'] : null,
-                ));
+                ]);
             }
         }
 
         // Evaluate sql result set mapping
         if (isset($xmlRoot->{'sql-result-set-mappings'})) {
             foreach ($xmlRoot->{'sql-result-set-mappings'}->{'sql-result-set-mapping'} as $rsmElement) {
-                $entities   = array();
-                $columns    = array();
+                $entities   = [];
+                $columns    = [];
                 foreach ($rsmElement as $entityElement) {
                     //<entity-result/>
                     if (isset($entityElement['entity-class'])) {
-                        $entityResult = array(
-                            'fields'                => array(),
+                        $entityResult = [
+                            'fields'                => [],
                             'entityClass'           => (string)$entityElement['entity-class'],
                             'discriminatorColumn'   => isset($entityElement['discriminator-column']) ? (string)$entityElement['discriminator-column'] : null,
-                        );
+                        ];
 
                         foreach ($entityElement as $fieldElement) {
-                            $entityResult['fields'][] = array(
+                            $entityResult['fields'][] = [
                                 'name'      => isset($fieldElement['name']) ? (string)$fieldElement['name'] : null,
                                 'column'    => isset($fieldElement['column']) ? (string)$fieldElement['column'] : null,
-                            );
+                            ];
                         }
 
                         $entities[] = $entityResult;
@@ -141,17 +141,17 @@ class XmlDriver extends FileDriver
 
                     //<column-result/>
                     if (isset($entityElement['name'])) {
-                        $columns[] = array(
+                        $columns[] = [
                             'name' => (string)$entityElement['name'],
-                        );
+                        ];
                     }
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => (string)$rsmElement['name'],
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -163,19 +163,19 @@ class XmlDriver extends FileDriver
                 // Evaluate <discriminator-column...>
                 if (isset($xmlRoot->{'discriminator-column'})) {
                     $discrColumn = $xmlRoot->{'discriminator-column'};
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name' => isset($discrColumn['name']) ? (string)$discrColumn['name'] : null,
                         'type' => isset($discrColumn['type']) ? (string)$discrColumn['type'] : null,
                         'length' => isset($discrColumn['length']) ? (string)$discrColumn['length'] : null,
                         'columnDefinition' => isset($discrColumn['column-definition']) ? (string)$discrColumn['column-definition'] : null
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate <discriminator-map...>
                 if (isset($xmlRoot->{'discriminator-map'})) {
-                    $map = array();
+                    $map = [];
                     foreach ($xmlRoot->{'discriminator-map'}->{'discriminator-mapping'} as $discrMapElement) {
                         $map[(string)$discrMapElement['value']] = (string)$discrMapElement['class'];
                     }
@@ -193,9 +193,9 @@ class XmlDriver extends FileDriver
 
         // Evaluate <indexes...>
         if (isset($xmlRoot->indexes)) {
-            $metadata->table['indexes'] = array();
+            $metadata->table['indexes'] = [];
             foreach ($xmlRoot->indexes->index as $indexXml) {
-                $index = array('columns' => explode(',', (string) $indexXml['columns']));
+                $index = ['columns' => explode(',', (string) $indexXml['columns'])];
 
                 if (isset($indexXml['flags'])) {
                     $index['flags'] = explode(',', (string) $indexXml['flags']);
@@ -215,9 +215,9 @@ class XmlDriver extends FileDriver
 
         // Evaluate <unique-constraints..>
         if (isset($xmlRoot->{'unique-constraints'})) {
-            $metadata->table['uniqueConstraints'] = array();
+            $metadata->table['uniqueConstraints'] = [];
             foreach ($xmlRoot->{'unique-constraints'}->{'unique-constraint'} as $uniqueXml) {
-                $unique = array('columns' => explode(',', (string) $uniqueXml['columns']));
+                $unique = ['columns' => explode(',', (string) $uniqueXml['columns'])];
 
 
                 if (isset($uniqueXml->options)) {
@@ -238,7 +238,7 @@ class XmlDriver extends FileDriver
 
         // The mapping assignment is done in 2 times as a bug might occurs on some php/xml lib versions
         // The internal SimpleXmlIterator get resetted, to this generate a duplicate field exception
-        $mappings = array();
+        $mappings = [];
         // Evaluate <field ...> mappings
         if (isset($xmlRoot->field)) {
             foreach ($xmlRoot->field as $fieldMapping) {
@@ -263,11 +263,11 @@ class XmlDriver extends FileDriver
                     ? $this->evaluateBoolean($embeddedMapping['use-column-prefix'])
                     : true;
 
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
                     'columnPrefix' => $useColumnPrefix ? $columnPrefix : false
-                );
+                ];
 
                 $metadata->mapEmbedded($mapping);
             }
@@ -282,17 +282,17 @@ class XmlDriver extends FileDriver
         }
 
         // Evaluate <id ...> mappings
-        $associationIds = array();
+        $associationIds = [];
         foreach ($xmlRoot->id as $idElement) {
             if (isset($idElement['association-key']) && $this->evaluateBoolean($idElement['association-key'])) {
                 $associationIds[(string)$idElement['name']] = true;
                 continue;
             }
 
-            $mapping = array(
+            $mapping = [
                 'id' => true,
                 'fieldName' => (string)$idElement['name']
-            );
+            ];
 
             if (isset($idElement['type'])) {
                 $mapping['type'] = (string)$idElement['type'];
@@ -326,16 +326,16 @@ class XmlDriver extends FileDriver
             // Check for SequenceGenerator/TableGenerator definition
             if (isset($idElement->{'sequence-generator'})) {
                 $seqGenerator = $idElement->{'sequence-generator'};
-                $metadata->setSequenceGeneratorDefinition(array(
+                $metadata->setSequenceGeneratorDefinition([
                     'sequenceName' => (string)$seqGenerator['sequence-name'],
                     'allocationSize' => (string)$seqGenerator['allocation-size'],
                     'initialValue' => (string)$seqGenerator['initial-value']
-                ));
+                ]);
             } else if (isset($idElement->{'custom-id-generator'})) {
                 $customGenerator = $idElement->{'custom-id-generator'};
-                $metadata->setCustomGeneratorDefinition(array(
+                $metadata->setCustomGeneratorDefinition([
                     'class' => (string) $customGenerator['class']
-                ));
+                ]);
             } else if (isset($idElement->{'table-generator'})) {
                 throw MappingException::tableIdGeneratorNotImplemented($className);
             }
@@ -344,10 +344,10 @@ class XmlDriver extends FileDriver
         // Evaluate <one-to-one ...> mappings
         if (isset($xmlRoot->{'one-to-one'})) {
             foreach ($xmlRoot->{'one-to-one'} as $oneToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$oneToOneElement['field'],
                     'targetEntity' => (string)$oneToOneElement['target-entity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -363,7 +363,7 @@ class XmlDriver extends FileDriver
                     if (isset($oneToOneElement['inversed-by'])) {
                         $mapping['inversedBy'] = (string)$oneToOneElement['inversed-by'];
                     }
-                    $joinColumns = array();
+                    $joinColumns = [];
 
                     if (isset($oneToOneElement->{'join-column'})) {
                         $joinColumns[] = $this->joinColumnToArray($oneToOneElement->{'join-column'});
@@ -396,11 +396,11 @@ class XmlDriver extends FileDriver
         // Evaluate <one-to-many ...> mappings
         if (isset($xmlRoot->{'one-to-many'})) {
             foreach ($xmlRoot->{'one-to-many'} as $oneToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$oneToManyElement['field'],
                     'targetEntity' => (string)$oneToManyElement['target-entity'],
                     'mappedBy' => (string)$oneToManyElement['mapped-by']
-                );
+                ];
 
                 if (isset($oneToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string)$oneToManyElement['fetch']);
@@ -415,7 +415,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($oneToManyElement->{'order-by'})) {
-                    $orderBy = array();
+                    $orderBy = [];
                     foreach ($oneToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
                         $orderBy[(string)$orderByField['name']] = (string)$orderByField['direction'];
                     }
@@ -440,10 +440,10 @@ class XmlDriver extends FileDriver
         // Evaluate <many-to-one ...> mappings
         if (isset($xmlRoot->{'many-to-one'})) {
             foreach ($xmlRoot->{'many-to-one'} as $manyToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$manyToOneElement['field'],
                     'targetEntity' => (string)$manyToOneElement['target-entity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -457,7 +457,7 @@ class XmlDriver extends FileDriver
                     $mapping['inversedBy'] = (string)$manyToOneElement['inversed-by'];
                 }
 
-                $joinColumns = array();
+                $joinColumns = [];
 
                 if (isset($manyToOneElement->{'join-column'})) {
                     $joinColumns[] = $this->joinColumnToArray($manyToOneElement->{'join-column'});
@@ -486,10 +486,10 @@ class XmlDriver extends FileDriver
         // Evaluate <many-to-many ...> mappings
         if (isset($xmlRoot->{'many-to-many'})) {
             foreach ($xmlRoot->{'many-to-many'} as $manyToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => (string)$manyToManyElement['field'],
                     'targetEntity' => (string)$manyToManyElement['target-entity']
-                );
+                ];
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string)$manyToManyElement['fetch']);
@@ -507,9 +507,9 @@ class XmlDriver extends FileDriver
                     }
 
                     $joinTableElement = $manyToManyElement->{'join-table'};
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => (string)$joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = (string)$joinTableElement['schema'];
@@ -531,7 +531,7 @@ class XmlDriver extends FileDriver
                 }
 
                 if (isset($manyToManyElement->{'order-by'})) {
-                    $orderBy = array();
+                    $orderBy = [];
                     foreach ($manyToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
                         $orderBy[(string)$orderByField['name']] = (string)$orderByField['direction'];
                     }
@@ -569,11 +569,11 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'association-overrides'})) {
             foreach ($xmlRoot->{'association-overrides'}->{'association-override'} as $overrideElement) {
                 $fieldName  = (string) $overrideElement['name'];
-                $override   = array();
+                $override   = [];
 
                 // Check for join-columns
                 if (isset($overrideElement->{'join-columns'})) {
-                    $joinColumns = array();
+                    $joinColumns = [];
                     foreach ($overrideElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
                         $joinColumns[] = $this->joinColumnToArray($joinColumnElement);
                     }
@@ -585,10 +585,10 @@ class XmlDriver extends FileDriver
                     $joinTable          = null;
                     $joinTableElement   = $overrideElement->{'join-table'};
 
-                    $joinTable = array(
+                    $joinTable = [
                         'name'      => (string) $joinTableElement['name'],
                         'schema'    => (string) $joinTableElement['schema']
-                    );
+                    ];
 
                     if (isset($joinTableElement->{'join-columns'})) {
                         foreach ($joinTableElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
@@ -651,7 +651,7 @@ class XmlDriver extends FileDriver
      */
     private function _parseOptions(SimpleXMLElement $options)
     {
-        $array = array();
+        $array = [];
 
         /* @var $option SimpleXMLElement */
         foreach ($options as $option) {
@@ -683,10 +683,10 @@ class XmlDriver extends FileDriver
      */
     private function joinColumnToArray(SimpleXMLElement $joinColumnElement)
     {
-        $joinColumn = array(
+        $joinColumn = [
             'name' => (string)$joinColumnElement['name'],
             'referencedColumnName' => (string)$joinColumnElement['referenced-column-name']
-        );
+        ];
 
         if (isset($joinColumnElement['unique'])) {
             $joinColumn['unique'] = $this->evaluateBoolean($joinColumnElement['unique']);
@@ -716,9 +716,9 @@ class XmlDriver extends FileDriver
      */
     private function columnToArray(SimpleXMLElement $fieldMapping)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => (string) $fieldMapping['name'],
-        );
+        ];
 
         if (isset($fieldMapping['type'])) {
             $mapping['type'] = (string) $fieldMapping['type'];
@@ -783,10 +783,10 @@ class XmlDriver extends FileDriver
             $usage = constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $usage);
         }
 
-        return array(
+        return [
             'usage'  => $usage,
             'region' => $region,
-        );
+        ];
     }
 
     /**
@@ -798,7 +798,7 @@ class XmlDriver extends FileDriver
      */
     private function _getCascadeMappings(SimpleXMLElement $cascadeElement)
     {
-        $cascades = array();
+        $cascades = [];
         /* @var $action SimpleXmlElement */
         foreach ($cascadeElement->children() as $action) {
             // According to the JPA specifications, XML uses "cascade-persist"
@@ -816,7 +816,7 @@ class XmlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        $result = array();
+        $result = [];
         $xmlElement = simplexml_load_file($file);
 
         if (isset($xmlElement->entity)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -73,7 +73,7 @@ class YamlDriver extends FileDriver
         }
 
         // Evaluate root level properties
-        $primaryTable = array();
+        $primaryTable = [];
 
         if (isset($element['table'])) {
             $primaryTable['name'] = $element['table'];
@@ -94,7 +94,7 @@ class YamlDriver extends FileDriver
         if (isset($element['namedQueries'])) {
             foreach ($element['namedQueries'] as $name => $queryMapping) {
                 if (is_string($queryMapping)) {
-                    $queryMapping = array('query' => $queryMapping);
+                    $queryMapping = ['query' => $queryMapping];
                 }
 
                 if ( ! isset($queryMapping['name'])) {
@@ -111,12 +111,12 @@ class YamlDriver extends FileDriver
                 if (!isset($mappingElement['name'])) {
                     $mappingElement['name'] = $name;
                 }
-                $metadata->addNamedNativeQuery(array(
+                $metadata->addNamedNativeQuery([
                     'name'              => $mappingElement['name'],
                     'query'             => isset($mappingElement['query']) ? $mappingElement['query'] : null,
                     'resultClass'       => isset($mappingElement['resultClass']) ? $mappingElement['resultClass'] : null,
                     'resultSetMapping'  => isset($mappingElement['resultSetMapping']) ? $mappingElement['resultSetMapping'] : null,
-                ));
+                ]);
             }
         }
 
@@ -127,22 +127,22 @@ class YamlDriver extends FileDriver
                     $resultSetMapping['name'] = $name;
                 }
 
-                $entities = array();
-                $columns  = array();
+                $entities = [];
+                $columns  = [];
                 if (isset($resultSetMapping['entityResult'])) {
                     foreach ($resultSetMapping['entityResult'] as $entityResultElement) {
-                        $entityResult = array(
-                            'fields'                => array(),
+                        $entityResult = [
+                            'fields'                => [],
                             'entityClass'           => isset($entityResultElement['entityClass']) ? $entityResultElement['entityClass'] : null,
                             'discriminatorColumn'   => isset($entityResultElement['discriminatorColumn']) ? $entityResultElement['discriminatorColumn'] : null,
-                        );
+                        ];
 
                         if (isset($entityResultElement['fieldResult'])) {
                             foreach ($entityResultElement['fieldResult'] as $fieldResultElement) {
-                                $entityResult['fields'][] = array(
+                                $entityResult['fields'][] = [
                                     'name'      => isset($fieldResultElement['name']) ? $fieldResultElement['name'] : null,
                                     'column'    => isset($fieldResultElement['column']) ? $fieldResultElement['column'] : null,
-                                );
+                                ];
                             }
                         }
 
@@ -153,17 +153,17 @@ class YamlDriver extends FileDriver
 
                 if (isset($resultSetMapping['columnResult'])) {
                     foreach ($resultSetMapping['columnResult'] as $columnResultAnnot) {
-                        $columns[] = array(
+                        $columns[] = [
                             'name' => isset($columnResultAnnot['name']) ? $columnResultAnnot['name'] : null,
-                        );
+                        ];
                     }
                 }
 
-                $metadata->addSqlResultSetMapping(array(
+                $metadata->addSqlResultSetMapping([
                     'name'          => $resultSetMapping['name'],
                     'entities'      => $entities,
                     'columns'       => $columns
-                ));
+                ]);
             }
         }
 
@@ -174,14 +174,14 @@ class YamlDriver extends FileDriver
                 // Evaluate discriminatorColumn
                 if (isset($element['discriminatorColumn'])) {
                     $discrColumn = $element['discriminatorColumn'];
-                    $metadata->setDiscriminatorColumn(array(
+                    $metadata->setDiscriminatorColumn([
                         'name' => isset($discrColumn['name']) ? (string)$discrColumn['name'] : null,
                         'type' => isset($discrColumn['type']) ? (string)$discrColumn['type'] : null,
                         'length' => isset($discrColumn['length']) ? (string)$discrColumn['length'] : null,
                         'columnDefinition' => isset($discrColumn['columnDefinition']) ? (string)$discrColumn['columnDefinition'] : null
-                    ));
+                    ]);
                 } else {
-                    $metadata->setDiscriminatorColumn(array('name' => 'dtype', 'type' => 'string', 'length' => 255));
+                    $metadata->setDiscriminatorColumn(['name' => 'dtype', 'type' => 'string', 'length' => 255]);
                 }
 
                 // Evaluate discriminatorMap
@@ -206,9 +206,9 @@ class YamlDriver extends FileDriver
                 }
 
                 if (is_string($indexYml['columns'])) {
-                    $index = array('columns' => array_map('trim', explode(',', $indexYml['columns'])));
+                    $index = ['columns' => array_map('trim', explode(',', $indexYml['columns']))];
                 } else {
-                    $index = array('columns' => $indexYml['columns']);
+                    $index = ['columns' => $indexYml['columns']];
                 }
 
                 if (isset($indexYml['flags'])) {
@@ -235,9 +235,9 @@ class YamlDriver extends FileDriver
                 }
 
                 if (is_string($uniqueYml['columns'])) {
-                    $unique = array('columns' => array_map('trim', explode(',', $uniqueYml['columns'])));
+                    $unique = ['columns' => array_map('trim', explode(',', $uniqueYml['columns']))];
                 } else {
-                    $unique = array('columns' => $uniqueYml['columns']);
+                    $unique = ['columns' => $uniqueYml['columns']];
                 }
 
                 if (isset($uniqueYml['options'])) {
@@ -252,7 +252,7 @@ class YamlDriver extends FileDriver
             $metadata->table['options'] = $element['options'];
         }
 
-        $associationIds = array();
+        $associationIds = [];
         if (isset($element['id'])) {
             // Evaluate identifier settings
             foreach ($element['id'] as $name => $idElement) {
@@ -261,10 +261,10 @@ class YamlDriver extends FileDriver
                     continue;
                 }
 
-                $mapping = array(
+                $mapping = [
                     'id' => true,
                     'fieldName' => $name
-                );
+                ];
 
                 if (isset($idElement['type'])) {
                     $mapping['type'] = $idElement['type'];
@@ -297,9 +297,9 @@ class YamlDriver extends FileDriver
                     $metadata->setSequenceGeneratorDefinition($idElement['sequenceGenerator']);
                 } else if (isset($idElement['customIdGenerator'])) {
                     $customGenerator = $idElement['customIdGenerator'];
-                    $metadata->setCustomGeneratorDefinition(array(
+                    $metadata->setCustomGeneratorDefinition([
                         'class' => (string) $customGenerator['class']
-                    ));
+                    ]);
                 } else if (isset($idElement['tableGenerator'])) {
                     throw MappingException::tableIdGeneratorNotImplemented($className);
                 }
@@ -331,11 +331,11 @@ class YamlDriver extends FileDriver
 
         if (isset($element['embedded'])) {
             foreach ($element['embedded'] as $name => $embeddedMapping) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'class' => $embeddedMapping['class'],
                     'columnPrefix' => isset($embeddedMapping['columnPrefix']) ? $embeddedMapping['columnPrefix'] : null,
-                );
+                ];
                 $metadata->mapEmbedded($mapping);
             }
         }
@@ -343,10 +343,10 @@ class YamlDriver extends FileDriver
         // Evaluate oneToOne relationships
         if (isset($element['oneToOne'])) {
             foreach ($element['oneToOne'] as $name => $oneToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $oneToOneElement['targetEntity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -363,7 +363,7 @@ class YamlDriver extends FileDriver
                         $mapping['inversedBy'] = $oneToOneElement['inversedBy'];
                     }
 
-                    $joinColumns = array();
+                    $joinColumns = [];
 
                     if (isset($oneToOneElement['joinColumn'])) {
                         $joinColumns[] = $this->joinColumnToArray($oneToOneElement['joinColumn']);
@@ -400,11 +400,11 @@ class YamlDriver extends FileDriver
         // Evaluate oneToMany relationships
         if (isset($element['oneToMany'])) {
             foreach ($element['oneToMany'] as $name => $oneToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $oneToManyElement['targetEntity'],
                     'mappedBy' => $oneToManyElement['mappedBy']
-                );
+                ];
 
                 if (isset($oneToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $oneToManyElement['fetch']);
@@ -439,10 +439,10 @@ class YamlDriver extends FileDriver
         // Evaluate manyToOne relationships
         if (isset($element['manyToOne'])) {
             foreach ($element['manyToOne'] as $name => $manyToOneElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $manyToOneElement['targetEntity']
-                );
+                ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -456,7 +456,7 @@ class YamlDriver extends FileDriver
                     $mapping['inversedBy'] = $manyToOneElement['inversedBy'];
                 }
 
-                $joinColumns = array();
+                $joinColumns = [];
 
                 if (isset($manyToOneElement['joinColumn'])) {
                     $joinColumns[] = $this->joinColumnToArray($manyToOneElement['joinColumn']);
@@ -488,10 +488,10 @@ class YamlDriver extends FileDriver
         // Evaluate manyToMany relationships
         if (isset($element['manyToMany'])) {
             foreach ($element['manyToMany'] as $name => $manyToManyElement) {
-                $mapping = array(
+                $mapping = [
                     'fieldName' => $name,
                     'targetEntity' => $manyToManyElement['targetEntity']
-                );
+                ];
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $manyToManyElement['fetch']);
@@ -502,9 +502,9 @@ class YamlDriver extends FileDriver
                 } else if (isset($manyToManyElement['joinTable'])) {
 
                     $joinTableElement = $manyToManyElement['joinTable'];
-                    $joinTable = array(
+                    $joinTable = [
                         'name' => $joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = $joinTableElement['schema'];
@@ -564,11 +564,11 @@ class YamlDriver extends FileDriver
         if (isset($element['associationOverride']) && is_array($element['associationOverride'])) {
 
             foreach ($element['associationOverride'] as $fieldName => $associationOverrideElement) {
-                $override   = array();
+                $override   = [];
 
                 // Check for joinColumn
                 if (isset($associationOverrideElement['joinColumn'])) {
-                    $joinColumns = array();
+                    $joinColumns = [];
                     foreach ($associationOverrideElement['joinColumn'] as $name => $joinColumnElement) {
                         if ( ! isset($joinColumnElement['name'])) {
                             $joinColumnElement['name'] = $name;
@@ -582,9 +582,9 @@ class YamlDriver extends FileDriver
                 if (isset($associationOverrideElement['joinTable'])) {
 
                     $joinTableElement   = $associationOverrideElement['joinTable'];
-                    $joinTable          =  array(
+                    $joinTable          =  [
                         'name' => $joinTableElement['name']
-                    );
+                    ];
 
                     if (isset($joinTableElement['schema'])) {
                         $joinTable['schema'] = $joinTableElement['schema'];
@@ -665,7 +665,7 @@ class YamlDriver extends FileDriver
      */
     private function joinColumnToArray($joinColumnElement)
     {
-        $joinColumn = array();
+        $joinColumn = [];
         if (isset($joinColumnElement['referencedColumnName'])) {
             $joinColumn['referencedColumnName'] = (string) $joinColumnElement['referencedColumnName'];
         }
@@ -707,9 +707,9 @@ class YamlDriver extends FileDriver
      */
     private function columnToArray($fieldName, $column)
     {
-        $mapping = array(
+        $mapping = [
             'fieldName' => $fieldName
-        );
+        ];
 
         if (isset($column['type'])) {
             $params = explode('(', $column['type']);
@@ -781,10 +781,10 @@ class YamlDriver extends FileDriver
             $usage = constant('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $usage);
         }
 
-        return array(
+        return [
             'usage'  => $usage,
             'region' => $region,
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/EntityListeners.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListeners.php
@@ -37,5 +37,5 @@ final class EntityListeners implements Annotation
      *
      * @var array<string>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/EntityResult.php
+++ b/lib/Doctrine/ORM/Mapping/EntityResult.php
@@ -45,7 +45,7 @@ final class EntityResult implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\FieldResult>
      */
-    public $fields = array();
+    public $fields = [];
 
     /**
      * Specifies the column name of the column in the SELECT list that is used to determine the type of the entity instance.

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -38,10 +38,10 @@ final class JoinTable implements Annotation
     /**
      * @var array<\Doctrine\ORM\Mapping\JoinColumn>
      */
-    public $joinColumns = array();
+    public $joinColumns = [];
 
     /**
      * @var array<\Doctrine\ORM\Mapping\JoinColumn>
      */
-    public $inverseJoinColumns = array();
+    public $inverseJoinColumns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
@@ -36,5 +36,5 @@ final class NamedNativeQueries implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\NamedNativeQuery>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
@@ -43,12 +43,12 @@ final class SqlResultSetMapping implements Annotation
      * 
      * @var array<\Doctrine\ORM\Mapping\EntityResult>
      */
-    public $entities = array();
+    public $entities = [];
 
     /**
      * Specifies the result set mapping to scalar values.
      *
      * @var array<\Doctrine\ORM\Mapping\ColumnResult>
      */
-    public $columns = array();
+    public $columns = [];
 }

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
@@ -36,5 +36,5 @@ final class SqlResultSetMappings implements Annotation
      *
      * @var array<\Doctrine\ORM\Mapping\SqlResultSetMapping>
      */
-    public $value = array();
+    public $value = [];
 }

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -48,5 +48,5 @@ final class Table implements Annotation
     /**
      * @var array
      */
-    public $options = array();
+    public $options = [];
 }

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -63,8 +63,8 @@ final class NativeQuery extends AbstractQuery
      */
     protected function _doExecute()
     {
-        $parameters = array();
-        $types      = array();
+        $parameters = [];
+        $types      = [];
 
         foreach ($this->getParameters() as $parameter) {
             $name  = $parameter->getName();

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -51,7 +51,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @var array
      */
-    private $snapshot = array();
+    private $snapshot = [];
 
     /**
      * The entity that owns this collection.
@@ -585,7 +585,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      */
     public function __sleep()
     {
-        return array('collection', 'initialized');
+        return ['collection', 'initialized'];
     }
 
     /**
@@ -633,7 +633,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $this->initialize();
 
         $this->owner    = null;
-        $this->snapshot = array();
+        $this->snapshot = [];
 
         $this->changed();
     }
@@ -695,7 +695,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     protected function doInitialize()
     {
         // Has NEW objects added through add(). Remember them.
-        $newObjects = array();
+        $newObjects = [];
 
         if ($this->isDirty) {
             $newObjects = $this->collection->toArray();

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -48,7 +48,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             return; // ignore inverse side
         }
 
-        $types = array();
+        $types = [];
         $class = $this->em->getClassMetadata($mapping['sourceEntity']);
 
         foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {
@@ -105,7 +105,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             ? $mapping['inversedBy']
             : $mapping['mappedBy'];
 
-        return $persister->load(array($mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index), null, $mapping, array(), 0, 1);
+        return $persister->load([$mappedKey => $collection->getOwner(), $mapping['indexBy'] => $index], null, $mapping, [], 0, 1);
     }
 
     /**
@@ -113,9 +113,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     public function count(PersistentCollection $collection)
     {
-        $conditions     = array();
-        $params         = array();
-        $types          = array();
+        $conditions     = [];
+        $params         = [];
+        $types          = [];
         $mapping        = $collection->getMapping();
         $id             = $this->uow->getEntityIdentifier($collection->getOwner());
         $sourceClass    = $this->em->getClassMetadata($mapping['sourceEntity']);
@@ -236,7 +236,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $mapping       = $collection->getMapping();
         $owner         = $collection->getOwner();
         $ownerMetadata = $this->em->getClassMetadata(get_class($owner));
-        $whereClauses  = $params = array();
+        $whereClauses  = $params = [];
 
         foreach ($mapping['relationToSourceKeyColumns'] as $key => $value) {
             $whereClauses[] = sprintf('t.%s = ?', $key);
@@ -296,7 +296,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $filterSql   = $this->generateFilterConditionSQL($rootClass, 'te');
 
         if ('' === $filterSql) {
-            return array('', '');
+            return ['', ''];
         }
 
         // A join is needed if there is filtering on the target entity
@@ -304,7 +304,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $joinSql   = ' JOIN ' . $tableName . ' te'
             . ' ON' . implode(' AND ', $this->getOnConditionSQL($mapping));
 
-        return array($joinSql, $filterSql);
+        return [$joinSql, $filterSql];
     }
 
     /**
@@ -317,7 +317,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function generateFilterConditionSQL(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        $filterClauses = array();
+        $filterClauses = [];
 
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ($filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {
@@ -348,7 +348,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             ? $association['joinTable']['inverseJoinColumns']
             : $association['joinTable']['joinColumns'];
 
-        $conditions = array();
+        $conditions = [];
 
         foreach ($joinColumns as $joinColumn) {
             $joinColumnName = $this->quoteStrategy->getJoinColumnName($joinColumn, $targetClass, $this->platform);
@@ -367,7 +367,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function getDeleteSQL(PersistentCollection $collection)
     {
-        $columns    = array();
+        $columns    = [];
         $mapping    = $collection->getMapping();
         $class      = $this->em->getClassMetadata(get_class($collection->getOwner()));
         $joinTable  = $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform);
@@ -393,12 +393,12 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         // Optimization for single column identifier
         if (count($mapping['relationToSourceKeyColumns']) === 1) {
-            return array(reset($identifier));
+            return [reset($identifier)];
         }
 
         // Composite identifier
         $sourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);
-        $params      = array();
+        $params      = [];
 
         foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
             $params[] = isset($sourceClass->fieldNames[$refColumnName])
@@ -422,8 +422,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $mapping     = $collection->getMapping();
         $class       = $this->em->getClassMetadata($mapping['sourceEntity']);
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
-        $columns     = array();
-        $types       = array();
+        $columns     = [];
+        $types       = [];
 
         foreach ($mapping['joinTable']['joinColumns'] as $joinColumn) {
             $columns[] = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
@@ -435,11 +435,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]   = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
         }
 
-        return array(
+        return [
             'DELETE FROM ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
             . ' WHERE ' . implode(' = ? AND ', $columns) . ' = ?',
             $types,
-        );
+        ];
     }
 
     /**
@@ -468,8 +468,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     protected function getInsertRowSQL(PersistentCollection $collection)
     {
-        $columns     = array();
-        $types       = array();
+        $columns     = [];
+        $types       = [];
         $mapping     = $collection->getMapping();
         $class       = $this->em->getClassMetadata($mapping['sourceEntity']);
         $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
@@ -484,13 +484,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]   = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
         }
 
-        return array(
+        return [
             'INSERT INTO ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
             . ' (' . implode(', ', $columns) . ')'
             . ' VALUES'
             . ' (' . implode(', ', array_fill(0, count($columns), '?')) . ')',
             $types,
-        );
+        ];
     }
 
     /**
@@ -520,7 +520,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      */
     private function collectJoinTableColumnParameters(PersistentCollection $collection, $element)
     {
-        $params      = array();
+        $params      = [];
         $mapping     = $collection->getMapping();
         $isComposite = count($mapping['joinTableColumns']) > 2;
 
@@ -587,14 +587,14 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $quotedJoinTable = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform). ' t';
-        $whereClauses    = array();
-        $params          = array();
-        $types           = array();
+        $whereClauses    = [];
+        $params          = [];
+        $types           = [];
 
         $joinNeeded = ! in_array($indexBy, $targetClass->identifier);
 
         if ($joinNeeded) { // extra join needed if indexBy is not a @id
-            $joinConditions = array();
+            $joinConditions = [];
 
             foreach ($joinColumns as $joinTableColumn) {
                 $joinConditions[] = 't.' . $joinTableColumn['name'] . ' = tr.' . $joinTableColumn['referencedColumnName'];
@@ -635,7 +635,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             }
         }
 
-        return array($quotedJoinTable, $whereClauses, $params, $types);
+        return [$quotedJoinTable, $whereClauses, $params, $types];
     }
 
     /**
@@ -669,9 +669,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $quotedJoinTable = $this->quoteStrategy->getJoinTableName($mapping, $sourceClass, $this->platform);
-        $whereClauses    = array();
-        $params          = array();
-        $types           = array();
+        $whereClauses    = [];
+        $params          = [];
+        $types           = [];
 
         foreach ($mapping['joinTableColumns'] as $joinTableColumn) {
             $whereClauses[] = ($addFilters ? 't.' : '') . $joinTableColumn . ' = ?';
@@ -701,7 +701,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             }
         }
 
-        return array($quotedJoinTable, $whereClauses, $params, $types);
+        return [$quotedJoinTable, $whereClauses, $params, $types];
     }
 
     /**
@@ -717,7 +717,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $expression = $criteria->getWhereExpression();
 
         if ($expression === null) {
-            return array();
+            return [];
         }
 
         $valueVisitor = new SqlValueVisitor();

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -84,13 +84,13 @@ class OneToManyPersister extends AbstractCollectionPersister
         $persister = $this->uow->getEntityPersister($mapping['targetEntity']);
 
         return $persister->load(
-            array(
+            [
                 $mapping['mappedBy'] => $collection->getOwner(),
                 $mapping['indexBy']  => $index
-            ),
+            ],
             null,
             $mapping,
-            array(),
+            [],
             null,
             1
         );
@@ -250,10 +250,10 @@ class OneToManyPersister extends AbstractCollectionPersister
         $columnDefinitions = [];
 
         foreach ($idColumnNames as $idColumnName) {
-            $columnDefinitions[$idColumnName] = array(
+            $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $this->em)),
-            );
+            ];
         }
 
         $statement = $this->platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable
@@ -272,7 +272,7 @@ class OneToManyPersister extends AbstractCollectionPersister
         $numDeleted = $this->conn->executeUpdate($statement, $parameters);
 
         // 3) Delete records on each table in the hierarchy
-        $classNames = array_merge($targetClass->parentClasses, array($targetClass->name), $targetClass->subClasses);
+        $classNames = array_merge($targetClass->parentClasses, [$targetClass->name], $targetClass->subClasses);
 
         foreach (array_reverse($classNames) as $className) {
             $tableName = $this->quoteStrategy->getTableName($this->em->getClassMetadata($className), $this->platform);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -86,7 +86,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * @var array
      */
-    static private $comparisonMap = array(
+    static private $comparisonMap = [
         Comparison::EQ       => '= %s',
         Comparison::IS       => '= %s',
         Comparison::NEQ      => '!= %s',
@@ -97,7 +97,7 @@ class BasicEntityPersister implements EntityPersister
         Comparison::IN       => 'IN (%s)',
         Comparison::NIN      => 'NOT IN (%s)',
         Comparison::CONTAINS => 'LIKE %s',
-    );
+    ];
 
     /**
      * Metadata object that describes the mapping of the mapped entity class.
@@ -132,7 +132,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @var array
      */
-    protected $queuedInserts = array();
+    protected $queuedInserts = [];
 
     /**
      * The map of column names to DBAL mapping types of all prepared columns used
@@ -143,7 +143,7 @@ class BasicEntityPersister implements EntityPersister
      * @see prepareInsertData($entity)
      * @see prepareUpdateData($entity)
      */
-    protected $columnTypes = array();
+    protected $columnTypes = [];
 
     /**
      * The map of quoted column names.
@@ -153,7 +153,7 @@ class BasicEntityPersister implements EntityPersister
      * @see prepareInsertData($entity)
      * @see prepareUpdateData($entity)
      */
-    protected $quotedColumns = array();
+    protected $quotedColumns = [];
 
     /**
      * The INSERT SQL statement used for entities handled by this persister.
@@ -257,10 +257,10 @@ class BasicEntityPersister implements EntityPersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return array();
+            return [];
         }
 
-        $postInsertIds  = array();
+        $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
 
@@ -282,13 +282,13 @@ class BasicEntityPersister implements EntityPersister
 
             if ($isPostInsertId) {
                 $generatedId = $idGenerator->generate($this->em, $entity);
-                $id = array(
+                $id = [
                     $this->class->identifier[0] => $generatedId
-                );
-                $postInsertIds[] = array(
+                ];
+                $postInsertIds[] = [
                     'generatedId' => $generatedId,
                     'entity' => $entity,
-                );
+                ];
             } else {
                 $id = $this->class->getIdentifierValues($entity);
             }
@@ -299,7 +299,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $stmt->closeCursor();
-        $this->queuedInserts = array();
+        $this->queuedInserts = [];
 
         return $postInsertIds;
     }
@@ -389,9 +389,9 @@ class BasicEntityPersister implements EntityPersister
      */
     protected final function updateTable($entity, $quotedTableName, array $updateData, $versioned = false)
     {
-        $set    = array();
-        $types  = array();
-        $params = array();
+        $set    = [];
+        $types  = [];
+        $params = [];
 
         foreach ($updateData as $columnName => $value) {
             $placeholder = '?';
@@ -420,7 +420,7 @@ class BasicEntityPersister implements EntityPersister
             $types[]    = $this->columnTypes[$columnName];
         }
 
-        $where      = array();
+        $where      = [];
         $identifier = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
 
         foreach ($this->class->identifier as $idField) {
@@ -503,9 +503,9 @@ class BasicEntityPersister implements EntityPersister
             $selfReferential = ($mapping['targetEntity'] == $mapping['sourceEntity']);
             $class           = $this->class;
             $association     = $mapping;
-            $otherColumns    = array();
-            $otherKeys       = array();
-            $keys            = array();
+            $otherColumns    = [];
+            $otherKeys       = [];
+            $keys            = [];
 
             if ( ! $mapping['isOwningSide']) {
                 $class       = $this->em->getClassMetadata($mapping['targetEntity']);
@@ -603,7 +603,7 @@ class BasicEntityPersister implements EntityPersister
     protected function prepareUpdateData($entity)
     {
         $versionField = null;
-        $result       = array();
+        $result       = [];
         $uow          = $this->em->getUnitOfWork();
 
         if (($versioned = $this->class->isVersioned) != false) {
@@ -646,7 +646,7 @@ class BasicEntityPersister implements EntityPersister
                     // The associated entity $newVal is not yet persisted, so we must
                     // set $newVal = null, in order to insert a null value and schedule an
                     // extra update on the UnitOfWork.
-                    $uow->scheduleExtraUpdate($entity, array($field => array(null, $newVal)));
+                    $uow->scheduleExtraUpdate($entity, [$field => [null, $newVal]]);
 
                     $newVal = null;
                 }
@@ -705,7 +705,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null)
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null)
     {
         $this->switchPersisterContext(null, $limit);
 
@@ -735,7 +735,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array())
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = [])
     {
         if (($foundEntity = $this->em->getUnitOfWork()->tryGetById($identifier, $assoc['targetEntity'])) != false) {
             return $foundEntity;
@@ -748,7 +748,7 @@ class BasicEntityPersister implements EntityPersister
 
             // Mark inverse side as fetched in the hints, otherwise the UoW would
             // try to load it in a separate query (remember: to-one inverse sides can not be lazy).
-            $hints = array();
+            $hints = [];
 
             if ($isInverseSingleValued) {
                 $hints['fetched']["r"][$assoc['inversedBy']] = true;
@@ -808,13 +808,13 @@ class BasicEntityPersister implements EntityPersister
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         $hydrator = $this->em->newHydrator(Query::HYDRATE_OBJECT);
-        $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(Query::HINT_REFRESH => true));
+        $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [Query::HINT_REFRESH => true]);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function count($criteria = array())
+    public function count($criteria = [])
     {
         $sql = $this->getCountSQL($criteria);
 
@@ -840,7 +840,7 @@ class BasicEntityPersister implements EntityPersister
         $stmt       = $this->conn->executeQuery($query, $params, $types);
         $hydrator   = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(UnitOfWork::HINT_DEFEREAGERLOAD => true));
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
     }
 
     /**
@@ -849,11 +849,11 @@ class BasicEntityPersister implements EntityPersister
     public function expandCriteriaParameters(Criteria $criteria)
     {
         $expression = $criteria->getWhereExpression();
-        $sqlParams  = array();
-        $sqlTypes   = array();
+        $sqlParams  = [];
+        $sqlTypes   = [];
 
         if ($expression === null) {
-            return array($sqlParams, $sqlTypes);
+            return [$sqlParams, $sqlTypes];
         }
 
         $valueVisitor = new SqlValueVisitor();
@@ -871,13 +871,13 @@ class BasicEntityPersister implements EntityPersister
             $sqlTypes = array_merge($sqlTypes, $this->getTypes($field, $value, $this->class));
         }
 
-        return array($sqlParams, $sqlTypes);
+        return [$sqlParams, $sqlTypes];
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null)
     {
         $this->switchPersisterContext($offset, $limit);
 
@@ -887,7 +887,7 @@ class BasicEntityPersister implements EntityPersister
 
         $hydrator = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, array(UnitOfWork::HINT_DEFEREAGERLOAD => true));
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
     }
 
     /**
@@ -913,7 +913,7 @@ class BasicEntityPersister implements EntityPersister
     private function loadArrayFromStatement($assoc, $stmt)
     {
         $rsm    = $this->currentPersisterContext->rsm;
-        $hints  = array(UnitOfWork::HINT_DEFEREAGERLOAD => true);
+        $hints  = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
 
         if (isset($assoc['indexBy'])) {
             $rsm = clone ($this->currentPersisterContext->rsm); // this is necessary because the "default rsm" should be changed.
@@ -935,10 +935,10 @@ class BasicEntityPersister implements EntityPersister
     private function loadCollectionFromStatement($assoc, $stmt, $coll)
     {
         $rsm   = $this->currentPersisterContext->rsm;
-        $hints = array(
+        $hints = [
             UnitOfWork::HINT_DEFEREAGERLOAD => true,
             'collection' => $coll
-        );
+        ];
 
         if (isset($assoc['indexBy'])) {
             $rsm = clone ($this->currentPersisterContext->rsm); // this is necessary because the "default rsm" should be changed.
@@ -975,8 +975,8 @@ class BasicEntityPersister implements EntityPersister
         $sourceClass    = $this->em->getClassMetadata($assoc['sourceEntity']);
         $class          = $sourceClass;
         $association    = $assoc;
-        $criteria       = array();
-        $parameters     = array();
+        $criteria       = [];
+        $parameters     = [];
 
         if ( ! $assoc['isOwningSide']) {
             $class       = $this->em->getClassMetadata($assoc['targetEntity']);
@@ -1018,11 +1018,11 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $criteria[$quotedJoinTable . '.' . $quotedKeyColumn] = $value;
-            $parameters[] = array(
+            $parameters[] = [
                 'value' => $value,
                 'field' => $field,
                 'class' => $sourceClass,
-            );
+            ];
         }
 
         $sql = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
@@ -1096,7 +1096,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
         $tableAlias = $this->getSQLTableAlias($this->class->name);
@@ -1132,7 +1132,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected final function getOrderBySQL(array $orderBy, $baseTableAlias)
     {
-        $orderByList = array();
+        $orderByList = [];
 
         foreach ($orderBy as $fieldName => $orientation) {
 
@@ -1194,7 +1194,7 @@ class BasicEntityPersister implements EntityPersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList = array();
+        $columnList = [];
         $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r'); // r for root
 
         // Add regular columns to select list
@@ -1247,7 +1247,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $association    = $assoc;
-            $joinCondition  = array();
+            $joinCondition  = [];
 
             if (isset($assoc['indexBy'])) {
                 $this->currentPersisterContext->rsm->addIndexBy($assocAlias, $assoc['indexBy']);
@@ -1315,7 +1315,7 @@ class BasicEntityPersister implements EntityPersister
             return '';
         }
 
-        $columnList    = array();
+        $columnList    = [];
         $targetClass   = $this->em->getClassMetadata($assoc['targetEntity']);
         $isIdentifier  = isset($assoc['id']) && $assoc['id'] === true;
         $sqlTableAlias = $this->getSQLTableAlias($class->name, ($alias == 'r' ? '' : $alias));
@@ -1343,7 +1343,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getSelectManyToManyJoinSQL(array $manyToMany)
     {
-        $conditions         = array();
+        $conditions         = [];
         $association        = $manyToMany;
         $sourceTableAlias   = $this->getSQLTableAlias($this->class->name);
 
@@ -1385,7 +1385,7 @@ class BasicEntityPersister implements EntityPersister
             return $this->insertSql;
         }
 
-        $values  = array();
+        $values  = [];
         $columns = array_unique($columns);
 
         foreach ($columns as $column) {
@@ -1419,7 +1419,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getInsertColumnList()
     {
-        $columns = array();
+        $columns = [];
 
         foreach ($this->class->reflFields as $name => $field) {
             if ($this->class->isVersioned && $this->class->versionField == $name) {
@@ -1579,7 +1579,7 @@ class BasicEntityPersister implements EntityPersister
      */
     public function getSelectConditionStatementSQL($field, $value, $assoc = null, $comparison = null)
     {
-        $selectedColumns = array();
+        $selectedColumns = [];
         $columns         = $this->getSelectConditionStatementColumnSQL($field, $assoc);
 
         if (count($columns) > 1 && $comparison === Comparison::IN) {
@@ -1660,13 +1660,13 @@ class BasicEntityPersister implements EntityPersister
                 ? $this->class->fieldMappings[$field]['inherited']
                 : $this->class->name;
 
-            return array($this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $this->class, $this->platform));
+            return [$this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $this->class, $this->platform)];
         }
 
         if (isset($this->class->associationMappings[$field])) {
             $association = $this->class->associationMappings[$field];
             // Many-To-Many requires join table check for joinColumn
-            $columns = array();
+            $columns = [];
             $class   = $this->class;
 
             if ($association['type'] === ClassMetadata::MANY_TO_MANY) {
@@ -1705,7 +1705,7 @@ class BasicEntityPersister implements EntityPersister
             // therefore checking for spaces and function calls which are not allowed.
 
             // found a join column condition, not really a "field"
-            return array($field);
+            return [$field];
         }
 
         throw ORMException::unrecognizedField($field);
@@ -1725,7 +1725,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getSelectConditionSQL(array $criteria, $assoc = null)
     {
-        $conditions = array();
+        $conditions = [];
 
         foreach ($criteria as $field => $value) {
             $conditions[] = $this->getSelectConditionStatementSQL($field, $value, $assoc);
@@ -1770,8 +1770,8 @@ class BasicEntityPersister implements EntityPersister
     {
         $this->switchPersisterContext($offset, $limit);
 
-        $criteria    = array();
-        $parameters  = array();
+        $criteria    = [];
+        $parameters  = [];
         $owningAssoc = $this->class->associationMappings[$assoc['mappedBy']];
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
         $tableAlias  = $this->getSQLTableAlias(isset($owningAssoc['inherited']) ? $owningAssoc['inherited'] : $this->class->name);
@@ -1787,11 +1787,11 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
-                $parameters[]                                   = array(
+                $parameters[]                                   = [
                     'value' => $value,
                     'field' => $field,
                     'class' => $sourceClass,
-                );
+                ];
 
                 continue;
             }
@@ -1800,11 +1800,11 @@ class BasicEntityPersister implements EntityPersister
             $value = $sourceClass->reflFields[$field]->getValue($sourceEntity);
 
             $criteria[$tableAlias . "." . $targetKeyColumn] = $value;
-            $parameters[] = array(
+            $parameters[] = [
                 'value' => $value,
                 'field' => $field,
                 'class' => $sourceClass,
-            );
+            ];
 
         }
 
@@ -1819,8 +1819,8 @@ class BasicEntityPersister implements EntityPersister
      */
     public function expandParameters($criteria)
     {
-        $params = array();
-        $types  = array();
+        $params = [];
+        $types  = [];
 
         foreach ($criteria as $field => $value) {
             if ($value === null) {
@@ -1831,7 +1831,7 @@ class BasicEntityPersister implements EntityPersister
             $params = array_merge($params, $this->getValues($value));
         }
 
-        return array($params, $types);
+        return [$params, $types];
     }
 
     /**
@@ -1848,8 +1848,8 @@ class BasicEntityPersister implements EntityPersister
      */
     private function expandToManyParameters($criteria)
     {
-        $params = array();
-        $types  = array();
+        $params = [];
+        $types  = [];
 
         foreach ($criteria as $criterion) {
             if ($criterion['value'] === null) {
@@ -1860,7 +1860,7 @@ class BasicEntityPersister implements EntityPersister
             $params = array_merge($params, $this->getValues($criterion['value']));
         }
 
-        return array($params, $types);
+        return [$params, $types];
     }
 
     /**
@@ -1875,11 +1875,11 @@ class BasicEntityPersister implements EntityPersister
      */
     private function getTypes($field, $value, ClassMetadata $class)
     {
-        $types = array();
+        $types = [];
 
         switch (true) {
             case (isset($class->fieldMappings[$field])):
-                $types = array_merge($types, array($class->fieldMappings[$field]['type']));
+                $types = array_merge($types, [$class->fieldMappings[$field]['type']]);
                 break;
 
             case (isset($class->associationMappings[$field])):
@@ -1926,19 +1926,19 @@ class BasicEntityPersister implements EntityPersister
     private function getValues($value)
     {
         if (is_array($value)) {
-            $newValue = array();
+            $newValue = [];
 
             foreach ($value as $itemValue) {
                 $newValue = array_merge($newValue, $this->getValues($itemValue));
             }
 
-            return array($newValue);
+            return [$newValue];
         }
 
         if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($value))) {
             $class = $this->em->getClassMetadata(get_class($value));
             if ($class->isIdentifierComposite) {
-                $newValue = array();
+                $newValue = [];
 
                 foreach ($class->getIdentifierValues($value) as $innerValue) {
                     $newValue = array_merge($newValue, $this->getValues($innerValue));
@@ -1948,7 +1948,7 @@ class BasicEntityPersister implements EntityPersister
             }
         }
 
-        return array($this->getIndividualValue($value));
+        return [$this->getIndividualValue($value)];
     }
 
     /**
@@ -2038,7 +2038,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function generateFilterConditionSQL(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        $filterClauses = array();
+        $filterClauses = [];
 
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ('' !== $filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {

--- a/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
@@ -76,7 +76,7 @@ class CachedPersisterContext
      *
      * @var array
      */
-    public $sqlTableAliases = array();
+    public $sqlTableAliases = [];
 
     /**
      * Whether this persistent context is considering limit operations applied to the selection queries

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -80,7 +80,7 @@ interface EntityPersister
      * @param  array|\Doctrine\Common\Collections\Criteria $criteria
      * @return string
      */
-    public function getCountSQL($criteria = array());
+    public function getCountSQL($criteria = []);
 
     /**
      * Expands the parameters from the given criteria and use the correct binding types if found.
@@ -164,7 +164,7 @@ interface EntityPersister
      *
      * @return int
      */
-    public function count($criteria = array());
+    public function count($criteria = []);
 
     /**
      * Gets the name of the table that owns the column the given field is mapped to.
@@ -196,7 +196,7 @@ interface EntityPersister
      *
      * @todo Check identity map? loadById method? Try to guess whether $criteria is the id?
      */
-    public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(), $lockMode = null, $limit = null, array $orderBy = null);
+    public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, array $orderBy = null);
 
     /**
      * Loads an entity by identifier.
@@ -224,7 +224,7 @@ interface EntityPersister
      *
      * @throws \Doctrine\ORM\Mapping\MappingException
      */
-    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = array());
+    public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = []);
 
     /**
      * Refreshes a managed entity.
@@ -259,7 +259,7 @@ interface EntityPersister
      *
      * @return array
      */
-    public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null);
+    public function loadAll(array $criteria = [], array $orderBy = null, $limit = null, $offset = null);
 
     /**
      * Gets (sliced or full) elements of the given collection.

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -46,14 +46,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      *
      * @var array
      */
-    private $owningTableMap = array();
+    private $owningTableMap = [];
 
     /**
      * Map of table to quoted table names.
      *
      * @var array
      */
-    private $quotedTableMap = array();
+    private $quotedTableMap = [];
 
     /**
      * {@inheritdoc}
@@ -128,10 +128,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     public function executeInserts()
     {
         if ( ! $this->queuedInserts) {
-            return array();
+            return [];
         }
 
-        $postInsertIds  = array();
+        $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
         $rootClass      = ($this->class->name !== $this->class->rootEntityName)
@@ -144,7 +144,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $rootTableStmt = $this->conn->prepare($rootPersister->getInsertSQL());
 
         // Prepare statements for sub tables.
-        $subTableStmts = array();
+        $subTableStmts = [];
 
         if ($rootClass !== $this->class) {
             $subTableStmts[$this->class->getTableName()] = $this->conn->prepare($this->getInsertSQL());
@@ -177,13 +177,13 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             if ($isPostInsertId) {
                 $generatedId = $idGenerator->generate($this->em, $entity);
-                $id = array(
+                $id = [
                     $this->class->identifier[0] => $generatedId
-                );
-                $postInsertIds[] = array(
+                ];
+                $postInsertIds[] = [
                     'generatedId' => $generatedId,
                     'entity' => $entity,
-                );
+                ];
             } else {
                 $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
             }
@@ -199,7 +199,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $paramIndex = 1;
                 $data       = isset($insertData[$tableName])
                     ? $insertData[$tableName]
-                    : array();
+                    : [];
 
                 foreach ((array) $id as $idName => $idVal) {
                     $type = isset($this->columnTypes[$idName]) ? $this->columnTypes[$idName] : Type::STRING;
@@ -223,7 +223,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $stmt->closeCursor();
         }
 
-        $this->queuedInserts = array();
+        $this->queuedInserts = [];
 
         return $postInsertIds;
     }
@@ -259,7 +259,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             if ( ! isset($updateData[$versionedTable])) {
                 $tableName = $this->quoteStrategy->getTableName($versionedClass, $this->platform);
 
-                $this->updateTable($entity, $tableName, array(), true);
+                $this->updateTable($entity, $tableName, [], true);
             }
 
             $identifiers = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
@@ -370,7 +370,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     /**
      * {@inheritDoc}
      */
-    public function getCountSQL($criteria = array())
+    public function getCountSQL($criteria = [])
     {
         $tableName      = $this->quoteStrategy->getTableName($this->class, $this->platform);
         $baseTableAlias = $this->getSQLTableAlias($this->class->name);
@@ -407,7 +407,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
-            $conditions     = array();
+            $conditions     = [];
             $tableAlias     = $this->getSQLTableAlias($parentClassName);
             $parentClass    = $this->em->getClassMetadata($parentClassName);
             $joinSql       .= ' INNER JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
@@ -434,7 +434,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList         = array();
+        $columnList         = [];
         $discrColumn        = $this->class->discriminatorColumn['name'];
         $discrColumnType    = $this->class->discriminatorColumn['type'];
         $baseTableAlias     = $this->getSQLTableAlias($this->class->name);
@@ -546,7 +546,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Identifier columns must always come first in the column list of subclasses.
         $columns = $this->class->parentClasses
             ? $this->class->getIdentifierColumnNames()
-            : array();
+            : [];
 
         foreach ($this->class->reflFields as $name => $field) {
             if (isset($this->class->fieldMappings[$name]['inherited'])
@@ -599,7 +599,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
-            $conditions   = array();
+            $conditions   = [];
             $parentClass  = $this->em->getClassMetadata($parentClassName);
             $tableAlias   = $this->getSQLTableAlias($parentClassName);
             $joinSql     .= ' INNER JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
@@ -614,7 +614,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         // OUTER JOIN sub tables
         foreach ($this->class->subClasses as $subClassName) {
-            $conditions  = array();
+            $conditions  = [];
             $subClass    = $this->em->getClassMetadata($subClassName);
             $tableAlias  = $this->getSQLTableAlias($subClassName);
             $joinSql    .= ' LEFT JOIN ' . $this->quoteStrategy->getTableName($subClass, $this->platform) . ' ' . $tableAlias . ' ON ';

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -164,7 +164,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
      */
     protected function getSelectConditionDiscriminatorValueSQL()
     {
-        $values = array();
+        $values = [];
 
         if ($this->class->discriminatorValue !== null) { // discriminators can be 0
             $values[] = $this->conn->quote($this->class->discriminatorValue);

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -70,7 +70,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
         if (isset($this->classMetadata->associationMappings[$field]) &&
             $value !== null &&
             ! is_object($value) &&
-            ! in_array($comparison->getOperator(), array(Comparison::IN, Comparison::NIN))) {
+            ! in_array($comparison->getOperator(), [Comparison::IN, Comparison::NIN])) {
 
             throw PersisterException::matchingAssocationFieldRequiresObject($this->classMetadata->name, $field);
         }
@@ -89,7 +89,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
      */
     public function walkCompositeExpression(CompositeExpression $expr)
     {
-        $expressionList = array();
+        $expressionList = [];
 
         foreach ($expr->getExpressionList() as $child) {
             $expressionList[] = $this->dispatch($child);

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -34,12 +34,12 @@ class SqlValueVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private $values = array();
+    private $values = [];
 
     /**
      * @var array
      */
-    private $types  = array();
+    private $types  = [];
 
     /**
      * Converts a comparison expression into the target query language output.
@@ -61,7 +61,7 @@ class SqlValueVisitor extends ExpressionVisitor
         }
 
         $this->values[] = $value;
-        $this->types[]  = array($field, $value);
+        $this->types[]  = [$field, $value];
     }
 
     /**
@@ -97,7 +97,7 @@ class SqlValueVisitor extends ExpressionVisitor
      */
     public function getParamsAndTypes()
     {
-        return array($this->values, $this->types);
+        return [$this->values, $this->types];
     }
 
     /**

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -135,7 +135,7 @@ final class Query extends AbstractQuery
      *
      * @var array
      */
-    private $_parsedTypes = array();
+    private $_parsedTypes = [];
 
     /**
      * Cached DQL query.
@@ -241,7 +241,7 @@ final class Query extends AbstractQuery
      */
     private function _parse()
     {
-        $types = array();
+        $types = [];
 
         foreach ($this->parameters as $parameter) {
             /** @var Query\Parameter $parameter */
@@ -352,8 +352,8 @@ final class Query extends AbstractQuery
      */
     private function processParameterMappings($paramMappings)
     {
-        $sqlParams = array();
-        $types     = array();
+        $sqlParams = [];
+        $types     = [];
 
         foreach ($this->parameters as $parameter) {
             $key    = $parameter->getName();
@@ -381,7 +381,7 @@ final class Query extends AbstractQuery
 
             // optimized multi value sql positions away for now,
             // they are not allowed in DQL anyways.
-            $value = array($value);
+            $value = [$value];
             $countValue = count($value);
 
             for ($i = 0, $l = count($sqlPositions); $i < $l; $i++) {
@@ -401,7 +401,7 @@ final class Query extends AbstractQuery
             $types = array_values($types);
         }
 
-        return array($sqlParams, $types);
+        return [$sqlParams, $types];
     }
 
     /**
@@ -665,7 +665,7 @@ final class Query extends AbstractQuery
      */
     public function setLockMode($lockMode)
     {
-        if (in_array($lockMode, array(LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE), true)) {
+        if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if ( ! $this->_em->getConnection()->isTransactionActive()) {
                 throw TransactionRequiredException::transactionRequired();
             }

--- a/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
@@ -35,7 +35,7 @@ class CoalesceExpression extends Node
     /**
      * @var array
      */
-    public $scalarExpressions = array();
+    public $scalarExpressions = [];
 
     /**
      * @param array $scalarExpressions

--- a/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
@@ -33,7 +33,7 @@ class ConditionalExpression extends Node
     /**
      * @var array
      */
-    public $conditionalTerms = array();
+    public $conditionalTerms = [];
 
     /**
      * @param array $conditionalTerms

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -32,7 +32,7 @@ class ConditionalTerm extends Node
     /**
      * @var array
      */
-    public $conditionalFactors = array();
+    public $conditionalFactors = [];
 
     /**
      * @param array $conditionalFactors

--- a/lib/Doctrine/ORM/Query/AST/FromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/FromClause.php
@@ -34,7 +34,7 @@ class FromClause extends Node
     /**
      * @var array
      */
-    public $identificationVariableDeclarations = array();
+    public $identificationVariableDeclarations = [];
 
     /**
      * @param array $identificationVariableDeclarations

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -38,7 +38,7 @@ class ConcatFunction extends FunctionNode
     
     public $secondStringPrimary;
     
-    public $concatExpressions = array();
+    public $concatExpressions = [];
     
     /**
      * @override
@@ -47,13 +47,13 @@ class ConcatFunction extends FunctionNode
     {
         $platform = $sqlWalker->getConnection()->getDatabasePlatform();
         
-        $args = array();
+        $args = [];
         
         foreach ($this->concatExpressions as $expression) {
             $args[] = $sqlWalker->walkStringPrimary($expression);
         }
         
-        return call_user_func_array(array($platform,'getConcatExpression'), $args);
+        return call_user_func_array([$platform,'getConcatExpression'], $args);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -35,7 +35,7 @@ class GeneralCaseExpression extends Node
     /**
      * @var array
      */
-    public $whenClauses = array();
+    public $whenClauses = [];
 
     /**
      * @var mixed

--- a/lib/Doctrine/ORM/Query/AST/GroupByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/GroupByClause.php
@@ -33,7 +33,7 @@ class GroupByClause extends Node
     /**
      * @var array
      */
-    public $groupByItems = array();
+    public $groupByItems = [];
 
     /**
      * @param array $groupByItems

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -43,7 +43,7 @@ class IdentificationVariableDeclaration extends Node
     /**
      * @var array
      */
-    public $joins = array();
+    public $joins = [];
 
     /**
      * @param RangeVariableDeclaration|null $rangeVariableDecl

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -42,7 +42,7 @@ class InExpression extends Node
     /**
      * @var array
      */
-    public $literals = array();
+    public $literals = [];
 
     /**
      * @var Subselect|null

--- a/lib/Doctrine/ORM/Query/AST/OrderByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByClause.php
@@ -33,7 +33,7 @@ class OrderByClause extends Node
     /**
      * @var array
      */
-    public $orderByItems = array();
+    public $orderByItems = [];
 
     /**
      * @param array $orderByItems

--- a/lib/Doctrine/ORM/Query/AST/SelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectClause.php
@@ -38,7 +38,7 @@ class SelectClause extends Node
     /**
      * @var array
      */
-    public $selectExpressions = array();
+    public $selectExpressions = [];
 
     /**
      * @param array $selectExpressions

--- a/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
@@ -33,7 +33,7 @@ class SimpleArithmeticExpression extends Node
     /**
      * @var array
      */
-    public $arithmeticTerms = array();
+    public $arithmeticTerms = [];
 
     /**
      * @param array $arithmeticTerms

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -40,7 +40,7 @@ class SimpleCaseExpression extends Node
     /**
      * @var array
      */
-    public $simpleWhenClauses = array();
+    public $simpleWhenClauses = [];
 
     /**
      * @var mixed

--- a/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
@@ -33,7 +33,7 @@ class SubselectFromClause extends Node
     /**
      * @var array
      */
-    public $identificationVariableDeclarations = array();
+    public $identificationVariableDeclarations = [];
 
     /**
      * @param array $identificationVariableDeclarations

--- a/lib/Doctrine/ORM/Query/AST/UpdateClause.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateClause.php
@@ -43,7 +43,7 @@ class UpdateClause extends Node
     /**
      * @var array
      */
-    public $updateItems = array();
+    public $updateItems = [];
 
     /**
      * @param string $abstractSchemaName

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -81,7 +81,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
         $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $primaryDqlAlias);
-        $fromClause = new AST\FromClause(array(new AST\IdentificationVariableDeclaration($rangeDecl, null, array())));
+        $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
         // Append WHERE clause, if there is one.
@@ -93,7 +93,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store DELETE statements
-        $classNames = array_merge($primaryClass->parentClasses, array($primaryClass->name), $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
         foreach (array_reverse($classNames) as $className) {
             $tableName = $quoteStrategy->getTableName($em->getClassMetadata($className), $platform);
             $this->_sqlStatements[] = 'DELETE FROM ' . $tableName
@@ -101,12 +101,12 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
-        $columnDefinitions = array();
+        $columnDefinitions = [];
         foreach ($idColumnNames as $idColumnName) {
-            $columnDefinitions[$idColumnName] = array(
+            $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $em)),
-            );
+            ];
         }
         $this->_createTempTableSql = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
                 . $platform->getColumnDeclarationListSQL($columnDefinitions) . ')';

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -52,7 +52,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
     /**
      * @var array
      */
-    private $_sqlParameters = array();
+    private $_sqlParameters = [];
 
     /**
      * @var int
@@ -92,7 +92,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
         $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $updateClause->aliasIdentificationVariable);
-        $fromClause = new AST\FromClause(array(new AST\IdentificationVariableDeclaration($rangeDecl, null, array())));
+        $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
 
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
@@ -100,7 +100,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store UPDATE statements
-        $classNames = array_merge($primaryClass->parentClasses, array($primaryClass->name), $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
         $i = -1;
 
         foreach (array_reverse($classNames) as $className) {
@@ -143,13 +143,13 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         }
 
         // 4. Store DDL for temporary identifier table.
-        $columnDefinitions = array();
+        $columnDefinitions = [];
 
         foreach ($idColumnNames as $idColumnName) {
-            $columnDefinitions[$idColumnName] = array(
+            $columnDefinitions[$idColumnName] = [
                 'notnull' => true,
                 'type'    => Type::getType(PersisterHelper::getTypeOfColumn($idColumnName, $rootClass, $em)),
-            );
+            ];
         }
 
         $this->_createTempTableSql = $platform->getCreateTemporaryTableSnippetSQL() . ' ' . $tempTable . ' ('
@@ -178,8 +178,8 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
 
             // Execute UPDATE statements
             foreach ($this->_sqlStatements as $key => $statement) {
-                $paramValues = array();
-                $paramTypes  = array();
+                $paramValues = [];
+                $paramTypes  = [];
 
                 if (isset($this->_sqlParameters[$key])) {
                     foreach ($this->_sqlParameters[$key] as $parameterKey => $parameterName) {

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -220,7 +220,7 @@ class Expr
      */
     public function avg($x)
     {
-        return new Expr\Func('AVG', array($x));
+        return new Expr\Func('AVG', [$x]);
     }
 
     /**
@@ -232,7 +232,7 @@ class Expr
      */
     public function max($x)
     {
-        return new Expr\Func('MAX', array($x));
+        return new Expr\Func('MAX', [$x]);
     }
 
     /**
@@ -244,7 +244,7 @@ class Expr
      */
     public function min($x)
     {
-        return new Expr\Func('MIN', array($x));
+        return new Expr\Func('MIN', [$x]);
     }
 
     /**
@@ -256,7 +256,7 @@ class Expr
      */
     public function count($x)
     {
-        return new Expr\Func('COUNT', array($x));
+        return new Expr\Func('COUNT', [$x]);
     }
 
     /**
@@ -280,7 +280,7 @@ class Expr
      */
     public function exists($subquery)
     {
-        return new Expr\Func('EXISTS', array($subquery));
+        return new Expr\Func('EXISTS', [$subquery]);
     }
 
     /**
@@ -292,7 +292,7 @@ class Expr
      */
     public function all($subquery)
     {
-        return new Expr\Func('ALL', array($subquery));
+        return new Expr\Func('ALL', [$subquery]);
     }
 
     /**
@@ -304,7 +304,7 @@ class Expr
      */
     public function some($subquery)
     {
-        return new Expr\Func('SOME', array($subquery));
+        return new Expr\Func('SOME', [$subquery]);
     }
 
     /**
@@ -316,7 +316,7 @@ class Expr
      */
     public function any($subquery)
     {
-        return new Expr\Func('ANY', array($subquery));
+        return new Expr\Func('ANY', [$subquery]);
     }
 
     /**
@@ -328,7 +328,7 @@ class Expr
      */
     public function not($restriction)
     {
-        return new Expr\Func('NOT', array($restriction));
+        return new Expr\Func('NOT', [$restriction]);
     }
 
     /**
@@ -340,7 +340,7 @@ class Expr
      */
     public function abs($x)
     {
-        return new Expr\Func('ABS', array($x));
+        return new Expr\Func('ABS', [$x]);
     }
 
     /**
@@ -429,7 +429,7 @@ class Expr
      */
     public function sqrt($x)
     {
-        return new Expr\Func('SQRT', array($x));
+        return new Expr\Func('SQRT', [$x]);
     }
 
     /**
@@ -546,7 +546,7 @@ class Expr
      */
     public function substring($x, $from, $len = null)
     {
-        $args = array($x, $from);
+        $args = [$x, $from];
         if (null !== $len) {
             $args[] = $len;
         }
@@ -562,7 +562,7 @@ class Expr
      */
     public function lower($x)
     {
-        return new Expr\Func('LOWER', array($x));
+        return new Expr\Func('LOWER', [$x]);
     }
 
     /**
@@ -574,7 +574,7 @@ class Expr
      */
     public function upper($x)
     {
-        return new Expr\Func('UPPER', array($x));
+        return new Expr\Func('UPPER', [$x]);
     }
 
     /**
@@ -586,7 +586,7 @@ class Expr
      */
     public function length($x)
     {
-        return new Expr\Func('LENGTH', array($x));
+        return new Expr\Func('LENGTH', [$x]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -38,12 +38,12 @@ class Andx extends Composite
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
         'Doctrine\ORM\Query\Expr\Orx',
         'Doctrine\ORM\Query\Expr\Andx',
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -48,17 +48,17 @@ abstract class Base
     /**
      * @var array
      */
-    protected $allowedClasses = array();
+    protected $allowedClasses = [];
 
     /**
      * @var array
      */
-    protected $parts = array();
+    protected $parts = [];
 
     /**
      * @param array $args
      */
-    public function __construct($args = array())
+    public function __construct($args = [])
     {
         $this->addMultiple($args);
     }
@@ -68,7 +68,7 @@ abstract class Base
      *
      * @return Base
      */
-    public function addMultiple($args = array())
+    public function addMultiple($args = [])
     {
         foreach ((array) $args as $arg) {
             $this->add($arg);

--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -39,7 +39,7 @@ class Composite extends Base
             return (string) $this->parts[0];
         }
 
-        $components = array();
+        $components = [];
 
         foreach ($this->parts as $part) {
             $components[] = $this->processQueryPart($part);

--- a/lib/Doctrine/ORM/Query/Expr/OrderBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/OrderBy.php
@@ -48,12 +48,12 @@ class OrderBy
     /**
      * @var array
      */
-    protected $allowedClasses = array();
+    protected $allowedClasses = [];
 
     /**
      * @var array
      */
-    protected $parts = array();
+    protected $parts = [];
 
     /**
      * @param string|null $sort

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -38,12 +38,12 @@ class Orx extends Composite
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Comparison',
         'Doctrine\ORM\Query\Expr\Func',
         'Doctrine\ORM\Query\Expr\Andx',
         'Doctrine\ORM\Query\Expr\Orx',
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Expr/Select.php
+++ b/lib/Doctrine/ORM/Query/Expr/Select.php
@@ -43,9 +43,9 @@ class Select extends Base
     /**
      * @var array
      */
-    protected $allowedClasses = array(
+    protected $allowedClasses = [
         'Doctrine\ORM\Query\Expr\Func'
-    );
+    ];
 
     /**
      * @return array

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -75,7 +75,7 @@ abstract class SQLFilter
             $type = ParameterTypeInferer::inferType($value);
         }
 
-        $this->parameters[$name] = array('value' => $value, 'type' => $type);
+        $this->parameters[$name] = ['value' => $value, 'type' => $type];
 
         // Keep the parameters sorted for the hash
         ksort($this->parameters);

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -59,7 +59,7 @@ class FilterCollection
      *
      * @var \Doctrine\ORM\Query\Filter\SQLFilter[]
      */
-    private $enabledFilters = array();
+    private $enabledFilters = [];
 
     /**
      * @var string The filter hash from the last time the query was parsed.

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -129,13 +129,13 @@ class Lexer extends \Doctrine\Common\Lexer
      */
     protected function getCatchablePatterns()
     {
-        return array(
+        return [
             '[a-z_][a-z0-9_]*\:[a-z_][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // aliased name
             '[a-z_\\\][a-z0-9_]*(?:\\\[a-z_][a-z0-9_]*)*', // identifier or qualified name
             '(?:[0-9]+(?:[\.][0-9]+)*)(?:e[+-]?[0-9]+)?', // numbers
             "'(?:[^']|'')*'", // quoted strings
             '\?[0-9]*|:[a-z_][a-z0-9_]*' // parameters
-        );
+        ];
     }
 
     /**
@@ -143,7 +143,7 @@ class Lexer extends \Doctrine\Common\Lexer
      */
     protected function getNonCatchablePatterns()
     {
-        return array('\s+', '(.)');
+        return ['\s+', '(.)'];
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -40,21 +40,21 @@ class Parser
      *
      * @var array
      */
-    private static $_STRING_FUNCTIONS = array(
+    private static $_STRING_FUNCTIONS = [
         'concat'    => 'Doctrine\ORM\Query\AST\Functions\ConcatFunction',
         'substring' => 'Doctrine\ORM\Query\AST\Functions\SubstringFunction',
         'trim'      => 'Doctrine\ORM\Query\AST\Functions\TrimFunction',
         'lower'     => 'Doctrine\ORM\Query\AST\Functions\LowerFunction',
         'upper'     => 'Doctrine\ORM\Query\AST\Functions\UpperFunction',
         'identity'  => 'Doctrine\ORM\Query\AST\Functions\IdentityFunction',
-    );
+    ];
 
     /**
      * READ-ONLY: Maps BUILT-IN numeric function names to AST class names.
      *
      * @var array
      */
-    private static $_NUMERIC_FUNCTIONS = array(
+    private static $_NUMERIC_FUNCTIONS = [
         'length'    => 'Doctrine\ORM\Query\AST\Functions\LengthFunction',
         'locate'    => 'Doctrine\ORM\Query\AST\Functions\LocateFunction',
         'abs'       => 'Doctrine\ORM\Query\AST\Functions\AbsFunction',
@@ -64,20 +64,20 @@ class Parser
         'date_diff' => 'Doctrine\ORM\Query\AST\Functions\DateDiffFunction',
         'bit_and'   => 'Doctrine\ORM\Query\AST\Functions\BitAndFunction',
         'bit_or'    => 'Doctrine\ORM\Query\AST\Functions\BitOrFunction',
-    );
+    ];
 
     /**
      * READ-ONLY: Maps BUILT-IN datetime function names to AST class names.
      *
      * @var array
      */
-    private static $_DATETIME_FUNCTIONS = array(
+    private static $_DATETIME_FUNCTIONS = [
         'current_date'      => 'Doctrine\ORM\Query\AST\Functions\CurrentDateFunction',
         'current_time'      => 'Doctrine\ORM\Query\AST\Functions\CurrentTimeFunction',
         'current_timestamp' => 'Doctrine\ORM\Query\AST\Functions\CurrentTimestampFunction',
         'date_add'          => 'Doctrine\ORM\Query\AST\Functions\DateAddFunction',
         'date_sub'          => 'Doctrine\ORM\Query\AST\Functions\DateSubFunction',
-    );
+    ];
 
     /*
      * Expressions that were encountered during parsing of identifiers and expressions
@@ -87,27 +87,27 @@ class Parser
     /**
      * @var array
      */
-    private $deferredIdentificationVariables = array();
+    private $deferredIdentificationVariables = [];
 
     /**
      * @var array
      */
-    private $deferredPartialObjectExpressions = array();
+    private $deferredPartialObjectExpressions = [];
 
     /**
      * @var array
      */
-    private $deferredPathExpressions = array();
+    private $deferredPathExpressions = [];
 
     /**
      * @var array
      */
-    private $deferredResultVariables = array();
+    private $deferredResultVariables = [];
 
     /**
      * @var array
      */
-    private $deferredNewObjectExpressions = array();
+    private $deferredNewObjectExpressions = [];
 
     /**
      * The lexer.
@@ -142,7 +142,7 @@ class Parser
      *
      * @var array
      */
-    private $queryComponents = array();
+    private $queryComponents = [];
 
     /**
      * Keeps the nesting level of defined ResultVariables.
@@ -156,7 +156,7 @@ class Parser
      *
      * @var array
      */
-    private $customTreeWalkers = array();
+    private $customTreeWalkers = [];
 
     /**
      * The custom last tree walker, if any, that is responsible for producing the output.
@@ -168,7 +168,7 @@ class Parser
     /**
      * @var array
      */
-    private $identVariableExpressions = array();
+    private $identVariableExpressions = [];
 
     /**
      * Checks if a function is internally defined. Used to prevent overwriting
@@ -541,7 +541,7 @@ class Parser
      */
     private function isMathOperator($token)
     {
-        return in_array($token['type'], array(Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY));
+        return in_array($token['type'], [Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY]);
     }
 
     /**
@@ -568,7 +568,7 @@ class Parser
      */
     private function isAggregateFunction($tokenType)
     {
-        return in_array($tokenType, array(Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT));
+        return in_array($tokenType, [Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT]);
     }
 
     /**
@@ -578,7 +578,7 @@ class Parser
      */
     private function isNextAllAnySome()
     {
-        return in_array($this->lexer->lookahead['type'], array(Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME));
+        return in_array($this->lexer->lookahead['type'], [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME]);
     }
 
     /**
@@ -787,7 +787,7 @@ class Parser
 
             if ( ! ($expectedType & $fieldType)) {
                 // We need to recognize which was expected type(s)
-                $expectedStringTypes = array();
+                $expectedStringTypes = [];
 
                 // Validate state field type
                 if ($expectedType & AST\PathExpression::TYPE_STATE_FIELD) {
@@ -933,11 +933,11 @@ class Parser
 
         $identVariable = $this->lexer->token['value'];
 
-        $this->deferredIdentificationVariables[] = array(
+        $this->deferredIdentificationVariables[] = [
             'expression'   => $identVariable,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $identVariable;
     }
@@ -1034,11 +1034,11 @@ class Parser
         $resultVariable = $this->lexer->token['value'];
 
         // Defer ResultVariable validation
-        $this->deferredResultVariables[] = array(
+        $this->deferredResultVariables[] = [
             'expression'   => $resultVariable,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $resultVariable;
     }
@@ -1106,11 +1106,11 @@ class Parser
         $pathExpr = new AST\PathExpression($expectedTypes, $identVariable, $field);
 
         // Defer PathExpression validation if requested to be deferred
-        $this->deferredPathExpressions[] = array(
+        $this->deferredPathExpressions[] = [
             'expression'   => $pathExpr,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $pathExpr;
     }
@@ -1189,7 +1189,7 @@ class Parser
         }
 
         // Process SelectExpressions (1..N)
-        $selectExpressions = array();
+        $selectExpressions = [];
         $selectExpressions[] = $this->SelectExpression();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1243,20 +1243,20 @@ class Parser
         $class = $this->em->getClassMetadata($abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $class,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token,
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
         $this->match(Lexer::T_SET);
 
-        $updateItems = array();
+        $updateItems = [];
         $updateItems[] = $this->UpdateItem();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1301,14 +1301,14 @@ class Parser
         $class = $this->em->getClassMetadata($deleteClause->abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $class,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token,
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
@@ -1324,7 +1324,7 @@ class Parser
     {
         $this->match(Lexer::T_FROM);
 
-        $identificationVariableDeclarations = array();
+        $identificationVariableDeclarations = [];
         $identificationVariableDeclarations[] = $this->IdentificationVariableDeclaration();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1345,7 +1345,7 @@ class Parser
     {
         $this->match(Lexer::T_FROM);
 
-        $identificationVariables = array();
+        $identificationVariables = [];
         $identificationVariables[] = $this->SubselectIdentificationVariableDeclaration();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1391,7 +1391,7 @@ class Parser
         $this->match(Lexer::T_GROUP);
         $this->match(Lexer::T_BY);
 
-        $groupByItems = array($this->GroupByItem());
+        $groupByItems = [$this->GroupByItem()];
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
             $this->match(Lexer::T_COMMA);
@@ -1412,7 +1412,7 @@ class Parser
         $this->match(Lexer::T_ORDER);
         $this->match(Lexer::T_BY);
 
-        $orderByItems = array();
+        $orderByItems = [];
         $orderByItems[] = $this->OrderByItem();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -1589,7 +1589,7 @@ class Parser
      */
     public function IdentificationVariableDeclaration()
     {
-        $joins                    = array();
+        $joins                    = [];
         $rangeVariableDeclaration = $this->RangeVariableDeclaration();
         $indexBy                  = $this->lexer->isNextToken(Lexer::T_INDEX)
             ? $this->IndexBy()
@@ -1746,14 +1746,14 @@ class Parser
         $classMetadata = $this->em->getClassMetadata($abstractSchemaName);
 
         // Building queryComponent
-        $queryComponent = array(
+        $queryComponent = [
             'metadata'     => $classMetadata,
             'parent'       => null,
             'relation'     => null,
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $token
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $queryComponent;
 
@@ -1783,14 +1783,14 @@ class Parser
         $targetClass = $this->em->getClassMetadata($class->associationMappings[$field]['targetEntity']);
 
         // Building queryComponent
-        $joinQueryComponent = array(
+        $joinQueryComponent = [
             'metadata'     => $targetClass,
             'parent'       => $joinAssociationPathExpression->identificationVariable,
             'relation'     => $class->getAssociationMapping($field),
             'map'          => null,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->lookahead
-        );
+        ];
 
         $this->queryComponents[$aliasIdentificationVariable] = $joinQueryComponent;
 
@@ -1807,7 +1807,7 @@ class Parser
     {
         $this->match(Lexer::T_PARTIAL);
 
-        $partialFieldSet = array();
+        $partialFieldSet = [];
 
         $identificationVariable = $this->IdentificationVariable();
 
@@ -1846,11 +1846,11 @@ class Parser
         $partialObjectExpression = new AST\PartialObjectExpression($identificationVariable, $partialFieldSet);
 
         // Defer PartialObjectExpression validation
-        $this->deferredPartialObjectExpressions[] = array(
+        $this->deferredPartialObjectExpressions[] = [
             'expression'   => $partialObjectExpression,
             'nestingLevel' => $this->nestingLevel,
             'token'        => $this->lexer->token,
-        );
+        ];
 
         return $partialObjectExpression;
     }
@@ -1882,11 +1882,11 @@ class Parser
         $expression = new AST\NewObjectExpression($className, $args);
 
         // Defer NewObjectExpression validation
-        $this->deferredNewObjectExpressions[] = array(
+        $this->deferredNewObjectExpressions[] = [
             'token'        => $token,
             'expression'   => $expression,
             'nestingLevel' => $this->nestingLevel,
-        );
+        ];
 
         return $expression;
     }
@@ -2066,7 +2066,7 @@ class Parser
         $this->match(Lexer::T_OPEN_PARENTHESIS);
 
         // Process ScalarExpressions (1..N)
-        $scalarExpressions = array();
+        $scalarExpressions = [];
         $scalarExpressions[] = $this->ScalarExpression();
 
         while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -2109,7 +2109,7 @@ class Parser
         $this->match(Lexer::T_CASE);
 
         // Process WhenClause (1..N)
-        $whenClauses = array();
+        $whenClauses = [];
 
         do {
             $whenClauses[] = $this->WhenClause();
@@ -2134,7 +2134,7 @@ class Parser
         $caseOperand = $this->StateFieldPathExpression();
 
         // Process SimpleWhenClause (1..N)
-        $simpleWhenClauses = array();
+        $simpleWhenClauses = [];
 
         do {
             $simpleWhenClauses[] = $this->SimpleWhenClause();
@@ -2291,11 +2291,11 @@ class Parser
             $aliasResultVariable = $this->AliasResultVariable();
 
             // Include AliasResultVariable in query components.
-            $this->queryComponents[$aliasResultVariable] = array(
+            $this->queryComponents[$aliasResultVariable] = [
                 'resultVariable' => $expression,
                 'nestingLevel'   => $this->nestingLevel,
                 'token'          => $token,
-            );
+            ];
         }
 
         // AST
@@ -2385,11 +2385,11 @@ class Parser
             $expr->fieldIdentificationVariable = $resultVariable;
 
             // Include AliasResultVariable in query components.
-            $this->queryComponents[$resultVariable] = array(
+            $this->queryComponents[$resultVariable] = [
                 'resultvariable' => $expr,
                 'nestingLevel'   => $this->nestingLevel,
                 'token'          => $token,
-            );
+            ];
         }
 
         return $expr;
@@ -2402,7 +2402,7 @@ class Parser
      */
     public function ConditionalExpression()
     {
-        $conditionalTerms = array();
+        $conditionalTerms = [];
         $conditionalTerms[] = $this->ConditionalTerm();
 
         while ($this->lexer->isNextToken(Lexer::T_OR)) {
@@ -2427,7 +2427,7 @@ class Parser
      */
     public function ConditionalTerm()
     {
-        $conditionalFactors = array();
+        $conditionalFactors = [];
         $conditionalFactors[] = $this->ConditionalFactor();
 
         while ($this->lexer->isNextToken(Lexer::T_AND)) {
@@ -2492,8 +2492,8 @@ class Parser
         // Peek beyond the matching closing parenthesis ')'
         $peek = $this->peekBeyondClosingParenthesis();
 
-        if (in_array($peek['value'], array("=",  "<", "<=", "<>", ">", ">=", "!=")) ||
-            in_array($peek['type'], array(Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS)) ||
+        if (in_array($peek['value'], ["=",  "<", "<=", "<>", ">", ">=", "!="]) ||
+            in_array($peek['type'], [Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS]) ||
             $this->isMathOperator($peek)) {
             $condPrimary->simpleConditionalExpression = $this->SimpleConditionalExpression();
 
@@ -2749,7 +2749,7 @@ class Parser
      */
     public function SimpleArithmeticExpression()
     {
-        $terms = array();
+        $terms = [];
         $terms[] = $this->ArithmeticTerm();
 
         while (($isPlus = $this->lexer->isNextToken(Lexer::T_PLUS)) || $this->lexer->isNextToken(Lexer::T_MINUS)) {
@@ -2775,7 +2775,7 @@ class Parser
      */
     public function ArithmeticTerm()
     {
-        $factors = array();
+        $factors = [];
         $factors[] = $this->ArithmeticFactor();
 
         while (($isMult = $this->lexer->isNextToken(Lexer::T_MULTIPLY)) || $this->lexer->isNextToken(Lexer::T_DIVIDE)) {
@@ -2996,7 +2996,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $isDistinct = false;
 
-        if ( ! in_array($lookaheadType, array(Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM))) {
+        if ( ! in_array($lookaheadType, [Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM])) {
             $this->syntaxError('One of: MAX, MIN, AVG, SUM, COUNT');
         }
 
@@ -3026,7 +3026,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $value = $this->lexer->lookahead['value'];
 
-        if ( ! in_array($lookaheadType, array(Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME))) {
+        if ( ! in_array($lookaheadType, [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME])) {
             $this->syntaxError('ALL, ANY or SOME');
         }
 
@@ -3105,7 +3105,7 @@ class Parser
         if ($this->lexer->isNextToken(Lexer::T_SELECT)) {
             $inExpression->subselect = $this->Subselect();
         } else {
-            $literals = array();
+            $literals = [];
             $literals[] = $this->InParameter();
 
             while ($this->lexer->isNextToken(Lexer::T_COMMA)) {
@@ -3138,7 +3138,7 @@ class Parser
         $this->match(Lexer::T_INSTANCE);
         $this->match(Lexer::T_OF);
 
-        $exprValues = array();
+        $exprValues = [];
 
         if ($this->lexer->isNextToken(Lexer::T_OPEN_PARENTHESIS)) {
             $this->match(Lexer::T_OPEN_PARENTHESIS);

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -51,7 +51,7 @@ class ParserResult
      *
      * @var array
      */
-    private $_parameterMappings = array();
+    private $_parameterMappings = [];
 
     /**
      * Initializes a new instance of the <tt>ParserResult</tt> class.

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -37,12 +37,12 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private static $operatorMap = array(
+    private static $operatorMap = [
         Comparison::GT => Expr\Comparison::GT,
         Comparison::GTE => Expr\Comparison::GTE,
         Comparison::LT  => Expr\Comparison::LT,
         Comparison::LTE => Expr\Comparison::LTE
-    );
+    ];
 
     /**
      * @var array
@@ -57,7 +57,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
     /**
      * @var array
      */
-    private $parameters = array();
+    private $parameters = [];
 
     /**
      * Constructor
@@ -88,7 +88,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function clearParameters()
     {
-        $this->parameters = array();
+        $this->parameters = [];
     }
 
     /**
@@ -108,7 +108,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function walkCompositeExpression(CompositeExpression $expr)
     {
-        $expressionList = array();
+        $expressionList = [];
 
         foreach ($expr->getExpressionList() as $child) {
             $expressionList[] = $this->dispatch($child);

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -57,7 +57,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $aliasMap = array();
+    public $aliasMap = [];
 
     /**
      * Maps alias names to related association field names.
@@ -65,7 +65,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $relationMap = array();
+    public $relationMap = [];
 
     /**
      * Maps alias names to parent alias names.
@@ -73,7 +73,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $parentAliasMap = array();
+    public $parentAliasMap = [];
 
     /**
      * Maps column names in the result set to field names for each class.
@@ -81,7 +81,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $fieldMappings = array();
+    public $fieldMappings = [];
 
     /**
      * Maps column names in the result set to the alias/field name to use in the mapped result.
@@ -89,7 +89,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $scalarMappings = array();
+    public $scalarMappings = [];
 
     /**
      * Maps column names in the result set to the alias/field type to use in the mapped result.
@@ -97,7 +97,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $typeMappings = array();
+    public $typeMappings = [];
 
     /**
      * Maps entities in the result set to the alias name to use in the mapped result.
@@ -105,7 +105,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $entityMappings = array();
+    public $entityMappings = [];
 
     /**
      * Maps column names of meta columns (foreign keys, discriminator columns, ...) to field names.
@@ -113,7 +113,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $metaMappings = array();
+    public $metaMappings = [];
 
     /**
      * Maps column names in the result set to the alias they belong to.
@@ -121,7 +121,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $columnOwnerMap = array();
+    public $columnOwnerMap = [];
 
     /**
      * List of columns in the result set that are used as discriminator columns.
@@ -129,7 +129,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $discriminatorColumns = array();
+    public $discriminatorColumns = [];
 
     /**
      * Maps alias names to field names that should be used for indexing.
@@ -137,7 +137,7 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $indexByMap = array();
+    public $indexByMap = [];
 
     /**
      * Map from column names to class names that declare the field the column is mapped to.
@@ -145,28 +145,28 @@ class ResultSetMapping
      * @ignore
      * @var array
      */
-    public $declaringClasses = array();
+    public $declaringClasses = [];
 
     /**
      * This is necessary to hydrate derivate foreign keys correctly.
      *
      * @var array
      */
-    public $isIdentifierColumn = array();
+    public $isIdentifierColumn = [];
 
     /**
      * Maps column names in the result set to field names for each new object expression.
      *
      * @var array
      */
-    public $newObjectMappings = array();
+    public $newObjectMappings = [];
 
     /**
      * Maps metadata parameter names to the metadata attribute.
      *
      * @var array
      */
-    public $metadataParameterMapping = array();
+    public $metadataParameterMapping = [];
 
     /**
      * Adds an entity result to this ResultSetMapping.

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -98,7 +98,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return void
      */
-    public function addRootEntityFromClassMetadata($class, $alias, $renamedColumns = array(), $renameMode = null)
+    public function addRootEntityFromClassMetadata($class, $alias, $renamedColumns = [], $renameMode = null)
     {
         $renameMode     = $renameMode ?: $this->defaultRenameMode;
         $columnAliasMap = $this->getColumnAliasMap($class, $renameMode, $renamedColumns);
@@ -120,7 +120,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return void
      */
-    public function addJoinedEntityFromClassMetadata($class, $alias, $parentAlias, $relation, $renamedColumns = array(), $renameMode = null)
+    public function addJoinedEntityFromClassMetadata($class, $alias, $parentAlias, $relation, $renamedColumns = [], $renameMode = null)
     {
         $renameMode     = $renameMode ?: $this->defaultRenameMode;
         $columnAliasMap = $this->getColumnAliasMap($class, $renameMode, $renamedColumns);
@@ -140,7 +140,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @throws \InvalidArgumentException
      */
-    protected function addAllClassFields($class, $alias, $columnAliasMap = array())
+    protected function addAllClassFields($class, $alias, $columnAliasMap = [])
     {
         $classMetadata = $this->em->getClassMetadata($class);
         $platform      = $this->em->getConnection()->getDatabasePlatform();
@@ -233,7 +233,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             $mode = self::COLUMN_RENAMING_CUSTOM;
         }
 
-        $columnAlias = array();
+        $columnAlias = [];
         $class       = $this->em->getClassMetadata($className);
 
         foreach ($class->getColumnNames() as $columnName) {
@@ -437,7 +437,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return string
      */
-    public function generateSelectClause($tableAliases = array())
+    public function generateSelectClause($tableAliases = [])
     {
         $sql = "";
 
@@ -471,6 +471,6 @@ class ResultSetMappingBuilder extends ResultSetMapping
      */
     public function __toString()
     {
-        return $this->generateSelectClause(array());
+        return $this->generateSelectClause([]);
     }
 }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -109,28 +109,28 @@ class SqlWalker implements TreeWalker
     /**
      * @var array
      */
-    private $tableAliasMap = array();
+    private $tableAliasMap = [];
 
     /**
      * Map from result variable names to their SQL column alias names.
      *
      * @var array
      */
-    private $scalarResultAliasMap = array();
+    private $scalarResultAliasMap = [];
 
     /**
      * Map from Table-Alias + Column-Name to OrderBy-Direction.
      *
      * @var array
      */
-    private $orderedColumnsMap = array();
+    private $orderedColumnsMap = [];
 
     /**
      * Map from DQL-Alias + Field-Name to SQL Column Alias.
      *
      * @var array
      */
-    private $scalarFields = array();
+    private $scalarFields = [];
 
     /**
      * Map of all components/classes that appear in the DQL query.
@@ -144,14 +144,14 @@ class SqlWalker implements TreeWalker
      *
      * @var array
      */
-    private $selectedClasses = array();
+    private $selectedClasses = [];
 
     /**
      * The DQL alias of the root class of the currently traversed query.
      *
      * @var array
      */
-    private $rootAliases = array();
+    private $rootAliases = [];
 
     /**
      * Flag that indicates whether to generate SQL table aliases in the SQL.
@@ -245,7 +245,7 @@ class SqlWalker implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);
@@ -354,7 +354,7 @@ class SqlWalker implements TreeWalker
             $sql .= isset($this->queryComponents[$dqlAlias]['relation']) ? ' LEFT ' : ' INNER ';
             $sql .= 'JOIN ' . $this->quoteStrategy->getTableName($parentClass, $this->platform) . ' ' . $tableAlias . ' ON ';
 
-            $sqlParts = array();
+            $sqlParts = [];
 
             foreach ($this->quoteStrategy->getIdentifierColumnNames($class, $this->platform) as $columnName) {
                 $sqlParts[] = $baseTableAlias . '.' . $columnName . ' = ' . $tableAlias . '.' . $columnName;
@@ -380,7 +380,7 @@ class SqlWalker implements TreeWalker
 
             $sql .= ' LEFT JOIN ' . $this->quoteStrategy->getTableName($subClass, $this->platform) . ' ' . $tableAlias . ' ON ';
 
-            $sqlParts = array();
+            $sqlParts = [];
 
             foreach ($this->quoteStrategy->getIdentifierColumnNames($subClass, $this->platform) as $columnName) {
                 $sqlParts[] = $baseTableAlias . '.' . $columnName . ' = ' . $tableAlias . '.' . $columnName;
@@ -397,7 +397,7 @@ class SqlWalker implements TreeWalker
      */
     private function _generateOrderedCollectionOrderByItems()
     {
-        $orderedColumns = array();
+        $orderedColumns = [];
 
         foreach ($this->selectedClasses as $selectedClass) {
             $dqlAlias  = $selectedClass['dqlAlias'];
@@ -439,7 +439,7 @@ class SqlWalker implements TreeWalker
      */
     private function _generateDiscriminatorColumnConditionSQL(array $dqlAliases)
     {
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($dqlAliases as $dqlAlias) {
             $class = $this->queryComponents[$dqlAlias]['metadata'];
@@ -447,7 +447,7 @@ class SqlWalker implements TreeWalker
             if ( ! $class->isInheritanceTypeSingleTable()) continue;
 
             $conn   = $this->em->getConnection();
-            $values = array();
+            $values = [];
 
             if ($class->discriminatorValue !== null) { // discriminators can be 0
                 $values[] = $conn->quote($class->discriminatorValue);
@@ -504,7 +504,7 @@ class SqlWalker implements TreeWalker
                 break;
         }
 
-        $filterClauses = array();
+        $filterClauses = [];
         foreach ($this->em->getFilters()->getEnabledFilters() as $filter) {
             if ('' !== $filterExpr = $filter->addFilterConstraint($targetEntity, $targetTableAlias)) {
                 $filterClauses[] = '(' . $filterExpr . ')';
@@ -607,7 +607,7 @@ class SqlWalker implements TreeWalker
     {
         $class      = $this->queryComponents[$identVariable]['metadata'];
         $tableAlias = $this->getSQLTableAlias($class->getTableName(), $identVariable);
-        $sqlParts   = array();
+        $sqlParts   = [];
 
         foreach ($this->quoteStrategy->getIdentifierColumnNames($class, $this->platform) as $columnName) {
             $sqlParts[] = $tableAlias . '.' . $columnName;
@@ -700,7 +700,7 @@ class SqlWalker implements TreeWalker
     public function walkSelectClause($selectClause)
     {
         $sql = 'SELECT ' . (($selectClause->isDistinct) ? 'DISTINCT ' : '');
-        $sqlSelectExpressions = array_filter(array_map(array($this, 'walkSelectExpression'), $selectClause->selectExpressions));
+        $sqlSelectExpressions = array_filter(array_map([$this, 'walkSelectExpression'], $selectClause->selectExpressions));
 
         if ($this->query->getHint(Query::HINT_INTERNAL_ITERATION) == true && $selectClause->isDistinct) {
             $this->query->setHint(self::HINT_DISTINCT, true);
@@ -813,7 +813,7 @@ class SqlWalker implements TreeWalker
     public function walkFromClause($fromClause)
     {
         $identificationVarDecls = $fromClause->identificationVariableDeclarations;
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($identificationVarDecls as $identificationVariableDecl) {
             $sqlParts[] = $this->walkIdentificationVariableDeclaration($identificationVariableDecl);
@@ -938,7 +938,7 @@ class SqlWalker implements TreeWalker
         // The owning side is necessary at this point because only it contains the JoinColumn information.
         switch (true) {
             case ($assoc['type'] & ClassMetadata::TO_ONE):
-                $conditions = array();
+                $conditions = [];
 
                 foreach ($assoc['joinColumns'] as $joinColumn) {
                     $quotedSourceColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $targetClass, $this->platform);
@@ -954,7 +954,7 @@ class SqlWalker implements TreeWalker
                 }
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($joinedDqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$joinedDqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -967,10 +967,10 @@ class SqlWalker implements TreeWalker
                     $conditions[] = $filterExpr;
                 }
 
-                $targetTableJoin = array(
+                $targetTableJoin = [
                     'table' => $targetTableName . ' ' . $targetTableAlias,
                     'condition' => implode(' AND ', $conditions),
-                );
+                ];
                 break;
 
             case ($assoc['type'] == ClassMetadata::MANY_TO_MANY):
@@ -979,7 +979,7 @@ class SqlWalker implements TreeWalker
                 $joinTableAlias = $this->getSQLTableAlias($joinTable['name'], $joinedDqlAlias);
                 $joinTableName  = $this->quoteStrategy->getJoinTableName($assoc, $sourceClass, $this->platform);
 
-                $conditions      = array();
+                $conditions      = [];
                 $relationColumns = ($relation['isOwningSide'])
                     ? $assoc['joinTable']['joinColumns']
                     : $assoc['joinTable']['inverseJoinColumns'];
@@ -996,7 +996,7 @@ class SqlWalker implements TreeWalker
                 // Join target table
                 $sql .= ($joinType == AST\Join::JOIN_TYPE_LEFT || $joinType == AST\Join::JOIN_TYPE_LEFTOUTER) ? ' LEFT JOIN ' : ' INNER JOIN ';
 
-                $conditions      = array();
+                $conditions      = [];
                 $relationColumns = ($relation['isOwningSide'])
                     ? $assoc['joinTable']['inverseJoinColumns']
                     : $assoc['joinTable']['joinColumns'];
@@ -1009,7 +1009,7 @@ class SqlWalker implements TreeWalker
                 }
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($joinedDqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$joinedDqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -1022,10 +1022,10 @@ class SqlWalker implements TreeWalker
                     $conditions[] = $filterExpr;
                 }
 
-                $targetTableJoin = array(
+                $targetTableJoin = [
                     'table' => $targetTableName . ' ' . $targetTableAlias,
                     'condition' => implode(' AND ', $conditions),
-                );
+                ];
                 break;
 
             default:
@@ -1075,7 +1075,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkOrderByClause($orderByClause)
     {
-        $orderByItems = array_map(array($this, 'walkOrderByItem'), $orderByClause->orderByItems);
+        $orderByItems = array_map([$this, 'walkOrderByItem'], $orderByClause->orderByItems);
 
         if (($collectionOrderByItems = $this->_generateOrderedCollectionOrderByItems()) !== '') {
             $orderByItems = array_merge($orderByItems, (array) $collectionOrderByItems);
@@ -1142,7 +1142,7 @@ class SqlWalker implements TreeWalker
                 $sql .= $this->walkRangeVariableDeclaration($joinDeclaration);
 
                 // Apply remaining inheritance restrictions
-                $discrSql = $this->_generateDiscriminatorColumnConditionSQL(array($dqlAlias));
+                $discrSql = $this->_generateDiscriminatorColumnConditionSQL([$dqlAlias]);
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
@@ -1207,7 +1207,7 @@ class SqlWalker implements TreeWalker
     {
         $sql = 'COALESCE(';
 
-        $scalarExpressions = array();
+        $scalarExpressions = [];
 
         foreach ($coalesceExpression->scalarExpressions as $scalarExpression) {
             $scalarExpressions[] = $this->walkSimpleArithmeticExpression($scalarExpression);
@@ -1376,7 +1376,7 @@ class SqlWalker implements TreeWalker
                     $partialFieldSet = $expr->partialFieldSet;
                 } else {
                     $dqlAlias = $expr;
-                    $partialFieldSet = array();
+                    $partialFieldSet = [];
                 }
 
                 $queryComp   = $this->queryComponents[$dqlAlias];
@@ -1384,14 +1384,14 @@ class SqlWalker implements TreeWalker
                 $resultAlias = $selectExpression->fieldIdentificationVariable ?: null;
 
                 if ( ! isset($this->selectedClasses[$dqlAlias])) {
-                    $this->selectedClasses[$dqlAlias] = array(
+                    $this->selectedClasses[$dqlAlias] = [
                         'class'       => $class,
                         'dqlAlias'    => $dqlAlias,
                         'resultAlias' => $resultAlias
-                    );
+                    ];
                 }
 
-                $sqlParts = array();
+                $sqlParts = [];
 
                 // Select all fields from the queried class
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
@@ -1476,7 +1476,7 @@ class SqlWalker implements TreeWalker
         $useAliasesBefore  = $this->useSqlTableAliases;
         $rootAliasesBefore = $this->rootAliases;
 
-        $this->rootAliases = array(); // reset the rootAliases for the subselect
+        $this->rootAliases = []; // reset the rootAliases for the subselect
         $this->useSqlTableAliases = true;
 
         $sql  = $this->walkSimpleSelectClause($subselect->simpleSelectClause);
@@ -1499,7 +1499,7 @@ class SqlWalker implements TreeWalker
     public function walkSubselectFromClause($subselectFromClause)
     {
         $identificationVarDecls = $subselectFromClause->identificationVariableDeclarations;
-        $sqlParts               = array ();
+        $sqlParts               = [];
 
         foreach ($identificationVarDecls as $subselectIdVarDecl) {
             $sqlParts[] = $this->walkIdentificationVariableDeclaration($subselectIdVarDecl);
@@ -1534,7 +1534,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkNewObject($newObjectExpression, $newObjectResultAlias=null)
     {
-        $sqlSelectExpressions = array();
+        $sqlSelectExpressions = [];
         $objIndex             = $newObjectResultAlias?:$this->newObjectCounter++;
 
         foreach ($newObjectExpression->args as $argIndex => $e) {
@@ -1582,11 +1582,11 @@ class SqlWalker implements TreeWalker
             $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
             $this->rsm->addScalarResult($columnAlias, $resultAlias, $fieldType);
 
-            $this->rsm->newObjectMappings[$columnAlias] = array(
+            $this->rsm->newObjectMappings[$columnAlias] = [
                 'className' => $newObjectExpression->className,
                 'objIndex'  => $objIndex,
                 'argIndex'  => $argIndex
-            );
+            ];
         }
 
         return implode(', ', $sqlSelectExpressions);
@@ -1663,7 +1663,7 @@ class SqlWalker implements TreeWalker
      */
     public function walkGroupByClause($groupByClause)
     {
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($groupByClause->groupByItems as $groupByItem) {
             $sqlParts[] = $this->walkGroupByItem($groupByItem);
@@ -1698,7 +1698,7 @@ class SqlWalker implements TreeWalker
         }
 
         // IdentificationVariable
-        $sqlParts = array();
+        $sqlParts = [];
 
         foreach ($this->queryComponents[$groupByItem]['metadata']->fieldNames as $field) {
             $item       = new AST\PathExpression(AST\PathExpression::TYPE_STATE_FIELD, $groupByItem, $field);
@@ -1746,7 +1746,7 @@ class SqlWalker implements TreeWalker
         $this->setSQLTableAlias($tableName, $tableName, $updateClause->aliasIdentificationVariable);
         $this->rootAliases[] = $updateClause->aliasIdentificationVariable;
 
-        $sql .= ' SET ' . implode(', ', array_map(array($this, 'walkUpdateItem'), $updateClause->updateItems));
+        $sql .= ' SET ' . implode(', ', array_map([$this, 'walkUpdateItem'], $updateClause->updateItems));
 
         return $sql;
     }
@@ -1790,7 +1790,7 @@ class SqlWalker implements TreeWalker
         $discrSql = $this->_generateDiscriminatorColumnConditionSql($this->rootAliases);
 
         if ($this->em->hasFilters()) {
-            $filterClauses = array();
+            $filterClauses = [];
             foreach ($this->rootAliases as $dqlAlias) {
                 $class = $this->queryComponents[$dqlAlias]['metadata'];
                 $tableAlias = $this->getSQLTableAlias($class->table['name'], $dqlAlias);
@@ -1831,7 +1831,7 @@ class SqlWalker implements TreeWalker
             return $this->walkConditionalTerm($condExpr);
         }
 
-        return implode(' OR ', array_map(array($this, 'walkConditionalTerm'), $condExpr->conditionalTerms));
+        return implode(' OR ', array_map([$this, 'walkConditionalTerm'], $condExpr->conditionalTerms));
     }
 
     /**
@@ -1845,7 +1845,7 @@ class SqlWalker implements TreeWalker
             return $this->walkConditionalFactor($condTerm);
         }
 
-        return implode(' AND ', array_map(array($this, 'walkConditionalFactor'), $condTerm->conditionalFactors));
+        return implode(' AND ', array_map([$this, 'walkConditionalFactor'], $condTerm->conditionalFactors));
     }
 
     /**
@@ -1930,7 +1930,7 @@ class SqlWalker implements TreeWalker
             $sql .= $this->quoteStrategy->getTableName($targetClass, $this->platform) . ' ' . $targetTableAlias . ' WHERE ';
 
             $owningAssoc = $targetClass->associationMappings[$assoc['mappedBy']];
-            $sqlParts    = array();
+            $sqlParts    = [];
 
             foreach ($owningAssoc['targetToSourceKeyColumns'] as $targetColumn => $sourceColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($class->fieldNames[$targetColumn], $class, $this->platform);
@@ -1964,7 +1964,7 @@ class SqlWalker implements TreeWalker
 
             // join conditions
             $joinColumns  = $assoc['isOwningSide'] ? $joinTable['inverseJoinColumns'] : $joinTable['joinColumns'];
-            $joinSqlParts = array();
+            $joinSqlParts = [];
 
             foreach ($joinColumns as $joinColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($targetClass->fieldNames[$joinColumn['referencedColumnName']], $targetClass, $this->platform);
@@ -1976,7 +1976,7 @@ class SqlWalker implements TreeWalker
             $sql .= ' WHERE ';
 
             $joinColumns = $assoc['isOwningSide'] ? $joinTable['joinColumns'] : $joinTable['inverseJoinColumns'];
-            $sqlParts    = array();
+            $sqlParts    = [];
 
             foreach ($joinColumns as $joinColumn) {
                 $targetColumn = $this->quoteStrategy->getColumnName($class->fieldNames[$joinColumn['referencedColumnName']], $class, $this->platform);
@@ -2039,7 +2039,7 @@ class SqlWalker implements TreeWalker
 
         $sql .= ($inExpr->subselect)
             ? $this->walkSubselect($inExpr->subselect)
-            : implode(', ', array_map(array($this, 'walkInParameter'), $inExpr->literals));
+            : implode(', ', array_map([$this, 'walkInParameter'], $inExpr->literals));
 
         $sql .= ')';
 
@@ -2066,7 +2066,7 @@ class SqlWalker implements TreeWalker
 
         $sql .= $class->discriminatorColumn['name'] . ($instanceOfExpr->not ? ' NOT IN ' : ' IN ');
 
-        $sqlParameterList = array();
+        $sqlParameterList = [];
 
         foreach ($instanceOfExpr->value as $parameter) {
             if ($parameter instanceof AST\InputParameter) {
@@ -2243,7 +2243,7 @@ class SqlWalker implements TreeWalker
             return $this->walkArithmeticTerm($simpleArithmeticExpr);
         }
 
-        return implode(' ', array_map(array($this, 'walkArithmeticTerm'), $simpleArithmeticExpr->arithmeticTerms));
+        return implode(' ', array_map([$this, 'walkArithmeticTerm'], $simpleArithmeticExpr->arithmeticTerms));
     }
 
     /**
@@ -2263,7 +2263,7 @@ class SqlWalker implements TreeWalker
             return $this->walkArithmeticFactor($term);
         }
 
-        return implode(' ', array_map(array($this, 'walkArithmeticFactor'), $term->arithmeticFactors));
+        return implode(' ', array_map([$this, 'walkArithmeticFactor'], $term->arithmeticFactors));
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -72,7 +72,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -72,7 +72,7 @@ class TreeWalkerChain implements TreeWalker
      */
     public function setQueryComponent($dqlAlias, array $queryComponent)
     {
-        $requiredKeys = array('metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token');
+        $requiredKeys = ['metadata', 'parent', 'relation', 'map', 'nestingLevel', 'token'];
 
         if (array_diff($requiredKeys, array_keys($queryComponent))) {
             throw QueryException::invalidQueryComponent($dqlAlias);

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -27,7 +27,7 @@ class TreeWalkerChainIterator implements \Iterator, \ArrayAccess
     /**
      * @var TreeWalker[]
      */
-    private $walkers = array();
+    private $walkers = [];
     /**
      * @var TreeWalkerChain
      */

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -57,17 +57,17 @@ class QueryBuilder
      *
      * @var array
      */
-    private $_dqlParts = array(
+    private $_dqlParts = [
         'distinct' => false,
-        'select'  => array(),
-        'from'    => array(),
-        'join'    => array(),
-        'set'     => array(),
+        'select'  => [],
+        'from'    => [],
+        'join'    => [],
+        'set'     => [],
         'where'   => null,
-        'groupBy' => array(),
+        'groupBy' => [],
         'having'  => null,
-        'orderBy' => array()
-    );
+        'orderBy' => []
+    ];
 
     /**
      * The type of query this is. Can be select, update or delete.
@@ -116,7 +116,7 @@ class QueryBuilder
      *
      * @var array
      */
-    private $joinRootAliases = array();
+    private $joinRootAliases = [];
 
      /**
      * Whether to use second level cache, if available.
@@ -442,7 +442,7 @@ class QueryBuilder
      */
     public function getRootAliases()
     {
-        $aliases = array();
+        $aliases = [];
 
         foreach ($this->_dqlParts['from'] as &$fromClause) {
             if (is_string($fromClause)) {
@@ -493,7 +493,7 @@ class QueryBuilder
      */
     public function getRootEntities()
     {
-        $entities = array();
+        $entities = [];
 
         foreach ($this->_dqlParts['from'] as &$fromClause) {
             if (is_string($fromClause)) {
@@ -704,7 +704,7 @@ class QueryBuilder
         // This is introduced for backwards compatibility reasons.
         // TODO: Remove for 3.0
         if ($dqlPartName == 'join') {
-            $newDqlPart = array();
+            $newDqlPart = [];
 
             foreach ($dqlPart as $k => $v) {
                 $k = is_numeric($k) ? $this->getRootAlias() : $k;
@@ -724,7 +724,7 @@ class QueryBuilder
                 $this->_dqlParts[$dqlPartName][] = $dqlPart;
             }
         } else {
-            $this->_dqlParts[$dqlPartName] = ($isMultiple) ? array($dqlPart) : $dqlPart;
+            $this->_dqlParts[$dqlPartName] = ($isMultiple) ? [$dqlPart] : $dqlPart;
         }
 
         $this->_state = self::STATE_DIRTY;
@@ -987,7 +987,7 @@ class QueryBuilder
             Expr\Join::INNER_JOIN, $join, $alias, $conditionType, $condition, $indexBy
         );
 
-        return $this->add('join', array($rootAlias => $join), true);
+        return $this->add('join', [$rootAlias => $join], true);
     }
 
     /**
@@ -1022,7 +1022,7 @@ class QueryBuilder
             Expr\Join::LEFT_JOIN, $join, $alias, $conditionType, $condition, $indexBy
         );
 
-        return $this->add('join', array($rootAlias => $join), true);
+        return $this->add('join', [$rootAlias => $join], true);
     }
 
     /**
@@ -1369,9 +1369,9 @@ class QueryBuilder
     private function _getDQLForDelete()
     {
          return 'DELETE'
-              . $this->_getReducedDQLQueryPart('from', array('pre' => ' ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
     /**
@@ -1380,10 +1380,10 @@ class QueryBuilder
     private function _getDQLForUpdate()
     {
          return 'UPDATE'
-              . $this->_getReducedDQLQueryPart('from', array('pre' => ' ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('set', array('pre' => ' SET ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('set', ['pre' => ' SET ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
     /**
@@ -1393,11 +1393,11 @@ class QueryBuilder
     {
         $dql = 'SELECT'
              . ($this->_dqlParts['distinct']===true ? ' DISTINCT' : '')
-             . $this->_getReducedDQLQueryPart('select', array('pre' => ' ', 'separator' => ', '));
+             . $this->_getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
 
         $fromParts   = $this->getDQLPart('from');
         $joinParts   = $this->getDQLPart('join');
-        $fromClauses = array();
+        $fromClauses = [];
 
         // Loop through all FROM clauses
         if ( ! empty($fromParts)) {
@@ -1417,10 +1417,10 @@ class QueryBuilder
         }
 
         $dql .= implode(', ', $fromClauses)
-              . $this->_getReducedDQLQueryPart('where', array('pre' => ' WHERE '))
-              . $this->_getReducedDQLQueryPart('groupBy', array('pre' => ' GROUP BY ', 'separator' => ', '))
-              . $this->_getReducedDQLQueryPart('having', array('pre' => ' HAVING '))
-              . $this->_getReducedDQLQueryPart('orderBy', array('pre' => ' ORDER BY ', 'separator' => ', '));
+              . $this->_getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
+              . $this->_getReducedDQLQueryPart('groupBy', ['pre' => ' GROUP BY ', 'separator' => ', '])
+              . $this->_getReducedDQLQueryPart('having', ['pre' => ' HAVING '])
+              . $this->_getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
 
         return $dql;
     }
@@ -1431,7 +1431,7 @@ class QueryBuilder
      *
      * @return string
      */
-    private function _getReducedDQLQueryPart($queryPartName, $options = array())
+    private function _getReducedDQLQueryPart($queryPartName, $options = [])
     {
         $queryPart = $this->getDQLPart($queryPartName);
 
@@ -1473,7 +1473,7 @@ class QueryBuilder
      */
     public function resetDQLPart($part)
     {
-        $this->_dqlParts[$part] = is_array($this->_dqlParts[$part]) ? array() : null;
+        $this->_dqlParts[$part] = is_array($this->_dqlParts[$part]) ? [] : null;
         $this->_state           = self::STATE_DIRTY;
 
         return $this;
@@ -1509,7 +1509,7 @@ class QueryBuilder
             }
         }
 
-        $parameters = array();
+        $parameters = [];
 
         foreach ($this->parameters as $parameter) {
             $parameters[] = clone $parameter;

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -34,7 +34,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
      *
      * @var \Doctrine\Common\Persistence\ObjectRepository[]
      */
-    private $repositoryList = array();
+    private $repositoryList = [];
 
     /**
      * {@inheritdoc}

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -33,7 +33,7 @@ class AttachEntityListenersListener
     /**
      * @var array[]
      */
-    private $entityListeners = array();
+    private $entityListeners = [];
 
     /**
      * Adds a entity listener for a specific entity.
@@ -47,11 +47,11 @@ class AttachEntityListenersListener
      */
     public function addEntityListener($entityClass, $listenerClass, $eventName, $listenerCallback = null)
     {
-        $this->entityListeners[ltrim($entityClass, '\\')][] = array(
+        $this->entityListeners[ltrim($entityClass, '\\')][] = [
             'event'  => $eventName,
             'class'  => $listenerClass,
             'method' => $listenerCallback ?: $eventName
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -46,12 +46,12 @@ class MetadataCommand extends Command
         $this
         ->setName('orm:clear-cache:metadata')
         ->setDescription('Clear all metadata cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the metadata cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -46,12 +46,12 @@ class QueryCommand extends Command
         $this
         ->setName('orm:clear-cache:query')
         ->setDescription('Clear all query cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the query cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -46,12 +46,12 @@ class ResultCommand extends Command
         $this
         ->setName('orm:clear-cache:result')
         ->setDescription('Clear all result cache of the various cache drivers.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'flush', null, InputOption::VALUE_NONE,
                 'If defined, cache entries will be flushed instead of deleted/invalidated.'
             )
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the result cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -102,9 +102,9 @@ class ConvertDoctrine1SchemaCommand extends Command
     {
         $this
         ->setName('orm:convert-d1-schema')
-        ->setAliases(array('orm:convert:d1-schema'))
+        ->setAliases(['orm:convert:d1-schema'])
         ->setDescription('Converts Doctrine 1.X schema into a Doctrine 2.X schema.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputArgument(
                 'from-path', InputArgument::REQUIRED, 'The path of Doctrine 1.X schema information.'
             ),
@@ -118,7 +118,7 @@ class ConvertDoctrine1SchemaCommand extends Command
             new InputOption(
                 'from', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Optional paths of Doctrine 1.X schema information.',
-                array()
+                []
             ),
             new InputOption(
                 'extend', null, InputOption::VALUE_OPTIONAL,
@@ -128,7 +128,7 @@ class ConvertDoctrine1SchemaCommand extends Command
                 'num-spaces', null, InputOption::VALUE_OPTIONAL,
                 'Defines the number of indentation spaces', 4
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Converts Doctrine 1.X schema into a Doctrine 2.X schema.
 EOT
@@ -141,7 +141,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Process source directories
-        $fromPaths = array_merge(array($input->getArgument('from-path')), $input->getOption('from'));
+        $fromPaths = array_merge([$input->getArgument('from-path')], $input->getOption('from'));
 
         // Process destination directory
         $destPath = realpath($input->getArgument('dest-path'));

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -49,9 +49,9 @@ class ConvertMappingCommand extends Command
     {
         $this
         ->setName('orm:convert-mapping')
-        ->setAliases(array('orm:convert:mapping'))
+        ->setAliases(['orm:convert:mapping'])
         ->setDescription('Convert mapping information between supported formats.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -82,7 +82,7 @@ class ConvertMappingCommand extends Command
                 'namespace', null, InputOption::VALUE_OPTIONAL,
                 'Defines a namespace for the generated entity classes, if converted from database.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Convert mapping information between supported formats.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -45,12 +45,12 @@ class EnsureProductionSettingsCommand extends Command
         $this
         ->setName('orm:ensure-production-settings')
         ->setDescription('Verify that Doctrine is properly configured for a production environment.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'complete', null, InputOption::VALUE_NONE,
                 'Flag to also inspect database connection existence.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Verify that Doctrine is properly configured for a production environment.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -47,9 +47,9 @@ class GenerateEntitiesCommand extends Command
     {
         $this
         ->setName('orm:generate-entities')
-        ->setAliases(array('orm:generate:entities'))
+        ->setAliases(['orm:generate:entities'])
         ->setDescription('Generate entity classes and method stubs from your mapping information.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -85,7 +85,7 @@ class GenerateEntitiesCommand extends Command
                 'no-backup', null, InputOption::VALUE_NONE,
                 'Flag to define if generator should avoid backuping existing entity file if it exists.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Generate entity classes and method stubs from your mapping information.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -45,9 +45,9 @@ class GenerateProxiesCommand extends Command
     {
         $this
         ->setName('orm:generate-proxies')
-        ->setAliases(array('orm:generate:proxies'))
+        ->setAliases(['orm:generate:proxies'])
         ->setDescription('Generates proxy classes for entity classes.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -56,7 +56,7 @@ class GenerateProxiesCommand extends Command
                 'dest-path', InputArgument::OPTIONAL,
                 'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Generates proxy classes for entity classes.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -46,9 +46,9 @@ class GenerateRepositoriesCommand extends Command
     {
         $this
         ->setName('orm:generate-repositories')
-        ->setAliases(array('orm:generate:repositories'))
+        ->setAliases(['orm:generate:repositories'])
         ->setDescription('Generate repository classes from your mapping information.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'A string pattern used to match entities that should be processed.'
@@ -56,7 +56,7 @@ class GenerateRepositoriesCommand extends Command
             new InputArgument(
                 'dest-path', InputArgument::REQUIRED, 'The path to generate your repository classes.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Generate repository classes from your mapping information.
 EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -81,14 +81,14 @@ EOT
     {
         $table = new Table($output);
 
-        $table->setHeaders(array('Field', 'Value'));
+        $table->setHeaders(['Field', 'Value']);
 
         $metadata = $this->getClassMetadata($entityName, $entityManager);
 
         array_map(
-            array($table, 'addRow'),
+            [$table, 'addRow'],
             array_merge(
-                array(
+                [
                     $this->formatField('Name', $metadata->name),
                     $this->formatField('Root entity name', $metadata->rootEntityName),
                     $this->formatField('Custom generator definition', $metadata->customGeneratorDefinition),
@@ -118,10 +118,10 @@ EOT
                     $this->formatField('Read only?', $metadata->isReadOnly),
 
                     $this->formatEntityListeners($metadata->entityListeners),
-                ),
-                array($this->formatField('Association mappings:', '')),
+                ],
+                [$this->formatField('Association mappings:', '')],
                 $this->formatMappings($metadata->associationMappings),
-                array($this->formatField('Field mappings:', '')),
+                [$this->formatField('Field mappings:', '')],
                 $this->formatMappings($metadata->fieldMappings)
             )
         );
@@ -251,7 +251,7 @@ EOT
             $value = '<comment>None</comment>';
         }
 
-        return array(sprintf('<info>%s</info>', $label), $this->formatValue($value));
+        return [sprintf('<info>%s</info>', $label), $this->formatValue($value)];
     }
 
     /**
@@ -263,7 +263,7 @@ EOT
      */
     private function formatMappings(array $propertyMappings)
     {
-        $output = array();
+        $output = [];
 
         foreach ($propertyMappings as $propertyName => $mapping) {
             $output[] = $this->formatField(sprintf('  %s', $propertyName), '');

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -46,7 +46,7 @@ class RunDqlCommand extends Command
         $this
         ->setName('orm:run-dql')
         ->setDescription('Executes arbitrary DQL directly from the command line.')
-        ->setDefinition(array(
+        ->setDefinition([
             new InputArgument('dql', InputArgument::REQUIRED, 'The DQL to execute.'),
             new InputOption(
                 'hydrate', null, InputOption::VALUE_REQUIRED,
@@ -69,7 +69,7 @@ class RunDqlCommand extends Command
                 'show-sql', null, InputOption::VALUE_NONE,
                 'Dump generated SQL instead of executing query'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Executes arbitrary DQL directly from the command line.
 EOT
@@ -126,7 +126,7 @@ EOT
             return;
         }
 
-        $resultSet = $query->execute(array(), constant($hydrationMode));
+        $resultSet = $query->execute([], constant($hydrationMode));
 
         $output->writeln(Debug::dump($resultSet, $input->getOption('depth'), true, false));
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -46,12 +46,12 @@ class CreateCommand extends AbstractCommand
         ->setDescription(
             'Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'dump-sql', null, InputOption::VALUE_NONE,
                 'Instead of trying to apply generated SQLs into EntityManager Storage Connection, output them.'
             )
-        ))
+        ])
         ->setHelp(<<<EOT
 Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -46,7 +46,7 @@ class DropCommand extends AbstractCommand
         ->setDescription(
             'Drop the complete database schema of EntityManager Storage Connection or generate the corresponding SQL output.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'dump-sql', null, InputOption::VALUE_NONE,
                 'Instead of trying to apply generated SQLs into EntityManager Storage Connection, output them.'
@@ -59,7 +59,7 @@ class DropCommand extends AbstractCommand
                 'full-database', null, InputOption::VALUE_NONE,
                 'Instead of using the Class Metadata to detect the database table schema, drop ALL assets that the database contains.'
             ),
-        ))
+        ])
         ->setHelp(<<<EOT
 Processes the schema and either drop the database schema of EntityManager Storage Connection or generate the SQL output.
 Beware that the complete database is dropped by this command, even tables that are not relevant to your metadata model.

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -53,7 +53,7 @@ class UpdateCommand extends AbstractCommand
         ->setDescription(
             'Executes (or dumps) the SQL needed to update the database schema to match the current mapping metadata.'
         )
-        ->setDefinition(array(
+        ->setDefinition([
             new InputOption(
                 'complete', null, InputOption::VALUE_NONE,
                 'If defined, all assets of the database which are not relevant to the current metadata will be dropped.'
@@ -67,7 +67,7 @@ class UpdateCommand extends AbstractCommand
                 'force', 'f', InputOption::VALUE_NONE,
                 'Causes the generated SQL statements to be physically executed against your database.'
             ),
-        ));
+        ]);
 
         $this->setHelp(<<<EOT
 The <info>%command.name%</info> command generates the SQL needed to

--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -40,10 +40,10 @@ class ConsoleRunner
      */
     public static function createHelperSet(EntityManagerInterface $entityManager)
     {
-        return new HelperSet(array(
+        return new HelperSet([
             'db' => new ConnectionHelper($entityManager->getConnection()),
             'em' => new EntityManagerHelper($entityManager)
-        ));
+        ]);
     }
 
     /**
@@ -54,7 +54,7 @@ class ConsoleRunner
      *
      * @return void
      */
-    static public function run(HelperSet $helperSet, $commands = array())
+    static public function run(HelperSet $helperSet, $commands = [])
     {
         $cli = self::createApplication($helperSet, $commands);
         $cli->run();
@@ -69,7 +69,7 @@ class ConsoleRunner
      *
      * @return \Symfony\Component\Console\Application
      */
-    static public function createApplication(HelperSet $helperSet, $commands = array())
+    static public function createApplication(HelperSet $helperSet, $commands = [])
     {
         $cli = new Application('Doctrine Command Line Interface', Version::VERSION);
         $cli->setCatchExceptions(true);
@@ -87,7 +87,7 @@ class ConsoleRunner
      */
     static public function addCommands(Application $cli)
     {
-        $cli->addCommands(array(
+        $cli->addCommands([
             // DBAL Commands
             new \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand(),
             new \Doctrine\DBAL\Tools\Console\Command\ImportCommand(),
@@ -109,7 +109,7 @@ class ConsoleRunner
             new \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand(),
             new \Doctrine\ORM\Tools\Console\Command\InfoCommand(),
             new \Doctrine\ORM\Tools\Console\Command\MappingDescribeCommand(),
-        ));
+        ]);
     }
 
     static public function printCliConfigTemplate()

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -35,7 +35,7 @@ class MetadataFilter extends \FilterIterator implements \Countable
     /**
      * @var array
      */
-    private $filter = array();
+    private $filter = [];
 
     /**
      * Filter Metadatas by one or more filter options.

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -44,12 +44,12 @@ class ConvertDoctrine1Schema
     /**
      * @var array
      */
-    private $legacyTypeMap = array(
+    private $legacyTypeMap = [
         // TODO: This list may need to be updated
         'clob' => 'text',
         'timestamp' => 'datetime',
         'enum' => 'string'
-    );
+    ];
 
     /**
      * Constructor passes the directory or array of directories
@@ -72,7 +72,7 @@ class ConvertDoctrine1Schema
      */
     public function getMetadata()
     {
-        $schema = array();
+        $schema = [];
         foreach ($this->from as $path) {
             if (is_dir($path)) {
                 $files = glob($path . '/*.yml');
@@ -84,7 +84,7 @@ class ConvertDoctrine1Schema
             }
         }
 
-        $metadatas = array();
+        $metadatas = [];
         foreach ($schema as $className => $mappingInformation) {
             $metadatas[] = $this->convertToClassMetadataInfo($className, $mappingInformation);
         }
@@ -153,12 +153,12 @@ class ConvertDoctrine1Schema
         }
 
         if ( ! $id) {
-            $fieldMapping = array(
+            $fieldMapping = [
                 'fieldName' => 'id',
                 'columnName' => 'id',
                 'type' => 'integer',
                 'id' => true
-            );
+            ];
             $metadata->mapField($fieldMapping);
             $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
         }
@@ -178,7 +178,7 @@ class ConvertDoctrine1Schema
     {
         if (is_string($column)) {
             $string = $column;
-            $column = array();
+            $column = [];
             $column['type'] = $string;
         }
 
@@ -208,7 +208,7 @@ class ConvertDoctrine1Schema
             throw ToolsException::couldNotMapDoctrine1Type($column['type']);
         }
 
-        $fieldMapping = array();
+        $fieldMapping = [];
 
         if (isset($column['primary'])) {
             $fieldMapping['id'] = true;
@@ -222,7 +222,7 @@ class ConvertDoctrine1Schema
             $fieldMapping['length'] = $column['length'];
         }
 
-        $allowed = array('precision', 'scale', 'unique', 'options', 'notnull', 'version');
+        $allowed = ['precision', 'scale', 'unique', 'options', 'notnull', 'version'];
 
         foreach ($column as $key => $value) {
             if (in_array($key, $allowed)) {
@@ -237,9 +237,9 @@ class ConvertDoctrine1Schema
         } elseif (isset($column['sequence'])) {
             $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
 
-            $definition = array(
+            $definition = [
                 'sequenceName' => is_array($column['sequence']) ? $column['sequence']['name']:$column['sequence']
-            );
+            ];
 
             if (isset($column['sequence']['size'])) {
                 $definition['allocationSize'] = $column['sequence']['size'];
@@ -272,9 +272,9 @@ class ConvertDoctrine1Schema
             $type = (isset($index['type']) && $index['type'] == 'unique')
                 ? 'uniqueConstraints' : 'indexes';
 
-            $metadata->table[$type][$name] = array(
+            $metadata->table[$type][$name] = [
                 'columns' => $index['fields']
-            );
+            ];
         }
     }
 
@@ -311,17 +311,17 @@ class ConvertDoctrine1Schema
             if (isset($relation['refClass'])) {
                 $type = 'many';
                 $foreignType = 'many';
-                $joinColumns = array();
+                $joinColumns = [];
             } else {
                 $type = isset($relation['type']) ? $relation['type'] : 'one';
                 $foreignType = isset($relation['foreignType']) ? $relation['foreignType'] : 'many';
-                $joinColumns = array(
-                    array(
+                $joinColumns = [
+                    [
                         'name' => $relation['local'],
                         'referencedColumnName' => $relation['foreign'],
                         'onDelete' => isset($relation['onDelete']) ? $relation['onDelete'] : null,
-                    )
-                );
+                    ]
+                ];
             }
 
             if ($type == 'one' && $foreignType == 'one') {
@@ -332,7 +332,7 @@ class ConvertDoctrine1Schema
                 $method = 'mapOneToMany';
             }
 
-            $associationMapping = array();
+            $associationMapping = [];
             $associationMapping['fieldName'] = $relation['alias'];
             $associationMapping['targetEntity'] = $relation['class'];
             $associationMapping['mappedBy'] = $relation['foreignAlias'];

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -78,7 +78,7 @@ class EntityGenerator
     /**
      * @var array
      */
-    protected $staticReflection = array();
+    protected $staticReflection = [];
 
     /**
      * Number of spaces to use for indention in generated code.
@@ -151,7 +151,7 @@ class EntityGenerator
      *
      * @var array
      */
-    protected $typeAlias = array(
+    protected $typeAlias = [
         Type::DATETIMETZ    => '\DateTime',
         Type::DATETIME      => '\DateTime',
         Type::DATE          => '\DateTime',
@@ -166,14 +166,14 @@ class EntityGenerator
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
         Type::BOOLEAN       => 'bool',
-    );
+    ];
 
     /**
      * Hash-map to handle generator types string.
      *
      * @var array
      */
-    protected static $generatorStrategyMap = array(
+    protected static $generatorStrategyMap = [
         ClassMetadataInfo::GENERATOR_TYPE_AUTO      => 'AUTO',
         ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE  => 'SEQUENCE',
         ClassMetadataInfo::GENERATOR_TYPE_TABLE     => 'TABLE',
@@ -181,30 +181,30 @@ class EntityGenerator
         ClassMetadataInfo::GENERATOR_TYPE_NONE      => 'NONE',
         ClassMetadataInfo::GENERATOR_TYPE_UUID      => 'UUID',
         ClassMetadataInfo::GENERATOR_TYPE_CUSTOM    => 'CUSTOM'
-    );
+    ];
 
     /**
      * Hash-map to handle the change tracking policy string.
      *
      * @var array
      */
-    protected static $changeTrackingPolicyMap = array(
+    protected static $changeTrackingPolicyMap = [
         ClassMetadataInfo::CHANGETRACKING_DEFERRED_IMPLICIT  => 'DEFERRED_IMPLICIT',
         ClassMetadataInfo::CHANGETRACKING_DEFERRED_EXPLICIT  => 'DEFERRED_EXPLICIT',
         ClassMetadataInfo::CHANGETRACKING_NOTIFY             => 'NOTIFY',
-    );
+    ];
 
     /**
      * Hash-map to handle the inheritance type string.
      *
      * @var array
      */
-    protected static $inheritanceTypeMap = array(
+    protected static $inheritanceTypeMap = [
         ClassMetadataInfo::INHERITANCE_TYPE_NONE            => 'NONE',
         ClassMetadataInfo::INHERITANCE_TYPE_JOINED          => 'JOINED',
         ClassMetadataInfo::INHERITANCE_TYPE_SINGLE_TABLE    => 'SINGLE_TABLE',
         ClassMetadataInfo::INHERITANCE_TYPE_TABLE_PER_CLASS => 'TABLE_PER_CLASS',
-    );
+    ];
 
     /**
      * @var string
@@ -376,7 +376,7 @@ public function __construct(<params>)
         if ( ! $this->isNew) {
             $this->parseTokensInEntityFile(file_get_contents($path));
         } else {
-            $this->staticReflection[$metadata->name] = array('properties' => array(), 'methods' => array());
+            $this->staticReflection[$metadata->name] = ['properties' => [], 'methods' => []];
         }
 
         if ($this->backupExisting && file_exists($path)) {
@@ -405,21 +405,21 @@ public function __construct(<params>)
      */
     public function generateEntityClass(ClassMetadataInfo $metadata)
     {
-        $placeHolders = array(
+        $placeHolders = [
             '<namespace>',
             '<useStatement>',
             '<entityAnnotation>',
             '<entityClassName>',
             '<entityBody>'
-        );
+        ];
 
-        $replacements = array(
+        $replacements = [
             $this->generateEntityNamespace($metadata),
             $this->generateEntityUse(),
             $this->generateEntityDocBlock($metadata),
             $this->generateEntityClassName($metadata),
             $this->generateEntityBody($metadata)
-        );
+        ];
 
         $code = str_replace($placeHolders, $replacements, static::$classTemplate) . "\n";
 
@@ -641,7 +641,7 @@ public function __construct(<params>)
         $stubMethods = $this->generateEntityStubMethods ? $this->generateEntityStubMethods($metadata) : null;
         $lifecycleCallbackMethods = $this->generateEntityLifecycleCallbackMethods($metadata);
 
-        $code = array();
+        $code = [];
 
         if ($fieldMappingProperties) {
             $code[] = $fieldMappingProperties;
@@ -683,7 +683,7 @@ public function __construct(<params>)
             return $this->generateEmbeddableConstructor($metadata);
         }
 
-        $collections = array();
+        $collections = [];
 
         foreach ($metadata->associationMappings as $mapping) {
             if ($mapping['type'] & ClassMetadataInfo::TO_MANY) {
@@ -705,14 +705,14 @@ public function __construct(<params>)
      */
     private function generateEmbeddableConstructor(ClassMetadataInfo $metadata)
     {
-        $paramTypes = array();
-        $paramVariables = array();
-        $params = array();
-        $fields = array();
+        $paramTypes = [];
+        $paramVariables = [];
+        $params = [];
+        $fields = [];
 
         // Resort fields to put optional fields at the end of the method signature.
-        $requiredFields = array();
-        $optionalFields = array();
+        $requiredFields = [];
+        $optionalFields = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if (empty($fieldMapping['nullable'])) {
@@ -777,11 +777,11 @@ public function __construct(<params>)
             $params = implode(', ', $params);
         }
 
-        $replacements = array(
+        $replacements = [
             '<paramTags>' => implode("\n * ", $paramTags),
             '<params>'    => $params,
             '<fields>'    => implode("\n" . $this->spaces, $fields),
-        );
+        ];
 
         $constructor = str_replace(
             array_keys($replacements),
@@ -810,14 +810,14 @@ public function __construct(<params>)
 
         for ($i = 0; $i < count($tokens); $i++) {
             $token = $tokens[$i];
-            if (in_array($token[0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT))) {
+            if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])) {
                 continue;
             }
 
             if ($inNamespace) {
                 if ($token[0] == T_NS_SEPARATOR || $token[0] == T_STRING) {
                     $lastSeenNamespace .= $token[1];
-                } elseif (is_string($token) && in_array($token, array(';', '{'))) {
+                } elseif (is_string($token) && in_array($token, [';', '{'])) {
                     $inNamespace = false;
                 }
             }
@@ -825,8 +825,8 @@ public function __construct(<params>)
             if ($inClass) {
                 $inClass = false;
                 $lastSeenClass = $lastSeenNamespace . ($lastSeenNamespace ? '\\' : '') . $token[1];
-                $this->staticReflection[$lastSeenClass]['properties'] = array();
-                $this->staticReflection[$lastSeenClass]['methods'] = array();
+                $this->staticReflection[$lastSeenClass]['properties'] = [];
+                $this->staticReflection[$lastSeenClass]['methods'] = [];
             }
 
             if ($token[0] == T_NAMESPACE) {
@@ -840,7 +840,7 @@ public function __construct(<params>)
                 } elseif ($tokens[$i+2] == "&" && $tokens[$i+3][0] == T_STRING) {
                     $this->staticReflection[$lastSeenClass]['methods'][] = strtolower($tokens[$i+3][1]);
                 }
-            } elseif (in_array($token[0], array(T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED)) && $tokens[$i+2][0] != T_FUNCTION) {
+            } elseif (in_array($token[0], [T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED]) && $tokens[$i+2][0] != T_FUNCTION) {
                 $this->staticReflection[$lastSeenClass]['properties'][] = substr($tokens[$i+2][1], 1);
             }
         }
@@ -920,7 +920,7 @@ public function __construct(<params>)
             ? new \ReflectionClass($metadata->name)
             : $metadata->reflClass;
 
-        $traits = array();
+        $traits = [];
 
         while ($reflClass !== false) {
             $traits = array_merge($traits, $reflClass->getTraits());
@@ -995,20 +995,20 @@ public function __construct(<params>)
      */
     protected function generateEntityDocBlock(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = '/**';
         $lines[] = ' * ' . $this->getClassName($metadata);
 
         if ($this->generateAnnotations) {
             $lines[] = ' *';
 
-            $methods = array(
+            $methods = [
                 'generateTableAnnotation',
                 'generateInheritanceAnnotation',
                 'generateDiscriminatorColumnAnnotation',
                 'generateDiscriminatorMapAnnotation',
                 'generateEntityAnnotation',
-            );
+            ];
 
             foreach ($methods as $method) {
                 if ($code = $this->$method($metadata)) {
@@ -1057,7 +1057,7 @@ public function __construct(<params>)
             return '';
         }
 
-        $table = array();
+        $table = [];
 
         if (isset($metadata->table['schema'])) {
             $table[] = 'schema="' . $metadata->table['schema'] . '"';
@@ -1092,9 +1092,9 @@ public function __construct(<params>)
      */
     protected function generateTableConstraints($constraintName, $constraints)
     {
-        $annotations = array();
+        $annotations = [];
         foreach ($constraints as $name => $constraint) {
-            $columns = array();
+            $columns = [];
             foreach ($constraint['columns'] as $column) {
                 $columns[] = '"' . $column . '"';
             }
@@ -1140,7 +1140,7 @@ public function __construct(<params>)
     protected function generateDiscriminatorMapAnnotation($metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
-            $inheritanceClassMap = array();
+            $inheritanceClassMap = [];
 
             foreach ($metadata->discriminatorMap as $type => $class) {
                 $inheritanceClassMap[] .= '"' . $type . '" = "' . $class . '"';
@@ -1157,7 +1157,7 @@ public function __construct(<params>)
      */
     protected function generateEntityStubMethods(ClassMetadataInfo $metadata)
     {
-        $methods = array();
+        $methods = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if (isset($fieldMapping['declaredField']) &&
@@ -1237,7 +1237,7 @@ public function __construct(<params>)
             $joinColumns = $associationMapping['joinColumns'];
         } else {
             //@todo there is no way to retrieve targetEntity metadata
-            $joinColumns = array();
+            $joinColumns = [];
         }
 
         foreach ($joinColumns as $joinColumn) {
@@ -1257,7 +1257,7 @@ public function __construct(<params>)
     protected function generateEntityLifecycleCallbackMethods(ClassMetadataInfo $metadata)
     {
         if (isset($metadata->lifecycleCallbacks) && $metadata->lifecycleCallbacks) {
-            $methods = array();
+            $methods = [];
 
             foreach ($metadata->lifecycleCallbacks as $name => $callbacks) {
                 foreach ($callbacks as $callback) {
@@ -1280,7 +1280,7 @@ public function __construct(<params>)
      */
     protected function generateEntityAssociationMappingProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->associationMappings as $associationMapping) {
             if ($this->hasProperty($associationMapping['fieldName'], $metadata)) {
@@ -1302,7 +1302,7 @@ public function __construct(<params>)
      */
     protected function generateEntityFieldMappingProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->fieldMappings as $fieldMapping) {
             if ($this->hasProperty($fieldMapping['fieldName'], $metadata) ||
@@ -1330,7 +1330,7 @@ public function __construct(<params>)
      */
     protected function generateEntityEmbeddedProperties(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
 
         foreach ($metadata->embeddedClasses as $fieldName => $embeddedClass) {
             if (isset($embeddedClass['declaredField']) || $this->hasProperty($fieldName, $metadata)) {
@@ -1357,7 +1357,7 @@ public function __construct(<params>)
     {
         $methodName = $type . Inflector::classify($fieldName);
         $variableName = Inflector::camelize($fieldName);
-        if (in_array($type, array("add", "remove"))) {
+        if (in_array($type, ["add", "remove"])) {
             $methodName = Inflector::singularize($methodName);
             $variableName = Inflector::singularize($variableName);
         }
@@ -1379,7 +1379,7 @@ public function __construct(<params>)
             $methodTypeHint =  '\\' . $typeHint . ' ';
         }
 
-        $replacements = array(
+        $replacements = [
           '<description>'       => ucfirst($type) . ' ' . $variableName,
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
@@ -1388,7 +1388,7 @@ public function __construct(<params>)
           '<fieldName>'         => $fieldName,
           '<variableDefault>'   => ($defaultValue !== null ) ? (' = '.$defaultValue) : '',
           '<entity>'            => $this->getClassName($metadata)
-        );
+        ];
 
         $method = str_replace(
             array_keys($replacements),
@@ -1413,10 +1413,10 @@ public function __construct(<params>)
         }
         $this->staticReflection[$metadata->name]['methods'][] = $methodName;
 
-        $replacements = array(
+        $replacements = [
             '<name>'        => $this->annotationsPrefix . ucfirst($name),
             '<methodName>'  => $methodName,
-        );
+        ];
 
         $method = str_replace(
             array_keys($replacements),
@@ -1434,7 +1434,7 @@ public function __construct(<params>)
      */
     protected function generateJoinColumnAnnotation(array $joinColumn)
     {
-        $joinColumnAnnot = array();
+        $joinColumnAnnot = [];
 
         if (isset($joinColumn['name'])) {
             $joinColumnAnnot[] = 'name="' . $joinColumn['name'] . '"';
@@ -1471,7 +1471,7 @@ public function __construct(<params>)
      */
     protected function generateAssociationMappingPropertyDocBlock(array $associationMapping, ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
 
         if ($associationMapping['type'] & ClassMetadataInfo::TO_MANY) {
@@ -1506,7 +1506,7 @@ public function __construct(<params>)
                     $type = 'ManyToMany';
                     break;
             }
-            $typeOptions = array();
+            $typeOptions = [];
 
             if (isset($associationMapping['targetEntity'])) {
                 $typeOptions[] = 'targetEntity="' . $associationMapping['targetEntity'] . '"';
@@ -1521,7 +1521,7 @@ public function __construct(<params>)
             }
 
             if ($associationMapping['cascade']) {
-                $cascades = array();
+                $cascades = [];
 
                 if ($associationMapping['isCascadePersist']) $cascades[] = '"persist"';
                 if ($associationMapping['isCascadeRemove']) $cascades[] = '"remove"';
@@ -1530,7 +1530,7 @@ public function __construct(<params>)
                 if ($associationMapping['isCascadeRefresh']) $cascades[] = '"refresh"';
 
                 if (count($cascades) === 5) {
-                    $cascades = array('"all"');
+                    $cascades = ['"all"'];
                 }
 
                 $typeOptions[] = 'cascade={' . implode(',', $cascades) . '}';
@@ -1541,10 +1541,10 @@ public function __construct(<params>)
             }
 
             if (isset($associationMapping['fetch']) && $associationMapping['fetch'] !== ClassMetadataInfo::FETCH_LAZY) {
-                $fetchMap = array(
+                $fetchMap = [
                     ClassMetadataInfo::FETCH_EXTRA_LAZY => 'EXTRA_LAZY',
                     ClassMetadataInfo::FETCH_EAGER      => 'EAGER',
-                );
+                ];
 
                 $typeOptions[] = 'fetch="' . $fetchMap[$associationMapping['fetch']] . '"';
             }
@@ -1554,7 +1554,7 @@ public function __construct(<params>)
             if (isset($associationMapping['joinColumns']) && $associationMapping['joinColumns']) {
                 $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'JoinColumns({';
 
-                $joinColumnsLines = array();
+                $joinColumnsLines = [];
 
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     if ($joinColumnAnnot = $this->generateJoinColumnAnnotation($joinColumn)) {
@@ -1567,7 +1567,7 @@ public function __construct(<params>)
             }
 
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
-                $joinTable = array();
+                $joinTable = [];
                 $joinTable[] = 'name="' . $associationMapping['joinTable']['name'] . '"';
 
                 if (isset($associationMapping['joinTable']['schema'])) {
@@ -1577,7 +1577,7 @@ public function __construct(<params>)
                 $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'JoinTable(' . implode(', ', $joinTable) . ',';
                 $lines[] = $this->spaces . ' *   joinColumns={';
 
-                $joinColumnsLines = array();
+                $joinColumnsLines = [];
 
                 foreach ($associationMapping['joinTable']['joinColumns'] as $joinColumn) {
                     $joinColumnsLines[] = $this->spaces . ' *     ' . $this->generateJoinColumnAnnotation($joinColumn);
@@ -1587,7 +1587,7 @@ public function __construct(<params>)
                 $lines[] = $this->spaces . ' *   },';
                 $lines[] = $this->spaces . ' *   inverseJoinColumns={';
 
-                $inverseJoinColumnsLines = array();
+                $inverseJoinColumnsLines = [];
 
                 foreach ($associationMapping['joinTable']['inverseJoinColumns'] as $joinColumn) {
                     $inverseJoinColumnsLines[] = $this->spaces . ' *     ' . $this->generateJoinColumnAnnotation($joinColumn);
@@ -1623,14 +1623,14 @@ public function __construct(<params>)
      */
     protected function generateFieldMappingPropertyDocBlock(array $fieldMapping, ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
         $lines[] = $this->spaces . ' * @var ' . $this->getType($fieldMapping['type']);
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';
 
-            $column = array();
+            $column = [];
             if (isset($fieldMapping['columnName'])) {
                 $column[] = 'name="' . $fieldMapping['columnName'] . '"';
             }
@@ -1683,7 +1683,7 @@ public function __construct(<params>)
                 }
 
                 if ($metadata->sequenceGeneratorDefinition) {
-                    $sequenceGenerator = array();
+                    $sequenceGenerator = [];
 
                     if (isset($metadata->sequenceGeneratorDefinition['sequenceName'])) {
                         $sequenceGenerator[] = 'sequenceName="' . $metadata->sequenceGeneratorDefinition['sequenceName'] . '"';
@@ -1718,14 +1718,14 @@ public function __construct(<params>)
      */
     protected function generateEmbeddedPropertyDocBlock(array $embeddedClass)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = $this->spaces . '/**';
         $lines[] = $this->spaces . ' * @var \\' . ltrim($embeddedClass['class'], '\\');
 
         if ($this->generateAnnotations) {
             $lines[] = $this->spaces . ' *';
 
-            $embedded = array('class="' . $embeddedClass['class'] . '"');
+            $embedded = ['class="' . $embeddedClass['class'] . '"'];
 
             if (isset($fieldMapping['columnPrefix'])) {
                 $embedded[] = 'columnPrefix=' . var_export($embeddedClass['columnPrefix'], true);
@@ -1814,7 +1814,7 @@ public function __construct(<params>)
      */
     private function exportTableOptions(array $options)
     {
-        $optionsStr = array();
+        $optionsStr = [];
 
         foreach($options as $name => $option) {
             if (is_array($option)) {

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -57,11 +57,11 @@ class <className> extends <repositoryName>
      */
     public function generateEntityRepositoryClass($fullClassName)
     {
-        $variables = array(
+        $variables = [
             '<namespace>'       => $this->generateEntityRepositoryNamespace($fullClassName),
             '<repositoryName>'  => $this->generateEntityRepositoryName($fullClassName),
             '<className>'       => $this->generateClassName($fullClassName)
-        );
+        ];
 
         return str_replace(array_keys($variables), array_values($variables), self::$_template);
     }

--- a/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
@@ -32,13 +32,13 @@ class ClassMetadataExporter
     /**
      * @var array
      */
-    private static $_exporterDrivers = array(
+    private static $_exporterDrivers = [
         'xml' => 'Doctrine\ORM\Tools\Export\Driver\XmlExporter',
         'yaml' => 'Doctrine\ORM\Tools\Export\Driver\YamlExporter',
         'yml' => 'Doctrine\ORM\Tools\Export\Driver\YamlExporter',
         'php' => 'Doctrine\ORM\Tools\Export\Driver\PhpExporter',
         'annotation' => 'Doctrine\ORM\Tools\Export\Driver\AnnotationExporter'
-    );
+    ];
 
     /**
      * Registers a new exporter driver class under a specified name.

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -35,7 +35,7 @@ abstract class AbstractExporter
     /**
      * @var array
      */
-    protected $_metadata = array();
+    protected $_metadata = [];
 
     /**
      * @var string|null

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -40,7 +40,7 @@ class PhpExporter extends AbstractExporter
      */
     public function exportClassMetadata(ClassMetadataInfo $metadata)
     {
-        $lines = array();
+        $lines = [];
         $lines[] = '<?php';
         $lines[] = null;
         $lines[] = 'use Doctrine\ORM\Mapping\ClassMetadataInfo;';
@@ -91,7 +91,7 @@ class PhpExporter extends AbstractExporter
         }
 
         foreach ($metadata->associationMappings as $associationMapping) {
-            $cascade = array('remove', 'persist', 'refresh', 'merge', 'detach');
+            $cascade = ['remove', 'persist', 'refresh', 'merge', 'detach'];
             foreach ($cascade as $key => $value) {
                 if ( ! $associationMapping['isCascade'.ucfirst($value)]) {
                     unset($cascade[$key]);
@@ -99,14 +99,14 @@ class PhpExporter extends AbstractExporter
             }
 
             if (count($cascade) === 5) {
-                $cascade = array('all');
+                $cascade = ['all'];
             }
 
-            $associationMappingArray = array(
+            $associationMappingArray = [
                 'fieldName'    => $associationMapping['fieldName'],
                 'targetEntity' => $associationMapping['targetEntity'],
                 'cascade'     => $cascade,
-            );
+            ];
 
             if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $associationMapping['fetch'];
@@ -114,21 +114,21 @@ class PhpExporter extends AbstractExporter
 
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $method = 'mapOneToOne';
-                $oneToOneMappingArray = array(
+                $oneToOneMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'joinColumns'   => $associationMapping['joinColumns'],
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToOneMappingArray);
             } elseif ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_MANY) {
                 $method = 'mapOneToMany';
-                $potentialAssociationMappingIndexes = array(
+                $potentialAssociationMappingIndexes = [
                     'mappedBy',
                     'orphanRemoval',
                     'orderBy',
-                );
+                ];
                 foreach ($potentialAssociationMappingIndexes as $index) {
                     if (isset($associationMapping[$index])) {
                         $oneToManyMappingArray[$index] = $associationMapping[$index];
@@ -137,11 +137,11 @@ class PhpExporter extends AbstractExporter
                 $associationMappingArray = array_merge($associationMappingArray, $oneToManyMappingArray);
             } elseif ($associationMapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
                 $method = 'mapManyToMany';
-                $potentialAssociationMappingIndexes = array(
+                $potentialAssociationMappingIndexes = [
                     'mappedBy',
                     'joinTable',
                     'orderBy',
-                );
+                ];
                 foreach ($potentialAssociationMappingIndexes as $index) {
                     if (isset($associationMapping[$index])) {
                         $manyToManyMappingArray[$index] = $associationMapping[$index];

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -126,7 +126,7 @@ class XmlExporter extends AbstractExporter
 
         $fields = $metadata->fieldMappings;
 
-        $id = array();
+        $id = [];
         foreach ($fields as $name => $field) {
             if (isset($field['id']) && $field['id']) {
                 $id[$name] = $field;
@@ -136,10 +136,10 @@ class XmlExporter extends AbstractExporter
 
         foreach ($metadata->associationMappings as $name => $assoc) {
             if (isset($assoc['id']) && $assoc['id']) {
-                $id[$name] = array(
+                $id[$name] = [
                     'fieldName' => $name,
                     'associationKey' => true
-                );
+                ];
             }
         }
 
@@ -225,12 +225,12 @@ class XmlExporter extends AbstractExporter
             }
         }
 
-        $orderMap = array(
+        $orderMap = [
             ClassMetadataInfo::ONE_TO_ONE,
             ClassMetadataInfo::ONE_TO_MANY,
             ClassMetadataInfo::MANY_TO_ONE,
             ClassMetadataInfo::MANY_TO_MANY,
-        );
+        ];
 
         uasort($metadata->associationMappings, function($m1, $m2) use (&$orderMap){
             $a1 = array_search($m1['type'], $orderMap);
@@ -273,7 +273,7 @@ class XmlExporter extends AbstractExporter
                 $associationMappingXml->addAttribute('fetch', $this->_getFetchModeString($associationMapping['fetch']));
             }
 
-            $cascade = array();
+            $cascade = [];
             if ($associationMapping['isCascadeRemove']) {
                 $cascade[] = 'cascade-remove';
             }
@@ -295,7 +295,7 @@ class XmlExporter extends AbstractExporter
             }
 
             if (count($cascade) === 5) {
-                $cascade  = array('cascade-all');
+                $cascade  = ['cascade-all'];
             }
 
             if ($cascade) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -41,7 +41,7 @@ class YamlExporter extends AbstractExporter
      */
     public function exportClassMetadata(ClassMetadataInfo $metadata)
     {
-        $array = array();
+        $array = [];
 
         if ($metadata->isMappedSuperclass) {
             $array['type'] = 'mappedSuperclass';
@@ -91,7 +91,7 @@ class YamlExporter extends AbstractExporter
 
         $fieldMappings = $metadata->fieldMappings;
 
-        $ids = array();
+        $ids = [];
         foreach ($fieldMappings as $name => $fieldMapping) {
             $fieldMapping['column'] = $fieldMapping['columnName'];
 
@@ -118,13 +118,13 @@ class YamlExporter extends AbstractExporter
 
         if ($fieldMappings) {
             if ( ! isset($array['fields'])) {
-                $array['fields'] = array();
+                $array['fields'] = [];
             }
             $array['fields'] = array_merge($array['fields'], $fieldMappings);
         }
 
         foreach ($metadata->associationMappings as $name => $associationMapping) {
-            $cascade = array();
+            $cascade = [];
 
             if ($associationMapping['isCascadeRemove']) {
                 $cascade[] = 'remove';
@@ -146,13 +146,13 @@ class YamlExporter extends AbstractExporter
                 $cascade[] = 'detach';
             }
             if (count($cascade) === 5) {
-                $cascade = array('all');
+                $cascade = ['all'];
             }
 
-            $associationMappingArray = array(
+            $associationMappingArray = [
                 'targetEntity' => $associationMapping['targetEntity'],
                 'cascade'     => $cascade,
-            );
+            ];
 
             if (isset($associationMapping['fetch'])) {
                 $associationMappingArray['fetch'] = $this->_getFetchModeString($associationMapping['fetch']);
@@ -164,7 +164,7 @@ class YamlExporter extends AbstractExporter
 
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $joinColumns = $associationMapping['joinColumns'];
-                $newJoinColumns = array();
+                $newJoinColumns = [];
 
                 foreach ($joinColumns as $joinColumn) {
                     $newJoinColumns[$joinColumn['name']]['referencedColumnName'] = $joinColumn['referencedColumnName'];
@@ -174,12 +174,12 @@ class YamlExporter extends AbstractExporter
                     }
                 }
 
-                $oneToOneMappingArray = array(
+                $oneToOneMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'joinColumns'   => $newJoinColumns,
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToOneMappingArray);
 
@@ -189,22 +189,22 @@ class YamlExporter extends AbstractExporter
                     $array['manyToOne'][$name] = $associationMappingArray;
                 }
             } elseif ($associationMapping['type'] == ClassMetadataInfo::ONE_TO_MANY) {
-                $oneToManyMappingArray = array(
+                $oneToManyMappingArray = [
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
                     'orderBy'       => isset($associationMapping['orderBy']) ? $associationMapping['orderBy'] : null
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $oneToManyMappingArray);
                 $array['oneToMany'][$name] = $associationMappingArray;
             } elseif ($associationMapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
-                $manyToManyMappingArray = array(
+                $manyToManyMappingArray = [
                     'mappedBy'   => $associationMapping['mappedBy'],
                     'inversedBy' => $associationMapping['inversedBy'],
                     'joinTable'  => isset($associationMapping['joinTable']) ? $associationMapping['joinTable'] : null,
                     'orderBy'    => isset($associationMapping['orderBy']) ? $associationMapping['orderBy'] : null
-                );
+                ];
 
                 $associationMappingArray = array_merge($associationMappingArray, $manyToManyMappingArray);
                 $array['manyToMany'][$name] = $associationMappingArray;
@@ -214,7 +214,7 @@ class YamlExporter extends AbstractExporter
             $array['lifecycleCallbacks'] = $metadata->lifecycleCallbacks;
         }
 
-        return $this->yamlDump(array($metadata->name => $array), 10);
+        return $this->yamlDump([$metadata->name => $array], 10);
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -102,7 +102,7 @@ class CountOutputWalker extends SqlWalker
         $rootIdentifier = $rootClass->identifier;
 
         // For every identifier, find out the SQL alias by combing through the ResultSetMapping
-        $sqlIdentifier = array();
+        $sqlIdentifier = [];
         foreach ($rootIdentifier as $property) {
             if (isset($rootClass->fieldMappings[$property])) {
                 foreach (array_keys($this->rsm->fieldMappings, $property) as $alias) {

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -75,11 +75,11 @@ class CountWalker extends TreeWalkerAdapter
         $pathExpression->type = $pathType;
 
         $distinct = $this->_getQuery()->getHint(self::HINT_DISTINCT);
-        $AST->selectClause->selectExpressions = array(
+        $AST->selectClause->selectExpressions = [
             new SelectExpression(
                 new AggregateExpression('count', $pathExpression, $distinct), null
             )
-        );
+        ];
 
         // ORDER BY is not needed, only increases query execution through unnecessary sorting.
         $AST->orderByClause = null;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -69,7 +69,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         $fromRoot  = reset($from);
         $rootAlias = $fromRoot->rangeVariableDeclaration->aliasIdentificationVariable;
         $rootClass = $queryComponents[$rootAlias]['metadata'];
-        $selectExpressions = array();
+        $selectExpressions = [];
 
         $this->validate($AST);
 

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -153,7 +153,7 @@ class Paginator implements \Countable, \IteratorAggregate
             $whereInQuery = $this->cloneQuery($this->query);
             // don't do this for an empty id array
             if (count($ids) === 0) {
-                return new \ArrayIterator(array());
+                return new \ArrayIterator([]);
             }
 
             $this->appendTreeWalker($whereInQuery, 'Doctrine\ORM\Tools\Pagination\WhereInWalker');
@@ -224,7 +224,7 @@ class Paginator implements \Countable, \IteratorAggregate
         $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
 
         if ($hints === false) {
-            $hints = array();
+            $hints = [];
         }
 
         $hints[] = $walkerClass;

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -97,7 +97,7 @@ class WhereInWalker extends TreeWalkerAdapter
         if ($count > 0) {
             $arithmeticExpression = new ArithmeticExpression();
             $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
-                array($pathExpression)
+                [$pathExpression]
             );
             $expression = new InExpression($arithmeticExpression);
             $expression->literals[] = new InputParameter(":" . self::PAGINATOR_ID_ALIAS);
@@ -113,29 +113,29 @@ class WhereInWalker extends TreeWalkerAdapter
             if ($AST->whereClause->conditionalExpression instanceof ConditionalTerm) {
                 $AST->whereClause->conditionalExpression->conditionalFactors[] = $conditionalPrimary;
             } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalPrimary) {
-                $AST->whereClause->conditionalExpression = new ConditionalExpression(array(
-                    new ConditionalTerm(array(
+                $AST->whereClause->conditionalExpression = new ConditionalExpression([
+                    new ConditionalTerm([
                         $AST->whereClause->conditionalExpression,
                         $conditionalPrimary
-                    ))
-                ));
+                    ])
+                ]);
             } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
                 || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
             ) {
                 $tmpPrimary = new ConditionalPrimary;
                 $tmpPrimary->conditionalExpression = $AST->whereClause->conditionalExpression;
-                $AST->whereClause->conditionalExpression = new ConditionalTerm(array(
+                $AST->whereClause->conditionalExpression = new ConditionalTerm([
                     $tmpPrimary,
                     $conditionalPrimary
-                ));
+                ]);
             }
         } else {
             $AST->whereClause = new WhereClause(
-                new ConditionalExpression(array(
-                    new ConditionalTerm(array(
+                new ConditionalExpression([
+                    new ConditionalTerm([
                         $conditionalPrimary
-                    ))
-                ))
+                    ])
+                ])
             );
         }
     }

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -39,17 +39,17 @@ class ResolveTargetEntityListener implements EventSubscriber
     /**
      * @var array[] indexed by original entity name
      */
-    private $resolveTargetEntities = array();
+    private $resolveTargetEntities = [];
 
     /**
      * {@inheritDoc}
      */
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             Events::loadClassMetadata,
             Events::onClassMetadataNotFound
-        );
+        ];
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -142,16 +142,16 @@ class SchemaTool
     public function getSchemaFromMetadata(array $classes)
     {
         // Reminder for processed classes, used for hierarchies
-        $processedClasses       = array();
+        $processedClasses       = [];
         $eventManager           = $this->em->getEventManager();
         $schemaManager          = $this->em->getConnection()->getSchemaManager();
         $metadataSchemaConfig   = $schemaManager->createSchemaConfig();
 
         $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
-        $schema = new Schema(array(), array(), $metadataSchemaConfig);
+        $schema = new Schema([], [], $metadataSchemaConfig);
 
-        $addedFks = array();
-        $blacklistedFks = array();
+        $addedFks = [];
+        $blacklistedFks = [];
 
         foreach ($classes as $class) {
             /** @var \Doctrine\ORM\Mapping\ClassMetadata $class */
@@ -182,7 +182,7 @@ class SchemaTool
                 }
             } elseif ($class->isInheritanceTypeJoined()) {
                 // Add all non-inherited fields as columns
-                $pkColumns = array();
+                $pkColumns = [];
                 foreach ($class->fieldMappings as $fieldName => $mapping) {
                     if ( ! isset($mapping['inherited'])) {
                         $columnName = $this->quoteStrategy->getColumnName(
@@ -205,7 +205,7 @@ class SchemaTool
                     $this->addDiscriminatorColumnDefinition($class, $table);
                 } else {
                     // Add an ID FK column to child tables
-                    $inheritedKeyColumns = array();
+                    $inheritedKeyColumns = [];
                     foreach ($class->identifier as $identifierField) {
                         $idMapping = $class->fieldMappings[$identifierField];
                         if (isset($idMapping['inherited'])) {
@@ -231,7 +231,7 @@ class SchemaTool
                             ),
                             $inheritedKeyColumns,
                             $inheritedKeyColumns,
-                            array('onDelete' => 'CASCADE')
+                            ['onDelete' => 'CASCADE']
                         );
                     }
 
@@ -246,7 +246,7 @@ class SchemaTool
                 $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
             }
 
-            $pkColumns = array();
+            $pkColumns = [];
 
             foreach ($class->identifier as $identifierField) {
                 if (isset($class->fieldMappings[$identifierField])) {
@@ -279,10 +279,10 @@ class SchemaTool
             if (isset($class->table['indexes'])) {
                 foreach ($class->table['indexes'] as $indexName => $indexData) {
                     if( ! isset($indexData['flags'])) {
-                        $indexData['flags'] = array();
+                        $indexData['flags'] = [];
                     }
 
-                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array)$indexData['flags'], isset($indexData['options']) ? $indexData['options'] : array());
+                    $table->addIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, (array)$indexData['flags'], isset($indexData['options']) ? $indexData['options'] : []);
                 }
             }
 
@@ -297,7 +297,7 @@ class SchemaTool
                         }
                     }
 
-                    $table->addUniqueIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, isset($indexData['options']) ? $indexData['options'] : array());
+                    $table->addUniqueIndex($indexData['columns'], is_numeric($indexName) ? null : $indexName, isset($indexData['options']) ? $indexData['options'] : []);
                 }
             }
 
@@ -364,10 +364,10 @@ class SchemaTool
             $discrColumn['length'] = 255;
         }
 
-        $options = array(
+        $options = [
             'length'    => isset($discrColumn['length']) ? $discrColumn['length'] : null,
             'notnull'   => true
-        );
+        ];
 
         if (isset($discrColumn['columnDefinition'])) {
             $options['columnDefinition'] = $discrColumn['columnDefinition'];
@@ -387,7 +387,7 @@ class SchemaTool
      */
     private function gatherColumns($class, Table $table)
     {
-        $pkColumns = array();
+        $pkColumns = [];
 
         foreach ($class->fieldMappings as $mapping) {
             if ($class->isInheritanceTypeSingleTable() && isset($mapping['inherited'])) {
@@ -422,14 +422,14 @@ class SchemaTool
         $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
         $columnType = $mapping['type'];
 
-        $options = array();
+        $options = [];
         $options['length'] = isset($mapping['length']) ? $mapping['length'] : null;
         $options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
         if ($class->isInheritanceTypeSingleTable() && count($class->parentClasses) > 0) {
             $options['notnull'] = false;
         }
 
-        $options['platformOptions'] = array();
+        $options['platformOptions'] = [];
         $options['platformOptions']['version'] = $class->isVersioned && $class->versionField == $mapping['fieldName'] ? true : false;
 
         if (strtolower($columnType) == 'string' && $options['length'] === null) {
@@ -453,7 +453,7 @@ class SchemaTool
         }
 
         if (isset($mapping['options'])) {
-            $knownOptions = array('comment', 'unsigned', 'fixed', 'default');
+            $knownOptions = ['comment', 'unsigned', 'fixed', 'default'];
 
             foreach ($knownOptions as $knownOption) {
                 if (array_key_exists($knownOption, $mapping['options'])) {
@@ -466,7 +466,7 @@ class SchemaTool
             $options['customSchemaOptions'] = $mapping['options'];
         }
 
-        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == array($mapping['fieldName'])) {
+        if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == [$mapping['fieldName']]) {
             $options['autoincrement'] = true;
         }
         if ($class->isInheritanceTypeJoined() && $class->name != $class->rootEntityName) {
@@ -482,7 +482,7 @@ class SchemaTool
 
         $isUnique = isset($mapping['unique']) ? $mapping['unique'] : false;
         if ($isUnique) {
-            $table->addUniqueIndex(array($columnName));
+            $table->addUniqueIndex([$columnName]);
         }
     }
 
@@ -510,7 +510,7 @@ class SchemaTool
             $foreignClass = $this->em->getClassMetadata($mapping['targetEntity']);
 
             if ($mapping['type'] & ClassMetadata::TO_ONE && $mapping['isOwningSide']) {
-                $primaryKeyColumns = array(); // PK is unnecessary for this relation-type
+                $primaryKeyColumns = []; // PK is unnecessary for this relation-type
 
                 $this->gatherRelationJoinColumns(
                     $mapping['joinColumns'],
@@ -532,7 +532,7 @@ class SchemaTool
                     $this->quoteStrategy->getJoinTableName($mapping, $foreignClass, $this->platform)
                 );
 
-                $primaryKeyColumns = array();
+                $primaryKeyColumns = [];
 
                 // Build first FK constraint (relation table => source table)
                 $this->gatherRelationJoinColumns(
@@ -580,7 +580,7 @@ class SchemaTool
         $referencedFieldName = $class->getFieldName($referencedColumnName);
 
         if ($class->hasField($referencedFieldName)) {
-            return array($class, $referencedFieldName);
+            return [$class, $referencedFieldName];
         }
 
         if (in_array($referencedColumnName, $class->getIdentifierColumnNames())) {
@@ -623,11 +623,11 @@ class SchemaTool
         &$addedFks,
         &$blacklistedFks
     ) {
-        $localColumns       = array();
-        $foreignColumns     = array();
-        $fkOptions          = array();
+        $localColumns       = [];
+        $foreignColumns     = [];
+        $fkOptions          = [];
         $foreignTableName   = $this->quoteStrategy->getTableName($class, $this->platform);
-        $uniqueConstraints  = array();
+        $uniqueConstraints  = [];
 
         foreach ($joinColumns as $joinColumn) {
 
@@ -668,7 +668,7 @@ class SchemaTool
                     $columnDef = $fieldMapping['columnDefinition'];
                 }
 
-                $columnOptions = array('notnull' => false, 'columnDefinition' => $columnDef);
+                $columnOptions = ['notnull' => false, 'columnDefinition' => $columnDef];
 
                 if (isset($joinColumn['nullable'])) {
                     $columnOptions['notnull'] = !$joinColumn['nullable'];
@@ -689,7 +689,7 @@ class SchemaTool
             }
 
             if (isset($joinColumn['unique']) && $joinColumn['unique'] == true) {
-                $uniqueConstraints[] = array('columns' => array($quotedColumnName));
+                $uniqueConstraints[] = ['columns' => [$quotedColumnName]];
             }
 
             if (isset($joinColumn['onDelete'])) {
@@ -719,7 +719,7 @@ class SchemaTool
             }
             $blacklistedFks[$compositeName] = true;
         } elseif (!isset($blacklistedFks[$compositeName])) {
-            $addedFks[$compositeName] = array('foreignTableName' => $foreignTableName, 'foreignColumns' => $foreignColumns);
+            $addedFks[$compositeName] = ['foreignTableName' => $foreignTableName, 'foreignColumns' => $foreignColumns];
             $theJoinTable->addUnnamedForeignKeyConstraint(
                 $foreignTableName,
                 $localColumns,

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -63,7 +63,7 @@ class SchemaValidator
      */
     public function validateMapping()
     {
-        $errors = array();
+        $errors = [];
         $cmf = $this->em->getMetadataFactory();
         $classes = $cmf->getAllMetadata();
 
@@ -85,7 +85,7 @@ class SchemaValidator
      */
     public function validateClass(ClassMetadataInfo $class)
     {
-        $ce = array();
+        $ce = [];
         $cmf = $this->em->getMetadataFactory();
 
         foreach ($class->fieldMappings as $fieldName => $mapping) {
@@ -211,7 +211,7 @@ class SchemaValidator
                     }
 
                     if (count($identifierColumns) != count($assoc['joinColumns'])) {
-                        $ids = array();
+                        $ids = [];
 
                         foreach ($assoc['joinColumns'] as $joinColumn) {
                             $ids[] = $joinColumn['name'];

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -106,7 +106,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $identityMap = array();
+    private $identityMap = [];
 
     /**
      * Map of all identifiers of managed entities.
@@ -114,7 +114,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityIdentifiers = array();
+    private $entityIdentifiers = [];
 
     /**
      * Map of the original entity data of managed entities.
@@ -127,7 +127,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $originalEntityData = array();
+    private $originalEntityData = [];
 
     /**
      * Map of entity changes. Keys are object ids (spl_object_hash).
@@ -135,7 +135,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityChangeSets = array();
+    private $entityChangeSets = [];
 
     /**
      * The (cached) states of any known entities.
@@ -143,7 +143,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $entityStates = array();
+    private $entityStates = [];
 
     /**
      * Map of entities that are scheduled for dirty checking at commit time.
@@ -152,49 +152,49 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $scheduledForSynchronization = array();
+    private $scheduledForSynchronization = [];
 
     /**
      * A list of all pending entity insertions.
      *
      * @var array
      */
-    private $entityInsertions = array();
+    private $entityInsertions = [];
 
     /**
      * A list of all pending entity updates.
      *
      * @var array
      */
-    private $entityUpdates = array();
+    private $entityUpdates = [];
 
     /**
      * Any pending extra updates that have been scheduled by persisters.
      *
      * @var array
      */
-    private $extraUpdates = array();
+    private $extraUpdates = [];
 
     /**
      * A list of all pending entity deletions.
      *
      * @var array
      */
-    private $entityDeletions = array();
+    private $entityDeletions = [];
 
     /**
      * All pending collection deletions.
      *
      * @var array
      */
-    private $collectionDeletions = array();
+    private $collectionDeletions = [];
 
     /**
      * All pending collection updates.
      *
      * @var array
      */
-    private $collectionUpdates = array();
+    private $collectionUpdates = [];
 
     /**
      * List of collections visited during changeset calculation on a commit-phase of a UnitOfWork.
@@ -203,7 +203,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $visitedCollections = array();
+    private $visitedCollections = [];
 
     /**
      * The EntityManager that "owns" this UnitOfWork instance.
@@ -217,14 +217,14 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $persisters = array();
+    private $persisters = [];
 
     /**
      * The collection persister instances used to persist collections.
      *
      * @var array
      */
-    private $collectionPersisters = array();
+    private $collectionPersisters = [];
 
     /**
      * The EventManager used for dispatching events.
@@ -252,21 +252,21 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @var array
      */
-    private $orphanRemovals = array();
+    private $orphanRemovals = [];
 
     /**
      * Read-Only objects are never evaluated
      *
      * @var array
      */
-    private $readOnlyObjects = array();
+    private $readOnlyObjects = [];
 
     /**
      * Map of Entity Class-Names and corresponding IDs that should eager loaded when requested.
      *
      * @var array
      */
-    private $eagerLoadingEntities = array();
+    private $eagerLoadingEntities = [];
 
     /**
      * @var boolean
@@ -428,7 +428,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->collectionDeletions =
         $this->visitedCollections =
         $this->scheduledForSynchronization =
-        $this->orphanRemovals = array();
+        $this->orphanRemovals = [];
     }
 
     /**
@@ -505,7 +505,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->getEntityPersister(get_class($entity))->update($entity);
         }
 
-        $this->extraUpdates = array();
+        $this->extraUpdates = [];
     }
 
     /**
@@ -523,7 +523,7 @@ class UnitOfWork implements PropertyChangedListener
             return $this->entityChangeSets[$oid];
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -578,7 +578,7 @@ class UnitOfWork implements PropertyChangedListener
             $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em), $invoke);
         }
 
-        $actualData = array();
+        $actualData = [];
 
         foreach ($class->reflFields as $name => $refProp) {
             $value = $refProp->getValue($entity);
@@ -622,11 +622,11 @@ class UnitOfWork implements PropertyChangedListener
             // Entity is either NEW or MANAGED but not yet fully persisted (only has an id).
             // These result in an INSERT.
             $this->originalEntityData[$oid] = $actualData;
-            $changeSet = array();
+            $changeSet = [];
 
             foreach ($actualData as $propName => $actualValue) {
                 if ( ! isset($class->associationMappings[$propName])) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = [null, $actualValue];
 
                     continue;
                 }
@@ -634,7 +634,7 @@ class UnitOfWork implements PropertyChangedListener
                 $assoc = $class->associationMappings[$propName];
 
                 if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = [null, $actualValue];
                 }
             }
 
@@ -646,7 +646,7 @@ class UnitOfWork implements PropertyChangedListener
             $isChangeTrackingNotify = $class->isChangeTrackingNotify();
             $changeSet              = ($isChangeTrackingNotify && isset($this->entityChangeSets[$oid]))
                 ? $this->entityChangeSets[$oid]
-                : array();
+                : [];
 
             foreach ($actualData as $propName => $actualValue) {
                 // skip field, its a partially omitted one!
@@ -667,7 +667,7 @@ class UnitOfWork implements PropertyChangedListener
                         continue;
                     }
 
-                    $changeSet[$propName] = array($orgValue, $actualValue);
+                    $changeSet[$propName] = [$orgValue, $actualValue];
 
                     continue;
                 }
@@ -707,7 +707,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 if ($assoc['type'] & ClassMetadata::TO_ONE) {
                     if ($assoc['isOwningSide']) {
-                        $changeSet[$propName] = array($orgValue, $actualValue);
+                        $changeSet[$propName] = [$orgValue, $actualValue];
                     }
 
                     if ($orgValue !== null && $assoc['orphanRemoval']) {
@@ -737,7 +737,7 @@ class UnitOfWork implements PropertyChangedListener
                 $val instanceof PersistentCollection &&
                 $val->isDirty()) {
 
-                $this->entityChangeSets[$oid]   = array();
+                $this->entityChangeSets[$oid]   = [];
                 $this->originalEntityData[$oid] = $actualData;
                 $this->entityUpdates[$oid]      = $entity;
             }
@@ -777,7 +777,7 @@ class UnitOfWork implements PropertyChangedListener
                     break;
 
                 default:
-                    $entitiesToProcess = array();
+                    $entitiesToProcess = [];
 
             }
 
@@ -824,7 +824,7 @@ class UnitOfWork implements PropertyChangedListener
         // Look through the entities, and in any of their associations,
         // for transient (new) entities, recursively. ("Persistence by reachability")
         // Unwrap. Uninitialized collections will simply be empty.
-        $unwrappedValue = ($assoc['type'] & ClassMetadata::TO_ONE) ? array($value) : $value->unwrap();
+        $unwrappedValue = ($assoc['type'] & ClassMetadata::TO_ONE) ? [$value] : $value->unwrap();
         $targetClass    = $this->em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($unwrappedValue as $key => $entry) {
@@ -890,7 +890,7 @@ class UnitOfWork implements PropertyChangedListener
             $idValue = $idGen->generate($this->em, $entity);
 
             if ( ! $idGen instanceof \Doctrine\ORM\Id\AssignedGenerator) {
-                $idValue = array($class->identifier[0] => $idValue);
+                $idValue = [$class->identifier[0] => $idValue];
 
                 $class->setIdentifierValues($entity, $idValue);
             }
@@ -938,7 +938,7 @@ class UnitOfWork implements PropertyChangedListener
             $class = $this->em->getClassMetadata(get_class($entity));
         }
 
-        $actualData = array();
+        $actualData = [];
 
         foreach ($class->reflFields as $name => $refProp) {
             if (( ! $class->isIdentifier($name) || ! $class->isIdGeneratorIdentity())
@@ -953,13 +953,13 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         $originalData = $this->originalEntityData[$oid];
-        $changeSet = array();
+        $changeSet = [];
 
         foreach ($actualData as $propName => $actualValue) {
             $orgValue = isset($originalData[$propName]) ? $originalData[$propName] : null;
 
             if ($orgValue !== $actualValue) {
-                $changeSet[$propName] = array($orgValue, $actualValue);
+                $changeSet[$propName] = [$orgValue, $actualValue];
             }
         }
 
@@ -983,7 +983,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeInserts($class)
     {
-        $entities   = array();
+        $entities   = [];
         $className  = $class->name;
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
@@ -1015,7 +1015,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $class->reflFields[$idField]->setValue($entity, $id);
 
-                $this->entityIdentifiers[$oid] = array($idField => $id);
+                $this->entityIdentifiers[$oid] = [$idField => $id];
                 $this->entityStates[$oid] = self::STATE_MANAGED;
                 $this->originalEntityData[$oid][$idField] = $id;
 
@@ -1125,7 +1125,7 @@ class UnitOfWork implements PropertyChangedListener
         // We have to inspect changeSet to be able to correctly build dependencies.
         // It is not possible to use IdentityMap here because post inserted ids
         // are not yet available.
-        $newNodes = array();
+        $newNodes = [];
 
         foreach ($entityChangeSet as $entity) {
             $class = $this->em->getClassMetadata(get_class($entity));
@@ -1277,12 +1277,12 @@ class UnitOfWork implements PropertyChangedListener
     public function scheduleExtraUpdate($entity, array $changeset)
     {
         $oid         = spl_object_hash($entity);
-        $extraUpdate = array($entity, $changeset);
+        $extraUpdate = [$entity, $changeset];
 
         if (isset($this->extraUpdates[$oid])) {
             list($ignored, $changeset2) = $this->extraUpdates[$oid];
 
-            $extraUpdate = array($entity, $changeset + $changeset2);
+            $extraUpdate = [$entity, $changeset + $changeset2];
         }
 
         $this->extraUpdates[$oid] = $extraUpdate;
@@ -1625,7 +1625,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function persist($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doPersist($entity, $visited);
     }
@@ -1702,7 +1702,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function remove($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doRemove($entity, $visited);
     }
@@ -1776,7 +1776,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function merge($entity)
     {
-        $visited = array();
+        $visited = [];
 
         return $this->doMerge($entity, $visited);
     }
@@ -1940,7 +1940,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function detach($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doDetach($entity, $visited);
     }
@@ -2001,7 +2001,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function refresh($entity)
     {
-        $visited = array();
+        $visited = [];
 
         $this->doRefresh($entity, $visited);
     }
@@ -2243,7 +2243,7 @@ class UnitOfWork implements PropertyChangedListener
             function ($assoc) { return $assoc['isCascadeRemove']; }
         );
 
-        $entitiesToCascade = array();
+        $entitiesToCascade = [];
 
         foreach ($associationMappings as $assoc) {
             if ($entity instanceof Proxy && !$entity->__isInitialized__) {
@@ -2376,9 +2376,9 @@ class UnitOfWork implements PropertyChangedListener
             $this->extraUpdates =
             $this->readOnlyObjects =
             $this->visitedCollections =
-            $this->orphanRemovals = array();
+            $this->orphanRemovals = [];
         } else {
-            $visited = array();
+            $visited = [];
 
             foreach ($this->identityMap as $className => $entities) {
                 if ($className !== $entityName) {
@@ -2491,7 +2491,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @todo Rename: getOrCreateEntity
      */
-    public function createEntity($className, array $data, &$hints = array())
+    public function createEntity($className, array $data, &$hints = [])
     {
         $class = $this->em->getClassMetadata($className);
         //$isReadOnly = isset($hints[Query::HINT_READ_ONLY]);
@@ -2622,7 +2622,7 @@ class UnitOfWork implements PropertyChangedListener
                         continue;
                     }
 
-                    $associatedId = array();
+                    $associatedId = [];
 
                     // TODO: Is this even computed right in all cases of composite keys?
                     foreach ($assoc['targetToSourceKeyColumns'] as $targetColumn => $srcColumn) {
@@ -2638,7 +2638,7 @@ class UnitOfWork implements PropertyChangedListener
                             && in_array($targetClass->getFieldForColumn($targetColumn), $targetClass->identifier, true)
                         ) {
                             // the missing key is part of target's entity primary key
-                            $associatedId = array();
+                            $associatedId = [];
                             break;
                         }
                     }
@@ -2787,7 +2787,7 @@ class UnitOfWork implements PropertyChangedListener
 
         // avoid infinite recursion
         $eagerLoadingEntities       = $this->eagerLoadingEntities;
-        $this->eagerLoadingEntities = array();
+        $this->eagerLoadingEntities = [];
 
         foreach ($eagerLoadingEntities as $entityName => $ids) {
             if ( ! $ids) {
@@ -2797,7 +2797,7 @@ class UnitOfWork implements PropertyChangedListener
             $class = $this->em->getClassMetadata($entityName);
 
             $this->getEntityPersister($entityName)->loadAll(
-                array_combine($class->identifier, array(array_values($ids)))
+                array_combine($class->identifier, [array_values($ids)])
             );
         }
     }
@@ -2855,7 +2855,7 @@ class UnitOfWork implements PropertyChangedListener
             return $this->originalEntityData[$oid];
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -3099,7 +3099,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function clearEntityChangeSet($oid)
     {
-        $this->entityChangeSets[$oid] = array();
+        $this->entityChangeSets[$oid] = [];
     }
 
     /* PropertyChangedListener implementation */
@@ -3126,7 +3126,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         // Update changeset and mark entity for synchronization
-        $this->entityChangeSets[$oid][$propertyName] = array($oldValue, $newValue);
+        $this->entityChangeSets[$oid][$propertyName] = [$oldValue, $newValue];
 
         if ( ! isset($this->scheduledForSynchronization[$class->rootEntityName][$oid])) {
             $this->scheduleForDirtyCheck($entity);
@@ -3391,7 +3391,7 @@ class UnitOfWork implements PropertyChangedListener
                                         $assoc2['targetEntity'],
                                         $relatedId
                                     );
-                                    $this->registerManaged($other, $relatedId, array());
+                                    $this->registerManaged($other, $relatedId, []);
                                 }
                             }
 

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -68,7 +68,7 @@ final class IdentifierFlattener
      */
     public function flattenIdentifier(ClassMetadata $class, array $id)
     {
-        $flatId = array();
+        $flatId = [];
 
         foreach ($class->identifier as $field) {
             if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_object($id[$field])) {
@@ -85,7 +85,7 @@ final class IdentifierFlattener
 
                 $flatId[$field] = implode(' ', $associatedId);
             } elseif (isset($class->associationMappings[$field])) {
-                $associatedId = array();
+                $associatedId = [];
 
                 foreach ($class->associationMappings[$field]['joinColumns'] as $joinColumn) {
                     $associatedId[] = $id[$joinColumn['name']];

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -46,11 +46,11 @@ class PersisterHelper
     public static function getTypeOfField($fieldName, ClassMetadata $class, EntityManagerInterface $em)
     {
         if (isset($class->fieldMappings[$fieldName])) {
-            return array($class->fieldMappings[$fieldName]['type']);
+            return [$class->fieldMappings[$fieldName]['type']];
         }
 
         if ( ! isset($class->associationMappings[$fieldName])) {
-            return array();
+            return [];
         }
 
         $assoc = $class->associationMappings[$fieldName];
@@ -65,7 +65,7 @@ class PersisterHelper
             $joinData = $assoc;
         }
 
-        $types       = array();
+        $types       = [];
         $targetClass = $em->getClassMetadata($assoc['targetEntity']);
 
         foreach ($joinData['joinColumns'] as $joinColumn) {


### PR DESCRIPTION
This was already started in https://github.com/doctrine/doctrine2/pull/1291 but due to v2.4 was "rejected", now that in the composer.json PHP 5.4+ is required I think this upgrade could be done.
