### PR TITLE
Allow the usage of embedded objects on parent classes.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -941,8 +941,13 @@ class ClassMetadataInfo implements ClassMetadata
                 continue;
             }
 
-            $parentReflFields[$property] = $reflService->getAccessibleProperty($this->name, $property);
-            $this->reflFields[$property] = $reflService->getAccessibleProperty($this->name, $property);
+            $fieldRefl = $reflService->getAccessibleProperty(
+                isset($embeddedClass['declared']) ? $embeddedClass['declared'] : $this->name,
+                $property
+            );
+
+            $parentReflFields[$property] = $fieldRefl;
+            $this->reflFields[$property] = $fieldRefl;
         }
 
         foreach ($this->fieldMappings as $field => $mapping) {

--- a/tests/Doctrine/Tests/Models/DDC3303/DDC3303Address.php
+++ b/tests/Doctrine/Tests/Models/DDC3303/DDC3303Address.php
@@ -1,0 +1,60 @@
+<?php
+namespace Doctrine\Tests\Models\DDC3303;
+
+/**
+ * @Embeddable
+ */
+class DDC3303Address
+{
+    /**
+     * @Column(type="string")
+     *
+     * @var string
+     */
+    private $street;
+
+    /**
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    private $number;
+
+    /**
+     * @Column(type="string")
+     *
+     * @var string
+     */
+    private $city;
+
+    public function __construct($street, $number, $city)
+    {
+        $this->street = $street;
+        $this->number = $number;
+        $this->city = $city;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStreet()
+    {
+        return $this->street;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3303/DDC3303Employee.php
+++ b/tests/Doctrine/Tests/Models/DDC3303/DDC3303Employee.php
@@ -1,0 +1,39 @@
+<?php
+namespace Doctrine\Tests\Models\DDC3303;
+
+/**
+ * @Entity
+ * @Table(name="ddc3303_employee")
+ */
+class DDC3303Employee extends DDC3303Person
+{
+    /**
+     * @Column(type="string")
+     *
+     * @var string
+     */
+    private $company;
+
+    public function __construct($name, DDC3303Address $address, $company)
+    {
+        parent::__construct($name, $address);
+
+        $this->company = $company;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompany()
+    {
+        return $this->company;
+    }
+
+    /**
+     * @param string $company
+     */
+    public function setCompany($company)
+    {
+        $this->company = $company;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC3303/DDC3303Person.php
+++ b/tests/Doctrine/Tests/Models/DDC3303/DDC3303Person.php
@@ -1,0 +1,61 @@
+<?php
+namespace Doctrine\Tests\Models\DDC3303;
+
+/**
+ * @MappedSuperclass
+ */
+abstract class DDC3303Person
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @Column(type="string")
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @Embedded(class="DDC3303Address")
+     *
+     * @var DDC3303Address
+     */
+    private $address;
+
+    public function __construct($name, DDC3303Address $address)
+    {
+        $this->name = $name;
+        $this->address = $address;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return DDC3303Address
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
@@ -1,0 +1,32 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\DDC3303\DDC3303Address;
+use Doctrine\Tests\Models\DDC3303\DDC3303Employee;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class DDC3303Test extends OrmFunctionalTestCase
+{
+    /**
+     * @before
+     */
+    public function createSchema()
+    {
+        $this->_schemaTool->createSchema(array($this->_em->getClassMetadata(DDC3303Employee::class)));
+    }
+
+    public function testEmbeddedObjectsAreAlsoInherited()
+    {
+        $employee = new DDC3303Employee(
+            'John Doe',
+            new DDC3303Address('Somewhere', 123, 'Over the rainbow'),
+            'Doctrine Inc'
+        );
+
+        $this->_em->persist($employee);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->assertEquals($employee, $this->_em->find(DDC3303Employee::class, 1));
+    }
+}


### PR DESCRIPTION
The `ClassMetadataInfo` was always using the "current class" to fetch the reflection of a property even when a field is declared on the parent class (which causes `ReflectionProperty` to throw an exception).
