### PR TITLE
Fix performance issue when using notify tracking policy and calling `flush($entity)` multiple times

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -328,7 +328,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         // Compute changes done since last commit.
-        if ($entity === null) {
+        if (null === $entity) {
             $this->computeChangeSets();
         } elseif (is_object($entity)) {
             $this->computeSingleEntityChangeSet($entity);
@@ -418,17 +418,40 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->dispatchPostFlushEvent();
 
+        $this->postCommitClear($entity);
+    }
+
+    /**
+     * @param null|object|array $entity
+     */
+    private function postCommitClear($entity = null)
+    {
+
         // Clear up
         $this->entityInsertions =
         $this->entityUpdates =
         $this->entityDeletions =
         $this->extraUpdates =
-        $this->entityChangeSets =
         $this->collectionUpdates =
         $this->collectionDeletions =
         $this->visitedCollections =
-        $this->scheduledForSynchronization =
         $this->orphanRemovals = array();
+
+        if (null === $entity) {
+            $this->entityChangeSets = $this->scheduledForSynchronization = array();
+            return;
+        }
+
+        if (is_object($entity)) {
+            $entity = [$entity];
+        }
+
+        foreach ($entity as $object) {
+            $oid = spl_object_hash($object);
+            $class = $this->em->getClassMetadata(get_class($object));
+            $this->clearEntityChangeSet($oid);
+            $this->clearScheduledForSynchronization($class, $oid);
+        }
     }
 
     /**
@@ -3109,9 +3132,18 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @return void
      */
-    public function clearEntityChangeSet($oid)
+    private function clearEntityChangeSet($oid)
     {
-        $this->entityChangeSets[$oid] = array();
+        unset($this->entityChangeSets[$oid]);
+    }
+
+    /**
+     * @param $class
+     * @param string $oid
+     */
+    private function clearScheduledForSynchronization($class, $oid)
+    {
+        unset($this->scheduledForSynchronization[$class->rootEntityName][$oid]);
     }
 
     /* PropertyChangedListener implementation */

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -150,7 +150,8 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $this->_unitOfWork->persist($entity);
 
         $this->_unitOfWork->commit();
-        $this->assertEquals(1, count($persister->getInserts()));
+        $this->assertCount(1, $persister->getInserts());
+
         $persister->reset();
 
         $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
@@ -319,6 +320,34 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
 
         $this->_unitOfWork->persist($entity);
         $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
+    }
+
+    /**
+     * @group 5579
+     */
+    public function testEntityChangeSetNotClearAfterFlushOnEntityOrArrayOfEntity()
+    {
+        // Create and Set first entity
+        $entity1 = new NotifyChangedEntity;
+        $entity1->setData('thedata');
+        $this->_unitOfWork->persist($entity1);
+
+        // Create and Set second entity
+        $entity2 = new NotifyChangedEntity;
+        $entity2->setData('thedata');
+        $this->_unitOfWork->persist($entity2);
+
+        $this->_unitOfWork->commit($entity1);
+        $this->assertCount(1, $this->_unitOfWork->getEntityChangeSet($entity2));
+
+        // Create and Set third entity
+        $entity3 = new NotifyChangedEntity;
+        $entity3->setData('thedata');
+        $this->_unitOfWork->persist($entity3);
+
+        $this->_unitOfWork->commit([$entity1,$entity2]);
+        $this->assertCount(1, $this->_unitOfWork->getEntityChangeSet($entity3));
+
     }
 
     /**


### PR DESCRIPTION
Hi,

First of all I want to apologize for the poor quality of my English.

We had some performance issues in one of our project and we decide to use the Notify tracking policy.
This tracking policy is really usefull for batch and import. For your information we improved the performance of more than 80%.

During our test we discover that flush operations were cleaning the $entityChangeset of the UnitOfWork.
This is a real issue for us because we are using flush with null and entity as parameter.
Example:

``` php
$object1->setData($data);
$object2->setData($data);
$this->entityManager->flush($object1);
$this->entityManager->flush($object2);
```

With the notify tracking policy this code above will only save the change of the object1. All the other changes are lost.
