### PR TITLE
Chaining EntityManager methods

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -565,7 +565,7 @@ use Doctrine\Common\Util\ClassUtils;
      *
      * @param object $entity The instance to make managed and persistent.
      *
-     * @return void
+     * @return self
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
@@ -579,6 +579,8 @@ use Doctrine\Common\Util\ClassUtils;
         $this->errorIfClosed();
 
         $this->unitOfWork->persist($entity);
+
+        return $this;
     }
 
     /**
@@ -589,7 +591,7 @@ use Doctrine\Common\Util\ClassUtils;
      *
      * @param object $entity The entity instance to remove.
      *
-     * @return void
+     * @return self
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
@@ -603,6 +605,8 @@ use Doctrine\Common\Util\ClassUtils;
         $this->errorIfClosed();
 
         $this->unitOfWork->remove($entity);
+
+        return $this;
     }
 
     /**
@@ -636,7 +640,7 @@ use Doctrine\Common\Util\ClassUtils;
      *
      * @param object $entity The entity to detach.
      *
-     * @return void
+     * @return self
      *
      * @throws ORMInvalidArgumentException
      */
@@ -647,6 +651,8 @@ use Doctrine\Common\Util\ClassUtils;
         }
 
         $this->unitOfWork->detach($entity);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Every time when I have to write some code like

```
 $em->persist($newEntity);
 $em->flush();
```

my eyes are little bit bleeding.
Can we make methods like "persist" and "remove" chainable?

```
 $em->persist($newEntity)->flush();
```

Thank you.
