### PR TITLE
Use `ClassMedatada#isIdGeneratorIdentity()` instead of constant to add the ID on query

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1442,7 +1442,7 @@ class BasicEntityPersister implements EntityPersister
                 continue;
             }
 
-            if ($this->class->generatorType != ClassMetadata::GENERATOR_TYPE_IDENTITY || $this->class->identifier[0] != $name) {
+            if (! $this->class->isIdGeneratorIdentity() || $this->class->identifier[0] != $name) {
                 $columns[]                = $this->quoteStrategy->getColumnName($name, $this->class, $this->platform);
                 $this->columnTypes[$name] = $this->class->fieldMappings[$name]['type'];
             }


### PR DESCRIPTION
It's quite handy when creating CUSTOM id generators that should also rely on AUTO_INCREMENT stuff (one can just extend the `ClassMedatadaFactory` and create a different instance of `ClassMetadata` that overrides that method).
