### PR TITLE
Make child entity share the timestamp region with parent class

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1037,7 +1037,7 @@ abstract class AbstractQuery
 
         $metadata = $this->_em->getClassMetadata($entityName);
 
-        return new Cache\TimestampCacheKey($metadata->getTableName());
+        return new Cache\TimestampCacheKey($metadata->rootEntityName);
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -130,7 +130,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $this->cacheLogger      = $cacheConfig->getCacheLogger();
         $this->timestampRegion  = $cacheFactory->getTimestampRegion();
         $this->hydrator         = $cacheFactory->buildEntityHydrator($em, $class);
-        $this->timestampKey     = new TimestampCacheKey($this->class->getTableName());
+        $this->timestampKey     = new TimestampCacheKey($this->class->rootEntityName);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\Cache\Attraction;
-use Doctrine\Tests\Models\Cache\AttractionInfo;
 use Doctrine\Tests\Models\Cache\AttractionContactInfo;
+use Doctrine\Tests\Models\Cache\AttractionInfo;
 use Doctrine\Tests\Models\Cache\AttractionLocationInfo;
 
 /**
@@ -187,5 +187,48 @@ class SecondLevelCacheJoinTableInheritanceTest extends SecondLevelCacheAbstractT
 
         $this->assertInstanceOf(AttractionContactInfo::CLASSNAME, $entity->getInfos()->get(0));
         $this->assertEquals($this->attractionsInfo[0]->getFone(), $entity->getInfos()->get(0)->getFone());
+    }
+
+    public function testQueryCacheShouldBeEvictedOnTimestampUpdate()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+        $this->loadFixturesAttractionsInfo();
+        $this->evictRegions();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+        $dql        = 'SELECT attractionInfo FROM Doctrine\Tests\Models\Cache\AttractionInfo attractionInfo';
+
+        $result1    = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(count($this->attractionsInfo), $result1);
+        $this->assertEquals($queryCount + 5, $this->getCurrentQueryCount());
+
+        $contact = new AttractionContactInfo(
+            '1234-1234',
+            $this->_em->find(Attraction::class, $this->attractions[5]->getId())
+        );
+
+        $this->_em->persist($contact);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+
+        $result2 = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(count($this->attractionsInfo) + 1, $result2);
+        $this->assertEquals($queryCount + 6, $this->getCurrentQueryCount());
+
+        foreach ($result2 as $entity) {
+            $this->assertInstanceOf(AttractionInfo::CLASSNAME, $entity);
+        }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php
@@ -210,4 +210,45 @@ class SecondLevelCacheSingleTableInheritanceTest extends SecondLevelCacheAbstrac
         $this->assertEquals($this->attractions[0]->getName(), $entity->getAttractions()->get(0)->getName());
         $this->assertEquals($this->attractions[1]->getName(), $entity->getAttractions()->get(1)->getName());
     }
+
+    public function testQueryCacheShouldBeEvictedOnTimestampUpdate()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+        $dql        = 'SELECT attraction FROM Doctrine\Tests\Models\Cache\Attraction attraction';
+
+        $result1    = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(count($this->attractions), $result1);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+
+        $contact = new Beach(
+            'Botafogo',
+            $this->_em->find(City::class, $this->cities[1]->getId())
+        );
+
+        $this->_em->persist($contact);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $queryCount = $this->getCurrentQueryCount();
+
+        $result2 = $this->_em->createQuery($dql)
+            ->setCacheable(true)
+            ->getResult();
+
+        $this->assertCount(count($this->attractions) + 1, $result2);
+        $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount());
+
+        foreach ($result2 as $entity) {
+            $this->assertInstanceOf(Attraction::CLASSNAME, $entity);
+        }
+    }
 }


### PR DESCRIPTION
With #6001 we didn't cover the eviction when using JOINED strategy 😭 
This fixes it.
