### PR TITLE
VersionedOneToOneTest: added failing test with update

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/VersionedOneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/VersionedOneToOneTest.php
@@ -60,4 +60,35 @@ class VersionedOneToOneTest extends OrmFunctionalTestCase
         $this->assertSame($secondRelatedEntity, $secondEntity);
         $this->assertSame($firstEntity->secondEntity, $secondEntity);
     }
+
+    public function testUpdateVersion()
+	{
+		$secondRelatedEntity = new SecondRelatedEntity();
+		$secondRelatedEntity->name = 'Bob';
+
+		$this->_em->persist($secondRelatedEntity);
+		$this->_em->flush();
+
+		$firstRelatedEntity = new FirstRelatedEntity();
+		$firstRelatedEntity->name = 'Fred';
+		$firstRelatedEntity->secondEntity = $secondRelatedEntity;
+
+		$this->_em->persist($firstRelatedEntity);
+		$this->_em->flush();
+
+		$this->assertSame(1, $firstRelatedEntity->version);
+		$this->assertSame(1, $secondRelatedEntity->version);
+		
+		$firstRelatedEntity->name = 'Fred2';
+		$this->_em->flush();
+
+		$firstEntity = $this->_em->getRepository('Doctrine\Tests\Models\VersionedOneToOne\FirstRelatedEntity')
+			->findOneBy(array('name' => 'Fred2'));
+
+		$secondEntity = $this->_em->getRepository('Doctrine\Tests\Models\VersionedOneToOne\SecondRelatedEntity')
+			->findOneBy(array('name' => 'Bob'));
+
+		$this->assertSame(1, $firstEntity->version);
+		$this->assertSame(2, $secondEntity->version);
+	}
 }


### PR DESCRIPTION
Updating versioned entity when using one-to-one association is broken as shown in failing test. It results in `Undefined index: second_entity_id` in IdentifierFlattener. Similar (but maybe not 100% same) error will occur when I use own type (e.g. Uuid object) for the id column of `SecondRelatedEntity`.


-----

*I was not able to find and fix the bug itself, so I hope this failing test will help you resolve this issue easily.*