### PR TITLE
Don't singularize TO_MANY field's variable names if target entity name is plural

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1358,7 +1358,8 @@ public function __construct(<params>)
     {
         $methodName = $type . Inflector::classify($fieldName);
         $variableName = Inflector::camelize($fieldName);
-        if (in_array($type, array("add", "remove"))) {
+
+        if (in_array($type, array('add', 'remove')) && substr($typeHint, -1) !== 's') {
             $methodName = Inflector::singularize($methodName);
             $variableName = Inflector::singularize($variableName);
         }

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -66,6 +66,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata->mapField(array('fieldName' => 'status', 'type' => 'string', 'options' => array('default' => 'published')));
         $metadata->mapField(array('fieldName' => 'id', 'type' => 'integer', 'id' => true));
         $metadata->mapOneToOne(array('fieldName' => 'author', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor', 'mappedBy' => 'book'));
+        $metadata->mapOneToMany(array('fieldName' => 'dnis', 'targetEntity' => 'Doctrine\Tests\ORM\Tools\EntityGeneratorDnis', 'mappedBy' => 'book'));
         $joinColumns = array(
             array('name' => 'author_id', 'referencedColumnName' => 'id')
         );
@@ -236,13 +237,16 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getComments'), "EntityGeneratorBook::getComments() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'addComment'), "EntityGeneratorBook::addComment() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'removeComment'), "EntityGeneratorBook::removeComment() missing.");
+        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getDnis'), "EntityGeneratorBook::getDnis() missing.");
+        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'addDnis'), "EntityGeneratorBook::addDnis() missing.");
+        $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'removeDnis'), "EntityGeneratorBook::removeDnis() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'setIsbn'), "EntityGeneratorBook::setIsbn() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getIsbn'), "EntityGeneratorBook::getIsbn() missing.");
 
         $reflClass = new \ReflectionClass($metadata->name);
 
-        $this->assertCount(6, $reflClass->getProperties());
-        $this->assertCount(15, $reflClass->getMethods());
+        $this->assertCount(7, $reflClass->getProperties());
+        $this->assertCount(18, $reflClass->getMethods());
 
         $this->assertEquals('published', $book->getStatus());
 
@@ -1100,3 +1104,4 @@ class
 
 class EntityGeneratorAuthor {}
 class EntityGeneratorComment {}
+class EntityGeneratorDnis {}


### PR DESCRIPTION
According to [this stackoverflow question](http://stackoverflow.com/q/36143291/4363634), the `Doctrine\ORM\Tools\EntityGenerator` singularises  the variables & methods names for `add` and `remove` setters and their parameters, for `T0_MANY` associations.

Example for a target entity called `Dnis`.

The expected result would be to have the `getDnis()`, `addDnis(Dnis $dnis)` and `removeDnis(Dnis $dnis)` methods generated.

But we would have  `getDnis()`, `addDni(Dnis $dni)` and `removeDni(Dnis $dni)`, that gives names that are not corresponding with the real target entity name.

I just added a small check that avoids calling `Inflector::singularize($variableName|$methodName)` for `add`+`remove` if the target entity name ends by `s`.
I also updated the test with the example I given.

I don't see any side effects for now, let me know if this breaks something, or if I can make improvements.
Thank's
