### PR TITLE
Fix getJoinTableName to care about schema emulation

### DIFF
--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -96,19 +96,21 @@ class DefaultQuoteStrategy implements QuoteStrategy
      */
     public function getJoinTableName(array $association, ClassMetadata $class, AbstractPlatform $platform)
     {
-        $schema = '';
+        $tableName = $association['joinTable']['name'];
 
         if (isset($association['joinTable']['schema'])) {
-            $schema = $association['joinTable']['schema'] . '.';
-        }
+            $tableName = $association['joinTable']['schema'] . '.' . $association['joinTable']['name'];
 
-        $tableName = $association['joinTable']['name'];
+            if ( ! $platform->supportsSchemas() && $platform->canEmulateSchemas()) {
+                $tableName = $association['joinTable']['schema'] . '__' . $association['joinTable']['name'];
+            }
+        }
 
         if (isset($association['joinTable']['quoted'])) {
             $tableName = $platform->quoteIdentifier($tableName);
         }
 
-        return $schema . $tableName;
+        return $tableName;
     }
 
     /**


### PR DESCRIPTION
Fix #5784.

Not sure if `$platform = new \Doctrine\DBAL\Platforms\SqlitePlatform;` is the best way to use another platform in tests.
