### PR TITLE
Custom persister support

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -194,6 +194,7 @@
     <xs:attribute name="table" type="xs:NMTOKEN" />
     <xs:attribute name="schema" type="xs:NMTOKEN" />
     <xs:attribute name="repository-class" type="xs:string"/>
+    <xs:attribute name="persister-class" type="xs:string"/>
     <xs:attribute name="inheritance-type" type="orm:inheritance-type"/>
     <xs:attribute name="change-tracking-policy" type="orm:change-tracking-policy" />
     <xs:attribute name="read-only" type="xs:boolean" default="false" />
@@ -493,6 +494,7 @@
     <xs:attribute name="index-by" type="xs:NMTOKEN" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
+    <xs:attribute name="persister" type="xs:string"/>
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
@@ -528,6 +530,7 @@
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
+    <xs:attribute name="persister" type="xs:string"/>
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -115,6 +115,20 @@ class ClassMetadataBuilder
     }
 
     /**
+     * Sets custom Persister class name.
+     *
+     * @param string $persisterClassName
+     *
+     * @return ClassMetadataBuilder
+     */
+    public function setCustomPersisterClass($persisterClassName)
+    {
+        $this->cm->setCustomPersisterClass($persisterClassName);
+
+        return $this;
+    }
+
+    /**
      * Marks class read only.
      *
      * @return ClassMetadataBuilder

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -143,6 +143,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
             if ($parent->isMappedSuperclass) {
                 $class->setCustomRepositoryClass($parent->customRepositoryClassName);
+                $class->setCustomPersisterClass($parent->customPersisterClassName);
             }
         }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -257,6 +257,14 @@ class ClassMetadataInfo implements ClassMetadata
     public $customRepositoryClassName;
 
     /**
+     * The name of the custom persister class used for the entity class.
+     * (Optional).
+     *
+     * @var string
+     */
+    public $customPersisterClassName;
+
+    /**
      * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
      *
      * @var boolean
@@ -832,6 +840,10 @@ class ClassMetadataInfo implements ClassMetadata
 
         if ($this->customRepositoryClassName) {
             $serialized[] = 'customRepositoryClassName';
+        }
+
+        if ($this->customPersisterClassName) {
+            $serialized[] = 'customPersisterClassName';
         }
 
         if ($this->inheritanceType != self::INHERITANCE_TYPE_NONE) {
@@ -2629,6 +2641,18 @@ class ClassMetadataInfo implements ClassMetadata
     public function setCustomRepositoryClass($repositoryClassName)
     {
         $this->customRepositoryClassName = $this->fullyQualifiedClassName($repositoryClassName);
+    }
+
+    /**
+     * Registers a custom persister class for the entity class.
+     *
+     * @param string $persisterClassName The class name of the custom mapper.
+     *
+     * @return void
+     */
+    public function setCustomPersisterClass($persisterClassName)
+    {
+        $this->customPersisterClassName = $this->fullyQualifiedClassName($persisterClassName);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1486,6 +1486,11 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['targetEntity'] = ltrim($mapping['targetEntity'], '\\');
         }
 
+        if (isset($mapping['persister'])) {
+            $mapping['persister'] = $this->fullyQualifiedClassName($mapping['persister']);
+            $mapping['persister'] = ltrim($mapping['persister'], '\\');
+        }
+
         if (($mapping['type'] & self::MANY_TO_ONE) > 0 && isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'] == true) {
             throw MappingException::illegalOrphanRemoval($this->name, $mapping['fieldName']);
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -80,6 +80,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $metadata->setCustomRepositoryClass($entityAnnot->repositoryClass);
             }
 
+            if ($entityAnnot->persisterClass !== null) {
+                $metadata->setCustomPersisterClass($entityAnnot->persisterClass);
+            }
+
             if ($entityAnnot->readOnly) {
                 $metadata->markReadOnly();
             }
@@ -87,6 +91,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $mappedSuperclassAnnot = $classAnnotations['Doctrine\ORM\Mapping\MappedSuperclass'];
 
             $metadata->setCustomRepositoryClass($mappedSuperclassAnnot->repositoryClass);
+            $metadata->setCustomPersisterClass($mappedSuperclassAnnot->persisterClass);
             $metadata->isMappedSuperclass = true;
         } else if (isset($classAnnotations['Doctrine\ORM\Mapping\Embeddable'])) {
             $metadata->isEmbeddedClass = true;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -361,6 +361,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $mapping['indexBy'] = $oneToManyAnnot->indexBy;
                 $mapping['orphanRemoval'] = $oneToManyAnnot->orphanRemoval;
                 $mapping['fetch'] = $this->getFetchMode($className, $oneToManyAnnot->fetch);
+                $mapping['persister'] = $oneToManyAnnot->persister;
 
                 if ($orderByAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\OrderBy')) {
                     $mapping['orderBy'] = $orderByAnnot->value;
@@ -404,6 +405,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 $mapping['indexBy'] = $manyToManyAnnot->indexBy;
                 $mapping['orphanRemoval'] = $manyToManyAnnot->orphanRemoval;
                 $mapping['fetch'] = $this->getFetchMode($className, $manyToManyAnnot->fetch);
+                $mapping['persister'] = $manyToManyAnnot->persister;
 
                 if ($orderByAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\OrderBy')) {
                     $mapping['orderBy'] = $orderByAnnot->value;

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -61,12 +61,18 @@ class XmlDriver extends FileDriver
             if (isset($xmlRoot['repository-class'])) {
                 $metadata->setCustomRepositoryClass((string) $xmlRoot['repository-class']);
             }
+            if (isset($xmlRoot['persister-class'])) {
+                $metadata->setCustomPersisterClass((string)$xmlRoot['persister-class']);
+            }
             if (isset($xmlRoot['read-only']) && $this->evaluateBoolean($xmlRoot['read-only'])) {
                 $metadata->markReadOnly();
             }
         } else if ($xmlRoot->getName() == 'mapped-superclass') {
             $metadata->setCustomRepositoryClass(
                 isset($xmlRoot['repository-class']) ? (string) $xmlRoot['repository-class'] : null
+            );
+            $metadata->setCustomPersisterClass(
+                isset($xmlRoot['persister-class']) ? (string)$xmlRoot['persister-class'] : null
             );
             $metadata->isMappedSuperclass = true;
         } else if ($xmlRoot->getName() == 'embeddable') {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -412,6 +412,10 @@ class XmlDriver extends FileDriver
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $oneToManyElement['fetch']);
                 }
 
+                if (isset($oneToManyElement['persister'])) {
+                    $mapping['persister'] = $oneToManyElement['persister'];
+                }
+
                 if (isset($oneToManyElement->cascade)) {
                     $mapping['cascade'] = $this->_getCascadeMappings($oneToManyElement->cascade);
                 }
@@ -499,6 +503,10 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $manyToManyElement['fetch']);
+                }
+
+                if (isset($manyToManyElement['persister'])) {
+                    $mapping['persister'] = $manyToManyElement['persister'];
                 }
 
                 if (isset($manyToManyElement['orphan-removal'])) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -58,12 +58,18 @@ class YamlDriver extends FileDriver
             if (isset($element['repositoryClass'])) {
                 $metadata->setCustomRepositoryClass($element['repositoryClass']);
             }
+            if (isset($element['persisterClass'])) {
+                $metadata->setCustomPersisterClass($element['persisterClass']);
+            }
             if (isset($element['readOnly']) && $element['readOnly'] == true) {
                 $metadata->markReadOnly();
             }
         } else if ($element['type'] == 'mappedSuperclass') {
             $metadata->setCustomRepositoryClass(
                 isset($element['repositoryClass']) ? $element['repositoryClass'] : null
+            );
+            $metadata->setCustomPersisterClass(
+                isset($element['persisterClass']) ? $element['persisterClass'] : null
             );
             $metadata->isMappedSuperclass = true;
         } else if ($element['type'] == 'embeddable') {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -416,6 +416,10 @@ class YamlDriver extends FileDriver
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $oneToManyElement['fetch']);
                 }
 
+                if (isset($oneToManyElement['persister'])) {
+                    $mapping['persister'] = $oneToManyElement['persister'];
+                }
+
                 if (isset($oneToManyElement['cascade'])) {
                     $mapping['cascade'] = $oneToManyElement['cascade'];
                 }
@@ -501,6 +505,10 @@ class YamlDriver extends FileDriver
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $manyToManyElement['fetch']);
+                }
+
+                if (isset($manyToManyElement['persister'])) {
+                    $mapping['persister'] = $manyToManyElement['persister'];
                 }
 
                 if (isset($manyToManyElement['mappedBy'])) {

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -31,6 +31,11 @@ final class Entity implements Annotation
     public $repositoryClass;
 
     /**
+     * @var string
+     */
+    public $persisterClass;
+
+    /**
      * @var boolean
      */
     public $readOnly = false;

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -63,4 +63,9 @@ final class ManyToMany implements Annotation
      * @var string
      */
     public $indexBy;
+
+    /**
+     * @var string
+     */
+    public $persister;
 }

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -58,4 +58,9 @@ final class OneToMany implements Annotation
      * @var string
      */
     public $indexBy;
+
+    /**
+     * @var string
+     */
+    public $persister;
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3014,7 +3014,14 @@ class UnitOfWork implements PropertyChangedListener
 
         $class = $this->em->getClassMetadata($entityName);
 
+        $class->customRepositoryClassName;
+
         switch (true) {
+            case ($class->customPersisterClassName !== null):
+                $persister = $class->customPersisterClassName;
+                $persister = new $persister($this->em, $class);
+                break;
+
             case ($class->isInheritanceTypeNone()):
                 $persister = new BasicEntityPersister($this->em, $class);
                 break;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -46,8 +46,6 @@ use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Persisters\Entity\SingleTablePersister;
 use Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister;
-use Doctrine\ORM\Persisters\Collection\OneToManyPersister;
-use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\ORM\Cache\AssociationCacheEntry;
 
@@ -3067,9 +3065,14 @@ class UnitOfWork implements PropertyChangedListener
             return $this->collectionPersisters[$role];
         }
 
-        $persister = ClassMetadata::ONE_TO_MANY === $association['type']
-            ? new OneToManyPersister($this->em)
-            : new ManyToManyPersister($this->em);
+        if (!isset($association['persister'])) {
+            $association['persister'] = (ClassMetadata::ONE_TO_MANY === $association['type'])
+                ? 'Doctrine\ORM\Persisters\Collection\OneToManyPersister'
+                : 'Doctrine\ORM\Persisters\Collection\ManyToManyPersister';
+        }
+
+        $persister = $association['persister'];
+        $persister = new $persister($this->em);
 
         if ($this->hasCache && isset($association['cache'])) {
             $persister = $this->em->getConfiguration()


### PR DESCRIPTION
- [x] Configuring entity persister class: Annotations, Xml, Yaml
- [x] Configuring collection persister class: Annotations, Xml, Yaml
- [ ] Refactor persisters to minimize range of error prone user customization

After having read #4767 I understand that this commit gives users way too much opportunity to shoot themselves in the foot.

Can you please refer me to documentation about what could/should be refactored to allow users less opportunity to sabotage themselves? Or someone could supply me with an explanation of the intended goals and I'll try to implement it.
