### PR TITLE
Catch `Throwable` instead of just catching `Exception`

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -19,7 +19,6 @@
 
 namespace Doctrine\ORM;
 
-use Exception;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
@@ -236,7 +235,12 @@ use Doctrine\Common\Util\ClassUtils;
             $this->conn->commit();
 
             return $return ?: true;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
+            $this->close();
+            $this->conn->rollBack();
+
+            throw $e;
+        } catch (\Exception $e) { // PHP 5
             $this->close();
             $this->conn->rollBack();
 

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -131,11 +131,15 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
             foreach ($this->_sqlStatements as $sql) {
                 $conn->executeUpdate($sql);
             }
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             // FAILURE! Drop temporary table to avoid possible collisions
             $conn->executeUpdate($this->_dropTempTableSql);
 
             // Re-throw exception
+            throw $exception;
+        } catch (\Exception $exception) { // PHP 5
+            $conn->executeUpdate($this->_dropTempTableSql);
+
             throw $exception;
         }
 

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -190,11 +190,15 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
 
                 $conn->executeUpdate($statement, $paramValues, $paramTypes);
             }
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             // FAILURE! Drop temporary table to avoid possible collisions
             $conn->executeUpdate($this->_dropTempTableSql);
 
             // Re-throw exception
+            throw $exception;
+        } catch (\Exception $exception) { // PHP 5
+            $conn->executeUpdate($this->_dropTempTableSql);
+
             throw $exception;
         }
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -70,7 +70,11 @@ EOT
             if ($input->getOption('complete') !== null) {
                 $em->getConnection()->connect();
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return 1;
+        } catch (\Exception $e) { // PHP 5
             $output->writeln('<error>' . $e->getMessage() . '</error>');
 
             return 1;

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -92,7 +92,9 @@ class SchemaTool
         foreach ($createSchemaSql as $sql) {
             try {
                 $conn->executeQuery($sql);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
+                throw ToolsException::schemaToolFailure($sql, $e);
+            } catch (\Exception $e) { // PHP 5
                 throw ToolsException::schemaToolFailure($sql, $e);
             }
         }
@@ -749,7 +751,9 @@ class SchemaTool
         foreach ($dropSchemaSql as $sql) {
             try {
                 $conn->executeQuery($sql);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
+
+            } catch (\Exception $e) { // PHP 5
 
             }
         }

--- a/lib/Doctrine/ORM/Tools/ToolsException.php
+++ b/lib/Doctrine/ORM/Tools/ToolsException.php
@@ -30,11 +30,11 @@ class ToolsException extends ORMException
 {
     /**
      * @param string     $sql
-     * @param \Exception $e
+     * @param \Exception $e   The original exception, or duck-typed Throwable in PHP 7.
      *
      * @return ToolsException
      */
-    public static function schemaToolFailure($sql, \Exception $e)
+    public static function schemaToolFailure($sql, $e)
     {
         return new self("Schema-Tool failed with Error '" . $e->getMessage() . "' while executing DDL: " . $sql, "0", $e);
     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -23,7 +23,6 @@ use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Mapping\Reflection\ReflectionPropertiesGetter;
-use Exception;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -400,7 +399,14 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             $conn->commit();
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
+            $this->em->close();
+            $conn->rollBack();
+
+            $this->afterTransactionRolledBack();
+
+            throw $e;
+        } catch (\Exception $e) { // PHP 5
             $this->em->close();
             $conn->rollBack();
 


### PR DESCRIPTION
Several code blocks have a catch-all `catch (\Exception) { ... }`. This is OK in PHP 5, but not sufficient in PHP 7, as the new base interface is `Throwable`, and catching `Exception` does not catch `Error` instances.

This PR catches `Throwable` by default, then catches `Exception` for PHP 5. The fact that `Throwable` is not defined in PHP 5 is not a problem in a catch block.

This leads to a bit of code duplication, but there's not much we can do to avoid this I'm afraid.
