### PR TITLE
Use constant consistently

### DIFF
--- a/docs/en/cookbook/mysql-enums.rst
+++ b/docs/en/cookbook/mysql-enums.rst
@@ -98,7 +98,7 @@ For example for the previous enum type:
 
         public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
-            return "ENUM('visible', 'invisible') COMMENT '(DC2Type:enumvisibility)'";
+            return sprintf("ENUM('visible', 'invisible') COMMENT '(DC2Type:%s)'", self::ENUM_VISIBILITY);
         }
 
         public function convertToPHPValue($value, AbstractPlatform $platform)


### PR DESCRIPTION
The type name returned by `getName()` must match the type name stored in the comment, otherwise the mapping will fail.

The example code should hence use the constant throughout, both for `getName()` and `getSQLDeclaration()`:

``` php
class EnumVisibilityType extends Type
{
    const ENUM_VISIBILITY = 'enumvisibility';
    const STATUS_VISIBLE = 'visible';
    const STATUS_INVISIBLE = 'invisible';

    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
    {
        // TODO: Use constant
        return "ENUM('visible', 'invisible') COMMENT '(DC2Type:enumvisibility)'";
    }

    public function convertToPHPValue($value, AbstractPlatform $platform)
    {
        return $value;
    }

    public function convertToDatabaseValue($value, AbstractPlatform $platform)
    {
        if (!in_array($value, array(self::STATUS_VISIBLE, self::STATUS_INVISIBLE))) {
            throw new \InvalidArgumentException("Invalid status");
        }
        return $value;
    }

    public function getName()
    {
        return self::ENUM_VISIBILITY;
    }
}
```
