### PR TITLE
Fix for SQL Server, LockMode::NONE is used to get "WITH (NOLOCK)"

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -455,7 +455,9 @@ use Doctrine\Common\Util\ClassUtils;
                 if ( ! $this->getConnection()->isTransactionActive()) {
                     throw TransactionRequiredException::transactionRequired();
                 }
+                return $persister->load($sortedId, null, null, array(), $lockMode);
 
+            case LockMode::NONE === $lockMode:
                 return $persister->load($sortedId, null, null, array(), $lockMode);
 
             default:


### PR DESCRIPTION
In SQL Server when you want to use "WITH (NOLOCK)" you can't, because there is no active transaction.
