### PR TITLE
Pre-flush event knows which entities are being flushed

### DIFF
--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -39,13 +39,20 @@ class PreFlushEventArgs extends EventArgs
     private $em;
 
     /**
+     * @var null|array
+     */
+    private $entities;
+
+    /**
      * Constructor.
      *
      * @param EntityManagerInterface $em
+     * @param null|array             $entities
      */
-    public function __construct(EntityManagerInterface $em)
+    public function __construct(EntityManagerInterface $em, array $entities = null)
     {
-        $this->em = $em;
+        $this->em       = $em;
+        $this->entities = $entities;
     }
 
     /**
@@ -54,5 +61,21 @@ class PreFlushEventArgs extends EventArgs
     public function getEntityManager()
     {
         return $this->em;
+    }
+
+    /**
+     * @return bool true if flushed for a specific set of entities (explicit flush).
+     */
+    public function hasEntities()
+    {
+        return null !== $this->entities;
+    }
+
+    /**
+     * @return null|array entities being flushed in an explicit flush.
+     */
+    public function getEntities()
+    {
+        return $this->entities;
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -323,7 +323,7 @@ class UnitOfWork implements PropertyChangedListener
     {
         // Raise preFlush
         if ($this->evm->hasListeners(Events::preFlush)) {
-            $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em));
+            $this->evm->dispatchEvent(Events::preFlush, new PreFlushEventArgs($this->em, is_object($entity) ? [$entity] : $entity));
         }
 
         // Compute changes done since last commit.
@@ -575,7 +575,7 @@ class UnitOfWork implements PropertyChangedListener
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::preFlush) & ~ListenersInvoker::INVOKE_MANAGER;
 
         if ($invoke !== ListenersInvoker::INVOKE_NONE) {
-            $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em), $invoke);
+            $this->listenersInvoker->invoke($class, Events::preFlush, $entity, new PreFlushEventArgs($this->em, is_object($entity) ? [$entity] : $entity), $invoke);
         }
 
         $actualData = array();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket5848Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket5848Test.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Doctrine\ORM\Events;
+
+class Ticket5848Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    private $collector;
+    private $listener;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->collector = new Ticket5848EntityCollector();
+        $this->listener  = new Ticket5848PreFlushListener();
+
+        $this->listener->collector = $this->collector;
+
+        try {
+            $this->_schemaTool->createSchema(array(
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\Ticket5848Authentication'),
+                $this->_em->getClassMetadata(__NAMESPACE__ . '\Ticket5848Client'),
+            ));
+        } catch (\Exception $e) {
+            // Swallow all exceptions. We do not test the schema tool here.
+        }
+
+
+        $this->_em->getEventManager()->addEventListener(Events::preFlush, $this->listener);
+    }
+
+    public function testExplicitFlushWithOne()
+    {
+        $e = new Ticket5848Client();
+
+        $this->_em->persist($e);
+        $this->_em->flush($e);
+
+        self::assertSame($e, $this->collector->entities[0]);
+    }
+
+    public function testExplicitFlushWithMany()
+    {
+        $e1 = new Ticket5848Client();
+        $e2 = new Ticket5848Authentication();
+        $e3 = new Ticket5848Client();
+
+        $this->_em->persist($e1);
+        $this->_em->persist($e2);
+        $this->_em->persist($e3);
+        $this->_em->flush([$e1, $e2]);
+
+        self::assertSame($e1, $this->collector->entities[0]);
+        self::assertSame($e2, $this->collector->entities[1]);
+    }
+
+    public function testExplicitFlushWithConsecutiveFlushes()
+    {
+        $e1 = new Ticket5848Client();
+        $e2 = new Ticket5848Authentication();
+        $e3 = new Ticket5848Client();
+
+        $this->_em->persist($e1);
+        $this->_em->persist($e2);
+        $this->_em->persist($e3);
+        $this->_em->flush([$e1, $e2]);
+        $this->_em->flush($e3);
+
+        self::assertSame($e3, $this->collector->entities[0]);
+    }
+
+    public function testImplicitFlush()
+    {
+        $e1 = new Ticket5848Client();
+        $e2 = new Ticket5848Authentication();
+        $e3 = new Ticket5848Client();
+
+        $this->_em->persist($e1);
+        $this->_em->persist($e2);
+        $this->_em->persist($e3);
+        $this->_em->flush();
+
+        self::assertSame($e1, $this->collector->entities[0]);
+        self::assertSame($e2, $this->collector->entities[1]);
+        self::assertSame($e3, $this->collector->entities[2]);
+    }
+
+    public function testExplicitFlushAfterImplicitFlush()
+    {
+        $e1 = new Ticket5848Client();
+        $e2 = new Ticket5848Authentication();
+        $e3 = new Ticket5848Client();
+
+        $this->_em->persist($e1);
+        $this->_em->persist($e2);
+        $this->_em->persist($e3);
+        $this->_em->flush();
+
+        self::assertSame($e1, $this->collector->entities[0]);
+        self::assertSame($e2, $this->collector->entities[1]);
+        self::assertSame($e3, $this->collector->entities[2]);
+
+        $e2->username = 'foo';
+
+        $this->_em->flush([$e2, $e3]);
+
+        self::assertSame($e2, $this->collector->entities[0]);
+        self::assertSame($e3, $this->collector->entities[1]);
+    }
+}
+
+class Ticket5848PreFlushListener
+{
+    public $collector;
+
+    public function preFlush(PreFlushEventArgs $event)
+    {
+        if (!$event->hasEntities()) {
+            $uow = $event->getEntityManager()->getUnitOfWork();
+            $uow->computeChangeSets();
+
+            $entities = array_values(array_merge($uow->getScheduledEntityInsertions(), $uow->getScheduledEntityUpdates()));
+        } else {
+            $entities = $event->getEntities();
+        }
+
+        $this->collector->entities = $entities;
+    }
+}
+
+class Ticket5848EntityCollector
+{
+    public $entities;
+}
+
+/**
+ * @Entity
+ * @Table(name="ticket_2481_authentications")
+ */
+class Ticket5848Authentication
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @column(type="string", nullable=true)
+     */
+    public $username;
+}
+
+/**
+ * @Entity
+ * @Table(name="ticket_2481_clients")
+ */
+class Ticket5848Client
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+}


### PR DESCRIPTION
**short description**
This PR focuses on adding the entities which are being flushed for explicit flushes to the PreFlushEvent (and if desired I can add other events too)

**A bit of background info**
For an event listener we need to know which fields have changed in an entity and we fire a custom entity changed event in case the entity is tracked. For normal requests this works fine but we hit a bottleneck in larger batches. The challenge we are facing is that we need to know if:
- The entity is tracked by our listener (`@Tracked` annotation)
- The entity state is changed (1 level deep, not recursive)

We're doing this pre-flush so that additional changes/new entities can be created and added to the 'to-be-changed-set', which results in being unable to use the doctrine changeset computation as it would run twice. We've created a lightweight variant for this but this is called for every single entity. We also create a new "entity" and use the hydration to create as it was in its original state when hydrated for the first time. This means we can compare/absorb the objects and know the exact changes and pass this along to our event: https://github.com/hostnet/entity-tracker-component/blob/master/src/Listener/EntityChangedListener.php

As we need to know which entities have changed to calculate the mutations and fire events, we have to check the internal state of the Unit of Work and calculate this. This is what you would expect from a `flush()`. However, if you have 1000 entities in memory and an explicit flush is done `flush(...)` or `flush([...]);` you already know which entities will be flushed. This makes it meaningless to iterate over all managed entities.

If this change is something you want to add, I will add tests (can't run the tests locally).
