### PR TITLE
Improve exception message for DQL single-valued association path expression to an inverse side (unsupported)

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -204,13 +204,15 @@ class QueryException extends \Doctrine\ORM\ORMException
     }
 
     /**
+     * @param object $pathExpr
+     *
      * @return QueryException
      */
-    public static function associationPathInverseSideNotSupported()
+    public static function associationPathInverseSideNotSupported($pathExpr)
     {
         return new self(
-            "A single-valued association path expression to an inverse side is not supported".
-            " in DQL queries. Use an explicit join instead."
+            "A single-valued association path expression to an inverse side is not supported in DQL queries. " .
+            "Instead of '" . $pathExpr->identificationVariable . "." . $pathExpr->field . "' use an explicit join."
         );
     }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -671,7 +671,7 @@ class SqlWalker implements TreeWalker
                 $assoc = $class->associationMappings[$fieldName];
 
                 if ( ! $assoc['isOwningSide']) {
-                    throw QueryException::associationPathInverseSideNotSupported();
+                    throw QueryException::associationPathInverseSideNotSupported($pathExpr);
                 }
 
                 // COMPOSITE KEYS NOT (YET?) SUPPORTED


### PR DESCRIPTION
Hello,
I have added path expression to the exception about single-valued association to an inverse side being not supported. The path expression makes it easier to identify the issue among many other expression in potentially complex query. 

[Seems like many people had an issue with this exception.](https://www.google.com/search?q=A+single-valued+association+path+expression+to+an+inverse+side+is+not+supported+in+DQL+queries.)

For a query:
```sql
SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.address IN (?1, ?2)
```

The exception message before:

> A single-valued association path expression to an inverse side is not supported in DQL queries. Use an explicit join instead.

The exception message after:

> A single-valued association path expression to an inverse side is not supported in DQL queries. Instead of 'u.address' use an explicit join.
