### PR TITLE
Invalid discrimination column value when discriminator column has custom type.

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -99,13 +99,21 @@ class SimpleObjectHydrator extends AbstractHydrator
             }
 
             $discrMap = $this->class->discriminatorMap;
+            $discrType = $discriminatorValue = $this->class->discriminatorColumn['type'];
 
-            if ( ! isset($discrMap[$sqlResult[$discrColumnName]])) {
+            if (Type::hasType($discrType)) {
+                $discrValue = Type::getType($discrType)->convertToPHPValue($sqlResult[$discrColumnName], $this->_platform);
+            } else {
+                $discrValue = $sqlResult[$discrColumnName];
+            }
+
+            if ( ! isset($discrMap[$discrValue])) {
                 throw HydrationException::invalidDiscriminatorValue($sqlResult[$discrColumnName], array_keys($discrMap));
             }
 
-            $entityName = $discrMap[$sqlResult[$discrColumnName]];
+            $entityName = $discrMap[$discrValue];
 
+            unset($discrValue);
             unset($sqlResult[$discrColumnName]);
         }
 


### PR DESCRIPTION
I have got discriminator config like below:
```xml
<discriminator-column name="type" type="dc_job_type_enum"></discriminator-column>
    <discriminator-map>
      <discriminator-mapping value="EMAIL" class="AppBundle\Entity\JobObjectEmail"/>
    </discriminator-map>
```

And EMAIL is PHP value and its mapping to 1 in database. 
Script throwing below error before changes:
```
HydrationException: The discriminator value "1" is invalid. It must be one of "EMAIL".
```
