### PR TITLE
Fix `custom-id-generator` XSD class attribute type: s/NMTOKEN/string

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -412,7 +412,7 @@
     <xs:sequence>
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
-    <xs:attribute name="class" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="class" type="xs:string" use="required" />
   </xs:complexType>
 
   <xs:complexType name="inverse-join-columns">


### PR DESCRIPTION
custom-id-generator tag's attribute type must be FQCN. But NMTOKEN type doesn't support backslash character.
