### PR TITLE
Use ResultSetMapper in cache key so schema changes invalidate cache

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -292,14 +292,18 @@ final class Query extends AbstractQuery
     {
         $executor = $this->_parse()->getSqlExecutor();
 
-        if ($this->_queryCacheProfile) {
-            $executor->setQueryCacheProfile($this->_queryCacheProfile);
-        } else {
-            $executor->removeQueryCacheProfile();
-        }
-
         if ($this->_resultSetMapping === null) {
             $this->_resultSetMapping = $this->_parserResult->getResultSetMapping();
+        }
+        
+        if ($this->_queryCacheProfile) {
+            $executor->setQueryCacheProfile(
+                $this->_queryCacheProfile->setRealCacheKeyPrefix(
+                    sha1(serialize($this->_resultSetMapping))
+                )
+            );
+        } else {
+            $executor->removeQueryCacheProfile();
         }
 
         // Prepare parameters


### PR DESCRIPTION
This fixes a long standing issue we've been facing with schema changes and result caching.  
When new code is deployed that contains a scheme change any queries hitting the result cache return null values because of [this check](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php#L482). Adding or removing any fields make the keys defined by the ResultSetMapper different then the keys stored in the cache. As a result the ObjectHydrator can't find the id so it return null for each which makes for some confusing errors. 

This change adds a hash of the current ResultSetMapper to the real key effectively invalidating the cache on any schema changes for any entity in the query. 

REQUIRES:
https://github.com/doctrine/dbal/pull/2383
