### PR TITLE
Pull default mapping values from concrete types

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
@@ -423,7 +424,7 @@ class SchemaTool
         $columnName = $this->quoteStrategy->getColumnName($mapping['fieldName'], $class, $this->platform);
         $columnType = $mapping['type'];
 
-        $options = array();
+        $options = Type::getType($columnType)->getDefaultMappingValues();
         $options['length'] = isset($mapping['length']) ? $mapping['length'] : null;
         $options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
         if ($class->isInheritanceTypeSingleTable() && count($class->parentClasses) > 0) {


### PR DESCRIPTION
This PR requires the https://github.com/doctrine/dbal/pull/2421 PR to be merged first.

It solves the problem where the comparator sees columns as changed when a custom type overrides parameters like length internally when returning the SQL statement to create/update the column.

This feature allows to supply those override values via a specific function, so the values are known to the schema tool and the comparator can compare the actual values. As an example, the following custom type always triggered the comparator to see a column as changed, even though it wasn't:

``` php
class LocaleType extends StringType
{
    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
    {
        return $platform->getVarcharTypeDeclarationSQL([
            'length' => '5',
            'fixed' => true,
        ]);
    }
}
```

In comparison, with the new method for types introduced, one can write an equal type which will work with the comparator:

``` php
class LocaleType extends StringType
{
    public function getDefaultMappingValues()
    {
        return [
            'length' => '5',
            'fixed' => true,
        ];
    }
}
```
