### PR TITLE
Fix discriminator column defaults

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -236,10 +236,13 @@ Example:
 @DiscriminatorColumn
 ~~~~~~~~~~~~~~~~~~~~~
 
-This annotation is a required annotation for the topmost/super
+This annotation is an optional annotation for the topmost/super
 class of an inheritance hierarchy. It specifies the details of the
 column which saves the name of the class, which the entity is
 actually instantiated as.
+
+If this annotation is not specified, the discriminator column defaults
+to a string column of length 255 called ``dtype``.
 
 Required attributes:
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -242,8 +242,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                     $metadata->setDiscriminatorColumn(array(
                         'name'             => $discrColumnAnnot->name,
-                        'type'             => $discrColumnAnnot->type,
-                        'length'           => $discrColumnAnnot->length,
+                        'type'             => $discrColumnAnnot->type ?: 'string',
+                        'length'           => $discrColumnAnnot->length ?: 255,
                         'columnDefinition' => $discrColumnAnnot->columnDefinition,
                     ));
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -165,8 +165,8 @@ class XmlDriver extends FileDriver
                     $discrColumn = $xmlRoot->{'discriminator-column'};
                     $metadata->setDiscriminatorColumn(array(
                         'name' => isset($discrColumn['name']) ? (string) $discrColumn['name'] : null,
-                        'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : null,
-                        'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : null,
+                        'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
+                        'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : 255,
                         'columnDefinition' => isset($discrColumn['column-definition']) ? (string) $discrColumn['column-definition'] : null
                     ));
                 } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -176,8 +176,8 @@ class YamlDriver extends FileDriver
                     $discrColumn = $element['discriminatorColumn'];
                     $metadata->setDiscriminatorColumn(array(
                         'name' => isset($discrColumn['name']) ? (string) $discrColumn['name'] : null,
-                        'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : null,
-                        'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : null,
+                        'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
+                        'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : 255,
                         'columnDefinition' => isset($discrColumn['columnDefinition']) ? (string) $discrColumn['columnDefinition'] : null
                     ));
                 } else {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\Company\CompanyFlexContract;
 use Doctrine\Tests\Models\Cache\City;
@@ -977,6 +979,52 @@ abstract class AbstractMappingDriverTest extends \Doctrine\Tests\OrmTestCase
         $this->assertSame('implicit_schema', $metadata->getSchemaName());
         $this->assertSame('implicit_table', $metadata->getTableName());
     }
+
+    /**
+     * @group DDC-514
+     * @group DDC-1015
+     */
+    public function testDiscriminatorColumnDefaultLength()
+    {
+        if (strpos(get_class($this), 'PHPMappingDriver') !== false) {
+            $this->markTestSkipped('PHP Mapping Drivers have no defaults.');
+        }
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityNoDiscriminatorColumnMapping');
+        $this->assertEquals(255, $class->discriminatorColumn['length']);
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityIncompleteDiscriminatorColumnMapping');
+        $this->assertEquals(255, $class->discriminatorColumn['length']);
+    }
+
+    /**
+     * @group DDC-514
+     * @group DDC-1015
+     */
+    public function testDiscriminatorColumnDefaultType()
+    {
+        if (strpos(get_class($this), 'PHPMappingDriver') !== false) {
+            $this->markTestSkipped('PHP Mapping Drivers have no defaults.');
+        }
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityNoDiscriminatorColumnMapping');
+        $this->assertEquals('string', $class->discriminatorColumn['type']);
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityIncompleteDiscriminatorColumnMapping');
+        $this->assertEquals('string', $class->discriminatorColumn['type']);
+    }
+
+    /**
+     * @group DDC-514
+     * @group DDC-1015
+     */
+    public function testDiscriminatorColumnDefaultName()
+    {
+        if (strpos(get_class($this), 'PHPMappingDriver') !== false) {
+            $this->markTestSkipped('PHP Mapping Drivers have no defaults.');
+        }
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityNoDiscriminatorColumnMapping');
+        $this->assertEquals('dtype', $class->discriminatorColumn['name']);
+        $class = $this->createClassMetadata(__NAMESPACE__ . '\SingleTableEntityIncompleteDiscriminatorColumnMapping');
+        $this->assertEquals('dtype', $class->discriminatorColumn['name']);
+    }
+
 }
 
 /**
@@ -1317,7 +1365,6 @@ class DDC807Entity
     }
 }
 
-
 class DDC807SubClasse1 {}
 class DDC807SubClasse2 {}
 
@@ -1357,3 +1404,68 @@ class Comment
         ));
     }
 }
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({
+ *     "ONE" = "SingleTableEntityNoDiscriminatorColumnMappingSub1",
+ *     "TWO" = "SingleTableEntityNoDiscriminatorColumnMappingSub2"
+ * })
+ */
+class SingleTableEntityNoDiscriminatorColumnMapping
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata)
+    {
+        $metadata->mapField(array(
+            'id' => true,
+            'fieldName' => 'id',
+        ));
+
+        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+    }
+}
+
+class SingleTableEntityNoDiscriminatorColumnMappingSub1 extends SingleTableEntityNoDiscriminatorColumnMapping {}
+class SingleTableEntityNoDiscriminatorColumnMappingSub2 extends SingleTableEntityNoDiscriminatorColumnMapping {}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({
+ *     "ONE" = "SingleTableEntityIncompleteDiscriminatorColumnMappingSub1",
+ *     "TWO" = "SingleTableEntityIncompleteDiscriminatorColumnMappingSub2"
+ * })
+ * @DiscriminatorColumn(name="dtype")
+ */
+class SingleTableEntityIncompleteDiscriminatorColumnMapping
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata)
+    {
+        $metadata->mapField(array(
+            'id' => true,
+            'fieldName' => 'id',
+        ));
+
+        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_NONE);
+    }
+}
+
+class SingleTableEntityIncompleteDiscriminatorColumnMappingSub1
+    extends SingleTableEntityIncompleteDiscriminatorColumnMapping {}
+class SingleTableEntityIncompleteDiscriminatorColumnMappingSub2
+    extends SingleTableEntityIncompleteDiscriminatorColumnMapping {}

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.SingleTableEntityIncompleteDiscriminatorColumnMapping.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.SingleTableEntityIncompleteDiscriminatorColumnMapping.dcm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+                              
+    <entity name="Doctrine\Tests\ORM\Mapping\SingleTableEntityIncompleteDiscriminatorColumnMapping" inheritance-type="SINGLE_TABLE">
+        <discriminator-column name="dtype" />
+
+        <discriminator-map>
+            <discriminator-mapping value="ONE" class="SingleTableEntityIncompleteDiscriminatorColumnMappingSub1" />
+            <discriminator-mapping value="TWO" class="SingleTableEntityIncompleteDiscriminatorColumnMappingSub2" />
+        </discriminator-map>
+
+        <id name="id">
+            <generator strategy="NONE"/>
+        </id>
+    </entity>
+        
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.SingleTableEntityNoDiscriminatorColumnMapping.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.SingleTableEntityNoDiscriminatorColumnMapping.dcm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+                              
+    <entity name="Doctrine\Tests\ORM\Mapping\SingleTableEntityNoDiscriminatorColumnMapping" inheritance-type="SINGLE_TABLE">
+        <discriminator-map>
+            <discriminator-mapping value="ONE" class="SingleTableEntityNoDiscriminatorColumnMappingSub1" />
+            <discriminator-mapping value="TWO" class="SingleTableEntityNoDiscriminatorColumnMappingSub2" />
+        </discriminator-map>
+
+        <id name="id">
+            <generator strategy="NONE"/>
+        </id>
+    </entity>
+        
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.SingleTableEntityIncompleteDiscriminatorColumnMapping.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.SingleTableEntityIncompleteDiscriminatorColumnMapping.dcm.yml
@@ -1,0 +1,12 @@
+Doctrine\Tests\ORM\Mapping\SingleTableEntityIncompleteDiscriminatorColumnMapping:
+  type: entity
+  inheritanceType: SINGLE_TABLE
+  discriminatorMap:
+    ONE: SingleTableEntityIncompleteDiscriminatorColumnMappingSub1
+    TWO: SingleTableEntityIncompleteDiscriminatorColumnMappingSub2
+  discriminatorColumn:
+    name: dtype
+  id:
+    id: 
+      generator:
+        strategy: NONE

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.SingleTableEntityNoDiscriminatorColumnMapping.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.SingleTableEntityNoDiscriminatorColumnMapping.dcm.yml
@@ -1,0 +1,10 @@
+Doctrine\Tests\ORM\Mapping\SingleTableEntityNoDiscriminatorColumnMapping:
+  type: entity
+  inheritanceType: SINGLE_TABLE
+  discriminatorMap:
+    ONE: SingleTableEntityNoDiscriminatorColumnMappingSub1
+    TWO: SingleTableEntityNoDiscriminatorColumnMappingSub2
+  id:
+    id: 
+      generator:
+        strategy: NONE


### PR DESCRIPTION
DiscriminatorColumn mapping generated by all 3 metadata drivers (annot, yml, xml) was lacking length and type when only the name is specified in the mapping. Even though this results in a columnDef that generates a string column of length 255, the mapping for the discriminator column should have those fields set properly, and should be consistent with the behavior when no discriminator column mapping is specified at all.

Adjusted docs to properly reflect that the @DiscriminatorColumn annotation is optional.

Closes: #1601 
