### PR TITLE
Fixed overwriting explicit cache namespace

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -145,7 +145,7 @@ class Setup
             $cache = new ArrayCache();
         }
 
-        if ($cache instanceof CacheProvider) {
+        if ($cache instanceof CacheProvider && $cache->getNamespace() === '') {
             $cache->setNamespace("dc2_" . md5($proxyDir) . "_"); // to avoid collisions
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -71,6 +71,22 @@ class SetupTest extends OrmTestCase
         $this->assertInstanceOf('Doctrine\ORM\Mapping\Driver\YamlDriver', $config->getMetadataDriverImpl());
     }
 
+    public function testConfigureCacheNamespace()
+    {
+        // automatically set namespace
+        $config = Setup::createConfiguration(false, '/foo');
+
+        $this->assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf_', $config->getMetadataCacheImpl()->getNamespace());
+
+
+        // manually set namespace
+        $cache = new ArrayCache();
+        $cache->setNamespace('foo');
+        $config = Setup::createConfiguration(false, '/foo', $cache);
+
+        $this->assertSame('foo', $config->getMetadataCacheImpl()->getNamespace());
+    }
+
     /**
      * @group DDC-1350
      */


### PR DESCRIPTION
When trying to use explicit namespace revision (i.e. revision as cache namespace: `$cache->setNamespace($revision)`), Doctrine overwrites the revision by some default namespace derived from proxy dir (which in environments like Docker does not differ from revision to revision).
