### PR TITLE
#6129 Added unit test for boolean option values.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -653,8 +653,6 @@ class XmlDriver extends FileDriver
     {
         $array = array();
 
-        $booleanOptions = ['unsigned', 'fixed'];
-
         /* @var $option SimpleXMLElement */
         foreach ($options as $option) {
             if ($option->count()) {
@@ -663,11 +661,11 @@ class XmlDriver extends FileDriver
                 $value = (string) $option;
             }
 
-            $attr = $option->attributes();
+            $attributes = $option->attributes();
 
-            if (isset($attr->name)) {
-                $attrName = (string) $attr->name;
-                $array[$attrName] = in_array($attrName, $booleanOptions)
+            if (isset($attributes->name)) {
+                $nameAttribute = (string) $attributes->name;
+                $array[$nameAttribute] = in_array($nameAttribute, ['unsigned', 'fixed'])
                     ? $this->evaluateBoolean($value)
                     : $value;
             } else {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -653,6 +653,8 @@ class XmlDriver extends FileDriver
     {
         $array = array();
 
+        $booleanOptions = ['unsigned', 'fixed'];
+
         /* @var $option SimpleXMLElement */
         foreach ($options as $option) {
             if ($option->count()) {
@@ -664,7 +666,10 @@ class XmlDriver extends FileDriver
             $attr = $option->attributes();
 
             if (isset($attr->name)) {
-                $array[(string) $attr->name] = $value;
+                $attrName = (string) $attr->name;
+                $array[$attrName] = in_array($attrName, $booleanOptions)
+                    ? $this->evaluateBoolean($value)
+                    : $value;
             } else {
                 $array[] = $value;
             }

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -210,11 +210,14 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
     /**
      * @depends testEntityTableNameAndInheritance
+     *
      * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
      */
-    public function testFieldOptions($class)
+    public function testFieldOptions(ClassMetadata $class)
     {
-        $expected = array('foo' => 'bar', 'baz' => array('key' => 'val'));
+        $expected = ['foo' => 'bar', 'baz' => ['key' => 'val'], 'fixed' => false];
         $this->assertEquals($expected, $class->fieldMappings['name']['options']);
 
         return $class;
@@ -226,7 +229,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testIdFieldOptions($class)
     {
-        $this->assertEquals(array('foo' => 'bar'), $class->fieldMappings['id']['options']);
+        $this->assertEquals(['foo' => 'bar', 'unsigned' => false], $class->fieldMappings['id']['options']);
 
         return $class;
     }
@@ -240,6 +243,26 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(array('id'), $class->identifier);
         $this->assertEquals('integer', $class->fieldMappings['id']['type']);
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_AUTO, $class->generatorType, "ID-Generator is not ClassMetadata::GENERATOR_TYPE_AUTO");
+
+        return $class;
+    }
+
+    /**
+     * @group #6129
+     *
+     * @depends testIdentifier
+     *
+     * @param ClassMetadata $class
+     *
+     * @return ClassMetadata
+     */
+    public function testBooleanValuesForOptionIsSetCorrectly(ClassMetadata $class)
+    {
+        $this->assertInternalType('bool', $class->fieldMappings['id']['options']['unsigned']);
+        $this->assertFalse($class->fieldMappings['id']['options']['unsigned']);
+
+        $this->assertInternalType('bool', $class->fieldMappings['name']['options']['fixed']);
+        $this->assertFalse($class->fieldMappings['name']['options']['fixed']);
 
         return $class;
     }
@@ -1048,14 +1071,14 @@ class User
 {
     /**
      * @Id
-     * @Column(type="integer", options={"foo": "bar"})
+     * @Column(type="integer", options={"foo": "bar", "unsigned": false})
      * @generatedValue(strategy="AUTO")
      * @SequenceGenerator(sequenceName="tablename_seq", initialValue=1, allocationSize=100)
      **/
     public $id;
 
     /**
-     * @Column(length=50, nullable=true, unique=true, options={"foo": "bar", "baz": {"key": "val"}})
+     * @Column(length=50, nullable=true, unique=true, options={"foo": "bar", "baz": {"key": "val"}, "fixed": false})
      */
     public $name;
 
@@ -1129,7 +1152,7 @@ class User
            'fieldName' => 'id',
            'type' => 'integer',
            'columnName' => 'id',
-           'options' => array('foo' => 'bar'),
+           'options' => array('foo' => 'bar', 'unsigned' => false),
           ));
         $metadata->mapField(array(
            'fieldName' => 'name',
@@ -1138,7 +1161,7 @@ class User
            'unique' => true,
            'nullable' => true,
            'columnName' => 'name',
-           'options' => array('foo' => 'bar', 'baz' => array('key' => 'val')),
+           'options' => array('foo' => 'bar', 'baz' => array('key' => 'val'), 'fixed' => false),
           ));
         $metadata->mapField(array(
            'fieldName' => 'email',

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -250,7 +250,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     /**
      * @group #6129
      *
-     * @depends testIdentifier
+     * @depends testLoadMapping
      *
      * @param ClassMetadata $class
      *

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -141,16 +141,6 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     }
 
     /**
-     * @group #6129
-     */
-    public function testBooleanValuesForOptionIsSetCorrectly()
-    {
-        $class = $this->createClassMetadata(User::class);
-        $this->assertInternalType('bool', $class->fieldMappings['name']['options']['bool_opt']);
-        $this->assertFalse($class->fieldMappings['name']['options']['bool_opt']);
-    }
-
-    /**
      * @param string $xmlMappingFile
      * @dataProvider dataValidSchema
      * @group DDC-2429

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -140,9 +140,12 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $this->createClassMetadata('Doctrine\Tests\Models\Generic\SerializationModel');
     }
 
+    /**
+     * @group #6129
+     */
     public function testBooleanValuesForOptionIsSetCorrectly()
     {
-        $class = $this->createClassMetadata('Doctrine\Tests\ORM\Mapping\User');
+        $class = $this->createClassMetadata(User::class);
         $this->assertInternalType('bool', $class->fieldMappings['name']['options']['bool_opt']);
         $this->assertFalse($class->fieldMappings['name']['options']['bool_opt']);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -34,7 +34,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     }
 
     /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
+     * @expectedException \Doctrine\ORM\Cache\CacheException
      * @expectedExceptionMessage Entity association field "Doctrine\Tests\ORM\Mapping\XMLSLC#foo" not configured as part of the second-level cache.
      */
     public function testFailingSecondLevelCacheAssociation()
@@ -132,12 +132,19 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @group DDC-1468
      *
-     * @expectedException Doctrine\Common\Persistence\Mapping\MappingException
+     * @expectedException \Doctrine\Common\Persistence\Mapping\MappingException
      * @expectedExceptionMessage Invalid mapping file 'Doctrine.Tests.Models.Generic.SerializationModel.dcm.xml' for class 'Doctrine\Tests\Models\Generic\SerializationModel'.
      */
     public function testInvalidMappingFileException()
     {
         $this->createClassMetadata('Doctrine\Tests\Models\Generic\SerializationModel');
+    }
+
+    public function testBooleanValuesForOptionIsSetCorrectly()
+    {
+        $class = $this->createClassMetadata('Doctrine\Tests\ORM\Mapping\User');
+        $this->assertInternalType('bool', $class->fieldMappings['name']['options']['bool_opt']);
+        $this->assertFalse($class->fieldMappings['name']['options']['bool_opt']);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -19,7 +19,7 @@ $metadata->mapField(array(
    'fieldName' => 'id',
    'type' => 'integer',
    'columnName' => 'id',
-   'options' => array('foo' => 'bar'),
+   'options' => array('foo' => 'bar', 'unsigned' => false),
   ));
 $metadata->mapField(array(
    'fieldName' => 'name',
@@ -28,7 +28,7 @@ $metadata->mapField(array(
    'unique' => true,
    'nullable' => true,
    'columnName' => 'name',
-   'options' => array('foo' => 'bar', 'baz' => array('key' => 'val')),
+   'options' => array('foo' => 'bar', 'baz' => array('key' => 'val'), 'fixed' => false),
   ));
 $metadata->mapField(array(
    'fieldName' => 'email',

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
@@ -50,6 +50,7 @@
                 <option name="baz">
                     <option name="key">val</option>
                 </option>
+                <option name="bool_opt">false</option>
             </options>
         </field>
         <field name="email" column="user_email" type="string" column-definition="CHAR(32) NOT NULL" />

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
@@ -41,6 +41,7 @@
             <sequence-generator sequence-name="tablename_seq" allocation-size="100" initial-value="1" />
             <options>
                 <option name="foo">bar</option>
+                <option name="unsigned">false</option>
             </options>
         </id>
 
@@ -50,7 +51,7 @@
                 <option name="baz">
                     <option name="key">val</option>
                 </option>
-                <option name="bool_opt">false</option>
+                <option name="fixed">false</option>
             </options>
         </field>
         <field name="email" column="user_email" type="string" column-definition="CHAR(32) NOT NULL" />

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
@@ -18,6 +18,7 @@ Doctrine\Tests\ORM\Mapping\User:
         initialValue: 1
       options:
         foo: bar
+        unsigned: false
   fields:
     name:
       type: string
@@ -28,6 +29,7 @@ Doctrine\Tests\ORM\Mapping\User:
         foo: bar
         baz:
           key: val
+        fixed: false
     email:
       type: string
       column: user_email


### PR DESCRIPTION
It fails now. In `XmlDriver::_parseOptions` we need somehow to maintain a list of options, that are supposed to be boolean, and then call `$this->evaluateBoolean()` on them.