### PR TITLE
In EntityGenerator, don't generate a 'get' method if there is an 'is'…

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1363,9 +1363,16 @@ public function __construct(<params>)
             $variableName = Inflector::singularize($variableName);
         }
 
+        // Don't generate a method if one already exists
         if ($this->hasMethod($methodName, $metadata)) {
             return '';
         }
+
+        // Don't generate a 'get' method if there is an 'is' method
+        if ($type=='get' && $this->hasMethod('is'.Inflector::classify($fieldName), $metadata)) {
+            return '';
+        }
+
         $this->staticReflection[$metadata->name]['methods'][] = strtolower($methodName);
 
         $var = sprintf('%sMethodTemplate', $type);


### PR DESCRIPTION
… method

Sometimes, particularly for boolean attributes it makes more sense to use getter method names like `isSelected()` rather than `getSelected()`. This is supported by other parts of the symfony ecosystem, e.g. PropertyAccessor.

This prevents a duplicate `getSelected` method being created if I have previously generated a method and renamed it to `isSelected`.
