### PR TITLE
issue: use doctrine:mapping:import with annotation lack of some database info

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1659,14 +1659,8 @@ public function __construct(<params>)
                 $column[] = 'nullable=' .  var_export($fieldMapping['nullable'], true);
             }
 
-            $options = [];
-
-            if (isset($fieldMapping['options']['unsigned']) && $fieldMapping['options']['unsigned']) {
-                $options[] = '"unsigned"=true';
-            }
-
-            if ($options) {
-                $column[] = 'options={'.implode(',', $options).'}';
+            if (isset($fieldMapping['options']) && $fieldMapping['options']) {
+                $column[] = json_encode($fieldMapping['options'], JSON_HEX_APOS|JSON_HEX_QUOT);
             }
 
             if (isset($fieldMapping['columnDefinition'])) {


### PR DESCRIPTION
generate extra information(such as `unsigned`, `comment`, `fixed`)


a generated use case
```
/**
 * Member
 *
 * @ORM\Table(name="member", uniqueConstraints={
 *     @ORM\UniqueConstraint(name="mobile_UNIQUE", columns={"mobile"}),
 *     @ORM\UniqueConstraint(name="email_UNIQUE", columns={"email"})
 * })
 * @ORM\Entity
 */
class Member
{
    /**
     * @var integer
     *
     * @ORM\Column(name="member_id", type="integer", nullable=false, {"unsigned":false,"comment":"\u7528\u6237\u4e3b\u952e"})
     * @ORM\Id
     * @ORM\GeneratedValue(strategy="IDENTITY")
     */
    private $memberId;

    /**
     * @var string
     *
     * @ORM\Column(name="username", type="string", length=50, nullable=false, {"fixed":true,"comment":"\u7528\u6237\u540d"})
     */
    private $username;
}
```