### PR TITLE
HAVING clause with variable and *, / math operators

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2271,6 +2271,27 @@ class SelectSqlGenerationTest extends \Doctrine\Tests\OrmTestCase
             'SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING sclr_0 IS NULL'
         );
     }
+
+    /**
+     * GitHub issue #4764: https://github.com/doctrine/doctrine2/issues/4764
+     * @group DDC-3907
+     * @dataProvider mathematicOperatorsProvider
+     */
+    public function testHavingRegressionUsingVariableWithMathOperatorsExpression($operator)
+    {
+        $this->assertSqlGeneration(
+            'SELECT COUNT(u.name) AS countName FROM Doctrine\Tests\Models\CMS\CmsUser u HAVING 1 ' . $operator . ' countName > 0',
+            'SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING 1 ' . $operator . ' sclr_0 > 0'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function mathematicOperatorsProvider()
+    {
+        return [['+'], ['-'], ['*'], ['/']];
+    }
 }
 
 class MyAbsFunction extends \Doctrine\ORM\Query\AST\Functions\FunctionNode


### PR DESCRIPTION
**This is integrated and completed in #5599**

I've produced a test for bug #4764 

As this regression highlights, this bug happens only with the `*` and `/` math operators used in the `HAVING` clause with variables from the `SELECT` clause; `+` and `-` math operators are fine.

Input DQL:

```
SELECT COUNT(u.name) AS countName FROM Doctrine\Tests\Models\CMS\CmsUser u HAVING 1  / countName > 0
```

Expected:

```
SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING 1 / sclr_0 > 0
```

Instead:

```
SELECT COUNT(c0_.name) AS sclr_0 FROM cms_users c0_ HAVING 1 / countName > 0
```
