### PR TITLE
Make ClassMetadataFactory more configurable

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -71,6 +71,23 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private $embeddablesActiveNesting = array();
 
     /**
+     * @var string
+     */
+    protected $metadataClass = 'Doctrine\ORM\Mapping\ClassMetadata';
+
+    /**
+     * @param $className string
+     * @throws \Exception
+     */
+    public function setMetadataClass($className)
+    {
+        if ( ! in_array('Doctrine\Common\Persistence\Mapping\ClassMetadata', class_implements($className))) {
+            throw new \Exception('Metadata class must implement \'Doctrine\Common\Persistence\Mapping\ClassMetadata\' interface');
+        }
+        $this->metadataClass = $className;
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function loadMetadata($name)
@@ -287,7 +304,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function newClassMetadataInstance($className)
     {
-        return new ClassMetadata($className, $this->em->getConfiguration()->getNamingStrategy());
+        return new $this->metadataClass($className, $this->em->getConfiguration()->getNamingStrategy());
     }
 
     /**


### PR DESCRIPTION
It looks reasonable to make the `ClassMetadataFactory` more configurable to avoid such tricks as I've implemented at Atlantic18/DoctrineExtensions#1512 for example.

In the past there was no reason for this changes as well as this tricks. But 8bdb7130738df5b7a9c5d8f73e3cbfb72149c909 changed things.

Also there are improvements to be made before this code can be merged.
1. `\Exception` is to general and non-informative.
2. I think `$metadataClass` must be configurable through `doctrine.orm.entity_managers` like `doctrine.orm.entity_managers.default.class_metadata_factory_name`

Suggestions and reviews are welcome!
