### PR TITLE
Support matching Criteria on PersistentCollection for ManyToMany associatons

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/Expr/MappingVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/Expr/MappingVisitor.php
@@ -1,0 +1,82 @@
+<?php
+
+
+namespace Doctrine\ORM\Persisters\Collection\Expr;
+
+
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\QuoteStrategy;
+
+class MappingVisitor extends ExpressionVisitor
+{
+    /** @var  QuoteStrategy */
+    private $quoteStrategy;
+    /** @var  ClassMetadata */
+    private $metadata;
+    /** @var  AbstractPlatform */
+    private $platform;
+
+    /**
+     * MappingVisitor constructor.
+     * @param QuoteStrategy $quoteStrategy
+     * @param ClassMetadata $metadata
+     * @param AbstractPlatform $platform
+     */
+    public function __construct(QuoteStrategy $quoteStrategy, ClassMetadata $metadata, AbstractPlatform $platform)
+    {
+        $this->quoteStrategy = $quoteStrategy;
+        $this->metadata = $metadata;
+        $this->platform = $platform;
+    }
+
+
+    /**
+     * Converts a comparison expression into the target query language output.
+     *
+     * @param Comparison $comparison
+     *
+     * @return mixed
+     */
+    public function walkComparison(Comparison $comparison)
+    {
+        return new Comparison(
+            $this->quoteStrategy->getColumnName($comparison->getField(), $this->metadata, $this->platform),
+            $comparison->getOperator(),
+            $comparison->getValue()
+        );
+    }
+
+    /**
+     * Converts a value expression into the target query language part.
+     *
+     * @param Value $value
+     *
+     * @return mixed
+     */
+    public function walkValue(Value $value)
+    {
+        return $value->getValue();
+    }
+
+    /**
+     * Converts a composite expression into the target query language output.
+     *
+     * @param CompositeExpression $expr
+     *
+     * @return mixed
+     */
+    public function walkCompositeExpression(CompositeExpression $expr)
+    {
+        $expressions = [];
+        foreach($expr->getExpressionList() as $expression) {
+            $expressions[] = $this->dispatch($expression);
+        }
+
+        return new CompositeExpression($expr->getType(), $expressions);
+    }
+}

--- a/lib/Doctrine/ORM/Persisters/Collection/Expr/MappingVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/Expr/MappingVisitor.php
@@ -60,7 +60,7 @@ class MappingVisitor extends ExpressionVisitor
      */
     public function walkValue(Value $value)
     {
-        return $value->getValue();
+        return $value;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -19,13 +19,10 @@
 
 namespace Doctrine\ORM\Persisters\Collection;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Collection\Expr\MappingVisitor;
-use Doctrine\ORM\Persisters\SqlExpressionVisitor;
-use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
@@ -239,75 +236,42 @@ class ManyToManyPersister extends AbstractCollectionPersister
     public function loadCriteria(PersistentCollection $collection, Criteria $criteria)
     {
         $mapping       = $collection->getMapping();
-        $owner         = $collection->getOwner();
-        $ownerMetadata = $this->em->getClassMetadata(get_class($owner));
-        $id            = $this->uow->getEntityIdentifier($owner);
         $targetClass   = $this->em->getClassMetadata($mapping['targetEntity']);
-        $onConditions  = $this->getOnConditionSQL($mapping);
-        $whereClauses  = array();
-        $params        = array();
-        $types         = array();
 
-        if ( ! $mapping['isOwningSide']) {
-            $associationSourceClass = $targetClass;
-            $mapping = $targetClass->associationMappings[$mapping['mappedBy']];
-            $sourceRelationMode = 'relationToTargetKeyColumns';
-        } else {
-            $associationSourceClass = $ownerMetadata;
-            $sourceRelationMode = 'relationToSourceKeyColumns';
-        }
-
-        foreach ($mapping[$sourceRelationMode] as $key => $value) {
-            $paramName = sprintf(':t%s', $key);
-            $whereClauses[] = sprintf('t.%s = %s', $key, $paramName);
-
-            $paramValue = $ownerMetadata->containsForeignIdentifier
-                ? $id[$ownerMetadata->getFieldForColumn($value)]
-                : $id[$ownerMetadata->fieldNames[$value]];
-
-            $params[] = new Parameter($paramName, $paramValue, $ownerMetadata->getTypeOfField($key));
-            $types[] = $ownerMetadata->getTypeOfField($key);
-        }
-
-        $mappingVisitor = new MappingVisitor(
-            $this->quoteStrategy,
-            $targetClass,
-            $this->platform
-        );
+        $queryBuilder = $this->createQueryBuilderForAssociation($collection);
 
         if ($whereExpr = $criteria->getWhereExpression()) {
+            $mappingVisitor = new MappingVisitor(
+                $this->quoteStrategy,
+                $targetClass,
+                $this->platform
+            );
+
             $mappedExpr = $mappingVisitor->dispatch($criteria->getWhereExpression());
 
             $whereClauseExpressionVisitor = new QueryExpressionVisitor(['te']);
             $whereExpr = $whereClauseExpressionVisitor->dispatch($mappedExpr);
-            $whereClauses[] = $whereExpr . '';
+            $queryBuilder->where($whereExpr . '');
 
             /** @var Parameter $parameter */
             foreach($whereClauseExpressionVisitor->getParameters() as $parameter) {
-                $params[] = $parameter;
-                $types[] = $parameter->getType();
+                $queryBuilder->setParameter($parameter->getName(), $parameter->getValue(), $parameter->getType());
             }
         }
 
-        $tableName    = $this->quoteStrategy->getTableName($targetClass, $this->platform);
-        $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);
+        $this->applyCriteriaOrdering($queryBuilder, $criteria, $targetClass);
+
+        $this->applyCriteriaLimit($queryBuilder, $criteria);
 
         $rsm = new Query\ResultSetMappingBuilder($this->em);
         $rsm->addRootEntityFromClassMetadata($targetClass->name, 'te');
 
-        $sql = 'SELECT ' . $rsm->generateSelectClause()
-            . ' FROM ' . $tableName . ' te'
-            . ' JOIN ' . $joinTable  . ' t ON'
-            . implode(' AND ', $onConditions)
-            . ' WHERE ' . implode(' AND ', $whereClauses);
+        $stmt = $queryBuilder->execute();
 
-        $sql .= $this->getOrderingSql($criteria, $targetClass);
-
-        $sql .= $this->getLimitSql($criteria);
-
-        $nativeQuery = $this->em->createNativeQuery($sql, $rsm);
-
-        return $nativeQuery->execute(new ArrayCollection($params));
+        return $this
+            ->em
+            ->newHydrator(Query::HYDRATE_OBJECT)
+            ->hydrateAll($stmt, $rsm);
     }
 
     /**
@@ -741,41 +705,79 @@ class ManyToManyPersister extends AbstractCollectionPersister
     }
 
     /**
+     * @param QueryBuilder $queryBuilder
      * @param Criteria $criteria
      * @param ClassMetadata $targetClass
-     * @return string
      */
-    private function getOrderingSql(Criteria $criteria, ClassMetadata $targetClass)
+    private function applyCriteriaOrdering(QueryBuilder $queryBuilder, Criteria $criteria, ClassMetadata $targetClass)
     {
         $orderings = $criteria->getOrderings();
         if ($orderings) {
-            $orderBy = [];
             foreach ($orderings as $name => $direction) {
                 $field = $this->quoteStrategy->getColumnName(
                     $name,
                     $targetClass,
                     $this->platform
                 );
-                $orderBy[] = $field . ' ' . $direction;
-            }
 
-            return ' ORDER BY ' . implode(', ', $orderBy);
+                $queryBuilder->addOrderBy($field, $direction);
+            }
         }
-        return '';
     }
 
     /**
+     * @param QueryBuilder $queryBuilder
      * @param Criteria $criteria
-     * @return string
-     * @throws \Doctrine\DBAL\DBALException
      */
-    private function getLimitSql(Criteria $criteria)
+    private function applyCriteriaLimit(QueryBuilder $queryBuilder, Criteria $criteria)
     {
-        $limit  = $criteria->getMaxResults();
-        $offset = $criteria->getFirstResult();
-        if ($limit !== null || $offset !== null) {
-            return $this->platform->modifyLimitQuery('', $limit, $offset);
+        $queryBuilder->setFirstResult($criteria->getFirstResult());
+        $queryBuilder->setMaxResults($criteria->getMaxResults());
+    }
+
+    /**
+     * @param PersistentCollection $collection
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    private function createQueryBuilderForAssociation(PersistentCollection $collection)
+    {
+        $qb = $this->em->getConnection()->createQueryBuilder();
+
+        $mapping       = $collection->getMapping();
+        $owner         = $collection->getOwner();
+        $ownerMetadata = $this->em->getClassMetadata(get_class($owner));
+        $id            = $this->uow->getEntityIdentifier($owner);
+        $targetClass   = $this->em->getClassMetadata($mapping['targetEntity']);
+        $onConditions  = $this->getOnConditionSQL($mapping);
+
+
+        if ( ! $mapping['isOwningSide']) {
+            $associationSourceClass = $targetClass;
+            $mapping = $targetClass->associationMappings[$mapping['mappedBy']];
+            $sourceRelationMode = 'relationToTargetKeyColumns';
+        } else {
+            $associationSourceClass = $ownerMetadata;
+            $sourceRelationMode = 'relationToSourceKeyColumns';
         }
-        return '';
+
+        foreach ($mapping[$sourceRelationMode] as $key => $value) {
+            $paramName = sprintf(':t%s', $key);
+            $qb->where(sprintf('t.%s = %s', $key, $paramName));
+
+            $paramValue = $ownerMetadata->containsForeignIdentifier
+                ? $id[$ownerMetadata->getFieldForColumn($value)]
+                : $id[$ownerMetadata->fieldNames[$value]];
+
+            $qb->setParameter($paramName, $paramValue, $ownerMetadata->getTypeOfField($key));
+        }
+
+        $tableName    = $this->quoteStrategy->getTableName($targetClass, $this->platform);
+        $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);
+
+        $qb->select('te.*');
+        $qb->from($tableName, 'te');
+        $qb->join('te', $joinTable, 't', join(' AND ', $onConditions));
+
+        return $qb;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -642,7 +642,7 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         $tag2 = new CmsTag;
         $tag3 = new CmsTag;
 
-        $tag1->name = '';
+        $tag1->name = null;
         $tag2->name = 'B';
         $tag3->name = 'C';
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -548,6 +548,7 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
     }
 
     /**
+     * @group DDC-3890
      * @dataProvider matchingWithComparisonsProvider
      * @param string $method
      * @param string $field
@@ -631,6 +632,9 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
         ];
     }
 
+    /**
+     * @group DDC-3890
+     */
     public function testMatchingWithIsNull()
     {
         $user = new CmsUser;

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -546,4 +546,130 @@ class ManyToManyBasicAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCa
 
         $this->assertFalse($user->groups->isInitialized(), "Post-condition: matching does not initialize collection");
     }
+
+    /**
+     * @dataProvider matchingWithComparisonsProvider
+     * @param string $method
+     * @param string $field
+     * @param mixed|mixed[] $value
+     * @param array $expectedTagNames
+     */
+    public function testMatchingWithComparisons($method, $field, $value, array $expectedTagNames)
+    {
+        $user = new CmsUser;
+        $user->name = 'Guilherme';
+        $user->username = 'gblanco';
+        $user->status = 'developer';
+
+        $tag1 = new CmsTag;
+        $tag2 = new CmsTag;
+        $tag3 = new CmsTag;
+
+        $tag1->name = 'A';
+        $tag2->name = 'B';
+        $tag3->name = 'C';
+
+        $user->addTag($tag1);
+        $user->addTag($tag2);
+        $user->addTag($tag3);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $criteria = Criteria::create();
+
+        $expr = Criteria::expr();
+        $condition = call_user_func([$expr, $method], $field, $value);
+        $criteria->where($condition);
+
+        $this->assertEquals(
+            $expectedTagNames,
+            $user
+                ->getTags()
+                ->matching($criteria)
+                ->map(function (CmsTag $tag) {
+                    return $tag->getName();
+                })
+                ->toArray()
+        );
+    }
+
+    public function matchingWithComparisonsProvider()
+    {
+        return [
+            'lt' => [
+                'lt', 'name', 'B', ['A']
+            ],
+            'lte' => [
+                'lte', 'name', 'B', ['A', 'B']
+            ],
+            'eq' => [
+                'eq', 'name', 'B', ['B']
+            ],
+            'neq' => [
+                'neq', 'name', 'B', ['A', 'C']
+            ],
+            'gt' => [
+                'gt', 'name', 'B', ['C']
+            ],
+            'gte' => [
+                'gte', 'name', 'B', ['B', 'C']
+            ],
+            'in' => [
+                'in', 'name', ['A', 'C'], ['A', 'C']
+            ],
+            'notIn' => [
+                'notIn', 'name', ['A', 'C'], ['B']
+            ],
+            'contains' => [
+                'contains', 'name', 'B', ['B']
+            ],
+        ];
+    }
+
+    public function testMatchingWithIsNull()
+    {
+        $user = new CmsUser;
+        $user->name = 'Guilherme';
+        $user->username = 'gblanco';
+        $user->status = 'developer';
+
+        $tag1 = new CmsTag;
+        $tag2 = new CmsTag;
+        $tag3 = new CmsTag;
+
+        $tag1->name = '';
+        $tag2->name = 'B';
+        $tag3->name = 'C';
+
+        $user->addTag($tag1);
+        $user->addTag($tag2);
+        $user->addTag($tag3);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $user = $this->_em->find(get_class($user), $user->id);
+
+        $criteria = Criteria::create();
+
+        $criteria->where(Criteria::expr()->isNull('name'));
+
+        $this->assertEquals(
+            [null],
+            $user
+                ->getTags()
+                ->matching($criteria)
+                ->map(function (CmsTag $tag) {
+                    return $tag->getName();
+                })
+                ->toArray()
+        );
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+
+namespace Doctrine\Tests\ORM\Persisters\Collection\Expr;
+
+
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Persisters\Collection\Expr\MappingVisitor;
+
+class MappingVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var  QuoteStrategy */
+    private $quoteStrategy;
+    /** @var  MappingVisitor */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        /** @var ClassMetadata $metadata */
+        $metadata = $this->getMockBuilder(ClassMetadata::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var AbstractPlatform $platform */
+        $platform = $this->getMockBuilder(AbstractPlatform::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->quoteStrategy = $this->getMockBuilder(QuoteStrategy::class)
+            ->getMock();
+
+        $this->quoteStrategy->expects($this->any())
+            ->method('getColumnName')
+            ->with('field', $metadata, $platform)
+            ->willReturn('column');
+
+        $this->sut = new MappingVisitor(
+            $this->quoteStrategy,
+            $metadata,
+            $platform
+        );
+    }
+
+
+    public function testWalkComparisonReturnsComparisonWithMappedField()
+    {
+        $expr = new Comparison('field', Comparison::GT, 73);
+        /** @var Comparison $mapped */
+        $mapped = $this->sut->dispatch($expr);
+        static::assertInstanceOf(Comparison::class, $mapped);
+        static::assertEquals('column', $mapped->getField());
+        static::assertEquals($expr->getOperator(), $mapped->getOperator());
+        static::assertEquals($expr->getValue(), $mapped->getValue());
+
+    }
+
+    public function testWalkValueReturnsValue()
+    {
+        $value = new Value('foo');
+        static::assertSame($value, $this->sut->dispatch($value));
+    }
+
+    public function testWalkCompositeExpressionReturnsMappedCompositeExpression()
+    {
+        $gtExpr = new Comparison('field', Comparison::GT, 73);
+        $ltExpr = new Comparison('field', Comparison::LT, 53);
+        $valExpr = new Value('foo');
+
+        $composite = new CompositeExpression(
+            CompositeExpression::TYPE_OR, [$gtExpr, $ltExpr, $valExpr]);
+
+        /** @var CompositeExpression $mapped */
+        $mapped = $this->sut->dispatch($composite);
+        static::assertInstanceOf(CompositeExpression::class, $mapped);
+        /** @var Comparison[]|Value[] $mappedExpressions */
+        $mappedExpressions = $mapped->getExpressionList();
+
+        static::assertCount(3, $mappedExpressions);
+
+        static::assertInstanceOf(Comparison::class, $mappedExpressions[0]);
+        static::assertInstanceOf(Comparison::class, $mappedExpressions[1]);
+        static::assertInstanceOf(Value::class, $mappedExpressions[2]);
+
+        static::assertEquals('column', $mappedExpressions[0]->getField());
+        static::assertEquals('column', $mappedExpressions[1]->getField());
+
+        static::assertEquals($gtExpr->getOperator(), $mappedExpressions[0]->getOperator());
+        static::assertEquals($ltExpr->getOperator(), $mappedExpressions[1]->getOperator());
+
+        static::assertEquals($gtExpr->getValue(), $mappedExpressions[0]->getValue());
+        static::assertEquals($ltExpr->getValue(), $mappedExpressions[1]->getValue());
+        static::assertEquals($valExpr->getValue(), $mappedExpressions[2]->getValue());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
@@ -71,10 +71,9 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
     {
         $gtExpr = new Comparison('field', Comparison::GT, 73);
         $ltExpr = new Comparison('field', Comparison::LT, 53);
-        $valExpr = new Value('foo');
 
         $composite = new CompositeExpression(
-            CompositeExpression::TYPE_OR, [$gtExpr, $ltExpr, $valExpr]);
+            CompositeExpression::TYPE_OR, [$gtExpr, $ltExpr]);
 
         /** @var CompositeExpression $mapped */
         $mapped = $this->sut->dispatch($composite);
@@ -82,11 +81,10 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
         /** @var Comparison[]|Value[] $mappedExpressions */
         $mappedExpressions = $mapped->getExpressionList();
 
-        static::assertCount(3, $mappedExpressions);
+        static::assertCount(2, $mappedExpressions);
 
         static::assertInstanceOf(Comparison::class, $mappedExpressions[0]);
         static::assertInstanceOf(Comparison::class, $mappedExpressions[1]);
-        static::assertInstanceOf(Value::class, $mappedExpressions[2]);
 
         static::assertEquals('column', $mappedExpressions[0]->getField());
         static::assertEquals('column', $mappedExpressions[1]->getField());
@@ -96,6 +94,5 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
 
         static::assertEquals($gtExpr->getValue(), $mappedExpressions[0]->getValue());
         static::assertEquals($ltExpr->getValue(), $mappedExpressions[1]->getValue());
-        static::assertEquals($valExpr->getValue(), $mappedExpressions[2]->getValue());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/Collection/Expr/MappingVisitorTest.php
@@ -24,16 +24,16 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         /** @var ClassMetadata $metadata */
-        $metadata = $this->getMockBuilder(ClassMetadata::class)
+        $metadata = $this->getMockBuilder('\Doctrine\ORM\Mapping\ClassMetadata')
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var AbstractPlatform $platform */
-        $platform = $this->getMockBuilder(AbstractPlatform::class)
+        $platform = $this->getMockBuilder('\Doctrine\DBAL\Platforms\AbstractPlatform')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->quoteStrategy = $this->getMockBuilder(QuoteStrategy::class)
+        $this->quoteStrategy = $this->getMockBuilder('\Doctrine\ORM\Mapping\QuoteStrategy')
             ->getMock();
 
         $this->quoteStrategy->expects($this->any())
@@ -54,7 +54,7 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
         $expr = new Comparison('field', Comparison::GT, 73);
         /** @var Comparison $mapped */
         $mapped = $this->sut->dispatch($expr);
-        static::assertInstanceOf(Comparison::class, $mapped);
+        static::assertInstanceOf('\Doctrine\Common\Collections\Expr\Comparison', $mapped);
         static::assertEquals('column', $mapped->getField());
         static::assertEquals($expr->getOperator(), $mapped->getOperator());
         static::assertEquals($expr->getValue(), $mapped->getValue());
@@ -77,14 +77,14 @@ class MappingVisitorTest extends \PHPUnit_Framework_TestCase
 
         /** @var CompositeExpression $mapped */
         $mapped = $this->sut->dispatch($composite);
-        static::assertInstanceOf(CompositeExpression::class, $mapped);
+        static::assertInstanceOf('\Doctrine\Common\Collections\Expr\CompositeExpression', $mapped);
         /** @var Comparison[]|Value[] $mappedExpressions */
         $mappedExpressions = $mapped->getExpressionList();
 
         static::assertCount(2, $mappedExpressions);
 
-        static::assertInstanceOf(Comparison::class, $mappedExpressions[0]);
-        static::assertInstanceOf(Comparison::class, $mappedExpressions[1]);
+        static::assertInstanceOf('\Doctrine\Common\Collections\Expr\Comparison', $mappedExpressions[0]);
+        static::assertInstanceOf('\Doctrine\Common\Collections\Expr\Comparison', $mappedExpressions[1]);
 
         static::assertEquals('column', $mappedExpressions[0]->getField());
         static::assertEquals('column', $mappedExpressions[1]->getField());


### PR DESCRIPTION
Addresses: 
- [DDC-3890: Support matching Criteria on PersistentCollection on ManyToMany when comparison is not "=" ](https://github.com/doctrine/doctrine2/issues/4745)
- [DDC-4157: ManyToMany matching criteria set wrong expressions](https://github.com/doctrine/doctrine2/issues/4910)
- [@ManyToMany relation matching criteria ignores isNull(column)](https://github.com/doctrine/doctrine2/issues/5587)

This MR builds on [Many to many criteria fixes](https://github.com/doctrine/doctrine2/pull/5668) which is an aggregate PR that addresses some other related criteria bugs.
