### PR TITLE
Add support for owning side associations in AbstractEntityPersister::loadOneToOneEntity

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
@@ -79,7 +79,7 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
         $entity2    = $this->_em->find(AttractionInfo::CLASSNAME, $entityId2);
 
         //load entity and relation whit sub classes
-        $this->assertEquals($queryCount + 4, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount());
 
         $this->assertTrue($this->cache->containsEntity(AttractionInfo::CLASSNAME, $entityId1));
         $this->assertTrue($this->cache->containsEntity(AttractionInfo::CLASSNAME, $entityId2));


### PR DESCRIPTION
Adds support for fetching cachable entity from cache on loadOneToOneEntity method.
