### PR TITLE
Correcting minor test case incompatibility with XDebug 2.4.x

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php
@@ -85,6 +85,6 @@ class RunDqlCommandTest extends OrmFunctionalTestCase
             ))
         );
 
-        $this->assertStringMatchesFormat('string%sSELECT %a', $this->tester->getDisplay());
+        $this->assertStringMatchesFormat('%Astring%sSELECT %a', $this->tester->getDisplay());
     }
 }


### PR DESCRIPTION
In PHP 5.x + XDebug < 2.4, the output would be `"string:..."`
In PHP 7.x + XDebug >= 2.4, the output would be `"the/file/name.php:11:string:..."`

This is an improvement in XDebug that is quite annoying for our purposes, but is actually welcome to most users anyway.

This commit simply fixes that incompatibility
