### PR TITLE
Remove EOL PHP 5.4 from `.travis.yml` and `composer.json` - Fixes #5862

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -28,10 +27,6 @@ after_script:
 
 matrix:
   include:
-    - php: 5.4
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
     - php: 5.5
       env: DB=mariadb
       addons:
@@ -49,10 +44,6 @@ matrix:
       addons:
         mariadb: 5.5
 
-    - php: 5.4
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
     - php: 5.5
       env: DB=mariadb
       addons:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",


### PR DESCRIPTION
See https://github.com/doctrine/doctrine2/issues/5862 for more info
