### PR TITLE
onFlush and postFlush Entity Listeners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION -lt '7.0' && $TRAVIS_PHP_VERSION != 'hhv*' ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer install --prefer-source
+  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
 
 script:
   - ENABLE_SECOND_LEVEL_CACHE=0 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml $PHPUNIT_FLAGS
@@ -37,6 +39,10 @@ matrix:
       env: DB=mariadb
       addons:
         mariadb: 10.1
+    - php: 7.1
+      env:
+        - DB=sqlite
+        - DEPENDENCIES='low'
     - php: hhvm
       sudo: true
       dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6.0"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.0",
         "ext-pdo": "*",
-        "doctrine/collections": "~1.2",
+        "doctrine/collections": "~1.3",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
         "doctrine/cache": "~1.5",
+        "doctrine/annotations": "~1.2",
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
-        "doctrine/cache": "~1.4",
+        "doctrine/cache": "~1.5",
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",
-        "phpunit/phpunit": "^5.4"
+        "phpunit/phpunit": "^5.7"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/docs/en/reference/second-level-cache.rst
+++ b/docs/en/reference/second-level-cache.rst
@@ -220,7 +220,7 @@ To specify a default lifetime for all regions or specify a different lifetime fo
 
     <?php
     /* @var $config \Doctrine\ORM\Configuration */
-    /* @var $cacheConfig \Doctrine\ORM\Configuration */
+    /* @var $cacheConfig \Doctrine\ORM\Cache\CacheConfiguration */
     $cacheConfig  =  $config->getSecondLevelCacheConfiguration();
     $regionConfig =  $cacheConfig->getRegionsConfiguration();
 

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -42,7 +42,9 @@ class EntityListenerBuilder
         Events::preUpdate   => true,
         Events::postUpdate  => true,
         Events::postLoad    => true,
-        Events::preFlush    => true
+        Events::preFlush    => true,
+        Events::onFlush     => true,
+        Events::postFlush   => true
     ];
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3299,12 +3299,48 @@ class UnitOfWork implements PropertyChangedListener
         if ($this->evm->hasListeners(Events::onFlush)) {
             $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
         }
+        foreach ($this->entityChangeSets as $oid => $entityChangeSet) {
+            foreach ($this->identityMap as $className => $entities) {
+                $hash = (isset($this->entityIdentifiers[$oid]) && isset($this->entityIdentifiers[$oid]['id'])) ? $this->entityIdentifiers[$oid]['id'] : null;
+                if ($hash) {
+                    if (is_object($hash) && method_exists($hash, '__toString')) $hash = $hash->__toString();
+                    if (isset($this->identityMap[$className][$hash])) {
+                        $entity = $this->identityMap[$className][$hash];
+                        if ($oid == spl_object_hash($entity)) {
+                            $class = $this->em->getClassMetadata(get_class($entity));
+                            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::onFlush) & ~ListenersInvoker::INVOKE_MANAGER;
+                            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
+                                $this->listenersInvoker->invoke($class, Events::onFlush, $entity, new OnFlushEventArgs($this->em), $invoke);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private function dispatchPostFlushEvent()
     {
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
+        }
+        foreach ($this->entityChangeSets as $oid => $entityChangeSet) {
+            foreach ($this->identityMap as $className => $entities) {
+                $hash = (isset($this->entityIdentifiers[$oid]) && isset($this->entityIdentifiers[$oid]['id'])) ? $this->entityIdentifiers[$oid]['id'] : null;
+                if ($hash) {
+                    if (is_object($hash) && method_exists($hash, '__toString')) $hash = $hash->__toString();
+                    if (isset($this->identityMap[$className][$hash])) {
+                        $entity = $this->identityMap[$className][$hash];
+                        if ($oid == spl_object_hash($entity)) {
+                            $class = $this->em->getClassMetadata(get_class($entity));
+                            $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postFlush) & ~ListenersInvoker::INVOKE_MANAGER;
+                            if ($invoke !== ListenersInvoker::INVOKE_NONE) {
+                                $this->listenersInvoker->invoke($class, Events::postFlush, $entity, new PostFlushEventArgs($this->em), $invoke);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/tests/Doctrine/Tests/DoctrineTestCase.php
+++ b/tests/Doctrine/Tests/DoctrineTestCase.php
@@ -2,9 +2,11 @@
 
 namespace Doctrine\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Base testcase class for all Doctrine testcases.
  */
-abstract class DoctrineTestCase extends \PHPUnit_Framework_TestCase
+abstract class DoctrineTestCase extends TestCase
 {
 }

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -17,13 +17,13 @@ use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
 use ReflectionClass;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for the Configuration object
  * @author Marco Pivetta <ocramius@gmail.com>
  */
-class ConfigurationTest extends PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @var Configuration

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -5,8 +5,9 @@ namespace Doctrine\Tests\ORM\Decorator;
 use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
+use PHPUnit\Framework\TestCase;
 
-class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
+class EntityManagerDecoratorTest extends TestCase
 {
     const VOID_METHODS = [
         'persist',

--- a/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
@@ -3,13 +3,14 @@
 namespace Doctrine\Tests\ORM;
 
 use Doctrine\ORM\EntityNotFoundException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \Doctrine\ORM\EntityNotFoundException}
  *
  * @covers \Doctrine\ORM\EntityNotFoundException
  */
-class EntityNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class EntityNotFoundExceptionTest extends TestCase
 {
     public function testFromClassNameAndIdentifier()
     {

--- a/tests/Doctrine/Tests/ORM/Event/OnClassMetadataNotFoundEventArgsTest.php
+++ b/tests/Doctrine/Tests/ORM/Event/OnClassMetadataNotFoundEventArgsTest.php
@@ -5,14 +5,14 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs}
  *
  * @covers \Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs
  */
-class OnClassMetadataNotFoundEventArgsTest extends PHPUnit_Framework_TestCase
+class OnClassMetadataNotFoundEventArgsTest extends TestCase
 {
     public function testEventArgsMutability()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -8,11 +8,12 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group DDC-2359
  */
-class DDC2359Test extends \PHPUnit_Framework_TestCase
+class DDC2359Test extends TestCase
 {
 
     /**

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -25,7 +25,7 @@ use Doctrine\ORM\Event\ListenersInvoker;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -33,7 +33,7 @@ use stdClass;
  *
  * @covers \Doctrine\ORM\Internal\HydrationCompleteHandler
  */
-class HydrationCompleteHandlerTest extends PHPUnit_Framework_TestCase
+class HydrationCompleteHandlerTest extends TestCase
 {
     /**
      * @var \Doctrine\ORM\Event\ListenersInvoker|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\LazyCriteriaCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -13,7 +14,7 @@ use stdClass;
  *
  * @covers \Doctrine\ORM\LazyCriteriaCollection
  */
-class LazyCriteriaCollectionTest extends \PHPUnit_Framework_TestCase
+class LazyCriteriaCollectionTest extends TestCase
 {
     /**
      * @var \Doctrine\ORM\Persisters\Entity\EntityPersister|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\Reflection\ReflectionPropertiesGetter;
 use Doctrine\Tests\Models\Reflection\ClassWithMixedProperties;
 use Doctrine\Tests\Models\Reflection\ParentClass;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
@@ -15,7 +15,7 @@ use ReflectionClass;
  *
  * @covers \Doctrine\ORM\Mapping\Reflection\ReflectionPropertiesGetter
  */
-class ReflectionPropertiesGetterTest extends PHPUnit_Framework_TestCase
+class ReflectionPropertiesGetterTest extends TestCase
 {
     public function testRetrievesProperties()
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -9,6 +9,7 @@ use Doctrine\Tests\Models\Mapping\Entity;
 use Doctrine\Tests\Models\Reflection\AbstractEmbeddable;
 use Doctrine\Tests\Models\Reflection\ArrayObjectExtendingClass;
 use Doctrine\Tests\Models\Reflection\ConcreteEmbeddable;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
 /**
@@ -16,7 +17,7 @@ use ReflectionProperty;
  *
  * @covers \Doctrine\ORM\Mapping\ReflectionEmbeddedProperty
  */
-class ReflectionEmbeddedPropertyTest extends \PHPUnit_Framework_TestCase
+class ReflectionEmbeddedPropertyTest extends TestCase
 {
     /**
      * @param ReflectionProperty $parentProperty  property of the embeddable/entity where to write the embeddable to

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -2,11 +2,12 @@
 
 namespace Doctrine\Tests\ORM\Mapping\Symfony;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group DDC-1418
  */
-abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractDriverTest extends TestCase
 {
     public function testFindMappingFile()
     {

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -21,12 +21,13 @@ use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\GeoNames\City;
 use Doctrine\Tests\Models\GeoNames\Country;
 use Doctrine\Tests\OrmTestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @covers \Doctrine\ORM\ORMInvalidArgumentException
  */
-class ORMInvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+class ORMInvalidArgumentExceptionTest extends TestCase
 {
     /**
      * @dataProvider invalidEntityNames

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -24,6 +24,7 @@ class LanguageRecognitionTest extends OrmTestCase
     {
         try {
             $parserResult = $this->parseDql($dql);
+            $this->addToAssertionCount(1);
         } catch (QueryException $e) {
             if ($debug) {
                 echo $e->getTraceAsString() . PHP_EOL;
@@ -44,6 +45,7 @@ class LanguageRecognitionTest extends OrmTestCase
                 echo $e->getMessage() . PHP_EOL;
                 echo $e->getTraceAsString() . PHP_EOL;
             }
+            $this->addToAssertionCount(1);
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserResultTest.php
@@ -5,8 +5,9 @@ namespace Doctrine\Tests\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\ResultSetMapping;
+use PHPUnit\Framework\TestCase;
 
-class ParserResultTest extends \PHPUnit_Framework_TestCase
+class ParserResultTest extends TestCase
 {
     public $parserResult;
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -9,13 +9,14 @@ use Doctrine\Common\Collections\ExpressionBuilder as CriteriaBuilder;
 use Doctrine\ORM\Query\Expr as QueryBuilder;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryExpressionVisitor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for QueryExpressionVisitor
  *
  * @author Kirill chEbba Chebunin <iam@chebba.org>
  */
-class QueryExpressionVisitorTest extends \PHPUnit_Framework_TestCase
+class QueryExpressionVisitorTest extends TestCase
 {
     /**
      * @var QueryExpressionVisitor

--- a/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -8,14 +8,14 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\Tests\Models\DDC753\DDC753DefaultRepository;
 use Doctrine\Tests\Models\DDC869\DDC869PaymentRepository;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \Doctrine\ORM\Repository\DefaultRepositoryFactory}
  *
  * @covers \Doctrine\ORM\Repository\DefaultRepositoryFactory
  */
-class DefaultRepositoryFactoryTest extends PHPUnit_Framework_TestCase
+class DefaultRepositoryFactoryTest extends TestCase
 {
     /**
      * @var \Doctrine\ORM\EntityManagerInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\EventListener\CacheMetadataListener;
 use Doctrine\Tests\Models;
+use PHPUnit\Framework\AssertionFailedError;
 
 /**
  * Base testcase class for all functional ORM testcases.
@@ -750,15 +751,15 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     }
 
     /**
-     * @param \Exception $e
+     * @param \Throwable $e
      *
      * @return void
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
-    protected function onNotSuccessfulTest($e)
+    protected function onNotSuccessfulTest(\Throwable $e)
     {
-        if ($e instanceof \PHPUnit_Framework_AssertionFailedError) {
+        if ($e instanceof AssertionFailedError) {
             throw $e;
         }
 


### PR DESCRIPTION
Simply check if an onFlush or postFlush entity listener is subscribed
for the current class in the entity manager during dispatch.

This is a rebased followup to #5822, per @lcobucci's review.