### PR TITLE
Added afterFlush event

### DIFF
--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -158,6 +158,13 @@ final class Events
     const postFlush = 'postFlush';
 
     /**
+     * The afterFlush event occurs when the EntityManager#flush() operation is completely finished
+     *
+     * @var string
+     */
+    const afterFlush = 'afterFlush';
+
+    /**
      * The onClear event occurs when the EntityManager#clear() operation is invoked,
      * after all references to entities have been removed from the unit of work.
      *

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -428,6 +428,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections =
         $this->scheduledForSynchronization =
         $this->orphanRemovals = array();
+
+        $this->dispatchAfterFlush();
     }
 
     /**
@@ -3306,6 +3308,13 @@ class UnitOfWork implements PropertyChangedListener
     {
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
+        }
+    }
+
+    private function dispatchAfterFlush()
+    {
+        if($this->evm->hasListeners(Events::afterFlush)) {
+            $this->evm->dispatchEvent(Events::afterFlush);
         }
     }
 


### PR DESCRIPTION
You cannot persist another entity in postPersist. So you schedule these updates after the lifecycle has finished and dispatch it all from the queue. It is for better control over the whole operation
