### PR TITLE
Use AS part of the query from platform

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1306,17 +1306,22 @@ class SqlWalker implements TreeWalker
                     : $class->getTableName();
 
                 $sqlTableAlias = $this->getSQLTableAlias($tableName, $dqlAlias);
+                $fieldType     = $class->getTypeOfField($fieldName);
                 $fieldMapping  = $class->fieldMappings[$fieldName];
                 $columnName    = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
                 $columnAlias   = $this->getSQLColumnAlias($fieldMapping['columnName']);
                 $col           = $sqlTableAlias . '.' . $columnName;
 
                 if (isset($fieldMapping['requireSQLConversion'])) {
-                    $type = Type::getType($fieldMapping['type']);
+                    $type = Type::getType($fieldType);
                     $col  = $type->convertToPHPValueSQL($col, $this->conn->getDatabasePlatform());
                 }
 
-                $sql .= $col . ' AS ' . $columnAlias;
+                $sql .= $this->conn->getDatabasePlatform()->selectAliasColumn(
+                    $col,
+                    $columnAlias,
+                    $fieldMapping
+                );
 
                 $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
 
@@ -1414,7 +1419,11 @@ class SqlWalker implements TreeWalker
                         $col = $type->convertToPHPValueSQL($col, $this->platform);
                     }
 
-                    $sqlParts[] = $col . ' AS '. $columnAlias;
+                    $sqlParts[] = $this->conn->getDatabasePlatform()->selectAliasColumn(
+                        $col,
+                        $columnAlias,
+                        $mapping
+                    );
 
                     $this->scalarResultAliasMap[$resultAlias][] = $columnAlias;
 
@@ -1445,7 +1454,11 @@ class SqlWalker implements TreeWalker
                                 $col = $type->convertToPHPValueSQL($col, $this->platform);
                             }
 
-                            $sqlParts[] = $col . ' AS ' . $columnAlias;
+                            $sqlParts[] = $this->conn->getDatabasePlatform()->selectAliasColumn(
+                                $col,
+                                $columnAlias,
+                                $mapping
+                            );
 
                             $this->scalarResultAliasMap[$resultAlias][] = $columnAlias;
 


### PR DESCRIPTION
This change was part of the "Add SAP Adaptive Server Enterprise vendor support" PR doctrine/doctrine2#5752. It has been seperated because it is not ASE specific and would increase platform independence in general.

It depends on the  "Add selectAliasColumn to AbstractPlatform" PR doctrine/dbal#2359.

It is required in the platform if the "AS" keyword may differ in platforms (which is probably not very common) and for creating workarounds when using deferred tables to simulate ROWNUM() by identity columns.
