### PR TITLE
Entity listeners are now processed by exporters

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1008,6 +1008,7 @@ public function __construct(<params>)
                 'generateDiscriminatorColumnAnnotation',
                 'generateDiscriminatorMapAnnotation',
                 'generateEntityAnnotation',
+                'generateEntityListenerAnnotation',
             );
 
             foreach ($methods as $method) {
@@ -1739,6 +1740,33 @@ public function __construct(<params>)
         $lines[] = $this->spaces . ' */';
 
         return implode("\n", $lines);
+    }
+
+    /**
+     * @param ClassMetadataInfo $metadata
+     *
+     * @return string
+     */
+    protected function generateEntityListenerAnnotation(ClassMetadataInfo $metadata)
+    {
+        if (0 === count($metadata->entityListeners)) {
+            return '';
+        }
+
+        $processedClasses = [];
+
+        foreach ($metadata->entityListeners as $event => $eventListeners) {
+            foreach ($eventListeners as $eventListener) {
+                $processedClasses[] = '"' . $eventListener['class'] . '"';
+            }
+        }
+
+        return sprintf(
+            '%s%s({%s})',
+            '@' . $this->annotationsPrefix,
+            'EntityListeners',
+            implode(',', array_unique($processedClasses))
+        );
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -82,6 +82,16 @@ class PhpExporter extends AbstractExporter
             }
         }
 
+        if (0 !== count($metadata->entityListeners)) {
+            foreach ($metadata->entityListeners as $event => $entityListenerConfig) {
+                foreach ($entityListenerConfig as $entityListener) {
+                    $class = $entityListener['class'];
+                    $method = $entityListener['method'];
+                    $lines[] = "\$metadata->addEntityListener('$event', '$class', '$method');";
+                }
+            }
+        }
+
         foreach ($metadata->fieldMappings as $fieldMapping) {
             $lines[] = '$metadata->mapField(' . $this->_varExport($fieldMapping) . ');';
         }

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -389,6 +389,27 @@ class XmlExporter extends AbstractExporter
             }
         }
 
+        if (0 !== count($metadata->entityListeners)) {
+            $entityListenersXml = $root->addChild('entity-listeners');
+            $entityListenersXmlMap = [];
+
+            foreach ($metadata->entityListeners as $event => $entityListenerConfig) {
+                foreach ($entityListenerConfig as $entityListener) {
+                    if (!isset($entityListenersXmlMap[$entityListener['class']])) {
+                        $entityListenerXml = $entityListenersXml->addChild('entity-listener');
+                        $entityListenerXml->addAttribute('class', $entityListener['class']);
+                        $entityListenersXmlMap[$entityListener['class']] = $entityListenerXml;
+                    } else {
+                        $entityListenerXml = $entityListenersXmlMap[$entityListener['class']];
+                    }
+
+                    $entityListenerCallbackXml = $entityListenerXml->addChild('lifecycle-callback');
+                    $entityListenerCallbackXml->addAttribute('type', $event);
+                    $entityListenerCallbackXml->addAttribute('method', $entityListener['method']);
+                }
+            }
+        }
+
         return $this->_asXml($xml);
     }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -214,6 +214,23 @@ class YamlExporter extends AbstractExporter
             $array['lifecycleCallbacks'] = $metadata->lifecycleCallbacks;
         }
 
+        if (0 !== count($metadata->entityListeners)) {
+            $array['entityListeners'] = [];
+
+            foreach ($metadata->entityListeners as $event => $entityListenerConfig) {
+                foreach ($entityListenerConfig as $entityListener) {
+                    if (!isset($array['entityListeners'][$entityListener['class']])) {
+                        $array['entityListeners'][$entityListener['class']] = null;
+                    }
+
+                    if (isset($entityListener['method'])) {
+                        $array['entityListeners'][$entityListener['class']][$event] = [$entityListener['method']];
+                    }
+                }
+
+            }
+        }
+
         return $this->yamlDump(array($metadata->name => $array), 10);
     }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -22,6 +22,7 @@
 namespace Doctrine\Tests\ORM\Tools\Export;
 
 use Doctrine\ORM\Configuration;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Tools\Export\ClassMetadataExporter;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Tools\EntityGenerator;
@@ -361,7 +362,8 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
     {
         $this->assertEquals('user', $class->associationMappings['address']['inversedBy']);
     }
-	/**
+
+    /**
      * @depends testExportDirectoryAndFilesAreCreated
      */
     public function testCascadeAllCollapsed()
@@ -386,6 +388,28 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
         } else {
             $this->markTestSkipped('Test not available for '.$type.' driver');
         }
+    }
+
+    /**
+     * @depends testExportedMetadataCanBeReadBackIn
+     *
+     * @param ClassMetadata $class
+     */
+    public function testEntityListenersGetExported($class)
+    {
+        $this->assertNotEmpty($class->entityListeners);
+
+        $this->assertCount(2, $class->entityListeners[Events::prePersist]);
+        $this->assertCount(2, $class->entityListeners[Events::postPersist]);
+
+        $this->assertEquals(UserListener::class, $class->entityListeners[Events::prePersist][0]['class']);
+        $this->assertEquals('customPrePersist', $class->entityListeners[Events::prePersist][0]['method']);
+        $this->assertEquals(GroupListener::class, $class->entityListeners[Events::prePersist][1]['class']);
+        $this->assertEquals('prePersist', $class->entityListeners[Events::prePersist][1]['method']);
+        $this->assertEquals(UserListener::class, $class->entityListeners[Events::postPersist][0]['class']);
+        $this->assertEquals('customPostPersist', $class->entityListeners[Events::postPersist][0]['method']);
+        $this->assertEquals(AddressListener::class, $class->entityListeners[Events::postPersist][1]['class']);
+        $this->assertEquals('customPostPersist', $class->entityListeners[Events::postPersist][1]['method']);
     }
 
     public function __destruct()
@@ -422,4 +446,30 @@ class Phonenumber
 class Group
 {
 
+}
+class UserListener
+{
+    /**
+     * @\Doctrine\ORM\Mapping\PrePersist
+     */
+    public function customPrePersist() {}
+
+    /**
+     * @\Doctrine\ORM\Mapping\PostPersist
+     */
+    public function customPostPersist() {}
+}
+class GroupListener
+{
+    /**
+     * @\Doctrine\ORM\Mapping\PrePersist
+     */
+    public function prePersist() {}
+}
+class AddressListener
+{
+    /**
+     * @\Doctrine\ORM\Mapping\PostPersist
+     */
+    public function customPostPersist() {}
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/annotation/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -4,8 +4,13 @@ namespace Doctrine\Tests\ORM\Tools\Export;
 
 /**
  * @Entity
- * @HasLifecycleCallbacks
  * @Table(name="cms_users",options={"engine"="MyISAM","foo"={"bar"="baz"}})
+ * @EntityListeners({
+ *     "Doctrine\Tests\ORM\Tools\Export\UserListener",
+ *     "Doctrine\Tests\ORM\Tools\Export\GroupListener",
+ *     "Doctrine\Tests\ORM\Tools\Export\AddressListener"
+ * })
+ * @HasLifecycleCallbacks
  */
 class User
 {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -1,7 +1,12 @@
 <?php
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Events;
+use Doctrine\Tests\ORM\Tools\Export\UserListener;
+use Doctrine\Tests\ORM\Tools\Export\GroupListener;
+use Doctrine\Tests\ORM\Tools\Export\AddressListener;
 
+/** @var \Doctrine\ORM\Mapping\ClassMetadata $metadata */
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(array(
    'name' => 'cms_users',
@@ -128,3 +133,7 @@ $metadata->mapManyToMany(array(
    ),
    'orderBy' => NULL,
   ));
+$metadata->addEntityListener(Events::prePersist, UserListener::class, 'customPrePersist');
+$metadata->addEntityListener(Events::postPersist, UserListener::class, 'customPostPersist');
+$metadata->addEntityListener(Events::prePersist, GroupListener::class, 'prePersist');
+$metadata->addEntityListener(Events::postPersist, AddressListener::class, 'customPostPersist');

--- a/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/xml/Doctrine.Tests.ORM.Tools.Export.User.dcm.xml
@@ -77,6 +77,19 @@
             </join-table>
         </many-to-many>
 
+        <entity-listeners>
+            <entity-listener class="Doctrine\Tests\ORM\Tools\Export\UserListener">
+                <lifecycle-callback type="prePersist" method="customPrePersist" />
+                <lifecycle-callback type="postPersist" method="customPostPersist" />
+            </entity-listener>
+            <entity-listener class="Doctrine\Tests\ORM\Tools\Export\GroupListener">
+                <lifecycle-callback type="prePersist" method="prePersist" />
+            </entity-listener>
+            <entity-listener class="Doctrine\Tests\ORM\Tools\Export\AddressListener">
+                <lifecycle-callback type="postPersist" method="customPostPersist" />
+            </entity-listener>
+        </entity-listeners>
+
     </entity>
 
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -75,3 +75,11 @@ Doctrine\Tests\ORM\Tools\Export\User:
   lifecycleCallbacks:
     prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ] 
     postPersist: [ doStuffOnPostPersist ] 
+  entityListeners:
+    Doctrine\Tests\ORM\Tools\Export\UserListener:
+       prePersist: [customPrePersist]
+       postPersist: [customPostPersist]
+    Doctrine\Tests\ORM\Tools\Export\GroupListener:
+       prePersist: [prePersist]
+    Doctrine\Tests\ORM\Tools\Export\AddressListener:
+       postPersist: [customPostPersist]


### PR DESCRIPTION
The current implementation of the exporters are not taking the entity
listeners into account. I have added test cases for most of the edge
cases I could think of and implemented the Exporter handling.

Again there are some test cases failing but I cannot see how they
are related.
