### PR TITLE
Fixes #5755 - Parent class fields are not cloned

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -196,7 +196,7 @@ class ProxyFactory extends AbstractProxyFactory
                 );
             }
 
-            foreach ($class->getReflectionClass()->getProperties() as $property) {
+            foreach ($class->getReflectionProperties() as $property) {
                 if ( ! $class->hasField($property->name) && ! $class->hasAssociation($property->name)) {
                     continue;
                 }

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -2,15 +2,15 @@
 
 namespace Doctrine\Tests\ORM\Proxy;
 
+use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Proxy\ProxyFactory;
-use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;
-use Doctrine\Tests\Mocks\DriverMock;
-use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
 
 /**
  * Test the proxy generator. Its work is generating on-the-fly subclasses of a given model, which implement the Proxy pattern.
@@ -62,9 +62,9 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
 
         $persister
             ->expects($this->atLeastOnce())
-              ->method('load')
-              ->with($this->equalTo($identifier), $this->isInstanceOf($proxyClass))
-              ->will($this->returnValue(new \stdClass()));
+            ->method('load')
+            ->with($this->equalTo($identifier), $this->isInstanceOf($proxyClass))
+            ->will($this->returnValue(new \stdClass()));
 
         $proxy->getDescription();
     }
@@ -135,6 +135,45 @@ class ProxyFactoryTest extends \Doctrine\Tests\OrmTestCase
         $this->assertFalse($proxy->__isInitialized());
         $this->assertInstanceOf('Closure', $proxy->__getInitializer(), 'The initializer wasn\'t removed');
         $this->assertInstanceOf('Closure', $proxy->__getCloner(), 'The cloner wasn\'t removed');
+    }
+
+    public function testProxyClonesParentFields()
+    {
+        $companyEmployee = new CompanyEmployee();
+        $companyEmployee->setSalary(1000); // A property on the CompanyEmployee
+        $companyEmployee->setName("Bob"); // A property on the parent class, CompanyPerson
+
+        // Set the id of the CompanyEmployee (which is in the parent CompanyPerson)
+        $class = new \ReflectionClass('Doctrine\Tests\Models\Company\CompanyPerson');
+
+        $property = $class->getProperty('id');
+        $property->setAccessible(true);
+
+        $property->setValue($companyEmployee, 42);
+
+        $classMetaData = $this->emMock->getClassMetadata('Doctrine\Tests\Models\Company\CompanyEmployee');
+
+        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load', 'getClassMetadata'), array(), '', false);
+        $this->uowMock->setEntityPersister('Doctrine\Tests\Models\Company\CompanyEmployee', $persister);
+
+        /* @var $proxy \Doctrine\Common\Proxy\Proxy */
+        $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\Company\CompanyEmployee', array('id' => 42));
+
+        $persister
+            ->expects($this->atLeastOnce())
+            ->method('load')
+            ->will($this->returnValue($companyEmployee));
+
+        $persister
+            ->expects($this->atLeastOnce())
+            ->method('getClassMetadata')
+            ->will($this->returnValue($classMetaData));
+
+        $cloned = clone $proxy;
+
+        $this->assertEquals(42, $cloned->getId(), "Expected the Id to be cloned");
+        $this->assertEquals(1000, $cloned->getSalary(), "Expect properties on the CompanyEmployee class to be cloned");
+        $this->assertEquals("Bob", $cloned->getName(), "Expect properties on the CompanyPerson class to be cloned");
     }
 }
 


### PR DESCRIPTION
This addresses #5755, which we have also just noticed as a result of upgrading from Symfony 2.3 to 2.8. The bug is that private/protected fields in a parent class are not cloned when cloning a proxy.

The relevant changes and what we're reversing are here:

https://github.com/doctrine/common/pull/168/files#diff-4415e2672350448f02229f989bcfca38R85 This is the original commit to migrate the clone functionality into Doctrine common. Note the use of `foreach ($metadata->getReflectionClass()->getProperties() as $reflProperty) {`.

The change this replaces is in https://github.com/Ocramius/doctrine2/commit/8272ffd23fd66bac13a0dc074c868a00b82c7707#diff-b8508327ba460ef291cee00db8cb7b23L432, which used `foreach ($class->reflFields as $field => $reflProperty) {`.
