### PR TITLE
Fix incorrect YAML datetime version field.

### DIFF
--- a/docs/en/reference/transactions-and-concurrency.rst
+++ b/docs/en/reference/transactions-and-concurrency.rst
@@ -247,8 +247,8 @@ timestamp or datetime):
           type: entity
           fields:
             version:
-              version:
-                type: datetime
+              type: datetime
+              version: true
 
 Version numbers (not timestamps) should however be preferred as
 they can not potentially conflict in a highly concurrent


### PR DESCRIPTION
Apologies @Ocramius , as I wasn't personally using a datetime version field I didn't notice the documentation was incorrect for datetime as well. This corrects the other example.