### PR TITLE
Fixed broken links on getting-started tutorial

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -51,7 +51,7 @@ Entities are PHP Objects that can be identified over many requests
 by a unique identifier or primary key. These classes don't need to extend any
 abstract base class or interface. An entity class must not be final
 or contain final methods. Additionally it must not implement
-**clone** nor **wakeup**, unless it `does so safely <../cookbook/implementing-wakeup-or-clone.rst>`_.
+**clone** nor **wakeup**, unless it :doc:`does so safely <../cookbook/implementing-wakeup-or-clone>`.
 
 An entity contains persistable properties. A persistable property
 is an instance variable of the entity that is saved into and retrieved from the database
@@ -62,7 +62,7 @@ An Example Model: Bug Tracker
 
 For this Getting Started Guide for Doctrine we will implement the
 Bug Tracker domain model from the
-`Zend\_Db\_Table <http://framework.zend.com/manual/en/zend.db.table.html>`_
+`Zend\_Db\_Table <http://framework.zend.com/manual/1.12/en/zend.db.adapter.html>`_
 documentation. Reading their documentation we can extract the
 requirements:
 
@@ -157,7 +157,7 @@ The second block consists of the instantiation of the ORM
 ``Configuration`` object using the Setup helper. It assumes a bunch
 of defaults that you don't have to bother about for now. You can
 read up on the configuration details in the
-`reference chapter on configuration <../reference/configuration.rst>`_.
+:doc:`reference chapter on configuration <../reference/configuration>`.
 
 The third block shows the configuration options required to connect
 to a database, in my case a file-based sqlite database. All the


### PR DESCRIPTION
Those links were broken in the web and pdf version. I tested both and now they are ok.

I used this tool http://website-link-checker.online-domain-tools.com/ to look for broken links. It seems now that there's left only links that pointed to Jira and some other ccs's and png's but the rest is ok.
