### PR TITLE
Fix loading of association with quoted JoinColumn

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1325,7 +1325,7 @@ class BasicEntityPersister implements EntityPersister
             $resultColumnName = $this->getSQLColumnAlias($joinColumn['name']);
             $type             = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
-            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName, $quotedColumn, $isIdentifier, $type);
+            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName,  $joinColumn['name'], $isIdentifier, $type);
 
             $columnList[] = sprintf('%s.%s AS %s', $sqlTableAlias, $quotedColumn, $resultColumnName);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/QuotedJoinColumnTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QuotedJoinColumnTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Quote\Phone;
+use Doctrine\Tests\Models\Quote\User;
+
+/**
+ * Tests that association with quoted JoinColumn is loaded
+ */
+class QuotedJoinColumnTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    protected function setUp()
+    {
+        $this->useModelSet('quote');
+        parent::setUp();
+    }
+
+    public function testLoadAssociationWithQuotedJoinColumn()
+    {
+        $user = new User();
+        $user->name = 'John Doe';
+        $phone = new Phone();
+        $phone->number = '123456789';
+        $phone->user = $user;
+        $user->phones->add($phone);
+
+        $this->_em->persist($user);
+        $this->_em->persist($phone);
+        $this->_em->flush();
+        $this->_em->clear();
+        $phoneNumber = $phone->number;
+        unset($user, $phone);
+
+        $persister = $this->_em->getUnitOfWork()->getEntityPersister('Doctrine\Tests\Models\Quote\Phone');
+        $entity = $persister->load(array ('number' => $phoneNumber));
+
+        $this->assertNotNull($entity->user);
+    }
+
+}


### PR DESCRIPTION
Consider this entity

```
/**
 * @ORM\Entity
 * @ORM\Table()
 */
class TravelInsurance
{

    /**
     * @ORM\Id
     * @ORM\OneToOne(targetEntity="\Foo\Order\Order")
     * @ORM\JoinColumn(name="`order`", nullable=false)
     * @var \Foo\Order\Order
     *
     * @get
     * @set(visibility='private')
     */
    private $order;

    /**
     * @ORM\Column(type="string", length=255)
     * @var string
     *
     * @get
     * @set(visibility='private')
     */
    private $contactName;
}
```

Loading this entity fails with error `ErrorException: Undefined index: order in...\lib\Doctrine\ORM\Utility\IdentifierFlattener.php:92`. The problem is, that data that goes to UoW::createEntity and to `flattenIdentifier` look like this 

```
array (6)
    contactName => "j8"
    "`order`" => 7050473951
```

note the backticks around order
_If the `order` column was generic `@Column`, the backticks would not be there_
_If `order` was association but not an ID, the loading would not fail, but silently leave `$order = null`_

The root cause, I think, is in method BaseEntityPersister::getSelectColumnAssociationSQL, where column name added to ResultSetMapping is the quoted version for JoinColumn, but for other ordinary columns it adds non-quoted version. The quoted version is then passed from ObjectHydrator to uow::createEntity and produces the error

This pull should fix the problem, although I'm not entirely sure if this is the only place with this issue.
