### PR TITLE
As of HHVM 3.15 pgsql is supported, add php 7.1 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 10.1
-    - php: hhvm-3.15
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next Trusty update

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - nightly
-  - hhvm
 
 env:
   - DB=mysql
@@ -27,6 +27,32 @@ after_script:
 
 matrix:
   include:
+    - php: hhvm-3.15
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+      env: DB=mysql
+    - php: hhvm-3.15
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      services:
+        - postgresql
+      env: DB=pgsql
+    - php: hhvm-3.15
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      env: DB=sqlite
+
     - php: 5.6
       env: DB=mariadb
       addons:
@@ -35,10 +61,17 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 5.5
-    - php: hhvm
+    - php: 7.1
       env: DB=mariadb
       addons:
         mariadb: 5.5
+    - php: hhvm-3.15
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 5.5
+      env: DB=mariadb
 
     - php: 5.6
       env: DB=mariadb
@@ -48,11 +81,19 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 10.1
-    - php: hhvm
+    - php: 7.1
       env: DB=mariadb
       addons:
         mariadb: 10.1
+    - php: hhvm-3.15
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.1
+      env: DB=mariadb
   allow_failures:
+    - php: 7.1
     - php: nightly
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.0' && $DB = 'sqlite' ]]; then PHPUNIT_FLAGS="--coverage-clover ./build/logs/clover.xml"; else PHPUNIT_FLAGS=""; fi
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != 'hhvm' ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION -lt '7.0' && $TRAVIS_PHP_VERSION != 'hhv*' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer install --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,6 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 10.1
-  exclude:
-    - php: hhvm
-      env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
   allow_failures:
     - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,25 @@ after_script:
 matrix:
   fast_finish: true
   include:
+    - php: 5.6
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 7.0
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: 7.1
+      env: DB=mariadb
+      addons:
+        mariadb: 10.1
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next Trusty update
+      addons:
+        mariadb: 10.1
+      env: DB=mariadb
     - php: hhvm
       sudo: true
       dist: trusty
@@ -55,45 +74,6 @@ matrix:
       group: edge # until the next update
       env: DB=sqlite
 
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-    - php: 7.0
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-    - php: 7.1
-      env: DB=mariadb
-      addons:
-        mariadb: 5.5
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next Trusty update
-      addons:
-        mariadb: 5.5
-      env: DB=mariadb
-
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-    - php: 7.0
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-    - php: 7.1
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # until the next Trusty update
-      addons:
-        mariadb: 10.1
-      env: DB=mariadb
   allow_failures:
     - php: 7.1
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,6 @@ matrix:
     - php: 7.1
     - php: nightly
     - php: hhvm-3.15
-      env: DB=pgsql
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ after_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.0' && $DB = 'sqlite' ]]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi
 
 matrix:
+  fast_finish: true
   include:
     - php: hhvm-3.15
       sudo: true
@@ -95,6 +96,8 @@ matrix:
   allow_failures:
     - php: 7.1
     - php: nightly
+    - php: hhvm-3.15
+      env: DB=pgsql
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 
 php:
@@ -28,7 +29,7 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - php: hhvm-3.15
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next update
@@ -41,14 +42,14 @@ matrix:
       services:
         - mysql
       env: DB=mysql
-    - php: hhvm-3.15
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next update
       services:
         - postgresql
       env: DB=pgsql
-    - php: hhvm-3.15
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next update
@@ -66,7 +67,7 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 5.5
-    - php: hhvm-3.15
+    - php: hhvm
       sudo: true
       dist: trusty
       group: edge # until the next Trusty update
@@ -96,9 +97,7 @@ matrix:
   allow_failures:
     - php: 7.1
     - php: nightly
-    - php: hhvm-3.15
-
-sudo: false
+    - php: hhvm
 
 cache:
   directories:


### PR DESCRIPTION
- Remove the HHVM exclusion now that pgsql is in core HHVM
- add PHP 7.1
- fix the xdebug line that was erroring the php 7.1+ and HHVM builds
