### PR TITLE
Fix PrePersist EventListener when using merge instead of persist

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1826,6 +1826,9 @@ class UnitOfWork implements PropertyChangedListener
             if ( ! $id) {
                 $managedCopy = $this->newInstance($class);
 
+                $this->mergeEntityStateIntoManagedCopy($entity, $managedCopy);
+                // The managedCopy is identical to entity
+                // So we can persist, as the listeners will has good values !
                 $this->persistNew($class, $managedCopy);
             } else {
                 $flatId = ($class->containsForeignIdentifier)
@@ -1857,6 +1860,9 @@ class UnitOfWork implements PropertyChangedListener
                     $managedCopy = $this->newInstance($class);
                     $class->setIdentifierValues($managedCopy, $id);
 
+                    $this->mergeEntityStateIntoManagedCopy($entity, $managedCopy);
+                    // The managedCopy is identical to entity
+                    // So we can persist, as the listeners will has good values !
                     $this->persistNew($class, $managedCopy);
                 }
             }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Company\CompanyContractListener;
+use Doctrine\Tests\Models\Company\CompanyFixContract;
+
+/**
+ * @group DDC-1955
+ */
+class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    /**
+     * @var \Doctrine\Tests\Models\Company\CompanyContractListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->useModelSet('company');
+        parent::setUp();
+
+        $this->listener = $this->_em->getConfiguration()
+            ->getEntityListenerResolver()
+            ->resolve('Doctrine\Tests\Models\Company\CompanyContractListener');
+    }
+
+    public function testPrePersistListeners()
+    {
+        $fix = new CompanyFixContract();
+        $fix->setFixPrice(2000);
+
+        $this->listener->prePersistCalls = [];
+
+        $fix = $this->_em->merge($fix);
+        $this->_em->flush();
+
+        $this->assertCount(1, $this->listener->prePersistCalls);
+
+        $this->assertSame($fix, $this->listener->prePersistCalls[0][0]);
+
+        $this->assertInstanceOf(
+            'Doctrine\Tests\Models\Company\CompanyFixContract',
+            $this->listener->prePersistCalls[0][0]
+        );
+
+        $this->assertInstanceOf(
+            'Doctrine\ORM\Event\LifecycleEventArgs',
+            $this->listener->prePersistCalls[0][1]
+        );
+
+        $this->assertArrayHasKey('fixPrice', $this->listener->snapshots[CompanyContractListener::PRE_PERSIST][0]);
+        $this->assertEquals(
+            $fix->getFixPrice(),
+            $this->listener->snapshots[CompanyContractListener::PRE_PERSIST][0]['fixPrice']
+        );
+    }
+}


### PR DESCRIPTION
The merge operation trigger PRE_PERSIST & POST_PERSIST events when we merge a new entity.

The bug that I encounter, is that the PRE_PERSIST event is trigger with the managed copy empty ! I that case my event listener can't access original data.

In order to fix this, I firstly merge entity state into managed copy. I think this is not the best move as it will be copied a second time at line 1888.

I tried to persist after this is done, but it break some unit tests.
