### PR TITLE
Fixed updating of entity with quoted association identifier

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -433,7 +433,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $params[]       = $identifier[$idField];
-            $where[]        = $this->class->associationMappings[$idField]['joinColumns'][0]['name'];
+            $where[]        = $this->quoteStrategy->getJoinColumnName($this->class->associationMappings[$idField]['joinColumns'][0], $this->class, $this->platform);
             $targetMapping  = $this->em->getClassMetadata($this->class->associationMappings[$idField]['targetEntity']);
 
             switch (true) {


### PR DESCRIPTION
Same issue as #5714 but when updating the entity. If the identifier id ordinary column, it gets quoted (few lines above the changed one) but association column for some reason does not...
