### PR TITLE
Include example of a cascaded "persist" operation

### DIFF
--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -500,7 +500,8 @@ and the "remove" operation.
         //...
     }
 
-Now you can persist the `User` entity like that:
+Since ``cascade: persist`` is configured for the ``User#commentsAuthored``
+association, you can now create a user and persist his comment as follows:
 
 .. code-block:: php
 

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -453,7 +453,7 @@ following code:
     $user->addComment($myFirstComment);
     
     $em->persist($user);
-    $em->persist($myFirstComment); // mandatory if `persist` isn't set
+    $em->persist($myFirstComment); // mandatory if `cascade: persist` isn't set
     $em->flush();
 
 Even if you *persist* a new User that contains our new Comment this

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -453,11 +453,11 @@ following code:
     $user->addComment($myFirstComment);
     
     $em->persist($user);
-    $em->persist($myFirstComment);
+    $em->persist($myFirstComment); // mandatory if `persist` isn't set
     $em->flush();
 
 Even if you *persist* a new User that contains our new Comment this
-code would fail if you removed the call to
+code requires the explicit call to
 ``EntityManager#persist($myFirstComment)``. Doctrine 2 does not
 cascade the persist operation to all nested entities that are new
 as well.
@@ -499,6 +499,18 @@ and the "remove" operation.
         private $commentsAuthored;
         //...
     }
+
+Now you can persist the `User` entity like that:
+
+.. code-block:: php
+
+    <?php
+    $user = new User();
+    $myFirstComment = new Comment();
+    $user->addComment($myFirstComment);
+    
+    $em->persist($user);
+    $em->flush();
 
 Even though automatic cascading is convenient it should be used
 with care. Do not blindly apply cascade=all to all associations as

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -405,25 +405,11 @@ There are two approaches to handle this problem in your code:
 Transitive persistence / Cascade Operations
 -------------------------------------------
 
-Persisting, removing, detaching, refreshing and merging individual entities can
-become pretty cumbersome, especially when a highly interweaved object graph
-is involved. Therefore Doctrine 2 provides a
-mechanism for transitive persistence through cascading of these
-operations. Each association to another entity or a collection of
-entities can be configured to automatically cascade certain
-operations. By default, no operations are cascaded.
-
-The following cascade options exist:
-
-
--  persist : Cascades persist operations to the associated
-   entities.
--  remove : Cascades remove operations to the associated entities.
--  merge : Cascades merge operations to the associated entities.
--  detach : Cascades detach operations to the associated entities.
--  refresh : Cascades refresh operations to the associated entities.
--  all : Cascades persist, remove, merge, refresh and detach operations to
-   associated entities.
+When working with many associated entities, you sometimes don't want to "expose" all entities to your PHP application.
+Therefore Doctrine 2 provides a mechanism for transitive persistence through cascading of certain operations.
+Each association to another entity or a collection of
+entities can be configured to automatically cascade the following operations to the associated entities:
+``persist``, ``remove``, ``merge``, ``detach``, ``refresh`` or ``all``.
 
 .. note::
 

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -453,7 +453,7 @@ following code:
     $user->addComment($myFirstComment);
     
     $em->persist($user);
-    $em->persist($myFirstComment); // mandatory if `cascade: persist` isn't set
+    $em->persist($myFirstComment); // required, if `cascade: persist` isn't set
     $em->flush();
 
 Even if you *persist* a new User that contains our new Comment this

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -513,8 +513,14 @@ association, you can now create a user and persist his comment as follows:
     $em->persist($user);
     $em->flush();
 
-Even though automatic cascading is convenient it should be used
-with care. Do not blindly apply cascade=all to all associations as
+.. note::
+
+    This code does not associate the newly created comment with the user.
+    To achieve this, you *always* have to call ``$myFirstComment->setUser($user);`` –
+    no matter if ``cascade: persist`` is set or not.
+
+Even though automatic cascading is convenient, it should be used
+with care. Do not blindly apply ``cascade=all`` to all associations as
 it will unnecessarily degrade the performance of your application.
 For each cascade operation that gets activated Doctrine also
 applies that operation to the association, be it single or

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -442,7 +442,7 @@ The following cascade options exist:
 
 The following example is an extension to the User-Comment example
 of this chapter. Suppose in our application a user is created
-whenever he writes his first comment. In this case we would use the
+whenever they write their first comment. In this case we would use the
 following code:
 
 .. code-block:: php
@@ -462,7 +462,7 @@ code requires an explicit call to
 cascade the persist operation to all nested entities that are new
 as well.
 
-More complicated is the deletion of all of a user's comments when he is
+More complicated is the deletion of all user's comments when the user is
 removed from the system:
 
 .. code-block:: php
@@ -501,7 +501,7 @@ and the "remove" operation.
     }
 
 Since ``cascade: persist`` is configured for the ``User#commentsAuthored``
-association, you can now create a user and persist his comment as follows:
+association, you can now create a user and persist their comments as follows:
 
 .. code-block:: php
 

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -457,7 +457,7 @@ following code:
     $em->flush();
 
 Even if you *persist* a new User that contains our new Comment this
-code requires the explicit call to
+code requires an explicit call to
 ``EntityManager#persist($myFirstComment)``. Doctrine 2 does not
 cascade the persist operation to all nested entities that are new
 as well.

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -495,6 +495,7 @@ association, you can now create a user and persist their comments as follows:
     $user = new User();
     $myFirstComment = new Comment();
     $user->addComment($myFirstComment);
+    $myFirstComment->setUser($user);
     
     $em->persist($user);
     $em->flush();


### PR DESCRIPTION
Following up on https://github.com/doctrine/doctrine2/issues/2943 I started to clarify how it's supposed to be done.

Please check if this would be necessary (at line 511):
`$myFirstComment->setUser($user);`
...and add it (in case).