### PR TITLE
[WIP] Use `DateTimeInterface` instead `DateTime` for hints, docblocks and type checks

### DIFF
--- a/docs/en/cookbook/validation-of-entities.rst
+++ b/docs/en/cookbook/validation-of-entities.rst
@@ -106,7 +106,7 @@ validation callbacks.
          */
         public function validate()
         {
-            if (!($this->plannedShipDate instanceof DateTime)) {
+            if (!($this->plannedShipDate instanceof DateTimeInterface)) {
                 throw new ValidateException();
             }
     

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -1,11 +1,11 @@
-Working with DateTime Instances
+Working with DateTimeInterface Instances
 ===============================
 
-There are many nitty gritty details when working with PHPs DateTime instances. You have know their inner
+There are many nitty gritty details when working with PHPs DateTimeInterface instances. You have know their inner
 workings pretty well not to make mistakes with date handling. This cookbook entry holds several
-interesting pieces of information on how to work with PHP DateTime instances in Doctrine 2.
+interesting pieces of information on how to work with PHP DateTimeInterface instances in Doctrine 2.
 
-DateTime changes are detected by Reference
+DateTimeInterface changes are detected by Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When calling ``EntityManager#flush()`` Doctrine computes the changesets of all the currently managed entities
@@ -45,7 +45,7 @@ The way to go would be:
 Default Timezone Gotcha
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-By default Doctrine assumes that you are working with a default timezone. Each DateTime instance that
+By default Doctrine assumes that you are working with a default timezone. Each DateTimeInterface instance that
 is created by Doctrine will be assigned the timezone that is currently the default, either through
 the ``date.timezone`` ini setting or by calling ``date_default_timezone_set()``.
 
@@ -60,17 +60,17 @@ If you first come across the requirement to save different timezones you may be 
 to manage this mess,
 however let me crush your expectations fast. There is not a single database out there (supported by Doctrine 2)
 that supports timezones correctly. Correctly here means that you can cover all the use-cases that
-can come up with timezones. If you don't believe me you should read up on `Storing DateTime
+can come up with timezones. If you don't believe me you should read up on `Storing DateTimeInterface
 in Databases <http://derickrethans.nl/storing-date-time-in-database.html>`_.
 
 The problem is simple. Not a single database vendor saves the timezone, only the differences to UTC.
 However with frequent daylight saving and political timezone changes you can have a UTC offset that moves
 in different offset directions depending on the real location.
 
-The solution for this dilemma is simple. Don't use timezones with DateTime and Doctrine 2. However there is a workaround
+The solution for this dilemma is simple. Don't use timezones with DateTimeInterface and Doctrine 2. However there is a workaround
 that even allows correct date-time handling with timezones:
 
-1. Always convert any DateTime instance to UTC.
+1. Always convert any DateTimeInterface instance to UTC.
 2. Only set Timezones for displaying purposes
 3. Save the Timezone in the Entity for persistence.
 
@@ -94,7 +94,7 @@ the UTC time at the time of the booking and the timezone the event happened in.
 
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
-            if ($value instanceof \DateTime) {
+            if ($value instanceof \DateTimeInterface) {
                 $value->setTimezone(self::getUtc());
             }
 
@@ -103,7 +103,7 @@ the UTC time at the time of the booking and the timezone the event happened in.
 
         public function convertToPHPValue($value, AbstractPlatform $platform)
         {
-            if (null === $value || $value instanceof \DateTime) {
+            if (null === $value || $value instanceof \DateTimeInterface) {
                 return $value;
             }
 
@@ -125,8 +125,8 @@ the UTC time at the time of the booking and the timezone the event happened in.
         }
     }
 
-This database type makes sure that every DateTime instance is always saved in UTC, relative
-to the current timezone that the passed DateTime instance has.
+This database type makes sure that every DateTimeInterface instance is always saved in UTC, relative
+to the current timezone that the passed DateTimeInterface instance has.
 
 To actually use this new type instead of the default ``datetime`` type, you need to run following
 code before bootstrapping the ORM:
@@ -167,7 +167,7 @@ requiring timezoned datetimes:
          */
         private $localized = false;
 
-        public function __construct(\DateTime $createDate)
+        public function __construct(\DateTimeInterface $createDate)
         {
             $this->localized = true;
             $this->created = $createDate;
@@ -184,6 +184,6 @@ requiring timezoned datetimes:
     }
 
 This snippet makes use of the previously discussed "changeset by reference only" property of
-objects. That means a new DateTime will only be used during updating if the reference
+objects. That means a new DateTimeInterface instance will only be used during updating if the reference
 changes between retrieval and flush operation. This means we can easily go and modify
 the instance by setting the previous local timezone.

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -1,12 +1,12 @@
 Working with DateTimeInterface Instances
-===============================
+========================================
 
 There are many nitty gritty details when working with PHPs DateTimeInterface instances. You have know their inner
 workings pretty well not to make mistakes with date handling. This cookbook entry holds several
 interesting pieces of information on how to work with PHP DateTimeInterface instances in Doctrine 2.
 
 DateTimeInterface changes are detected by Reference
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When calling ``EntityManager#flush()`` Doctrine computes the changesets of all the currently managed entities
 and saves the differences to the database. In case of object properties (@Column(type="datetime") or @Column(type="object"))

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -113,7 +113,7 @@ Cookbook
   :doc:`Array Access <cookbook/implementing-arrayaccess-for-domain-objects>` |
   :doc:`Notify ChangeTracking Example <cookbook/implementing-the-notify-changetracking-policy>` |
   :doc:`Using Wakeup Or Clone <cookbook/implementing-wakeup-or-clone>` |
-  :doc:`Working with DateTime <cookbook/working-with-datetime>` |
+  :doc:`Working with DateTimeInterface <cookbook/working-with-datetime>` |
   :doc:`Validation <cookbook/validation-of-entities>` |
   :doc:`Entities in the Session <cookbook/entities-in-session>` |
   :doc:`Keeping your Modules independent <cookbook/resolve-target-entity-listener>`

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -234,13 +234,13 @@ built-in mapping types:
 -  ``bigint``: Type that maps a database BIGINT to a PHP string.
 -  ``boolean``: Type that maps a SQL boolean or equivalent (TINYINT) to a PHP boolean.
 -  ``decimal``: Type that maps a SQL DECIMAL to a PHP string.
--  ``date``: Type that maps a SQL DATETIME to a PHP DateTime
+-  ``date``: Type that maps a SQL DATETIME to a PHP DateTimeInterface
    object.
--  ``time``: Type that maps a SQL TIME to a PHP DateTime object.
+-  ``time``: Type that maps a SQL TIME to a PHP DateTimeInterface object.
 -  ``datetime``: Type that maps a SQL DATETIME/TIMESTAMP to a PHP
-   DateTime object.
+   DateTimeInterface object.
 -  ``datetimetz``: Type that maps a SQL DATETIME/TIMESTAMP to a PHP
-   DateTime object with timezone.
+   DateTimeInterface object with timezone.
 -  ``text``: Type that maps a SQL CLOB to a PHP string.
 -  ``object``: Type that maps a SQL CLOB to a PHP object using
    ``serialize()`` and ``unserialize()``
@@ -263,7 +263,7 @@ A cookbook article shows how to define :doc:`your own custom mapping types
 
 .. note::
 
-    DateTime and Object types are compared by reference, not by value. Doctrine
+    DateTimeInterface and Object types are compared by reference, not by value. Doctrine
     updates this values if the reference changes and therefore behaves as if
     these objects are immutable value objects.
 

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -245,7 +245,7 @@ Note that numeric placeholders start with a ? followed by a number
 while the named placeholders start with a : followed by a string.
 
 Calling ``setParameter()`` automatically infers which type you are setting as
-value. This works for integers, arrays of strings/integers, DateTime instances
+value. This works for integers, arrays of strings/integers, DateTimeInterface instances
 and for managed entities. If you want to set a type explicitly you can call
 the third argument to ``setParameter()`` explicitly. It accepts either a PDO
 type or a DBAL Type name for conversion.

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -480,7 +480,7 @@ We continue with the bug tracker domain, by creating the missing classes
         protected $description;
         /**
          * @Column(type="datetime")
-         * @var DateTime
+         * @var DateTimeInterface
          */
         protected $created;
         /**
@@ -504,7 +504,7 @@ We continue with the bug tracker domain, by creating the missing classes
             $this->description = $description;
         }
 
-        public function setCreated(DateTime $created)
+        public function setCreated(DateTimeInterface $created)
         {
             $this->created = $created;
         }
@@ -888,7 +888,7 @@ the ``Product`` before:
 Here we have the entity, id and primitive type definitions.
 For the "created" field we have used the ``datetime`` type, 
 which translates the YYYY-mm-dd HH:mm:ss database format 
-into a PHP DateTime instance and back.
+into a PHP DateTimeInterface instance and back.
 
 After the field definitions the two qualified references to the
 user entity are defined. They are created by the ``many-to-one``

--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -73,8 +73,8 @@ class OptimisticLockException extends ORMException
      */
     public static function lockFailedVersionMismatch($entity, $expectedLockVersion, $actualLockVersion)
     {
-        $expectedLockVersion = ($expectedLockVersion instanceof \DateTime) ? $expectedLockVersion->getTimestamp() : $expectedLockVersion;
-        $actualLockVersion = ($actualLockVersion instanceof \DateTime) ? $actualLockVersion->getTimestamp() : $actualLockVersion;
+        $expectedLockVersion = ($expectedLockVersion instanceof \DateTimeInterface) ? $expectedLockVersion->getTimestamp() : $expectedLockVersion;
+        $actualLockVersion = ($actualLockVersion instanceof \DateTimeInterface) ? $actualLockVersion->getTimestamp() : $actualLockVersion;
 
         return new self("The optimistic lock failed, version " . $expectedLockVersion . " was expected, but is actually ".$actualLockVersion, $entity);
     }

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -53,7 +53,7 @@ class ParameterTypeInferer
             return Type::BOOLEAN;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
+        if ($value instanceof \DateTimeInterface) {
             return Type::DATETIME;
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -152,10 +152,10 @@ class EntityGenerator
      * @var array
      */
     protected $typeAlias = array(
-        Type::DATETIMETZ    => '\DateTime',
-        Type::DATETIME      => '\DateTime',
-        Type::DATE          => '\DateTime',
-        Type::TIME          => '\DateTime',
+        Type::DATETIMETZ    => '\DateTimeInterface',
+        Type::DATETIME      => '\DateTimeInterface',
+        Type::DATE          => '\DateTimeInterface',
+        Type::TIME          => '\DateTimeInterface',
         Type::OBJECT        => '\stdClass',
         Type::INTEGER       => 'int',
         Type::BIGINT        => 'int',

--- a/tests/Doctrine/Tests/Models/Cache/Travel.php
+++ b/tests/Doctrine/Tests/Models/Cache/Travel.php
@@ -103,7 +103,7 @@ class Travel
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt()
     {

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
@@ -33,7 +33,7 @@ abstract class DDC1590Entity
     /**
      * Set createdAt
      *
-     * @param \DateTime $createdAt
+     * @param \DateTimeInterface $createdAt
      *
      * @return DDC1590User
      */
@@ -47,7 +47,7 @@ abstract class DDC1590Entity
     /**
      * Get createdAt
      *
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt()
     {

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
@@ -27,13 +27,13 @@ abstract class DDC3597Root {
     protected $id;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      * @Column(name="created_at", type="datetime", nullable=false)
      */
     protected $createdAt = null;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      * @Column(name="updated_at", type="datetime", nullable=false)
      */
     protected $updatedAt = null;
@@ -65,14 +65,14 @@ abstract class DDC3597Root {
 
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt() {
         return $this->createdAt;
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getUpdatedAt() {
         return $this->updatedAt;

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\DBAL\LockMode;
-use DateTime;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class OptimisticTest extends OrmFunctionalTestCase
@@ -189,7 +188,7 @@ class OptimisticTest extends OrmFunctionalTestCase
         $this->_em->persist($test);
         $this->_em->flush();
 
-        $this->assertInstanceOf('DateTime', $test->version);
+        $this->assertInstanceOf('DateTimeInterface', $test->version);
 
         return $test;
     }
@@ -205,7 +204,7 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         $test = $q->getSingleResult();
 
-        $this->assertInstanceOf('DateTime', $test->version);
+        $this->assertInstanceOf('DateTimeInterface', $test->version);
 
         // Manually increment the version datetime column
         $format = $this->_em->getConnection()->getDatabasePlatform()->getDateTimeFormatString();
@@ -238,13 +237,13 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         $test = $q->getSingleResult();
 
-        $this->assertInstanceOf('DateTime', $test->version);
+        $this->assertInstanceOf('DateTimeInterface', $test->version);
 
         // Try to lock the record with an older timestamp and it should throw an exception
         $caughtException = null;
 
         try {
-            $expectedVersionExpired = DateTime::createFromFormat('U', $test->version->getTimestamp()-3600);
+            $expectedVersionExpired = \DateTime::createFromFormat('U', $test->version->getTimestamp()-3600);
 
             $this->_em->lock($test, LockMode::OPTIMISTIC, $expectedVersionExpired);
         } catch (OptimisticLockException $e) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -177,7 +177,7 @@ class DDC1430Order
         $this->products = new \Doctrine\Common\Collections\ArrayCollection();
     }
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getDate()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -55,7 +55,7 @@ abstract class AbstractDDC2895
 {
     /**
      * @Column(name="last_modified", type="datetimetz", nullable=false)
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $lastModified;
 
@@ -69,7 +69,7 @@ abstract class AbstractDDC2895
     }
 
     /**
-     * @param \DateTime $lastModified
+     * @param \DateTimeInterface $lastModified
      */
     public function setLastModified( $lastModified )
     {
@@ -77,7 +77,7 @@ abstract class AbstractDDC2895
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getLastModified()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -46,7 +46,7 @@ class DDC345Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertEquals(1, $membership->prePersistCallCount);
         $this->assertEquals(0, $membership->preUpdateCallCount);
-        $this->assertInstanceOf('DateTime', $membership->updated);
+        $this->assertInstanceOf('DateTimeInterface', $membership->updated);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
@@ -26,9 +26,9 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertInstanceOf('Doctrine\Tests\Models\Generic\DateTimeModel', $datetime);
 
-        $this->assertInstanceOf('DateTime', $datetime->datetime);
-        $this->assertInstanceOf('DateTime', $datetime->time);
-        $this->assertInstanceOf('DateTime', $datetime->date);
+        $this->assertInstanceOf('DateTimeInterface', $datetime->datetime);
+        $this->assertInstanceOf('DateTimeInterface', $datetime->time);
+        $this->assertInstanceOf('DateTimeInterface', $datetime->date);
     }
 
     public function testScalarResult()
@@ -54,13 +54,13 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertCount(2,$result);
 
-        $this->assertInstanceOf('DateTime', $result[0]['datetime']);
-        $this->assertInstanceOf('DateTime', $result[0]['time']);
-        $this->assertInstanceOf('DateTime', $result[0]['date']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['datetime']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['time']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['date']);
 
-        $this->assertInstanceOf('DateTime', $result[1]['datetime']);
-        $this->assertInstanceOf('DateTime', $result[1]['time']);
-        $this->assertInstanceOf('DateTime', $result[1]['date']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['datetime']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['time']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['date']);
     }
 
     public function testTicketSingleResult()
@@ -70,9 +70,9 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertTrue(is_array($datetime));
 
-        $this->assertInstanceOf('DateTime', $datetime['datetime']);
-        $this->assertInstanceOf('DateTime', $datetime['time']);
-        $this->assertInstanceOf('DateTime', $datetime['date']);
+        $this->assertInstanceOf('DateTimeInterface', $datetime['datetime']);
+        $this->assertInstanceOf('DateTimeInterface', $datetime['time']);
+        $this->assertInstanceOf('DateTimeInterface', $datetime['date']);
     }
 
     public function testTicketResult()
@@ -82,15 +82,15 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertCount(2,$result);
 
-        $this->assertInstanceOf('DateTime', $result[0]['time']);
-        $this->assertInstanceOf('DateTime', $result[0]['date']);
-        $this->assertInstanceOf('DateTime', $result[0]['datetime']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['time']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['date']);
+        $this->assertInstanceOf('DateTimeInterface', $result[0]['datetime']);
 
         $this->assertEquals('2010-01-01 11:11:11', $result[0]['datetime']->format('Y-m-d G:i:s'));
 
-        $this->assertInstanceOf('DateTime', $result[1]['time']);
-        $this->assertInstanceOf('DateTime', $result[1]['date']);
-        $this->assertInstanceOf('DateTime', $result[1]['datetime']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['time']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['date']);
+        $this->assertInstanceOf('DateTimeInterface', $result[1]['datetime']);
 
         $this->assertEquals('2010-02-02 12:12:12', $result[1]['datetime']->format('Y-m-d G:i:s'));
     }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -107,7 +107,7 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find('Doctrine\Tests\Models\Generic\DateTimeModel', $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTimeDb->date);
+        $this->assertInstanceOf('DateTimeInterface', $dateTimeDb->date);
         $this->assertEquals('2009-10-01', $dateTimeDb->date->format('Y-m-d'));
     }
 
@@ -122,7 +122,7 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find('Doctrine\Tests\Models\Generic\DateTimeModel', $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTimeDb->datetime);
+        $this->assertInstanceOf('DateTimeInterface', $dateTimeDb->datetime);
         $this->assertEquals('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
 
         $articles = $this->_em->getRepository( 'Doctrine\Tests\Models\Generic\DateTimeModel' )->findBy( array( 'datetime' => new \DateTime( "now" ) ) );
@@ -175,7 +175,7 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find('Doctrine\Tests\Models\Generic\DateTimeModel', $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTime->time);
+        $this->assertInstanceOf('DateTimeInterface', $dateTime->time);
         $this->assertEquals('19:27:20', $dateTime->time->format('H:i:s'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -360,7 +360,7 @@ class DDC93Timestamps
     /** @Column(type = "datetime") */
     public $createdAt;
 
-    public function __construct(\DateTime $createdAt)
+    public function __construct(\DateTimeInterface $createdAt)
     {
         $this->createdAt = $createdAt;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -933,14 +933,14 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertSame('field1', $reflParameters[0]->getName());
         $this->assertFalse($reflParameters[0]->isOptional());
 
-        $this->assertSame('DateTime', $reflParameters[1]->getClass()->name);
+        $this->assertSame('DateTimeInterface', $reflParameters[1]->getClass()->name);
         $this->assertSame('field3', $reflParameters[1]->getName());
         $this->assertFalse($reflParameters[1]->isOptional());
 
         $this->assertSame('field2', $reflParameters[2]->getName());
         $this->assertTrue($reflParameters[2]->isOptional());
 
-        $this->assertSame('DateTime', $reflParameters[3]->getClass()->name);
+        $this->assertSame('DateTimeInterface', $reflParameters[3]->getClass()->name);
         $this->assertSame('field4', $reflParameters[3]->getName());
         $this->assertTrue($reflParameters[3]->isOptional());
     }
@@ -971,25 +971,25 @@ class EntityGeneratorTest extends OrmTestCase
         return array(
             array(array(
                 'fieldName' => 'datetimetz',
-                'phpType' => '\\DateTime',
+                'phpType' => '\\DateTimeInterface',
                 'dbType' => 'datetimetz',
                 'value' => new \DateTime
             )),
             array(array(
                 'fieldName' => 'datetime',
-                'phpType' => '\\DateTime',
+                'phpType' => '\\DateTimeInterface',
                 'dbType' => 'datetime',
                 'value' => new \DateTime
             )),
             array(array(
                 'fieldName' => 'date',
-                'phpType' => '\\DateTime',
+                'phpType' => '\\DateTimeInterface',
                 'dbType' => 'date',
                 'value' => new \DateTime
             )),
             array(array(
                 'fieldName' => 'time',
-                'phpType' => '\DateTime',
+                'phpType' => '\DateTimeInterface',
                 'dbType' => 'time',
                 'value' => new \DateTime
             )),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

**TODO:**
- [ ] Add tests with `\DateTimeImmutable` instances.
