### PR TITLE
Cleanup - `ClassMetadataInfo#getColumnNames()` simplification

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1873,17 +1873,11 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getColumnNames(array $fieldNames = null)
     {
-        if ($fieldNames === null) {
+        if (null === $fieldNames) {
             return array_keys($this->fieldNames);
         }
 
-        $columnNames = array();
-
-        foreach ($fieldNames as $fieldName) {
-            $columnNames[] = $this->getColumnName($fieldName);
-        }
-
-        return $columnNames;
+        return array_values(array_map([$this, 'getColumnName'], $fieldNames));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1150,6 +1150,18 @@ class ClassMetadataTest extends \Doctrine\Tests\OrmTestCase
 
         $this->assertEquals(array('test' => null, 'test.embeddedProperty' => null), $classMetadata->getReflectionProperties());
     }
+
+    public function testGetColumnNamesWithGivenFieldNames()
+    {
+        $metadata = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
+        $metadata->initializeReflection(new RuntimeReflectionService());
+
+        $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'columnName' => 'foo'));
+        $metadata->mapField(array('fieldName' => 'username', 'type' => 'string', 'columnName' => 'bar'));
+        $metadata->mapField(array('fieldName' => 'name', 'type' => 'string', 'columnName' => 'baz'));
+
+        self::assertSame(['foo', 'baz'], $metadata->getColumnNames(['status', 'name']));
+    }
 }
 
 /**


### PR DESCRIPTION
Just noticed this bit of code and I compulsively felt like I had to cover/kill it.
