### PR TITLE
Fix generated fake ManyToMany

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -292,11 +292,12 @@ class DatabaseDriver implements MappingDriver
             }
 
             $pkColumns = $table->getPrimaryKey()->getColumns();
+            $allColumns = $table->getColumns();
 
             sort($pkColumns);
             sort($allForeignKeyColumns);
 
-            if ($pkColumns == $allForeignKeyColumns && count($foreignKeys) == 2) {
+            if ($pkColumns == $allForeignKeyColumns && count($foreignKeys) == 2 && count($allColumns) <= count($allForeignKeyColumns)) {
                 $this->manyToManyTables[$tableName] = $table;
             } else {
                 // lower-casing is necessary because of Oracle Uppercase Tablenames,


### PR DESCRIPTION
Many users, including myself, didn't get why some of our tables were not generated when using doctrine:mapping:import.
The engine wrongly detects a join table for a ManyToMany association, even if the table has more columns than foreign keys columns. So the table is not generated. See this stackoverflow [link](http://stackoverflow.com/questions/15616157/doctrine-2-and-many-to-many-link-table-with-an-extra-field).

With that fix, the user in that case will now receive this error : 
It is not possible to map entity 'ExempleBundle\Entity\Entite1' with a composite primary key as part of the primary key of another entity 'ExempleBundle\Entity\Entite2#entite1'.

So he can stop scratching his head and cursing Doctrine and start to think about another data model.
