### PR TITLE
Cleanup no longer used coveralls settings; use scrutinizer badges

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-# for php-coveralls
-service_name: travis-ci
-src_dir: lib
-coverage_clover: build/logs/clover*.xml

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ without requiring unnecessary code duplication.
 
   [Master image]: https://img.shields.io/travis/doctrine/doctrine2/master.svg?style=flat-square
   [Master]: https://travis-ci.org/doctrine/doctrine2
-  [Master coverage image]: https://img.shields.io/coveralls/doctrine/doctrine2/master.svg?style=flat-square
-  [Master coverage]: https://coveralls.io/r/doctrine/doctrine2?branch=master
+  [Master coverage image]: https://img.shields.io/scrutinizer/coverage/g/doctrine/doctrine2/master.svg?style=flat-square
+  [Master coverage]: https://scrutinizer-ci.com/g/doctrine/doctrine2/?branch=master
   [2.5 image]: https://img.shields.io/travis/doctrine/doctrine2/2.5.svg?style=flat-square
   [2.5]: https://github.com/doctrine/doctrine2/tree/2.5
-  [2.5 coverage image]: https://img.shields.io/coveralls/doctrine/doctrine2/2.5.svg?style=flat-square
-  [2.5 coverage]: https://coveralls.io/r/doctrine/doctrine2?branch=2.5
+  [2.5 coverage image]: https://img.shields.io/scrutinizer/coverage/g/doctrine/doctrine2/2.5.svg?style=flat-square
+  [2.5 coverage]: https://scrutinizer-ci.com/g/doctrine/doctrine2/?branch=2.5

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,6 @@
         }
     },
     "archive": {
-        "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar", "vendor/satooshi", "lib/vendor", "*.swp", "*coveralls.yml"]
+        "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar", "vendor/satooshi", "lib/vendor", "*.swp"]
     }
 }


### PR DESCRIPTION
Since https://github.com/doctrine/doctrine2/pull/5580 the .coveralls.yml is no longer used.

Also the badges leads to out-of-date coveralls coverage.

And please note the [scrutinizer project for doctrine](https://scrutinizer-ci.com/g/doctrine/doctrine2/) is currently set to only track master branch - to make the badge (and other scrutinizer metrics) working also for 2.5 branch, the scrutinizer settings would have to be updated on its Settings page, which will probably be something like https://scrutinizer-ci.com/g/doctrine/doctrine2/settings.
