### PR TITLE
Clear $this->collection even when empty, to reset keys

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -542,6 +542,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function clear()
     {
         if ($this->initialized && $this->isEmpty()) {
+            $this->collection->clear();
+            
             return;
         }
 

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -107,4 +107,29 @@ class PersistentCollectionTest extends OrmTestCase
         $this->assertSame("dummy", $this->collection->get(2));
         $this->assertSame(null, $this->collection->get(3));
     }
+
+    /**
+     * Test that PersistentCollection::clear() clear elements, and reset keys
+     */
+    public function testClear()
+    {
+        $this->setUpPersistentCollection();
+
+        $this->collection->add('dummy');
+        $this->assertEquals([0], array_keys($this->collection->toArray()));
+
+        $this->collection->removeElement('dummy');
+        $this->assertEquals([], array_keys($this->collection->toArray()));
+
+        $this->collection->add('dummy');
+        $this->collection->clear();
+        $this->assertEquals([], array_keys($this->collection->toArray()));
+
+        // test fix clear doesn't reset collection keys when collection is empty
+        $this->collection->add('dummy');
+        $this->collection->removeElement('dummy');
+        $this->collection->clear();
+        $this->collection->add('dummy');
+        $this->assertEquals([0], array_keys($this->collection->toArray()));
+    }
 }


### PR DESCRIPTION
To have same behavior as when $this->empty() === false, that is to say reset $this->collection keys