### PR TITLE
Bug - #6190 many to many collection cleared on inverse side association is cleared when unbalanced

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue6190Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue6190Test.php
@@ -10,14 +10,17 @@ class Issue6190Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()
     {
-        $this->useModelSet('issue5989');
         parent::setUp();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(Issue6190User::CLASSNAME),
+            $this->_em->getClassMetadata(Issue6190Group::CLASSNAME),
+        ));
     }
 
     public function testManyToManyCollectionItemsArePreserved()
     {
-        $user = new Issue6190User();
-
+        $user  = new Issue6190User();
         $group = new Issue6190Group();
 
         $this->_em->persist($user);
@@ -38,7 +41,7 @@ class Issue6190Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 /**
- * @ORM\Entity
+ * @Entity
  */
 class Issue6190User
 {
@@ -47,14 +50,14 @@ class Issue6190User
     /**
      * @var integer
      *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
      */
     public $id;
 
     /**
-     * @ORM\ManyToMany(targetEntity=Issue6190Group::CLASSNAME, inversedBy="users")
+     * @ManyToMany(targetEntity="Issue6190Group", inversedBy="users")
      */
     private $groups;
 
@@ -65,8 +68,8 @@ class Issue6190User
 }
 
 /**
- * @ORM\Table
- * @ORM\Entity
+ * @Table
+ * @Entity
  */
 class Issue6190Group
 {
@@ -75,14 +78,14 @@ class Issue6190Group
     /**
      * @var integer
      *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
      */
     public $id;
 
     /**
-     * @ORM\ManyToMany(targetEntity=Issue6190User::CLASSNAME, mappedBy="groups")
+     * @ManyToMany(targetEntity="Issue6190User", mappedBy="groups")
      */
     public $users;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue6190Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue6190Test.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @group issue-6190
+ */
+class Issue6190Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->useModelSet('issue5989');
+        parent::setUp();
+    }
+
+    public function testManyToManyCollectionItemsArePreserved()
+    {
+        $user = new Issue6190User();
+
+        $group = new Issue6190Group();
+
+        $this->_em->persist($user);
+        $this->_em->persist($group);
+        $this->_em->flush();
+
+        /* @var $user Issue6190User */
+        $user = $this->_em->find(Issue6190User::CLASSNAME, $user->id);
+        /* @var $group Issue6190Group */
+        $group = $this->_em->find(Issue6190Group::CLASSNAME, $group->id);
+
+        $group->users->add($user);
+
+        $this->_em->flush();
+
+        self::assertCount(1, $group->users);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class Issue6190User
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=Issue6190Group::CLASSNAME, inversedBy="users")
+     */
+    private $groups;
+
+    public function __construct()
+    {
+        $this->groups = new ArrayCollection();
+    }
+}
+
+/**
+ * @ORM\Table
+ * @ORM\Entity
+ */
+class Issue6190Group
+{
+    const CLASSNAME = __CLASS__;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=Issue6190User::CLASSNAME, mappedBy="groups")
+     */
+    public $users;
+
+    public function __construct()
+    {
+        $this->users = new ArrayCollection();
+    }
+}


### PR DESCRIPTION
This is a test case imported from #6190

Created because the issue seemed very bad, but seems invalid after a first glance.