### PR TITLE
Updated all commands to use the SymfonyStyle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": ">=2.5-dev,<2.7-dev",
         "doctrine/cache": "~1.4",
-        "symfony/console": "~2.5|~3.0"
+        "symfony/console": "~2.7|~3.0"
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache;
 
@@ -82,6 +83,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io          = new SymfonyStyle($input, $output);
         $em          = $this->getHelper('em')->getEntityManager();
         $ownerClass  = $input->getArgument('owner-class');
         $assoc       = $input->getArgument('association');
@@ -108,13 +110,13 @@ EOT
 
             $collectionRegion->getCache()->flushAll();
 
-            $output->writeln(sprintf('Flushing cache provider configured for <info>"%s#%s"</info>', $ownerClass, $assoc));
+            $io->comment(sprintf('Flushing cache provider configured for <info>"%s#%s"</info>', $ownerClass, $assoc));
 
             return;
         }
 
         if ($input->getOption('all')) {
-            $output->writeln('Clearing <info>all</info> second-level cache collection regions');
+            $io->comment('Clearing <info>all</info> second-level cache collection regions');
 
             $cache->evictEntityRegions();
 
@@ -122,13 +124,13 @@ EOT
         }
 
         if ($ownerId) {
-            $output->writeln(sprintf('Clearing second-level cache entry for collection <info>"%s#%s"</info> owner entity identified by <info>"%s"</info>', $ownerClass, $assoc, $ownerId));
+            $io->comment(sprintf('Clearing second-level cache entry for collection <info>"%s#%s"</info> owner entity identified by <info>"%s"</info>', $ownerClass, $assoc, $ownerId));
             $cache->evictCollection($ownerClass, $assoc, $ownerId);
 
             return;
         }
 
-        $output->writeln(sprintf('Clearing second-level cache for collection <info>"%s#%s"</info>', $ownerClass, $assoc));
+        $io->comment(sprintf('Clearing second-level cache for collection <info>"%s#%s"</info>', $ownerClass, $assoc));
         $cache->evictCollectionRegion($ownerClass, $assoc);
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache;
 
@@ -81,6 +82,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io          = new SymfonyStyle($input, $output);
         $em          = $this->getHelper('em')->getEntityManager();
         $entityClass = $input->getArgument('entity-class');
         $entityId    = $input->getArgument('entity-id');
@@ -106,13 +108,13 @@ EOT
 
             $entityRegion->getCache()->flushAll();
 
-            $output->writeln(sprintf('Flushing cache provider configured for entity named <info>"%s"</info>', $entityClass));
+            $io->comment(sprintf('Flushing cache provider configured for entity named <info>"%s"</info>', $entityClass));
 
             return;
         }
 
         if ($input->getOption('all')) {
-            $output->writeln('Clearing <info>all</info> second-level cache entity regions');
+            $io->comment('Clearing <info>all</info> second-level cache entity regions');
 
             $cache->evictEntityRegions();
 
@@ -120,13 +122,13 @@ EOT
         }
 
         if ($entityId) {
-            $output->writeln(sprintf('Clearing second-level cache entry for entity <info>"%s"</info> identified by <info>"%s"</info>', $entityClass, $entityId));
+            $io->comment(sprintf('Clearing second-level cache entry for entity <info>"%s"</info> identified by <info>"%s"</info>', $entityClass, $entityId));
             $cache->evictEntity($entityClass, $entityId);
 
             return;
         }
 
-        $output->writeln(sprintf('Clearing second-level cache for entity <info>"%s"</info>', $entityClass));
+        $io->comment(sprintf('Clearing second-level cache for entity <info>"%s"</info>', $entityClass));
         $cache->evictEntityRegion($entityClass);
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\XcacheCache;
 
@@ -78,6 +79,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
         $cacheDriver = $em->getConfiguration()->getMetadataCacheImpl();
 
@@ -93,8 +95,7 @@ EOT
             throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
 
-
-        $output->writeln('Clearing ALL Metadata cache entries');
+        $io->comment('Clearing ALL Metadata cache entries');
 
         $result  = $cacheDriver->deleteAll();
         $message = ($result) ? 'Successfully deleted cache entries.' : 'No cache entries were deleted.';
@@ -104,6 +105,10 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        $output->writeln($message);
+        if ($result) {
+            $io->success($message);
+        } else {
+            $io->error($message);
+        }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\XcacheCache;
 
@@ -78,6 +79,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
         $cacheDriver = $em->getConfiguration()->getQueryCacheImpl();
 
@@ -91,8 +93,8 @@ EOT
         if ($cacheDriver instanceof XcacheCache) {
             throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
-        
-        $output->write('Clearing ALL Query cache entries' . PHP_EOL);
+
+        $io->comment('Clearing ALL Query cache entries');
 
         $result  = $cacheDriver->deleteAll();
         $message = ($result) ? 'Successfully deleted cache entries.' : 'No cache entries were deleted.';
@@ -102,6 +104,10 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        $output->write($message . PHP_EOL);
+        if ($result) {
+            $io->success($message);
+        } else {
+            $io->error($message);
+        }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\ORM\Cache;
 
@@ -80,6 +81,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io    = new SymfonyStyle($input, $output);
         $em    = $this->getHelper('em')->getEntityManager();
         $name  = $input->getArgument('region-name');
         $cache = $em->getCache();
@@ -105,20 +107,20 @@ EOT
 
             $queryRegion->getCache()->flushAll();
 
-            $output->writeln(sprintf('Flushing cache provider configured for second-level cache query region named <info>"%s"</info>', $name));
+            $io->comment(sprintf('Flushing cache provider configured for second-level cache query region named <info>"%s"</info>', $name));
 
             return;
         }
 
         if ($input->getOption('all')) {
-            $output->writeln('Clearing <info>all</info> second-level cache query regions');
+            $io->comment('Clearing <info>all</info> second-level cache query regions');
 
             $cache->evictQueryRegions();
 
             return;
         }
 
-        $output->writeln(sprintf('Clearing second-level cache query region named <info>"%s"</info>', $name));
+        $io->comment(sprintf('Clearing second-level cache query region named <info>"%s"</info>', $name));
         $cache->evictQueryRegion($name);
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\XcacheCache;
 
@@ -78,6 +79,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
         $cacheDriver = $em->getConfiguration()->getResultCacheImpl();
 
@@ -92,8 +94,8 @@ EOT
         if ($cacheDriver instanceof XcacheCache) {
             throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
         }
-        
-        $output->writeln('Clearing ALL Result cache entries');
+
+        $io->comment('Clearing ALL Result cache entries');
 
         $result  = $cacheDriver->deleteAll();
         $message = ($result) ? 'Successfully deleted cache entries.' : 'No cache entries were deleted.';
@@ -103,6 +105,10 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        $output->writeln($message);
+        if ($result) {
+            $io->success($message);
+        } else {
+            $io->error($message);
+        }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -27,6 +27,7 @@ use Doctrine\ORM\Tools\ConvertDoctrine1Schema;
 use Doctrine\ORM\Tools\EntityGenerator;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -140,6 +141,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
+
         // Process source directories
         $fromPaths = array_merge(array($input->getArgument('from-path')), $input->getOption('from'));
 
@@ -150,7 +153,7 @@ EOT
         $extend = $input->getOption('extend');
         $numSpaces = $input->getOption('num-spaces');
 
-        $this->convertDoctrine1Schema($fromPaths, $destPath, $toType, $numSpaces, $extend, $output);
+        $this->convertDoctrine1Schema($fromPaths, $destPath, $toType, $numSpaces, $extend, $io);
     }
 
     /**
@@ -159,11 +162,11 @@ EOT
      * @param string          $toType
      * @param int             $numSpaces
      * @param string|null     $extend
-     * @param OutputInterface $output
+     * @param SymfonyStyle    $io
      *
      * @throws \InvalidArgumentException
      */
-    public function convertDoctrine1Schema(array $fromPaths, $destPath, $toType, $numSpaces, $extend, OutputInterface $output)
+    public function convertDoctrine1Schema(array $fromPaths, $destPath, $toType, $numSpaces, $extend, SymfonyStyle $io)
     {
         foreach ($fromPaths as &$dirName) {
             $dirName = realpath($dirName);
@@ -211,20 +214,20 @@ EOT
         $metadata = $converter->getMetadata();
 
         if ($metadata) {
-            $output->writeln('');
+            $io->newLine();
 
             foreach ($metadata as $class) {
-                $output->writeln(sprintf('Processing entity "<info>%s</info>"', $class->name));
+                $io->comment(sprintf('Processing entity "<info>%s</info>"', $class->name));
             }
 
             $exporter->setMetadata($metadata);
             $exporter->export();
 
-            $output->writeln(PHP_EOL . sprintf(
+            $io->text(PHP_EOL . sprintf(
                 'Converting Doctrine 1.X schema to "<info>%s</info>" mapping type in "<info>%s</info>"', $toType, $destPath
             ));
         } else {
-            $output->writeln('No Metadata Classes to process.');
+            $io->text('No Metadata Classes to process.');
         }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -114,6 +115,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
 
         if ($input->getOption('from-database') === true) {
@@ -171,17 +173,17 @@ EOT
 
         if (count($metadata)) {
             foreach ($metadata as $class) {
-                $output->writeln(sprintf('Processing entity "<info>%s</info>"', $class->name));
+                $io->comment(sprintf('Processing entity "<info>%s</info>"', $class->name));
             }
 
             $exporter->setMetadata($metadata);
             $exporter->export();
 
-            $output->writeln(PHP_EOL . sprintf(
+            $io->text(PHP_EOL . sprintf(
                 'Exporting "<info>%s</info>" mapping information to "<info>%s</info>"', $toType, $destPath
             ));
         } else {
-            $output->writeln('No Metadata Classes to process.');
+            $io->text('No Metadata Classes to process.');
         }
     }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -23,6 +23,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Command to ensure that Doctrine is properly configured for a production environment.
@@ -62,6 +63,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
 
         try {
@@ -71,11 +73,11 @@ EOT
                 $em->getConnection()->connect();
             }
         } catch (\Exception $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            $io->error($e->getMessage());
 
             return 1;
         }
 
-        $output->writeln('<info>Environment is correctly configured for production.</info>');
+        $io->success('Environment is correctly configured for production.');
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -152,7 +153,7 @@ EOT
             }
 
             foreach ($metadatas as $metadata) {
-                $output->writeln(
+                $io->comment(
                     sprintf('Processing entity "<info>%s</info>"', $metadata->name)
                 );
             }
@@ -161,9 +162,9 @@ EOT
             $entityGenerator->generate($metadatas, $destPath);
 
             // Outputting information message
-            $output->writeln(PHP_EOL . sprintf('Entity classes generated to "<info>%s</INFO>"', $destPath));
+            $io->success(sprintf('Entity classes generated to "<info>%s</info>"', $destPath));
         } else {
-            $output->writeln('No Metadata Classes to process.');
+            $io->text('No Metadata Classes to process.');
         }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -68,6 +69,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
@@ -96,9 +98,9 @@ EOT
             );
         }
 
-        if ( count($metadatas)) {
+        if (count($metadatas)) {
             foreach ($metadatas as $metadata) {
-                $output->writeln(
+                $io->comment(
                     sprintf('Processing entity "<info>%s</info>"', $metadata->name)
                 );
             }
@@ -107,9 +109,9 @@ EOT
             $em->getProxyFactory()->generateProxyClasses($metadatas, $destPath);
 
             // Outputting information message
-            $output->writeln(PHP_EOL . sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath));
+            $io->success(sprintf('Proxy classes generated to "<info>%s</INFO>"', $destPath));
         } else {
-            $output->writeln('No Metadata Classes to process.');
+            $io->text('No Metadata Classes to process.');
         }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -25,6 +25,7 @@ use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\EntityRepositoryGenerator;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 
 /**
@@ -68,6 +69,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         $em = $this->getHelper('em')->getEntityManager();
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();
@@ -98,7 +100,7 @@ EOT
 
             foreach ($metadatas as $metadata) {
                 if ($metadata->customRepositoryClassName) {
-                    $output->writeln(
+                    $io->comment(
                         sprintf('Processing repository "<info>%s</info>"', $metadata->customRepositoryClassName)
                     );
 
@@ -110,12 +112,12 @@ EOT
 
             if ($numRepositories) {
                 // Outputting information message
-                $output->writeln(PHP_EOL . sprintf('Repository classes generated to "<info>%s</INFO>"', $destPath));
+                $io->success(PHP_EOL . sprintf('Repository classes generated to "<info>%s</INFO>"', $destPath));
             } else {
-                $output->writeln('No Repository classes were found to be processed.');
+                $io->text('No Repository classes were found to be processed.');
             }
         } else {
-            $output->writeln('No Metadata Classes to process.');
+            $io->text('No Metadata Classes to process.');
         }
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\Mapping\MappingException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Show information about mapped entities.
@@ -54,6 +55,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
@@ -68,18 +70,16 @@ EOT
             );
         }
 
-        $output->writeln(sprintf("Found <info>%d</info> mapped entities:", count($entityClassNames)));
+        $io->comment(sprintf("Found <info>%d</info> mapped entities:", count($entityClassNames)));
 
         $failure = false;
 
         foreach ($entityClassNames as $entityClassName) {
             try {
                 $entityManager->getClassMetadata($entityClassName);
-                $output->writeln(sprintf("<info>[OK]</info>   %s", $entityClassName));
+                $io->text(sprintf("<info>[OK]</info>   %s", $entityClassName));
             } catch (MappingException $e) {
-                $output->writeln("<error>[FAIL]</error> ".$entityClassName);
-                $output->writeln(sprintf("<comment>%s</comment>", $e->getMessage()));
-                $output->writeln('');
+                $io->error(array($entityClassName, $e->getMessage()));
 
                 $failure = true;
             }

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -26,6 +26,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Show information about mapped entities.
@@ -62,10 +63,11 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io = new SymfonyStyle($input, $output);
         /* @var $entityManager \Doctrine\ORM\EntityManagerInterface */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
-        $this->displayEntity($input->getArgument('entityName'), $entityManager, $output);
+        $this->displayEntity($input->getArgument('entityName'), $entityManager, $io);
 
         return 0;
     }
@@ -77,56 +79,47 @@ EOT
      * @param EntityManagerInterface $entityManager
      * @param OutputInterface        $output
      */
-    private function displayEntity($entityName, EntityManagerInterface $entityManager, OutputInterface $output)
+    private function displayEntity($entityName, EntityManagerInterface $entityManager, SymfonyStyle $io)
     {
-        $table = new Table($output);
-
-        $table->setHeaders(array('Field', 'Value'));
-
         $metadata = $this->getClassMetadata($entityName, $entityManager);
 
-        array_map(
-            array($table, 'addRow'),
-            array_merge(
-                array(
-                    $this->formatField('Name', $metadata->name),
-                    $this->formatField('Root entity name', $metadata->rootEntityName),
-                    $this->formatField('Custom generator definition', $metadata->customGeneratorDefinition),
-                    $this->formatField('Custom repository class', $metadata->customRepositoryClassName),
-                    $this->formatField('Mapped super class?', $metadata->isMappedSuperclass),
-                    $this->formatField('Embedded class?', $metadata->isEmbeddedClass),
-                    $this->formatField('Parent classes', $metadata->parentClasses),
-                    $this->formatField('Sub classes', $metadata->subClasses),
-                    $this->formatField('Embedded classes', $metadata->subClasses),
-                    $this->formatField('Named queries', $metadata->namedQueries),
-                    $this->formatField('Named native queries', $metadata->namedNativeQueries),
-                    $this->formatField('SQL result set mappings', $metadata->sqlResultSetMappings),
-                    $this->formatField('Identifier', $metadata->identifier),
-                    $this->formatField('Inheritance type', $metadata->inheritanceType),
-                    $this->formatField('Discriminator column', $metadata->discriminatorColumn),
-                    $this->formatField('Discriminator value', $metadata->discriminatorValue),
-                    $this->formatField('Discriminator map', $metadata->discriminatorMap),
-                    $this->formatField('Generator type', $metadata->generatorType),
-                    $this->formatField('Table', $metadata->table),
-                    $this->formatField('Composite identifier?', $metadata->isIdentifierComposite),
-                    $this->formatField('Foreign identifier?', $metadata->containsForeignIdentifier),
-                    $this->formatField('Sequence generator definition', $metadata->sequenceGeneratorDefinition),
-                    $this->formatField('Table generator definition', $metadata->tableGeneratorDefinition),
-                    $this->formatField('Change tracking policy', $metadata->changeTrackingPolicy),
-                    $this->formatField('Versioned?', $metadata->isVersioned),
-                    $this->formatField('Version field', $metadata->versionField),
-                    $this->formatField('Read only?', $metadata->isReadOnly),
+        $io->table(array('Field', 'Value'), array_merge(
+            array(
+                $this->formatField('Name', $metadata->name),
+                $this->formatField('Root entity name', $metadata->rootEntityName),
+                $this->formatField('Custom generator definition', $metadata->customGeneratorDefinition),
+                $this->formatField('Custom repository class', $metadata->customRepositoryClassName),
+                $this->formatField('Mapped super class?', $metadata->isMappedSuperclass),
+                $this->formatField('Embedded class?', $metadata->isEmbeddedClass),
+                $this->formatField('Parent classes', $metadata->parentClasses),
+                $this->formatField('Sub classes', $metadata->subClasses),
+                $this->formatField('Embedded classes', $metadata->subClasses),
+                $this->formatField('Named queries', $metadata->namedQueries),
+                $this->formatField('Named native queries', $metadata->namedNativeQueries),
+                $this->formatField('SQL result set mappings', $metadata->sqlResultSetMappings),
+                $this->formatField('Identifier', $metadata->identifier),
+                $this->formatField('Inheritance type', $metadata->inheritanceType),
+                $this->formatField('Discriminator column', $metadata->discriminatorColumn),
+                $this->formatField('Discriminator value', $metadata->discriminatorValue),
+                $this->formatField('Discriminator map', $metadata->discriminatorMap),
+                $this->formatField('Generator type', $metadata->generatorType),
+                $this->formatField('Table', $metadata->table),
+                $this->formatField('Composite identifier?', $metadata->isIdentifierComposite),
+                $this->formatField('Foreign identifier?', $metadata->containsForeignIdentifier),
+                $this->formatField('Sequence generator definition', $metadata->sequenceGeneratorDefinition),
+                $this->formatField('Table generator definition', $metadata->tableGeneratorDefinition),
+                $this->formatField('Change tracking policy', $metadata->changeTrackingPolicy),
+                $this->formatField('Versioned?', $metadata->isVersioned),
+                $this->formatField('Version field', $metadata->versionField),
+                $this->formatField('Read only?', $metadata->isReadOnly),
 
-                    $this->formatEntityListeners($metadata->entityListeners),
-                ),
-                array($this->formatField('Association mappings:', '')),
-                $this->formatMappings($metadata->associationMappings),
-                array($this->formatField('Field mappings:', '')),
-                $this->formatMappings($metadata->fieldMappings)
-            )
-        );
-
-        $table->render();
+                $this->formatEntityListeners($metadata->entityListeners),
+            ),
+            array($this->formatField('Association mappings:', '')),
+            $this->formatMappings($metadata->associationMappings),
+            array($this->formatField('Field mappings:', '')),
+            $this->formatMappings($metadata->fieldMappings)
+        ));
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\Common\Util\Debug;
 
 /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Command\Command;
 use Doctrine\ORM\Tools\SchemaTool;
 
@@ -37,20 +38,20 @@ use Doctrine\ORM\Tools\SchemaTool;
 abstract class AbstractCommand extends Command
 {
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
+     * @param SymfonyStyle    $io
      * @param SchemaTool      $schemaTool
-     * @param array           $metadatas
+     * @param array           $metadatass
      *
      * @return null|int Null or 0 if everything went fine, or an error code.
      */
-    abstract protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas);
+    abstract protected function executeSchemaCommand(SymfonyStyle $io, SchemaTool $schemaTool, array $metadatas);
 
     /**
      * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $io       = new SymfonyStyle($input, $output);
         $emHelper = $this->getHelper('em');
 
         /* @var $em \Doctrine\ORM\EntityManager */
@@ -62,10 +63,9 @@ abstract class AbstractCommand extends Command
             // Create SchemaTool
             $tool = new SchemaTool($em);
 
-            return $this->executeSchemaCommand($input, $output, $tool, $metadatas);
+            return $this->executeSchemaCommand($io, $tool, $metadatas);
         } else {
-            $output->writeln('No Metadata Classes to process.');
-
+            $io->text('No Metadata Classes to process.');
             return 0;
         }
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -20,8 +20,7 @@
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Tools\SchemaTool;
 
 /**
@@ -67,17 +66,17 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas)
+    protected function executeSchemaCommand(SymfonyStyle $io, SchemaTool $schemaTool, array $metadatas)
     {
         if ($input->getOption('dump-sql')) {
             $sqls = $schemaTool->getCreateSchemaSql($metadatas);
-            $output->writeln(implode(';' . PHP_EOL, $sqls) . ';');
+            $io->text(implode(';' . PHP_EOL, $sqls) . ';');
         } else {
-            $output->writeln('ATTENTION: This operation should not be executed in a production environment.' . PHP_EOL);
+            $io->warning('ATTENTION: This operation should not be executed in a production environment.');
 
-            $output->writeln('Creating database schema...');
+            $io->comment('Creating database schema...');
             $schemaTool->createSchema($metadatas);
-            $output->writeln('Database schema created successfully!');
+            $io->success('Database schema created successfully!');
         }
 
         return 0;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -20,8 +20,7 @@
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Tools\SchemaTool;
 
 /**
@@ -76,7 +75,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas)
+    protected function executeSchemaCommand(SymfonyStyle $io, SchemaTool $schemaTool, array $metadatas)
     {
         $isFullDatabaseDrop = $input->getOption('full-database');
 
@@ -86,13 +85,13 @@ EOT
             } else {
                 $sqls = $schemaTool->getDropSchemaSQL($metadatas);
             }
-            $output->writeln(implode(';' . PHP_EOL, $sqls));
+            $io->text(implode(';' . PHP_EOL, $sqls));
 
             return 0;
         }
 
         if ($input->getOption('force')) {
-            $output->writeln('Dropping database schema...');
+            $io->comment('Dropping database schema...');
 
             if ($isFullDatabaseDrop) {
                 $schemaTool->dropDatabase();
@@ -100,12 +99,12 @@ EOT
                 $schemaTool->dropSchema($metadatas);
             }
 
-            $output->writeln('Database schema dropped successfully!');
+            $io->success('Database schema dropped successfully!');
 
             return 0;
         }
 
-        $output->writeln('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.' . PHP_EOL);
+        $io->warning('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.');
 
         if ($isFullDatabaseDrop) {
             $sqls = $schemaTool->getDropDatabaseSQL();
@@ -114,16 +113,17 @@ EOT
         }
 
         if (count($sqls)) {
-            $output->writeln(sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)));
-            $output->writeln('Please run the operation by passing one - or both - of the following options:');
-
-            $output->writeln(sprintf('    <info>%s --force</info> to execute the command', $this->getName()));
-            $output->writeln(sprintf('    <info>%s --dump-sql</info> to dump the SQL statements to the screen', $this->getName()));
+            $io->text(array(
+                sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)),
+                'Please run the operation by passing one - or both - of the following options:',
+                sprintf('    <info>%s --force</info> to execute the command', $this->getName()),
+                sprintf('    <info>%s --dump-sql</info> to dump the SQL statements to the screen', $this->getName())
+            ));
 
             return 1;
         }
 
-        $output->writeln('Nothing to drop. The database is empty!');
+        $io->text('Nothing to drop. The database is empty!');
 
         return 0;
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -20,8 +20,7 @@
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Doctrine\ORM\Tools\SchemaTool;
 
 /**
@@ -105,7 +104,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeSchemaCommand(InputInterface $input, OutputInterface $output, SchemaTool $schemaTool, array $metadatas)
+    protected function executeSchemaCommand(SymfonyStyle $io, SchemaTool $schemaTool, array $metadatas)
     {
         // Defining if update is complete or not (--complete not defined means $saveMode = true)
         $saveMode = ! $input->getOption('complete');
@@ -113,7 +112,7 @@ EOT
         $sqls = $schemaTool->getUpdateSchemaSql($metadatas, $saveMode);
 
         if (0 === count($sqls)) {
-            $output->writeln('Nothing to update - your database is already in sync with the current entity metadata.');
+            $io->text('Nothing to update - your database is already in sync with the current entity metadata.');
 
             return 0;
         }
@@ -122,35 +121,35 @@ EOT
         $force   = true === $input->getOption('force');
 
         if ($dumpSql) {
-            $output->writeln(implode(';' . PHP_EOL, $sqls) . ';');
+            $io->text(implode(';' . PHP_EOL, $sqls) . ';');
         }
 
         if ($force) {
             if ($dumpSql) {
-                $output->writeln('');
+                $io->newLine();
             }
-            $output->writeln('Updating database schema...');
+            $io->comment('Updating database schema...');
             $schemaTool->updateSchema($metadatas, $saveMode);
 
             $pluralization = (1 === count($sqls)) ? 'query was' : 'queries were';
 
-            $output->writeln(sprintf('Database schema updated successfully! "<info>%s</info>" %s executed', count($sqls), $pluralization));
+            $io->success(sprintf('Database schema updated successfully! "<info>%s</info>" %s executed', count($sqls), $pluralization));
         }
 
         if ($dumpSql || $force) {
             return 0;
         }
 
-        $output->writeln('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.');
-        $output->writeln('           Use the incremental update to detect changes during development and use');
-        $output->writeln('           the SQL DDL provided to manually update your database in production.');
-        $output->writeln('');
-
-        $output->writeln(sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)));
-        $output->writeln('Please run the operation by passing one - or both - of the following options:');
-
-        $output->writeln(sprintf('    <info>%s --force</info> to execute the command', $this->getName()));
-        $output->writeln(sprintf('    <info>%s --dump-sql</info> to dump the SQL statements to the screen', $this->getName()));
+        $io->text(array(
+            '<comment>ATTENTION</comment>: This operation should not be executed in a production environment.',
+            '           Use the incremental update to detect changes during development and use',
+            '           the SQL DDL provided to manually update your database in production.',
+            '',
+            sprintf('The Schema-Tool would execute <info>"%s"</info> queries to update the database.', count($sqls)),
+            'Please run the operation by passing one - or both - of the following options:',
+            sprintf('    <info>%s --force</info> to execute the command', $this->getName()),
+            sprintf('    <info>%s --dump-sql</info> to dump the SQL statements to the screen', $this->getName()),
+        ));
 
         return 1;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
@@ -48,7 +48,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             '--all'   => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing all second-level cache collection regions' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing all second-level cache collection regions' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearByOwnerEntityClassName()
@@ -61,7 +61,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             'association'   => 'cities',
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache for collection "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache for collection "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearCacheEntryName()
@@ -75,7 +75,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             'owner-id'      => 1,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache entry for collection "Doctrine\Tests\Models\Cache\State#cities" owner entity identified by "1"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache entry for collection "Doctrine\Tests\Models\Cache\State#cities" owner entity identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testFlushRegionName()
@@ -89,6 +89,6 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             '--flush'       => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Flushing cache provider configured for "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Flushing cache provider configured for "Doctrine\Tests\Models\Cache\State#cities"' . PHP_EOL, $tester->getDisplay());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php
@@ -48,7 +48,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             '--all'   => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing all second-level cache entity regions' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing all second-level cache entity regions' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearByEntityClassName()
@@ -60,7 +60,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             'entity-class'  => 'Doctrine\Tests\Models\Cache\Country',
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache for entity "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache for entity "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearCacheEntryName()
@@ -73,7 +73,7 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             'entity-id'     => 1,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by "1"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache entry for entity "Doctrine\Tests\Models\Cache\Country" identified by "1"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testFlushRegionName()
@@ -86,6 +86,6 @@ class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
             '--flush'       => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Flushing cache provider configured for entity named "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Flushing cache provider configured for entity named "Doctrine\Tests\Models\Cache\Country"' . PHP_EOL, $tester->getDisplay());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php
@@ -48,7 +48,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
             '--all'   => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing all second-level cache query regions' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing all second-level cache query regions' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearDefaultRegionName()
@@ -60,7 +60,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
             'region-name'   => null,
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache query region named "query_cache_region"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache query region named "query_cache_region"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testClearByRegionName()
@@ -72,7 +72,7 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
             'region-name'   => 'my_region',
         ), array('decorated' => false));
 
-        $this->assertEquals('Clearing second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Clearing second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }
 
     public function testFlushRegionName()
@@ -85,6 +85,6 @@ class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
             '--flush'       => true,
         ), array('decorated' => false));
 
-        $this->assertEquals('Flushing cache provider configured for second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
+        $this->assertEquals(PHP_EOL . ' // Flushing cache provider configured for second-level cache query region named "my_region"' . PHP_EOL, $tester->getDisplay());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
@@ -12,9 +12,11 @@ class ConvertDoctrine1SchemaCommandTest extends \Doctrine\Tests\OrmTestCase
         $command = new ConvertDoctrine1SchemaCommand();
         $command->setEntityGenerator($entityGenerator);
 
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->getMockBuilder('Symfony\Component\Console\Style\SymfonyStyle')
+                       ->disableOriginalConstructor()
+                       ->getMock();
         $output->expects($this->once())
-               ->method('writeln')
+               ->method('text')
                ->with($this->equalTo('No Metadata Classes to process.'));
 
         $command->convertDoctrine1Schema(array(), sys_get_temp_dir(), 'annotation', 4, null, $output);

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -84,4 +84,3 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         ));
     }
 }
-


### PR DESCRIPTION
The Symfony Style defines one default style for all commands using the Symfony Console code. Because Docrine has a number of commands, it would look nice if the commands made use of the Symfony style. This makes the output more human friendly to read.

Additions and comments are welcome, for example about which style to use for which messages.

All tests pass (although some commands are not tested). 

Some text about the style guide is written in http://symfony.com/blog/new-in-symfony-2-8-console-style-guide. 
