### PR TITLE
Remove duplicated enum type comment from declaration.

### DIFF
--- a/docs/en/cookbook/mysql-enums.rst
+++ b/docs/en/cookbook/mysql-enums.rst
@@ -98,7 +98,7 @@ For example for the previous enum type:
 
         public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
         {
-            return sprintf("ENUM('visible', 'invisible') COMMENT '(DC2Type:%s)'", self::ENUM_VISIBILITY);
+            return "ENUM('visible', 'invisible')";
         }
 
         public function convertToPHPValue($value, AbstractPlatform $platform)
@@ -117,6 +117,11 @@ For example for the previous enum type:
         public function getName()
         {
             return self::ENUM_VISIBILITY;
+        }
+
+        public function requiresSQLCommentHint(AbstractPlatform $platform)
+        {
+            return true;
         }
     }
 
@@ -152,7 +157,7 @@ You can generalize this approach easily to create a base class for enums:
         {
             $values = array_map(function($val) { return "'".$val."'"; }, $this->values);
 
-            return "ENUM(".implode(", ", $values).") COMMENT '(DC2Type:".$this->name.")'";
+            return "ENUM(".implode(", ", $values).")";
         }
 
         public function convertToPHPValue($value, AbstractPlatform $platform)
@@ -171,6 +176,11 @@ You can generalize this approach easily to create a base class for enums:
         public function getName()
         {
             return $this->name;
+        }
+
+        public function requiresSQLCommentHint(AbstractPlatform $platform)
+        {
+            return true;
         }
     }
 


### PR DESCRIPTION
Diff command generate duplicated comment declaration:
ALTER TABLE test CHANGE type type ENUM(\'enabled\', \'disabled\', \'bonus\', \'jackpot\') COMMENT \'(DC2Type:enum_status)\' NOT NULL COMMENT \'(DC2Type:enum_status)\''
