### PR TITLE
XMLDriver does not parse inversed-by when no Join is defined.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -501,11 +501,11 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToManyElement['mapped-by'])) {
                     $mapping['mappedBy'] = (string) $manyToManyElement['mapped-by'];
-                } else if (isset($manyToManyElement->{'join-table'})) {
-                    if (isset($manyToManyElement['inversed-by'])) {
-                        $mapping['inversedBy'] = (string) $manyToManyElement['inversed-by'];
-                    }
-
+                }
+                if (isset($manyToManyElement['inversed-by'])) {
+                    $mapping['inversedBy'] = (string) $manyToManyElement['inversed-by'];
+                }
+                if (isset($manyToManyElement->{'join-table'})) {
                     $joinTableElement = $manyToManyElement->{'join-table'};
                     $joinTable = array(
                         'name' => (string) $joinTableElement['name']


### PR DESCRIPTION
Since 2.5 (https://github.com/doctrine/doctrine2/issues/1749) the Join no longer required, but this causes an invalid warning because the "inversed-by" is not being parsed and added to the metadata of the association.

The warning:

```
The field Customer#accounts is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Account#customers does not contain the required 'inversedBy="accounts"' attribute.
```

The doctrine mapping xml's:

``` xml
   <entity name="Customer">
       ...
        <many-to-many target-entity="Account" field="accounts" mapped-by="customers" >
            <cascade>
                <cascade-all/>
            </cascade>
        </many-to-many>
    </entity>

    <entity name="Account">
        ...
        <many-to-many inversed-by="accounts" target-entity="Customer" field="customers">
            <cascade>
                <cascade-all/>
            </cascade>
        </many-to-many>
    </entity>
```
