### PR TITLE
Make test suite compatible with PHPUnit 5.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^5.4"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -2,8 +2,11 @@
 
 namespace Doctrine\Tests\ORM\Cache;
 
-use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\ORM\Cache\CacheConfiguration;
+use Doctrine\ORM\Cache\CacheFactory;
+use Doctrine\ORM\Cache\QueryCacheValidator;
+use Doctrine\ORM\Cache\Logging\CacheLogger;
+use Doctrine\Tests\DoctrineTestCase;
 
 /**
  * @group DDC-2183
@@ -42,7 +45,7 @@ class CacheConfigTest extends DoctrineTestCase
 
     public function testSetGetCacheLogger()
     {
-        $logger = $this->getMock('Doctrine\ORM\Cache\Logging\CacheLogger');
+        $logger = $this->createMock(CacheLogger::class);
 
         $this->assertNull($this->config->getCacheLogger());
 
@@ -53,7 +56,7 @@ class CacheConfigTest extends DoctrineTestCase
 
     public function testSetGetCacheFactory()
     {
-        $factory = $this->getMock('Doctrine\ORM\Cache\CacheFactory');
+        $factory = $this->createMock(CacheFactory::class);
 
         $this->assertNull($this->config->getCacheFactory());
 
@@ -64,7 +67,7 @@ class CacheConfigTest extends DoctrineTestCase
 
     public function testSetGetQueryValidator()
     {
-        $validator = $this->getMock('Doctrine\ORM\Cache\QueryCacheValidator');
+        $validator = $this->createMock(QueryCacheValidator::class);
 
         $this->assertInstanceOf('Doctrine\ORM\Cache\TimestampQueryCacheValidator', $this->config->getQueryValidator());
 

--- a/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Cache;
 
+use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\Logging\CacheLoggerChain;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\EntityCacheKey;
@@ -29,7 +30,7 @@ class CacheLoggerChainTest extends DoctrineTestCase
         parent::setUp();
 
         $this->logger = new CacheLoggerChain();
-        $this->mock   = $this->getMock('Doctrine\ORM\Cache\Logging\CacheLogger');
+        $this->mock   = $this->createMock(CacheLogger::class);
     }
 
     public function testGetAndSetLogger()

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Cache;
 
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use \Doctrine\Tests\OrmTestCase;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -39,9 +41,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->em               = $this->_getTestEntityManager();
         $this->regionsConfig    = new RegionsConfiguration;
         $arguments              = array($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
-        $this->factory          = $this->getMock('\Doctrine\ORM\Cache\DefaultCacheFactory', array(
-            'getRegion'
-        ), $arguments);
+        $this->factory          = $this->getMockBuilder(DefaultCacheFactory::class)
+                                       ->setMethods(array('getRegion'))
+                                       ->setConstructorArgs($arguments)
+                                       ->getMock();
     }
 
     public function testImplementsCacheFactory()
@@ -284,7 +287,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
     public function testBuildsDefaultCacheRegionFromGenericCacheRegion()
     {
         /* @var $cache \Doctrine\Common\Cache\Cache */
-        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache = $this->createMock(Cache::class);
 
         $factory = new DefaultCacheFactory($this->regionsConfig, $cache);
 
@@ -300,7 +303,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
     public function testBuildsMultiGetCacheRegionFromGenericCacheRegion()
     {
         /* @var $cache \Doctrine\Common\Cache\CacheProvider */
-        $cache = $this->getMockForAbstractClass('Doctrine\Common\Cache\CacheProvider');
+        $cache = $this->getMockForAbstractClass(CacheProvider::class);
 
         $factory = new DefaultCacheFactory($this->regionsConfig, $cache);
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Cache;
 
 use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
@@ -66,11 +67,11 @@ class DefaultRegionTest extends AbstractRegionTest
     public function testEvictAllWithGenericCacheThrowsUnsupportedException()
     {
         /* @var $cache \Doctrine\Common\Cache\Cache */
-        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache = $this->createMock(Cache::class);
 
         $region = new DefaultRegion('foo', $cache);
 
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
 
         $region->evictAll();
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -80,10 +80,9 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
 
         $this->em                   = $this->_getTestEntityManager();
         $this->region               = $this->createRegion();
-        $this->collectionPersister  = $this->getMock(
-            'Doctrine\ORM\Persisters\Collection\CollectionPersister',
-            $this->collectionPersisterMockMethods
-        );
+        $this->collectionPersister  = $this->getMockBuilder(CollectionPersister::class)
+                                           ->setMethods($this->collectionPersisterMockMethods)
+                                           ->getMock();
     }
 
     /**
@@ -91,7 +90,9 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
      */
     protected function createRegion()
     {
-        return $this->getMock('Doctrine\ORM\Cache\Region', $this->regionMockMethods);
+        return $this->getMockBuilder(Region::class)
+                    ->setMethods($this->regionMockMethods)
+                    ->getMock();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
+use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
@@ -40,7 +41,9 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
      */
     protected function createRegion()
     {
-        return $this->getMock('Doctrine\ORM\Cache\ConcurrentRegion', $this->regionMockMethods);
+        return $this->getMockBuilder(ConcurrentRegion::class)
+                    ->setMethods($this->regionMockMethods)
+                    ->getMock();
     }
 
     public function testDeleteShouldLockItem()

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -99,10 +99,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
 
         $this->em               = $this->_getTestEntityManager();
         $this->region           = $this->createRegion();
-        $this->entityPersister  = $this->getMock(
-            'Doctrine\ORM\Persisters\Entity\EntityPersister',
-            $this->entityPersisterMockMethods
-        );
+        $this->entityPersister  = $this->getMockBuilder(EntityPersister::class)
+                                       ->setMethods($this->entityPersisterMockMethods)
+                                       ->getMock();
     }
 
     /**
@@ -110,7 +109,9 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
      */
     protected function createRegion()
     {
-        return $this->getMock('Doctrine\ORM\Cache\Region', $this->regionMockMethods);
+        return $this->getMockBuilder(Region::class)
+                    ->setMethods($this->regionMockMethods)
+                    ->getMock();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
+use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Cache\Lock;
@@ -41,7 +42,9 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
      */
     protected function createRegion()
     {
-        return $this->getMock('Doctrine\ORM\Cache\ConcurrentRegion', $this->regionMockMethods);
+        return $this->getMockBuilder(ConcurrentRegion::class)
+                    ->setConstructorArgs($this->regionMockMethods)
+                    ->getMock();
     }
 
     public function testDeleteShouldLockItem()

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Decorator;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 
 class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
@@ -11,7 +12,7 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->wrapped = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->wrapped = $this->createMock(EntityManagerInterface::class);
         $this->decorator = $this->getMockBuilder('Doctrine\ORM\Decorator\EntityManagerDecorator')
             ->setConstructorArgs(array($this->wrapped))
             ->setMethods(null)

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM;
 
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\OrmTestCase;
 
@@ -142,8 +144,9 @@ class EntityManagerTest extends OrmTestCase
      * @dataProvider dataMethodsAffectedByNoObjectArguments
      */
     public function testThrowsExceptionOnNonObjectValues($methodName) {
-        $this->setExpectedException('Doctrine\ORM\ORMInvalidArgumentException',
-            'EntityManager#'.$methodName.'() expects parameter 1 to be an entity object, NULL given.');
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage('EntityManager#' . $methodName . '() expects parameter 1 to be an entity object, NULL given.');
+
         $this->_em->$methodName(null);
     }
 
@@ -164,7 +167,8 @@ class EntityManagerTest extends OrmTestCase
      */
     public function testAffectedByErrorIfClosedException($methodName)
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'closed');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('closed');
 
         $this->_em->close();
         $this->_em->$methodName(new \stdClass());
@@ -189,7 +193,9 @@ class EntityManagerTest extends OrmTestCase
 
     public function testTransactionalThrowsInvalidArgumentExceptionIfNonCallablePassed()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Expected argument of type "callable", got "object"');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected argument of type "callable", got "object"');
+
         $this->_em->transactional($this);
     }
 

--- a/tests/Doctrine/Tests/ORM/Event/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Doctrine/Tests/ORM/Event/OnClassMetadataNotFoundEventArgsTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use PHPUnit_Framework_TestCase;
 
@@ -15,7 +17,7 @@ class OnClassMetadataNotFoundEventArgsTest extends PHPUnit_Framework_TestCase
     public function testEventArgsMutability()
     {
         /* @var $objectManager \Doctrine\Common\Persistence\ObjectManager */
-        $objectManager = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $objectManager = $this->createMock(ObjectManager::class);
 
         $args = new OnClassMetadataNotFoundEventArgs('foo', $objectManager);
 
@@ -25,7 +27,7 @@ class OnClassMetadataNotFoundEventArgsTest extends PHPUnit_Framework_TestCase
         $this->assertNull($args->getFoundMetadata());
 
         /* @var $metadata \Doctrine\Common\Persistence\Mapping\ClassMetadata */
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock(ClassMetadata::class);
 
         $args->setFoundMetadata($metadata);
 

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -1118,7 +1119,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $user->username = 'domnikl';
         $user->status = 'developer';
 
-        $this->setExpectedException('InvalidArgumentException', 'Entity has to be managed or scheduled for removal for single computation');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entity has to be managed or scheduled for removal for single computation');
+
         $this->_em->flush($user);
     }
 
@@ -1195,7 +1198,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $article1->author = $user;
         $user->articles[] = $article1;
 
-        $this->setExpectedException('InvalidArgumentException', "A new entity was found through the relationship 'Doctrine\Tests\Models\CMS\CmsUser#articles'");
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("A new entity was found through the relationship 'Doctrine\Tests\Models\CMS\CmsUser#articles'");
+
         $this->_em->flush($user);
     }
 
@@ -1291,10 +1296,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $user->status = 'developer';
         $user->address = $user;
 
-        $this->setExpectedException(
-            'Doctrine\ORM\ORMInvalidArgumentException',
-            'Expected value of type "Doctrine\Tests\Models\CMS\CmsAddress" for association field '
-            . '"Doctrine\Tests\Models\CMS\CmsUser#$address", got "Doctrine\Tests\Models\CMS\CmsUser" instead.'
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Expected value of type "Doctrine\Tests\Models\CMS\CmsAddress" for association field ' .
+            '"Doctrine\Tests\Models\CMS\CmsUser#$address", got "Doctrine\Tests\Models\CMS\CmsUser" instead.'
         );
 
         $this->_em->persist($user);

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\Models\Navigation\NavCountry;
 use Doctrine\Tests\Models\Navigation\NavPointOfInterest;
 use Doctrine\Tests\Models\Navigation\NavTour;
@@ -67,7 +69,9 @@ class CompositePrimaryKeyTest extends OrmFunctionalTestCase
 
         $dql = 'SELECT t FROM Doctrine\Tests\Models\Navigation\NavPhotos t WHERE t.poi = ?1';
 
-        $this->setExpectedException('Doctrine\ORM\Query\QueryException', 'A single-valued association path expression to an entity with a composite primary key is not supported.');
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('A single-valued association path expression to an entity with a composite primary key is not supported.');
+
         $sql = $this->_em->createQuery($dql)->getSQL();
     }
 
@@ -133,13 +137,17 @@ class CompositePrimaryKeyTest extends OrmFunctionalTestCase
 
     public function testSpecifyUnknownIdentifierPrimaryKeyFails()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'The identifier long is missing for a query of Doctrine\Tests\Models\Navigation\NavPointOfInterest');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('The identifier long is missing for a query of Doctrine\Tests\Models\Navigation\NavPointOfInterest');
+
         $poi = $this->_em->find('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('key1' => 100));
     }
 
     public function testUnrecognizedIdentifierFieldsOnGetReference()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', "Unrecognized identifier fields: 'key1'");
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage("Unrecognized identifier fields: 'key1'");
+
         $poi = $this->_em->getReference('Doctrine\Tests\Models\Navigation\NavPointOfInterest', array('lat' => 10, 'long' => 20, 'key1' => 100));
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\OptimisticLockException;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -217,7 +218,9 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $sql = "UPDATE cms_articles SET version = version+1 WHERE id = " . $article->id;
         $this->_em->getConnection()->executeUpdate($sql);
 
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException', 'The optimistic lock failed, version 1 was expected, but is actually 2');
+        $this->expectException(OptimisticLockException::class);
+        $this->expectExceptionMessage('The optimistic lock failed, version 1 was expected, but is actually 2');
+
         $this->_em->merge($article);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -4,6 +4,9 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\TransactionRequiredException;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsAddress;
@@ -291,7 +294,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testPessimisticReadLockWithoutTransaction_ThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\TransactionRequiredException');
+        $this->expectException(TransactionRequiredException::class);
 
         $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
                   ->find(1, LockMode::PESSIMISTIC_READ);
@@ -303,7 +306,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testPessimisticWriteLockWithoutTransaction_ThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\TransactionRequiredException');
+        $this->expectException(TransactionRequiredException::class);
 
         $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
                   ->find(1, LockMode::PESSIMISTIC_WRITE);
@@ -315,7 +318,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testOptimisticLockUnversionedEntity_ThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException');
+        $this->expectException(OptimisticLockException::class);
 
         $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser')
                   ->find(1, LockMode::OPTIMISTIC);
@@ -338,7 +341,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $userId);
 
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException');
+        $this->expectException(OptimisticLockException::class);
+
         $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $userId, LockMode::OPTIMISTIC);
     }
 
@@ -360,7 +364,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testInvalidMagicCall()
     {
-        $this->setExpectedException('BadMethodCallException');
+        $this->expectException(\BadMethodCallException::class);
 
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repos->foo();
@@ -374,7 +378,9 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         list($userId, $addressId) = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $this->setExpectedException('Doctrine\ORM\ORMException', "You cannot search for the association field 'Doctrine\Tests\Models\CMS\CmsUser#address', because it is the inverse side of an association. Find methods only work on owning side associations.");
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage("You cannot search for the association field 'Doctrine\Tests\Models\CMS\CmsUser#address', because it is the inverse side of an association. Find methods only work on owning side associations.");
+
         $user = $repos->findBy(array('address' => $addressId));
     }
 
@@ -460,7 +466,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
     {
         $repos = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $repos->createNamedQuery('invalidNamedQuery');
     }
@@ -658,7 +664,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testInvalidOrientation()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'Invalid order by orientation specified for Doctrine\Tests\Models\CMS\CmsUser#username');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Invalid order by orientation specified for Doctrine\Tests\Models\CMS\CmsUser#username');
 
         $repo = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repo->findBy(array('status' => 'test'), array('username' => 'INVALID'));
@@ -918,7 +925,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindByFieldInjectionPrevented()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized field: ');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Unrecognized field: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repository->findBy(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test'));
@@ -929,7 +937,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindOneByFieldInjectionPrevented()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized field: ');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Unrecognized field: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repository->findOneBy(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test'));
@@ -940,7 +949,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testMatchingInjectionPrevented()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized field: ');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Unrecognized field: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $result     = $repository->matching(new Criteria(
@@ -956,7 +966,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindInjectionPrevented()
     {
-        $this->setExpectedException('Doctrine\ORM\ORMException', 'Unrecognized identifier fields: ');
+        $this->expectException(ORMException::class);
+        $this->expectExceptionMessage('Unrecognized identifier fields: ');
 
         $repository = $this->_em->getRepository('Doctrine\Tests\Models\CMS\CmsUser');
         $repository->find(array('username = ?; DELETE FROM cms_users; SELECT 1 WHERE 1' => 'test', 'id' => 1));

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -3,7 +3,9 @@
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\TransactionRequiredException;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -47,7 +49,8 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException');
+        $this->expectException(OptimisticLockException::class);
+
         $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
@@ -64,7 +67,8 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException');
+        $this->expectException(OptimisticLockException::class);
+
         $this->_em->lock($user, LockMode::OPTIMISTIC);
     }
 
@@ -75,7 +79,9 @@ class LockTest extends OrmFunctionalTestCase
     public function testLockUnmanagedEntity_ThrowsException() {
         $article = new CmsArticle();
 
-        $this->setExpectedException('InvalidArgumentException', 'Entity Doctrine\Tests\Models\CMS\CmsArticle');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entity Doctrine\Tests\Models\CMS\CmsArticle');
+
         $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
 
@@ -91,7 +97,8 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $this->setExpectedException('Doctrine\ORM\TransactionRequiredException');
+        $this->expectException(TransactionRequiredException::class);
+
         $this->_em->lock($article, LockMode::PESSIMISTIC_READ);
     }
 
@@ -107,7 +114,8 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $this->setExpectedException('Doctrine\ORM\TransactionRequiredException');
+        $this->expectException(TransactionRequiredException::class);
+
         $this->_em->lock($article, LockMode::PESSIMISTIC_WRITE);
     }
 
@@ -181,7 +189,9 @@ class LockTest extends OrmFunctionalTestCase
     {
         $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'";
 
-        $this->setExpectedException('Doctrine\ORM\OptimisticLockException', 'The optimistic lock on an entity failed.');
+        $this->expectException(OptimisticLockException::class);
+        $this->expectExceptionMessage('The optimistic lock on an entity failed.');
+
         $sql = $this->_em->createQuery($dql)->setHint(
             Query::HINT_LOCK_MODE, LockMode::OPTIMISTIC
         )->getSQL();

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
+use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Query\Parameter;
@@ -324,7 +325,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
      */
     public function testAbstractClassInSingleTableInheritanceSchemaWithRSMBuilderThrowsException()
     {
-        $this->setExpectedException('\InvalidArgumentException', 'ResultSetMapping builder does not currently support your inheritance scheme.');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('ResultSetMapping builder does not currently support your inheritance scheme.');
+
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('Doctrine\Tests\Models\Company\CompanyContract', 'c');
     }
@@ -351,10 +354,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $query = $this->_em->createNativeQuery('SELECT u.*, a.*, a.id AS a_id FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
         $query->setParameter(1, 'romanb');
 
-        $this->setExpectedException(
-            "Doctrine\ORM\Internal\Hydration\HydrationException",
-            "The parent object of entity result with alias 'a' was not found. The parent alias is 'un'."
-        );
+        $this->expectException(HydrationException::class);
+        $this->expectExceptionMessage("The parent object of entity result with alias 'a' was not found. The parent alias is 'un'.");
+
         $users = $query->getResult();
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -74,10 +74,9 @@ class PaginationTest extends OrmFunctionalTestCase
         $paginator = new Paginator($query);
         $paginator->setUseOutputWalkers(false);
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Cannot count query that uses a HAVING clause. Use the output walkers for pagination'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot count query that uses a HAVING clause. Use the output walkers for pagination');
+
         $this->assertCount(3, $paginator);
     }
 
@@ -495,7 +494,9 @@ class PaginationTest extends OrmFunctionalTestCase
 
     public function testIterateWithFetchJoinOneToManyWithOrderByColumnFromBothWithLimitWithoutOutputWalker()
     {
-        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.");
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.');
+
         $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY c.name';
         $dqlAsc = $dql . " ASC, d.name";
         $dqlDesc = $dql . " DESC, d.name";
@@ -552,7 +553,9 @@ class PaginationTest extends OrmFunctionalTestCase
 
     public function testIterateWithFetchJoinOneToManyWithOrderByColumnFromJoinedWithLimitWithoutOutputWalker()
     {
-        $this->setExpectedException("RuntimeException", "Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.");
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers.');
+
         $dql = 'SELECT c, d FROM Doctrine\Tests\Models\Pagination\Company c JOIN c.departments d ORDER BY d.name';
 
         $this->iterateWithOrderAscWithLimit(false, true, $dql, "name");
@@ -595,10 +598,8 @@ class PaginationTest extends OrmFunctionalTestCase
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Query\SqlWalker');
         $paginator = new Paginator($query);
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Cannot count query that uses a HAVING clause. Use the output walkers for pagination'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot count query that uses a HAVING clause. Use the output walkers for pagination');
 
         count($paginator);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -36,7 +36,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
     public function testLoadedEntityUsingFindShouldTriggerEvent()
     {
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsUser and CmsAddres, because it's a ToOne inverse side on CmsUser
         $mockListener
@@ -53,7 +53,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
     public function testLoadedEntityUsingQueryShouldTriggerEvent()
     {
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsUser and CmsAddres, because it's a ToOne inverse side on CmsUser
         $mockListener
@@ -73,7 +73,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
     public function testLoadedAssociationToOneShouldTriggerEvent()
     {
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsUser (root), CmsAddress (ToOne inverse side), CmsEmail (joined association)
         $mockListener
@@ -93,7 +93,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
 
     public function testLoadedAssociationToManyShouldTriggerEvent()
     {
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsUser (root), CmsAddress (ToOne inverse side), 2 CmsPhonenumber (joined association)
         $mockListener
@@ -116,7 +116,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         $eventManager = $this->_em->getEventManager();
 
         // Should not be invoked during getReference call
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         $mockListener
             ->expects($this->never())
@@ -130,7 +130,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         // Now deactivate original listener and attach new one
         $eventManager->removeEventListener(array(Events::postLoad), $mockListener);
 
-        $mockListener2 = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener2 = $this->createMock(PostLoadListener::class);
 
         $mockListener2
             ->expects($this->exactly(2))
@@ -147,7 +147,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
         $eventManager = $this->_em->getEventManager();
 
         // Should not be invoked during getReference call
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsUser (partially loaded), CmsAddress (inverse ToOne), 2 CmsPhonenumber
         $mockListener
@@ -167,7 +167,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
     {
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
 
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // CmsEmail (proxy)
         $mockListener
@@ -188,7 +188,7 @@ class PostLoadEventTest extends OrmFunctionalTestCase
     {
         $user = $this->_em->find('Doctrine\Tests\Models\CMS\CmsUser', $this->userId);
 
-        $mockListener = $this->getMock('Doctrine\Tests\ORM\Functional\PostLoadListener');
+        $mockListener = $this->createMock(PostLoadListener::class);
 
         // 2 CmsPhonenumber (proxy)
         $mockListener

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -3,6 +3,10 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+use Doctrine\ORM\Query\ParserResult;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -105,7 +109,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
+        $cache = $this->createMock(Cache::class);
 
         $query->setQueryCacheDriver($cache);
 
@@ -123,18 +127,23 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $sqlExecMock = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', array('execute'));
+        $sqlExecMock = $this->getMockBuilder(AbstractSqlExecutor::class)
+                            ->setMethods(array('execute'))
+                            ->getMock();
+
         $sqlExecMock->expects($this->once())
                     ->method('execute')
                     ->will($this->returnValue( 10 ));
 
-        $parserResultMock = $this->getMock('Doctrine\ORM\Query\ParserResult');
+        $parserResultMock = $this->createMock(ParserResult::class);
         $parserResultMock->expects($this->once())
                          ->method('getSqlExecutor')
                          ->will($this->returnValue($sqlExecMock));
 
-        $cache = $this->getMock('Doctrine\Common\Cache\CacheProvider',
-                array('doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats'));
+        $cache = $this->getMockBuilder(CacheProvider::class)
+                      ->setMethods(array('doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats'))
+                      ->getMock();
+
         $cache->expects($this->at(0))->method('doFetch')->will($this->returnValue(1));
         $cache->expects($this->at(1))
               ->method('doFetch')

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\UnexpectedResultException;
 use Doctrine\Tests\Models\CMS\CmsUser,
     Doctrine\Tests\Models\CMS\CmsArticle,
@@ -118,10 +120,8 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testUsingUnknownQueryParameterShouldThrowException()
     {
-        $this->setExpectedException(
-            "Doctrine\ORM\Query\QueryException",
-            "Invalid parameter: token 2 is not defined in the query."
-        );
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Invalid parameter: token 2 is not defined in the query.');
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
         $q->setParameter(2, 'jwage');
@@ -130,10 +130,8 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testTooManyParametersShouldThrowException()
     {
-        $this->setExpectedException(
-            "Doctrine\ORM\Query\QueryException",
-            "Too many parameters: the query defines 1 parameters and you bound 2"
-        );
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Too many parameters: the query defines 1 parameters and you bound 2');
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
         $q->setParameter(1, 'jwage');
@@ -144,10 +142,8 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testTooFewParametersShouldThrowException()
     {
-        $this->setExpectedException(
-            "Doctrine\ORM\Query\QueryException",
-            "Too few parameters: the query defines 1 parameters but you only bound 0"
-        );
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Too few parameters: the query defines 1 parameters but you only bound 0');
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
 
@@ -156,7 +152,7 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testInvalidInputParameterThrowsException()
     {
-        $this->setExpectedException("Doctrine\ORM\Query\QueryException");
+        $this->expectException(QueryException::class);
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?');
         $q->setParameter(1, 'jwage');
@@ -505,7 +501,8 @@ class QueryTest extends OrmFunctionalTestCase
 
         $query = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u");
 
-        $this->setExpectedException('Doctrine\ORM\NonUniqueResultException');
+        $this->expectException(NonUniqueResultException::class);
+        
         $fetchedUser = $query->getOneOrNullResult();
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Persisters\PersisterException;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\Company\CompanyFlexContract;
@@ -371,7 +372,9 @@ class SingleTableInheritanceTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository("Doctrine\Tests\Models\Company\CompanyContract");
 
-        $this->setExpectedException('Doctrine\ORM\Persisters\PersisterException', 'annot match on Doctrine\Tests\Models\Company\CompanyContract::salesPerson with a non-object value.');
+        $this->expectException(PersisterException::class);
+        $this->expectExceptionMessage('annot match on Doctrine\Tests\Models\Company\CompanyContract::salesPerson with a non-object value.');
+
         $contracts = $repository->matching(new Criteria(
             Criteria::expr()->eq('salesPerson', $this->salesPerson->getId())
         ));

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
@@ -55,7 +55,9 @@ class DDC1685Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->paginator->setUseOutputWalkers(false);
 
-        $this->setExpectedException('RuntimeException', 'Paginating an entity with foreign key as identifier only works when using the Output Walkers. Call Paginator#setUseOutputWalkers(true) before iterating the paginator.');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Paginating an entity with foreign key as identifier only works when using the Output Walkers. Call Paginator#setUseOutputWalkers(true) before iterating the paginator.');
+
         foreach ($this->paginator as $ad) {
             $this->assertInstanceOf('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails', $ad);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -1,6 +1,13 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
 
 /**
  * @group DDC-2359
@@ -14,18 +21,20 @@ class DDC2359Test extends \PHPUnit_Framework_TestCase
      */
     public function testIssue()
     {
-        $mockDriver      = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver');
-        $mockMetadata    = $this->getMock('Doctrine\\ORM\\Mapping\\ClassMetadata', array(), array(), '', false);
-        $entityManager   = $this->getMock('Doctrine\\ORM\\EntityManager', array(), array(), '', false);
+        $mockDriver      = $this->createMock(MappingDriver::class);
+        $mockMetadata    = $this->createMock(ClassMetadata::class);
+        $entityManager   = $this->createMock(EntityManager::class);
 
         /* @var $metadataFactory \Doctrine\ORM\Mapping\ClassMetadataFactory|\PHPUnit_Framework_MockObject_MockObject */
-        $metadataFactory = $this->getMock(
-            'Doctrine\\ORM\\Mapping\\ClassMetadataFactory',
-            array('newClassMetadataInstance', 'wakeupReflection')
-        );
-        
-        $configuration   = $this->getMock('Doctrine\\ORM\\Configuration', array('getMetadataDriverImpl'));
-        $connection      = $this->getMock('Doctrine\\DBAL\\Connection', array(), array(), '', false);
+        $metadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)
+                                ->setMethods(array('newClassMetadataInstance', 'wakeupReflection'))
+                                ->getMock();
+
+        $configuration = $this->getMockBuilder(Configuration::class)
+                              ->setMethods(array('getMetadataDriverImpl'))
+                              ->getMock();
+
+        $connection = $this->createMock(Connection::class);
 
         $configuration
             ->expects($this->any())
@@ -37,7 +46,7 @@ class DDC2359Test extends \PHPUnit_Framework_TestCase
         $entityManager
             ->expects($this->any())
             ->method('getEventManager')
-            ->will($this->returnValue($this->getMock('Doctrine\\Common\\EventManager')));
+            ->will($this->returnValue($this->createMock(EventManager::class)));
 
         $metadataFactory->expects($this->any())->method('newClassMetadataInstance')->will($this->returnValue($mockMetadata));
         $metadataFactory->expects($this->once())->method('wakeupReflection');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -29,7 +29,10 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIsListenerCalledOnlyOnceOnPreFlush()
     {
-        $listener = $this->getMock('Doctrine\Tests\ORM\Functional\Ticket\DDC2692Listener', array('preFlush'));
+        $listener = $this->getMockBuilder(DDC2692Listener::class)
+                         ->setMethods(array('preFlush'))
+                         ->getMock();
+
         $listener->expects($this->once())->method('preFlush');
 
         $this->_em->getEventManager()->addEventSubscriber($listener);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
@@ -28,7 +28,9 @@ class DDC3123Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($user);
         $uow->scheduleExtraUpdate($user, array('name' => 'changed name'));
 
-        $listener = $this->getMock('stdClass', array(Events::postFlush));
+        $listener = $this->getMockBuilder(\stdClass::class)
+                         ->setMethods(array(Events::postFlush))
+                         ->getMock();
 
         $listener
             ->expects($this->once())

--- a/tests/Doctrine/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -22,7 +23,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "A managed+dirty entity Doctrine\Tests\Models\CMS\CmsUser");
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage('A managed+dirty entity Doctrine\Tests\Models\CMS\CmsUser');
+
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
     }
 
@@ -37,7 +40,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
 
         $this->_em->remove($user);
 
-        $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "Removed entity Doctrine\Tests\Models\CMS\CmsUser");
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage('Removed entity Doctrine\Tests\Models\CMS\CmsUser');
+
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
     }
 
@@ -50,7 +55,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
 
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
 
-        $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "Entity Doctrine\Tests\Models\CMS\CmsUser");
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage('Entity Doctrine\Tests\Models\CMS\CmsUser');
+
         $this->_em->getUnitOfWork()->scheduleForInsert($user);
     }
 
@@ -58,7 +65,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
     {
         $user = new CmsUser();
 
-        $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "The given entity of type 'Doctrine\Tests\Models\CMS\CmsUser' (Doctrine\Tests\Models\CMS\CmsUser@");
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage("The given entity of type 'Doctrine\Tests\Models\CMS\CmsUser' (Doctrine\Tests\Models\CMS\CmsUser@");
+
         $this->_em->getUnitOfWork()->registerManaged($user, array(), array());
     }
 
@@ -66,7 +75,9 @@ class UnitOfWorkLifecycleTest extends OrmFunctionalTestCase
     {
         $user = new CmsUser();
 
-        $this->setExpectedException("Doctrine\ORM\ORMInvalidArgumentException", "Only managed entities can be marked or checked as read only. But Doctrine\Tests\Models\CMS\CmsUser@");
+        $this->expectException(ORMInvalidArgumentException::class);
+        $this->expectExceptionMessage('Only managed entities can be marked or checked as read only. But Doctrine\Tests\Models\CMS\CmsUser@');
+
         $this->_em->getUnitOfWork()->markReadOnly($user);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -228,7 +230,8 @@ class ValueObjectsTest extends OrmFunctionalTestCase
 
     public function testDqlWithNonExistentEmbeddableField()
     {
-        $this->setExpectedException('Doctrine\ORM\Query\QueryException', 'no field or association named address.asdfasdf');
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('no field or association named address.asdfasdf');
 
         $this->_em->createQuery("SELECT p FROM " . __NAMESPACE__ . "\\DDC93Person p WHERE p.address.asdfasdf IS NULL")
             ->execute();
@@ -236,8 +239,9 @@ class ValueObjectsTest extends OrmFunctionalTestCase
     
     public function testPartialDqlWithNonExistentEmbeddableField()
     {
-        $this->setExpectedException('Doctrine\ORM\Query\QueryException', "no mapped field named 'address.asdfasdf'");
-        
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage("no mapped field named 'address.asdfasdf'");
+
         $this->_em->createQuery("SELECT PARTIAL p.{id,address.asdfasdf} FROM " . __NAMESPACE__ . "\\DDC93Person p")
             ->execute();
     }
@@ -297,8 +301,8 @@ class ValueObjectsTest extends OrmFunctionalTestCase
      */
     public function testThrowsExceptionOnInfiniteEmbeddableNesting($embeddableClassName, $declaredEmbeddableClassName)
     {
-        $this->setExpectedException(
-            'Doctrine\ORM\Mapping\MappingException',
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
             sprintf(
                 'Infinite nesting detected for embedded property %s::nested. ' .
                 'You cannot embed an embeddable from the same type inside an embeddable.',

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -1004,7 +1005,11 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyInstance = new \Doctrine\Tests\Models\ECommerce\ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', array('getProxy'), array(), '', false, false, false);
+        $proxyFactory = $this->getMockBuilder(ProxyFactory::class)
+                             ->setMethods(array('getProxy'))
+                             ->disableOriginalConstructor()
+                             ->getMock();
+
         $proxyFactory->expects($this->once())
                      ->method('getProxy')
                      ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), array('id' => 42))
@@ -1049,7 +1054,11 @@ class ObjectHydratorTest extends HydrationTestCase
         $proxyInstance = new \Doctrine\Tests\Models\ECommerce\ECommerceShipping();
 
         // mocking the proxy factory
-        $proxyFactory = $this->getMock('Doctrine\ORM\Proxy\ProxyFactory', array('getProxy'), array(), '', false, false, false);
+        $proxyFactory = $this->getMockBuilder(ProxyFactory::class)
+                             ->setMethods(array('getProxy'))
+                             ->disableOriginalConstructor()
+                             ->getMock();
+
         $proxyFactory->expects($this->once())
                      ->method('getProxy')
                      ->with($this->equalTo('Doctrine\Tests\Models\ECommerce\ECommerceShipping'), array('id' => 42))

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -20,9 +20,11 @@
 namespace Doctrine\Tests\ORM\Internal;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 
@@ -53,8 +55,8 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->listenersInvoker = $this->getMock('Doctrine\ORM\Event\ListenersInvoker', array(), array(), '', false);
-        $this->entityManager    = $this->getMock('Doctrine\ORM\EntityManagerInterface');
+        $this->listenersInvoker = $this->createMock(ListenersInvoker::class);
+        $this->entityManager    = $this->createMock(EntityManagerInterface::class);
         $this->handler          = new HydrationCompleteHandler($this->listenersInvoker, $this->entityManager);
     }
 
@@ -66,7 +68,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testDefersPostLoadOfEntity($listenersFlag)
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata      = $this->createMock(ClassMetadata::class);
         $entity        = new stdClass();
         $entityManager = $this->entityManager;
 
@@ -104,7 +106,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testDefersPostLoadOfEntityOnlyOnce($listenersFlag)
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata = $this->createMock(ClassMetadata::class);
         $entity   = new stdClass();
 
         $this
@@ -131,8 +133,8 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     {
         /* @var $metadata1 \Doctrine\ORM\Mapping\ClassMetadata */
         /* @var $metadata2 \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata1      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
-        $metadata2      = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata1      = $this->createMock(ClassMetadata::class);
+        $metadata2      = $this->createMock(ClassMetadata::class);
         $entity1        = new stdClass();
         $entity2        = new stdClass();
         $entityManager  = $this->entityManager;
@@ -168,7 +170,7 @@ class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
     public function testSkipsDeferredPostLoadOfMetadataWithNoInvokedListeners()
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        $metadata = $this->getMock('Doctrine\ORM\Mapping\ClassMetadata', array(), array(), '', false);
+        $metadata = $this->createMock(ClassMetadata::class);
         $entity   = new stdClass();
 
         $this

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\LazyCriteriaCollection;
+use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use stdClass;
 
 /**
@@ -33,7 +34,7 @@ class LazyCriteriaCollectionTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->persister              = $this->getMock('Doctrine\ORM\Persisters\Entity\EntityPersister');
+        $this->persister              = $this->createMock(EntityPersister::class);
         $this->criteria               = new Criteria();
         $this->lazyCriteriaCollection = new LazyCriteriaCollection($this->persister, $this->criteria);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -520,7 +521,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testInvalidEntityOrMappedSuperClassShouldMentionParentClasses()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'Class "Doctrine\Tests\Models\DDC889\DDC889Class" sub class of "Doctrine\Tests\Models\DDC889\DDC889SuperClass" is not a valid entity or mapped super class.');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Class "Doctrine\Tests\Models\DDC889\DDC889Class" sub class of "Doctrine\Tests\Models\DDC889\DDC889SuperClass" is not a valid entity or mapped super class.');
 
         $this->createClassMetadata('Doctrine\Tests\Models\DDC889\DDC889Class');
     }
@@ -532,7 +534,9 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     {
         $factory = $this->createClassMetadataFactory();
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'No identifier/primary key specified for Entity "Doctrine\Tests\Models\DDC889\DDC889Entity" sub class of "Doctrine\Tests\Models\DDC889\DDC889SuperClass". Every Entity must have an identifier/primary key.');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('No identifier/primary key specified for Entity "Doctrine\Tests\Models\DDC889\DDC889Entity" sub class of "Doctrine\Tests\Models\DDC889\DDC889SuperClass". Every Entity must have an identifier/primary key.');
+
         $factory->getMetadataFor('Doctrine\Tests\Models\DDC889\DDC889Entity');
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -2,11 +2,13 @@
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Mapping\MappingException;
 
 class AnnotationDriverTest extends AbstractMappingDriverTest
 {
@@ -20,7 +22,7 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $reader = new AnnotationReader();
         $annotationDriver = new AnnotationDriver($reader);
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
     }
 
@@ -157,9 +159,12 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory = new ClassMetadataFactory();
         $factory->setEntityManager($em);
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException',
-            "It is illegal to put an inverse side one-to-many or many-to-many association on ".
-            "mapped superclass 'Doctrine\Tests\ORM\Mapping\InvalidMappedSuperClass#users'");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            "It is illegal to put an inverse side one-to-many or many-to-many association on " .
+            "mapped superclass 'Doctrine\Tests\ORM\Mapping\InvalidMappedSuperClass#users'"
+        );
+
         $usingInvalidMsc = $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\UsingInvalidMappedSuperClass');
     }
 
@@ -175,9 +180,12 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory = new ClassMetadataFactory();
         $factory->setEntityManager($em);
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException',
-            "It is not supported to define inheritance information on a mapped ".
-            "superclass 'Doctrine\Tests\ORM\Mapping\MappedSuperClassInheritence'.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+            "It is not supported to define inheritance information on a mapped " .
+            "superclass 'Doctrine\Tests\ORM\Mapping\MappedSuperClassInheritence'."
+        );
+
         $usingInvalidMsc = $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\MappedSuperClassInheritence');
     }
 
@@ -224,8 +232,9 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory = new ClassMetadataFactory();
         $factory->setEntityManager($em);
 
-        $this->setExpectedException('Doctrine\Common\Annotations\AnnotationException',
-            '[Enum Error] Attribute "fetch" of @Doctrine\ORM\Mapping\OneToMany declared on property Doctrine\Tests\ORM\Mapping\InvalidFetchOption::$collection accept only [LAZY, EAGER, EXTRA_LAZY], but got eager.');
+        $this->expectException(AnnotationException::class);
+        $this->expectExceptionMessage('[Enum Error] Attribute "fetch" of @Doctrine\ORM\Mapping\OneToMany declared on property Doctrine\Tests\ORM\Mapping\InvalidFetchOption::$collection accept only [LAZY, EAGER, EXTRA_LAZY], but got eager.');
+
         $factory->getMetadataFor('Doctrine\Tests\ORM\Mapping\InvalidFetchOption');
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Tests\Models\DDC869\DDC869Payment;
 use Doctrine\Tests\OrmTestCase;
 
@@ -26,7 +27,7 @@ class BasicInheritanceMappingTest extends OrmTestCase
 
     public function testGetMetadataForTransientClassThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $this->cmf->getMetadataFor('Doctrine\Tests\ORM\Mapping\TransientBaseClass');
     }
@@ -122,12 +123,13 @@ class BasicInheritanceMappingTest extends OrmTestCase
      */
     public function testUnmappedEntityInHierarchy()
     {
-        $this->setExpectedException(
-            'Doctrine\ORM\Mapping\MappingException',
-            'Entity \'Doctrine\Tests\ORM\Mapping\HierarchyBEntity\' has to be part of the discriminator map'
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(
+              'Entity \'Doctrine\Tests\ORM\Mapping\HierarchyBEntity\' has to be part of the discriminator map'
             . ' of \'Doctrine\Tests\ORM\Mapping\HierarchyBase\' to be properly mapped in the inheritance hierarchy.'
             . ' Alternatively you can make \'Doctrine\Tests\ORM\Mapping\HierarchyBEntity\' an abstract class to'
-            . ' avoid this exception from occurring.');
+            . ' avoid this exception from occurring.'
+        );
 
         $this->cmf->getMetadataFor(__NAMESPACE__ . '\\HierarchyE');
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -528,7 +528,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
     public function testThrowsExceptionOnCreateOneToOneWithIdentityOnInverseSide()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $this
             ->builder
@@ -624,7 +624,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
     public function testThrowsExceptionOnCreateManyToManyWithIdentity()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $this->builder->createManyToMany('groups', 'Doctrine\Tests\Models\CMS\CmsGroup')
                           ->makePrimaryKey()
@@ -677,7 +677,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
     public function testThrowsExceptionOnCreateOneToManyWithIdentity()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $this->builder->createOneToMany('groups', 'Doctrine\Tests\Models\CMS\CmsGroup')
                 ->makePrimaryKey()
@@ -775,7 +775,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
 
     public function testExceptionOnOrphanRemovalOnManyToOne()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
 
         $this->builder
             ->createManyToOne('groups', 'Doctrine\Tests\Models\CMS\CmsGroup')

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -3,14 +3,19 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\ORMException;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -78,7 +83,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm1->customGeneratorDefinition = array("class" => "NotExistingGenerator");
         $cmf = $this->_createTestFactory();
         $cmf->setMetadataForClass($cm1->name, $cm1);
-        $this->setExpectedException("Doctrine\ORM\ORMException");
+        $this->expectException(ORMException::class);
 
         $actual = $cmf->getMetadataFor($cm1->name);
     }
@@ -89,7 +94,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $cmf = $this->_createTestFactory();
         $cmf->setMetadataForClass($cm1->name, $cm1);
-        $this->setExpectedException("Doctrine\ORM\ORMException");
+        $this->expectException(ORMException::class);
 
         $actual = $cmf->getMetadataFor($cm1->name);
     }
@@ -119,7 +124,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     public function testIsTransient()
     {
         $cmf = new ClassMetadataFactory();
-        $driver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver = $this->createMock(MappingDriver::class);
         $driver->expects($this->at(0))
                ->method('isTransient')
                ->with($this->equalTo('Doctrine\Tests\Models\CMS\CmsUser'))
@@ -141,7 +146,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     public function testIsTransientEntityNamespace()
     {
         $cmf = new ClassMetadataFactory();
-        $driver = $this->getMock('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $driver = $this->createMock(MappingDriver::class);
         $driver->expects($this->at(0))
                ->method('isTransient')
                ->with($this->equalTo('Doctrine\Tests\Models\CMS\CmsUser'))
@@ -189,7 +194,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         // ClassMetadataFactory::addDefaultDiscriminatorMap shouldn't be called again, because the
         // discriminator map is already cached
-        $cmf = $this->getMock('Doctrine\ORM\Mapping\ClassMetadataFactory', array('addDefaultDiscriminatorMap'));
+        $cmf = $this->getMockBuilder(ClassMetadataFactory::class)->setMethods(array('addDefaultDiscriminatorMap'))->getMock();
         $cmf->setEntityManager($em);
         $cmf->expects($this->never())
             ->method('addDefaultDiscriminatorMap');
@@ -200,9 +205,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     public function testGetAllMetadataWorksWithBadConnection()
     {
         // DDC-3551
-        $conn = $this->getMockBuilder('Doctrine\DBAL\Connection')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $conn = $this->createMock(Connection::class);
         $mockDriver    = new MetadataDriverMock();
         $em = $this->_createEntityManager($mockDriver, $conn);
 
@@ -361,11 +364,11 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $test          = $this;
         /* @var $metadata \Doctrine\Common\Persistence\Mapping\ClassMetadata */
-        $metadata      = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata      = $this->createMock(ClassMetadata::class);
         $cmf           = new ClassMetadataFactory();
         $mockDriver    = new MetadataDriverMock();
         $em = $this->_createEntityManager($mockDriver);
-        $listener      = $this->getMock('stdClass', array('onClassMetadataNotFound'));
+        $listener      = $this->getMockBuilder(\stdClass::class)->setMethods(array('onClassMetadataNotFound'))->getMock();
         $eventManager  = $em->getEventManager();
 
         $cmf->setEntityManager($em);
@@ -394,7 +397,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $classMetadataFactory = new ClassMetadataFactory();
 
         /* @var $entityManager EntityManager */
-        $entityManager        = $this->getMock('Doctrine\\ORM\\EntityManagerInterface');
+        $entityManager        = $this->createMock(EntityManagerInterface::class);
 
         $classMetadataFactory->setEntityManager($entityManager);
 
@@ -419,10 +422,8 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $cmf->setMetadataForClass($metadata->name, $metadata);
 
-        $this->setExpectedException(
-            'Doctrine\ORM\Mapping\MappingException',
-            'The embed mapping \'embedded\' misses the \'class\' attribute.'
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The embed mapping \'embedded\' misses the \'class\' attribute.');
 
         $cmf->getMetadataFor($metadata->name);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Persistence\Mapping\StaticReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser;
@@ -182,7 +183,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->setVersionMapping($field);
     }
 
@@ -192,7 +193,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->isIdentifierComposite  = true;
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->getSingleIdentifierFieldName();
     }
 
@@ -205,7 +206,7 @@ class ClassMetadataTest extends OrmTestCase
         $a2 = array('fieldName' => 'foo', 'sourceEntity' => 'stdClass', 'targetEntity' => 'stdClass', 'mappedBy' => 'foo');
 
         $cm->addInheritedAssociationMapping($a1);
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->addInheritedAssociationMapping($a2);
     }
 
@@ -216,7 +217,7 @@ class ClassMetadataTest extends OrmTestCase
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->mapField(array('fieldName' => 'username', 'columnName' => 'name'));
     }
 
@@ -227,7 +228,7 @@ class ClassMetadataTest extends OrmTestCase
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->setDiscriminatorColumn(array('name' => 'name'));
     }
 
@@ -238,7 +239,7 @@ class ClassMetadataTest extends OrmTestCase
 
         $cm->setDiscriminatorColumn(array('name' => 'name'));
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
     }
 
@@ -249,7 +250,7 @@ class ClassMetadataTest extends OrmTestCase
 
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
     }
 
@@ -260,7 +261,7 @@ class ClassMetadataTest extends OrmTestCase
 
         $cm->mapOneToOne(array('fieldName' => 'name', 'targetEntity' => 'CmsUser'));
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->mapField(array('fieldName' => 'name', 'columnName' => 'name'));
     }
 
@@ -395,7 +396,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', "No mapping found for field 'foo' on class 'Doctrine\Tests\Models\CMS\CmsUser'.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("No mapping found for field 'foo' on class 'Doctrine\Tests\Models\CMS\CmsUser'.");
+
         $cm->getFieldMapping('foo');
     }
 
@@ -439,7 +442,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'The orphan removal option is not allowed on an association that');
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('The orphan removal option is not allowed on an association that');
+
         $cm->mapOneToOne(array(
             'fieldName' => 'article',
             'id' => true,
@@ -457,8 +462,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
         $cm->initializeReflection(new RuntimeReflectionService());
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('An inverse association is not allowed to be identifier in');
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'An inverse association is not allowed to be identifier in');
         $cm->mapOneToOne(array(
             'fieldName' => 'article',
             'id' => true,
@@ -476,8 +482,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\DDC117\DDC117ArticleDetails');
         $cm->initializeReflection(new RuntimeReflectionService());
 
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Many-to-many or one-to-many associations are not allowed to be identifier in');
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException', 'Many-to-many or one-to-many associations are not allowed to be identifier in');
         $cm->mapManyToMany(array(
             'fieldName' => 'article',
             'id' => true,
@@ -491,8 +498,9 @@ class ClassMetadataTest extends OrmTestCase
      */
     public function testEmptyFieldNameThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException',
-            "The field or association mapping misses the 'fieldName' attribute in entity 'Doctrine\Tests\Models\CMS\CmsUser'.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("The field or association mapping misses the 'fieldName' attribute in entity 'Doctrine\Tests\Models\CMS\CmsUser'.");
+
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -833,7 +841,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addLifecycleCallback('notfound', 'postLoad');
 
-        $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "Entity 'Doctrine\Tests\Models\CMS\CmsUser' has no method 'notfound' to be registered as lifecycle callback.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("Entity 'Doctrine\Tests\Models\CMS\CmsUser' has no method 'notfound' to be registered as lifecycle callback.");
+
         $cm->validateLifecycleCallbacks(new RuntimeReflectionService());
     }
 
@@ -846,7 +856,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass'));
 
-        $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "The target-entity Doctrine\Tests\Models\CMS\UnknownClass cannot be found in 'Doctrine\Tests\Models\CMS\CmsUser#address'.");
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("The target-entity Doctrine\Tests\Models\CMS\UnknownClass cannot be found in 'Doctrine\Tests\Models\CMS\CmsUser#address'.");
+
         $cm->validateAssociations();
     }
 
@@ -972,8 +984,8 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->setExpectedException("Doctrine\ORM\Mapping\MappingException", "You have specified invalid cascade options for Doctrine\Tests\Models\CMS\CmsUser::\$address: 'invalid'; available options: 'remove', 'persist', 'refresh', 'merge', and 'detach'");
-
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("You have specified invalid cascade options for Doctrine\Tests\Models\CMS\CmsUser::\$address: 'invalid'; available options: 'remove', 'persist', 'refresh', 'merge', and 'detach'");
 
         $cm->mapManyToOne(array('fieldName' => 'address', 'targetEntity' => 'UnknownClass', 'cascade' => array('invalid')));
      }
@@ -1080,7 +1092,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->setExpectedException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectException(\Doctrine\ORM\Mapping\MappingException::class);
         $cm->setSequenceGeneratorDefinition(array());
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
@@ -90,7 +90,7 @@ class ReflectionPropertiesGetterTest extends PHPUnit_Framework_TestCase
     public function testPropertyGetterWillSkipPropertiesNotRetrievedByTheRuntimeReflectionService()
     {
         /* @var $reflectionService ReflectionService|\PHPUnit_Framework_MockObject_MockObject */
-        $reflectionService = $this->getMock('Doctrine\Common\Persistence\Mapping\ReflectionService');
+        $reflectionService = $this->createMock(ReflectionService::class);
 
         $reflectionService
             ->expects($this->exactly(2))
@@ -113,7 +113,7 @@ class ReflectionPropertiesGetterTest extends PHPUnit_Framework_TestCase
     public function testPropertyGetterWillSkipClassesNotRetrievedByTheRuntimeReflectionService()
     {
         /* @var $reflectionService ReflectionService|\PHPUnit_Framework_MockObject_MockObject */
-        $reflectionService = $this->getMock('Doctrine\Common\Persistence\Mapping\ReflectionService');
+        $reflectionService = $this->createMock(ReflectionService::class);
 
         $reflectionService
             ->expects($this->once())

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -18,6 +18,7 @@
 */
 
 namespace Doctrine\Tests\ORM\Mapping\Symfony;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 
 /**
  * @group DDC-1418
@@ -47,10 +48,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testFindMappingFileNamespacedFoundFileNotFound()
     {
-        $this->setExpectedException(
-            'Doctrine\Common\Persistence\Mapping\MappingException',
-            "No mapping file found named"
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('No mapping file found named');
 
         $driver = $this->getDriver(array(
             'MyNamespace\MySubnamespace\Entity' => $this->dir,
@@ -61,10 +60,8 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testFindMappingNamespaceNotFound()
     {
-        $this->setExpectedException(
-            'Doctrine\Common\Persistence\Mapping\MappingException',
-            "No mapping file found named 'Foo".$this->getFileExtension()."' for class 'MyOtherNamespace\MySubnamespace\Entity\Foo'."
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage("No mapping file found named 'Foo" . $this->getFileExtension() . "' for class 'MyOtherNamespace\MySubnamespace\Entity\Foo'.");
 
         $driver = $this->getDriver(array(
             'MyNamespace\MySubnamespace\Entity' => $this->dir,

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Proxy;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\Proxy\ProxyFactory;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -56,7 +57,8 @@ class ProxyFactoryTest extends OrmTestCase
     {
         $identifier = array('id' => 42);
         $proxyClass = 'Proxies\__CG__\Doctrine\Tests\Models\ECommerce\ECommerceFeature';
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister  = $this->getMockBuilder(BasicEntityPersister::class)->setMethods(array('load'))->disableOriginalConstructor()->getMock();
+
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         $proxy = $this->proxyFactory->getProxy('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $identifier);
@@ -89,7 +91,7 @@ class ProxyFactoryTest extends OrmTestCase
      */
     public function testFailedProxyLoadingDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMockBuilder(BasicEntityPersister::class)->setMethods(array('load'))->disableOriginalConstructor()->getMock();
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */
@@ -116,7 +118,7 @@ class ProxyFactoryTest extends OrmTestCase
      */
     public function testFailedProxyCloningDoesNotMarkTheProxyAsInitialized()
     {
-        $persister = $this->getMock('Doctrine\ORM\Persisters\Entity\BasicEntityPersister', array('load'), array(), '', false);
+        $persister = $this->getMockBuilder(BasicEntityPersister::class)->setMethods(array('load'))->disableOriginalConstructor()->getMock();
         $this->uowMock->setEntityPersister('Doctrine\Tests\Models\ECommerce\ECommerceFeature', $persister);
 
         /* @var $proxy \Doctrine\Common\Proxy\Proxy */

--- a/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php
@@ -20,6 +20,7 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\OrmTestCase;
 
 /**
@@ -90,7 +91,9 @@ class CustomTreeWalkersTest extends OrmTestCase
 
     public function testSetUnknownQueryComponentThrowsException()
     {
-        $this->setExpectedException("Doctrine\ORM\Query\QueryException", "Invalid query component given for DQL alias 'x', requires 'metadata', 'parent', 'relation', 'map', 'nestingLevel' and 'token' keys.");
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage("Invalid query component given for DQL alias 'x', requires 'metadata', 'parent', 'relation', 'map', 'nestingLevel' and 'token' keys.");
+
         $this->generateSql(
             'select u from Doctrine\Tests\Models\CMS\CmsUser u',
             array(),

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -84,7 +84,7 @@ class LanguageRecognitionTest extends OrmTestCase
      */
     public function testRejectsInvalidDQL($dql)
     {
-        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+        $this->expectException(QueryException::class);
 
         $this->_em->getConfiguration()->setEntityNamespaces(array(
             'Unknown' => 'Unknown',

--- a/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Query;
 
+use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 
 class ParserResultTest extends \PHPUnit_Framework_TestCase
@@ -25,7 +26,7 @@ class ParserResultTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNull($this->parserResult->getSqlExecutor());
 
-        $executor = $this->getMock('Doctrine\ORM\Query\Exec\AbstractSqlExecutor', array('execute'));
+        $executor = $this->getMockBuilder(AbstractSqlExecutor::class)->setMethods(array('execute'))->getMock();
         $this->parserResult->setSqlExecutor($executor);
         $this->assertSame($executor, $this->parserResult->getSqlExecutor());
     }

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\OrmTestCase;
 
 class ParserTest extends OrmTestCase
@@ -90,7 +91,7 @@ class ParserTest extends OrmTestCase
      */
     public function testMatchFailure($expectedToken, $inputString)
     {
-        $this->setExpectedException('\Doctrine\ORM\Query\QueryException');
+        $this->expectException(QueryException::class);
 
         $parser = $this->createParser($inputString);
 

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Query as ORMQuery;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
@@ -76,7 +77,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function assertInvalidSqlGeneration($dqlToBeTested, $expectedException, array $queryHints = array(), array $queryParams = array())
     {
-        $this->setExpectedException($expectedException);
+        $this->expectException($expectedException);
 
         $query = $this->_em->createQuery($dqlToBeTested);
 
@@ -429,7 +430,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function testJoinOnClause_NotYetSupported_ThrowsException()
     {
-        $this->setExpectedException('Doctrine\ORM\Query\QueryException');
+        $this->expectException(QueryException::class);
 
         $sql = $this->_em->createQuery(
             "SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a ON a.topic LIKE '%foo%'"

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1083,7 +1083,8 @@ class QueryBuilderTest extends OrmTestCase
      */
     public function testWhereAppend()
     {
-        $this->setExpectedException('InvalidArgumentException', "Using \$append = true does not have an effect with 'where' or 'having' parts. See QueryBuilder#andWhere() for an example for correct usage.");
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Using \$append = true does not have an effect with 'where' or 'having' parts. See QueryBuilder#andWhere() for an example for correct usage.");
 
         $qb = $this->_em->createQueryBuilder()
             ->add('where', 'u.foo = ?1')

--- a/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\Tests\ORM\Repository;
 
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use PHPUnit_Framework_TestCase;
 
@@ -32,7 +35,7 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->configuration     = $this->getMock('Doctrine\\ORM\\Configuration');
+        $this->configuration     = $this->createMock(Configuration::class);
         $this->entityManager     = $this->createEntityManager();
         $this->repositoryFactory = new DefaultRepositoryFactory();
 
@@ -122,10 +125,7 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
     public function buildClassMetadata($className)
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata|\PHPUnit_Framework_MockObject_MockObject */
-        $metadata = $this
-            ->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $metadata = $this->createMock(ClassMetadata::class);
 
         $metadata->expects($this->any())->method('getName')->will($this->returnValue($className));
 
@@ -139,7 +139,7 @@ class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
      */
     private function createEntityManager()
     {
-        $entityManager = $this->getMock('Doctrine\\ORM\\EntityManagerInterface');
+        $entityManager = $this->createMock(EntityManagerInterface::class);
 
         $entityManager
             ->expects($this->any())

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
@@ -3,17 +3,19 @@
 namespace Doctrine\Tests\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand;
+use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\Tests\OrmTestCase;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ConvertDoctrine1SchemaCommandTest extends OrmTestCase
 {
     public function testExecution()
     {
-        $entityGenerator = $this->getMock('Doctrine\ORM\Tools\EntityGenerator');
+        $entityGenerator = $this->createMock(EntityGenerator::class);
         $command = new ConvertDoctrine1SchemaCommand();
         $command->setEntityGenerator($entityGenerator);
 
-        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->createMock(OutputInterface::class);
         $output->expects($this->once())
                ->method('writeln')
                ->with($this->equalTo('No Metadata Classes to process.'));

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -613,7 +613,9 @@ class EntityGeneratorTest extends OrmTestCase
             $this->assertEquals($expected, $actual);
         }
 
-        $this->setExpectedException('\InvalidArgumentException', 'Invalid provided InheritanceType: INVALID');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid provided InheritanceType: INVALID');
+
         $method->invoke($this->_generator, 'INVALID');
     }
 
@@ -640,7 +642,9 @@ class EntityGeneratorTest extends OrmTestCase
             $this->assertEquals($expected, $actual);
         }
 
-        $this->setExpectedException('\InvalidArgumentException', 'Invalid provided ChangeTrackingPolicy: INVALID');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid provided ChangeTrackingPolicy: INVALID');
+
         $method->invoke($this->_generator, 'INVALID');
     }
 
@@ -667,7 +671,9 @@ class EntityGeneratorTest extends OrmTestCase
             $this->assertEquals($expected, $actual);
         }
 
-        $this->setExpectedException('\InvalidArgumentException', 'Invalid provided IdGeneratorType: INVALID');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid provided IdGeneratorType: INVALID');
+
         $method->invoke($this->_generator, 'INVALID');
     }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
@@ -83,10 +83,8 @@ class CountWalkerTest extends PaginationTestCase
         $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Doctrine\ORM\Tools\Pagination\CountWalker'));
         $query->setFirstResult(null)->setMaxResults(null);
 
-        $this->setExpectedException(
-            'RuntimeException',
-            'Cannot count query that uses a HAVING clause. Use the output walkers for pagination'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot count query that uses a HAVING clause. Use the output walkers for pagination');
 
         $query->getSQL();
     }

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Version;
 use Doctrine\Tests\OrmTestCase;
@@ -97,9 +98,7 @@ class SetupTest extends OrmTestCase
      */
     public function testConfigureCacheCustomInstance()
     {
-        $cache = $this->getMock('Doctrine\Common\Cache\Cache');
-        $cache->expects($this->never())->method('setNamespace');
-
+        $cache  = $this->createMock(Cache::class);
         $config = Setup::createConfiguration(array(), true, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -248,7 +248,7 @@ class UnitOfWorkTest extends OrmTestCase
      */
     public function testLockWithoutEntityThrowsException()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $this->_unitOfWork->lock(null, null, null);
     }
 
@@ -273,7 +273,7 @@ class UnitOfWorkTest extends OrmTestCase
         $user->username = 'John';
         $user->avatar   = $invalidValue;
 
-        $this->setExpectedException('Doctrine\ORM\ORMInvalidArgumentException');
+        $this->expectException(\Doctrine\ORM\ORMInvalidArgumentException::class);
 
         $this->_unitOfWork->persist($user);
     }
@@ -301,7 +301,7 @@ class UnitOfWorkTest extends OrmTestCase
         $user->username = 'John';
         $user->avatar   = $invalidValue;
 
-        $this->setExpectedException('Doctrine\ORM\ORMInvalidArgumentException');
+        $this->expectException(\Doctrine\ORM\ORMInvalidArgumentException::class);
 
         $this->_unitOfWork->computeChangeSet($metadata, $user);
     }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -742,7 +742,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      *
      * @throws \Exception
      */
-    protected function onNotSuccessfulTest(\Exception $e)
+    protected function onNotSuccessfulTest($e)
     {
         if ($e instanceof \PHPUnit_Framework_AssertionFailedError) {
             throw $e;


### PR DESCRIPTION
- Use createMock() and getMockBuilder() instead of getMock()
- Use expectException() and expectExceptionMessage() instead of setExpectedException()
## Output with PHPUnit 4.8 before these changes

```
PHPUnit 4.8.26-3-ga973e60 by Sebastian Bergmann and contributors.

.........................................................E...   61 / 3111 (  1%)
............S................................................  122 / 3111 (  3%)
.............................................................  183 / 3111 (  5%)
.............................................................  244 / 3111 (  7%)
.............................................................  305 / 3111 (  9%)
.............................................................  366 / 3111 ( 11%)
.........................................S........SSSS.S.....  427 / 3111 ( 13%)
.............................................................  488 / 3111 ( 15%)
............................................F................  549 / 3111 ( 17%)
....................................SS.......................  610 / 3111 ( 19%)
.............................................................  671 / 3111 ( 21%)
.............................................................  732 / 3111 ( 23%)
.............................................................  793 / 3111 ( 25%)
.............................................................  854 / 3111 ( 27%)
....................F........................................  915 / 3111 ( 29%)
.............................................................  976 / 3111 ( 31%)
......................................S.SSSSSSSSSSSS......... 1037 / 3111 ( 33%)
......................................................F...... 1098 / 3111 ( 35%)
..................................................SS......... 1159 / 3111 ( 37%)
.....................S...S...........S....................... 1220 / 3111 ( 39%)
.......S.......................................F......F...... 1281 / 3111 ( 41%)
.............................S............................... 1342 / 3111 ( 43%)
......F...................................................... 1403 / 3111 ( 45%)
............................................................. 1464 / 3111 ( 47%)
..................SS.................................S....... 1525 / 3111 ( 49%)
............................................................. 1586 / 3111 ( 50%)
............................................................. 1647 / 3111 ( 52%)
............................................................. 1708 / 3111 ( 54%)
............................................................. 1769 / 3111 ( 56%)
............................................................. 1830 / 3111 ( 58%)
............................................................. 1891 / 3111 ( 60%)
............................................................. 1952 / 3111 ( 62%)
.............................................S............... 2013 / 3111 ( 64%)
...SSS.............................II........................ 2074 / 3111 ( 66%)
S................SSS......................................... 2135 / 3111 ( 68%)
............................................................. 2196 / 3111 ( 70%)
............................................................. 2257 / 3111 ( 72%)
............................................................. 2318 / 3111 ( 74%)
............................................................. 2379 / 3111 ( 76%)
............................................................. 2440 / 3111 ( 78%)
............................................................. 2501 / 3111 ( 80%)
............................................................. 2562 / 3111 ( 82%)
............................................................. 2623 / 3111 ( 84%)
............................................................. 2684 / 3111 ( 86%)
............................................................. 2745 / 3111 ( 88%)
............................................................. 2806 / 3111 ( 90%)
............................................................. 2867 / 3111 ( 92%)
............................................................. 2928 / 3111 ( 94%)
...................S.......S......S.......S.................. 2989 / 3111 ( 96%)
.....S...........S........................................... 3050 / 3111 ( 98%)
............................................................. 3111 / 3111 (100%)


Time: 10.07 seconds, Memory: 148.00MB

There was 1 error:

1) Doctrine\Tests\ORM\Cache\DefaultQueryCacheTest::testPutToOneAssociation2LevelsQueryResult
Undefined property: Doctrine\Tests\Models\Cache\City::$country

/usr/local/src/doctrine2/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:782
/usr/local/src/doctrine2/lib/Doctrine/ORM/Cache/DefaultQueryCache.php:266
/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php:183

--

There were 6 failures:

1) Doctrine\Tests\ORM\Functional\ExtraLazyCollectionTest::testGetIndexByIdentifier
Getting the same entity should not cause an extra query to be executed
Failed asserting that 30 matches expected 28.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php:772

2) Doctrine\Tests\ORM\Functional\ProxiesLikeEntitiesTest::testPersistUpdate
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Marco Pivetta'
+'Marco'

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php:65

3) Doctrine\Tests\ORM\Functional\SecondLevelCacheOneToManyTest::testLoadOneToManyCollectionFromDatabaseWhenEntityMissing
Failed asserting that 17 matches expected 16.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php:151

4) Doctrine\Tests\ORM\Functional\Ticket\DDC1655Test::testPostLoadInheritanceChild
Failed asserting that 2 matches expected 1.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php:69

5) Doctrine\Tests\ORM\Functional\Ticket\DDC1690Test::testChangeTracking
Failed asserting that actual size 1 matches expected size 0.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php:57

6) Doctrine\Tests\ORM\Functional\Ticket\DDC2862Test::testIssueReopened
Failed asserting that 8 matches expected 7.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php:107

FAILURES!
Tests: 3111, Assertions: 11368, Errors: 1, Failures: 6, Skipped: 46, Incomplete: 2.
```
## Output with PHPUnit 5.5-dev after these changes

```
PHPUnit 5.5-gf570814 by Sebastian Bergmann and contributors.

.........................................................E...   61 / 3111 (  1%)
............S................................................  122 / 3111 (  3%)
.............................................................  183 / 3111 (  5%)
.............................................................  244 / 3111 (  7%)
.............................................................  305 / 3111 (  9%)
.............................................................  366 / 3111 ( 11%)
.........................................S........SSSS.S.....  427 / 3111 ( 13%)
.............................................................  488 / 3111 ( 15%)
............................................F................  549 / 3111 ( 17%)
....................................SS.......................  610 / 3111 ( 19%)
.............................................................  671 / 3111 ( 21%)
.............................................................  732 / 3111 ( 23%)
.............................................................  793 / 3111 ( 25%)
.............................................................  854 / 3111 ( 27%)
....................F........................................  915 / 3111 ( 29%)
.............................................................  976 / 3111 ( 31%)
......................................S.SSSSSSSSSSSS......... 1037 / 3111 ( 33%)
......................................................F...... 1098 / 3111 ( 35%)
..................................................SS......... 1159 / 3111 ( 37%)
.....................S...S...........S....................... 1220 / 3111 ( 39%)
.......S.......................................F......F...... 1281 / 3111 ( 41%)
.............................S............................... 1342 / 3111 ( 43%)
......F...................................................... 1403 / 3111 ( 45%)
............................................................. 1464 / 3111 ( 47%)
..................SS.................................S....... 1525 / 3111 ( 49%)
............................................................. 1586 / 3111 ( 50%)
............................................................. 1647 / 3111 ( 52%)
............................................................. 1708 / 3111 ( 54%)
............................................................. 1769 / 3111 ( 56%)
............................................................. 1830 / 3111 ( 58%)
............................................................. 1891 / 3111 ( 60%)
............................................................. 1952 / 3111 ( 62%)
.............................................S............... 2013 / 3111 ( 64%)
...SSS.............................II........................ 2074 / 3111 ( 66%)
S................SSS......................................... 2135 / 3111 ( 68%)
............................................................. 2196 / 3111 ( 70%)
............................................................. 2257 / 3111 ( 72%)
............................................................. 2318 / 3111 ( 74%)
............................................................. 2379 / 3111 ( 76%)
............................................................. 2440 / 3111 ( 78%)
............................................................. 2501 / 3111 ( 80%)
............................................................. 2562 / 3111 ( 82%)
............................................................. 2623 / 3111 ( 84%)
............................................................. 2684 / 3111 ( 86%)
............................................................. 2745 / 3111 ( 88%)
............................................................. 2806 / 3111 ( 90%)
............................................................. 2867 / 3111 ( 92%)
............................................................. 2928 / 3111 ( 94%)
...................S.......S......S.......S.................. 2989 / 3111 ( 96%)
.....S...........S........................................... 3050 / 3111 ( 98%)
............................................................. 3111 / 3111 (100%)


Time: 9.82 seconds, Memory: 152.00MB

There was 1 error:

1) Doctrine\Tests\ORM\Cache\DefaultQueryCacheTest::testPutToOneAssociation2LevelsQueryResult
Undefined property: Doctrine\Tests\Models\Cache\City::$country

/usr/local/src/doctrine2/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:782
/usr/local/src/doctrine2/lib/Doctrine/ORM/Cache/DefaultQueryCache.php:266
/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php:183

--

There were 6 failures:

1) Doctrine\Tests\ORM\Functional\ExtraLazyCollectionTest::testGetIndexByIdentifier
Getting the same entity should not cause an extra query to be executed
Failed asserting that 30 matches expected 28.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php:772

2) Doctrine\Tests\ORM\Functional\ProxiesLikeEntitiesTest::testPersistUpdate
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Marco Pivetta'
+'Marco'

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php:65

3) Doctrine\Tests\ORM\Functional\SecondLevelCacheOneToManyTest::testLoadOneToManyCollectionFromDatabaseWhenEntityMissing
Failed asserting that 17 matches expected 16.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php:151

4) Doctrine\Tests\ORM\Functional\Ticket\DDC1655Test::testPostLoadInheritanceChild
Failed asserting that 2 matches expected 1.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php:69

5) Doctrine\Tests\ORM\Functional\Ticket\DDC1690Test::testChangeTracking
Failed asserting that actual size 1 matches expected size 0.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php:57

6) Doctrine\Tests\ORM\Functional\Ticket\DDC2862Test::testIssueReopened
Failed asserting that 8 matches expected 7.

/usr/local/src/doctrine2/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php:107
```
