### PR TITLE
EntityManager::transactional() returns value returned by the closure

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -104,18 +104,11 @@ functionally equivalent to the previously shown code looks as follows:
         $em->persist($user);
     });
 
-.. warning::
-
-    For historical reasons, ``EntityManager#transactional($func)`` will return
-    ``true`` whenever the return value of ``$func`` is loosely false.
-    Some examples of this include ``array()``, ``"0"``, ``""``, ``0``, and
-    ``null``.
 
 The difference between ``Connection#transactional($func)`` and
 ``EntityManager#transactional($func)`` is that the latter
 abstraction flushes the ``EntityManager`` prior to transaction
-commit and rolls back the transaction when an
-exception occurs.
+commit.
 
 .. _transactions-and-concurrency_exception-handling:
 
@@ -241,15 +234,15 @@ either when calling ``EntityManager#find()``:
     <?php
     use Doctrine\DBAL\LockMode;
     use Doctrine\ORM\OptimisticLockException;
-    
+
     $theEntityId = 1;
     $expectedVersion = 184;
-    
+
     try {
         $entity = $em->find('User', $theEntityId, LockMode::OPTIMISTIC, $expectedVersion);
-    
+
         // do the work
-    
+
         $em->flush();
     } catch(OptimisticLockException $e) {
         echo "Sorry, but someone else has already changed this entity. Please apply the changes again!";
@@ -262,16 +255,16 @@ Or you can use ``EntityManager#lock()`` to find out:
     <?php
     use Doctrine\DBAL\LockMode;
     use Doctrine\ORM\OptimisticLockException;
-    
+
     $theEntityId = 1;
     $expectedVersion = 184;
-    
+
     $entity = $em->find('User', $theEntityId);
-    
+
     try {
         // assert version
         $em->lock($entity, LockMode::OPTIMISTIC, $expectedVersion);
-    
+
     } catch(OptimisticLockException $e) {
         echo "Sorry, but someone else has already changed this entity. Please apply the changes again!";
     }
@@ -310,7 +303,7 @@ See the example code, The form (GET Request):
 
     <?php
     $post = $em->find('BlogPost', 123456);
-    
+
     echo '<input type="hidden" name="id" value="' . $post->getId() . '" />';
     echo '<input type="hidden" name="version" value="' . $post->getCurrentVersion() . '" />';
 
@@ -321,7 +314,7 @@ And the change headline action (POST Request):
     <?php
     $postId = (int)$_GET['id'];
     $postVersion = (int)$_GET['version'];
-    
+
     $post = $em->find('BlogPost', $postId, \Doctrine\DBAL\LockMode::OPTIMISTIC, $postVersion);
 
 .. _transactions-and-concurrency_pessimistic-locking:

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -71,7 +71,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritdoc}
      */
-    public function transactional($func)
+    public function transactional(callable $func)
     {
         return $this->wrapped->transactional($func);
     }

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -222,12 +222,8 @@ use Doctrine\Common\Util\ClassUtils;
     /**
      * {@inheritDoc}
      */
-    public function transactional($func)
+    public function transactional(callable $func)
     {
-        if (!is_callable($func)) {
-            throw new \InvalidArgumentException('Expected argument of type "callable", got "' . gettype($func) . '"');
-        }
-
         $this->conn->beginTransaction();
 
         try {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -233,7 +233,7 @@ use Doctrine\Common\Util\ClassUtils;
             $this->conn->commit();
 
             return $return;
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $this->close();
             $this->conn->rollBack();
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -236,7 +236,7 @@ use Doctrine\Common\Util\ClassUtils;
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
+            return $return;
         } catch (Exception $e) {
             $this->close();
             $this->conn->rollBack();

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -227,7 +227,7 @@ use Doctrine\Common\Util\ClassUtils;
         $this->conn->beginTransaction();
 
         try {
-            $return = call_user_func($func, $this);
+            $return = $func($this);
 
             $this->flush();
             $this->conn->commit();

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -81,7 +81,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @param callable $func The function to execute transactionally.
      *
-     * @return mixed The non-empty value returned from the closure or true instead.
+     * @return mixed The value returned from the closure.
      */
     public function transactional($func);
 

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -83,7 +83,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @return mixed The value returned from the closure.
      */
-    public function transactional($func);
+    public function transactional(callable $func);
 
     /**
      * Commits a transaction on the underlying database connection.

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -82,6 +82,8 @@ interface EntityManagerInterface extends ObjectManager
      * @param callable $func The function to execute transactionally.
      *
      * @return mixed The value returned from the closure.
+     *
+     * @throws \Throwable
      */
     public function transactional(callable $func);
 

--- a/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -97,7 +97,7 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function transactional($func)
+    public function transactional(callable $func)
     {
         return $this->realEntityManager->transactional($func);
     }

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -174,30 +174,31 @@ class EntityManagerTest extends OrmTestCase
         $this->_em->$methodName(new \stdClass());
     }
 
-    /**
-     * @group DDC-1125
-     */
-    public function testTransactionalAcceptsReturn()
+    public function dataToBeReturnedByTransactional()
     {
-        $return = $this->_em->transactional(function ($em) {
-            return 'foo';
-        });
+        return array(
+            array(null),
+            array(false),
+            array('foo'),
+        );
+    }
 
-        self::assertEquals('foo', $return);
+    /**
+     * @dataProvider dataToBeReturnedByTransactional
+     */
+    public function testTransactionalAcceptsReturn($value)
+    {
+        self::assertSame(
+            $value,
+            $this->_em->transactional(function ($em) use ($value) {
+                return $value;
+            })
+        );
     }
 
     public function testTransactionalAcceptsVariousCallables()
     {
         self::assertSame('callback', $this->_em->transactional(array($this, 'transactionalCallback')));
-    }
-
-    public function testTransactionalAcceptsReturnFalse()
-    {
-        $return = $this->_em->transactional(function ($em) {
-            return false;
-        });
-
-        self::assertEquals(false, $return);
     }
 
     public function transactionalCallback($em)

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -72,9 +72,9 @@ class EntityManagerTest extends OrmTestCase
     {
         $rsm = new ResultSetMapping();
         $this->_em->getConfiguration()->addNamedNativeQuery('foo', 'SELECT foo', $rsm);
-        
+
         $query = $this->_em->createNamedNativeQuery('foo');
-        
+
         self::assertInstanceOf('Doctrine\ORM\NativeQuery', $query);
     }
 
@@ -116,14 +116,14 @@ class EntityManagerTest extends OrmTestCase
         self::assertInstanceOf('Doctrine\ORM\Query', $q);
         self::assertEquals('SELECT 1', $q->getDql());
     }
-    
+
     /**
      * @covers Doctrine\ORM\EntityManager::createNamedQuery
      */
     public function testCreateNamedQuery()
     {
         $this->_em->getConfiguration()->addNamedQuery('foo', 'SELECT 1');
-        
+
         $query = $this->_em->createNamedQuery('foo');
         self::assertInstanceOf('Doctrine\ORM\Query', $query);
         self::assertEquals('SELECT 1', $query->getDql());
@@ -197,6 +197,15 @@ class EntityManagerTest extends OrmTestCase
         $this->expectExceptionMessage('Expected argument of type "callable", got "object"');
 
         $this->_em->transactional($this);
+    }
+
+    public function testTransactionalAcceptsReturnFalse()
+    {
+        $return = $this->_em->transactional(function ($em) {
+            return false;
+        });
+
+        self::assertEquals(false, $return);
     }
 
     public function transactionalCallback($em)

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -191,14 +191,6 @@ class EntityManagerTest extends OrmTestCase
         self::assertSame('callback', $this->_em->transactional(array($this, 'transactionalCallback')));
     }
 
-    public function testTransactionalThrowsInvalidArgumentExceptionIfNonCallablePassed()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected argument of type "callable", got "object"');
-
-        $this->_em->transactional($this);
-    }
-
     public function testTransactionalAcceptsReturnFalse()
     {
         $return = $this->_em->transactional(function ($em) {


### PR DESCRIPTION
As requested this PR replaces #6146 and is meant for Doctrine 3.0.

`Doctrine\DBAL\Connection::transactional()` already works this way in the master branch of `doctrine/dbal`.