### PR TITLE
Updated broken links

### DIFF
--- a/docs/en/cookbook/dql-user-defined-functions.rst
+++ b/docs/en/cookbook/dql-user-defined-functions.rst
@@ -132,7 +132,7 @@ dql statement.
 
 The ``ArithmeticPrimary`` method call is the most common
 denominator of valid EBNF tokens taken from the
-`DQL EBNF grammar <http://www.doctrine-project.org/documentation/manual/2_0/en/dql-doctrine-query-language#ebnf>`_
+`DQL EBNF grammar <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html#ebnf>`_
 that matches our requirements for valid input into the DateDiff Dql
 function. Picking the right tokens for your methods is a tricky
 business, but the EBNF grammar is pretty helpful finding it, as is

--- a/docs/en/cookbook/implementing-wakeup-or-clone.rst
+++ b/docs/en/cookbook/implementing-wakeup-or-clone.rst
@@ -4,7 +4,7 @@ Implementing Wakeup or Clone
 .. sectionauthor:: Roman Borschel (roman@code-factory.org)
 
 As explained in the
-`restrictions for entity classes in the manual <http://www.doctrine-project.org/documentation/manual/2_0/en/architecture#entities>`_,
+`restrictions for entity classes in the manual <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/architecture.html#entities>`_,
 it is usually not allowed for an entity to implement ``__wakeup``
 or ``__clone``, because Doctrine makes special use of them.
 However, it is quite easy to make use of these methods in a safe

--- a/docs/en/cookbook/integrating-with-codeigniter.rst
+++ b/docs/en/cookbook/integrating-with-codeigniter.rst
@@ -111,7 +111,7 @@ APC, get rid of EchoSqlLogger, and turn off
 autoGenerateProxyClasses.
 
 For more details, consult the
-`Doctrine 2 Configuration documentation <http://www.doctrine-project.org/documentation/manual/2_0/en/configuration#configuration-options>`_.
+`Doctrine 2 Configuration documentation <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/configuration.html>`_.
 
 Now to use it
 -------------

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -162,7 +162,7 @@ read up on the configuration details in the
 The third block shows the configuration options required to connect
 to a database, in my case a file-based sqlite database. All the
 configuration options for all the shipped drivers are given in the
-`DBAL Configuration section of the manual <http://www.doctrine-project.org/documentation/manual/2_0/en/dbal>`_.
+`DBAL Configuration section of the manual <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/>`_.
 
 The last block shows how the ``EntityManager`` is obtained from a
 factory method.


### PR DESCRIPTION
Updated all links pointing to
http://www.doctrine-project.org/documentation/* to their
http://docs.doctrine-project.org counterparts

This should fix the broken link of issue #5575