### PR TITLE
Fix #4286 DDC-3476: JoinTable options are not inherited

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -557,6 +557,12 @@ class SchemaTool
                     $blacklistedFks
                 );
 
+                if (isset($foreignClass->table['options'])) {
+                    foreach ($foreignClass->table['options'] as $key => $val) {
+                        $theJoinTable->addOption($key, $val);
+                    }
+                }
+
                 $theJoinTable->setPrimaryKey($primaryKeyColumns);
             }
         }

--- a/tests/Doctrine/Tests/Models/DDC3476/DDC3476Group.php
+++ b/tests/Doctrine/Tests/Models/DDC3476/DDC3476Group.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3476;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="groups", options={"engine"="MyISAM", "collate"="utf8_general_ci"})
+ */
+class DDC3476Group
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+}

--- a/tests/Doctrine/Tests/Models/DDC3476/DDC3476User.php
+++ b/tests/Doctrine/Tests/Models/DDC3476/DDC3476User.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC3476;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\JoinTable;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\Table;
+
+/**
+ * @Entity
+ * @Table(name="users", options={"engine"="MyISAM", "collate"="utf8_general_ci"})
+ */
+class DDC3476User
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @var \Doctrine\Common\Collections\Collection|DDC3476Group[]
+     *
+     * @ManyToMany(targetEntity="DDC3476Group")
+     * @JoinTable(name="user_groups",
+     *     joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
+     *     inverseJoinColumns={@JoinColumn(name="group_id", referencedColumnName="id")}
+     *     )
+     */
+    private $groups;
+
+    /**
+     * DDC3476User constructor.
+     */
+    public function __construct()
+    {
+        $this->groups = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3476Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3476Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-3476
+ */
+class DDC3476Test extends OrmFunctionalTestCase
+{
+    public function testJoinTableInheritsParentTableOptions()
+    {
+        $em = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $classes = array(
+            $em->getClassMetadata('Doctrine\Tests\Models\DDC3476\DDC3476User'),
+            $em->getClassMetadata('Doctrine\Tests\Models\DDC3476\DDC3476Group'),
+        );
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        $this->assertTrue($schema->hasTable('users'), 'Table users should exist.');
+        $this->assertTrue($schema->hasTable('groups'), 'Table groups should exist.');
+        $this->assertTrue($schema->hasTable('user_groups'), 'Table user_groups should exist.');
+
+        $joinTable = $schema->getTable('user_groups');
+        $this->assertArrayHasKey('engine', $joinTable->getOptions(), 'Join table should have option engine');
+        $this->assertEquals(
+            'MyISAM',
+            $joinTable->getOption('engine'),
+            'Option engine should be MyISAM'
+        );
+        $this->assertArrayHasKey('collate', $joinTable->getOptions(), 'Join table should have option collate');
+        $this->assertEquals(
+            'utf8_general_ci',
+            $joinTable->getOption('collate'),
+            'Option collate should be utf8_general_ci'
+        );
+    }
+}


### PR DESCRIPTION
A JoinTable in a ManyToMany relation should inherit the options (`engine`, `collate`, …) from its "parent" table.

Implement solution proposed in #4286 by original author.
