### PR TITLE
Adds a failing test case for #5607

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5607Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5607Test.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
+use Doctrine\Tests\OrmTestCase;
+
+class DDC5607Test extends OrmTestCase
+{
+    public function testOracleColumnAlias()
+    {
+        $quoteStrategy = new DefaultQuoteStrategy();
+        $platform = new OraclePlatform();
+
+        $this->assertSame(
+            'THIS_IS_A_29_CHAR_STRING_XX_0',
+            $quoteStrategy->getColumnAlias('X_THIS_IS_A_29_CHAR_STRING_XX', 0, $platform)
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\OrmTestCase;
@@ -137,6 +138,17 @@ class QuoteStrategyTest extends OrmTestCase
         $this->assertEquals('column_name_1', $this->strategy->getColumnAlias('column_name', $i++, $this->platform));
         $this->assertEquals('COLUMN_NAME_2', $this->strategy->getColumnAlias('COLUMN_NAME', $i++, $this->platform));
         $this->assertEquals('COLUMNNAME_3', $this->strategy->getColumnAlias('COLUMN-NAME-', $i++, $this->platform));
+    }
+
+    public function testOracleColumnAlias()
+    {
+        $quoteStrategy = new DefaultQuoteStrategy();
+        $platform = new OraclePlatform();
+
+        $this->assertSame(
+            'THIS_IS_A_29_CHAR_STRING_XX_0',
+            $quoteStrategy->getColumnAlias('X_THIS_IS_A_29_CHAR_STRING_XX', 0, $platform)
+        );
     }
 
     public function testQuoteIdentifierJoinColumns()

--- a/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/QuoteStrategyTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\OrmTestCase;
@@ -138,17 +137,6 @@ class QuoteStrategyTest extends OrmTestCase
         $this->assertEquals('column_name_1', $this->strategy->getColumnAlias('column_name', $i++, $this->platform));
         $this->assertEquals('COLUMN_NAME_2', $this->strategy->getColumnAlias('COLUMN_NAME', $i++, $this->platform));
         $this->assertEquals('COLUMNNAME_3', $this->strategy->getColumnAlias('COLUMN-NAME-', $i++, $this->platform));
-    }
-
-    public function testOracleColumnAlias()
-    {
-        $quoteStrategy = new DefaultQuoteStrategy();
-        $platform = new OraclePlatform();
-
-        $this->assertSame(
-            'THIS_IS_A_29_CHAR_STRING_XX_0',
-            $quoteStrategy->getColumnAlias('X_THIS_IS_A_29_CHAR_STRING_XX', 0, $platform)
-        );
     }
 
     public function testQuoteIdentifierJoinColumns()


### PR DESCRIPTION
Adds a failing test case for #5607.
The columnAlias shouldn't start with an underscore for the Oracle platform as it generates an exception.

The test case is expecting `THIS_IS_A_29_CHAR_STRING_XX_0` but is actually getting `_THIS_IS_A_29_CHAR_STRING_XX_0` back, which would be invalid for the above platform. This assumes that leading underscores would be removed from the generated alias.
