### PR TITLE
Verify embeddables do not define associations

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -254,6 +254,15 @@ class SchemaValidator
             }
         }
 
+        foreach ($class->embeddedClasses as $propertyName => $embeddedClass) {
+            $embeddedMeta = $this->em->getClassMetadata($embeddedClass['class']);
+
+            foreach ($embeddedMeta->associationMappings as $fieldName => $mapping) {
+                $ce[] = "Embeddables do not support associations, but one is defined on '" . $embeddedClass['class']
+                    . '#' . $fieldName .  "'.";
+            }
+        }
+
         return $ce;
     }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -203,6 +203,18 @@ class SchemaValidatorTest extends \Doctrine\Tests\OrmTestCase
             $ce
         );
     }
+
+    public function testEmbeddableWithAssociation()
+    {
+        $class = $this->em->getClassMetadata(__NAMESPACE__ . '\EmbeddingEmbeddableWithAssociation');
+        $ce = $this->validator->validateClass($class);
+        $this->assertEquals(
+            array(
+                "Embeddables do not support associations, but one is defined on 'Doctrine\Tests\ORM\Tools\EmbeddableWithAssociation#associationTarget'."
+            ),
+            $ce
+        );
+    }
 }
 
 /**
@@ -519,4 +531,37 @@ class DDC3322Three
      * @OrderBy({"oneToOneInverse" = "ASC"})
      */
     private $invalidAssoc;
+}
+
+/**
+ * @Entity
+ */
+class EmbeddingEmbeddableWithAssociation
+{
+    /**
+     * @Id
+     * @Column
+     */
+    private  $id;
+
+    /**
+     * @Embedded(class="EmbeddableWithAssociation")
+     */
+    private $embeddableWithAssociation;
+}
+
+/** @Embeddable */
+class EmbeddableWithAssociation
+{
+    /**
+     * @ManyToOne(targetEntity="AssociationTarget")
+     */
+    private $associationTarget;
+}
+
+/**
+ * @Entity
+ */
+class AssociationTarget
+{
 }


### PR DESCRIPTION
If I define an association on an embeddable, the following happens:
- The schema validates without errors;
- Yet my association is ignored!

There are two ways to solve this problem: invalidate the schema, or add associations of the embeddable.

Personally I would find it intuitive if the associations work. Currently we've placed a workaround, but we'd prefer adding the association mapping in the embeddable.

According to #4291, Doctrine consciously does not support associations in embeddables. That is why I opted for stricter validation. That way the error would have at least been found sooner.
