### PR TITLE
Typehint @return at get method for OneToMany target

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1380,6 +1380,14 @@ public function __construct(<params>)
             $variableType   =  '\\' . ltrim($variableType, '\\');
             $methodTypeHint =  '\\' . $typeHint . ' ';
         }
+        
+        if($metadata->hasAssociation($fieldName)) {
+            $assoc = $metadata->getAssociationMapping($fieldName);
+            if($assoc['type'] === ClassMetadataInfo::ONE_TO_MANY) {
+                $target = '\\' . ltrim($metadata->getAssociationMapping($fieldName)['targetEntity'], '\\');
+                $variableType .= '|'.$target.'[]';
+            }
+        }
 
         $replacements = [
           '<description>'       => ucfirst($type) . ' ' . $variableName . '.',


### PR DESCRIPTION
Currently when using doctrine:generate:entityies for @ORM\OneToMany relation get method will generate as follows

```
    /**
     * @ORM\OneToMany(targetEntity="AppBundle\Entity\Action", mappedBy="player")
     */
    protected $actions;

    /**
     * Get actions
     *
     * @return \Doctrine\Common\Collections\Collection
     */
    public function getActions()
    {
        return $this->actions;
    }
```
Proposed change will add entity array hint as alternative for return as follows:

```

    /**
     * Get actions
     *
     * @return \Doctrine\Common\Collections\Collection|\AppBundle\Entity\Action[]
     */
    public function getActions()
    {
        return $this->actions;
    }
```