### PR TITLE
Allow empty string identifiers

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1400,7 +1400,7 @@ class UnitOfWork implements PropertyChangedListener
         $classMetadata = $this->em->getClassMetadata(get_class($entity));
         $identifier    = $this->entityIdentifiers[spl_object_hash($entity)];
 
-        if (in_array(null, $identifier, true)) {
+        if (empty($identifier) || in_array(null, $identifier, true)) {
             throw ORMInvalidArgumentException::entityWithoutIdentity($classMetadata->name, $entity);
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1398,12 +1398,13 @@ class UnitOfWork implements PropertyChangedListener
     public function addToIdentityMap($entity)
     {
         $classMetadata = $this->em->getClassMetadata(get_class($entity));
-        $idHash        = implode(' ', $this->entityIdentifiers[spl_object_hash($entity)]);
+        $identifier    = $this->entityIdentifiers[spl_object_hash($entity)];
 
-        if ($idHash === '') {
+        if (in_array(null, $identifier, true)) {
             throw ORMInvalidArgumentException::entityWithoutIdentity($classMetadata->name, $entity);
         }
 
+        $idHash    = implode(' ', $identifier);
         $className = $classMetadata->rootEntityName;
 
         if (isset($this->identityMap[$className][$idHash])) {

--- a/tests/Doctrine/Tests/Models/Cache/Action.php
+++ b/tests/Doctrine/Tests/Models/Cache/Action.php
@@ -14,13 +14,8 @@ class Action
 
     /**
      * @Id
-     * @GeneratedValue
-     * @Column(type="integer")
-     */
-    public $id;
-
-    /**
-     * @Column
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/Cache/ComplexAction.php
+++ b/tests/Doctrine/Tests/Models/Cache/ComplexAction.php
@@ -20,14 +20,14 @@ class ComplexAction
     /**
      * @Id
      * @OneToOne(targetEntity="Action", cascade={"persist", "remove"})
-     * @JoinColumn(name="action1_id", referencedColumnName="id")
+     * @JoinColumn(name="action1_name", referencedColumnName="name")
      */
     public $action1;
 
     /**
      * @Id
      * @OneToOne(targetEntity="Action", cascade={"persist", "remove"})
-     * @JoinColumn(name="action2_id", referencedColumnName="id")
+     * @JoinColumn(name="action2_name", referencedColumnName="name")
      */
     public $action2;
 

--- a/tests/Doctrine/Tests/Models/Cache/Token.php
+++ b/tests/Doctrine/Tests/Models/Cache/Token.php
@@ -36,7 +36,7 @@ class Token
 
     /**
      * @ManyToOne(targetEntity="Action", cascade={"persist", "remove"}, inversedBy="tokens")
-     * @JoinColumn(name="action_id", referencedColumnName="id")
+     * @JoinColumn(name="action_name", referencedColumnName="name")
      * @var array
      */
     public $action;
@@ -44,8 +44,8 @@ class Token
     /**
      * @ManyToOne(targetEntity="ComplexAction", cascade={"persist", "remove"}, inversedBy="tokens")
      * @JoinColumns({
-     *   @JoinColumn(name="complex_action1_id", referencedColumnName="action1_id"),
-     *   @JoinColumn(name="complex_action2_id", referencedColumnName="action2_id")
+     *   @JoinColumn(name="complex_action1_name", referencedColumnName="action1_name"),
+     *   @JoinColumn(name="complex_action2_name", referencedColumnName="action2_name")
      * })
      * @var ComplexAction
      */

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php
@@ -193,7 +193,7 @@ class SecondLevelCacheManyToOneTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
 
         $this->assertTrue($this->cache->containsEntity(Token::CLASSNAME, $token->token));
-        $this->assertFalse($this->cache->containsEntity(Token::CLASSNAME, $action->id));
+        $this->assertFalse($this->cache->containsEntity(Token::CLASSNAME, $action->name));
 
         $queryCount = $this->getCurrentQueryCount();
         $entity = $this->_em->find(Token::CLASSNAME, $token->token);
@@ -204,7 +204,7 @@ class SecondLevelCacheManyToOneTest extends SecondLevelCacheAbstractTest
         $this->assertInstanceOf(Action::CLASSNAME, $entity->getAction());
         $this->assertEquals('exec', $entity->getAction()->name);
 
-        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
     }
 
     public function testPutAndLoadNonCacheableCompositeManyToOne()
@@ -231,9 +231,9 @@ class SecondLevelCacheManyToOneTest extends SecondLevelCacheAbstractTest
         $this->_em->clear();
 
         $this->assertTrue($this->cache->containsEntity(Token::CLASSNAME, $token->token));
-        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action1->id));
-        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action2->id));
-        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action3->id));
+        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action1->name));
+        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action2->name));
+        $this->assertFalse($this->cache->containsEntity(Action::CLASSNAME, $action3->name));
 
         $queryCount = $this->getCurrentQueryCount();
         /**
@@ -255,8 +255,8 @@ class SecondLevelCacheManyToOneTest extends SecondLevelCacheAbstractTest
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
 
         $this->assertEquals('login', $entity->getComplexAction()->getAction1()->name);
-        $this->assertEquals($queryCount + 2, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         $this->assertEquals('rememberme', $entity->getComplexAction()->getAction2()->name);
-        $this->assertEquals($queryCount + 3, $this->getCurrentQueryCount());
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -375,11 +375,7 @@ class UnitOfWorkTest extends OrmTestCase
      */
     public function testAddToIdentityMapValidIdentifiers($entity, $idHash)
     {
-        $this->_unitOfWork->registerManaged(
-            $entity,
-            $this->_emMock->getClassMetadata(get_class($entity))->getIdentifierValues($entity),
-            []
-        );
+        $this->_unitOfWork->persist($entity);
         $this->_unitOfWork->addToIdentityMap($entity);
 
         // note: cloning to avoid lookup by spl_object_hash()
@@ -428,20 +424,15 @@ class UnitOfWorkTest extends OrmTestCase
      * @dataProvider entitiesWithInvalidIdentifiersProvider
      *
      * @param object $entity
+     * @param array  $identifier
      *
      * @return void
      */
-    public function testAddToIdentityMapInvalidIdentifiers($entity)
+    public function testAddToIdentityMapInvalidIdentifiers($entity, array $identifier)
     {
-        $this->_unitOfWork->registerManaged(
-            $entity,
-            $this->_emMock->getClassMetadata(get_class($entity))->getIdentifierValues($entity),
-            []
-        );
-
         $this->expectException(ORMInvalidArgumentException::class);
 
-        $this->_unitOfWork->addToIdentityMap($entity);
+        $this->_unitOfWork->registerManaged($entity, $identifier, []);
     }
 
 
@@ -456,10 +447,10 @@ class UnitOfWorkTest extends OrmTestCase
         $secondNullString->id1 = uniqid('id1', true);
 
         return [
-            'null string, single field'      => [new EntityWithStringIdentifier()],
-            'null strings, two fields'       => [new EntityWithCompositeStringIdentifier()],
-            'first null string, two fields'  => [$firstNullString],
-            'second null string, two fields' => [$secondNullString],
+            'null string, single field'      => [new EntityWithStringIdentifier(), ['id' => null]],
+            'null strings, two fields'       => [new EntityWithCompositeStringIdentifier(), ['id1' => null, 'id2' => null]],
+            'first null string, two fields'  => [$firstNullString, ['id1' => null, 'id2' => $firstNullString->id2]],
+            'second null string, two fields' => [$secondNullString, ['id1' => $secondNullString->id1, 'id2' => null]],
         ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -419,6 +419,13 @@ class UnitOfWorkTest extends OrmTestCase
         ];
     }
 
+    public function testRegisteringAManagedInstanceRequiresANonEmptyIdentifier()
+    {
+        $this->expectException(ORMInvalidArgumentException::class);
+
+        $this->_unitOfWork->registerManaged(new EntityWithBooleanIdentifier(), [], []);
+    }
+
     /**
      * @dataProvider entitiesWithInvalidIdentifiersProvider
      *

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -363,6 +363,43 @@ class UnitOfWorkTest extends OrmTestCase
             [new ArrayCollection()],
         ];
     }
+
+    /**
+     * @dataProvider entitiesWithValidIdentifiersProvider
+     *
+     * @param object $entity
+     *
+     * @return void
+     */
+    public function testAddToIdentityMapValidIdentifiers($entity)
+    {
+        $this->_unitOfWork->registerManaged(
+            $entity,
+            $this->_emMock->getClassMetadata(get_class($entity))->getIdentifierValues($entity),
+            []
+        );
+        $this->_unitOfWork->addToIdentityMap($entity);
+
+        self::assertInternalType('string', $this->_unitOfWork->getEntityIdentifier($entity));
+        // note: cloning to avoid lookup by spl_object_hash()
+        self::assertTrue($this->_unitOfWork->isInIdentityMap(clone $entity));
+    }
+
+    public function entitiesWithValidIdentifiersProvider()
+    {
+        $emptyString = new EntityWithStringIdentifier();
+
+        $emptyString->id = '';
+
+        $nonEmptyString = new EntityWithStringIdentifier();
+
+        $nonEmptyString->id = uniqid('', true);
+
+        return [
+            'empty string, single field'     => [$emptyString],
+            'non-empty string, single field' => [$nonEmptyString],
+        ];
+    }
 }
 
 /**
@@ -468,4 +505,44 @@ class VersionedAssignedIdentifierEntity
      * @Version @Column(type="integer")
      */
     public $version;
+}
+
+/** @Entity */
+class EntityWithStringIdentifier
+{
+    /**
+     * @Id @Column(type="string")
+     *
+     * @var string|null
+     */
+    public $id;
+}
+
+/** @Entity */
+class EntityWithBooleanIdentifier
+{
+    /**
+     * @Id @Column(type="boolean")
+     *
+     * @var bool|null
+     */
+    public $id;
+}
+
+/** @Entity */
+class EntityWithCompositeStringIdentifier
+{
+    /**
+     * @Id @Column(type="string")
+     *
+     * @var string|null
+     */
+    public $id1;
+
+    /**
+     * @Id @Column(type="string")
+     *
+     * @var string|null
+     */
+    public $id2;
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -368,10 +368,11 @@ class UnitOfWorkTest extends OrmTestCase
      * @dataProvider entitiesWithValidIdentifiersProvider
      *
      * @param object $entity
+     * @param string $idHash
      *
      * @return void
      */
-    public function testAddToIdentityMapValidIdentifiers($entity)
+    public function testAddToIdentityMapValidIdentifiers($entity, $idHash)
     {
         $this->_unitOfWork->registerManaged(
             $entity,
@@ -380,9 +381,8 @@ class UnitOfWorkTest extends OrmTestCase
         );
         $this->_unitOfWork->addToIdentityMap($entity);
 
-        self::assertInternalType('string', $this->_unitOfWork->getEntityIdentifier($entity));
         // note: cloning to avoid lookup by spl_object_hash()
-        self::assertTrue($this->_unitOfWork->isInIdentityMap(clone $entity));
+        self::assertSame($entity, $this->_unitOfWork->getByIdHash($idHash, get_class($entity)));
     }
 
     public function entitiesWithValidIdentifiersProvider()
@@ -395,9 +395,15 @@ class UnitOfWorkTest extends OrmTestCase
 
         $nonEmptyString->id = uniqid('', true);
 
+        $emptyStrings = new EntityWithCompositeStringIdentifier();
+
+        $emptyStrings->id1 = '';
+        $emptyStrings->id2 = '';
+
         return [
-            'empty string, single field'     => [$emptyString],
-            'non-empty string, single field' => [$nonEmptyString],
+            'empty string, single field'     => [$emptyString, ''],
+            'non-empty string, single field' => [$nonEmptyString, $nonEmptyString->id],
+            'empty strings, two fields'      => [$emptyStrings, ' '],
         ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -378,7 +378,6 @@ class UnitOfWorkTest extends OrmTestCase
         $this->_unitOfWork->persist($entity);
         $this->_unitOfWork->addToIdentityMap($entity);
 
-        // note: cloning to avoid lookup by spl_object_hash()
         self::assertSame($entity, $this->_unitOfWork->getByIdHash($idHash, get_class($entity)));
     }
 

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -447,35 +447,19 @@ class UnitOfWorkTest extends OrmTestCase
 
     public function entitiesWithInvalidIdentifiersProvider()
     {
-        $emptyString = new EntityWithStringIdentifier();
+        $firstNullString  = new EntityWithCompositeStringIdentifier();
 
-        $emptyString->id = '';
+        $firstNullString->id2 = uniqid('id2', true);
 
-        $nonEmptyString = new EntityWithStringIdentifier();
+        $secondNullString = new EntityWithCompositeStringIdentifier();
 
-        $nonEmptyString->id = uniqid('id', true);
-
-        $emptyStrings = new EntityWithCompositeStringIdentifier();
-
-        $emptyStrings->id1 = '';
-        $emptyStrings->id2 = '';
-
-        $nonEmptyStrings = new EntityWithCompositeStringIdentifier();
-
-        $nonEmptyStrings->id1 = uniqid('id1', true);
-        $nonEmptyStrings->id2 = uniqid('id2', true);
-
-        $booleanTrue = new EntityWithBooleanIdentifier();
-
-        $booleanTrue->id = true;
-
-        $booleanFalse = new EntityWithBooleanIdentifier();
-
-        $booleanFalse->id = false;
+        $secondNullString->id1 = uniqid('id1', true);
 
         return [
-            'null string, single field' => [new EntityWithStringIdentifier()],
-            'null strings, two fieldds' => [new EntityWithCompositeStringIdentifier()],
+            'null string, single field'      => [new EntityWithStringIdentifier()],
+            'null strings, two fields'       => [new EntityWithCompositeStringIdentifier()],
+            'first null string, two fields'  => [$firstNullString],
+            'second null string, two fields' => [$secondNullString],
         ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -393,17 +393,23 @@ class UnitOfWorkTest extends OrmTestCase
 
         $nonEmptyString = new EntityWithStringIdentifier();
 
-        $nonEmptyString->id = uniqid('', true);
+        $nonEmptyString->id = uniqid('id', true);
 
         $emptyStrings = new EntityWithCompositeStringIdentifier();
 
         $emptyStrings->id1 = '';
         $emptyStrings->id2 = '';
 
+        $nonEmptyStrings = new EntityWithCompositeStringIdentifier();
+
+        $nonEmptyStrings->id1 = uniqid('id1', true);
+        $nonEmptyStrings->id2 = uniqid('id2', true);
+
         return [
             'empty string, single field'     => [$emptyString, ''],
             'non-empty string, single field' => [$nonEmptyString, $nonEmptyString->id],
             'empty strings, two fields'      => [$emptyStrings, ' '],
+            'non-empty strings, two fields'  => [$nonEmptyStrings, $nonEmptyStrings->id1 . ' ' . $nonEmptyStrings->id2],
         ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -419,7 +419,7 @@ class UnitOfWorkTest extends OrmTestCase
             'empty strings, two fields'      => [$emptyStrings, ' '],
             'non-empty strings, two fields'  => [$nonEmptyStrings, $nonEmptyStrings->id1 . ' ' . $nonEmptyStrings->id2],
             'boolean true'                   => [$booleanTrue, '1'],
-            'boolean false'                  => [$booleanTrue, ''],
+            'boolean false'                  => [$booleanFalse, ''],
         ];
     }
 }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -405,11 +405,21 @@ class UnitOfWorkTest extends OrmTestCase
         $nonEmptyStrings->id1 = uniqid('id1', true);
         $nonEmptyStrings->id2 = uniqid('id2', true);
 
+        $booleanTrue = new EntityWithBooleanIdentifier();
+
+        $booleanTrue->id = true;
+
+        $booleanFalse = new EntityWithBooleanIdentifier();
+
+        $booleanFalse->id = false;
+
         return [
             'empty string, single field'     => [$emptyString, ''],
             'non-empty string, single field' => [$nonEmptyString, $nonEmptyString->id],
             'empty strings, two fields'      => [$emptyStrings, ' '],
             'non-empty strings, two fields'  => [$nonEmptyStrings, $nonEmptyStrings->id1 . ' ' . $nonEmptyStrings->id2],
+            'boolean true'                   => [$booleanTrue, '1'],
+            'boolean false'                  => [$booleanTrue, ''],
         ];
     }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -460,8 +460,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM cache_state');
             $conn->executeUpdate('DELETE FROM cache_country');
             $conn->executeUpdate('DELETE FROM cache_login');
-            $conn->executeUpdate('DELETE FROM cache_complex_action');
             $conn->executeUpdate('DELETE FROM cache_token');
+            $conn->executeUpdate('DELETE FROM cache_complex_action');
             $conn->executeUpdate('DELETE FROM cache_action');
             $conn->executeUpdate('DELETE FROM cache_client');
         }


### PR DESCRIPTION
This PR fixes a subtle bug that disallowed the UnitOfWork from containing entities with a `''` identifier.

Note: this fix targets ORM 2.6, because empty identifiers are still subject to bug https://github.com/doctrine/doctrine2/issues/5923
