### PR TITLE
Add missing type hints, add strictness for some checks, remove some useless calls

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
@@ -35,7 +35,7 @@ class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollecti
      */
     public function update(PersistentCollection $collection)
     {
-        if ($collection->isDirty() && count($collection->getSnapshot()) > 0) {
+        if ($collection->isDirty() && $collection->getSnapshot()) {
             throw CacheException::updateReadOnlyCollection(ClassUtils::getClass($collection->getOwner()), $this->association['fieldName']);
         }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -104,7 +104,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * Associations configured as FETCH_EAGER, as well as all inverse one-to-one associations.
      *
-     * @var array
+     * @var array|null
      */
     protected $joinedAssociations;
 
@@ -476,7 +476,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $cacheEntry = $this->hydrator->buildCacheEntry($class, $cacheKey, $entity);
         $cached     = $this->region->put($cacheKey, $cacheEntry);
 
-        if ($cached && ($this->joinedAssociations === null || count($this->joinedAssociations) > 0)) {
+        if ($cached && (null === $this->joinedAssociations || $this->joinedAssociations)) {
             $this->storeJoinedAssociations($entity);
         }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -720,7 +720,7 @@ class ClassMetadataInfo implements ClassMetadata
             foreach ($this->identifier as $idField) {
                 $value = $this->reflFields[$idField]->getValue($entity);
 
-                if ($value !== null) {
+                if (null !== $value) {
                     $id[$idField] = $value;
                 }
             }
@@ -1085,7 +1085,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function enableAssociationCache($fieldName, array $cache)
     {
-        $this->associationMappings[$fieldName]['cache'] = $this->getAssociationCacheDefaults ($fieldName, $cache);
+        $this->associationMappings[$fieldName]['cache'] = $this->getAssociationCacheDefaults($fieldName, $cache);
     }
 
     /**
@@ -1128,7 +1128,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function isChangeTrackingDeferredExplicit()
     {
-        return $this->changeTrackingPolicy == self::CHANGETRACKING_DEFERRED_EXPLICIT;
+        return self::CHANGETRACKING_DEFERRED_EXPLICIT === $this->changeTrackingPolicy;
     }
 
     /**
@@ -1138,7 +1138,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function isChangeTrackingDeferredImplicit()
     {
-        return $this->changeTrackingPolicy == self::CHANGETRACKING_DEFERRED_IMPLICIT;
+        return self::CHANGETRACKING_DEFERRED_IMPLICIT === $this->changeTrackingPolicy;
     }
 
     /**
@@ -1148,7 +1148,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function isChangeTrackingNotify()
     {
-        return $this->changeTrackingPolicy == self::CHANGETRACKING_NOTIFY;
+        return self::CHANGETRACKING_NOTIFY === $this->changeTrackingPolicy;
     }
 
     /**
@@ -1169,7 +1169,7 @@ class ClassMetadataInfo implements ClassMetadata
             return $fieldName === $this->identifier[0];
         }
 
-        return in_array($fieldName, $this->identifier);
+        return in_array($fieldName, $this->identifier, true);
     }
 
     /**
@@ -1183,11 +1183,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $mapping = $this->getFieldMapping($fieldName);
 
-        if ($mapping !== false) {
-            return isset($mapping['unique']) && $mapping['unique'] == true;
-        }
-
-        return false;
+        return false !== $mapping && isset($mapping['unique']) && $mapping['unique'];
     }
 
     /**
@@ -1201,11 +1197,7 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $mapping = $this->getFieldMapping($fieldName);
 
-        if ($mapping !== false) {
-            return isset($mapping['nullable']) && $mapping['nullable'] == true;
-        }
-
-        return false;
+        return false !== $mapping && isset($mapping['nullable']) && $mapping['nullable'];
     }
 
     /**
@@ -1391,7 +1383,7 @@ class ClassMetadataInfo implements ClassMetadata
     protected function _validateAndCompleteFieldMapping(array &$mapping)
     {
         // Check mandatory fields
-        if ( ! isset($mapping['fieldName']) || strlen($mapping['fieldName']) == 0) {
+        if ( ! isset($mapping['fieldName']) || !$mapping['fieldName']) {
             throw MappingException::missingFieldName($this->name);
         }
 
@@ -1405,21 +1397,21 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['columnName'] = $this->namingStrategy->propertyToColumnName($mapping['fieldName'], $this->name);
         }
 
-        if ($mapping['columnName'][0] === '`') {
+        if ('`' === $mapping['columnName'][0]) {
             $mapping['columnName']  = trim($mapping['columnName'], '`');
             $mapping['quoted']      = true;
         }
 
         $this->columnNames[$mapping['fieldName']] = $mapping['columnName'];
 
-        if (isset($this->fieldNames[$mapping['columnName']]) || ($this->discriminatorColumn != null && $this->discriminatorColumn['name'] == $mapping['columnName'])) {
+        if (isset($this->fieldNames[$mapping['columnName']]) || ($this->discriminatorColumn && $this->discriminatorColumn['name'] === $mapping['columnName'])) {
             throw MappingException::duplicateColumnName($this->name, $mapping['columnName']);
         }
 
         $this->fieldNames[$mapping['columnName']] = $mapping['fieldName'];
 
         // Complete id mapping
-        if (isset($mapping['id']) && $mapping['id'] === true) {
+        if (isset($mapping['id']) && true === $mapping['id']) {
             if ($this->versionField == $mapping['fieldName']) {
                 throw MappingException::cannotVersionIdField($this->name, $mapping['fieldName']);
             }
@@ -1435,7 +1427,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         if (Type::hasType($mapping['type']) && Type::getType($mapping['type'])->canRequireSQLConversion()) {
-            if (isset($mapping['id']) && $mapping['id'] === true) {
+            if (isset($mapping['id']) && true === $mapping['id']) {
                  throw MappingException::sqlConversionNotAllowedForIdentifiers($this->name, $mapping['fieldName'], $mapping['type']);
             }
 
@@ -1478,13 +1470,13 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['targetEntity'] = ltrim($mapping['targetEntity'], '\\');
         }
 
-        if (($mapping['type'] & self::MANY_TO_ONE) > 0 && isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'] == true) {
+        if (($mapping['type'] & self::MANY_TO_ONE) > 0 && isset($mapping['orphanRemoval']) && $mapping['orphanRemoval']) {
             throw MappingException::illegalOrphanRemoval($this->name, $mapping['fieldName']);
         }
 
         // Complete id mapping
-        if (isset($mapping['id']) && $mapping['id'] === true) {
-            if (isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'] == true) {
+        if (isset($mapping['id']) && true === $mapping['id']) {
+            if (isset($mapping['orphanRemoval']) && $mapping['orphanRemoval']) {
                 throw MappingException::illegalOrphanRemovalOnIdentifierAssociation($this->name, $mapping['fieldName']);
             }
 
@@ -1511,7 +1503,7 @@ class ClassMetadataInfo implements ClassMetadata
 
         // Mandatory attributes for both sides
         // Mandatory: fieldName, targetEntity
-        if ( ! isset($mapping['fieldName']) || strlen($mapping['fieldName']) == 0) {
+        if ( ! isset($mapping['fieldName']) || !$mapping['fieldName']) {
             throw MappingException::missingFieldName($this->name);
         }
 
@@ -1531,7 +1523,7 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['isOwningSide'] = false;
         }
 
-        if (isset($mapping['id']) && $mapping['id'] === true && $mapping['type'] & self::TO_MANY) {
+        if (isset($mapping['id']) && true === $mapping['id'] && $mapping['type'] & self::TO_MANY) {
             throw MappingException::illegalToManyIdentifierAssociation($this->name, $mapping['fieldName']);
         }
 
@@ -3247,7 +3239,7 @@ class ClassMetadataInfo implements ClassMetadata
             return $className;
         }
 
-        if ($className !== null && strpos($className, '\\') === false && strlen($this->namespace) > 0) {
+        if ($className !== null && strpos($className, '\\') === false && $this->namespace) {
             return $this->namespace . '\\' . $className;
         }
 

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -47,7 +47,7 @@ class InputParameter extends Node
      */
     public function __construct($value)
     {
-        if (strlen($value) == 1) {
+        if (strlen($value) === 1) {
             throw \Doctrine\ORM\Query\QueryException::invalidParameterFormat($value);
         }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2119,10 +2119,9 @@ class SqlWalker implements TreeWalker
                 return $this->conn->quote($literal->value);
 
             case AST\Literal::BOOLEAN:
-                $bool = strtolower($literal->value) == 'true' ? true : false;
-                $boolVal = $this->conn->getDatabasePlatform()->convertBooleans($bool);
+                $bool = 'true' === strtolower($literal->value);
 
-                return $boolVal;
+                return $this->conn->getDatabasePlatform()->convertBooleans($bool);
 
             case AST\Literal::NUMERIC:
                 return $literal->value;

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -371,7 +371,7 @@ public function __construct(<params>)
             mkdir($dir, 0775, true);
         }
 
-        $this->isNew = !file_exists($path) || (file_exists($path) && $this->regenerateEntityIfExists);
+        $this->isNew = !file_exists($path) || $this->regenerateEntityIfExists;
 
         if ( ! $this->isNew) {
             $this->parseTokensInEntityFile(file_get_contents($path));
@@ -390,7 +390,7 @@ public function __construct(<params>)
         if ($this->isNew) {
             file_put_contents($path, $this->generateEntityClass($metadata));
         // If entity exists and we're allowed to update the entity class
-        } elseif ( ! $this->isNew && $this->updateEntityIfExists) {
+        } elseif ($this->updateEntityIfExists) {
             file_put_contents($path, $this->generateUpdatedEntityClass($metadata, $path));
         }
         chmod($path, 0664);
@@ -442,7 +442,7 @@ public function __construct(<params>)
         $body = str_replace('<spaces>', $this->spaces, $body);
         $last = strrpos($currentCode, '}');
 
-        return substr($currentCode, 0, $last) . $body . (strlen($body) > 0 ? "\n" : '') . "}\n";
+        return substr($currentCode, 0, $last) . $body . ($body ? "\n" : '') . "}\n";
     }
 
     /**
@@ -802,22 +802,23 @@ public function __construct(<params>)
     protected function parseTokensInEntityFile($src)
     {
         $tokens = token_get_all($src);
-        $lastSeenNamespace = "";
+        $tokensCount = count($tokens);
+        $lastSeenNamespace = '';
         $lastSeenClass = false;
 
         $inNamespace = false;
         $inClass = false;
 
-        for ($i = 0; $i < count($tokens); $i++) {
+        for ($i = 0; $i < $tokensCount; $i++) {
             $token = $tokens[$i];
-            if (in_array($token[0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT))) {
+            if (in_array($token[0], array(T_WHITESPACE, T_COMMENT, T_DOC_COMMENT), true)) {
                 continue;
             }
 
             if ($inNamespace) {
-                if ($token[0] == T_NS_SEPARATOR || $token[0] == T_STRING) {
+                if (in_array($token[0], array(T_NS_SEPARATOR, T_STRING), true)) {
                     $lastSeenNamespace .= $token[1];
-                } elseif (is_string($token) && in_array($token, array(';', '{'))) {
+                } elseif (is_string($token) && in_array($token, array(';', '{'), true)) {
                     $inNamespace = false;
                 }
             }
@@ -829,18 +830,18 @@ public function __construct(<params>)
                 $this->staticReflection[$lastSeenClass]['methods'] = array();
             }
 
-            if ($token[0] == T_NAMESPACE) {
-                $lastSeenNamespace = "";
+            if (T_NAMESPACE === $token[0]) {
+                $lastSeenNamespace = '';
                 $inNamespace = true;
-            } elseif ($token[0] == T_CLASS && $tokens[$i-1][0] != T_DOUBLE_COLON) {
+            } elseif (T_CLASS === $token[0] && T_DOUBLE_COLON !== $tokens[$i-1][0]) {
                 $inClass = true;
-            } elseif ($token[0] == T_FUNCTION) {
-                if ($tokens[$i+2][0] == T_STRING) {
+            } elseif (T_FUNCTION === $token[0]) {
+                if (T_STRING === $tokens[$i+2][0]) {
                     $this->staticReflection[$lastSeenClass]['methods'][] = strtolower($tokens[$i+2][1]);
-                } elseif ($tokens[$i+2] == "&" && $tokens[$i+3][0] == T_STRING) {
+                } elseif ($tokens[$i+2] == '&' && T_STRING === $tokens[$i+3][0]) {
                     $this->staticReflection[$lastSeenClass]['methods'][] = strtolower($tokens[$i+3][1]);
                 }
-            } elseif (in_array($token[0], array(T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED)) && $tokens[$i+2][0] != T_FUNCTION) {
+            } elseif (in_array($token[0], array(T_VAR, T_PUBLIC, T_PRIVATE, T_PROTECTED), true) && T_FUNCTION !== $tokens[$i+2][0]) {
                 $this->staticReflection[$lastSeenClass]['properties'][] = substr($tokens[$i+2][1], 1);
             }
         }
@@ -871,7 +872,7 @@ public function __construct(<params>)
 
         return (
             isset($this->staticReflection[$metadata->name]) &&
-            in_array($property, $this->staticReflection[$metadata->name]['properties'])
+            in_array($property, $this->staticReflection[$metadata->name]['properties'], true)
         );
     }
 
@@ -901,7 +902,7 @@ public function __construct(<params>)
 
         return (
             isset($this->staticReflection[$metadata->name]) &&
-            in_array(strtolower($method), $this->staticReflection[$metadata->name]['methods'])
+            in_array(strtolower($method), $this->staticReflection[$metadata->name]['methods'], true)
         );
     }
 
@@ -938,7 +939,7 @@ public function __construct(<params>)
      */
     protected function hasNamespace(ClassMetadataInfo $metadata)
     {
-        return strpos($metadata->name, '\\') ? true : false;
+        return (bool) strpos($metadata->name, '\\');
     }
 
     /**
@@ -946,7 +947,7 @@ public function __construct(<params>)
      */
     protected function extendsClass()
     {
-        return $this->classToExtend ? true : false;
+        return (bool) $this->classToExtend;
     }
 
     /**
@@ -1051,7 +1052,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateTableAnnotation($metadata)
+    protected function generateTableAnnotation(ClassMetadataInfo $metadata)
     {
         if ($metadata->isEmbeddedClass) {
             return '';
@@ -1090,7 +1091,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateTableConstraints($constraintName, $constraints)
+    protected function generateTableConstraints($constraintName, array $constraints)
     {
         $annotations = array();
         foreach ($constraints as $name => $constraint) {
@@ -1109,7 +1110,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateInheritanceAnnotation($metadata)
+    protected function generateInheritanceAnnotation(ClassMetadataInfo $metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
             return '@' . $this->annotationsPrefix . 'InheritanceType("'.$this->getInheritanceTypeString($metadata->inheritanceType).'")';
@@ -1121,7 +1122,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateDiscriminatorColumnAnnotation($metadata)
+    protected function generateDiscriminatorColumnAnnotation(ClassMetadataInfo $metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
             $discrColumn = $metadata->discriminatorColumn;
@@ -1138,7 +1139,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateDiscriminatorMapAnnotation($metadata)
+    protected function generateDiscriminatorMapAnnotation(ClassMetadataInfo $metadata)
     {
         if ($metadata->inheritanceType != ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
             $inheritanceClassMap = array();
@@ -1228,7 +1229,7 @@ public function __construct(<params>)
      *
      * @return bool
      */
-    protected function isAssociationIsNullable($associationMapping)
+    protected function isAssociationIsNullable(array $associationMapping)
     {
         if (isset($associationMapping['id']) && $associationMapping['id']) {
             return false;
@@ -1381,7 +1382,7 @@ public function __construct(<params>)
         }
 
         $replacements = array(
-          '<description>'       => ucfirst($type) . ' ' . $variableName,
+          '<description>'       => ucfirst($type) . ' ' . $variableName . '.',
           '<methodTypeHint>'    => $methodTypeHint,
           '<variableType>'      => $variableType,
           '<variableName>'      => $variableName,
@@ -1407,7 +1408,7 @@ public function __construct(<params>)
      *
      * @return string
      */
-    protected function generateLifecycleCallbackMethod($name, $methodName, $metadata)
+    protected function generateLifecycleCallbackMethod($name, $methodName, ClassMetadataInfo $metadata)
     {
         if ($this->hasMethod($methodName, $metadata)) {
             return '';

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -426,14 +426,14 @@ class SchemaTool
         $options = array();
         $options['length'] = isset($mapping['length']) ? $mapping['length'] : null;
         $options['notnull'] = isset($mapping['nullable']) ? ! $mapping['nullable'] : true;
-        if ($class->isInheritanceTypeSingleTable() && count($class->parentClasses) > 0) {
+        if ($class->isInheritanceTypeSingleTable() && $class->parentClasses) {
             $options['notnull'] = false;
         }
 
         $options['platformOptions'] = array();
-        $options['platformOptions']['version'] = $class->isVersioned && $class->versionField == $mapping['fieldName'] ? true : false;
+        $options['platformOptions']['version'] = $class->isVersioned && $class->versionField === $mapping['fieldName'];
 
-        if (strtolower($columnType) == 'string' && $options['length'] === null) {
+        if (strtolower($columnType) === 'string' && null === $options['length']) {
             $options['length'] = 255;
         }
 
@@ -470,7 +470,7 @@ class SchemaTool
         if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == array($mapping['fieldName'])) {
             $options['autoincrement'] = true;
         }
-        if ($class->isInheritanceTypeJoined() && $class->name != $class->rootEntityName) {
+        if ($class->isInheritanceTypeJoined() && $class->name !== $class->rootEntityName) {
             $options['autoincrement'] = false;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -126,7 +126,7 @@ class LockTest extends OrmFunctionalTestCase
     public function testLockPessimisticWrite()
     {
         $writeLockSql = $this->_em->getConnection()->getDatabasePlatform()->getWriteLockSQL();
-        if (strlen($writeLockSql) == 0) {
+        if (!$writeLockSql) {
             $this->markTestSkipped('Database Driver has no Write Lock support.');
         }
 
@@ -157,7 +157,7 @@ class LockTest extends OrmFunctionalTestCase
     public function testLockPessimisticRead()
     {
         $readLockSql = $this->_em->getConnection()->getDatabasePlatform()->getReadLockSQL();
-        if (strlen($readLockSql) == 0) {
+        if (!$readLockSql) {
             $this->markTestSkipped('Database Driver has no Write Lock support.');
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1126 |
| License | MIT |
| Doc PR | n/a |

CHANGELOG:
- Remove calls to `strlen()`, `count()`, `empty()` when the intended behavior can be achieved via type juggling.
- Add strictness for comparisons where possible.
- Use Yoda conditions.
- Add missing type hints.
