### PR TITLE
Fixed test failing due to changes in AnnotationReader

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -16,7 +16,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
     {
         $cm = new ClassMetadata('stdClass');
         $cm->initializeReflection(new \Doctrine\Common\Persistence\Mapping\RuntimeReflectionService);
-        $reader = new \Doctrine\Common\Annotations\AnnotationReader(new \Doctrine\Common\Cache\ArrayCache());
+        $reader = new \Doctrine\Common\Annotations\AnnotationReader();
         $annotationDriver = new \Doctrine\ORM\Mapping\Driver\AnnotationDriver($reader);
 
         $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');


### PR DESCRIPTION
```
Doctrine\Tests\ORM\Mapping\AnnotationDriverTest::testLoadMetadataForNonEntityThrowsException
Argument 1 passed to Doctrine\Common\Annotations\AnnotationReader::__construct() must be an instance of Doctrine\Common\Annotations\DocParser, instance of Doctrine\Common\Cache\ArrayCache given, called in .../tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php on line 19 and defined
```

See: [https://revive.beccati.com/bamboo/browse/PHP-DOCTR-PHP55-646/test/case/11813971]()
