### PR TITLE
Add an optional method on entity to check if entities from cache are valid

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -567,12 +567,14 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
             $list    = $persister->loadCollectionCache($coll, $key);
 
-            foreach ($list as $entity) {
-                if(is_object($entity) && method_exists($entity, "isCacheValid") && !$entity->isCacheValid()) {
-                    $result = null;
-                    break;
+            if ($list !== null) {  
+                foreach ($list as $entity) {
+                    if(is_object($entity) && method_exists($entity, "isCacheValid") && !$entity->isCacheValid()) {
+                        $result = null;
+                        break;
+                    }
                 }
-            }
+           }
 
             if ($list !== null) {
                 if ($this->cacheLogger) {

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -417,7 +417,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $queryCache = $this->cache->getQueryCache($this->regionName);
         $result     = $queryCache->get($queryKey, $rsm);
 
-	if(is_array($result)) {
+	if($result !== null) {
             foreach ($result as $subresult) {
                 if(is_object($subresult) && method_exists($subresult, "isCacheValid") && !$subresult->isCacheValid()) {
                     $result = null;
@@ -609,10 +609,12 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
             $list    = $persister->loadCollectionCache($coll, $key);
 
-            foreach ($list as $entity) {
-                if(is_object($entity) && method_exists($entity, "isCacheValid") && !$entity->isCacheValid()) {
-                    $result = null;
-                    break;
+            if ($list !== null) {        
+                foreach ($list as $entity) {
+                    if(is_object($entity) && method_exists($entity, "isCacheValid") && !$entity->isCacheValid()) {
+                        $result = null;
+                        break;
+                    }
                 }
             }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -417,10 +417,12 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $queryCache = $this->cache->getQueryCache($this->regionName);
         $result     = $queryCache->get($queryKey, $rsm);
 
-        foreach ($result as $subresult) {
-            if(is_object($subresult) && method_exists($subresult, "isCacheValid") && !$subresult->isCacheValid()) {
-                $result = null;
-                break;
+	if(is_array($result)) {
+            foreach ($result as $subresult) {
+                if(is_object($subresult) && method_exists($subresult, "isCacheValid") && !$subresult->isCacheValid()) {
+                    $result = null;
+                    break;
+                }
             }
         }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -429,7 +429,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             }
         }
 
-        if ($valid && $result !== null) {
+        if ($result !== null) {
             if ($this->cacheLogger) {
                 $this->cacheLogger->queryCacheHit($this->regionName, $queryKey);
             }


### PR DESCRIPTION
To prevent error, you could add checks on entities with a method isCacheValid on your entities.
If you create this method, and it returns false, the EntityPersister will load it frtom th database. In other case, it will keep it original working.
