### PR TITLE
Check for Xcache availability from INI setting

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -126,7 +126,7 @@ class Setup
         if ($isDevMode === false && $cache === null) {
             if (extension_loaded('apc')) {
                 $cache = new \Doctrine\Common\Cache\ApcCache();
-            } elseif (extension_loaded('xcache')) {
+            } elseif (ini_get('xcache.cacher')) {
                 $cache = new \Doctrine\Common\Cache\XcacheCache();
             } elseif (extension_loaded('memcache')) {
                 $memcache = new \Memcache();


### PR DESCRIPTION
On a shared webhosting the Xcache module is loaded, but it can be disabled with .htaccess `php_flag xcache.cacher Off`
So module is loaded, but Xcache is disabled via php.ini
