### PR TITLE
Add OR to PersistentCollection matching()

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -646,7 +646,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @throws \RuntimeException
      */
-    public function matching(Criteria $criteria)
+    public function matching(Criteria $criteria, $or = false)
     {
         if ($this->isDirty) {
             $this->initialize();
@@ -665,7 +665,12 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $builder         = Criteria::expr();
         $ownerExpression = $builder->eq($this->backRefFieldName, $this->owner);
         $expression      = $criteria->getWhereExpression();
-        $expression      = $expression ? $builder->andX($expression, $ownerExpression) : $ownerExpression;
+
+        if ($expression) {
+            $expression = $or ? $builder->orX($expression, $ownerExpression) : $builder->andX($expression, $ownerExpression);
+        } else {
+            $expression = $ownerExpression;
+        }
 
         $criteria = clone $criteria;
         $criteria->where($expression);


### PR DESCRIPTION
Hi guys, i'm wondering if this could be a option.

Now when i have a `OneToMany`, and want to add a option to also include many entities which have a null. We have entities which are assigned to a other entity, but we also have them assigned to null, which means they are default and are assiged to all entities.

The method to get the collection would look like:

``` php
    public function getElements(): Collection
    {
        $cr = Criteria::create();
        $cr->orWhere(Criteria::expr()->isNull('house'));

        return $this->elements->matching($cr, true);
    }
```

But because the `PersistentCollection` only uses andX this was not possible. Therefore this pull request.
