### PR TITLE
Fix `CountOutputWalker` for queries containing a `GROUP BY` clause, which was producing invalid SQL

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -91,6 +91,14 @@ class CountOutputWalker extends SqlWalker
 
         $sql = parent::walkSelectStatement($AST);
 
+        if ($AST->groupByClause) {
+            return sprintf(
+                'SELECT %s AS dctrn_count FROM (%s) dctrn_table',
+                $this->platform->getCountExpression('*'),
+                $sql
+            );
+        }
+
         // Find out the SQL alias of the identifier column of the root entity
         // It may be possible to make this work with multiple root entities but that
         // would probably require issuing multiple queries or doing a UNION SELECT

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
@@ -31,15 +31,27 @@ class CountOutputWalkerTest extends PaginationTestCase
         );
     }
 
-    public function testCountQuery_Having()
+    public function testCountQuery_GroupBy(): void
+    {
+        $query = $this->entityManager->createQuery(
+            'SELECT p.name FROM Doctrine\Tests\ORM\Tools\Pagination\Person p GROUP BY p.name');
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, CountOutputWalker::class);
+        $query->setFirstResult(null)->setMaxResults(null);
+
+        $this->assertSame(
+            "SELECT COUNT(*) AS dctrn_count FROM (SELECT p0_.name AS name_0 FROM Person p0_ GROUP BY p0_.name) dctrn_table", $query->getSQL()
+        );
+    }
+
+    public function testCountQuery_Having(): void
     {
         $query = $this->entityManager->createQuery(
             'SELECT g, u, count(u.id) AS userCount FROM Doctrine\Tests\ORM\Tools\Pagination\Group g LEFT JOIN g.users u GROUP BY g.id HAVING userCount > 0');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, CountOutputWalker::class);
         $query->setFirstResult(null)->setMaxResults(null);
 
-        $this->assertEquals(
-            "SELECT COUNT(*) AS dctrn_count FROM (SELECT DISTINCT id_1 FROM (SELECT count(u0_.id) AS sclr_0, g1_.id AS id_1, u0_.id AS id_2 FROM groups g1_ LEFT JOIN user_group u2_ ON g1_.id = u2_.group_id LEFT JOIN User u0_ ON u0_.id = u2_.user_id GROUP BY g1_.id HAVING sclr_0 > 0) dctrn_result) dctrn_table", $query->getSQL()
+        $this->assertSame(
+            "SELECT COUNT(*) AS dctrn_count FROM (SELECT count(u0_.id) AS sclr_0, g1_.id AS id_1, u0_.id AS id_2 FROM groups g1_ LEFT JOIN user_group u2_ ON g1_.id = u2_.group_id LEFT JOIN User u0_ ON u0_.id = u2_.user_id GROUP BY g1_.id HAVING sclr_0 > 0) dctrn_table", $query->getSQL()
         );
     }
 


### PR DESCRIPTION
Currently CountOutputWalker doesn't work with queries with GROUP BY. It throws this exception:

```
RuntimeException
Not all identifier properties can be found in the ResultSetMapping: id
```

Fortunately it's easy to fix. When GROUP BY is used we don't need the additional logic for distinct identifiers.