### PR TITLE
Readonly column property for generated/virtual columns

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -154,6 +154,20 @@ class FieldBuilder
     }
 
     /**
+     * Sets readOnly.
+     *
+     * @param bool $flag
+     *
+     * @return FieldBuilder
+     */
+    public function readOnly($flag = true)
+    {
+        $this->mapping['readOnly'] = (bool) $flag;
+
+        return $this;
+    }
+
+    /**
      * Sets field as primary key.
      *
      * @deprecated Use makePrimaryKey() instead

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -380,6 +380,9 @@ class ClassMetadataInfo implements ClassMetadata
      * - <b>nullable</b> (boolean, optional)
      * Whether the column is nullable. Defaults to FALSE.
      *
+     * - <b>readOnly</b> (boolean, optional)
+     * Whether the column is readOnly. Defaults to FALSE.
+     *
      * - <b>columnDefinition</b> (string, optional, schema-only)
      * The SQL fragment that is used when generating the DDL for the column.
      *
@@ -1198,6 +1201,24 @@ class ClassMetadataInfo implements ClassMetadata
 
         if ($mapping !== false) {
             return isset($mapping['nullable']) && $mapping['nullable'] == true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the field is readOnly.
+     *
+     * @param string $fieldName The field name.
+     *
+     * @return boolean TRUE if the field is readOnly, FALSE otherwise.
+     */
+    public function isReadOnly($fieldName)
+    {
+        $mapping = $this->getFieldMapping($fieldName);
+
+        if ($mapping !== false) {
+            return isset($mapping['readOnly']) && $mapping['readOnly'] == true;
         }
 
         return false;

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -65,6 +65,11 @@ final class Column implements Annotation
     public $nullable = false;
 
     /**
+     * @var boolean
+     */
+    public $readOnly = false;
+
+    /**
      * @var array
      */
     public $options = array();

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -617,7 +617,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
             'length'    => $column->length,
             'unique'    => $column->unique,
             'nullable'  => $column->nullable,
-            'precision' => $column->precision
+            'precision' => $column->precision,
+            'readOnly' => $column->readOnly
         );
 
         if ($column->options) {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -748,6 +748,10 @@ class XmlDriver extends FileDriver
             $mapping['nullable'] = $this->evaluateBoolean($fieldMapping['nullable']);
         }
 
+        if (isset($fieldMapping['readOnly'])) {
+            $mapping['readOnly'] = $this->evaluateBoolean($fieldMapping['readOnly']);
+        }
+
         if (isset($fieldMapping['version']) && $fieldMapping['version']) {
             $mapping['version'] = $this->evaluateBoolean($fieldMapping['version']);
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -750,6 +750,10 @@ class YamlDriver extends FileDriver
             $mapping['nullable'] = $column['nullable'];
         }
 
+        if (isset($column['readOnly'])) {
+            $mapping['readOnly'] = $column['readOnly'];
+        }
+
         if (isset($column['version']) && $column['version']) {
             $mapping['version'] = $column['version'];
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -619,6 +619,10 @@ class BasicEntityPersister implements EntityPersister
                 continue;
             }
 
+            if ($this->class->hasField($field) && $this->class->isReadOnly($field)) {
+                continue;
+            }
+
             $newVal = $change[1];
 
             if ( ! isset($this->class->associationMappings[$field])) {
@@ -1427,6 +1431,10 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if (isset($this->class->embeddedClasses[$name])) {
+                continue;
+            }
+
+            if ($this->class->hasField($name) && $this->class->isReadOnly($name)) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -222,6 +222,10 @@ class XmlExporter extends AbstractExporter
                 if (isset($field['nullable'])) {
                     $fieldXml->addAttribute('nullable', $field['nullable'] ? 'true' : 'false');
                 }
+
+                if (isset($field['readOnly'])) {
+                    $fieldXml->addAttribute('readOnly', $field['readOnly'] ? 'true' : 'false');
+                }
             }
         }
 

--- a/tests/Doctrine/Tests/Models/ReadOnlyColumn/Item.php
+++ b/tests/Doctrine/Tests/Models/ReadOnlyColumn/Item.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\Tests\Models\ReadOnlyColumn;
+
+/**
+ * @Entity
+ * @Table(name="readonly_column")
+ */
+class Item
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $label;
+
+    /**
+     * @Column(type="string", readOnly=false)
+     */
+    public $content;
+
+    /**
+     * @Column(type="string", readOnly=true)
+     */
+    public $generatedString;
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterReadOnlyColumnTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterReadOnlyColumnTest.php
@@ -27,7 +27,7 @@ class BasicEntityPersisterReadOnlyColumnTest extends \Doctrine\Tests\OrmTestCase
 
         $this->_em = $this->_getTestEntityManager();
 
-        $this->_persister = new BasicEntityPersister($this->_em, $this->_em->getClassMetadata(Item::class));
+        $this->_persister = new BasicEntityPersister($this->_em, $this->_em->getClassMetadata('Doctrine\Tests\Models\ReadOnlyColumn\Item'));
     }
 
     public function testGetSelectSQLUsesReadOnlyColumn()

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterReadOnlyColumnTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterReadOnlyColumnTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\Tests\Models\ReadOnlyColumn\Item;
+
+class BasicEntityPersisterReadOnlyColumnTest extends \Doctrine\Tests\OrmTestCase
+{
+    /**
+     * @var BasicEntityPersister
+     */
+    protected $_persister;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $_em;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_em = $this->_getTestEntityManager();
+
+        $this->_persister = new BasicEntityPersister($this->_em, $this->_em->getClassMetadata(Item::class));
+    }
+
+    public function testGetSelectSQLUsesReadOnlyColumn()
+    {
+        $method = new \ReflectionMethod($this->_persister, 'getSelectSQL');
+        $method->setAccessible(true);
+
+        $sql = $method->invoke($this->_persister, new Criteria());
+
+        $this->assertGreaterThan(0, stripos($sql, '.generatedString'));
+    }
+
+    public function testGetInsertSQLUsesReadOnlyColumn()
+    {
+        $method = new \ReflectionMethod($this->_persister, 'getInsertSQL');
+        $method->setAccessible(true);
+
+        $sql = $method->invoke($this->_persister);
+
+        $this->assertEquals('INSERT INTO readonly_column (label, content) VALUES (?, ?)', $sql);
+    }
+
+    public function testGetUpdateSQLUsesReadOnlyColumn()
+    {
+        $item = new Item();
+        $this->_em->persist($item);
+        $this->_em->flush();
+
+        $item->label = 'foo';
+        $item->generatedString = 'bar';
+
+        $this->_em->getUnitOfWork()->computeChangeSets();
+
+        $method = new \ReflectionMethod($this->_persister, 'update');
+        $method->setAccessible(true);
+        $method->invoke($this->_persister, $item);
+
+        $updates = $this->_em->getConnection()->getExecuteUpdates();
+        $lastUpdate = end($updates);
+
+        $this->assertNotEmpty($lastUpdate);
+
+        $sql = $lastUpdate['query'];
+        $updateParams = $lastUpdate['params'];
+
+        $this->assertContains('label', $sql, '', true);
+        $this->assertContains('foo', $updateParams, '', true, true, true);
+
+        $this->assertNotContains('generatedString', $sql, '', true);
+        $this->assertNotContains('bar', $updateParams, '', true, true, true);
+    }
+}


### PR DESCRIPTION
MySQL and MariaDB both support virtual/computed/generated columns.
This is a column in a table that has its value automatically calculated using a deterministic expression, in particular from the values of other fields in the table.
These columns are queried like any other column, but its values cannot be inserted or updated.
To use these columns in entities and DQL, Doctrine must find a way to define them, but not include them in updates and inserts. This PR accomplishes just that.

More info on these columns:
- MariaDB: https://mariadb.com/kb/en/mariadb/virtual-computed-columns/
- Mysql: http://mysqlserverteam.com/generated-columns-in-mysql-5-7-5/
