### PR TITLE
Wrong error on identifier is null value

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -400,7 +400,7 @@ use Doctrine\Common\Util\ClassUtils;
         $sortedId = array();
 
         foreach ($class->identifier as $identifier) {
-            if ( ! isset($id[$identifier])) {
+            if ( ! array_key_exists($identifier, $id)) {
                 throw ORMException::missingIdentifierField($class->name, $identifier);
             }
 
@@ -477,7 +477,7 @@ use Doctrine\Common\Util\ClassUtils;
         $sortedId = array();
 
         foreach ($class->identifier as $identifier) {
-            if ( ! isset($id[$identifier])) {
+            if ( ! array_key_exists($identifier, $id)) {
                 throw ORMException::missingIdentifierField($class->name, $identifier);
             }
 


### PR DESCRIPTION
When a `id` have `null` value - we have exception 

> The identifier id is missing for a query...

Because `isset` of array with `null` return `false`.
