### PR TITLE
#5882 recommend using latest stable PHP version in the getting started guide

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -17,7 +17,7 @@ This guide is designed for beginners that haven't worked with Doctrine ORM
 before. There are some prerequesites for the tutorial that have to be
 installed:
 
-- PHP 5.4 or above
+- PHP (latest stable version)
 - Composer Package Manager (`Install Composer
   <http://getcomposer.org/doc/00-intro.md>`_)
 


### PR DESCRIPTION
As @Ocramius suggested in #5882: dropping the specific PHP version from the getting started guide.
