### PR TITLE
[QueryBuilder] setParameter : trim the input key when comparing it to…

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -325,8 +325,10 @@ abstract class AbstractQuery
         $filteredParameters = $this->parameters->filter(
             function ($parameter) use ($key)
             {
+                $trimmedKey = trim($key, ':');
+
                 // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+                return ($trimmedKey == $parameter->getName());
             }
         );
 
@@ -374,8 +376,10 @@ abstract class AbstractQuery
         $filteredParameters = $this->parameters->filter(
             function ($parameter) use ($key)
             {
+                $trimmedKey = trim($key, ':');
+
                 // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+                return ($trimmedKey == $parameter->getName());
             }
         );
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -536,6 +536,7 @@ class QueryBuilder
             function ($parameter) use ($key)
             {
                 $trimmedKey = trim($key, ':');
+
                 /* @var Query\Parameter $parameter */
                 // Must not be identical because of string to integer conversion
                 return ($trimmedKey == $parameter->getName());
@@ -617,9 +618,11 @@ class QueryBuilder
         $filteredParameters = $this->parameters->filter(
             function ($parameter) use ($key)
             {
+                $trimmedKey = trim($key, ':');
+
                 /* @var Query\Parameter $parameter */
                 // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+                return ($trimmedKey == $parameter->getName());
             }
         );
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -535,9 +535,10 @@ class QueryBuilder
         $filteredParameters = $this->parameters->filter(
             function ($parameter) use ($key)
             {
+                $trimmedKey = trim($key, ':');
                 /* @var Query\Parameter $parameter */
                 // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+                return ($trimmedKey == $parameter->getName());
             }
         );
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -837,4 +837,60 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $users[2]);
         $this->assertNull($users[3]);
     }
+
+    public function testQueryParametersWithALeadingColonInTheParameterKey()
+    {
+        $parameterKey = ':username';
+        $firstParameterValue = 'fancyweb';
+        $newParameterValue = 'bewycnaf';
+
+        $query = $this->_em->createQuery(sprintf('select u from Doctrine\Tests\Models\CMS\CmsUser where u.username = %s', $parameterKey));
+        $query->setParameter($parameterKey, $firstParameterValue);
+
+        $parameter = $query->getParameter($parameterKey);
+        $this->assertNotNull($parameter);
+        if (null !== $parameter) {
+            $this->assertEquals($firstParameterValue, $parameter->getValue());
+        }
+
+        $query->setParameter($parameterKey, $newParameterValue);
+
+        $parameter = $query->getParameter($parameterKey);
+        $this->assertNotNull($parameter);
+        if (null !== $parameter) {
+            $this->assertEquals($newParameterValue, $parameter->getValue());
+        }
+
+        $this->assertEquals(1, count($query->getParameters()));
+    }
+
+    public function testQueryBuilderParametersWithALeadingColonInTheParameterKey()
+    {
+        $parameterKey = ':username';
+        $firstParameterValue = 'fancyweb';
+        $newParameterValue = 'bewycnaf';
+
+        $qb = $this->_em->createQueryBuilder()
+            ->select('u')
+            ->from('Doctrine\Tests\Models\CMS\CmsUser', 'u')
+            ->where(sprintf('u.username = %s', $parameterKey));
+
+        $qb->setParameter($parameterKey, $firstParameterValue);
+
+        $parameter = $qb->getParameter($parameterKey);
+        $this->assertNotNull($parameter);
+        if (null !== $parameter) {
+            $this->assertEquals($firstParameterValue, $parameter->getValue());
+        }
+
+        $qb->setParameter($parameterKey, $newParameterValue);
+
+        $parameter = $qb->getParameter($parameterKey);
+        $this->assertNotNull($parameter);
+        if (null !== $parameter) {
+            $this->assertEquals($newParameterValue, $parameter->getValue());
+        }
+
+        $this->assertEquals(1, count($qb->getParameters()));
+    }
 }


### PR DESCRIPTION
… existing parameters keys

Basically when you first use setParameter with a parameter name starting with ":" it trims it in the Doctrine\ORM\Query\Parameter constructor.
When you later want to change the value of this parameter, still using the name starting with ":", the parameter is not found because it compares it with the trimmed name stored in the Parameter object so it duplicates it.
