### PR TITLE
Fixed typos regarding the strategy for composite keys (xml mapping)

### DIFF
--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -321,12 +321,12 @@ Using the simplified definition above Doctrine will use no
 identifier strategy for this entity. That means you have to
 manually set the identifier before calling
 ``EntityManager#persist($entity)``. This is the so called
-``ASSIGNED`` strategy.
+``NONE`` strategy.
 
 If you want to switch the identifier generation strategy you have
 to nest a ``<generator />`` element inside the id-element. This of
 course only works for surrogate keys. For composite keys you always
-have to use the ``ASSIGNED`` strategy.
+have to use the ``NONE`` strategy.
 
 .. code-block:: xml
 


### PR DESCRIPTION
The strategy for composite primary keys must be "NONE" although the id generator class is \Doctrine\ORM\Id\AssignedGenerator. Calling the strategy "ASSIGNED" is misleading.