### PR TITLE
#1497 - fix call to method removed in df12963

### DIFF
--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -95,7 +95,9 @@ the UTC time at the time of the booking and the timezone the event happened in.
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
             if ($value instanceof \DateTime) {
-                $value->setTimezone(self::getUtc());
+                $value->setTimezone(
+                    self::$utc ? self::$utc : self::$utc = new \DateTimeZone('UTC')
+                );
             }
 
             return parent::convertToDatabaseValue($value, $platform);


### PR DESCRIPTION
_Note:_ I did not reintroduce the `getUtc` method, since it was purposely removed in df129635cf2de5f137145af478335bcda78ed019 for performance reasons,
but now the “`self::$utc ? self::$utc : self::$utc = new \DateTimeZone('UTC')`” logic is duplicated in 2 places, not sure if OK...

_Edit:_ After checking, I guess it _is_ OK, because commit df129635cf2de5f137145af478335bcda78ed019 actually reverted (partly) the refactoring of `(self::$utc) ? self::$utc : (self::$utc = new \DateTimeZone('UTC'))` into `self::getUtc()` which was done in commit 93806a80369a84a904f41c76ec3467fa31a54c8c, and the net result diff https://github.com/doctrine/doctrine2/compare/93806a80369a84a904f41c76ec3467fa31a54c8c%5E...df129635cf2de5f137145af478335bcda78ed019 shows that the ternary logic was already duplicated originally.