### PR TITLE
respect indexBy when using second level cache

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -87,9 +87,20 @@ class DefaultCollectionHydrator implements CollectionHydrator
             return null;
         }
 
-        /* @var $entityEntries \Doctrine\ORM\Cache\EntityCacheEntry[] */
-        foreach ($entityEntries as $index => $entityEntry) {
-            $list[$index] = $this->uow->createEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
+        if (isset($assoc['indexBy'])) {
+            /* @var $entityEntries \Doctrine\ORM\Cache\EntityCacheEntry[] */
+            foreach ($entityEntries as $entityEntry) {
+                $entity = $this->uow->createEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
+
+                $entityClassMetadata = $this->em->getClassMetadata($entityEntry->class);
+                $index = $entityClassMetadata->getFieldValue($entity, $assoc['indexBy']);
+                $list[$index] = $entity;
+            }
+        } else {
+            /* @var $entityEntries \Doctrine\ORM\Cache\EntityCacheEntry[] */
+            foreach ($entityEntries as $index => $entityEntry) {
+                $list[$index] = $this->uow->createEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
+            }
         }
 
         array_walk($list, function($entity, $index) use ($collection) {

--- a/tests/Doctrine/Tests/Models/DDC5889/DDC5889PageModel.php
+++ b/tests/Doctrine/Tests/Models/DDC5889/DDC5889PageModel.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC5889;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity()
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class DDC5889PageModel
+{
+    /**
+     * @Id()
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var ArrayCollection
+     * @Cache(usage="NONSTRICT_READ_WRITE")
+     * @OneToMany(targetEntity="\Doctrine\Tests\Models\DDC5889\DDC5889TranslationModel", mappedBy="page", cascade={"persist", "remove"}, indexBy="language", orphanRemoval=true)
+     */
+    private $translations;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    private $title;
+
+    /**
+     * DDC5889PageModel constructor.
+     * @param string $title
+     */
+    public function __construct($title)
+    {
+        $this->translations = new ArrayCollection();
+        $this->title = $title;
+    }
+
+    /**
+     * @return ArrayCollection
+     */
+    public function getTranslations()
+    {
+        return $this->translations;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC5889/DDC5889TranslationModel.php
+++ b/tests/Doctrine/Tests/Models/DDC5889/DDC5889TranslationModel.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC5889;
+
+/**
+ * @Entity()
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class DDC5889TranslationModel
+{
+    /**
+     * @Id()
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * DDC5889PageModel
+     * @ManyToOne(targetEntity="\Doctrine\Tests\Models\DDC5889\DDC5889PageModel", inversedBy="translations")
+     */
+    private $page;
+
+    /**
+     * @var string
+     * @Column(type="text")
+     */
+    private $translatedText;
+
+    /**
+     * @var string
+     * @Column(type="string")
+     */
+    private $language;
+
+    /**
+     * DDC5889TranslationModel constructor.
+     * @param $page
+     * @param $translatedText
+     * @param $language
+     */
+    public function __construct($page, $translatedText, $language)
+    {
+        $this->page = $page;
+        $this->translatedText = $translatedText;
+        $this->language = $language;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5889Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5889Test.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\DDC5889\DDC5889PageModel;
+use Doctrine\Tests\Models\DDC5889\DDC5889TranslationModel;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class DDC5889Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->enableSecondLevelCache();
+
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(DDC5889PageModel::class),
+            $this->_em->getClassMetadata(DDC5889TranslationModel::class),
+        ));
+    }
+
+    public function testSecondLevelCacheDoesReturnCorrectIndex()
+    {
+        $page = new DDC5889PageModel('phpunit');
+
+        $translation1 = new DDC5889TranslationModel($page, 'phpunit-1', 'en');
+        $page->getTranslations()->add($translation1);
+
+        $translation2 = new DDC5889TranslationModel($page, 'phpunit-2', 'pl');
+        $page->getTranslations()->add($translation2);
+
+        $this->_em->persist($page);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $fetchedPage = $this->_em->find(DDC5889PageModel::class, $page->getId());
+        $translations = $fetchedPage->getTranslations();
+
+        $this->assertCount(2, $translations, 'Page does contain translations');
+
+        $this->assertArrayHasKey('en', $translations);
+        $this->assertArrayHasKey('pl', $translations);
+
+    }
+}


### PR DESCRIPTION
Hello,

this fixes issue #5889.

As this is my first contribution to doctrine, please review thoroughly. Any feedback is very welcome.

Things to consider:
- Should i rename the functional test from DDC5889 to GH5889?
- I would prefer to already write the correct index to the cache (because written to the cache may occur less often then reading from it). However, there is [code which expects the index from the cache keys to be the same as the index from the initial collection](https://github.com/BreiteSeite/doctrine2/blob/ff4e02f202a6977492ed530b435fb28e828d3d8b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php#L193). Thats why "reindex" occurs on reading from the cache now. As a small positive side effect: this means the caching adapter does not have to support indexes. Also no need for cache purging for metadata changes when indexing occurs on the read-side.
- If you agree that the implementation is okay so far, i might add a unit test for the DefaultCollectionHydrator class if you want.
