### PR TITLE
Fix hydration in a joined inheritance with simple array or json array

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -122,7 +122,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             }
 
             // Check if value is null before conversion (because some types convert null to something else)
-            $valueIsNull = $value === null;
+            $valueIsNull = null === $value;
 
             // Convert field to a valid PHP value
             if (isset($cacheKeyInfo['type'])) {

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -121,6 +121,9 @@ class SimpleObjectHydrator extends AbstractHydrator
                 continue;
             }
 
+            // Check if value is null before conversion (because some types convert null to something else)
+            $valueIsNull = $value === null;
+
             // Convert field to a valid PHP value
             if (isset($cacheKeyInfo['type'])) {
                 $type  = $cacheKeyInfo['type'];
@@ -130,7 +133,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             $fieldName = $cacheKeyInfo['fieldName'];
 
             // Prevent overwrite in case of inherit classes using same property name (See AbstractHydrator)
-            if ( ! isset($data[$fieldName]) || $value !== null) {
+            if ( ! isset($data[$fieldName]) || ! $valueIsNull) {
                 $data[$fieldName] = $value;
             }
         }

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Employee.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Employee.php
@@ -9,19 +9,9 @@ namespace Doctrine\Tests\Models\Issue5989;
 class Issue5989Employee extends Issue5989Person
 {
     /**
-     * @column(type="simple_array", nullable=true)
+     * @Column(type="simple_array", nullable=true)
      *
      * @var array
      */
-    private $tags;
-
-    public function getTags()
-    {
-        return $this->tags;
-    }
-
-    public function setTags(array $tags)
-    {
-        $this->tags = $tags;
-    }
+    public $tags;
 }

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Employee.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Employee.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\Issue5989;
+
+/**
+ * @Entity
+ * @Table(name="issue5989_employees")
+ */
+class Issue5989Employee extends Issue5989Person
+{
+    /**
+     * @column(type="simple_array", nullable=true)
+     *
+     * @var array
+     */
+    private $tags;
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function setTags(array $tags)
+    {
+        $this->tags = $tags;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Manager.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Manager.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\Issue5989;
+
+/**
+ * @Entity
+ * @Table(name="issue5989_managers")
+ */
+class Issue5989Manager extends Issue5989Person
+{
+    /**
+     * @column(type="simple_array", nullable=true)
+     *
+     * @var array
+     */
+    private $tags;
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    public function setTags(array $tags)
+    {
+        $this->tags = $tags;
+    }
+}

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Manager.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Manager.php
@@ -9,19 +9,9 @@ namespace Doctrine\Tests\Models\Issue5989;
 class Issue5989Manager extends Issue5989Person
 {
     /**
-     * @column(type="simple_array", nullable=true)
+     * @Column(type="simple_array", nullable=true)
      *
      * @var array
      */
-    private $tags;
-
-    public function getTags()
-    {
-        return $this->tags;
-    }
-
-    public function setTags(array $tags)
-    {
-        $this->tags = $tags;
-    }
+    public $tags;
 }

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
@@ -20,10 +20,5 @@ class Issue5989Person
      * @Column(type="integer")
      * @GeneratedValue
      */
-    private $id;
-
-    public function getId()
-    {
-        return  $this->id;
-    }
+    public $id;
 }

--- a/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
+++ b/tests/Doctrine/Tests/Models/Issue5989/Issue5989Person.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Tests\Models\Issue5989;
+
+/**
+ * @Entity
+ * @Table(name="issue5989_persons")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "person"    = "Issue5989Person",
+ *      "manager"   = "Issue5989Manager",
+ *      "employee"  = "Issue5989Employee"
+ * })
+ */
+class Issue5989Person
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    public function getId()
+    {
+        return  $this->id;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue5989Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue5989Test.php
@@ -21,20 +21,20 @@ class Issue5989Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $manager = new Issue5989Manager();
 
-        $managerTags = array('tag1', 'tag2');
-        $manager->setTags($managerTags);
+        $managerTags = ['tag1', 'tag2'];
+        $manager->tags = $managerTags;
         $this->_em->persist($manager);
 
         $employee = new Issue5989Employee();
 
-        $employeeTags = array('tag2', 'tag3');
-        $employee->setTags($employeeTags);
+        $employeeTags =['tag2', 'tag3'];
+        $employee->tags = $employeeTags;
         $this->_em->persist($employee);
 
         $this->_em->flush();
 
-        $managerId = $manager->getId();
-        $employeeId = $employee->getId();
+        $managerId = $manager->id;
+        $employeeId = $employee->id;
 
         // clear entity manager so that $repository->find actually fetches them and uses the hydrator
         // instead of just returning the existing managed entities
@@ -45,7 +45,7 @@ class Issue5989Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $manager = $repository->find($managerId);
         $employee = $repository->find($employeeId);
 
-        static::assertEquals($managerTags, $manager->getTags());
-        static::assertEquals($employeeTags, $employee->getTags());
+        static::assertEquals($managerTags, $manager->tags);
+        static::assertEquals($employeeTags, $employee->tags);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue5989Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue5989Test.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Issue5989\Issue5989Employee;
+use Doctrine\Tests\Models\Issue5989\Issue5989Manager;
+use Doctrine\Tests\Models\Issue5989\Issue5989Person;
+
+/**
+ * @group issue-5989
+ */
+class Issue5989Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->useModelSet('issue5989');
+        parent::setUp();
+    }
+
+    public function testSimpleArrayTypeHydratedCorrectlyInJoinedInheritance()
+    {
+        $manager = new Issue5989Manager();
+
+        $managerTags = array('tag1', 'tag2');
+        $manager->setTags($managerTags);
+        $this->_em->persist($manager);
+
+        $employee = new Issue5989Employee();
+
+        $employeeTags = array('tag2', 'tag3');
+        $employee->setTags($employeeTags);
+        $this->_em->persist($employee);
+
+        $this->_em->flush();
+
+        $managerId = $manager->getId();
+        $employeeId = $employee->getId();
+
+        // clear entity manager so that $repository->find actually fetches them and uses the hydrator
+        // instead of just returning the existing managed entities
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(Issue5989Person::class);
+
+        $manager = $repository->find($managerId);
+        $employee = $repository->find($employeeId);
+
+        static::assertEquals($managerTags, $manager->getTags());
+        static::assertEquals($employeeTags, $employee->getTags());
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -295,6 +295,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\VersionedManyToOne\Category',
             'Doctrine\Tests\Models\VersionedManyToOne\Article',
         ),
+        'issue5989' => array(
+            'Doctrine\Tests\Models\Issue5989\Issue5989Person',
+            'Doctrine\Tests\Models\Issue5989\Issue5989Employee',
+            'Doctrine\Tests\Models\Issue5989\Issue5989Manager',
+        ),
     );
 
     /**
@@ -561,6 +566,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($this->_usedModelSets['versioned_many_to_one'])) {
             $conn->executeUpdate('DELETE FROM versioned_many_to_one_article');
             $conn->executeUpdate('DELETE FROM versioned_many_to_one_category');
+        }
+
+        if (isset($this->_usedModelSets['issue5989'])) {
+            $conn->executeUpdate('DELETE FROM issue5989_persons');
+            $conn->executeUpdate('DELETE FROM issue5989_employees');
+            $conn->executeUpdate('DELETE FROM issue5989_managers');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
Both SimpleArrayType and JsonArrayType convert the value `null` to an empty array, which fails the null check that is used to prevent overwrite (in https://github.com/doctrine/doctrine2/blob/v2.5.4/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php#L134).
Fixes issue #5989 

It could be debated that the issue is actually with the types that convert null to something else (especially since ArrayType actually returns null when the value is null). But changing them would be a BC break so I think it is a separate issue. Also, there is no way to know how custom types will convert null values, so it seems like a reasonable approach to check for null before the conversion since it's quite a serious bug to overwrite data in the hydrator.
