### PR TITLE
Convert generated id value to its PHP representation.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -890,7 +890,11 @@ class UnitOfWork implements PropertyChangedListener
             $idValue = $idGen->generate($this->em, $entity);
 
             if ( ! $idGen instanceof \Doctrine\ORM\Id\AssignedGenerator) {
-                $idValue = array($class->identifier[0] => $idValue);
+                $idField = $class->identifier[0];
+                $idType  = $class->getTypeOfField($idField);
+
+                $idValue = $this->em->getConnection()->convertToPHPValue($idValue, $idType);
+                $idValue = array($idField => $idValue);
 
                 $class->setIdentifierValues($entity, $idValue);
             }
@@ -1008,16 +1012,20 @@ class UnitOfWork implements PropertyChangedListener
         if ($postInsertIds) {
             // Persister returned post-insert IDs
             foreach ($postInsertIds as $postInsertId) {
-                $id      = $postInsertId['generatedId'];
+                $idField = $class->identifier[0];
+                $idType  = $class->getTypeOfField($idField);
+
+                $idValue = $postInsertId['generatedId'];
+                $idValue = $this->em->getConnection()->convertToPHPValue($idValue, $idType);
+
                 $entity  = $postInsertId['entity'];
                 $oid     = spl_object_hash($entity);
-                $idField = $class->identifier[0];
 
-                $class->reflFields[$idField]->setValue($entity, $id);
+                $class->reflFields[$idField]->setValue($entity, $idValue);
 
-                $this->entityIdentifiers[$oid] = array($idField => $id);
+                $this->entityIdentifiers[$oid] = array($idField => $idValue);
                 $this->entityStates[$oid] = self::STATE_MANAGED;
-                $this->originalEntityData[$oid][$idField] = $id;
+                $this->originalEntityData[$oid][$idField] = $idValue;
 
                 $this->addToIdentityMap($entity);
             }

--- a/tests/Doctrine/Tests/DbalTypes/GeneratedValueCustomIdObjectType.php
+++ b/tests/Doctrine/Tests/DbalTypes/GeneratedValueCustomIdObjectType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+
+class GeneratedValueCustomIdObjectType extends Type
+{
+    const NAME = 'GeneratedValueCustomIdObject';
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return $value->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return new CustomIdObject($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getIntegerTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return self::NAME;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GeneratedValueCustomType/GeneratedValueCustomTypeUser.php
+++ b/tests/Doctrine/Tests/Models/GeneratedValueCustomType/GeneratedValueCustomTypeUser.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\GeneratedValueCustomType;
+
+/**
+ * @Entity
+ * @Table(name="custom_id_user")
+ */
+class GeneratedValueCustomTypeUser
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="GeneratedValueCustomIdObject")
+     */
+    public $id;
+
+    /**
+     * @Column
+     */
+    public $username;
+
+    public function __construct($username)
+    {
+        $this->username = $username;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/GeneratedValueCustomIdObjectTypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GeneratedValueCustomIdObjectTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\DbalTypes\CustomIdObject;
+use Doctrine\Tests\DbalTypes\GeneratedValueCustomIdObjectType;
+use Doctrine\Tests\Models\GeneratedValueCustomType\GeneratedValueCustomTypeUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GeneratedValueCustomIdObjectTypeTest extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        if (DBALType::hasType(GeneratedValueCustomIdObjectType::NAME)) {
+            DBALType::overrideType(GeneratedValueCustomIdObjectType::NAME, GeneratedValueCustomIdObjectType::CLASSNAME);
+        } else {
+            DBALType::addType(GeneratedValueCustomIdObjectType::NAME, GeneratedValueCustomIdObjectType::CLASSNAME);
+        }
+
+        $this->useModelSet('generated_value_custom_id_object_type');
+
+        parent::setUp();
+    }
+
+    public function testPersist()
+    {
+        $user = new GeneratedValueCustomTypeUser('foo');
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->assertInstanceOf(CustomIdObject::class, $user->id);
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -300,6 +300,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             'Doctrine\Tests\Models\Issue5989\Issue5989Employee',
             'Doctrine\Tests\Models\Issue5989\Issue5989Manager',
         ),
+        'generated_value_custom_id_object_type' => array(
+            'Doctrine\Tests\Models\GeneratedValueCustomType\GeneratedValueCustomTypeUser',
+        ),
     );
 
     /**
@@ -572,6 +575,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM issue5989_persons');
             $conn->executeUpdate('DELETE FROM issue5989_employees');
             $conn->executeUpdate('DELETE FROM issue5989_managers');
+        }
+
+        if (isset($this->_usedModelSets['generated_value_custom_id_object_type'])) {
+            $conn->executeUpdate('DELETE FROM custom_id_user');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
This makes it possible for post-insert ids to be converted into a custom object as it happens for any other identity strategy.

According to the conversion rules of a specific DBAL mapping type.
