### PR TITLE
Treat boolean as string in Expr\Comparison

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Comparison.php
+++ b/lib/Doctrine/ORM/Query/Expr/Comparison.php
@@ -95,6 +95,16 @@ class Comparison
      */
     public function __toString()
     {
-        return $this->leftExpr . ' ' . $this->operator . ' ' . $this->rightExpr;
+        return $this->transform($this->leftExpr) . ' ' . $this->operator . ' ' . $this->transform($this->rightExpr);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    protected function transform($value)
+    {
+        return is_bool($value) ? ($value ? 'true' : 'false') : $value;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/Expr/ComparisonTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/Expr/ComparisonTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\ORM\Query\Expr;
+
+use Doctrine\ORM\Query\Expr\Comparison;
+
+/**
+ * @author Benjamin Lazarecki <benjamin.lazarecki@gmail.com>
+ */
+class ComparisonTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider comparisonProvider
+     */
+    public function testThatComparisonCanHandleBoolean($left, $right, $expected)
+    {
+        $comparison = new Comparison($left, Comparison::EQ, $right);
+
+        $this->assertSame($expected, $comparison->__toString());
+    }
+
+    public static function comparisonProvider()
+    {
+        return [
+            [true, false, 'true = false'],
+            ['true', 'false', 'true = false'],
+            [1, 0, '1 = 0'],
+            ['foo', 'bar', 'foo = bar'],
+        ];
+    }
+}


### PR DESCRIPTION
Hi,

I was getting an error when I try to use comparison with boolean false.

Here my issue: when you are calling `$queryBuilder->set('o.enabled', false)` then the result is `o.enabled =` and then you have an SQL exception.

This PR allow to use boolean for comparison.
For example, you can now use `->set('o.enabled', false)` instead of `->set('o.enabled', 'false')`

The previous exemple will give `o.enabled = false`.

What do you think of it ?
