### PR TITLE
Change condition to check the connection with DB

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -67,7 +67,7 @@ EOT
         try {
             $em->getConfiguration()->ensureProductionSettings();
 
-            if ($input->getOption('complete') !== null) {
+            if ($input->getOption('complete')) {
                 $em->getConnection()->connect();
             }
         } catch (\Exception $e) {

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command;
+
+use Doctrine\Common\Cache\MemcachedCache;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Application;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
+
+class EnsureProductionSettingsCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Application
+     */
+    private $application;
+
+    /**
+     * @var \Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand
+     */
+    private $command;
+
+    /**
+     * @var \Symfony\Component\Console\Tester\CommandTester
+     */
+    private $tester;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->application = new Application();
+        $command           = new EnsureProductionSettingsCommand();
+
+        $this->application->setHelperSet(new HelperSet(array(
+            'em' => new EntityManagerHelper($this->_em)
+        )));
+
+        $this->application->add($command);
+
+        $this->command = $this->application->find('orm:ensure-production-settings');
+        $this->tester  = new CommandTester($command);
+        $this->enableProductionSettings();
+    }
+
+    public function testWillNotCheckConnection()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            '--complete' => false
+        ));
+
+        $this->assertContains('Environment is correctly configured for production.', $this->tester->getDisplay());
+    }
+
+    public function testWillCheckConnection()
+    {
+        $this->tester->execute(array(
+            'command' => $this->command->getName(),
+            '--complete' => true
+        ));
+
+        $this->assertContains('Environment is correctly configured for production.', $this->tester->getDisplay());
+    }
+
+    private function enableProductionSettings()
+    {
+        $config = $this->_em->getConfiguration();
+        $config->setMetadataCacheImpl(new MemcachedCache);
+        $config->setQueryCacheImpl(new MemcachedCache);
+        $config->setResultCacheImpl(new MemcachedCache);
+        $config->setAutoGenerateProxyClasses(false);
+    }
+}


### PR DESCRIPTION
The option "complete" is false by default instead of null. So, we need to check whether the "complete" option is true or not to verify the connection with database.
