### PR TITLE
Embeddable value object

### DIFF
--- a/lib/Doctrine/ORM/DoctrineValueObject.php
+++ b/lib/Doctrine/ORM/DoctrineValueObject.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\ORM;
+
+/**
+ * Every ValueObject which implements this interface can be safely
+ * set on an Entity property mapped for ORM.
+ *
+ * @package Doctrine\ORM
+ */
+interface DoctrineValueObject
+{
+    /**
+     * ValueObject should be usable as a string.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function equals($value);
+}

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -626,7 +626,7 @@ class UnitOfWork implements PropertyChangedListener
 
             foreach ($actualData as $propName => $actualValue) {
                 if ( ! isset($class->associationMappings[$propName])) {
-                    $changeSet[$propName] = array(null, (!$actualValue instanceof DoctrineValueObject) ?: $actualValue->toPhpValue());
+                    $changeSet[$propName] = array(null, $actualValue);
 
                     continue;
                 }
@@ -634,7 +634,7 @@ class UnitOfWork implements PropertyChangedListener
                 $assoc = $class->associationMappings[$propName];
 
                 if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {
-                    $changeSet[$propName] = array(null, (!$actualValue instanceof DoctrineValueObject) ?: $actualValue->toPhpValue());
+                    $changeSet[$propName] = array(null, $actualValue);
                 }
             }
 
@@ -661,12 +661,9 @@ class UnitOfWork implements PropertyChangedListener
                     continue;
                 }
 
-                if ($actualValue instanceof DoctrineValueObject) {
-                    if ($actualValue->equals($orgValue)) {
-                        continue;
-                    }
-
-                    $changeSet[$propName] = array($orgValue, $actualValue->toPhpValue());
+                // skip if value haven't changed
+                if ($actualValue instanceof DoctrineValueObject && $actualValue->equals($orgValue)) {
+                    continue;
                 }
 
                 // if regular field

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -626,7 +626,7 @@ class UnitOfWork implements PropertyChangedListener
 
             foreach ($actualData as $propName => $actualValue) {
                 if ( ! isset($class->associationMappings[$propName])) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = array(null, (!$actualValue instanceof DoctrineValueObject) ?: $actualValue->toPhpValue());
 
                     continue;
                 }
@@ -634,7 +634,7 @@ class UnitOfWork implements PropertyChangedListener
                 $assoc = $class->associationMappings[$propName];
 
                 if ($assoc['isOwningSide'] && $assoc['type'] & ClassMetadata::TO_ONE) {
-                    $changeSet[$propName] = array(null, $actualValue);
+                    $changeSet[$propName] = array(null, (!$actualValue instanceof DoctrineValueObject) ?: $actualValue->toPhpValue());
                 }
             }
 
@@ -659,6 +659,14 @@ class UnitOfWork implements PropertyChangedListener
                 // skip if value haven't changed
                 if ($orgValue === $actualValue) {
                     continue;
+                }
+
+                if ($actualValue instanceof DoctrineValueObject) {
+                    if ($actualValue->equals($orgValue)) {
+                        continue;
+                    }
+
+                    $changeSet[$propName] = array($orgValue, $actualValue->toPhpValue());
                 }
 
                 // if regular field

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2016Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2016Test.php
@@ -61,7 +61,7 @@ class DDC2016Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testDoctrineNotMarkAsChangedIfVOImplementsDoctrineValueObjectInterface()
     {
-        $metadata = $this->_em->getClassMetadata(DC2016UserWithVo::class);
+        $metadata = $this->_em->getClassMetadata(DC2016UserWithVo::CLASS_NAME);
         $uow      = $this->_em->getUnitOfWork();
 
         $txtUser  = 'validUser';
@@ -80,12 +80,12 @@ class DDC2016Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->getRepository(DC2016UserWithVo::class)->find($user->id);
-        $this->assertInstanceOf(DC2016UserWithVo::class, $user);
+        $user = $this->_em->getRepository(DC2016UserWithVo::CLASS_NAME)->find($user->id);
+        $this->assertInstanceOf(DC2016UserWithVo::CLASS_NAME, $user);
         $this->assertEquals($txtUser, (string)$user->getUsername());
 
         $username = $user->getUsername();
-        $this->assertInstanceOf(DC2016UsernameVo::class, $username);
+        $this->assertInstanceOf(DC2016UsernameVo::CLASS_NAME, $username);
 
         $uow->computeChangeSet($metadata, $user);
         $changeSet = $uow->getEntityChangeSet($user);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2016Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2016Test.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\DoctrineValueObject;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\MappedSuperclass;
+
+/**
+ * @group DDC-2016
+ */
+class DDC2016Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    /**
+     * Verifies that when eager loading is triggered, proxies are kept managed.
+     *
+     * The problem resides in the refresh hint passed to {@see \Doctrine\ORM\UnitOfWork::createEntity},
+     * which, as of DDC-1734, causes the proxy to be marked as un-managed.
+     * The check against the identity map only uses the identifier hash and the passed in class name, and
+     * does not take into account the fact that the set refresh hint may be for an entity of a different
+     * type from the one passed to {@see \Doctrine\ORM\UnitOfWork::createEntity}
+     *
+     * As a result, a refresh requested for an entity `Foo` with identifier `123` may cause a proxy
+     * of type `Bar` with identifier `123` to be marked as un-managed.
+     */
+    public function testIssue()
+    {
+        $metadata = $this->_em->getClassMetadata(DDC2016User::class);
+        $uow      = $this->_em->getUnitOfWork();
+
+        $username = new DDC2016Username('validUser');
+        $user     = new DDC2016User($username);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->getRepository(DDC2016User::class)->find($user->id);
+        $this->assertInstanceOf(DDC2016User::class, $user);
+
+        /*
+         * Call the getter which validate the DB value with Value Object and set the doctrine property to
+         * avoid duplicate validation and continuously re-creating the Value Object.
+         *
+         * Issue:
+         *
+         * Because we set the property, computeChangeSet will detect as a change and will update the entity.
+         */
+        $username = $user->getUsername();
+        $this->assertInstanceOf(DDC2016Username::class, $username);
+
+        $uow->computeChangeSet($metadata, $user);
+        $changeset = $uow->getEntityChangeSet($user);
+
+        /*
+         * User not changed, just called the getter, which create and validate! the data from db.
+         * Unfortunately, doctrine detect as a change and will mark property as changed.
+         */
+        $this->assertNotEmpty($changeset, 'Changeset not empty, but should!');
+    }
+
+    public function testDoctrineNotMarkAsChangedIfVOImplementsDoctrineValueObjectInterface()
+    {
+        $metadata = $this->_em->getClassMetadata(DC2016UserWithVo::class);
+        $uow      = $this->_em->getUnitOfWork();
+
+        $txtUser  = 'validUser';
+        $username = new DC2016UsernameVo($txtUser);
+        $user     = new DC2016UserWithVo($username);
+        $this->_em->persist($user);
+
+        $uow->computeChangeSet($metadata, $user);
+        $changeSet = $uow->getEntityChangeSet($user);
+
+        /*
+         * Changeset should hold the dbValue not the ValueObject.
+         */
+        $this->assertInternalType('string', $changeSet['username'][1]);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $user = $this->_em->getRepository(DC2016UserWithVo::class)->find($user->id);
+        $this->assertInstanceOf(DC2016UserWithVo::class, $user);
+        $this->assertEquals($txtUser, $user->getUsername()->toPhpValue());
+
+        $username = $user->getUsername();
+        $this->assertInstanceOf(DC2016UsernameVo::class, $username);
+
+        $uow->computeChangeSet($metadata, $user);
+        $changeSet = $uow->getEntityChangeSet($user);
+
+        /*
+         * We called the getter which set the Doctrine property to VO. Because of VO implements DoctrineValueObject,
+         * $changeSet should be an empty array.
+         */
+        $this->assertEmpty($changeSet, 'Changeset should empty now, because we implement DoctrineValueObject!');
+    }
+
+    public function testUsernameGetUsernameReturnUsername()
+    {
+        $usernameString = 'validUserName';
+
+        $username = new DDC2016Username($usernameString);
+
+        $this->assertEquals($usernameString, $username->getUsername());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testUsernameThrowExceptionOnNonString()
+    {
+        new DDC2016Username(123);
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testUsernameThrowExceptionOnInvalidUsername()
+    {
+        new DDC2016Username('invalidUser-INVALID');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2016User'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DC2016UserWithVo'),
+        ));
+    }
+
+    protected function tearDown()
+    {
+        $this->_schemaTool->dropSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DDC2016User'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\DC2016UserWithVo'),
+        ));
+
+        parent::tearDown();
+    }
+}
+
+/**
+ * @Entity
+ * @MappedSuperclass()
+ */
+class DDC2016User
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /**
+     * @var DDC2016Username
+     *
+     * @Column(type="string", length=128, nullable=false)
+     */
+    public $username;
+
+    /** Constructor
+     *
+     * @param DDC2016Username $username
+     */
+    public function __construct(DDC2016Username $username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return DDC2016Username
+     */
+    public function getUsername()
+    {
+        return ($this->username instanceof DDC2016Username)
+            ? $this->username
+            : $this->username = new DDC2016Username($this->username);
+    }
+
+    /**
+     * @param DDC2016Username $username
+     *
+     * @return $this
+     */
+    public function setUsername(DDC2016Username $username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+}
+
+/**
+ * Username ValueObject
+ */
+class DDC2016Username
+{
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @param string $username
+     *
+     * @throws \InvalidArgumentException If $username is not a string.
+     * @throws \UnexpectedValueException If $username is not acceptable.
+     */
+    public function __construct($username)
+    {
+        if ( ! is_string($username)) {
+            throw new \InvalidArgumentException(
+                sprintf('Username should be a string. [received: %s]', gettype($username))
+            );
+        }
+
+        if (preg_match('/.*-INVALID$/', $username)) {
+            throw new \UnexpectedValueException(
+                sprintf('Username not acceptable. [username: %s]', $username)
+            );
+        }
+
+        $this->username = $username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+}
+
+class DC2016UsernameVo extends DDC2016Username implements DoctrineValueObject
+{
+    public $test = 'valami';
+
+    /**
+     * @return mixed
+     */
+    public function toPhpValue()
+    {
+//        return $this->test;
+        return $this->getUsername();
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function equals($value)
+    {
+        if ($value instanceof DoctrineValueObject) {
+            return $this->getUsername() == $value->toPhpValue();
+        }
+
+        return $this->getUsername() == $value;
+    }
+}
+
+/**
+ * @Entity()
+ */
+class DC2016UserWithVo
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /**
+     * @var DDC2016Username
+     *
+     * @Column(type="string", length=128, nullable=false)
+     */
+    public $username;
+
+    /** Constructor
+     *
+     * @param DDC2016Username $username
+     */
+    public function __construct(DDC2016Username $username)
+    {
+        $this->username = $username;
+    }
+
+    public function getUsername()
+    {
+        return ($this->username instanceof DC2016UsernameVo)
+            ? $this->username
+            : $this->username = new DC2016UsernameVo($this->username);
+    }
+
+    /**
+     * @param DDC2016Username $username
+     *
+     * @return $this
+     */
+    public function setUsername(DDC2016Username $username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## Doctrine and Value Object (not Embeddable)

Many times I need to return with a  `Value Object` from an Entity. Frequently we simply create the Value Object in the Entity`s getter. When we do, we add extra cost every time when we call the getter, because it always create a new instance of a VO + need to convert back and forth the value in the Entity's setter / getter.

``` php
/**
 * @Entity
 */
class DDC2016User
{
    /** @Id @Column(type="integer") @GeneratedValue */
    public $id;

    /**
     * @var string
     *
     * @Column(type="string", length=128, nullable=false)
     */
    public $username;

    /** Constructor
     *
     * @param DDC2016Username $username
     */
    public function __construct(DDC2016Username $username)
    {
        $this->username = $username->__toString(); //Convert back
    }

    /**
     * @return DDC2016Username
     */
    public function getUsername()
    {
        return new Username($this->username); //Convert forth
    }
```

This PR add a `DoctrineValueObject` interface to the project. If a Value Object implements this interface, doctrine will call the `equals` method on the VO to compare instances instead of using the `===` comparison. Developer can define the rules how the changes has been determined.
## Example of usage:

``` php
/**
 * @Entity
 */
class DDC2016User
{
    /** @Id @Column(type="integer") @GeneratedValue */
    public $id;

    /**
     * @var string
     *
     * @Column(type="string", length=128, nullable=false)
     */
    public $username;

    /** Constructor
     *
     * @param DDC2016Username $username
     */
    public function __construct(DDC2016UsernameVO $username)
    {
        $this->username = $username; //Convert back gone away
    }

    /**
     * @return DDC2016Username
     */
    public function getUsername()
    {
        return ($this->username instanceof DDC2016UsernameVO)
                   ? $this->username
                   : $this->username = new Username($this->username); //Create instance one per lifecycle
    }
```
