### PR TITLE
Support for ClassMetadataInfo::isSingleAssociationJoinColumnNullable()

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2893,6 +2893,24 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
+     * Checks whether the single association join column (if any) is nullable.
+     *
+     * @param string $fieldName
+     *
+     * @return bool
+     *
+     * @throws MappingException
+     */
+    public function isSingleAssociationJoinColumnNullable($fieldName)
+    {
+        if ( ! $this->isAssociationWithSingleJoinColumn($fieldName)) {
+            throw MappingException::noSingleAssociationJoinColumnFound($this->name, $fieldName);
+        }
+
+        return isset($this->associationMappings[$fieldName]['joinColumns'][0]['nullable']) && $this->associationMappings[$fieldName]['joinColumns'][0]['nullable'] == true;
+    }
+
+    /**
      * Returns the single association join column (if any).
      *
      * @param string $fieldName

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -328,6 +328,32 @@ class ClassMetadataTest extends OrmTestCase
         $this->assertEquals('cmsuser_id', $cm->associationMappings['user']['joinTable']['inverseJoinColumns'][0]['name']);
     }
 
+    public function testIsSingleAssociationJoinColumnNullable()
+    {
+        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapOneToOne(array(
+            'fieldName' => 'user',
+            'targetEntity' => 'CmsUser',
+            'joinColumns' => array(array('referencedColumnName' => 'id', 'nullable' => true))));
+
+        $this->assertTrue($cm->isSingleAssociationJoinColumnNullable('user'));
+    }
+
+    public function testIsSingleAssociationJoinColumnNotNullable()
+    {
+        $cm = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsAddress');
+        $cm->initializeReflection(new RuntimeReflectionService());
+
+        $cm->mapOneToOne(array(
+            'fieldName' => 'user',
+            'targetEntity' => 'CmsUser',
+            'joinColumns' => array(array('referencedColumnName' => 'id', 'nullable' => false))));
+
+        $this->assertFalse($cm->isSingleAssociationJoinColumnNullable('user'));
+    }
+
     /**
      * @group DDC-559
      */


### PR DESCRIPTION
Some context here: https://github.com/doctrine/doctrine2/issues/5696, when generating getters / setters etc based on metadata, it is good to know whether an association allows null values:

```php
class Image
{
    /**
     * Multiple Images "can" belong to one Article, it is not mandatory, so NULL is allowed, for example to unset.
     */
    public function setArticle(Article $article = null){
        //..code here
    }

}