### PR TITLE
Fix #5684 - Fix mapping on insertion for autoincrement columns with custom types

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1010,11 +1010,11 @@ class UnitOfWork implements PropertyChangedListener
         if ($postInsertIds) {
             // Persister returned post-insert IDs
             foreach ($postInsertIds as $postInsertId) {
-                $id      = $postInsertId['generatedId'];
-                $entity  = $postInsertId['entity'];
-                $oid     = spl_object_hash($entity);
-                $idField = $class->identifier[0];
-                $idType  = $this->em->getClassMetadata(get_class($entity))->fieldMappings[$idField]['type'];
+                $id       = $postInsertId['generatedId'];
+                $entity   = $postInsertId['entity'];
+                $oid      = spl_object_hash($entity);
+                $idField  = $class->identifier[0];
+                $idType   = $this->em->getClassMetadata(get_class($entity))->fieldMappings[$idField]['type'];
                 $mappedId = Types\Type::getType($idType)->convertToPHPValue($id, $platform);
 
                 $class->reflFields[$idField]->setValue($entity, $mappedId);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1019,9 +1019,9 @@ class UnitOfWork implements PropertyChangedListener
 
                 $class->reflFields[$idField]->setValue($entity, $mappedId);
 
-                $this->entityIdentifiers[$oid] = array($idField => $id);
+                $this->entityIdentifiers[$oid] = array($idField => $mappedId);
                 $this->entityStates[$oid] = self::STATE_MANAGED;
-                $this->originalEntityData[$oid][$idField] = $id;
+                $this->originalEntityData[$oid][$idField] = $mappedId;
 
                 $this->addToIdentityMap($entity);
             }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -891,7 +891,11 @@ class UnitOfWork implements PropertyChangedListener
             $idValue = $idGen->generate($this->em, $entity);
 
             if ( ! $idGen instanceof \Doctrine\ORM\Id\AssignedGenerator) {
-                $idValue = array($class->identifier[0] => $idValue);
+                $platform       = $this->em->getConnection()->getDatabasePlatform();
+                $idField        = $class->identifier[0];
+                $idType         = $this->em->getClassMetadata(get_class($entity))->fieldMappings[$idField]['type'];
+                $mappedIdValue  = Types\Type::getType($idType)->convertToPHPValue($idValue, $platform);
+                $idValue        = array($idField => $mappedIdValue);
 
                 $class->setIdentifierValues($entity, $idValue);
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -22,6 +22,15 @@ class DDC5684Test extends \Doctrine\Tests\OrmFunctionalTestCase
         ));
     }
 
+    protected function tearDown()
+    {
+        $this->_schemaTool->dropSchema(array(
+            $this->_em->getClassMetadata(DDC5684Object::CLASSNAME)
+        ));
+
+        parent::tearDown();
+    }
+
     public function testAutoIncrementIdWithCustomType()
     {
         $object = new DDC5684Object();
@@ -29,6 +38,22 @@ class DDC5684Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->assertInstanceOf(DDC5684ObjectId::CLASSNAME, $object->id);
+    }
+
+    public function testFetchObjectWithAutoIncrementedCustomType()
+    {
+        $object = new DDC5684Object();
+        $this->_em->persist($object);
+        $this->_em->flush();
+
+        $rawId = $object->id->value;
+
+        $this->_em->detach($object);
+
+        $object = $this->_em->find(DDC5684Object::CLASSNAME, new DDC5684ObjectId($rawId));
+
+        $this->assertInstanceOf(DDC5684ObjectId::CLASSNAME, $object->id);
+        $this->assertEquals($rawId, $object->id->value);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -93,6 +93,11 @@ class DDC5684ObjectId
     {
         $this->value = $value;
     }
+
+    public function __toString()
+    {
+        return (string) $this->value;
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -18,7 +18,7 @@ class DDC5684Test extends \Doctrine\Tests\OrmFunctionalTestCase
         }
 
         $this->_schemaTool->createSchema(array(
-            $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC5684Object')
+            $this->_em->getClassMetadata(DDC5684Object::CLASSNAME)
         ));
     }
 
@@ -39,9 +39,7 @@ class DDC5684ObjectIdType extends DBALTypes\IntegerType
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        $id = new DDC5684ObjectId();
-        $id->value = $value;
-        return $id;
+        return new DDC5684ObjectId($value);
     }
 
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
@@ -65,6 +63,11 @@ class DDC5684ObjectId
     const CLASSNAME = __CLASS__;
 
     public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types as DBALTypes;
+
+class DDC5684Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (DBALTypes\Type::hasType(DDC5684ObjectIdType::NAME)) {
+            DBALTypes\Type::overrideType(DDC5684ObjectIdType::NAME, DDC5684ObjectIdType::CLASSNAME);
+        } else {
+            DBALTypes\Type::addType(DDC5684ObjectIdType::NAME, DDC5684ObjectIdType::CLASSNAME);
+        }
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata('Doctrine\Tests\ORM\Functional\Ticket\DDC5684Object')
+        ));
+    }
+
+    public function testAutoIncrementIdWithCustomType()
+    {
+        $object = new DDC5684Object();
+        $this->_em->persist($object);
+        $this->_em->flush();
+
+        $this->assertInstanceOf(DDC5684ObjectId::CLASSNAME, $object->id);
+    }
+}
+
+class DDC5684ObjectIdType extends DBALTypes\IntegerType
+{
+    const NAME      = 'ticket_5684_object_id';
+    const CLASSNAME = __CLASS__;
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        $id = new DDC5684ObjectId();
+        $id->value = $value;
+        return $id;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value->value;
+    }
+
+    public function getName()
+    {
+        return self::NAME;
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}
+
+class DDC5684ObjectId
+{
+    const CLASSNAME = __CLASS__;
+
+    public $value;
+}
+
+/**
+ * @Entity
+ * @Table(name="ticket_5684_objects")
+ */
+class DDC5684Object
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+    * @Id @Column(type="ticket_5684_object_id")
+    * @GeneratedValue(strategy="AUTO")
+    */
+    public $id;
+}


### PR DESCRIPTION
Fixes #5684

The problem when using a custom type for autoincrement columns is that the value of autoincrement column returned by the database gets assigned directly without respecting mapping information. This only happens for insertion. When you fetch the records, the value is already mapped correctly.
