### PR TITLE
Fix incorrect YAML example for versioning a field.

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -214,8 +214,8 @@ example we'll use an integer.
           type: entity
           fields:
             version:
-              version:
-                type: integer
+              type: integer
+              version: true
 
 Alternatively a datetime type can be used (which maps to a SQL
 timestamp or datetime):


### PR DESCRIPTION
The example failed for me in practice, until I made the fix here. A casual comparison of the YAML and XML example in the doc file also supports "version" and "type" being configured at the same indentation level.