### PR TITLE
Improve the error by showing wich object entity was being used when t…

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -224,11 +224,7 @@ class EntityRepository implements ObjectRepository, Selectable
                 break;
 
             default:
-                throw new \BadMethodCallException(
-                    "Undefined method called: " . $this->_entityName . 
-                    "::{$method}(). If absent the repository  method name must start with ".
-                    "either findBy or findOneBy!"
-                );
+                throw new UnknownEntityRepositoryMethod($this->_entityName, $method);
         }
 
         if (empty($arguments)) {

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -225,7 +225,7 @@ class EntityRepository implements ObjectRepository, Selectable
 
             default:
                 throw new \BadMethodCallException(
-                    "In " . $this->_entityName . 
+                    "In Repository for Entity " . $this->_entityName . 
                     " Undefined method '$method'. The method name must start with ".
                     "either findBy or findOneBy!"
                 );

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -225,7 +225,8 @@ class EntityRepository implements ObjectRepository, Selectable
 
             default:
                 throw new \BadMethodCallException(
-                    "Undefined method '$method'. The method name must start with ".
+                    "In " . $this->_entityName . 
+                    " Undefined method '$method'. The method name must start with ".
                     "either findBy or findOneBy!"
                 );
         }

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -225,8 +225,8 @@ class EntityRepository implements ObjectRepository, Selectable
 
             default:
                 throw new \BadMethodCallException(
-                    "In Repository for Entity " . $this->_entityName . 
-                    " Undefined method '$method'. The method name must start with ".
+                    "Undefined method called: " . $this->_entityName . 
+                    "::{$method}(). If absent the repository  method name must start with ".
                     "either findBy or findOneBy!"
                 );
         }

--- a/lib/Doctrine/ORM/UnknownEntityRepositoryMethod.php
+++ b/lib/Doctrine/ORM/UnknownEntityRepositoryMethod.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM;
+
+/**
+ * Exception thrown when a method is not found in a Entity
+ *
+ * @author odnanref
+ */
+class UnknownEntityRepositoryMethod extends \BadMethodCallException
+{
+    /**
+     * Constructor.
+     *
+     * @param string   $className
+     * @param string $method
+     *
+     * @return self
+     */
+    public function __construct($className, $method)
+    {
+        parent::__construct(
+            'Entity of type \'' . $className . '\'' . " has no method " .
+            $method . "() in the Repository class." .
+            "Use findBy or findOneBy or implement the method."
+        );
+    }
+}
+

--- a/tests/Doctrine/Tests/ORM/UnknownEntityRepositoryMethodTest.php
+++ b/tests/Doctrine/Tests/ORM/UnknownEntityRepositoryMethodTest.php
@@ -14,7 +14,7 @@ class UnknownEntityRepositoryMethodTest extends PHPUnit_Framework_TestCase
 {
     public function testFromClassNameAndIdentifier()
     {
-        $exception = new UnknownEntityRepositoryMethod('foo', 'bar')
+        $exception = new UnknownEntityRepositoryMethod('foo', 'bar');
 
         $this->assertInstanceOf('Doctrine\ORM\UnknownEntityRepositoryMethod', $exception);
         $this->assertSame('Entity of type \'foo\' has no method bar() in the Repository class.Use findBy or findOneBy or implement the method.', $exception->getMessage());

--- a/tests/Doctrine/Tests/ORM/UnknownEntityRepositoryMethodTest.php
+++ b/tests/Doctrine/Tests/ORM/UnknownEntityRepositoryMethodTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\ORM\UnknownEntityRepositoryMethod;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests for {@see \Doctrine\ORM\UnknownEntityRepositoryMethod}
+ *
+ * @covers \Doctrine\ORM\UnknownEntityRepositoryMethod
+ */
+class UnknownEntityRepositoryMethodTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromClassNameAndIdentifier()
+    {
+        $exception = new UnknownEntityRepositoryMethod('foo', 'bar')
+
+        $this->assertInstanceOf('Doctrine\ORM\UnknownEntityRepositoryMethod', $exception);
+        $this->assertSame('Entity of type \'foo\' has no method bar() in the Repository class.Use findBy or findOneBy or implement the method.', $exception->getMessage());
+
+    }
+}


### PR DESCRIPTION
…he method was detected missing

I had a error that didn't show which class didn't have the method, this litle hack allowed me to have that information.
The current error shows withouth the entity to which the method is missing.
 request.CRITICAL: Uncaught PHP Exception BadMethodCallException: " Undefined method 'getAll'. The method name must start with either findBy or findOneBy!" at /home/andref/workspace/moneytrak/mt2/vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php line 196 {"exception":"[object](BadMethodCallException:  Undefined method 'getAll'. The method name must start with either findBy or findOneBy! at /home/andref/workspace/moneytrak/mt2/vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php:196)"} []

This change improves the error shown:
 request.CRITICAL: Uncaught PHP Exception BadMethodCallException: "In Far\MT\AccountBundle\Entity\Holder Undefined method 'getAll'. The method name must start with either findBy or findOneBy!" at /home/andref/workspace/moneytrak/mt2/vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php line 196 {"exception":"[object](BadMethodCallException: In Far\MT\AccountBundle\Entity\Holder Undefined method 'getAll'. The method name must start with either findBy or findOneBy! at /home/andref/workspace/moneytrak/mt2/vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php:196)"} []

Now I have the Entity to which the method is missing.
(BadMethodCallException: In Far\MT\AccountBundle\Entity\Holder
