### PR TITLE
[WIP] Generate unique index name across tables

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1627,7 +1627,7 @@ class ClassMetadataInfo implements ClassMetadata
                     throw new RuntimeException("ClassMetadataInfo::setTable() has to be called before defining a one to one relationship.");
                 }
 
-                $this->table['uniqueConstraints'][$mapping['fieldName'] . "_uniq"] = [
+                $this->table['uniqueConstraints'][$this->table['name'] . '_' . $mapping['fieldName'] . "_uniq"] = [
                     'columns' => $uniqueConstraintColumns
                 ];
             }


### PR DESCRIPTION
SQLite does not support multiple unique indexes with same name across tables

... this fixes the issue with name generation

This is an early PR to get some feedbacks in case I am missing somthing. I'll come up with a test case for it by the end of the week.