### PR TITLE
DDC-1551 #2186 In postFlush event, user can access flushed entities

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -158,11 +158,25 @@ class UnitOfWork implements PropertyChangedListener
     private $entityInsertions = [];
 
     /**
+     * A list of all inserted entities.
+     *
+     * @var array
+     */
+    private $insertedEntities = array();
+
+    /**
      * A list of all pending entity updates.
      *
      * @var array
      */
     private $entityUpdates = [];
+
+    /**
+     * A list of all updated entities.
+     *
+     * @var array
+     */
+    private $updatedEntities = array();
 
     /**
      * Any pending extra updates that have been scheduled by persisters.
@@ -177,6 +191,13 @@ class UnitOfWork implements PropertyChangedListener
      * @var array
      */
     private $entityDeletions = [];
+
+    /**
+     * A list of all deleted entities.
+     *
+     * @var array
+     */
+    private $deletedEntities = array();
 
     /**
      * All pending collection deletions.
@@ -416,8 +437,11 @@ class UnitOfWork implements PropertyChangedListener
 
         // Clear up
         $this->entityInsertions =
+        $this->insertedEntities =
         $this->entityUpdates =
+        $this->updatedEntities =
         $this->entityDeletions =
+        $this->deletedEntities =
         $this->extraUpdates =
         $this->entityChangeSets =
         $this->collectionUpdates =
@@ -993,6 +1017,7 @@ class UnitOfWork implements PropertyChangedListener
 
             $persister->addInsert($entity);
 
+            $this->insertedEntities[$oid] = $entity;
             unset($this->entityInsertions[$oid]);
 
             if ($invoke !== ListenersInvoker::INVOKE_NONE) {
@@ -1055,6 +1080,7 @@ class UnitOfWork implements PropertyChangedListener
                 $persister->update($entity);
             }
 
+            $this->updatedEntities[$oid] = $entity;
             unset($this->entityUpdates[$oid]);
 
             if ($postUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
@@ -1083,6 +1109,7 @@ class UnitOfWork implements PropertyChangedListener
 
             $persister->delete($entity);
 
+	    $this->deletedEntities[$oid] = $entity;
             unset(
                 $this->entityDeletions[$oid],
                 $this->entityIdentifiers[$oid],
@@ -2386,8 +2413,11 @@ class UnitOfWork implements PropertyChangedListener
             $this->entityStates =
             $this->scheduledForSynchronization =
             $this->entityInsertions =
+            $this->insertedEntities =
             $this->entityUpdates =
+            $this->updatedEntities =
             $this->entityDeletions =
+            $this->deletedEntities =
             $this->collectionDeletions =
             $this->collectionUpdates =
             $this->extraUpdates =
@@ -3146,6 +3176,16 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * Gets the entities inserted in this UnitOfWork
+     *
+     * @return array
+     */
+    public function getInsertedEntities()
+    {
+        return $this->insertedEntities;
+    }
+
+    /**
      * Gets the currently scheduled entity updates in this UnitOfWork.
      *
      * @return array
@@ -3156,6 +3196,16 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
+     * Gets the entities updated in this UnitOfWork
+     *
+     * @return array
+     */
+    public function getUpdatedEntities()
+    {
+        return $this->updatedEntities;
+    }
+
+    /**
      * Gets the currently scheduled entity deletions in this UnitOfWork.
      *
      * @return array
@@ -3163,6 +3213,16 @@ class UnitOfWork implements PropertyChangedListener
     public function getScheduledEntityDeletions()
     {
         return $this->entityDeletions;
+    }
+
+    /**
+     * Gets the entities deleted in this UnitOfWork
+     *
+     * @return array
+     */
+    public function getDeletedEntities()
+    {
+        return $this->deletedEntities;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1551Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1551Test.php
@@ -1,19 +1,16 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Functional;
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
- * PostFlushEventTest
  *
- * @author Daniel Freudenberger <df@rebuy.de>
  * @author Tom Lei <tomlei90@gmail.com>
  */
-class PostFlushEventTest extends OrmFunctionalTestCase
+class DDC1511Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     /**
      * @var PostFlushListener
@@ -31,45 +28,13 @@ class PostFlushEventTest extends OrmFunctionalTestCase
 
     protected function tearDown()
     {
-      $this->listener->postFlushAssertions = null;
-      parent::tearDown();
-    }
-
-    public function testListenerShouldBeNotified()
-    {
-        $this->_em->persist($this->createNewValidUser());
-        $this->_em->flush();
-        $this->assertTrue($this->listener->wasNotified);
-    }
-
-    public function testListenerShouldNotBeNotifiedWhenFlushThrowsException()
-    {
-        $user = new CmsUser();
-        $user->username = 'dfreudenberger';
-        $this->_em->persist($user);
-        $exceptionRaised = false;
-
-        try {
-            $this->_em->flush();
-        } catch (\Exception $ex) {
-            $exceptionRaised = true;
-        }
-
-        $this->assertTrue($exceptionRaised);
-        $this->assertFalse($this->listener->wasNotified);
-    }
-
-    public function testListenerShouldReceiveEntityManagerThroughArgs()
-    {
-        $this->_em->persist($this->createNewValidUser());
-        $this->_em->flush();
-        $receivedEm = $this->listener->receivedArgs->getEntityManager();
-        $this->assertSame($this->_em, $receivedEm);
+        $this->listener->postFlushAssertions = null;
+        parent::tearDown();
     }
 
     public function testUnitOfWorkInPostFlushShouldHaveInsertedEntities()
     {
-        $testUser = $this->createNewUser('tom.lei@applesauce', 'Tom Lei');
+        $testUser = $this->createNewValidUser('tom.lei@blues', 'Tom Lei');
 
         $this->listener->postFlushAssertions = function(PostFlushEventArgs $args) use ($testUser) {
             $uow = $args->getEntityManager()->getUnitOfWork();
@@ -84,7 +49,7 @@ class PostFlushEventTest extends OrmFunctionalTestCase
 
     public function testUnitOfWorkInPostFlushShouldHaveUpdatedEntities()
     {
-        $testUser = $this->createNewUser('tom.lei@applesauce', 'Tom Lei');
+        $testUser = $this->createNewValidUser('tom.lei@molson', 'Tom Lei');
         $this->_em->persist($testUser);
         $this->_em->flush();
 
@@ -102,7 +67,7 @@ class PostFlushEventTest extends OrmFunctionalTestCase
 
     public function testUnitOfWorkInPostFlushShouldHaveDeletedEntities()
     {
-        $testUser = $this->createNewUser('tom.lei@applesauce', 'Tom Lei');
+        $testUser = $this->createNewValidUser('tom.lei@applesauce', 'Tom Lei');
         $this->_em->persist($testUser);
         $this->_em->flush();
 
@@ -120,36 +85,17 @@ class PostFlushEventTest extends OrmFunctionalTestCase
     /**
      * @return CmsUser
      */
-    private function createNewValidUser()
-    {
-        return $this->createNewUser('dfreudenberger', 'Daniel Freudenberger');
-    }
-
-    /**
-     * @return CmsUser
-     */
-    private function createNewUser($userName, $name)
+    private function createNewValidUser($userName, $name)
     {
         $user = new CmsUser();
         $user->username = $userName;
         $user->name = $name;
-
         return $user;
     }
 }
 
 class PostFlushListener
 {
-    /**
-     * @var bool
-     */
-    public $wasNotified = false;
-
-    /**
-     * @var PostFlushEventArgs
-     */
-    public $receivedArgs;
-
     /**
      * @var callable | null
      */
@@ -158,11 +104,7 @@ class PostFlushListener
     /**
      * @param PostFlushEventArgs $args
      */
-    public function postFlush(PostFlushEventArgs $args)
-    {
-        $this->wasNotified = true;
-        $this->receivedArgs = $args;
-
+    public function postFlush(PostFlushEventArgs $args) {
         if (is_callable($this->postFlushAssertions)) {
             call_user_func($this->postFlushAssertions, $args);
         }


### PR DESCRIPTION
Original issue is #2186 
User can get flushed entites via the following getters of UnitOfWork
- getInsertedEntities
- getUpdatedEntities
- getDeletedEntities
