### PR TITLE
many-to-many criteria related bug-fix aggregate patch

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -266,6 +266,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
+        $limit  = $criteria->getMaxResults();
+        $offset = $criteria->getFirstResult();
+        if ($limit !== null || $offset !== null) {
+            $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset);
+        }
+
+
         $stmt = $this->conn->executeQuery($sql, $params);
 
         return $this

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -278,6 +278,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
+        $sql .= $this->getOrderingSql($criteria);
+
         $stmt = $this->conn->executeQuery($sql, $params);
 
         return $this
@@ -739,5 +741,23 @@ class ManyToManyPersister extends AbstractCollectionPersister
         list($values, $types) = $valueVisitor->getParamsAndTypes();
 
         return $types;
+    }
+
+    /**
+     * @param Criteria $criteria
+     * @return string
+     */
+    private function getOrderingSql(Criteria $criteria)
+    {
+        $orderings = $criteria->getOrderings();
+        if ($orderings) {
+            $orderBy = [];
+            foreach ($orderings as $field => $direction) {
+                $orderBy[] = $field . ' ' . $direction;
+            }
+
+            return ' ORDER BY ' . implode(', ', $orderBy);
+        }
+        return '';
     }
 }

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -278,7 +278,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             . implode(' AND ', $onConditions)
             . ' WHERE ' . implode(' AND ', $whereClauses);
 
-        $sql .= $this->getOrderingSql($criteria);
+        $sql .= $this->getOrderingSql($criteria, $targetClass);
 
         $sql .= $this->getLimitSql($criteria);
 
@@ -747,14 +747,20 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
     /**
      * @param Criteria $criteria
+     * @param ClassMetadata $targetClass
      * @return string
      */
-    private function getOrderingSql(Criteria $criteria)
+    private function getOrderingSql(Criteria $criteria, ClassMetadata $targetClass)
     {
         $orderings = $criteria->getOrderings();
         if ($orderings) {
             $orderBy = [];
-            foreach ($orderings as $field => $direction) {
+            foreach ($orderings as $name => $direction) {
+                $field = $this->quoteStrategy->getColumnName(
+                    $name,
+                    $targetClass,
+                    $this->platform
+                );
                 $orderBy[] = $field . ' ' . $direction;
             }
 

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -229,29 +229,41 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $mapping       = $collection->getMapping();
         $owner         = $collection->getOwner();
         $ownerMetadata = $this->em->getClassMetadata(get_class($owner));
+        $id            = $this->uow->getEntityIdentifier($owner);
+        $targetClass   = $this->em->getClassMetadata($mapping['targetEntity']);
+        $onConditions  = $this->getOnConditionSQL($mapping);
         $whereClauses  = $params = array();
 
-        foreach ($mapping['relationToSourceKeyColumns'] as $key => $value) {
+        if ( ! $mapping['isOwningSide']) {
+            $associationSourceClass = $targetClass;
+            $mapping = $targetClass->associationMappings[$mapping['mappedBy']];
+            $sourceRelationMode = 'relationToTargetKeyColumns';
+        } else {
+            $associationSourceClass = $ownerMetadata;
+            $sourceRelationMode = 'relationToSourceKeyColumns';
+        }
+
+        foreach ($mapping[$sourceRelationMode] as $key => $value) {
             $whereClauses[] = sprintf('t.%s = ?', $key);
-            $params[]       = $ownerMetadata->getFieldValue($owner, $value);
+            $params[] = $ownerMetadata->containsForeignIdentifier
+                ? $id[$ownerMetadata->getFieldForColumn($value)]
+                : $id[$ownerMetadata->fieldNames[$value]];
         }
 
         $parameters = $this->expandCriteriaParameters($criteria);
 
         foreach ($parameters as $parameter) {
             list($name, $value) = $parameter;
-            $whereClauses[]     = sprintf('te.%s = ?', $name);
+            $field = $this->quoteStrategy->getColumnName($name, $targetClass, $this->platform);
+            $whereClauses[]     = sprintf('te.%s = ?', $field);
             $params[]           = $value;
         }
 
-        $mapping      = $collection->getMapping();
-        $targetClass  = $this->em->getClassMetadata($mapping['targetEntity']);
         $tableName    = $this->quoteStrategy->getTableName($targetClass, $this->platform);
-        $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $ownerMetadata, $this->platform);
-        $onConditions = $this->getOnConditionSQL($mapping);
+        $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);
 
         $rsm = new Query\ResultSetMappingBuilder($this->em);
-        $rsm->addRootEntityFromClassMetadata($mapping['targetEntity'], 'te');
+        $rsm->addRootEntityFromClassMetadata($targetClass->name, 'te');
 
         $sql = 'SELECT ' . $rsm->generateSelectClause()
             . ' FROM ' . $tableName . ' te'

--- a/tests/Doctrine/Tests/Models/CMS/CmsTag.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTag.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace Doctrine\Tests\Models\CMS;
+
+/**
+ * Description of CmsTag
+ *
+ * @Entity
+ * @Table(name="cms_tags")
+ */
+class CmsTag
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+    /**
+     * @Column(length=50, name="tag_name", nullable=true)
+     */
+    public $name;
+    /**
+     * @ManyToMany(targetEntity="CmsUser", mappedBy="tags")
+     */
+    public $users;
+
+    public function setName($name) {
+        $this->name = $name;
+    }
+
+    public function getName() {
+        return $this->name;
+    }
+
+    public function addUser(CmsUser $user) {
+        $this->users[] = $user;
+    }
+
+    public function getUsers() {
+        return $this->users;
+    }
+}
+

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -162,6 +162,14 @@ class CmsUser
      *      )
      */
     public $groups;
+    /**
+     * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"persist", "merge", "detach"})
+     * @JoinTable(name="cms_users_tags",
+     *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
+     *      inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id")}
+     *      )
+     */
+    public $tags;
 
     public $nonPersistedProperty;
 
@@ -171,6 +179,7 @@ class CmsUser
         $this->phonenumbers = new ArrayCollection;
         $this->articles = new ArrayCollection;
         $this->groups = new ArrayCollection;
+        $this->tags = new ArrayCollection;
     }
 
     public function getId() {
@@ -215,6 +224,15 @@ class CmsUser
 
     public function getGroups() {
         return $this->groups;
+    }
+
+    public function addTag(CmsTag $tag) {
+        $this->tags[] = $tag;
+        $tag->addUser($this);
+    }
+
+    public function getTags() {
+        return $this->tags;
     }
 
     public function removePhonenumber($index) {

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -163,7 +163,7 @@ class CmsUser
      */
     public $groups;
     /**
-     * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"persist", "merge", "detach"})
+     * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"all"})
      * @JoinTable(name="cms_users_tags",
      *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
      *      inverseJoinColumns={@JoinColumn(name="tag_id", referencedColumnName="id")}

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -166,7 +166,7 @@ class CmsUser
      * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"persist", "merge", "detach"})
      * @JoinTable(name="cms_users_tags",
      *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id")}
+     *      inverseJoinColumns={@JoinColumn(name="tag_id", referencedColumnName="id")}
      *      )
      */
     public $tags;

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -377,6 +377,44 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         $this->assertEquals(0, count($user->groups));
     }
 
+    /**
+     * @group DDC-3952
+     */
+    public function testManyToManyOrderByIsNotIgnored()
+    {
+        $user = $this->addCmsUserGblancoWithGroups(1);
+
+        $group = new CmsGroup;
+        $group->name = 'C';
+        $user->addGroup($group);
+
+        $group = new CmsGroup;
+        $group->name = 'A';
+        $user->addGroup($group);
+
+        $group = new CmsGroup;
+        $group->name = 'B';
+        $user->addGroup($group);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $criteria = Criteria::create()
+            ->orderBy(['name' => Criteria::ASC]);
+        $groups   = $user->getGroups()->matching($criteria);
+
+        $existingOrder = [];
+        foreach ($groups as $group) {
+            $existingOrder[] = $group->getName();
+        }
+
+        $this->assertEquals(['A', 'B', 'C', 'Developers_0'], $existingOrder);
+    }
+
     public function testMatching()
     {
         $user = $this->addCmsUserGblancoWithGroups(2);

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -384,17 +384,17 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
     {
         $user = $this->addCmsUserGblancoWithGroups(1);
 
-        $group = new CmsGroup;
-        $group->name = 'C';
-        $user->addGroup($group);
+        $group1 = new CmsGroup;
+        $group2 = new CmsGroup;
+        $group3 = new CmsGroup;
 
-        $group = new CmsGroup;
-        $group->name = 'A';
-        $user->addGroup($group);
+        $group1->name = 'C';
+        $group2->name = 'A';
+        $group3->name = 'B';
 
-        $group = new CmsGroup;
-        $group->name = 'B';
-        $user->addGroup($group);
+        $user->addGroup($group1);
+        $user->addGroup($group2);
+        $user->addGroup($group3);
 
         $this->_em->persist($user);
         $this->_em->flush();
@@ -405,14 +405,17 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
 
         $criteria = Criteria::create()
             ->orderBy(['name' => Criteria::ASC]);
-        $groups   = $user->getGroups()->matching($criteria);
 
-        $existingOrder = [];
-        foreach ($groups as $group) {
-            $existingOrder[] = $group->getName();
-        }
-
-        $this->assertEquals(['A', 'B', 'C', 'Developers_0'], $existingOrder);
+        $this->assertEquals(
+            ['A', 'B', 'C', 'Developers_0'],
+            $user
+                ->getGroups()
+                ->matching($criteria)
+                ->map(function (CmsGroup $group) {
+                    return $group->getName();
+                })
+                ->toArray()
+        );
     }
 
     public function testMatchingWithLimit()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
@@ -24,10 +24,10 @@ class DDC3719Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testCriteriaOnNotOwningSide()
     {
         $manager = new CompanyManager();
-		$manager->setName('Gandalf');
-		$manager->setSalary(666);
-		$manager->setTitle('Boss');
-		$manager->setDepartment('Marketing');
+        $manager->setName('Gandalf');
+        $manager->setSalary(666);
+        $manager->setTitle('Boss');
+        $manager->setDepartment('Marketing');
         $this->_em->persist($manager);
 
         $contractA = new CompanyFlexContract();
@@ -43,12 +43,12 @@ class DDC3719Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->refresh($manager);
 
         $contracts = $manager->managedContracts;
-		static::assertCount(2, $contracts);
+        static::assertCount(2, $contracts);
 
-		$criteria = Criteria::create();
-		$criteria->where(Criteria::expr()->eq("completed", true));
+        $criteria = Criteria::create();
+        $criteria->where(Criteria::expr()->eq("completed", true));
 
-		$completedContracts = $contracts->matching($criteria);
-		static::assertCount(1, $completedContracts);
+        $completedContracts = $contracts->matching($criteria);
+        static::assertCount(1, $completedContracts);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Tests\Models\Company\CompanyFlexContract;
+use Doctrine\Tests\Models\Company\CompanyManager;
+
+/**
+ * @author Jean Carlo Machado <contato@jeancarlomachado.com.br>
+ */
+class DDC3719Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->useModelSet('company');
+        parent::setUp();
+    }
+
+    /**
+     * @group DDC-3719
+     */
+    public function testCriteriaOnNotOwningSide()
+    {
+        $manager = new CompanyManager();
+		$manager->setName('Gandalf');
+		$manager->setSalary(666);
+		$manager->setTitle('Boss');
+		$manager->setDepartment('Marketing');
+        $this->_em->persist($manager);
+
+        $contractA = new CompanyFlexContract();
+        $contractA->markCompleted();
+        $contractA->addManager($manager);
+        $this->_em->persist($contractA);
+
+        $contractB = new CompanyFlexContract();
+        $contractB->addManager($manager);
+        $this->_em->persist($contractB);
+
+        $this->_em->flush();
+        $this->_em->refresh($manager);
+
+        $contracts = $manager->managedContracts;
+		static::assertCount(2, $contracts);
+
+		$criteria = Criteria::create();
+		$criteria->where(Criteria::expr()->eq("completed", true));
+
+		$completedContracts = $contracts->matching($criteria);
+		static::assertCount(1, $completedContracts);
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -320,6 +320,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['cms'])) {
             $conn->executeUpdate('DELETE FROM cms_users_groups');
             $conn->executeUpdate('DELETE FROM cms_groups');
+            $conn->executeUpdate('DELETE FROM cms_tags');
             $conn->executeUpdate('DELETE FROM cms_addresses');
             $conn->executeUpdate('DELETE FROM cms_phonenumbers');
             $conn->executeUpdate('DELETE FROM cms_comments');

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -320,6 +320,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['cms'])) {
             $conn->executeUpdate('DELETE FROM cms_users_groups');
             $conn->executeUpdate('DELETE FROM cms_groups');
+            $conn->executeUpdate('DELETE FROM cms_users_tags');
             $conn->executeUpdate('DELETE FROM cms_tags');
             $conn->executeUpdate('DELETE FROM cms_addresses');
             $conn->executeUpdate('DELETE FROM cms_phonenumbers');

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -83,6 +83,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\CMS\CmsAddress',
             'Doctrine\Tests\Models\CMS\CmsEmail',
             'Doctrine\Tests\Models\CMS\CmsGroup',
+            'Doctrine\Tests\Models\CMS\CmsTag',
             'Doctrine\Tests\Models\CMS\CmsArticle',
             'Doctrine\Tests\Models\CMS\CmsComment',
         ),


### PR DESCRIPTION
Needed to utilize criteria against a non-owning side of a many-to-many association so we aggregated a few related (criteria + many-to-many) pull requests so we'd have a working patch branch to service our project. Mostly just merged the existing PR but also addressed some PR comments like adding missing tests.

Patches includes in this PR
- #5638 criteria not working on non-owning side 
- #1535 criteria ordering ignored
- #5653 criteria limit/offset ignored
