### PR TITLE
Fix incompatibility w/ PHP7.2+

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -135,7 +135,9 @@ class QueryCacheTest extends OrmFunctionalTestCase
                     ->method('execute')
                     ->will($this->returnValue( 10 ));
 
-        $parserResultMock = $this->createMock(ParserResult::class);
+        $parserResultMock = $this->getMockBuilder(ParserResult::class)
+                                 ->setMethods(array('getSqlExecutor'))
+                                 ->getMock();
         $parserResultMock->expects($this->once())
                          ->method('getSqlExecutor')
                          ->will($this->returnValue($sqlExecMock));


### PR DESCRIPTION
Mock_ParserResult_*::getParameterMappings() was returning null, which was then passed to count() on Query.php:308, causing a "Parameter must be an array or an object that implements Countable" error.