### PR TITLE
Fix `MetadataFilter` regression after #507 (#2815) not testing filters after first one

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -84,10 +84,6 @@ class MetadataFilter extends \FilterIterator implements \Countable
                 );
             }
 
-            if ($pregResult === 0) {
-                return false;
-            }
-
             if ($pregResult) {
                 return true;
             }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console;
+
+use Doctrine\ORM\Tools\Console\MetadataFilter;
+use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
+
+/**
+ * Tests for {@see \Doctrine\ORM\Tools\Console\MetadataFilter}
+ *
+ * @covers \Doctrine\ORM\Tools\Console\MetadataFilter
+ */
+class MetadataFilterTest extends \Doctrine\Tests\OrmTestCase
+{
+    /**
+     * @var DisconnectedClassMetadataFactory
+     */
+    private $cmf;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $driver = $this->createAnnotationDriver();
+        $em     = $this->_getTestEntityManager();
+        $em->getConfiguration()->setMetadataDriverImpl($driver);
+
+        $this->cmf = new DisconnectedClassMetadataFactory();
+        $this->cmf->setEntityManager($em);
+    }
+
+    public function testFilterWithArray()
+    {
+        $originalMetadatas = array(
+            $metadataAaa = $this->cmf->getMetadataFor(MetadataFilterTestEntityAaa::CLASSNAME),
+            $metadataBbb = $this->cmf->getMetadataFor(MetadataFilterTestEntityBbb::CLASSNAME),
+            $metadataCcc = $this->cmf->getMetadataFor(MetadataFilterTestEntityCcc::CLASSNAME),
+        );
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, array(
+            'MetadataFilterTestEntityAaa',
+            'MetadataFilterTestEntityCcc',
+        ));
+
+        $this->assertContains($metadataAaa, $metadatas);
+        $this->assertNotContains($metadataBbb, $metadatas);
+        $this->assertContains($metadataCcc, $metadatas);
+        $this->assertCount(2, $metadatas);
+    }
+}
+
+/** @Entity */
+class MetadataFilterTestEntityAaa
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}
+
+/** @Entity */
+class MetadataFilterTestEntityBbb
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}
+
+/** @Entity */
+class MetadataFilterTestEntityCcc
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
@@ -77,6 +77,23 @@ class MetadataFilterTest extends \Doctrine\Tests\OrmTestCase
         $this->assertCount(1, $metadatas);
     }
 
+    public function testFilterWithString2()
+    {
+        $originalMetadatas = array(
+            $metadataFoo    = $this->cmf->getMetadataFor(MetadataFilterTestEntityFoo::CLASSNAME),
+            $metadataFooBar = $this->cmf->getMetadataFor(MetadataFilterTestEntityFooBar::CLASSNAME),
+            $metadataBar    = $this->cmf->getMetadataFor(MetadataFilterTestEntityBar::CLASSNAME),
+        );
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'MetadataFilterTestEntityFoo');
+
+        $this->assertContains($metadataFoo, $metadatas);
+        $this->assertContains($metadataFooBar, $metadatas);
+        $this->assertNotContains($metadataBar, $metadatas);
+        $this->assertCount(2, $metadatas);
+    }
+
     public function testFilterWithArray()
     {
         $originalMetadatas = array(
@@ -94,6 +111,31 @@ class MetadataFilterTest extends \Doctrine\Tests\OrmTestCase
         $this->assertContains($metadataAaa, $metadatas);
         $this->assertNotContains($metadataBbb, $metadatas);
         $this->assertContains($metadataCcc, $metadatas);
+        $this->assertCount(2, $metadatas);
+    }
+
+    public function testFilterWithRegex()
+    {
+        $originalMetadatas = array(
+            $metadataFoo    = $this->cmf->getMetadataFor(MetadataFilterTestEntityFoo::CLASSNAME),
+            $metadataFooBar = $this->cmf->getMetadataFor(MetadataFilterTestEntityFooBar::CLASSNAME),
+            $metadataBar    = $this->cmf->getMetadataFor(MetadataFilterTestEntityBar::CLASSNAME),
+        );
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'Foo$');
+
+        $this->assertContains($metadataFoo, $metadatas);
+        $this->assertNotContains($metadataFooBar, $metadatas);
+        $this->assertNotContains($metadataBar, $metadatas);
+        $this->assertCount(1, $metadatas);
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'Bar$');
+
+        $this->assertNotContains($metadataFoo, $metadatas);
+        $this->assertContains($metadataFooBar, $metadatas);
+        $this->assertContains($metadataBar, $metadatas);
         $this->assertCount(2, $metadatas);
     }
 }
@@ -118,6 +160,33 @@ class MetadataFilterTestEntityBbb
 
 /** @Entity */
 class MetadataFilterTestEntityCcc
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}
+
+/** @Entity */
+class MetadataFilterTestEntityFoo
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}
+
+/** @Entity */
+class MetadataFilterTestEntityBar
+{
+    const CLASSNAME = __CLASS__;
+
+    /** @Id @Column(type="integer") */
+    protected $id;
+}
+
+/** @Entity */
+class MetadataFilterTestEntityFooBar
 {
     const CLASSNAME = __CLASS__;
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php
@@ -29,6 +29,54 @@ class MetadataFilterTest extends \Doctrine\Tests\OrmTestCase
         $this->cmf->setEntityManager($em);
     }
 
+    public function testFilterWithEmptyArray()
+    {
+        $originalMetadatas = array(
+            $metadataAaa = $this->cmf->getMetadataFor(MetadataFilterTestEntityAaa::CLASSNAME),
+            $metadataBbb = $this->cmf->getMetadataFor(MetadataFilterTestEntityBbb::CLASSNAME),
+        );
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, array());
+
+        $this->assertContains($metadataAaa, $metadatas);
+        $this->assertContains($metadataBbb, $metadatas);
+        $this->assertCount(count($originalMetadatas), $metadatas);
+    }
+
+    public function testFilterWithString()
+    {
+        $originalMetadatas = array(
+            $metadataAaa = $this->cmf->getMetadataFor(MetadataFilterTestEntityAaa::CLASSNAME),
+            $metadataBbb = $this->cmf->getMetadataFor(MetadataFilterTestEntityBbb::CLASSNAME),
+            $metadataCcc = $this->cmf->getMetadataFor(MetadataFilterTestEntityCcc::CLASSNAME),
+        );
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'MetadataFilterTestEntityAaa');
+
+        $this->assertContains($metadataAaa, $metadatas);
+        $this->assertNotContains($metadataBbb, $metadatas);
+        $this->assertNotContains($metadataCcc, $metadatas);
+        $this->assertCount(1, $metadatas);
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'MetadataFilterTestEntityBbb');
+
+        $this->assertNotContains($metadataAaa, $metadatas);
+        $this->assertContains($metadataBbb, $metadatas);
+        $this->assertNotContains($metadataCcc, $metadatas);
+        $this->assertCount(1, $metadatas);
+
+        $metadatas = $originalMetadatas;
+        $metadatas = MetadataFilter::filter($metadatas, 'MetadataFilterTestEntityCcc');
+
+        $this->assertNotContains($metadataAaa, $metadatas);
+        $this->assertNotContains($metadataBbb, $metadatas);
+        $this->assertContains($metadataCcc, $metadatas);
+        $this->assertCount(1, $metadatas);
+    }
+
     public function testFilterWithArray()
     {
         $originalMetadatas = array(


### PR DESCRIPTION
PR #507 (issue #2815 [DDC-2128]) introduced a **regression**, with the effect that when providing a filter array with more than one string, _only the first pattern is tested_ (and the subsequent ones are like ignored).

With the series of commits https://github.com/doctrine/doctrine2/compare/6963bf60286a3b4f3d74f3769a6a2a1f0d001ad0%5E...9a3cf77919b0541048be5bfe7806a001c31974d1, the function `accept()` was modified so that, if the first pattern of the `$this->filter` array (is not invalid, but) does not match `$metadata->name`, then the function returns `false` early, _never trying the next patterns in the array_.
Instead, it should continue to iterate, and only return `true` on the first encountered pattern that matches (if any) or return `false` after the end of the loop (if no pattern matched). _(That's what it was doing before the series of commits, see https://github.com/doctrine/doctrine2/blob/6963bf60286a3b4f3d74f3769a6a2a1f0d001ad0%5E/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php#L78-L84.)_

~~Sorry I cannot practically write a unit-test for this fix, but feel free to add one (or help me).~~
_Update:_ I added a test (and checked that it was passing before the regression, is failing without the fix and is passing with the fix).
_Update (2):_ I amended the test commits (sorry for the confusion if any). The fix is only for version 2.5+ but the test could be suitable for 2.4 (and maybe even older branches) by not taking the last commit.
