### PR TITLE
Avoid adding a column for the discriminator if the column is already defined

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -358,23 +358,26 @@ class SchemaTool
     {
         $discrColumn = $class->discriminatorColumn;
 
-        if ( ! isset($discrColumn['type']) ||
-            (strtolower($discrColumn['type']) == 'string' && $discrColumn['length'] === null)
-        ) {
-            $discrColumn['type'] = 'string';
-            $discrColumn['length'] = 255;
+        //the discriminator might already be defined by an association or a column
+        if (!($table->hasColumn($discrColumn['name']))) {
+            if ( ! isset($discrColumn['type']) ||
+                (strtolower($discrColumn['type']) == 'string' && $discrColumn['length'] === null)
+            ) {
+                $discrColumn['type'] = 'string';
+                $discrColumn['length'] = 255;
+            }
+
+            $options = array(
+                'length'    => isset($discrColumn['length']) ? $discrColumn['length'] : null,
+                'notnull'   => true
+            );
+
+            if (isset($discrColumn['columnDefinition'])) {
+                $options['columnDefinition'] = $discrColumn['columnDefinition'];
+            }
+
+            $table->addColumn($discrColumn['name'], $discrColumn['type'], $options);
         }
-
-        $options = array(
-            'length'    => isset($discrColumn['length']) ? $discrColumn['length'] : null,
-            'notnull'   => true
-        );
-
-        if (isset($discrColumn['columnDefinition'])) {
-            $options['columnDefinition'] = $discrColumn['columnDefinition'];
-        }
-
-        $table->addColumn($discrColumn['name'], $discrColumn['type'], $options);
     }
 
     /**


### PR DESCRIPTION
Avoid adding a column for the discriminator if the column is already defined.

Use case:
The User entity has a ManyToOne relationship to the UserType entity.
The ManyToOne relationship is done using the column user_type_id.

I want to use this column user_type_id for the discriminator map.

Everything works except the doctrine:shema:update.

An exception is raised: The column is already defined.
The solution: For the discriminator column, do not try to add the column if this one has already been set.
