### PR TITLE
[WIP] Fixed wrong operator use in condition

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -337,12 +337,13 @@ class UnitOfWork implements PropertyChangedListener
             }
         }
 
-        if ( ! ($this->entityInsertions ||
-                $this->entityDeletions ||
-                $this->entityUpdates ||
-                $this->collectionUpdates ||
-                $this->collectionDeletions ||
-                $this->orphanRemovals)) {
+        if (!$this->entityInsertions &&
+            !$this->entityDeletions &&
+            !$this->entityUpdates &&
+            !$this->collectionUpdates &&
+            !$this->collectionDeletions &&
+            !$this->orphanRemovals) {
+
             $this->dispatchOnFlushEvent();
             $this->dispatchPostFlushEvent();
 


### PR DESCRIPTION
Hello,
this fix will allow **Unit of Work** to stop early when there is nothing to do. Currently Doctrine starts _transaction_ and _commits_ it each time flush is called as this condition is invalid.
