### PR TITLE
Note on Entity listeners

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -888,6 +888,9 @@ you need to map the listener method using the event type mapping:
               preRemove: [preRemoveHandler]
           # ....
 
+.. note::
+
+    The order of execution of multiple methods for the same event (e.g. multiple @PrePersist) is not guaranteed.
 
 
 Entity listeners resolver


### PR DESCRIPTION
As requested here https://github.com/doctrine/doctrine2/issues/6247#issuecomment-274123780 I thought it should be interesting to note that.
The note could be longer, like "You should avoid to have multiple methods for the same event (e.g. multiple @PrePersist) since the execution order is not guaranteed".