### PR TITLE
Merging a new entity with PrePersist event make changes in callback not be considered

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
@@ -2,17 +2,28 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Tests\Models\Company\CompanyContractListener;
+use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\DDC3597\DDC3597Image;
 use Doctrine\Tests\Models\DDC3597\DDC3597Media;
 use Doctrine\Tests\Models\DDC3597\DDC3597Root;
 
 /**
+ * @group DDC-1955
  */
 class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
 {
+
+    /**
+     * @var \Doctrine\Tests\Models\Company\CompanyContractListener
+     */
+    private $listener;
+
     protected function setUp()
     {
+        $this->useModelSet('company');
         parent::setUp();
+
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(DDC3597Root::class),
@@ -20,6 +31,10 @@ class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->_em->getClassMetadata(DDC3597Image::class),
             ]
         );
+
+        $this->listener = $this->_em->getConfiguration()
+            ->getEntityListenerResolver()
+            ->resolve('Doctrine\Tests\Models\Company\CompanyContractListener');
     }
 
     protected function tearDown()
@@ -46,5 +61,36 @@ class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->assertNotNull($imageEntity->getCreatedAt());
         $this->assertNotNull($imageEntity->getUpdatedAt());
+    }
+
+    public function testPrePersistListeners()
+    {
+        $fix = new CompanyFixContract();
+        $fix->setFixPrice(2000);
+
+        $this->listener->prePersistCalls = [];
+
+        $fix = $this->_em->merge($fix);
+        $this->_em->flush();
+
+        $this->assertCount(1, $this->listener->prePersistCalls);
+
+        $this->assertSame($fix, $this->listener->prePersistCalls[0][0]);
+
+        $this->assertInstanceOf(
+            'Doctrine\Tests\Models\Company\CompanyFixContract',
+            $this->listener->prePersistCalls[0][0]
+        );
+
+        $this->assertInstanceOf(
+            'Doctrine\ORM\Event\LifecycleEventArgs',
+            $this->listener->prePersistCalls[0][1]
+        );
+
+        $this->assertArrayHasKey('fixPrice', $this->listener->snapshots[CompanyContractListener::PRE_PERSIST][0]);
+        $this->assertEquals(
+            $fix->getFixPrice(),
+            $this->listener->snapshots[CompanyContractListener::PRE_PERSIST][0]['fixPrice']
+        );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
@@ -63,7 +63,7 @@ class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertNotNull($imageEntity->getUpdatedAt());
     }
 
-    public function testPrePersistListeners()
+    public function testPrePersistListenersShouldBeFiredWithCorrectEntityData()
     {
         $fix = new CompanyFixContract();
         $fix->setFixPrice(2000);

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersOnMergeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\DDC3597\DDC3597Image;
+use Doctrine\Tests\Models\DDC3597\DDC3597Media;
+use Doctrine\Tests\Models\DDC3597\DDC3597Root;
+
+/**
+ */
+class EntityListenersOnMergeTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(DDC3597Root::class),
+                $this->_em->getClassMetadata(DDC3597Media::class),
+                $this->_em->getClassMetadata(DDC3597Image::class),
+            ]
+        );
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        $this->_schemaTool->dropSchema(
+            [
+                $this->_em->getClassMetadata(DDC3597Root::class),
+                $this->_em->getClassMetadata(DDC3597Media::class),
+                $this->_em->getClassMetadata(DDC3597Image::class),
+            ]
+        );
+    }
+
+    public function testMergeNewEntityLifecyleEventsModificationsShouldBeKept()
+    {
+        $imageEntity = new DDC3597Image('foobar');
+        $imageEntity->setFormat('JPG');
+        $imageEntity->setSize(123);
+        $imageEntity->getDimension()->setWidth(300);
+        $imageEntity->getDimension()->setHeight(500);
+
+        $imageEntity = $this->_em->merge($imageEntity);
+
+        $this->assertNotNull($imageEntity->getCreatedAt());
+        $this->assertNotNull($imageEntity->getUpdatedAt());
+    }
+}


### PR DESCRIPTION
When merging a new entity, the must act like a basic persist. But it seems that changes made into the PrePersist event callback are not persisted.

To fix this I firstly refactor two features in the  `doMerge`:
   - Added `ensureVersionMatch`: that check the requested merge entity version is correct (in case of versionned one) 
   - Move the `isLoaded` test used before  ̀mergeEntityStateIntoManagedCopy` into `mergeEntityStateIntoManagedCopy`

Then I move `mergeEntityStateIntoManagedCopy` calls to ensure that it will be called always before `persistNew`.

This will also fixed one of my previously PR (#5570) that is schedule for the next patch release. 