### PR TITLE
Fix many-to-many matching ignoring offset/limit

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -266,6 +266,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
+        $limit  = $criteria->getMaxResults();
+        $offset = $criteria->getFirstResult();
+        if ($limit !== null || $offset !== null) {
+            $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset);
+        }
+
+
         $stmt = $this->conn->executeQuery($sql, $params);
 
         return $this


### PR DESCRIPTION
When using ->matching on ManyToMany with a criteria having offset and/or the resulting query does not contain LIMIT/OFFSET

``` php
$criteria = new Criteria();
$criteria->setFirstResult(10);
$criteria->setMaxResults(5);
$entity->getUsers()->matching($criteria);
```
