### PR TITLE
Multi get implementation in QueryCache

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -112,20 +112,29 @@ class DefaultQueryCache implements QueryCache
         $regionName  = $region->getName();
 
         $cm = $this->em->getClassMetadata($entityName);
+
+        $entityCacheKeys = [];
+        foreach ($entry->result as $index => $concreteEntry) {
+            $entityCacheKeys[$index] = new EntityCacheKey($cm->rootEntityName, $concreteEntry['identifier']);
+        }
+        $entries = $region->getMultiple(new CollectionCacheEntry($entityCacheKeys));
+
         // @TODO - move to cache hydration component
         foreach ($entry->result as $index => $entry) {
 
-            if (($entityEntry = $region->get($entityKey = new EntityCacheKey($cm->rootEntityName, $entry['identifier']))) === null) {
+            $entityEntry = is_array($entries) && array_key_exists($index, $entries) ? $entries[$index] : null;
+
+            if ($entityEntry === null) {
 
                 if ($this->cacheLogger !== null) {
-                    $this->cacheLogger->entityCacheMiss($regionName, $entityKey);
+                    $this->cacheLogger->entityCacheMiss($regionName, $entityCacheKeys[$index]);
                 }
 
                 return null;
             }
 
             if ($this->cacheLogger !== null) {
-                $this->cacheLogger->entityCacheHit($regionName, $entityKey);
+                $this->cacheLogger->entityCacheHit($regionName, $entityCacheKeys[$index]);
             }
 
             if ( ! $hasRelation) {

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -276,8 +276,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         );
 
         $this->region->addReturn('get', $entry);
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[0]));
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[1]));
+        $this->region->addReturn('getMultiple', array(
+            new EntityCacheEntry(Country::CLASSNAME, $data[0]),
+            new EntityCacheEntry(Country::CLASSNAME, $data[1])
+        ));
 
         $rsm->addRootEntityFromClassMetadata(Country::CLASSNAME, 'c');
 
@@ -434,8 +436,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         $entry->time = time() - 100;
 
         $this->region->addReturn('get', $entry);
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $entities[0]));
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $entities[1]));
+        $this->region->addReturn('getMultiple', array(
+            new EntityCacheEntry(Country::CLASSNAME, $entities[0]),
+            new EntityCacheEntry(Country::CLASSNAME, $entities[1])
+        ));
 
         $rsm->addRootEntityFromClassMetadata(Country::CLASSNAME, 'c');
 
@@ -457,8 +461,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         );
 
         $this->region->addReturn('get', $entry);
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[0]));
-        $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $data[1]));
+        $this->region->addReturn('getMultiple', array(
+            new EntityCacheEntry(Country::CLASSNAME, $data[0]),
+            new EntityCacheEntry(Country::CLASSNAME, $data[1])
+        ));
 
         $rsm->addRootEntityFromClassMetadata(Country::CLASSNAME, 'c');
 
@@ -475,7 +481,7 @@ class DefaultQueryCacheTest extends OrmTestCase
         ));
 
         $this->region->addReturn('get', $entry);
-        $this->region->addReturn('get', null);
+        $this->region->addReturn('getMultiple', [null]);
 
         $rsm->addRootEntityFromClassMetadata(Country::CLASSNAME, 'c');
 


### PR DESCRIPTION
Hi

There is significant performance degradation when doctrine tries to check the cache (memcache) after fetching multiple thousands of rows. It occurs because it doesn't use memcache's multiple get function.

This modification implements multiple get cache checking as it has been done here: https://github.com/doctrine/doctrine2/pull/954
