### PR TITLE
Remove final restriction from Doctrine\ORM\Query to allow mocking

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -35,7 +35,7 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @author  Konsta Vesterinen <kvesteri@cc.hut.fi>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-final class Query extends AbstractQuery
+/* final */class Query extends AbstractQuery
 {
     /**
      * A query object is in CLEAN state when it has NO unparsed/unprocessed DQL parts.


### PR DESCRIPTION
The `Doctrine\ORM\Query` class is marked as final but does not have a full interface, so mocking it is basically next to impossible.

I propose dropping the final restriction, leaving it commented as it was done in the `EntityManager`. Documentation could also recommend **not to** extend it.