### PR TITLE
Update EntityManager::create() to allow extend

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -847,7 +847,7 @@ use Doctrine\Common\Util\ClassUtils;
                 throw new \InvalidArgumentException("Invalid argument: " . $conn);
         }
 
-        return new EntityManager($conn, $config, $conn->getEventManager());
+        return new static($conn, $config, $conn->getEventManager());
     }
 
     /**


### PR DESCRIPTION
This PR aims to allow `Doctrine\ORM\EntityManager` to be extended even if you use `::create()` method to create a new instance.
