### PR TITLE
added IdGeneratorInterface and generateId for custom entity-managers

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -243,7 +243,7 @@ This annotations allows you to specify a user-provided class to generate identif
 
 Required attributes:
 
--  **class**: name of the class which should extend Doctrine\ORM\Id\AbstractIdGenerator
+-  **class**: name of the class which should implement Doctrine\ORM\Id\IdGeneratorInterface
 
 Example:
 
@@ -251,7 +251,7 @@ Example:
 
     <?php
     /**
-     * @Id 
+     * @Id
      * @Column(type="integer")
      * @GeneratedValue(strategy="CUSTOM")
      * @CustomIdGenerator(class="My\Namespace\MyIdGenerator")
@@ -1321,4 +1321,3 @@ Example:
      * @Version
      */
     protected $version;
-

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -20,11 +20,14 @@
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\EntityManagerInterface;
 
-abstract class AbstractIdGenerator
+abstract class AbstractIdGenerator implements IdGeneratorInterface
 {
     /**
-     * Generates an identifier for an entity.
+     * {@inheritDoc}
      *
      * @param EntityManager $em
      * @param \Doctrine\ORM\Mapping\Entity $entity
@@ -32,10 +35,29 @@ abstract class AbstractIdGenerator
      */
     abstract public function generate(EntityManager $em, $entity);
 
+    public final function generateId(EntityManagerInterface $em, $entity)
+    {
+        /* @var $id mixed */
+        $id = null;
+
+        if ($em instanceof EntityManager) {
+            $id = $this->generate($em, $entity);
+
+        } else {
+            throw new ORMException(sprintf(
+                "Tried to use non-doctrine entity-manager %s with old id-generator %s which is not supported! ".
+                "This id-generator must be upgraded to use the %s to make it work with different entity-managers!",
+                get_class($em),
+                get_class($this),
+                IdGeneratorInterface::class
+            ));
+        }
+
+        return $id;
+    }
+
     /**
-     * Gets whether this generator is a post-insert generator which means that
-     * {@link generate()} must be called after the entity has been inserted
-     * into the database.
+     * {@inheritDoc}
      *
      * By default, this method returns FALSE. Generators that have this requirement
      * must override this method and return TRUE.

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -37,13 +37,7 @@ abstract class AbstractIdGenerator implements IdGeneratorInterface
 
     public final function generateId(EntityManagerInterface $em, $entity)
     {
-        /* @var $id mixed */
-        $id = null;
-
-        if ($em instanceof EntityManager) {
-            $id = $this->generate($em, $entity);
-
-        } else {
+        if (!$em instanceof EntityManager) {
             throw new ORMException(sprintf(
                 "Tried to use non-doctrine entity-manager %s with old id-generator %s which is not supported! ".
                 "This id-generator must be upgraded to use the %s to make it work with different entity-managers!",
@@ -53,7 +47,7 @@ abstract class AbstractIdGenerator implements IdGeneratorInterface
             ));
         }
 
-        return $id;
+        return $this->generate($em, $entity);
     }
 
     /**

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -21,6 +21,8 @@ namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Special generator for application-assigned identifiers (doesn't really generate anything).
@@ -31,7 +33,7 @@ use Doctrine\ORM\ORMException;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class AssignedGenerator extends AbstractIdGenerator
+class AssignedGenerator implements IdGeneratorInterface
 {
     /**
      * Returns the identifier assigned to the given entity.
@@ -40,7 +42,7 @@ class AssignedGenerator extends AbstractIdGenerator
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         $class      = $em->getClassMetadata(get_class($entity));
         $idFields   = $class->getIdentifierFieldNames();
@@ -63,4 +65,13 @@ class AssignedGenerator extends AbstractIdGenerator
 
         return $identifier;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPostInsertGenerator()
+    {
+        return false;
+    }
+
 }

--- a/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
@@ -20,13 +20,15 @@
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
  * that automatically get a database-generated, auto-incremented identifier on INSERT.
  * This generator obtains the last insert id after such an insert.
  */
-class BigIntegerIdentityGenerator extends AbstractIdGenerator
+class BigIntegerIdentityGenerator implements IdGeneratorInterface
 {
     /**
      * The name of the sequence to pass to lastInsertId(), if any.
@@ -50,7 +52,7 @@ class BigIntegerIdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         return (string) $em->getConnection()->lastInsertId($this->sequenceName);
     }
@@ -63,4 +65,3 @@ class BigIntegerIdentityGenerator extends AbstractIdGenerator
         return true;
     }
 }
-

--- a/lib/Doctrine/ORM/Id/IdGeneratorInterface.php
+++ b/lib/Doctrine/ORM/Id/IdGeneratorInterface.php
@@ -19,35 +19,30 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Id\IdGeneratorInterface;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
- * Represents an ID generator that uses the database UUID expression
- *
- * @since 2.3
- * @author Maarten de Keizer <m.de.keizer@markei.nl>
+ * The class implementing this can generate entity-id's.
  */
-class UuidGenerator implements IdGeneratorInterface
+interface IdGeneratorInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function generateId(EntityManagerInterface $em, $entity)
-    {
-        $conn = $em->getConnection();
-        $sql = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();
-
-        return $conn->query($sql)->fetchColumn(0);
-    }
 
     /**
-     * {@inheritdoc}
+     * Generates an identifier for an entity.
+     *
+     * @param EntityManagerInterface $em
+     * @param \Doctrine\ORM\Mapping\Entity $entity
+     * @return mixed
      */
-    public function isPostInsertGenerator()
-    {
-        return false;
-    }
+    public function generateId(EntityManagerInterface $em, $entity);
+
+    /**
+     * Gets whether this generator is a post-insert generator which means that
+     * {@link generate()} must be called after the entity has been inserted
+     * into the database.
+     *
+     * @return boolean
+     */
+    public function isPostInsertGenerator();
 
 }

--- a/lib/Doctrine/ORM/Id/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/IdentityGenerator.php
@@ -20,13 +20,15 @@
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
  * that automatically get a database-generated, auto-incremented identifier on INSERT.
  * This generator obtains the last insert id after such an insert.
  */
-class IdentityGenerator extends AbstractIdGenerator
+class IdentityGenerator implements IdGeneratorInterface
 {
     /**
      * The name of the sequence to pass to lastInsertId(), if any.
@@ -50,7 +52,7 @@ class IdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         return (int) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -21,6 +21,8 @@ namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
 use Serializable;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Represents an ID generator that uses a database sequence.
@@ -28,7 +30,7 @@ use Serializable;
  * @since 2.0
  * @author Roman Borschel <roman@code-factory.org>
  */
-class SequenceGenerator extends AbstractIdGenerator implements Serializable
+class SequenceGenerator implements Serializable, IdGeneratorInterface
 {
     /**
      * The allocation size of the sequence.
@@ -69,7 +71,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values
@@ -82,6 +84,15 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
 
         return $this->_nextValue++;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPostInsertGenerator()
+    {
+        return false;
+    }
+
 
     /**
      * Gets the maximum value of the currently allocated bag of values.

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -20,6 +20,8 @@
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\IdGeneratorInterface;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that uses a single-row database table and a hi/lo algorithm.
@@ -30,7 +32,7 @@ use Doctrine\ORM\EntityManager;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class TableGenerator extends AbstractIdGenerator
+class TableGenerator implements IdGeneratorInterface
 {
     /**
      * @var string
@@ -72,8 +74,7 @@ class TableGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(
-        EntityManager $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity)
     {
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values
@@ -106,4 +107,13 @@ class TableGenerator extends AbstractIdGenerator
 
         return $this->_nextValue++;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPostInsertGenerator()
+    {
+        return false;
+    }
+
 }

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -251,7 +251,7 @@ class FieldBuilder
 
     /**
      * Set the FQCN of the custom ID generator.
-     * This class must extend \Doctrine\ORM\Id\AbstractIdGenerator.
+     * This class must implement \Doctrine\ORM\Id\IdGeneratorInterface.
      *
      * @param string $customIdGenerator
      *

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -550,7 +550,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * READ-ONLY: The ID generator used for generating IDs for this class.
      *
-     * @var \Doctrine\ORM\Id\AbstractIdGenerator
+     * @var \Doctrine\ORM\Id\IdGeneratorInterface
      *
      * @todo Remove!
      */
@@ -2951,7 +2951,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Sets the ID generator used to generate IDs for instances of this class.
      *
-     * @param \Doctrine\ORM\Id\AbstractIdGenerator $generator
+     * @param \Doctrine\ORM\Id\IdGeneratorInterface $generator
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -37,6 +37,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\ORM\Utility\PersisterHelper;
+use Doctrine\ORM\Id\IdGeneratorInterface;
 
 /**
  * A BasicEntityPersister maps an entity to a single table in a relational database.
@@ -260,8 +261,10 @@ class BasicEntityPersister implements EntityPersister
             return [];
         }
 
-        $postInsertIds  = [];
+        /* @var $idGenerator IdGeneratorInterface */
         $idGenerator    = $this->class->idGenerator;
+        $postInsertIds  = [];
+
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
 
         $stmt       = $this->conn->prepare($this->getInsertSQL());
@@ -281,7 +284,7 @@ class BasicEntityPersister implements EntityPersister
             $stmt->execute();
 
             if ($isPostInsertId) {
-                $generatedId = $idGenerator->generate($this->em, $entity);
+                $generatedId = $idGenerator->generateId($this->em, $entity);
                 $id = [
                     $this->class->identifier[0] => $generatedId
                 ];

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Types\Type;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Utility\PersisterHelper;
+use Doctrine\ORM\Id\IdGeneratorInterface;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -130,8 +131,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return [];
         }
 
-        $postInsertIds  = [];
+        /* @var $idGenerator IdGeneratorInterface */
         $idGenerator    = $this->class->idGenerator;
+        $postInsertIds  = [];
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
         $rootClass      = ($this->class->name !== $this->class->rootEntityName)
             ? $this->em->getClassMetadata($this->class->rootEntityName)
@@ -175,7 +177,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $rootTableStmt->execute();
 
             if ($isPostInsertId) {
-                $generatedId = $idGenerator->generate($this->em, $entity);
+                $generatedId = $idGenerator->generateId($this->em, $entity);
                 $id = [
                     $this->class->identifier[0] => $generatedId
                 ];

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -46,6 +46,7 @@ use Doctrine\ORM\Utility\IdentifierFlattener;
 use Exception;
 use InvalidArgumentException;
 use UnexpectedValueException;
+use Doctrine\ORM\Id\IdGeneratorInterface;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
@@ -881,10 +882,11 @@ class UnitOfWork implements PropertyChangedListener
             $this->listenersInvoker->invoke($class, Events::prePersist, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
         }
 
+        /* @var $idGen IdGeneratorInterface */
         $idGen = $class->idGenerator;
 
         if ( ! $idGen->isPostInsertGenerator()) {
-            $idValue = $idGen->generate($this->em, $entity);
+            $idValue = $idGen->generateId($this->em, $entity);
 
             if ( ! $idGen instanceof \Doctrine\ORM\Id\AssignedGenerator) {
                 $idValue = [$class->getSingleIdentifierFieldName() => $this->convertSingleFieldIdentifierToPHPValue($class, $idValue)];

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -5,6 +5,15 @@ namespace Doctrine\Tests\ORM\Id;
 use Doctrine\ORM\Id\AssignedGenerator;
 use Doctrine\ORM\ORMException;
 use Doctrine\Tests\OrmTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit_Framework_MockObject_MockBuilder as MockBuilder;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use ReflectionClass;
+use ReflectionProperty;
+use Doctrine\Tests\ORM\Id\AssignedCompositeIdEntity;
+use Doctrine\Tests\ORM\Id\AssignedSingleIdEntity;
+use Exception;
+use Doctrine\ORM\Mapping\MappingException;
 
 /**
  * AssignedGeneratorTest
@@ -14,41 +23,152 @@ use Doctrine\Tests\OrmTestCase;
 class AssignedGeneratorTest extends OrmTestCase
 {
     private $_em;
+    private $_emMock;
     private $_assignedGen;
 
     protected function setUp()
     {
         $this->_em = $this->_getTestEntityManager();
         $this->_assignedGen = new AssignedGenerator;
+
+        /* @var $metadatas ClassMetadata[] */
+        $metadatas = array();
+
+        foreach ([
+            AssignedSingleIdEntity::class => ['myId'],
+            AssignedCompositeIdEntity::class => ['myId1', 'myId2'],
+        ] as $entityClass => $fieldNames) {
+
+            $classMetadata = new ClassMetadata($entityClass);
+
+            $entityReflection = new ReflectionClass($entityClass);
+
+            foreach ($fieldNames as $fieldName) {
+                $classMetadata->fieldMappings[$fieldName] = [
+                    'columnName' => $fieldName,
+                    'fieldName' => $fieldName,
+                    'type' => "string"
+                ];
+                $classMetadata->reflFields[$fieldName] = $entityReflection->getProperty($fieldName);
+                $classMetadata->fieldNames[$fieldName] = $fieldName;
+            }
+
+            $classMetadata->setIdentifier($fieldNames);
+
+            $metadatas[$entityClass] = $classMetadata;
+        }
+
+        /* @var $entityManagerMock EntityManagerInterface */
+        $entityManagerMock = $this->createMock(EntityManagerInterface::class);
+
+        $entityManagerMock->method('getClassMetadata')->will($this->returnCallback(
+            function ($entityClass) use ($metadatas) {
+                if (!isset($metadatas[$entityClass])) {
+                    throw MappingException::classIsNotAValidEntityOrMappedSuperClass($entityClass);
+                }
+
+                return $metadatas[$entityClass];
+            }
+        ));
+
+        $this->_emMock = $entityManagerMock;
     }
 
-    public function testThrowsExceptionIfIdNotAssigned()
-    {
+    /**
+     * @dataProvider provideTestDataForExceptionIfIdNotAssigned
+     */
+    public function testThrowsExceptionIfIdNotAssigned(
+        $useEntityManagerMock,
+        $entity
+    ) {
+        /* @var $em EntityManagerInterface */
+        $em = $this->_em;
+        if ($useEntityManagerMock) {
+            $em = $this->_emMock;
+        }
         try {
-            $entity = new AssignedSingleIdEntity;
-            $this->_assignedGen->generateId($this->_em, $entity);
-            $this->fail('Assigned generator did not throw exception even though ID was missing.');
-        } catch (ORMException $expected) {}
-
-        try {
-            $entity = new AssignedCompositeIdEntity;
-            $this->_assignedGen->generateId($this->_em, $entity);
+            $this->_assignedGen->generateId($em, $entity);
             $this->fail('Assigned generator did not throw exception even though ID was missing.');
         } catch (ORMException $expected) {}
     }
 
-    public function testCorrectIdGeneration()
-    {
-        $entity = new AssignedSingleIdEntity;
-        $entity->myId = 1;
-        $id = $this->_assignedGen->generateId($this->_em, $entity);
-        $this->assertEquals(['myId' => 1], $id);
+    /**
+     * @dataProvider provideTestDataForCorrectIdGeneration
+     */
+    public function testCorrectIdGeneration(
+        $useEntityManagerMock,
+        $entity,
+        $expectedId
+    ) {
+        /* @var $em EntityManagerInterface */
+        $em = $this->_em;
+        if ($useEntityManagerMock) {
+            $em = $this->_emMock;
+        }
+        $id = $this->_assignedGen->generateId($em, $entity);
+        $this->assertEquals($expectedId, $id);
+    }
 
-        $entity = new AssignedCompositeIdEntity;
-        $entity->myId2 = 2;
-        $entity->myId1 = 4;
-        $id = $this->_assignedGen->generateId($this->_em, $entity);
-        $this->assertEquals(['myId1' => 4, 'myId2' => 2], $id);
+    /**
+     * @return array
+     */
+    public function provideTestDataForExceptionIfIdNotAssigned()
+    {
+        if (is_null($this->_em)) {
+            $this->setUp();
+        }
+
+        return [
+            [
+                false,
+                new AssignedSingleIdEntity,
+            ],
+            [
+                false,
+                new AssignedCompositeIdEntity,
+            ],
+            [
+                true,
+                new AssignedSingleIdEntity,
+            ],
+            [
+                true,
+                new AssignedCompositeIdEntity,
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function provideTestDataForCorrectIdGeneration()
+    {
+        if (is_null($this->_em)) {
+            $this->setUp();
+        }
+
+        return [
+            [
+                false,
+                new AssignedSingleIdEntity(1),
+                ['myId' => 1],
+            ],
+            [
+                false,
+                new AssignedCompositeIdEntity(4, 2),
+                ['myId1' => 4, 'myId2' => 2],
+            ],
+            [
+                true,
+                new AssignedSingleIdEntity(1),
+                ['myId' => 1],
+            ],
+            [
+                true,
+                new AssignedCompositeIdEntity(4, 2),
+                ['myId1' => 4, 'myId2' => 2],
+            ],
+        ];
     }
 }
 
@@ -56,6 +176,11 @@ class AssignedGeneratorTest extends OrmTestCase
 class AssignedSingleIdEntity {
     /** @Id @Column(type="integer") */
     public $myId;
+
+    function __construct($myId = null)
+    {
+        $this->myId = $myId;
+    }
 }
 
 /** @Entity */
@@ -64,4 +189,10 @@ class AssignedCompositeIdEntity {
     public $myId1;
     /** @Id @Column(type="integer") */
     public $myId2;
+
+    function __construct($myId1 = null, $myId2 = null)
+    {
+        $this->myId1 = $myId1;
+        $this->myId2 = $myId2;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -26,13 +26,13 @@ class AssignedGeneratorTest extends OrmTestCase
     {
         try {
             $entity = new AssignedSingleIdEntity;
-            $this->_assignedGen->generate($this->_em, $entity);
+            $this->_assignedGen->generateId($this->_em, $entity);
             $this->fail('Assigned generator did not throw exception even though ID was missing.');
         } catch (ORMException $expected) {}
 
         try {
             $entity = new AssignedCompositeIdEntity;
-            $this->_assignedGen->generate($this->_em, $entity);
+            $this->_assignedGen->generateId($this->_em, $entity);
             $this->fail('Assigned generator did not throw exception even though ID was missing.');
         } catch (ORMException $expected) {}
     }
@@ -41,13 +41,13 @@ class AssignedGeneratorTest extends OrmTestCase
     {
         $entity = new AssignedSingleIdEntity;
         $entity->myId = 1;
-        $id = $this->_assignedGen->generate($this->_em, $entity);
+        $id = $this->_assignedGen->generateId($this->_em, $entity);
         $this->assertEquals(['myId' => 1], $id);
 
         $entity = new AssignedCompositeIdEntity;
         $entity->myId2 = 2;
         $entity->myId1 = 4;
-        $id = $this->_assignedGen->generate($this->_em, $entity);
+        $id = $this->_assignedGen->generateId($this->_em, $entity);
         $this->assertEquals(['myId1' => 4, 'myId2' => 2], $id);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -114,10 +114,6 @@ class AssignedGeneratorTest extends OrmTestCase
      */
     public function provideTestDataForExceptionIfIdNotAssigned()
     {
-        if (is_null($this->_em)) {
-            $this->setUp();
-        }
-
         return [
             [
                 false,
@@ -143,10 +139,6 @@ class AssignedGeneratorTest extends OrmTestCase
      */
     public function provideTestDataForCorrectIdGeneration()
     {
-        if (is_null($this->_em)) {
-            $this->setUp();
-        }
-
         return [
             [
                 false,

--- a/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/SequenceGeneratorTest.php
@@ -27,7 +27,7 @@ class SequenceGeneratorTest extends OrmTestCase
             if ($i % 10 == 0) {
                 $this->_em->getConnection()->setFetchOneResult((int)($i / 10) * 10);
             }
-            $id = $this->_seqGen->generate($this->_em, null);
+            $id = $this->_seqGen->generateId($this->_em, null);
             $this->assertEquals($i, $id);
             $this->assertEquals((int)($i / 10) * 10 + 10, $this->_seqGen->getCurrentMaxValue());
             $this->assertEquals($i + 1, $this->_seqGen->getNextValue());
@@ -36,4 +36,3 @@ class SequenceGeneratorTest extends OrmTestCase
 
     }
 }
-


### PR DESCRIPTION
Hello doctrine maintainers,

while trying to write a replacement for doctrine's own entity-manager (to experiment with different behavior regarding transactions) i have noticed that currently there are hard-coded dependencies to doctrine's own entity-manager in the id-generator classes. In order to make the id-generation process work with third-party entity-managers while still maintaining full backwards-compatibility, i have added an interface called IdGeneratorInterface which specifies a "generateId" method that depends only on the EntityManagerInterface instead of EntityManager, allowing third-party entity-managers to be used with it.

The AbstractIdGenerator class still exists as an adapter translating the new method to the old (if possible). This allows full backward compatibility because other (old) third party id-generators (like these defined in the unit-tests) extend the AbstractIdGenerator which in turn translates all calls from "generateId" to "generate" if doctrine's own entity-manager is used. The only situation where this fails is when an old id-generator (extending AbstractIdGenerator) is used with a third-party entity-manager, which is a situation that is currently also not supported anyway. Old third-party id-generators can (in almost all cases) simply be upgraded to use the IdGeneratorInterface and the "generateId" method to be able to be used with third-party entity-managers.

I have made sure that all tests pass on my computer with the inmemory sqlite driver.