### PR TITLE
Allow EntityGenerator to create PHP7 compliant methods

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1917,7 +1917,7 @@ public function __construct(<params>)
     private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $fieldName, $variableType)
     {
         if (in_array($type, array('set', 'add'))) {
-            return sprintf(': %s', $this->getClassName($metadata));
+            return sprintf(': self', $this->getClassName($metadata));
         }
 
         if ('get' === $type) {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -147,6 +147,13 @@ class EntityGenerator
     protected $embeddablesImmutable = false;
 
     /**
+     * Whether or not to add PHP strict types.
+     *
+     * @var boolean
+     */
+    protected $strictTypes = false;
+
+    /**
      * Hash-map for handle types.
      *
      * @var array
@@ -211,7 +218,7 @@ class EntityGenerator
      */
     protected static $classTemplate =
 '<?php
-
+<strictTypes>
 <namespace>
 <useStatement>
 <entityAnnotation>
@@ -406,6 +413,7 @@ public function __construct(<params>)
     public function generateEntityClass(ClassMetadataInfo $metadata)
     {
         $placeHolders = array(
+            '<strictTypes>',
             '<namespace>',
             '<useStatement>',
             '<entityAnnotation>',
@@ -414,6 +422,7 @@ public function __construct(<params>)
         );
 
         $replacements = array(
+            $this->generateEntityStrictTypes(),
             $this->generateEntityNamespace($metadata),
             $this->generateEntityUse(),
             $this->generateEntityDocBlock($metadata),
@@ -583,6 +592,22 @@ public function __construct(<params>)
     }
 
     /**
+     * Set whether or not to add PHP strict types.
+     *
+     * @param bool $bool
+     *
+     * @return void
+     */
+    public function setStrictTypes($bool)
+    {
+        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
+            throw new \InvalidArgumentException('Strict types mode is only available for PHP >= 7.0.0');
+        }
+
+        $this->strictTypes = $bool;
+    }
+
+    /**
      * @param string $type
      *
      * @return string
@@ -594,6 +619,16 @@ public function __construct(<params>)
         }
 
         return $type;
+    }
+
+    /**
+     * @return string
+     */
+    protected function generateEntityStrictTypes()
+    {
+        if ($this->strictTypes) {
+            return "\n".'declare(strict_types=1);'."\n";
+        }
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -623,10 +623,6 @@ public function __construct(<params>)
      */
     public function setStrictTypes($bool)
     {
-        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
-            throw new \InvalidArgumentException('Strict types mode is only available for PHP >= 7.0.0');
-        }
-
         $this->strictTypes = $bool;
     }
 
@@ -639,10 +635,6 @@ public function __construct(<params>)
      */
     public function setGenerateMethodsTypeHinting($bool)
     {
-        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
-            throw new \InvalidArgumentException('Scalar type hinting and method return types are only available for PHP >= 7.0.0');
-        }
-
         $this->generateMethodsTypeHinting = $bool;
     }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -192,8 +192,6 @@ class EntityGenerator
         Type::SIMPLE_ARRAY  => 'array',
         Type::JSON_ARRAY    => 'array',
         Type::STRING        => 'string',
-        Type::BINARY        => 'resource',
-        Type::BLOB          => 'resource',
         Type::FLOAT         => 'float',
         Type::GUID          => 'string',
     );
@@ -660,6 +658,8 @@ public function __construct(<params>)
         if ($this->strictTypes) {
             return "\n".'declare(strict_types=1);'."\n";
         }
+
+        return '';
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1456,7 +1456,7 @@ public function __construct(<params>)
 
         $methodReturnType = null;
         if ($this->generateMethodsTypeHinting) {
-            $methodReturnType = $this->getMethodReturnType($metadata, $type, $variableType);
+            $methodReturnType = $this->getMethodReturnType($metadata, $type, $fieldName, $variableType);
 
             if (null === $methodTypeHint) {
                 $type = isset($this->typeHintingAlias[$variableType]) ? $this->typeHintingAlias[$variableType] : $variableType;
@@ -1918,16 +1918,24 @@ public function __construct(<params>)
     /**
      * @param ClassMetadataInfo $metadata
      * @param string            $type
+     * @param string            $fieldName
      * @param string            $variableType
      * @return string
      */
-    private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $variableType)
+    private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $fieldName, $variableType)
     {
         if (in_array($type, array('set', 'add'))) {
             return sprintf(': %s', $this->getClassName($metadata));
         }
 
         if ('get' === $type) {
+            if (
+                $metadata->isSingleValuedAssociation($fieldName) ||
+                (!$metadata->hasAssociation($fieldName) && $metadata->isNullable($fieldName))
+            ) {
+                return null;
+            }
+
             $type = isset($this->typeHintingAlias[$variableType]) ? $this->typeHintingAlias[$variableType] : $variableType;
             return sprintf(': %s', $type);
         }

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -981,7 +981,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals('string', $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getName');
         $this->assertEquals('string', $reflMethod->getReturnType());
@@ -990,7 +990,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals('string', $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getStatus');
         $this->assertEquals('string', $reflMethod->getReturnType());
@@ -1000,13 +1000,13 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals($authorClass, (string) $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
         $this->assertNull($reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
-        $this->assertEquals($metadata->name, $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
         $this->assertEquals('bool', $reflMethod->getReturnType());
@@ -1047,7 +1047,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals($type, $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, $getter);
         $this->assertEquals($type, (string) $reflMethod->getReturnType());

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -958,30 +958,6 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertSame($classTest,$classNew);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testStrictTypesGenerationClassWithNonCompatiblePHP()
-    {
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-            $this->markTestSkipped('Strict mode is available in PHP > 7.0.0');
-        }
-
-        $this->_generator->setStrictTypes(true);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGenerateMethodsTypeHintingWithNonCompatiblePHP()
-    {
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
-        }
-
-        $this->_generator->setGenerateMethodsTypeHinting(true);
-    }
-
     public function testGenerateMethodsTypeHinting()
     {
         if (version_compare(PHP_VERSION, '7.0.0', '<')) {
@@ -1050,10 +1026,6 @@ class EntityGeneratorTest extends OrmTestCase
      */
     public function testEntityMethodTypeHintingAlias(array $field)
     {
-        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
-            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
-        }
-
         $this->_generator->setGenerateMethodsTypeHinting(true);
 
         $metadata   = $this->generateEntityTypeFixture($field);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -32,6 +32,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->setGenerateAnnotations(true);
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
+        $this->_generator->setStrictTypes(false);
         $this->_generator->setUpdateEntityIfExists(true);
         $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
@@ -954,6 +955,18 @@ class EntityGeneratorTest extends OrmTestCase
         $classNew = file_get_contents($path);
 
         $this->assertSame($classTest,$classNew);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testStrictTypesGenerationClassWithNonCompatiblePHP()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->markTestSkipped('Strict mode is available in PHP > 7.0.0');
+        }
+
+        $this->_generator->setStrictTypes(true);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1027,7 +1027,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
-        $this->assertEquals($authorClass, $reflMethod->getReturnType());
+        $this->assertNull($reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
         $this->assertEquals($metadata->name, $reflMethod->getReturnType());

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -33,6 +33,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
         $this->_generator->setStrictTypes(false);
+        $this->_generator->setGenerateMethodsTypeHinting(false);
         $this->_generator->setUpdateEntityIfExists(true);
         $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
@@ -967,6 +968,117 @@ class EntityGeneratorTest extends OrmTestCase
         }
 
         $this->_generator->setStrictTypes(true);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testGenerateMethodsTypeHintingWithNonCompatiblePHP()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+    }
+
+    public function testGenerateMethodsTypeHinting()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+
+        $metadata = $this->generateBookEntityFixture();
+        $this->loadEntityClass($metadata);
+
+        $reflClass = new \ReflectionClass($metadata->name);
+
+        $this->assertCount(5, $reflClass->getProperties());
+        $this->assertCount(13, $reflClass->getMethods());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getId');
+        $this->assertEquals('int', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setName');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals('string', $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getName');
+        $this->assertEquals('string', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setStatus');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals('string', $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getStatus');
+        $this->assertEquals('string', $reflMethod->getReturnType());
+
+        $authorClass = get_class(new EntityGeneratorAuthor());
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setAuthor');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals($authorClass, (string) $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
+        $this->assertEquals($authorClass, $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
+        $this->assertEquals($metadata->name, $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
+        $this->assertEquals('bool', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getComments');
+        $this->assertEquals('Doctrine\Common\Collections\Collection', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'loading');
+        $this->assertNull($reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'willBeRemoved');
+        $this->assertNull($reflMethod->getReturnType());
+    }
+
+    /**
+     * @dataProvider getEntityTypeAliasDataProvider
+     */
+    public function testEntityMethodTypeHintingAlias(array $field)
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+
+        $metadata   = $this->generateEntityTypeFixture($field);
+        $path       = $this->_tmpDir . '/'. $this->_namespace . '/EntityType.php';
+
+        $this->assertFileExists($path);
+        require_once $path;
+
+        $type   = $field['phpType'];
+        if ('\\' === $type[0]) {
+            $type = substr($type, 1);
+        }
+
+        $name   = $field['fieldName'];
+        $getter = "get" . ucfirst($name);
+        $setter = "set" . ucfirst($name);
+
+        $reflMethod = new \ReflectionMethod($metadata->name, $setter);
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals($type, $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, $getter);
+        $this->assertEquals($type, (string) $reflMethod->getReturnType());
     }
 
     /**


### PR DESCRIPTION
PHP files are in weak type-checking mode. Since PHP 7, strict type-checking mode is used for function calls and return statements in the the file.

This PR add support for generate class with are strict_types compliant.
