### PR TITLE
[master]: hotfix, remove namespace in UnderscoreNamingStrategy::__con…

### DIFF
--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -41,7 +41,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
      *
      * @param integer $case CASE_LOWER | CASE_UPPER
      */
-    public function __construct($case = CASE_LOWER)
+    public function __construct($case = \CASE_LOWER)
     {
         $this->case = $case;
     }


### PR DESCRIPTION
Resolve bug: 

Unable to resolve constant Doctrine\ORM\Mapping\CASE_LOWER used as default value of $case in Doctrine\ORM\Mapping\UnderscoreNamingStrategy::__construct()