### PR TITLE
Fix PHP syntax error in composite-primary-keys.rst

### DIFF
--- a/docs/en/tutorials/composite-primary-keys.rst
+++ b/docs/en/tutorials/composite-primary-keys.rst
@@ -38,7 +38,7 @@ and year of production as primary keys:
             /** @Id @Column(type="string") */
             private $name;
             /** @Id @Column(type="integer") */
-            private $year
+            private $year;
 
             public function __construct($name, $year)
             {


### PR DESCRIPTION
Add missing semicolon after `private $year` on line 12 of `Car` class example code to fix `Parse error: syntax error, unexpected 'public' (T_PUBLIC), expecting ',' or ';' in [...]/VehicleCatalogue/Model/Car.php on line 14`
