### PR TITLE
Exporters should only inspect `joinColumns` for owning side in bi-directional OneToOne

### DIFF
--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -117,7 +117,7 @@ class PhpExporter extends AbstractExporter
                 $oneToOneMappingArray = array(
                     'mappedBy'      => $associationMapping['mappedBy'],
                     'inversedBy'    => $associationMapping['inversedBy'],
-                    'joinColumns'   => $associationMapping['joinColumns'],
+                    'joinColumns'   => $associationMapping['isOwningSide'] ? $associationMapping['joinColumns'] : [],
                     'orphanRemoval' => $associationMapping['orphanRemoval'],
                 );
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -163,7 +163,7 @@ class YamlExporter extends AbstractExporter
             }
 
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
-                $joinColumns = $associationMapping['joinColumns'];
+                $joinColumns = $associationMapping['isOwningSide'] ? $associationMapping['joinColumns'] : [];
                 $newJoinColumns = array();
 
                 foreach ($joinColumns as $joinColumn) {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -62,6 +62,18 @@ $metadata->mapOneToOne(array(
    'orphanRemoval' => true,
    'fetch' => ClassMetadataInfo::FETCH_EAGER,
   ));
+$metadata->mapOneToOne(array(
+    'fieldName' => 'cart',
+    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Cart',
+    'mappedBy' => 'user',
+    'cascade' =>
+        array(
+            0 => 'persist',
+        ),
+    'inversedBy' => NULL,
+    'orphanRemoval' => false,
+    'fetch' => ClassMetadataInfo::FETCH_EAGER,
+));
 $metadata->mapOneToMany(array(
    'fieldName' => 'phonenumbers',
    'targetEntity' => 'Doctrine\\Tests\\ORM\\Tools\\Export\\Phonenumber',

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
@@ -35,6 +35,12 @@
             <join-column name="address_id" referenced-column-name="id" on-delete="CASCADE" on-update="CASCADE"/>
         </one-to-one>
 
+        <one-to-one field="cart" target-entity="Doctrine\Tests\ORM\Tools\Export\Cart" mapped-by="user">
+            <cascade>
+                <cascade-remove/>
+            </cascade>
+        </one-to-one>
+
         <many-to-one field="mainGroup" target-entity="Doctrine\Tests\ORM\Tools\Export\Group" />
 
         <one-to-many field="phonenumbers" target-entity="Doctrine\Tests\ORM\Tools\Export\Phonenumber" mapped-by="user" orphan-removal="true" fetch="LAZY">

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -34,6 +34,10 @@ Doctrine\Tests\ORM\Tools\Export\User:
       inversedBy: user
       orphanRemoval: true
       fetch: EAGER
+    cart:
+      targetEntity: Doctrine\Tests\ORM\Tools\Export\Cart
+      mappedBy: user
+      cascade: [ remove ]
   manyToOne:
     mainGroup:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Group


### PR DESCRIPTION
After having run the YamlExporter in one of our projects there was a weird behavior when a bi-directional OneToOne association was defined.

I managed to replicate the behavior with adding an inversed bi-directional mapping to the test metadata:

`Doctrine.Tests.ORM.Tools.Export.User.dcm.yml`

```
#snip
  oneToOne:
    address:
      targetEntity: Doctrine\Tests\ORM\Tools\Export\Address
      joinColumn:
        name: address_id
        referencedColumnName: id
        onDelete: CASCADE
      cascade: [ persist ]
      inversedBy: user
      orphanRemoval: true
      fetch: EAGER
    cart:
      targetEntity: Doctrine\Tests\ORM\Tools\Export\Cart
      mappedBy: user
      cascade: [ remove ]
#snip
```

```
$ ./vendor/bin/phpunit -vv tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
PHPUnit 4.8.26-3-ga973e60 by Sebastian Bergmann and contributors.

Runtime:    PHP 5.6.22-1~dotdeb+7.1 with Xdebug 2.3.3
Configuration:  /vagrant/libs/doctrine2/phpunit.xml.dist

ESSSSSSSSSSSSSS

Time: 156 ms, Memory: 9.75MB

There was 1 error:

1) Doctrine\Tests\ORM\Tools\Export\YamlClassMetadataExporterTest::testExportDirectoryAndFilesAreCreated
Undefined index: joinColumns

/vagrant/libs/doctrine2/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php:166
/vagrant/libs/doctrine2/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php:138
/vagrant/libs/doctrine2/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php:121
```

So the problem is that the `joinColumn` array index is not set for the inversed side but will still be inspected. After applying the check for `$associationMapping['isOwningSide'] === true ? $associationMapping['joinColumns'] : array();` the export works as expected.

`Doctrine.Tests.ORM.Tools.Export.ExportedUser.dcm.yml`

```
# snip
    oneToOne:
        address:
            targetEntity: Doctrine\Tests\ORM\Tools\Export\Address
            cascade:
                - remove
                - persist
            fetch: EAGER
            mappedBy: null
            inversedBy: user
            joinColumns:
                address_id:
                    referencedColumnName: id
                    onDelete: CASCADE
            orphanRemoval: true
        cart:
            targetEntity: Doctrine\Tests\ORM\Tools\Export\Cart
            cascade:
                - remove
            fetch: LAZY
            mappedBy: user
            inversedBy: null
            joinColumns: {  }
            orphanRemoval: false
# snip
```

**EDIT**

Same applies to the `PhpExporter` when duplicating the test case to the test metadata:

```
$ ./vendor/bin/phpunit -vv tests/Doctrine/Tests/ORM/Tools/Export
PHPUnit 4.8.26-3-ga973e60 by Sebastian Bergmann and contributors.

Runtime:    PHP 5.6.22-1~dotdeb+7.1 with Xdebug 2.3.3
Configuration:  /vagrant/libs/doctrine2/phpunit.xml.dist

......S.......SESSSSSSSSSSSSSS......................S........

Time: 410 ms, Memory: 13.00MB

There was 1 error:

1) Doctrine\Tests\ORM\Tools\Export\PhpClassMetadataExporterTest::testExportDirectoryAndFilesAreCreated
Undefined index: joinColumns

/vagrant/libs/doctrine2/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php:120
/vagrant/libs/doctrine2/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php:138
/vagrant/libs/doctrine2/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php:125
```
