### PR TITLE
Add missing group to DDC2660Test.php

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 
 /**
- * @group
+ * @group DDC-2660
  */
 class DDC2660Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {


### PR DESCRIPTION
With the current PHPUnit version and PHP 7.2/master, the test fails with:

1) Doctrine\Tests\ORM\Functional\Ticket\DDC2660Test::testIssueWithExtraColumn
array_flip(): Can only flip STRING and INTEGER values!

2) Doctrine\Tests\ORM\Functional\Ticket\DDC2660Test::testIssueWithoutExtraColumn
array_flip(): Can only flip STRING and INTEGER values!

Due to the group being NULL vs "" on older PHP versions.

I will also file a bug report or fix to PHPUnit and/or PHP itself, but it sounds
like the missing group was just a typo.