### PR TITLE
Included additional time units to DATE_ADD and DATE_SUB functions

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -20,9 +20,9 @@
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\Lexer;
-use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * "DATE_ADD" "(" ArithmeticPrimary "," ArithmeticPrimary "," StringPrimary ")"
@@ -51,6 +51,12 @@ class DateAddFunction extends FunctionNode
                     $this->intervalExpression->dispatch($sqlWalker)
                 );
 
+            case 'minute':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddMinutesExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             case 'hour':
                 return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddHourExpression(
                     $this->firstDateExpression->dispatch($sqlWalker),
@@ -62,15 +68,33 @@ class DateAddFunction extends FunctionNode
                     $this->intervalExpression->dispatch($sqlWalker)
                 );
 
+            case 'week':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddWeeksExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             case 'month':
                 return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddMonthExpression(
                     $this->firstDateExpression->dispatch($sqlWalker),
                     $this->intervalExpression->dispatch($sqlWalker)
                 );
 
+            case 'quarter':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddQuartersExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
+            case 'year':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateAddYearsExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             default:
                 throw QueryException::semanticalError(
-                    'DATE_ADD() only supports units of type second, hour, day and month.'
+                    'DATE_ADD() only supports units of type second, minute, hour, day, week, month, quarter and year.'
                 );
         }
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -39,6 +39,18 @@ class DateSubFunction extends DateAddFunction
     public function getSql(SqlWalker $sqlWalker)
     {
         switch (strtolower($this->unit->value)) {
+            case 'second':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubSecondsExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
+            case 'minute':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubMinutesExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             case 'hour':
                 return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubHourExpression(
                     $this->firstDateExpression->dispatch($sqlWalker),
@@ -50,15 +62,33 @@ class DateSubFunction extends DateAddFunction
                     $this->intervalExpression->dispatch($sqlWalker)
                 );
 
+            case 'week':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubWeeksExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             case 'month':
                 return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubMonthExpression(
                     $this->firstDateExpression->dispatch($sqlWalker),
                     $this->intervalExpression->dispatch($sqlWalker)
                 );
 
+            case 'quarter':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubQuartersExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
+            case 'year':
+                return $sqlWalker->getConnection()->getDatabasePlatform()->getDateSubYearsExpression(
+                    $this->firstDateExpression->dispatch($sqlWalker),
+                    $this->intervalExpression->dispatch($sqlWalker)
+                );
+
             default:
                 throw QueryException::semanticalError(
-                    'DATE_SUB() only supports units of type hour, day and month.'
+                    'DATE_SUB() only supports units of type second, minute, hour, day, week, month, quarter and year.'
                 );
         }
     }


### PR DESCRIPTION
I noticed there are a few time units missing from the DATE_ADD function, so I went ahead and added them. Once I added them, I repeated the process for the DATE_SUB function.
