### PR TITLE
Embeddable attribute override support

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -301,6 +301,11 @@
   </xs:complexType>
 
   <xs:complexType name="embedded">
+    <xs:sequence>
+      <xs:element name="attribute-overrides" type="orm:attribute-overrides" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="attribute-override" type="orm:attribute-override" minOccurs="0" maxOccurs="1" />
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="class" type="xs:string" use="required" />
     <xs:attribute name="column-prefix" type="xs:string" use="optional" />
@@ -582,7 +587,7 @@
 
   <xs:complexType name="attribute-override">
     <xs:sequence>
-      <xs:element name="field" type="orm:attribute-override-field" minOccurs="1" />
+      <xs:element name="field" type="orm:attribute-override-field" minOccurs="0" />
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="required" />

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -185,6 +185,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     $this->addNestedEmbeddedClasses($embeddableMetadata, $class, $property);
                 }
 
+                if ($embeddableClass['attributeOverrides']) {
+                    foreach ($embeddableClass['attributeOverrides'] as $name => $attributeOverride) {
+                        $embeddableMetadata->setAttributeOverride($name, $attributeOverride);
+                    }
+                }
+
                 $identifier = $embeddableMetadata->getIdentifier();
 
                 if (! empty($identifier)) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -187,7 +187,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 if ($embeddableClass['attributeOverrides']) {
                     foreach ($embeddableClass['attributeOverrides'] as $name => $attributeOverride) {
-                        $embeddableMetadata->setAttributeOverride($name, $attributeOverride);
+                        if ($attributeOverride) {
+                            $embeddableMetadata->setAttributeOverride($name, $attributeOverride);
+                        } else {
+                            $embeddableMetadata->removeFieldMapping($name);
+                        }
                     }
                 }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2203,6 +2203,18 @@ class ClassMetadataInfo implements ClassMetadata
             $overrideMapping['id'] = $mapping['id'];
         }
 
+        if (isset($mapping['originalClass'])) {
+            $overrideMapping['originalClass'] = $mapping['originalClass'];
+        }
+
+        if (isset($mapping['declaredField'])) {
+            $overrideMapping['declaredField'] = $mapping['declaredField'];
+        }
+
+        if (isset($mapping['originalField'])) {
+            $overrideMapping['originalField'] = $mapping['originalField'];
+        }
+
         if ( ! isset($overrideMapping['type'])) {
             $overrideMapping['type'] = $mapping['type'];
         }
@@ -3286,6 +3298,7 @@ class ClassMetadataInfo implements ClassMetadata
             'columnPrefix' => $mapping['columnPrefix'],
             'declaredField' => isset($mapping['declaredField']) ? $mapping['declaredField'] : null,
             'originalField' => isset($mapping['originalField']) ? $mapping['originalField'] : null,
+            'attributeOverrides' => isset($mapping['attributeOverrides']) ? $mapping['attributeOverrides'] : null,
         );
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2227,13 +2227,32 @@ class ClassMetadataInfo implements ClassMetadata
             throw MappingException::invalidOverrideFieldType($this->name, $fieldName);
         }
 
-        unset($this->fieldMappings[$fieldName]);
-        unset($this->fieldNames[$mapping['columnName']]);
-        unset($this->columnNames[$mapping['fieldName']]);
-
+        $this->removeFieldMapping($fieldName);
         $this->_validateAndCompleteFieldMapping($overrideMapping);
 
         $this->fieldMappings[$fieldName] = $overrideMapping;
+    }
+
+    /**
+     * Remove a mapped field.
+     *
+     * @param string $fieldName
+     *
+     * @return void
+     *
+     * @throws MappingException
+     */
+    public function removeFieldMapping($fieldName)
+    {
+        if ( ! isset($this->fieldMappings[$fieldName])) {
+            throw MappingException::mappingNotFound($this->name, $fieldName);
+        }
+
+        $mapping = $this->fieldMappings[$fieldName];
+
+        unset($this->fieldMappings[$mapping['fieldName']]);
+        unset($this->fieldNames[$mapping['columnName']]);
+        unset($this->columnNames[$mapping['fieldName']]);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -406,6 +406,22 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 $metadata->mapManyToMany($mapping);
             } else if ($embeddedAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Embedded')) {
+                // Evaluate Embeddable AttributeOverrides annotation
+                if ($attributeOverridesAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\AttributeOverrides')) {
+                    $mapping['attributeOverrides'] = array_reduce($attributeOverridesAnnot->value, function($map, $attributeOverrideAnnot) {
+                        $attributeOverride = ($attributeOverrideAnnot->column)
+                            ? $this->columnToArray($attributeOverrideAnnot->name, $attributeOverrideAnnot->column)
+                            : null;
+                        $map[$attributeOverrideAnnot->name] = $attributeOverride;
+                        return $map;
+                    }, []);
+                }
+                // Evaluate Embeddable AttributeOverride annotation
+                else if ($attributeOverrideAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\AttributeOverride')) {
+                    $attributeOverride = $this->columnToArray($attributeOverrideAnnot->name, $attributeOverrideAnnot->column);
+                    $mapping['attributeOverrides'] = array($attributeOverrideAnnot->name => $attributeOverride);
+                }
+
                 $mapping['class'] = $embeddedAnnot->class;
                 $mapping['columnPrefix'] = $embeddedAnnot->columnPrefix;
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -406,7 +406,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 $metadata->mapManyToMany($mapping);
             } else if ($embeddedAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Embedded')) {
-                // Evaluate Embeddable AttributeOverrides annotation
                 if ($attributeOverridesAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\AttributeOverrides')) {
                     $mapping['attributeOverrides'] = array_reduce($attributeOverridesAnnot->value, function($map, $attributeOverrideAnnot) {
                         $attributeOverride = ($attributeOverrideAnnot->column)
@@ -415,10 +414,10 @@ class AnnotationDriver extends AbstractAnnotationDriver
                         $map[$attributeOverrideAnnot->name] = $attributeOverride;
                         return $map;
                     }, []);
-                }
-                // Evaluate Embeddable AttributeOverride annotation
-                else if ($attributeOverrideAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\AttributeOverride')) {
-                    $attributeOverride = $this->columnToArray($attributeOverrideAnnot->name, $attributeOverrideAnnot->column);
+                } else if ($attributeOverrideAnnot = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\AttributeOverride')) {
+                    $attributeOverride = ($attributeOverrideAnnot->column)
+                        ? $this->columnToArray($attributeOverrideAnnot->name, $attributeOverrideAnnot->column)
+                        : null;
                     $mapping['attributeOverrides'] = array($attributeOverrideAnnot->name => $attributeOverride);
                 }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -336,6 +336,18 @@ class YamlDriver extends FileDriver
                     'class' => $embeddedMapping['class'],
                     'columnPrefix' => isset($embeddedMapping['columnPrefix']) ? $embeddedMapping['columnPrefix'] : null,
                 );
+
+                if (isset($embeddedMapping['attributeOverrides']) && is_array($embeddedMapping['attributeOverrides'])) {
+                    $attributeOverrides = $embeddedMapping['attributeOverrides'];
+                    $mapping['attributeOverrides'] = array_reduce(array_keys($attributeOverrides), function($map, $fieldName) use ($attributeOverrides) {
+                        $attributeOverride = ($attributeOverrides[$fieldName]['column'])
+                            ? $this->columnToArray($fieldName, $attributeOverrides[$fieldName])
+                            : null;
+                        $map[$fieldName] = $attributeOverride;
+                        return $map;
+                    }, []);
+                }
+
                 $metadata->mapEmbedded($mapping);
             }
         }

--- a/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableOverriddenAndRemovedAttributes.php
+++ b/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableOverriddenAndRemovedAttributes.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\Overrides;
+
+/**
+ * @Entity
+ */
+class EntityWithEmbeddableOverriddenAndRemovedAttributes
+{
+
+    /** @Id @Column(type="integer") */
+    private $id;
+
+    /**
+     * @Embedded(class="Doctrine\Tests\Models\ValueObjects\ValueObject", columnPrefix=false)
+     * @AttributeOverrides({
+     *     @AttributeOverride(name="value", column=@Column(type="string", name="value_override")),
+     *     @AttributeOverride(name="count", column=null),
+     * })
+     */
+    public $valueObject;
+}

--- a/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableOverriddenAttribute.php
+++ b/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableOverriddenAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\Models\Overrides;
+
+/**
+ * @Entity
+ */
+class EntityWithEmbeddableOverriddenAttribute
+{
+    /** @Id @Column(type="integer") */
+    private $id;
+
+    /**
+     * @Embedded(class="Doctrine\Tests\Models\ValueObjects\ValueObject", columnPrefix=false)
+     * @AttributeOverride(name="value", column=@Column(type="string", name="value_override"))
+     */
+    public $valueObject;
+}

--- a/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableRemovedAttribute.php
+++ b/tests/Doctrine/Tests/Models/Overrides/EntityWithEmbeddableRemovedAttribute.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\Tests\Models\Overrides;
+
+/**
+ * @Entity
+ */
+class EntityWithEmbeddableRemovedAttribute
+{
+    /** @Id @Column(type="integer") */
+    private $id;
+
+    /**
+     * @Embedded(class="Doctrine\Tests\Models\ValueObjects\ValueObject", columnPrefix=false)
+     * @AttributeOverride(name="value", column=null)
+     */
+    public $valueObject;
+}

--- a/tests/Doctrine/Tests/Models/Overrides/EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.php
+++ b/tests/Doctrine/Tests/Models/Overrides/EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Doctrine\Tests\Models\Overrides;
+
+/**
+ * @Entity
+ */
+class EntityWithNestedEmbeddableOverriddenAndRemovedAttributes
+{
+
+    /** @Id @Column(type="integer") */
+    private $id;
+
+    /**
+     * @Embedded(class="Doctrine\Tests\Models\ValueObjects\NestedValueObject", columnPrefix=false)
+     * @AttributeOverrides({
+     *     @AttributeOverride(name="nested.value", column=@Column(type="string", name="value_override")),
+     *     @AttributeOverride(name="nested.count", column=null),
+     * })
+     */
+    public $nestedValueObject;
+}

--- a/tests/Doctrine/Tests/Models/ValueObjects/NestedValueObject.php
+++ b/tests/Doctrine/Tests/Models/ValueObjects/NestedValueObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueObjects;
+
+/**
+ * @Embeddable
+ */
+class NestedValueObject
+{
+  /**
+   * @Embedded(class="Doctrine\Tests\Models\ValueObjects\ValueObject\ValueObject", columnPrefix=false)
+   */
+  public $nested;
+}

--- a/tests/Doctrine/Tests/Models/ValueObjects/ValueObject.php
+++ b/tests/Doctrine/Tests/Models/ValueObjects/ValueObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Doctrine\Tests\Models\ValueObjects;
+
+/**
+ * @Embeddable
+ */
+class ValueObject
+{
+    /**
+     * @Column(type="string")
+     */
+    public $value;
+
+    /**
+     * @Column(type="integer")
+     */
+    public $count;
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -250,6 +250,56 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $this->assertArrayHasKey('example_trait_bar_id', $metadataWithoutOverride->associationMappings['bar']['joinColumnFieldNames']);
         $this->assertArrayHasKey('example_entity_overridden_bar_id', $metadataWithOverride->associationMappings['bar']['joinColumnFieldNames']);
     }
+
+    public function testEmbeddableAttributeOverride()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+    }
+
+    public function testEmbeddableAttributeRemoval()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableRemovedAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']);
+    }
+
+    public function testEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']));
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('count', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['count']);
+    }
+
+    public function testNestedEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithNestedEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('nestedValueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['nestedValueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('nested.value', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']));
+        $this->assertEquals($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('nested.count', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.count']);
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -57,6 +57,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'columnPrefix' => null,
                 'declaredField' => null,
                 'originalField' => null,
+                'attributeOverrides' => null,
             )
         ), $this->cm->embeddedClasses);
     }
@@ -77,6 +78,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'columnPrefix' => 'nm_',
                 'declaredField' => null,
                 'originalField' => null,
+                'attributeOverrides' => null,
             )
         ), $this->cm->embeddedClasses);
     }
@@ -94,7 +96,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
                 'columnPrefix' => null,
                 'declaredField' => null,
-                'originalField' => null
+                'originalField' => null,
+                'attributeOverrides' => null,
             ),
             $this->cm->embeddedClasses['name']
         );
@@ -113,7 +116,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'class' => 'Doctrine\Tests\Models\ValueObjects\Name',
                 'columnPrefix' => 'nm_',
                 'declaredField' => null,
-                'originalField' => null
+                'originalField' => null,
+                'attributeOverrides' => null,
             ),
             $this->cm->embeddedClasses['name']
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1166,6 +1166,80 @@ class ClassMetadataTest extends OrmTestCase
         $this->assertEquals(array('test' => null, 'test.embeddedProperty' => null), $classMetadata->getReflectionProperties());
     }
 
+    /**
+     * @expectedException        Doctrine\ORM\Mapping\MappingException
+     * @expectedExceptionMessage No mapping found for field 'foo' on class 'Doctrine\Tests\ORM\Mapping\TestEntity1'.
+     */
+    public function testRemoveFieldMappingInvalidFieldException()
+    {
+        $classMetadata = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
+        $classMetadata->removeFieldMapping('foo');
+    }
+
+    public function testRemoveFieldMapping()
+    {
+        $classMetadata = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
+        $classMetadata->mapEmbedded(array(
+            'fieldName'    => 'test',
+            'class'        => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'columnPrefix' => false,
+        ));
+
+        $field = array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'originalClass' => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'declaredField' => 'test',
+            'originalField' => 'embeddedProperty',
+        );
+        $classMetadata->mapField($field);
+
+        $this->assertArrayHasKey('test.embeddedProperty', $classMetadata->fieldNames);
+        $this->assertArrayHasKey('test.embeddedProperty', $classMetadata->fieldMappings);
+        $this->assertArrayHasKey('test.embeddedProperty', $classMetadata->columnNames);
+
+        $classMetadata->removeFieldMapping('test.embeddedProperty');
+
+        $this->assertArrayNotHasKey('test.embeddedProperty', $classMetadata->fieldNames);
+        $this->assertArrayNotHasKey('test.embeddedProperty', $classMetadata->fieldMappings);
+        $this->assertArrayNotHasKey('test.embeddedProperty', $classMetadata->columnNames);
+    }
+
+    public function testEmbeddableAttributeOverride()
+    {
+        $classMetadata = new ClassMetadata('Doctrine\Tests\ORM\Mapping\TestEntity1');
+        $classMetadata->mapEmbedded(array(
+            'fieldName'    => 'test',
+            'class'        => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'columnPrefix' => false,
+        ));
+
+        $field = array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'originalClass' => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'declaredField' => 'test',
+            'originalField' => 'embeddedProperty',
+        );
+        $classMetadata->mapField($field);
+
+        $overridefield = array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'columnName' => 'test.overridden',
+        );
+        $classMetadata->setAttributeOverride('test.embeddedProperty', $overridefield);
+
+        $this->assertEquals($classMetadata->fieldMappings['test.embeddedProperty'], array(
+            'fieldName' => 'test.embeddedProperty',
+            'type' => 'string',
+            'columnName' => 'test.overridden',
+            'originalClass' => 'Doctrine\Tests\ORM\Mapping\TestEntity1',
+            'declaredField' => 'test',
+            'originalField' => 'embeddedProperty',
+        ));
+    }
+
     public function testGetColumnNamesWithGivenFieldNames()
     {
         $metadata = new ClassMetadata('Doctrine\Tests\Models\CMS\CmsUser');

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -123,6 +123,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
                     'columnPrefix' => 'nm_',
                     'declaredField' => null,
                     'originalField' => null,
+                    'attributeOverrides' => null,
                 )
             ),
             $class->embeddedClasses
@@ -179,6 +180,56 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     public function testinvalidEntityOrMappedSuperClassShouldMentionParentClasses()
     {
         $this->createClassMetadata('Doctrine\Tests\Models\DDC889\DDC889Class');
+    }
+
+    public function testEmbeddableAttributeOverride()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+    }
+
+    public function testEmbeddableAttributeRemoval()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableRemovedAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']);
+    }
+
+    public function testEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']));
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('count', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['count']);
+    }
+
+    public function testNestedEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithNestedEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('nestedValueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['nestedValueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('nested.value', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']));
+        $this->assertEquals($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('nested.count', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.count']);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -74,6 +74,56 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
         $this->assertEquals(255, $valueField['length']);
     }
 
+    public function testEmbeddableAttributeOverride()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+    }
+
+    public function testEmbeddableAttributeRemoval()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableRemovedAttribute');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']);
+    }
+
+    public function testEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('valueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['valueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('value', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']));
+        $this->assertEquals($metadata->embeddedClasses['valueObject']['attributeOverrides']['value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('count', $metadata->embeddedClasses['valueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['valueObject']['attributeOverrides']['count']);
+    }
+
+    public function testNestedEmbeddableAttributeOverrides()
+    {
+        $metadata = $this->createClassMetadata('Doctrine\Tests\Models\Overrides\EntityWithNestedEmbeddableOverriddenAndRemovedAttributes');
+
+        $this->assertArrayHasKey('nestedValueObject', $metadata->embeddedClasses);
+        $this->assertArrayHasKey('attributeOverrides', $metadata->embeddedClasses['nestedValueObject']);
+        $this->assertNotNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertArrayHasKey('nested.value', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertTrue(is_array($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']));
+        $this->assertEquals($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.value']['columnName'], 'value_override');
+        $this->assertArrayHasKey('nested.count', $metadata->embeddedClasses['nestedValueObject']['attributeOverrides']);
+        $this->assertNull($metadata->embeddedClasses['nestedValueObject']['attributeOverrides']['nested.count']);
+    }
+
 }
 
 class DDC2069Entity

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAndRemovedAttributes.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAndRemovedAttributes.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAndRemovedAttributes" table="entity">
+        <id name="id" column="id"/>
+        <embedded name="valueObject"
+                class="Doctrine\Tests\Models\ValueObjects\ValueObject"
+                use-column-prefix="false">
+            <attribute-overrides>
+                <attribute-override name="value">
+                    <field column="value_override" type="string"/>
+                </attribute-override>
+                <attribute-override name="count"/>
+            </attribute-overrides>
+        </embedded>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAttribute.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAttribute.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAttribute" table="entity">
+        <id name="id" column="id"/>
+        <embedded name="valueObject"
+                class="Doctrine\Tests\Models\ValueObjects\ValueObject"
+                use-column-prefix="false">
+            <attribute-override name="value">
+                <field column="value_override" type="string"/>
+            </attribute-override>
+        </embedded>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableRemovedAttribute.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableRemovedAttribute.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Overrides\EntityWithEmbeddableRemovedAttribute" table="entity">
+        <id name="id" column="id"/>
+        <embedded name="valueObject"
+                class="Doctrine\Tests\Models\ValueObjects\ValueObject"
+                use-column-prefix="false">
+            <attribute-override name="value"/>
+        </embedded>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Overrides.EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.dcm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <entity name="Doctrine\Tests\Models\Overrides\EntityWithNestedEmbeddableOverriddenAndRemovedAttributes" table="entity">
+        <id name="id" column="id"/>
+        <embedded name="nestedValueObject"
+                class="Doctrine\Tests\Models\ValueObjects\NestedValueObject"
+                use-column-prefix="false">
+            <attribute-overrides>
+                <attribute-override name="nested.value">
+                    <field column="value_override" type="string"/>
+                </attribute-override>
+                <attribute-override name="nested.count"/>
+            </attribute-overrides>
+        </embedded>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.ValueObjects.NestedValueObject.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.ValueObjects.NestedValueObject.dcm.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <embeddable name="Doctrine\Tests\Models\ValueObjects\NestedValueObject">
+        <embedded name="nested"
+                class="Doctrine\Tests\Models\ValueObjects\ValueObject"
+                use-column-prefix="false"/>
+    </embeddable>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.ValueObjects.ValueObject.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.ValueObjects.ValueObject.dcm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+    <embeddable name="Doctrine\Tests\Models\ValueObjects\ValueObject">
+        <field name="value" type="string" />
+        <field name="count" type="integer" />
+    </embeddable>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAndRemovedAttributes.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAndRemovedAttributes.dcm.yml
@@ -1,0 +1,15 @@
+Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAndRemovedAttributes:
+  type: entity
+  id:
+    id:
+      type: integer
+  embedded:
+    valueObject:
+      class: Doctrine\Tests\Models\ValueObjects\ValueObject
+      columnPrefix: false
+      attributeOverrides:
+        value:
+          column: value_override
+          type: string
+        count:
+          column: null

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAttribute.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableOverriddenAttribute.dcm.yml
@@ -1,0 +1,13 @@
+Doctrine\Tests\Models\Overrides\EntityWithEmbeddableOverriddenAttribute:
+  type: entity
+  id:
+    id:
+      type: integer
+  embedded:
+    valueObject:
+      class: Doctrine\Tests\Models\ValueObjects\ValueObject
+      columnPrefix: false
+      attributeOverrides:
+        value:
+          column: value_override
+          type: string

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableRemovedAttribute.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithEmbeddableRemovedAttribute.dcm.yml
@@ -1,0 +1,12 @@
+Doctrine\Tests\Models\Overrides\EntityWithEmbeddableRemovedAttribute:
+  type: entity
+  id:
+    id:
+      type: integer
+  embedded:
+    valueObject:
+      class: Doctrine\Tests\Models\ValueObjects\ValueObject
+      columnPrefix: false
+      attributeOverrides:
+        value:
+          column: null

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Overrides.EntityWithNestedEmbeddableOverriddenAndRemovedAttributes.dcm.yml
@@ -1,0 +1,15 @@
+Doctrine\Tests\Models\Overrides\EntityWithNestedEmbeddableOverriddenAndRemovedAttributes:
+  type: entity
+  id:
+    id:
+      type: integer
+  embedded:
+    nestedValueObject:
+      class: Doctrine\Tests\Models\ValueObjects\NestedValueObject
+      columnPrefix: false
+      attributeOverrides:
+        nested.value:
+          column: value_override
+          type: string
+        nested.count:
+          column: null

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.ValueObjects.NestedValueObject.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.ValueObjects.NestedValueObject.dcm.yml
@@ -1,0 +1,6 @@
+Doctrine\Tests\Models\ValueObjects\NestedValueObject:
+  type: embeddable
+  embedded:
+    nested:
+      class: Doctrine\Tests\Models\ValueObjects\ValueObject
+      columnPrefix: false

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.ValueObjects.ValueObject.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.ValueObjects.ValueObject.dcm.yml
@@ -1,0 +1,7 @@
+Doctrine\Tests\Models\ValueObjects\ValueObject:
+  type: embeddable
+  fields:
+    value:
+      type: string
+    count:
+      type: integer


### PR DESCRIPTION
This allows for overriding of embeddable mapping definitions from the parent entity/embeddable. 

Nested embeddables are supported via dot notation along with the ability to drop column(s) from the embedded object if necessary.

The syntax is equivalent to attribute overrides on a subclass with the addition of passing a `null` value for a overridden column to drop it from the parent's field mappings.

Via annotations:
```php
/** @Embeddable */
class ValueObject {

    /** @Column(type="string") */
    public $value;

    /** @Column(type="integer") */
    public $count;

}

/** @Embeddable */
class NestedValueObject {

    /** @Embedded(class="ValueObject", columnPrefix=false) */
    public $nested;

}

/** @Entity */
class FooEntity {

    /** @Id @Column(type="integer") */
    private $id;

    /**
     * @Embedded(class="ValueObject", columnPrefix=false)
     * @AttributeOverride(name="value", column=@Column(type="string", name="single_value_override"))
     */
    public $valueObjectWithSingleOverride;

    /**
     * @Embedded(class="ValueObject", columnPrefix=false)
     * @AttributeOverrides({
     *     @AttributeOverride(name="value", column=@Column(type="string", name="multiple_value_override")),
     *     @AttributeOverride(name="count", column=null)
     * })
     */
    public $valueObjectWithMultipleOverrides;

    /**
     * @Embedded(class="NestedValueObject", columnPrefix=false)
     * @AttributeOverrides({
     *     @AttributeOverride(name="nested.value", column=@Column(type="string", name="nested_value_override")),
     *     @AttributeOverride(name="nested.count", column=null)
     * })
     */
    public $valueObjectWithNestedOverrides;
}
```

Via XML:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
    <embeddable name="ValueObject">
        <field name="value" type="string" />
        <field name="count" type="integer" />
    </embeddable>
</doctrine-mapping>

<?xml version="1.0" encoding="UTF-8"?>
<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
    <embeddable name="NestedValueObject">
        <embedded name="nested"
                class="ValueObject"
                use-column-prefix="false"/>
    </embeddable>
</doctrine-mapping>

<?xml version="1.0" encoding="UTF-8"?>
<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                            https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
    <entity name="FooEntity" table="entity">
        <id name="id" column="id"/>
        <embedded name="valueObjectWithSingleOverride"
                class="ValueObject"
                use-column-prefix="false">
            <attribute-override name="value">
                <field column="single_value_override" type="string"/>
            </attribute-override>
        </embedded>
        <embedded name="valueObjectWithMultipleOverrides"
                class="ValueObject"
                use-column-prefix="false">
            <attribute-overrides>
                <attribute-override name="value">
                    <field column="multiple_value_override" type="string"/>
                </attribute-override>
                <attribute-override name="count"/>
            </attribute-overrides>
        </embedded>
        <embedded name="valueObjectWithNestedOverrides"
                class="NestedValueObject"
                use-column-prefix="false">
            <attribute-overrides>
                <attribute-override name="nested.value">
                    <field column="nested_value_override" type="string"/>
                </attribute-override>
                <attribute-override name="nested.count"/>
            </attribute-overrides>
        </embedded>
    </entity>
</doctrine-mapping>
```

Via YML:
```yaml
ValueObject:
  type: embeddable
  fields:
    value:
      type: string
    count:
      type: integer

NestedValueObject:
  type: embeddable
  embedded:
    nested:
      class: ValueObject
      columnPrefix: false

FooEntity:
  type: entity
  id:
    id:
      type: integer
  embedded:
    valueObjectWithSingleOverride:
      class: ValueObject
      columnPrefix: false
      attributeOverrides:
        value:
          column: single_value_override
          type: string
    valueObjectWithMultipleOverrides:
      class: ValueObject
      columnPrefix: false
      attributeOverrides:
        value:
          column: multiple_value_override
          type: string
        count:
          column: null
    valueObjectWithNestedOverrides:
      class: NestedValueObject
      columnPrefix: false
      attributeOverrides:
        nested.value:
          column: nested_value_override
          type: string
        nested.count:
          column: null
```

A further improvement could be to merge the column override over the top of the original column instead of replacing it.  Doing so would remove the need to redefine original column attributes even if they have not been changed.  This change is outside the scope of this pull request.

References #6047 
