### PR TITLE
Allow to clear up UOW only with given entity

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -343,7 +343,11 @@ use Doctrine\Common\Util\ClassUtils;
      * If an entity is explicitly passed to this method only this entity and
      * the cascade-persist semantics + scheduled inserts/removals are synchronized.
      *
+     * Also if you want to keep your changeSets for another entities you should explicitly provide
+     * $leaveUnflushedChanges as true, so you still can flush changed entities afterwards.
+     *
      * @param null|object|array $entity
+     * @param boolean           $leaveUnflushedChanges allows you to keep changes stored with notify policy
      *
      * @return void
      *
@@ -351,11 +355,11 @@ use Doctrine\Common\Util\ClassUtils;
      *         makes use of optimistic locking fails.
      * @throws ORMException
      */
-    public function flush($entity = null)
+    public function flush($entity = null, $leaveUnflushedChanges = false)
     {
         $this->errorIfClosed();
 
-        $this->unitOfWork->commit($entity);
+        $this->unitOfWork->commit($entity, $leaveUnflushedChanges);
     }
 
     /**


### PR DESCRIPTION
When flushing only given entities you are loosing already computed changesSets. This is little bit weird, because you may want to wirte something in very far distant place (like some listener or something like this).

With this changes nothing become borken, and you need no changes in your code, but you are allowed now to keep already computed changesets and save them after you already flushed single (or several) entities.
