### PR TITLE
Allow EntityRepository::findAll() method takes parameter for ordering

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -158,11 +158,13 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Finds all entities in the repository.
      *
+     * @param array|null $orderBy
+     *
      * @return array The entities.
      */
-    public function findAll()
+    public function findAll(array $orderBy = null)
     {
-        return $this->findBy(array());
+        return $this->findBy(array(), $orderBy);
     }
 
     /**


### PR DESCRIPTION
Resolve the #5632 .

The main question is:
Why should I use `findBy()` method with empty criteria in order to simply fetch all ordered rows?
I think it's just fine to be able to sort results by `findAll()` method.
