### PR TITLE
Make query cache rely on entity timestamp region

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,11 @@
 # Upgrade to 2.5
 
+## Minor BC BREAK: query cache key time is now a float
+
+As of 2.5, the `QueryCacheEntry#time` property will contain a float value
+instead of an integer in order to have more precision and also to be consistent
+with the `TimestampCacheEntry#time`.
+
 ## Minor BC BREAK: discriminator map must now include all non-transient classes
 
 It is now required that you declare the root of an inheritance in the

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -28,6 +28,7 @@ use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 
 use Doctrine\ORM\Cache;
+use Doctrine\ORM\Query\ResultSetMapping;
 
 /**
  * Base contract for ORM queries. Base class for Query and NativeQuery.
@@ -991,30 +992,52 @@ abstract class AbstractQuery
     private function executeUsingQueryCache($parameters = null, $hydrationMode = null)
     {
         $rsm        = $this->getResultSetMapping();
-        $querykey   = new QueryCacheKey($this->getHash(), $this->lifetime, $this->cacheMode ?: Cache::MODE_NORMAL);
         $queryCache = $this->_em->getCache()->getQueryCache($this->cacheRegion);
-        $result     = $queryCache->get($querykey, $rsm, $this->_hints);
+        $queryKey   = new QueryCacheKey(
+            $this->getHash(),
+            $this->lifetime,
+            $this->cacheMode ?: Cache::MODE_NORMAL,
+            $this->getTimestampKey()
+        );
+
+        $result     = $queryCache->get($queryKey, $rsm, $this->_hints);
 
         if ($result !== null) {
             if ($this->cacheLogger) {
-                $this->cacheLogger->queryCacheHit($queryCache->getRegion()->getName(), $querykey);
+                $this->cacheLogger->queryCacheHit($queryCache->getRegion()->getName(), $queryKey);
             }
 
             return $result;
         }
 
         $result = $this->executeIgnoreQueryCache($parameters, $hydrationMode);
-        $cached = $queryCache->put($querykey, $rsm, $result, $this->_hints);
+        $cached = $queryCache->put($queryKey, $rsm, $result, $this->_hints);
 
         if ($this->cacheLogger) {
-            $this->cacheLogger->queryCacheMiss($queryCache->getRegion()->getName(), $querykey);
+            $this->cacheLogger->queryCacheMiss($queryCache->getRegion()->getName(), $queryKey);
 
             if ($cached) {
-                $this->cacheLogger->queryCachePut($queryCache->getRegion()->getName(), $querykey);
+                $this->cacheLogger->queryCachePut($queryCache->getRegion()->getName(), $queryKey);
             }
         }
 
         return $result;
+    }
+
+    /**
+     * @return \Doctrine\ORM\Cache\TimestampCacheKey|null
+     */
+    private function getTimestampKey()
+    {
+        $entityName = reset($this->_resultSetMapping->aliasMap);
+
+        if (empty($entityName)) {
+            return null;
+        }
+
+        $metadata = $this->_em->getClassMetadata($entityName);
+
+        return new Cache\TimestampCacheKey($metadata->getTableName());
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -110,7 +110,9 @@ class CacheConfiguration
     public function getQueryValidator()
     {
         if ($this->queryValidator === null) {
-            $this->queryValidator = new TimestampQueryCacheValidator();
+            $this->queryValidator = new TimestampQueryCacheValidator(
+                $this->cacheFactory->getTimestampRegion()
+            );
         }
 
          return $this->queryValidator;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -287,17 +287,16 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      * @param array   $orderBy
      * @param integer $limit
      * @param integer $offset
-     * @param integer $timestamp
      *
      * @return string
      */
-    protected function getHash($query, $criteria, array $orderBy = null, $limit = null, $offset = null, $timestamp = null)
+    protected function getHash($query, $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
         list($params) = ($criteria instanceof Criteria)
             ? $this->persister->expandCriteriaParameters($criteria)
             : $this->persister->expandParameters($criteria);
 
-        return sha1($query . serialize($params) . serialize($orderBy) . $limit . $offset . $timestamp);
+        return sha1($query . serialize($params) . serialize($orderBy) . $limit . $offset);
     }
 
     /**
@@ -368,9 +367,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         }
 
         //handle only EntityRepository#findOneBy
-        $timestamp  = $this->timestampRegion->get($this->timestampKey);
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, null, $orderBy);
-        $hash       = $this->getHash($query, $criteria, null, null, null, $timestamp ? $timestamp->time : null);
+        $hash       = $this->getHash($query, $criteria, null, null, null);
         $rsm        = $this->getResultSetMapping();
         $queryKey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache = $this->cache->getQueryCache($this->regionName);
@@ -408,9 +406,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
     {
-        $timestamp  = $this->timestampRegion->get($this->timestampKey);
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
-        $hash       = $this->getHash($query, $criteria, null, null, null, $timestamp ? $timestamp->time : null);
+        $hash       = $this->getHash($query, $criteria, null, null, null);
         $rsm        = $this->getResultSetMapping();
         $queryKey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache = $this->cache->getQueryCache($this->regionName);
@@ -511,8 +508,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $limit       = $criteria->getMaxResults();
         $offset      = $criteria->getFirstResult();
         $query       = $this->persister->getSelectSQL($criteria);
-        $timestamp   = $this->timestampRegion->get($this->timestampKey);
-        $hash        = $this->getHash($query, $criteria, $orderBy, $limit, $offset, $timestamp ? $timestamp->time : null);
+        $hash        = $this->getHash($query, $criteria, $orderBy, $limit, $offset);
         $rsm         = $this->getResultSetMapping();
         $queryKey    = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache  = $this->cache->getQueryCache($this->regionName);

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -372,13 +372,13 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, null, $orderBy);
         $hash       = $this->getHash($query, $criteria, null, null, null, $timestamp ? $timestamp->time : null);
         $rsm        = $this->getResultSetMapping();
-        $querykey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL);
+        $queryKey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache = $this->cache->getQueryCache($this->regionName);
-        $result     = $queryCache->get($querykey, $rsm);
+        $result     = $queryCache->get($queryKey, $rsm);
 
         if ($result !== null) {
             if ($this->cacheLogger) {
-                $this->cacheLogger->queryCacheHit($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheHit($this->regionName, $queryKey);
             }
 
             return $result[0];
@@ -388,15 +388,15 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             return null;
         }
 
-        $cached = $queryCache->put($querykey, $rsm, array($result));
+        $cached = $queryCache->put($queryKey, $rsm, array($result));
 
         if ($this->cacheLogger) {
             if ($result) {
-                $this->cacheLogger->queryCacheMiss($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheMiss($this->regionName, $queryKey);
             }
 
             if ($cached) {
-                $this->cacheLogger->queryCachePut($this->regionName, $querykey);
+                $this->cacheLogger->queryCachePut($this->regionName, $queryKey);
             }
         }
 
@@ -412,28 +412,28 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $query      = $this->persister->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
         $hash       = $this->getHash($query, $criteria, null, null, null, $timestamp ? $timestamp->time : null);
         $rsm        = $this->getResultSetMapping();
-        $querykey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL);
+        $queryKey   = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache = $this->cache->getQueryCache($this->regionName);
-        $result     = $queryCache->get($querykey, $rsm);
+        $result     = $queryCache->get($queryKey, $rsm);
 
         if ($result !== null) {
             if ($this->cacheLogger) {
-                $this->cacheLogger->queryCacheHit($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheHit($this->regionName, $queryKey);
             }
 
             return $result;
         }
 
         $result = $this->persister->loadAll($criteria, $orderBy, $limit, $offset);
-        $cached = $queryCache->put($querykey, $rsm, $result);
+        $cached = $queryCache->put($queryKey, $rsm, $result);
 
         if ($this->cacheLogger) {
             if ($result) {
-                $this->cacheLogger->queryCacheMiss($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheMiss($this->regionName, $queryKey);
             }
 
             if ($cached) {
-                $this->cacheLogger->queryCachePut($this->regionName, $querykey);
+                $this->cacheLogger->queryCachePut($this->regionName, $queryKey);
             }
         }
 
@@ -514,28 +514,28 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $timestamp   = $this->timestampRegion->get($this->timestampKey);
         $hash        = $this->getHash($query, $criteria, $orderBy, $limit, $offset, $timestamp ? $timestamp->time : null);
         $rsm         = $this->getResultSetMapping();
-        $querykey    = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL);
+        $queryKey    = new QueryCacheKey($hash, 0, Cache::MODE_NORMAL, $this->timestampKey);
         $queryCache  = $this->cache->getQueryCache($this->regionName);
-        $cacheResult = $queryCache->get($querykey, $rsm);
+        $cacheResult = $queryCache->get($queryKey, $rsm);
 
         if ($cacheResult !== null) {
             if ($this->cacheLogger) {
-                $this->cacheLogger->queryCacheHit($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheHit($this->regionName, $queryKey);
             }
 
             return $cacheResult;
         }
 
         $result = $this->persister->loadCriteria($criteria);
-        $cached = $queryCache->put($querykey, $rsm, $result);
+        $cached = $queryCache->put($queryKey, $rsm, $result);
 
         if ($this->cacheLogger) {
             if ($result) {
-                $this->cacheLogger->queryCacheMiss($this->regionName, $querykey);
+                $this->cacheLogger->queryCacheMiss($this->regionName, $queryKey);
             }
 
             if ($cached) {
-                $this->cacheLogger->queryCachePut($this->regionName, $querykey);
+                $this->cacheLogger->queryCachePut($this->regionName, $queryKey);
             }
         }
 

--- a/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
@@ -38,18 +38,18 @@ class QueryCacheEntry implements CacheEntry
     /**
      * READ-ONLY: Public only for performance reasons, it should be considered immutable.
      *
-     * @var integer Time creation of this cache entry
+     * @var float Time creation of this cache entry
      */
     public $time;
 
     /**
-     * @param array   $result
-     * @param integer $time
+     * @param array $result
+     * @param float $time
      */
     public function __construct($result, $time = null)
     {
         $this->result = $result;
-        $this->time   = $time ?: time();
+        $this->time   = $time ?: microtime(true);
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/QueryCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheKey.php
@@ -45,14 +45,27 @@ class QueryCacheKey extends CacheKey
     public $cacheMode;
 
     /**
-     * @param string  $hash      Result cache id
-     * @param integer $lifetime  Query lifetime
-     * @param integer $cacheMode Query cache mode
+     * READ-ONLY: Public only for performance reasons, it should be considered immutable.
+     *
+     * @var TimestampCacheKey|null
      */
-    public function __construct($hash, $lifetime = 0, $cacheMode = Cache::MODE_NORMAL)
-    {
-        $this->hash      = $hash;
-        $this->lifetime  = $lifetime;
-        $this->cacheMode = $cacheMode;
+    public $timestampKey;
+
+    /**
+     * @param string $hash Result cache id
+     * @param integer $lifetime Query lifetime
+     * @param int $cacheMode Query cache mode
+     * @param TimestampCacheKey|null $timestampKey
+     */
+    public function __construct(
+        $hash,
+        $lifetime = 0,
+        $cacheMode = Cache::MODE_NORMAL,
+        TimestampCacheKey $timestampKey = null
+    ) {
+        $this->hash         = $hash;
+        $this->lifetime     = $lifetime;
+        $this->cacheMode    = $cacheMode;
+        $this->timestampKey = $timestampKey;
     }
 }

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -27,14 +27,48 @@ namespace Doctrine\ORM\Cache;
 class TimestampQueryCacheValidator implements QueryCacheValidator
 {
     /**
+     * @var TimestampRegion
+     */
+    private $timestampRegion;
+
+    /**
+     * @param TimestampRegion $timestampRegion
+     */
+    public function __construct(TimestampRegion $timestampRegion)
+    {
+        $this->timestampRegion = $timestampRegion;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function isValid(QueryCacheKey $key, QueryCacheEntry $entry)
     {
+        if ($this->regionUpdated($key, $entry)) {
+            return false;
+        }
+
         if ($key->lifetime == 0) {
             return true;
         }
 
         return ($entry->time + $key->lifetime) > microtime(true);
+    }
+
+    /**
+     * @param QueryCacheKey   $key
+     * @param QueryCacheEntry $entry
+     *
+     * @return bool
+     */
+    private function regionUpdated(QueryCacheKey $key, QueryCacheEntry $entry)
+    {
+        if ($key->timestampKey === null) {
+            return false;
+        }
+
+        $timestamp = $this->timestampRegion->get($key->timestampKey);
+
+        return $timestamp && $timestamp->time > $entry->time;
     }
 }

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -35,6 +35,6 @@ class TimestampQueryCacheValidator implements QueryCacheValidator
             return true;
         }
 
-        return ($entry->time + $key->lifetime) > time();
+        return ($entry->time + $key->lifetime) > microtime(true);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\CacheFactory;
 use Doctrine\ORM\Cache\QueryCacheValidator;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
+use Doctrine\ORM\Cache\TimestampRegion;
 use Doctrine\Tests\DoctrineTestCase;
 
 /**
@@ -67,6 +68,11 @@ class CacheConfigTest extends DoctrineTestCase
 
     public function testSetGetQueryValidator()
     {
+        $factory = $this->createMock(CacheFactory::class);
+        $factory->method('getTimestampRegion')->willReturn($this->createMock(TimestampRegion::class));
+
+        $this->config->setCacheFactory($factory);
+
         $validator = $this->createMock(QueryCacheValidator::class);
 
         $this->assertInstanceOf('Doctrine\ORM\Cache\TimestampQueryCacheValidator', $this->config->getQueryValidator());

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -436,7 +436,7 @@ class DefaultQueryCacheTest extends OrmTestCase
             array('id'=>2, 'name' => 'Bar')
         );
 
-        $entry->time = time() - 100;
+        $entry->time = microtime(true) - 100;
 
         $this->region->addReturn('get', $entry);
         $this->region->addReturn('get', new EntityCacheEntry(Country::CLASSNAME, $entities[0]));

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1120,4 +1120,37 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
     }
+
+    public function testQueryCacheShouldBeEvictedOnTimestampUpdate()
+    {
+        $this->loadFixturesCountries();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+        $dql        = 'SELECT country FROM Doctrine\Tests\Models\Cache\Country country';
+
+        $result1    = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(2, $result1);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+
+        $this->_em->persist(new Country('France'));
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+
+        $result2 = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(3, $result2);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+
+        foreach ($result2 as $entity) {
+            $this->assertInstanceOf(Country::CLASSNAME, $entity);
+        }
+    }
 }


### PR DESCRIPTION
As far as I saw that's the default Hibernate behavior (https://vladmihalcea.com/2015/06/08/how-does-hibernate-query-cache-work/) to keep the query cache consistent.

I'm just not sure if that is the way to go, basically because of the change on the `CachedEntityPersister` interface (I didn't want to duplicate the logic that generates the timestamp key).
