### PR TITLE
Pinning dev dependency symfony/yaml to working version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.3|~3.0",
+        "symfony/yaml": "^3.2@stable",
         "phpunit/phpunit": "^5.4"
     },
     "suggest": {


### PR DESCRIPTION
You've been having some [weird build breaks](https://travis-ci.org/doctrine/doctrine2/jobs/215427291) in [pull requests](https://github.com/doctrine/doctrine2/pull/6359) recently.  This is because the latest version of `symfony/yaml` that you're getting with `"minimum-stability": "dev"` is `3.3.x-dev`, which isn't working for you.

This PR makes your build run with a stable version of `symfony/yaml`, which we know works for your test suite.