### PR TITLE
NamingStrategy::joinTableName not being called

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -450,7 +450,7 @@
       <xs:element name="inverse-join-columns" type="orm:join-columns" />
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
-    <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="name" type="xs:NMTOKEN" use="optional" />
     <xs:attribute name="schema" type="xs:NMTOKEN" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -508,7 +508,7 @@ class XmlDriver extends FileDriver
 
                     $joinTableElement = $manyToManyElement->{'join-table'};
                     $joinTable = array(
-                        'name' => (string) $joinTableElement['name']
+                        'name' => empty($joinTableElement['name']) ? null : (string) $joinTableElement['name']
                     );
 
                     if (isset($joinTableElement['schema'])) {


### PR DESCRIPTION
This problem exists for M2M without a tableName (because a NamingStrategy may take care of the table name) and XML Drivers

Explanation:

Although a joinTable MUST have an tableName eventually, it is actually valid to have it not declared IF a naming strategy would generate one (always true if not defined (null)).

However this XML driver will will parse an omitted declaration as an empty string. The ClassMetadataInfo Class is expecting an unset value or it will break.

ClassMetadataInfo will show a `Notice: Uninitialized string offset: 0` which makes sense if you look at

```
// remember $mapping['joinTable']['name'] is now "";
if (isset($mapping['joinTable']['name']) && $mapping['joinTable']['name'][0] === '`') {
```

[see](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1521)

More importantly the (default) naming strategy will now never be called and the resulting ClassMetadataInfo has no table name defined, which results in a 'Invalid table name specified' Exception

```
if ( ! isset($mapping['joinTable']['name'])) {
    $mapping['joinTable']['name'] = $this->namingStrategy->joinTableName($mapping['sourceEntity'], $mapping['targetEntity'], $mapping['fieldName']);
}
```

[see](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L1703-L1705)

Please tell me if this is something we can merge without further proof, I don't really understand how to add a test case for it (I have looked at the existing cases, but... pfft)
