### PR TITLE
Avoid conflicts due to spl_object_hash.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3425,7 +3425,7 @@ class UnitOfWork implements PropertyChangedListener
                         $managedCol->setOwner($managedCopy, $assoc2);
                         $prop->setValue($managedCopy, $managedCol);
 
-                        $this->originalEntityData[spl_object_hash($entity)][$name] = $managedCol;
+//                        $this->originalEntityData[spl_object_hash($entity)][$name] = $managedCol;
                     }
 
                     if ($assoc2['isCascadeMerge']) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3424,8 +3424,6 @@ class UnitOfWork implements PropertyChangedListener
                         );
                         $managedCol->setOwner($managedCopy, $assoc2);
                         $prop->setValue($managedCopy, $managedCol);
-
-//                        $this->originalEntityData[spl_object_hash($entity)][$name] = $managedCol;
                     }
 
                     if ($assoc2['isCascadeMerge']) {

--- a/tests/Doctrine/Tests/ORM/Functional/OidReuseTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OidReuseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class OidReuseTest extends OrmFunctionalTestCase
+{
+
+    private $userId;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testOidReuse()
+    {
+        $user = new CmsUser();
+        $this->_em->merge($user);
+
+        $user = null;
+
+        $user = new CmsUser();
+        $this->_em->persist($user);
+    }
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/OidReuseTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OidReuseTest.php
@@ -22,10 +22,18 @@ class OidReuseTest extends OrmFunctionalTestCase
 
     public function testOidReuse()
     {
+        $uow = $this->_em->getUnitOfWork();
+        $reflexion = new \ReflectionClass(get_class($uow));
+        $originalEntityDataProperty = $reflexion->getProperty('originalEntityData');
+        $originalEntityDataProperty->setAccessible(true);
+
         $user = new CmsUser();
+        $oid = spl_object_hash($user);
         $this->_em->merge($user);
 
         $user = null;
+
+        $this->assertArrayNotHasKey($oid, $originalEntityDataProperty->getValue($uow));
 
         $user = new CmsUser();
         $this->_em->persist($user);


### PR DESCRIPTION
When merging an entity with a to-many association, it will store the
original entity data using the object hash of the to-be-merged entity
instead of the managed entity. Since this to-be-merged entity is not
managed by Doctrine, it can disappear from the memory. A new object
can reuse the same memory location and thus have the same object hash.
When one tries to persist this object as new, Doctrine will refuse it
because it thinks that the entity is managed+dirty.

This patch is a very naive fix: it just disables storing the original
entity data in case of to-many associations. It may not be the ideal
or even a good solution at all, but it solves the problem of object
hash reuse.

The test case relies on the immediate reusing of memory locations by
PHP. The variable $user has twice the same object hash, though referring
a different object. Tested on PHP 5.6.17

Without the fix, the test fails on the last line with:
A managed+dirty entity Doctrine\Tests\Models\CMS\CmsUser@[...] can not
be scheduled for insertion.
