### PR TITLE
Fix quoting issues related to ticket #6402

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1327,7 +1327,7 @@ class BasicEntityPersister implements EntityPersister
             $resultColumnName = $this->getSQLColumnAlias($joinColumn['name']);
             $type             = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
-            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName, $joinColumn["name"], $isIdentifier, $type);
+            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName, $joinColumn['name'], $isIdentifier, $type);
 
             $columnList[] = sprintf('%s.%s AS %s', $sqlTableAlias, $quotedColumn, $resultColumnName);
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1327,7 +1327,7 @@ class BasicEntityPersister implements EntityPersister
             $resultColumnName = $this->getSQLColumnAlias($joinColumn['name']);
             $type             = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
-            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName, $quotedColumn, $isIdentifier, $type);
+            $this->currentPersisterContext->rsm->addMetaResult($alias, $resultColumnName, $joinColumn["name"], $isIdentifier, $type);
 
             $columnList[] = sprintf('%s.%s AS %s', $sqlTableAlias, $quotedColumn, $resultColumnName);
         }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -764,7 +764,8 @@ class SqlWalker implements TreeWalker
                     $columnAlias = $this->getSQLColumnAlias($columnName);
                     $columnType  = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
-                    $sqlSelectExpressions[] = $sqlTableAlias . '.' . $columnName . ' AS ' . $columnAlias;
+                    $quotedColumnName = $this->quoteStrategy->getJoinColumnName($joinColumn, $class, $this->platform);
+                    $sqlSelectExpressions[] = $sqlTableAlias . '.' . $quotedColumnName . ' AS ' . $columnAlias;
 
                     $this->rsm->addMetaResult($dqlAlias, $columnAlias, $columnName, $isIdentifier, $columnType);
                 }

--- a/tests/Doctrine/Tests/ORM/Functional/QuoteTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QuoteTest.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Doctrine\Tests\ORM\Functional;
+
+
+use Doctrine\Tests\Models\Quote\Address;
+use Doctrine\Tests\Models\Quote\Group;
+use Doctrine\Tests\Models\Quote\Phone;
+use Doctrine\Tests\Models\Quote\User;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class QuoteTest extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        try {
+            $this->setUpEntitySchema([
+                Address::class,
+                Group::class,
+                Phone::class,
+                User::class,
+            ]);
+        } catch (\Exception $exception) {
+        }
+    }
+
+    public function testFind()
+    {
+        $id = $this->createAddress();
+
+        $address = $this->_em->find(Address::class, $id);
+        self::assertNotNull($address->user);
+    }
+
+    public function testQuery()
+    {
+        $id = $this->createAddress();
+
+        $addresses = $this->_em->createQuery("SELECT a FROM " . Address::class . " a WHERE a.id = :id")
+            ->setParameter("id", $id)
+            ->getResult();
+
+        self::assertCount(1, $addresses);
+        self::assertNotNull($addresses[0]->user);
+    }
+
+    private function createAddress()
+    {
+        $user = new User();
+        $user->name = "foo";
+
+        $address = new Address();
+        $address->zip = "bar";
+        $user->setAddress($address);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return $address->id;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6402Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6402Test.php
@@ -1,8 +1,6 @@
 <?php
 
-
-namespace Doctrine\Tests\ORM\Functional;
-
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Quote\Address;
 use Doctrine\Tests\Models\Quote\Group;
@@ -10,7 +8,10 @@ use Doctrine\Tests\Models\Quote\Phone;
 use Doctrine\Tests\Models\Quote\User;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-class QuoteTest extends OrmFunctionalTestCase
+/**
+ * @group GH-6402
+ */
+class GH6402Test extends OrmFunctionalTestCase
 {
     protected function setUp()
     {


### PR DESCRIPTION
Apply quoting strategy to foreign key columns of one-to-one relation so
that correct select statements are generated. And use unquoted column
names in result mapping instead of quoted ones, as consumers (namely
IdentifierFlattener) expect unquoted column names.