### PR TITLE
Fatal error with empty primary key in table definition

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -504,6 +504,10 @@ class DatabaseDriver implements MappingDriver
      */
     private function getTablePrimaryKeys(Table $table)
     {
+        if ( ! $table->hasPrimaryKey()) {
+            return array();
+        }
+
         try {
             return $table->getPrimaryKey()->getColumns();
         } catch(SchemaException $e) {

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -77,6 +77,25 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $this->assertTrue($metadata->fieldMappings['bar']['nullable']);
     }
 
+    public function testLoadMetadataWithoutPrimaryKeyFromDatabase()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table("dbdriver_foo");
+        $table->addColumn('id', 'integer');
+        $table->addColumn('bar', 'string', array('notnull' => false, 'length' => 200));
+
+        $this->_sm->dropAndCreateTable($table);
+
+        try {
+            $this->extractClassMetadata(array("DbdriverFoo"));
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Doctrine\ORM\Mapping\MappingException', $e);
+            $this->_sm->dropTable('dbdriver_foo');
+            return;
+        }
+
+        $this->fail('Doctrine\ORM\Mapping\MappingException was not thrown.');
+    }
+
     public function testLoadMetadataWithForeignKeyFromDatabase()
     {
         if (!$this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5551Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5551Test.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Tests\ORM\Functional\DatabaseDriverTestCase;
+
+class GH5551Test extends DatabaseDriverTestCase
+{
+    public function testLoadMetadataFromManualTableWithoutPrimaryKey()
+    {
+        $table = new \Doctrine\DBAL\Schema\Table("dbdriver_foo");
+        $table->addColumn('id', 'integer');
+        $table->addColumn('bar', 'string', array('notnull' => false, 'length' => 200));
+
+        $sm = $this->_em->getConnection()->getSchemaManager();
+        $driver = new \Doctrine\ORM\Mapping\Driver\DatabaseDriver($sm);
+        $driver->setTables(array($table), array());
+
+        foreach ($driver->getAllClassNames() as $className) {
+            $class = new ClassMetadataInfo($className);
+            $driver->loadMetadataForClass($className, $class);
+        }
+
+        // At this point a fatal error would be thrown without this fix
+        // Fatal error: Call to a member function getColumns() on null in .../lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php on line 511
+    }
+}


### PR DESCRIPTION
I'm using the `DatabaseDriver` but used `setTables` to add table information. This can result in the following error because the return value of `Doctrine\DBAL\Schema\Table:getPrimaryKey` can be `null`.

```
Fatal error: Call to a member function getColumns() on null in .../lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php on line 511
```

PS: While working on a test case I also figured out there is no test for a missing primary key in general.
