### PR TITLE
Allow to configure hints for the QueryBuilder

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -118,6 +118,13 @@ class QueryBuilder
      */
     private $joinRootAliases = [];
 
+    /**
+     * The map of query hints.
+     *
+     * @var array
+     */
+    private $_hints = [];
+
      /**
      * Whether to use second level cache, if available.
      *
@@ -265,6 +272,55 @@ class QueryBuilder
     }
 
     /**
+     * Sets a query hint.
+     *
+     * @param string $name  The name of the hint.
+     * @param mixed  $value The value of the hint.
+     *
+     * @return self
+     */
+    public function setHint($name, $value)
+    {
+        $this->_hints[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Gets the value of a query hint. If the hint name is not recognized, FALSE is returned.
+     *
+     * @param string $name The name of the hint.
+     *
+     * @return mixed The value of the hint or FALSE, if the hint name is not recognized.
+     */
+    public function getHint($name)
+    {
+        return $this->_hints[$name] ?? false;
+    }
+
+    /**
+     * Check if the query has a hint
+     *
+     * @param string $name The name of the hint
+     *
+     * @return bool False if the query does not have any hint
+     */
+    public function hasHint($name)
+    {
+        return isset($this->_hints[$name]);
+    }
+
+    /**
+     * Return the key value map of query hints that are currently set.
+     *
+     * @return array
+     */
+    public function getHints()
+    {
+        return $this->_hints;
+    }
+
+    /**
      * Gets the type of the currently built query.
      *
      * @return integer
@@ -368,6 +424,12 @@ class QueryBuilder
 
         if ($this->cacheRegion) {
             $query->setCacheRegion($this->cacheRegion);
+        }
+
+        if ($this->_hints) {
+            foreach ($this->_hints as $name => $value) {
+                $query->setHint($name, $value);
+            }
         }
 
         return $query;

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1115,6 +1115,47 @@ class QueryBuilderTest extends OrmTestCase
         $this->assertEquals(Cache::MODE_REFRESH, $query->getCacheMode());
     }
 
+    public function testQueryHints()
+    {
+        $defaultQueryBuilder = $this->_em->createQueryBuilder()
+            ->select('s')
+            ->from(State::class, 's');
+
+        $this->assertFalse($defaultQueryBuilder->hasHint('foo'));
+        $this->assertFalse($defaultQueryBuilder->getHint('foo'));
+        $this->assertEquals([], $defaultQueryBuilder->getHints());
+
+        $defaultQuery = $defaultQueryBuilder->getQuery();
+
+        $this->assertFalse($defaultQuery->hasHint('foo'));
+
+        $builder = $this->_em->createQueryBuilder()
+            ->select('s')
+            ->from(State::class, 's')
+            ->setHint('foo', 'bar')
+            ->setHint('foo_reg', $value = new \stdClass())
+        ;
+
+        $this->assertTrue($builder->hasHint('foo'));
+        $this->assertTrue($builder->hasHint('foo_reg'));
+        $this->assertFalse($builder->hasHint('fool'));
+        $this->assertEquals(['foo' => 'bar', 'foo_reg' => $value], $builder->getHints());
+
+        $this->assertEquals('bar', $builder->getHint('foo'));
+        $this->assertEquals($value, $builder->getHint('foo_reg'));
+        $this->assertFalse($builder->getHint('fool'));
+
+        $query = $builder->getQuery();
+
+        $this->assertTrue($query->hasHint('foo'));
+        $this->assertTrue($query->hasHint('foo_reg'));
+        $this->assertFalse($query->hasHint('fool'));
+
+        $this->assertEquals('bar', $query->getHint('foo'));
+        $this->assertEquals($value, $query->getHint('foo_reg'));
+        $this->assertFalse($query->getHint('fool'));
+    }
+
     /**
      * @group DDC-2253
      */


### PR DESCRIPTION
Background: In the RollerworksSearch (Doctrine ORM ConditionGenerator) I use a Query-Hint to pass conversion information to DQL functions. But now to integrate RollerworksSearch with the Api-platform I need to work with the QueryBuilder which doesn't allow to set hints.

I copied the description from the AbstractQuery class. If possible can this be back ported to 2.5 also? I know you prefer to merge everything to master but without this I'm kinda stuck, and I don't know when 2.6 will be released 😅 