### PR TITLE
Documentation: Fixes missing namespaces on class call

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -385,7 +385,7 @@ First you need to retrieve the metadata instances with the
         )
     );
     
-    $cmf = new DisconnectedClassMetadataFactory();
+    $cmf = new \Doctrine\ORM\Tools\DisconnectedClassMetadataFactory();
     $cmf->setEntityManager($em);
     $metadata = $cmf->getAllMetadata();
 
@@ -395,7 +395,7 @@ to yml:
 .. code-block:: php
 
     <?php
-    $cme = new ClassMetadataExporter();
+    $cme = new \Doctrine\ORM\Tools\Export\ClassMetadataExporter();
     $exporter = $cme->getExporter('yml', '/path/to/export/yml');
     $exporter->setMetadata($metadata);
     $exporter->export();


### PR DESCRIPTION
On http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/tools.html#reverse-engineering there are calls like the following:

```php
$cmf = new DisconnectedClassMetadataFactory();
```

Which would cause fatal error if not in the namespace call list, however as documentation for this feature already starts with 

```php
$em->getConfiguration()->setMetadataDriverImpl(
    new \Doctrine\ORM\Mapping\Driver\DatabaseDriver(
        $em->getConnection()->getSchemaManager()
    )
);
```

I added the namespace on the calls itself to maintain consistency.