### PR TITLE
Add SAP Adaptive Server Enterprise database vendor support

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1306,17 +1306,22 @@ class SqlWalker implements TreeWalker
                     : $class->getTableName();
 
                 $sqlTableAlias = $this->getSQLTableAlias($tableName, $dqlAlias);
+                $fieldType     = $class->getTypeOfField($fieldName);
                 $fieldMapping  = $class->fieldMappings[$fieldName];
                 $columnName    = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
                 $columnAlias   = $this->getSQLColumnAlias($fieldMapping['columnName']);
                 $col           = $sqlTableAlias . '.' . $columnName;
 
                 if (isset($fieldMapping['requireSQLConversion'])) {
-                    $type = Type::getType($fieldMapping['type']);
+                    $type = Type::getType($fieldType);
                     $col  = $type->convertToPHPValueSQL($col, $this->conn->getDatabasePlatform());
                 }
 
-                $sql .= $col . ' AS ' . $columnAlias;
+                $sql .= $this->conn->getDatabasePlatform()->selectAliasColumn(
+                    $col,
+                    $columnAlias,
+                    $fieldMapping
+                );
 
                 $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
 
@@ -1414,7 +1419,11 @@ class SqlWalker implements TreeWalker
                         $col = $type->convertToPHPValueSQL($col, $this->platform);
                     }
 
-                    $sqlParts[] = $col . ' AS '. $columnAlias;
+                    $sqlParts[] = $this->conn->getDatabasePlatform()->selectAliasColumn(
+                        $col,
+                        $columnAlias,
+                        $mapping
+                    );
 
                     $this->scalarResultAliasMap[$resultAlias][] = $columnAlias;
 
@@ -1445,7 +1454,11 @@ class SqlWalker implements TreeWalker
                                 $col = $type->convertToPHPValueSQL($col, $this->platform);
                             }
 
-                            $sqlParts[] = $col . ' AS ' . $columnAlias;
+                            $sqlParts[] = $this->conn->getDatabasePlatform()->selectAliasColumn(
+                                $col,
+                                $columnAlias,
+                                $mapping
+                            );
 
                             $this->scalarResultAliasMap[$resultAlias][] = $columnAlias;
 

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -79,7 +79,7 @@ class CountOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform->getName() === "mssql") {
+        if ($this->platform->getName() === "mssql" || $this->platform->getName() === "ase") {
             $AST->orderByClause = null;
         }
 


### PR DESCRIPTION
This PR adds support for SAP ASE. It depends on doctrine/dbal#2347.
It is required because ASE not supports offsets in limit queries. So there is a need for a temporary table. Because you cannot add identity columns twice we need to convert them to a integer.

I hope this addition is appreciated and any feedback/help on the above issues would be welcomed.
