### PR TITLE
EntityManager: Implement singleton pattern, use global injection (minor BC break)

### DIFF
--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -724,7 +724,18 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $evm->addEventListener(array('onFlush'), new \Doctrine\ORM\Tools\DebugUnitOfWorkListener());
         }
 
-        return \Doctrine\ORM\EntityManager::create($conn, $config);
+        // reset EntityManager singleton
+        // ONLY FOR TESTS, NEVER DO THIS YOURSELF
+        $reflection = new \ReflectionProperty(EntityManager::class, 'god');
+        $reflection->setAccessible(TRUE);
+        $reflection->setValue(NULL);
+
+        // rename variables to match globals
+        /** @noinspection PhpUnusedLocalVariableInspection Liar! It's global! */
+        $configuration = $config;
+        /** @noinspection PhpUnusedLocalVariableInspection Liar! It's global! */
+        $connection = $conn;
+        return \Doctrine\ORM\EntityManager::getInstance();
     }
 
     /**


### PR DESCRIPTION
As per [the article](http://www.doctrine-project.org/2017/04/01/announcing-doctrine-4.html), since Doctrine is moving to modern static interface, let's start immediately with EntityManager.

This PR introduces:
* Singleton pattern - Why should anyone track the instance? Let EntityManager do it itself!
* Global injection - Parameters are boring, this is easier.

Targets 2.5 as this should be introduced ASAP - preferably in the next bugfix version.

TODO:
* [ ] Fix tests.