### PR TITLE
Make sure we're using the rootEntityName on all places

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -65,8 +65,9 @@ class DefaultCollectionHydrator implements CollectionHydrator
         $data = [];
 
         foreach ($collection as $index => $entity) {
-            $data[$index] = new EntityCacheKey($metadata->name, $this->uow->getEntityIdentifier($entity));
+            $data[$index] = new EntityCacheKey($metadata->rootEntityName, $this->uow->getEntityIdentifier($entity));
         }
+
         return new CollectionCacheEntry($data);
     }
 

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -175,7 +175,8 @@ class DefaultEntityHydrator implements EntityHydrator
                 continue;
             }
 
-            $assocKey       = new EntityCacheKey($assoc['targetEntity'], $assocId);
+            $assocMetadata  = $this->em->getClassMetadata($assoc['targetEntity']);
+            $assocKey       = new EntityCacheKey($assocMetadata->rootEntityName, $assocId);
             $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
             $assocRegion    = $assocPersister->getCacheRegion();
             $assocEntry     = $assocRegion->get($assocKey);

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -148,13 +148,13 @@ class DefaultQueryCache implements QueryCache
             $data = $entityEntry->data;
 
             foreach ($entry['associations'] as $name => $assoc) {
-
                 $assocPersister  = $this->uow->getEntityPersister($assoc['targetEntity']);
                 $assocRegion     = $assocPersister->getCacheRegion();
+                $assocMetadata   = $this->em->getClassMetadata($assoc['targetEntity']);
 
                 if ($assoc['type'] & ClassMetadata::TO_ONE) {
 
-                    if (($assocEntry = $assocRegion->get($assocKey = new EntityCacheKey($assoc['targetEntity'], $assoc['identifier']))) === null) {
+                    if (($assocEntry = $assocRegion->get($assocKey = new EntityCacheKey($assocMetadata->rootEntityName, $assoc['identifier']))) === null) {
 
                         if ($this->cacheLogger !== null) {
                             $this->cacheLogger->entityCacheMiss($assocRegion->getName(), $assocKey);
@@ -178,12 +178,11 @@ class DefaultQueryCache implements QueryCache
                     continue;
                 }
 
-                $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
-                $collection  = new PersistentCollection($this->em, $targetClass, new ArrayCollection());
+                $collection  = new PersistentCollection($this->em, $assocMetadata, new ArrayCollection());
 
                 foreach ($assoc['list'] as $assocIndex => $assocId) {
 
-                    if (($assocEntry = $assocRegion->get($assocKey = new EntityCacheKey($assoc['targetEntity'], $assocId))) === null) {
+                    if (($assocEntry = $assocRegion->get($assocKey = new EntityCacheKey($assocMetadata->rootEntityName, $assocId))) === null) {
 
                         if ($this->cacheLogger !== null) {
                             $this->cacheLogger->entityCacheMiss($assocRegion->getName(), $assocKey);

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -272,7 +272,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             }
 
             $assocId        = $this->uow->getEntityIdentifier($assocEntity);
-            $assocKey       = new EntityCacheKey($assoc['targetEntity'], $assocId);
+            $assocMetadata  = $this->metadataFactory->getMetadataFor($assoc['targetEntity']);
+            $assocKey       = new EntityCacheKey($assocMetadata->rootEntityName, $assocId);
             $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
 
             $assocPersister->storeEntityCache($assocEntity, $assocKey);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5562Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5562Test.php
@@ -1,0 +1,128 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH5562Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->enableSecondLevelCache();
+
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(GH5562User::class),
+                $this->_em->getClassMetadata(GH5562Manager::class),
+                $this->_em->getClassMetadata(GH5562Merchant::class),
+            ]
+        );
+    }
+
+    /**
+     * @group 5562
+     */
+    public function testCacheShouldBeUpdatedWhenAssociationChanges()
+    {
+        $manager = new GH5562Manager();
+        $merchant = new GH5562Merchant();
+
+        $manager->username = 'username';
+        $manager->merchant = $merchant;
+        $merchant->manager = $manager;
+
+        $merchant->name = 'Merchant';
+
+        $this->_em->persist($merchant);
+        $this->_em->persist($manager);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $merchant = $this->_em->find(GH5562Merchant::class, $merchant->id);
+
+        $merchant->name = mt_rand();
+        $merchant->manager->username = 'usernameUPDATE';
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $merchant = $this->_em->find(GH5562Merchant::class, $merchant->id);
+
+        self::assertEquals('usernameUPDATE', $merchant->manager->username);
+    }
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH5562Merchant
+{
+    /**
+     * @var integer
+     *
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+
+    /**
+     * @var GH5562Manager
+     *
+     * @OneToOne(targetEntity=GH5562Manager::class, mappedBy="merchant")
+     * @Cache(usage="NONSTRICT_READ_WRITE")
+     */
+    public $manager;
+
+    /**
+     * @var string
+     *
+     * @Column(name="name", type="string", length=255, nullable=false)
+     */
+    public $name;
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({"MANAGER"  = GH5562Manager::class})
+ */
+abstract class GH5562User
+{
+    /**
+     * @var integer
+     *
+     * @Id
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH5562Manager extends GH5562User
+{
+
+    /**
+     * @var string
+     *
+     * @Column
+     */
+    public $username;
+
+    /**
+     * @var GH5562Merchant
+     *
+     * @OneToOne(targetEntity=GH5562Merchant::class, inversedBy="manager")
+     */
+    public $merchant;
+}


### PR DESCRIPTION
Otherwise we might end up with duplicated cache entries and weird results (specially regarding associations).

Fixes #5562 and #5793.