### PR TITLE
Fix Runtime Notice: Only variables should be passed by reference

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1049,7 +1049,8 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $this->getEntityChangeSet($entity)), $preUpdateInvoke);
+                $entityChanges = $this->getEntityChangeSet($entity);
+                $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $entityChanges), $preUpdateInvoke);
 
                 $this->recomputeSingleEntityChangeSet($class, $entity);
             }


### PR DESCRIPTION
Commit [here](https://github.com/doctrine/doctrine2/commit/86cde3a9dff818573971efb0b4ac54a45560ae0b) results in PHP Runtime Notice: `Only variables should be passed by reference` if strict standards are enabled (default setting for symfony2). This PR fixes this.
