### PR TITLE
Appends cache namespace when it exists (for L2C regions)

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -200,14 +200,9 @@ class DefaultCacheFactory implements CacheFactory
             return $this->regions[$cache['region']];
         }
 
-        $cacheAdapter = clone $this->cache;
-
-        if ($cacheAdapter instanceof CacheProvider) {
-            $cacheAdapter->setNamespace($cache['region']);
-        }
-
-        $name     = $cache['region'];
-        $lifetime = $this->regionsConfig->getLifetime($cache['region']);
+        $name         = $cache['region'];
+        $cacheAdapter = $this->createRegionCache($name);
+        $lifetime     = $this->regionsConfig->getLifetime($cache['region']);
 
         $region = ($cacheAdapter instanceof MultiGetCache)
             ? new DefaultMultiGetRegion($name, $cacheAdapter, $lifetime)
@@ -227,6 +222,30 @@ class DefaultCacheFactory implements CacheFactory
         }
 
         return $this->regions[$cache['region']] = $region;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return CacheAdapter
+     */
+    private function createRegionCache($name)
+    {
+        $cacheAdapter = clone $this->cache;
+
+        if (!$cacheAdapter instanceof CacheProvider) {
+            return $cacheAdapter;
+        }
+
+        $namespace = $cacheAdapter->getNamespace();
+
+        if ('' !== $namespace) {
+            $namespace .= ':';
+        }
+
+        $cacheAdapter->setNamespace($namespace . $name);
+
+        return $cacheAdapter;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -52,13 +52,13 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->enableSecondLevelCache();
         parent::setUp();
 
-        $this->em               = $this->_getTestEntityManager();
-        $this->regionsConfig    = new RegionsConfiguration;
-        $arguments              = [$this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl()];
-        $this->factory          = $this->getMockBuilder(DefaultCacheFactory::class)
-                                       ->setMethods(['getRegion'])
-                                       ->setConstructorArgs($arguments)
-                                       ->getMock();
+        $this->em            = $this->_getTestEntityManager();
+        $this->regionsConfig = new RegionsConfiguration;
+        $arguments           = [$this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl()];
+        $this->factory       = $this->getMockBuilder(DefaultCacheFactory::class)
+                                    ->setMethods(['getRegion'])
+                                    ->setConstructorArgs($arguments)
+                                    ->getMock();
     }
 
     public function testImplementsCacheFactory()
@@ -68,10 +68,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedEntityPersisterReadOnly()
     {
-        $em         = $this->em;
-        $metadata   = clone $em->getClassMetadata(State::class);
-        $persister  = new BasicEntityPersister($em, $metadata);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = clone $em->getClassMetadata(State::class);
+        $persister = new BasicEntityPersister($em, $metadata);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $metadata->cache['usage'] = ClassMetadata::CACHE_USAGE_READ_ONLY;
 
@@ -88,10 +88,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedEntityPersisterReadWrite()
     {
-        $em         = $this->em;
-        $metadata   = clone $em->getClassMetadata(State::class);
-        $persister  = new BasicEntityPersister($em, $metadata);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = clone $em->getClassMetadata(State::class);
+        $persister = new BasicEntityPersister($em, $metadata);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $metadata->cache['usage'] = ClassMetadata::CACHE_USAGE_READ_WRITE;
 
@@ -108,10 +108,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedEntityPersisterNonStrictReadWrite()
     {
-        $em         = $this->em;
-        $metadata   = clone $em->getClassMetadata(State::class);
-        $persister  = new BasicEntityPersister($em, $metadata);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = clone $em->getClassMetadata(State::class);
+        $persister = new BasicEntityPersister($em, $metadata);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $metadata->cache['usage'] = ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE;
 
@@ -128,11 +128,11 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedCollectionPersisterReadOnly()
     {
-        $em         = $this->em;
-        $metadata   = $em->getClassMetadata(State::class);
-        $mapping    = $metadata->associationMappings['cities'];
-        $persister  = new OneToManyPersister($em);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = $em->getClassMetadata(State::class);
+        $mapping   = $metadata->associationMappings['cities'];
+        $persister = new OneToManyPersister($em);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_READ_ONLY;
 
@@ -150,11 +150,11 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedCollectionPersisterReadWrite()
     {
-        $em         = $this->em;
-        $metadata   = $em->getClassMetadata(State::class);
-        $mapping    = $metadata->associationMappings['cities'];
-        $persister  = new OneToManyPersister($em);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = $em->getClassMetadata(State::class);
+        $mapping   = $metadata->associationMappings['cities'];
+        $persister = new OneToManyPersister($em);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_READ_WRITE;
 
@@ -171,11 +171,11 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
     public function testBuildCachedCollectionPersisterNonStrictReadWrite()
     {
-        $em         = $this->em;
-        $metadata   = $em->getClassMetadata(State::class);
-        $mapping    = $metadata->associationMappings['cities'];
-        $persister  = new OneToManyPersister($em);
-        $region     = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
+        $em        = $this->em;
+        $metadata  = $em->getClassMetadata(State::class);
+        $mapping   = $metadata->associationMappings['cities'];
+        $persister = new OneToManyPersister($em);
+        $region    = new ConcurrentRegionMock(new DefaultRegion('regionName', $this->getSharedSecondLevelCacheDriverImpl()));
 
         $mapping['cache']['usage'] = ClassMetadata::CACHE_USAGE_NONSTRICT_READ_WRITE;
 
@@ -234,9 +234,9 @@ class DefaultCacheFactoryTest extends OrmTestCase
      */
     public function testBuildCachedEntityPersisterNonStrictException()
     {
-        $em         = $this->em;
-        $metadata   = clone $em->getClassMetadata(State::class);
-        $persister  = new BasicEntityPersister($em, $metadata);
+        $em        = $this->em;
+        $metadata  = clone $em->getClassMetadata(State::class);
+        $persister = new BasicEntityPersister($em, $metadata);
 
         $metadata->cache['usage'] = -1;
 
@@ -249,10 +249,10 @@ class DefaultCacheFactoryTest extends OrmTestCase
      */
     public function testBuildCachedCollectionPersisterException()
     {
-        $em         = $this->em;
-        $metadata   = $em->getClassMetadata(State::class);
-        $mapping    = $metadata->associationMappings['cities'];
-        $persister  = new OneToManyPersister($em);
+        $em        = $this->em;
+        $metadata  = $em->getClassMetadata(State::class);
+        $mapping   = $metadata->associationMappings['cities'];
+        $persister = new OneToManyPersister($em);
 
         $mapping['cache']['usage'] = -1;
 
@@ -269,8 +269,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $factory->getRegion(
             [
-            'usage'   => ClassMetadata::CACHE_USAGE_READ_WRITE,
-            'region'  => 'foo'
+                'usage'   => ClassMetadata::CACHE_USAGE_READ_WRITE,
+                'region'  => 'foo'
             ]
         );
     }
@@ -281,14 +281,14 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         $fooRegion = $factory->getRegion(
             [
-            'region' => 'foo',
-            'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+                'region' => 'foo',
+                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
             ]
         );
         $barRegion = $factory->getRegion(
             [
-            'region' => 'bar',
-            'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+                'region' => 'bar',
+                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
             ]
         );
 
@@ -331,8 +331,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
             DefaultRegion::class,
             $factory->getRegion(
                 [
-                'region' => 'bar',
-                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+                    'region' => 'bar',
+                    'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
                 ]
             )
         );
@@ -349,8 +349,8 @@ class DefaultCacheFactoryTest extends OrmTestCase
             DefaultMultiGetRegion::class,
             $factory->getRegion(
                 [
-                'region' => 'bar',
-                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+                    'region' => 'bar',
+                    'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
                 ]
             )
         );

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -296,6 +296,30 @@ class DefaultCacheFactoryTest extends OrmTestCase
         $this->assertSame('bar', $barRegion->getCache()->getNamespace());
     }
 
+    public function testAppendsNamespacedCacheInstancePerRegionInstanceWhenItsAlreadySet()
+    {
+        $cache = clone $this->getSharedSecondLevelCacheDriverImpl();
+        $cache->setNamespace('testing');
+
+        $factory = new DefaultCacheFactory($this->regionsConfig, $cache);
+
+        $fooRegion = $factory->getRegion(
+            [
+                'region' => 'foo',
+                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+            ]
+        );
+        $barRegion = $factory->getRegion(
+            [
+                'region' => 'bar',
+                'usage'  => ClassMetadata::CACHE_USAGE_READ_ONLY,
+            ]
+        );
+
+        $this->assertSame('testing:foo', $fooRegion->getCache()->getNamespace());
+        $this->assertSame('testing:bar', $barRegion->getCache()->getNamespace());
+    }
+
     public function testBuildsDefaultCacheRegionFromGenericCacheRegion()
     {
         /* @var $cache \Doctrine\Common\Cache\Cache */


### PR DESCRIPTION
We're overriding the namespace without even checking if it was previously set, what causes problems when people uses that feature :wink: