### PR TITLE
Allow doctrine/common 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.6-dev",
         "doctrine/instantiator": "~1.0.1",
-        "doctrine/common": ">=2.5-dev,<2.7-dev",
+        "doctrine/common": ">=2.5-dev,<2.8-dev",
         "doctrine/cache": "~1.4",
         "symfony/console": "~2.5|~3.0"
     },


### PR DESCRIPTION
To ease the process I just edited the current constraint schema, but I would rather use caret version ^2.4 if you agree.