### PR TITLE
Improved Output in Validation with no Entities

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -76,7 +76,9 @@ EOT
 
         if ($input->getOption('skip-mapping')) {
             $output->writeln('<comment>[Mapping]  Skipped mapping check.</comment>');
-        } elseif ($errors = $validator->validateMapping()) {
+        } elseif (($errors = $validator->validateMapping()) === false) {
+            $output->writeln('<error>[Mapping]  FAIL - No entities defined!</error>');
+        } elseif (count($errors) > 0) {
             foreach ($errors as $className => $errorMessages) {
                 $output->writeln("<error>[Mapping]  FAIL - The entity-class '" . $className . "' mapping is invalid:</error>");
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -67,6 +67,10 @@ class SchemaValidator
         $cmf = $this->em->getMetadataFactory();
         $classes = $cmf->getAllMetadata();
 
+        if (count($classes) === 0) {
+            return false;
+        }
+
         foreach ($classes as $class) {
             if ($ce = $this->validateClass($class)) {
                 $errors[$class->name] = $ce;

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -2,9 +2,12 @@
 
 namespace Doctrine\Tests\ORM\Tools;
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\ORM\Configuration;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 
 class SchemaValidatorTest extends OrmTestCase
 {
@@ -22,6 +25,22 @@ class SchemaValidatorTest extends OrmTestCase
     {
         $this->em = $this->_getTestEntityManager();
         $this->validator = new SchemaValidator($this->em);
+    }
+
+    public function testZeroEntitiesValidation()
+    {
+        // set up entity manager with no mapping files
+        $config = new Configuration();
+        $config->setMetadataDriverImpl(new ZeroEntitiesMappingDriver());
+        $config->setProxyDir(__DIR__ . '/Proxies');
+        $config->setProxyNamespace('Doctrine\Tests\Proxies');
+        $em = $this->_getTestEntityManager(null, $config, null, true);
+
+        // setup new validator for $em
+        $validator = new SchemaValidator($em);
+
+        $result = $validator->validateMapping();
+        $this->assertFalse($result);
     }
 
     public function testCmsModelSet()
@@ -521,4 +540,19 @@ class DDC3322Three
      * @OrderBy({"oneToOneInverse" = "ASC"})
      */
     private $invalidAssoc;
+}
+
+class ZeroEntitiesMappingDriver implements MappingDriver
+{
+    public function loadMetadataForClass($className, ClassMetadata $metadata) {
+        return;
+    }
+
+    public function getAllClassNames() {
+        return array();
+    }
+
+    public function isTransient($className) {
+        return false;
+    }
 }

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -116,22 +116,24 @@ abstract class OrmTestCase extends DoctrineTestCase
      *
      * @return \Doctrine\ORM\EntityManager
      */
-    protected function _getTestEntityManager($conn = null, $conf = null, $eventManager = null, $withSharedMetadata = true)
+    protected function _getTestEntityManager($conn = null, $config = null, $eventManager = null, $withSharedMetadata = true)
     {
         $metadataCache = $withSharedMetadata
             ? self::getSharedMetadataCacheImpl()
             : new ArrayCache();
 
-        $config = new Configuration();
+        if (is_null($config)) {
+            $config = new Configuration();
 
-        $config->setMetadataCacheImpl($metadataCache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
-        $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
-        $config->setProxyDir(__DIR__ . '/Proxies');
-        $config->setProxyNamespace('Doctrine\Tests\Proxies');
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(
-            realpath(__DIR__ . '/Models/Cache')
-        ), true));
+            $config->setMetadataCacheImpl($metadataCache);
+            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(), true));
+            $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
+            $config->setProxyDir(__DIR__ . '/Proxies');
+            $config->setProxyNamespace('Doctrine\Tests\Proxies');
+            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(array(
+                realpath(__DIR__ . '/Models/Cache')
+            ), true));
+        }
 
         if ($this->isSecondLevelCacheEnabled) {
 


### PR DESCRIPTION
Instead of "OK - The mapping files are correct" it now says "FAIL - No
entities defined!".

Maybe someone can help me write a correct test for the
ValidateSchemaCommand, I wasn't able to provide that, mostly because
there is no test for this command yet.
