### PR TITLE
#5934 - add `fetch` option to `AssociationOverride` in order to override fetch strategy for subclasses of entities

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -455,6 +455,7 @@ Things to note:
 -  The association type *CANNOT* be changed.
 -  The override could redefine the joinTables or joinColumns depending on the association type.
 -  The override could redefine inversedBy to reference more than one extended entity.
+-  The override could redefine fetch to modify the fetch strategy of the extended entity.
 
 Attribute Override
 ~~~~~~~~~~~~~~~~~~~~

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -567,6 +567,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />
+    <xs:attribute name="fetch" type="orm:fetch-type" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="inversed-by-override">

--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -57,4 +57,13 @@ final class AssociationOverride implements Annotation
      * @var string
      */
     public $inversedBy;
+
+    /**
+     * The fetching strategy to use for the association.
+     *
+     * @var string
+     *
+     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
+     */
+    public $fetch;
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2153,6 +2153,10 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['joinTable'] = $overrideMapping['joinTable'];
         }
 
+        if (isset($overrideMapping['fetch'])) {
+            $mapping['fetch'] = $overrideMapping['fetch'];
+        }
+
         $mapping['joinColumnFieldNames']        = null;
         $mapping['joinTableColumns']            = null;
         $mapping['sourceToTargetKeyColumns']    = null;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -470,6 +470,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     $override['inversedBy'] = $associationOverride->inversedBy;
                 }
 
+                // Check for `fetch`
+                if ($associationOverride->fetch) {
+                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $associationOverride->fetch);
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -472,7 +472,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 // Check for `fetch`
                 if ($associationOverride->fetch) {
-                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . $associationOverride->fetch);
+                    $override['fetch'] = constant(Mapping\ClassMetadata::class . '::FETCH_' . $associationOverride->fetch);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -472,7 +472,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 // Check for `fetch`
                 if ($associationOverride->fetch) {
-                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $associationOverride->fetch);
+                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . $associationOverride->fetch);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -24,6 +24,7 @@ use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Mapping\ClassMetadata as Metadata;
 
 /**
  * XmlDriver is a metadata driver that enables mapping through XML files.
@@ -623,7 +624,7 @@ class XmlDriver extends FileDriver
 
                 // Check for `fetch`
                 if (isset($overrideElement['fetch'])) {
-                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . (string) $overrideElement['fetch']);
+                    $override['fetch'] = constant(Metadata::class . '::FETCH_' . (string) $overrideElement['fetch']);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -623,7 +623,7 @@ class XmlDriver extends FileDriver
 
                 // Check for `fetch`
                 if (isset($overrideElement['fetch'])) {
-                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $overrideElement['fetch']);
+                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . (string) $overrideElement['fetch']);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -621,6 +621,11 @@ class XmlDriver extends FileDriver
                     $override['inversedBy'] = (string) $overrideElement->{'inversed-by'}['name'];
                 }
 
+                // Check for `fetch`
+                if (isset($overrideElement['fetch'])) {
+                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $overrideElement['fetch']);
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -622,6 +622,11 @@ class YamlDriver extends FileDriver
                     $override['inversedBy'] = (string) $associationOverrideElement['inversedBy'];
                 }
 
+                // Check for `fetch`
+                if (isset($associationOverrideElement['fetch'])) {
+                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $associationOverrideElement['fetch']);
+                }
+
                 $metadata->setAssociationOverride($fieldName, $override);
             }
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Mapping\Driver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\ORM\Mapping\ClassMetadata as Metadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -624,7 +625,7 @@ class YamlDriver extends FileDriver
 
                 // Check for `fetch`
                 if (isset($associationOverrideElement['fetch'])) {
-                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . $associationOverrideElement['fetch']);
+                    $override['fetch'] = constant(Metadata::class . '::FETCH_' . $associationOverrideElement['fetch']);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -624,7 +624,7 @@ class YamlDriver extends FileDriver
 
                 // Check for `fetch`
                 if (isset($associationOverrideElement['fetch'])) {
-                    $override['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $associationOverrideElement['fetch']);
+                    $override['fetch'] = constant(ClassMetadata::class . '::FETCH_' . $associationOverrideElement['fetch']);
                 }
 
                 $metadata->setAssociationOverride($fieldName, $override);

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC5934;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+/**
+ * @Entity
+ */
+class DDC5934BaseContract
+{
+    /**
+     * @Id()
+     * @Column(name="id", type="integer")
+     * @GeneratedValue()
+     */
+    public $id;
+
+    /**
+     * @var ArrayCollection
+     *
+     * @ManyToMany(targetEntity="DDC5934Member", fetch="LAZY", inversedBy="contracts")
+     */
+    public $members;
+
+    public function __construct()
+    {
+        $this->members = new ArrayCollection();
+    }
+
+    public static function loadMetadata(ClassMetadata $metadata)
+    {
+        $metadata->mapField([
+            'id'         => true,
+            'fieldName'  => 'id',
+            'type'       => 'integer',
+            'columnName' => 'id',
+        ]);
+
+        $metadata->mapManyToMany([
+            'fieldName'    => 'members',
+            'targetEntity' => 'DDC5934Member',
+        ]);
+
+        $metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934Contract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934Contract.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC5934;
+
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverrides;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * @Entity
+ * @AssociationOverrides(
+ *     @AssociationOverride(name="members", fetch="EXTRA_LAZY")
+ * )
+ */
+class DDC5934Contract extends DDC5934BaseContract
+{
+    public static function loadMetadata(ClassMetadata $metadata)
+    {
+        $metadata->setAssociationOverride('members', [
+            'fetch' => ClassMetadata::FETCH_EXTRA_LAZY,
+        ]);
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934Member.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934Member.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC5934;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class DDC5934Member
+{
+    /**
+     * @var ArrayCollection
+     *
+     * @ORM\ManyToMany(targetEntity="DDC5934BaseContract", mappedBy="members")
+     */
+    public $contracts;
+
+    public function __construct()
+    {
+        $this->contracts = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -28,6 +28,7 @@ use Doctrine\Tests\Models\DDC1476\DDC1476EntityWithDefaultFieldType;
 use Doctrine\Tests\Models\DDC2825\ExplicitSchemaAndTable;
 use Doctrine\Tests\Models\DDC2825\SchemaAndTableInTableName;
 use Doctrine\Tests\Models\DDC3579\DDC3579Admin;
+use Doctrine\Tests\Models\DDC5934\DDC5934Contract;
 use Doctrine\Tests\Models\DDC869\DDC869ChequePayment;
 use Doctrine\Tests\Models\DDC869\DDC869CreditCardPayment;
 use Doctrine\Tests\Models\DDC869\DDC869PaymentRepository;
@@ -814,6 +815,18 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         // assert override
         $this->assertEquals('admins', $adminGroups['inversedBy']);
+    }
+
+    /**
+     * @group DDC-5934
+     */
+    public function testFetchOverrideMapping()
+    {
+        // check override metadata
+        $contractMetadata = $this->createClassMetadataFactory()->getMetadataFor(DDC5934Contract::class);
+
+        $this->assertArrayHasKey('members', $contractMetadata->associationMappings);
+        $this->assertSame(ClassMetadata::FETCH_EXTRA_LAZY, $contractMetadata->associationMappings['members']['fetch']);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
@@ -1,0 +1,17 @@
+<?php
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+$metadata->mapField([
+   'id'         => true,
+   'fieldName'  => 'id',
+   'type'       => 'integer',
+   'columnName' => 'id',
+]);
+
+$metadata->mapManyToMany([
+    'fieldName'    => 'members',
+    'targetEntity' => 'DDC5934Member',
+]);
+
+$metadata->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934Contract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934Contract.php
@@ -1,0 +1,7 @@
+<?php
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+$metadata->setAssociationOverride('members', [
+    'fetch' => ClassMetadata::FETCH_EXTRA_LAZY,
+]);

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                        http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC5934\DDC5934BaseContract">
+        <id name="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <many-to-many target-entity="DDC5934Member" inversed-by="contract" fetch="LAZY" field="members" />
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934Contract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC5934.DDC5934Contract.dcm.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                        http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\DDC5934\DDC5934Contract">
+        <association-overrides>
+            <association-override name="members" fetch="EXTRA_LAZY" />
+        </association-overrides>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.dcm.yml
@@ -1,0 +1,12 @@
+Doctrine\Tests\Models\DDC5934\DDC5934BaseContract:
+  type: mappedSuperclass
+  id:
+    id:
+      type: integer
+      column: id
+      generator:
+        strategy: AUTO
+  manyToMany:
+    members:
+      targetEntity: DDC5934Member
+      inversedBy: contract

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934Contract.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.DDC5934.DDC5934Contract.dcm.yml
@@ -1,0 +1,5 @@
+Doctrine\Tests\Models\DDC5934\DDC5934Contract:
+  type: entity
+  associationOverride:
+    members:
+      fetch: EXTRA_LAZY


### PR DESCRIPTION
adds the `fetch` option to the `association-override` sequence.

see #5934 
