### PR TITLE
Avoid error when entityName isn't a string

### DIFF
--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -101,7 +101,7 @@ class ORMException extends Exception
         return new self("Unrecognized field: $field");
     }
 
-     /**
+    /**
      *
      * @param string $class
      * @param string $association
@@ -339,5 +339,17 @@ class ORMException extends Exception
     public static function cantUseInOperatorOnCompositeKeys()
     {
         return new self("Can't use IN operator on entities that have composite keys.");
+    }
+
+    /**
+     * Used when a given entityName hasn't the good type
+     *
+     * @param mixed $entityName The given entity (which shouldn't be a string)
+     *
+     * @return ORMException
+     */
+    public static function invalidEntityName($entityName)
+    {
+        return new self(sprintf('Entity name must be a string, %s given', gettype($entityName)));
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2370,7 +2370,7 @@ class UnitOfWork implements PropertyChangedListener
     public function clear($entityName = null)
     {
         if ($entityName !== null && !is_string($entityName)) {
-            throw new \InvalidArgumentException(sprintf('Argument 1 passed to %s() must be a string, %s given', __METHOD__, gettype($entityName)));
+            throw ORMException::invalidEntityName($entityName);
         }
 
         if ($entityName === null) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2369,6 +2369,10 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function clear($entityName = null)
     {
+        if ($entityName !== null && !is_string($entityName)) {
+            throw new \InvalidArgumentException(sprintf('Argument 1 passed to %s() must be a string, %s given', __METHOD__, gettype($entityName)));
+        }
+
         if ($entityName === null) {
             $this->identityMap =
             $this->entityIdentifiers =
@@ -3448,10 +3452,6 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function clearIdentityMapForEntityName($entityName)
     {
-        if (is_object($entityName)) {
-            return;
-        }
-
         if (! isset($this->identityMap[$entityName])) {
             return;
         }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3448,6 +3448,10 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function clearIdentityMapForEntityName($entityName)
     {
+        if (is_object($entityName)) {
+            return;
+        }
+
         if (! isset($this->identityMap[$entityName])) {
             return;
         }

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\PropertyChangedListener;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\ORM\ORMException;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\DriverMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
@@ -351,7 +352,7 @@ class UnitOfWorkTest extends OrmTestCase
 
     public function testClearManagerWithObject()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(ORMException::class);
         $this->expectExceptionMessage('must be a string');
 
         $entity = new Country(456, 'United Kingdom');

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -351,16 +351,28 @@ class UnitOfWorkTest extends OrmTestCase
 
     public function testClearManagerWithObject()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be a string');
+
         $entity = new Country(456, 'United Kingdom');
 
         $this->_unitOfWork->persist($entity);
         $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
 
         $this->_unitOfWork->clear($entity);
+    }
 
-        // true because entity wasn't a string so it wasn't cleared
+    public function testClearManagerWithNullValue()
+    {
+        $entity = new Country(456, 'United Kingdom');
+
+        $this->_unitOfWork->persist($entity);
         $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
-        $this->assertTrue($this->_unitOfWork->isScheduledForInsert($entity));
+
+        $this->_unitOfWork->clear();
+
+        $this->assertFalse($this->_unitOfWork->isInIdentityMap($entity));
+        $this->assertFalse($this->_unitOfWork->isScheduledForInsert($entity));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -357,18 +357,12 @@ class UnitOfWorkTest extends OrmTestCase
 
         $entity = new Country(456, 'United Kingdom');
 
-        $this->_unitOfWork->persist($entity);
-        $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
-
         $this->_unitOfWork->clear($entity);
     }
 
     public function testClearManagerWithNullValue()
     {
         $entity = new Country(456, 'United Kingdom');
-
-        $this->_unitOfWork->persist($entity);
-        $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
 
         $this->_unitOfWork->clear();
 

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -349,6 +349,20 @@ class UnitOfWorkTest extends OrmTestCase
         $this->assertFalse($this->_unitOfWork->isScheduledForInsert($entity2));
     }
 
+    public function testClearManagerWithObject()
+    {
+        $entity = new Country(456, 'United Kingdom');
+
+        $this->_unitOfWork->persist($entity);
+        $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
+
+        $this->_unitOfWork->clear($entity);
+
+        // true because entity wasn't a string so it wasn't cleared
+        $this->assertTrue($this->_unitOfWork->isInIdentityMap($entity));
+        $this->assertTrue($this->_unitOfWork->isScheduledForInsert($entity));
+    }
+
     /**
      * Data Provider
      *


### PR DESCRIPTION
Previously I wasn't used the `->clear()` method in the correct way. I always put the full entity object in parameter instead of the entity name. It _worked_ before the 2.5.5 even if in fact it cleared nothing ...

With 2.5.5 a check has been added in `clearIdentityMapForEntityName` to verify if the given entity name exist in the entityMap.

Using `isset` with the entity object generated a PHP error `Illegal offset type in isset or empty`.

This PR aim to remove that error.

I'm not sure if this is the right way to fix that problem. I'm maybe the only person who gave the entity object as parameter to the `clear` function.
Maybe we should better detect if it's an object in the `clear` function and use the `:class` attribute to get the class name?

Like 

``` php
public function clear($entityName = null)
{
    if (is_object($entityName)) {
        $entityName = $entityName::class;
    }
```
