### PR TITLE
EntityGenerator produces class with 2 empty lines at the end of the file

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -421,7 +421,7 @@ public function __construct(<params>)
             $this->generateEntityBody($metadata)
         );
 
-        $code = str_replace($placeHolders, $replacements, static::$classTemplate) . "\n";
+        $code = str_replace($placeHolders, $replacements, static::$classTemplate);
 
         return str_replace('<spaces>', $this->spaces, $code);
     }


### PR DESCRIPTION
orm:generate:entities genrates 2 blank lines
PSR2: All PHP files MUST end with a single blank line.

this worked for me