### PR TITLE
Update ClassMetadataInfo

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1051,6 +1051,10 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getReflectionClass()
     {
+        if ( ! $this->reflClass) {
+            $this->reflClass = new ReflectionClass($this->name);
+        }
+        
         return $this->reflClass;
     }
 


### PR DESCRIPTION
Some times when I am listening to loadClassMetada event the reflClass attribute of ClassMetadata is null. I have found in the doctrine doc this code ( http://www.doctrine-project.org/api/orm/2.5/source-class-Doctrine.ORM.Mapping.ClassMetadataInfo.html#_getReflectionClass ) but when I check the code of vendors and github repo I did not find the same that fix my error. That is the reason that I have done this PR.

some idea why is not the same?
