### PR TITLE
Allow using custom collections

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -35,6 +35,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\ORM\Repository\RepositoryFactory;
 
@@ -923,5 +924,33 @@ class Configuration extends \Doctrine\DBAL\Configuration
     public function setDefaultQueryHint($name, $value)
     {
         $this->_attributes['defaultQueryHints'][$name] = $value;
+    }
+
+    /**
+     * Gets the type of the result set root that should be returned. By default its an array, but we can set it as
+     * 'collection', in which case the ORM returns the collection specified for the entity contained in the result set.
+     *
+     * @since 2.5
+     *
+     * @return string $type The name of the type: 'array' or 'collection'.
+     */
+    public function getResultRootType()
+    {
+        return isset($this->_attributes['resultRootType'])
+            ? $this->_attributes['resultRootType']
+            : EntityPersister::RESULT_ROOT_TYPE_ARRAY;
+    }
+
+    /**
+     * Gets the type of the result set root that should be returned. By default its an array, but we can set it as
+     * 'collection', in which case the ORM returns the collection specified for the entity contained in the result set.
+     *
+     * @since 2.5
+     *
+     * @param string $type The name of the type: 'array' or 'collection'.
+     */
+    public function setResultRootType($type)
+    {
+        $this->_attributes['resultRootType'] = $type;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -257,6 +257,14 @@ class ClassMetadataInfo implements ClassMetadata
     public $customRepositoryClassName;
 
     /**
+     * The name of the custom collection class used for the entity class.
+     * (Optional).
+     *
+     * @var string
+     */
+    public $customCollectionClassName;
+
+    /**
      * READ-ONLY: Whether this class describes the mapping of a mapped superclass.
      *
      * @var boolean
@@ -2629,6 +2637,16 @@ class ClassMetadataInfo implements ClassMetadata
     public function setCustomRepositoryClass($repositoryClassName)
     {
         $this->customRepositoryClassName = $this->fullyQualifiedClassName($repositoryClassName);
+    }
+
+    /**
+     * @param string $collectionClassName
+     *
+     * @return void
+     */
+    public function setCustomCollectionClass($collectionClassName)
+    {
+        $this->customCollectionClassName = $this->fullyQualifiedClassName($collectionClassName);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -79,7 +79,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
             if ($entityAnnot->repositoryClass !== null) {
                 $metadata->setCustomRepositoryClass($entityAnnot->repositoryClass);
             }
-
+            
+            if ($entityAnnot->collectionClass !== null) {
+                $metadata->setCustomCollectionClass($entityAnnot->collectionClass);
+            }
+            
             if ($entityAnnot->readOnly) {
                 $metadata->markReadOnly();
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -61,6 +61,9 @@ class XmlDriver extends FileDriver
             if (isset($xmlRoot['repository-class'])) {
                 $metadata->setCustomRepositoryClass((string) $xmlRoot['repository-class']);
             }
+            if (isset($xmlRoot['collection-class'])) {
+                $metadata->setCustomCollectionClass((string) $xmlRoot['collection-class']);
+            }
             if (isset($xmlRoot['read-only']) && $this->evaluateBoolean($xmlRoot['read-only'])) {
                 $metadata->markReadOnly();
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -58,6 +58,9 @@ class YamlDriver extends FileDriver
             if (isset($element['repositoryClass'])) {
                 $metadata->setCustomRepositoryClass($element['repositoryClass']);
             }
+            if (isset($element['collectionClass'])) {
+                $metadata->setCustomCollectionClass($element['collectionClass']);
+            }
             if (isset($element['readOnly']) && $element['readOnly'] == true) {
                 $metadata->markReadOnly();
             }

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -31,6 +31,11 @@ final class Entity implements Annotation
     public $repositoryClass;
 
     /**
+     * @var string
+     */
+    public $collectionClass;
+
+    /**
      * @var boolean
      */
     public $readOnly = false;

--- a/lib/Doctrine/ORM/Mapping/Factory/CollectionFactory.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/CollectionFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\ORM\Mapping\Factory;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\ORM\PersistentCollection;
+
+class CollectionFactory
+{
+    /**
+     * This method creates a custom collection for the entity defined by ClassMetadata $class.
+     * If no custom collection is specified, it will fallback to PersistentCollection.
+     * The custom collection must extend from PersistentCollection.
+     *
+     * @param EntityManagerInterface $em
+     * @param ClassMetadata          $class
+     * @param Collection             $collection the contents of the specific collection to create
+     *
+     * @return PersistentCollection
+     */
+    public function create(EntityManagerInterface $em, ClassMetadata $class, Collection $collection)
+    {
+        $customCollectionClassName = $class->customCollectionClassName;
+
+        if (empty($customCollectionClassName)) {
+            $customCollectionClassName = PersistentCollection::class;
+        } elseif (! is_a($customCollectionClassName, PersistentCollection::class, true)) {
+            throw new ORMInvalidArgumentException(
+                'The custom collection specified for entity ' . $class->getName()
+                . ' (' . $customCollectionClassName . ') must extend ' . PersistentCollection::class . '.'
+            );
+        }
+
+        return new $customCollectionClassName($em, $class, $collection);
+    }
+
+    /**
+     * This method creates the default collection to be used in the UnitOfWork.
+     *
+     * @param EntityManagerInterface $em
+     * @param ClassMetadata          $class
+     * @param Collection             $collection the contents of the specific collection to create
+     *
+     * @return PersistentCollection
+     */
+    public function createDefault(EntityManagerInterface $em, ClassMetadata $class, Collection $collection)
+    {
+        return new PersistentCollection($em, $class, $collection);
+    }
+}

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -41,7 +41,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  * @author    Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
  * @author    Stefano Rodriguez <stefano.rodriguez@fubles.com>
  */
-final class PersistentCollection extends AbstractLazyCollection implements Selectable
+class PersistentCollection extends AbstractLazyCollection implements Selectable
 {
     /**
      * A snapshot of the collection at the moment it was fetched from the database.
@@ -103,7 +103,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * @param ClassMetadata          $class      The class descriptor of the entity type of this collection.
      * @param Collection             $collection The collection elements.
      */
-    public function __construct(EntityManagerInterface $em, $class, Collection $collection)
+    public final function __construct(EntityManagerInterface $em, $class, Collection $collection)
     {
         $this->collection  = $collection;
         $this->em          = $em;

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -31,6 +31,9 @@ use Doctrine\Common\Collections\Criteria;
  */
 interface EntityPersister
 {
+    const RESULT_ROOT_TYPE_ARRAY      = 'array';
+    const RESULT_ROOT_TYPE_COLLECTION = 'collection';
+
     /**
      * @return \Doctrine\ORM\Mapping\ClassMetadata
      */

--- a/tests/Doctrine/Tests/Models/StockExchange/Bond.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Bond.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * Bonds have many stocks. This uses a many to many association and fails to model how many of a
  * particular stock a bond has. But i Need a many-to-many association, so please bear with my modelling skills ;)
  *
- * @Entity
+ * @Entity(collectionClass="Doctrine\Tests\Models\StockExchange\Collection\BondCollection")
  * @Table(name="exchange_bonds")
  */
 class Bond

--- a/tests/Doctrine/Tests/Models/StockExchange/Collection/BondCollection.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Collection/BondCollection.php
@@ -1,0 +1,8 @@
+<?php
+namespace Doctrine\Tests\Models\StockExchange\Collection;
+
+use Doctrine\ORM\PersistentCollection;
+
+class BondCollection extends PersistentCollection
+{
+}

--- a/tests/Doctrine/Tests/Models/StockExchange/Collection/MarketCollection.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Collection/MarketCollection.php
@@ -1,0 +1,8 @@
+<?php
+namespace Doctrine\Tests\Models\StockExchange\Collection;
+
+use Doctrine\ORM\PersistentCollection;
+
+class MarketCollection extends PersistentCollection
+{
+}

--- a/tests/Doctrine/Tests/Models/StockExchange/Collection/StockCollection.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Collection/StockCollection.php
@@ -1,0 +1,8 @@
+<?php
+namespace Doctrine\Tests\Models\StockExchange\Collection;
+
+use Doctrine\ORM\PersistentCollection;
+
+class StockCollection extends PersistentCollection
+{
+}

--- a/tests/Doctrine/Tests/Models/StockExchange/Market.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Market.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\Models\StockExchange;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @Entity
+ * @Entity(collectionClass="Doctrine\Tests\Models\StockExchange\Collection\MarketCollection")
  * @Table(name="exchange_markets")
  */
 class Market

--- a/tests/Doctrine/Tests/Models/StockExchange/Stock.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Stock.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\Models\StockExchange;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /**
- * @Entity
+ * @Entity(collectionClass="Doctrine\Tests\Models\StockExchange\Collection\StockCollection")
  * @Table(name="exchange_stocks")
  */
 class Stock

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Mapping as AnnotationNamespace;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use ReflectionClass;
 use PHPUnit_Framework_TestCase;
 
@@ -345,6 +346,17 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->configuration->getSecondLevelCacheConfiguration());
         $this->configuration->setSecondLevelCacheConfiguration($mockClass);
         $this->assertEquals($mockClass, $this->configuration->getSecondLevelCacheConfiguration());
+    }
+
+    /**
+     * @group custom-collections
+     */
+    public function testSetGetResultRootType()
+    {
+        $this->assertEquals(EntityPersister::RESULT_ROOT_TYPE_ARRAY, $this->configuration->getResultRootType());
+
+        $this->configuration->setResultRootType(EntityPersister::RESULT_ROOT_TYPE_COLLECTION);
+        $this->assertSame(EntityPersister::RESULT_ROOT_TYPE_COLLECTION, $this->configuration->getResultRootType());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/Factory/CollectionFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Factory/CollectionFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Doctrine\Tests\ORM\Mapping\Factory;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Factory\CollectionFactory;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\ORM\Persisters\Collection\ExtensionOfPersistentCollection;
+use Doctrine\Tests\OrmTestCase;
+
+class CollectionFactoryTest extends OrmTestCase
+{
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $_em;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var ClassMetadata
+     */
+    protected $classMetadata;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_em = $this->_getTestEntityManager();
+
+        $this->classMetadata = $this->_em->getClassMetadata('Doctrine\Tests\Models\GeoNames\Admin1AlternateName');
+
+        $this->collectionFactory = new CollectionFactory();
+    }
+
+    /**
+     * @group custom-collections
+     */
+    public function testCollectionFactoryInstantiatesPersistentCollectionIfCollectionTypeIsNotSet()
+    {
+        $result = $this->collectionFactory->create(
+            $this->_em,
+            $this->classMetadata,
+            new ArrayCollection([])
+        );
+
+        $this->assertInstanceOf(PersistentCollection::class, $result);
+    }
+
+    /**
+     * @group custom-collections
+     */
+    public function testCollectionFactoryInstantiatesTheRequiredCollection()
+    {
+        $this->classMetadata->setCustomCollectionClass(ExtensionOfPersistentCollection::class);
+
+        $result = $this->collectionFactory->create(
+            $this->_em,
+            $this->classMetadata,
+            new ArrayCollection([])
+        );
+
+        $this->assertInstanceOf(ExtensionOfPersistentCollection::class, $result);
+    }
+
+    /**
+     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
+     *
+     * @group custom-collections
+     */
+    public function testCollectionFactoryThrowsExceptionIfCollectionTypeIsNotPersistentCollection()
+    {
+        $this->classMetadata->setCustomCollectionClass(ArrayCollection::class);
+
+        $this->collectionFactory->create(
+            $this->_em,
+            $this->classMetadata,
+            new ArrayCollection([])
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTest.php
@@ -1,0 +1,91 @@
+<?php
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use Doctrine\Tests\ORM\Persisters\Collection\ExtensionOfPersistentCollection;
+use Doctrine\Tests\OrmTestCase;
+
+class BasicEntityPersisterTest extends OrmTestCase
+{
+    /**
+     * @var BasicEntityPersister
+     */
+    protected $_persister;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $_em;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_em = $this->_getTestEntityManager();
+
+        $this->_persister = new BasicEntityPersister(
+            $this->_em,
+            $this->_em->getClassMetadata('Doctrine\Tests\Models\GeoNames\Admin1AlternateName')
+        );
+    }
+
+    /**
+     * @group custom-collections
+     */
+    public function testLoadAllReturnTypeIsArray()
+    {
+        $this->_em->getConfiguration()->setResultRootType(EntityPersister::RESULT_ROOT_TYPE_ARRAY);
+
+        $result = $this->_persister->loadAll();
+
+        $this->assertTrue(is_array($result));
+    }
+
+    /**
+     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
+     *
+     * @group custom-collections
+     */
+    public function testLoadAllThrowsExceptionIfCollectionClassIsNotSet()
+    {
+        $this->_em->getConfiguration()->setResultRootType(EntityPersister::RESULT_ROOT_TYPE_COLLECTION);
+
+        $result = $this->_persister->loadAll();
+
+        $this->assertTrue(is_array($result));
+    }
+
+    /**
+     * @group custom-collections
+     */
+    public function testLoadAllReturnTypeIsCollection()
+    {
+        $this->_em->getConfiguration()->setResultRootType(EntityPersister::RESULT_ROOT_TYPE_COLLECTION);
+        $this->_persister->getClassMetadata()->setCustomCollectionClass(ExtensionOfPersistentCollection::class);
+
+        $result = $this->_persister->loadAll();
+
+        $this->assertInstanceOf(Collection::class, $result);
+    }
+
+    /**
+     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
+     *
+     * @group custom-collections
+     */
+    public function testLoadAllReturnTypeIsNotPersistentCollectionThrowsException()
+    {
+        $this->_em->getConfiguration()->setResultRootType(EntityPersister::RESULT_ROOT_TYPE_COLLECTION);
+        $this->_persister->getClassMetadata()->setCustomCollectionClass(ArrayCollection::class);
+
+        $result = $this->_persister->loadAll();
+
+        $this->assertInstanceOf(Collection::class, $result);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/Collection/ExtensionOfPersistentCollection.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/Collection/ExtensionOfPersistentCollection.php
@@ -1,0 +1,9 @@
+<?php
+namespace Doctrine\Tests\ORM\Persisters\Collection;
+
+use Doctrine\ORM\PersistentCollection;
+
+class ExtensionOfPersistentCollection extends PersistentCollection
+{
+
+}

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -14,6 +14,9 @@ use Doctrine\Tests\Mocks\EntityPersisterMock;
 use Doctrine\Tests\Mocks\UnitOfWorkMock;
 use Doctrine\Tests\Models\Forum\ForumAvatar;
 use Doctrine\Tests\Models\Forum\ForumUser;
+use Doctrine\Tests\Models\StockExchange\Bond;
+use Doctrine\Tests\Models\StockExchange\Collection\StockCollection;
+use Doctrine\Tests\Models\StockExchange\Market;
 use stdClass;
 
 /**
@@ -63,6 +66,36 @@ class UnitOfWorkTest extends \Doctrine\Tests\OrmTestCase
         $this->assertFalse($this->_unitOfWork->isScheduledForDelete($user));
     }
 
+    /**
+     * @param string $className
+     * @param array  $data
+     * @param string $expectedCollectionClass
+     * @param string $expectedCollectionFieldName
+     *
+     * @dataProvider dataForTestToManyReturnsCollectionSpecificToEntity
+     * 
+     * @group custom-collections
+     */
+    public function testToManyReturnsCollectionSpecificToEntity(
+        $className,
+        $data,
+        $expectedCollectionClass,
+        $expectedCollectionFieldName
+    ) {
+        $hints = ['deferEagerLoad' => true];
+
+        $entity = $this->_unitOfWork->createEntity($className, $data, $hints);
+
+        $this->assertInstanceOf($expectedCollectionClass, $entity->$expectedCollectionFieldName);
+    }
+
+    public function dataForTestToManyReturnsCollectionSpecificToEntity()
+    {
+        return [
+            'MANY_TO_MANY' => [Bond::class, ['id'   => 1, 'name' => 'A_Bond'], StockCollection::class, 'stocks'],
+            'ONE_TO_MANY' => [Market::class, ['id' => 1, 'name' => 'A_Market'], StockCollection::class, 'stocks'],
+        ];
+    }
 
     /* Operational tests */
 


### PR DESCRIPTION
### Current situation

When querying the DB, Doctrine retrieves the 1-n and n-n associations in its own collection, the PersistentCollection, and the query result set as an array. As this is a specific DoctrineCollection, tied to the implementation, it is currently impossible to specify a Domain Collection to be used instead of the PersistentCollection.
### Proposed enhancement

Allow to specify a Collection for each entity type, to be used when retrieving 1-n and n-n relations, as well as the query result set .

The specified collection must be extended from PersistentCollection, in order to maintain the persistence capabilities of the associations. If the specified collection is not extended from PersistentCollection, an ORMInvalidArgumentException will be thrown.
If a collection is not specified, Doctrine will maintain the current behavior of using a PersistentCollection. I understand that this ties the domain collections to the ORM, but I feel that having this functionality is more important than that, also because it is not mandatory to use this functionality, it is completely optional for the developer to do so or not.

The query result set however will still be an array, as it is the current behavior of Doctrine and changing it would break BC. This, however, can be changed by adding an option to override the default behavior and return the query result set as the collection specified for the entities returned in the query result set.

This PR somewhat relates to:
- https://github.com/doctrine/doctrine2/issues/5057
- https://github.com/doctrine/doctrine2/commits/custom-collections
