### PR TITLE
Remove support for PHP 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly
@@ -29,10 +28,6 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: DB=mariadb
-      addons:
-        mariadb: 10.1
     - php: 7.0
       env: DB=mariadb
       addons:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | [![Build status][Master image]][Master] | [![Build status][2.5 image]][2.5] |
 | [![Coverage Status][Master coverage image]][Master coverage] | [![Coverage Status][2.5 coverage image]][2.5 coverage] |
 
-Doctrine 2 is an object-relational mapper (ORM) for PHP 5.6+ that provides transparent persistence
+Doctrine 2 is an object-relational mapper (ORM) for PHP 7.0+ that provides transparent persistence
 for PHP objects. It sits on top of a powerful database abstraction layer (DBAL). One of its key features
 is the option to write database queries in a proprietary object oriented SQL dialect called Doctrine Query Language (DQL),
 inspired by Hibernate's HQL. This provides developers with a powerful alternative to SQL that maintains flexibility

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",


### PR DESCRIPTION
Per twitter request, this removes support for the PHP 5.x branch from composer.json