### PR TITLE
ID generators require concrete EntityManager instance instead of EntityManagerInterface

### DIFF
--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -19,18 +19,18 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 abstract class AbstractIdGenerator
 {
     /**
      * Generates an identifier for an entity.
      *
-     * @param EntityManager|EntityManager $em
+     * @param EntityManagerInterface $em
      * @param \Doctrine\ORM\Mapping\Entity $entity
      * @return mixed
      */
-    abstract public function generate(EntityManager $em, $entity);
+    abstract public function generate(EntityManagerInterface $em, $entity);
 
     /**
      * Gets whether this generator is a post-insert generator which means that

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 
 /**
@@ -40,7 +40,7 @@ class AssignedGenerator extends AbstractIdGenerator
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         $class      = $em->getClassMetadata(get_class($entity));
         $idFields   = $class->getIdentifierFieldNames();

--- a/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -50,7 +50,7 @@ class BigIntegerIdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return (string) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Id/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/IdentityGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -50,8 +50,7 @@ class IdentityGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(
-        EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return (int)$em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Serializable;
 
 /**
@@ -69,7 +69,7 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that uses a single-row database table and a hi/lo algorithm.
@@ -72,8 +72,7 @@ class TableGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(
-        EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         if ($this->_maxValue === null || $this->_nextValue == $this->_maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM\Id;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Represents an ID generator that uses the database UUID expression
@@ -32,7 +32,7 @@ class UuidGenerator extends AbstractIdGenerator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         $conn = $em->getConnection();
         $sql = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\Driver\StaticPHPDriver;
@@ -97,7 +97,7 @@ class DDC2415ChildEntity extends DDC2415ParentEntity
 
 class DDC2415Generator extends AbstractIdGenerator
 {
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return md5($entity->getName());
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\EventManager;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\AbstractIdGenerator;
@@ -390,7 +390,7 @@ class ClassMetadataFactoryTest extends \Doctrine\Tests\OrmTestCase
     {
         $classMetadataFactory = new ClassMetadataFactory();
 
-        /* @var $entityManager EntityManager */
+        /* @var $entityManager EntityManagerInterface */
         $entityManager        = $this->getMock('Doctrine\\ORM\\EntityManagerInterface');
 
         $classMetadataFactory->setEntityManager($entityManager);
@@ -463,7 +463,7 @@ class TestEntity1
 
 class CustomIdGenerator extends AbstractIdGenerator
 {
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
     }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -36,7 +36,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     protected static $_sharedConn;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $_em;
 
@@ -642,7 +642,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      * @param \Doctrine\ORM\Configuration   $config       The Configuration to pass to the EntityManager.
      * @param \Doctrine\Common\EventManager $eventManager The EventManager to pass to the EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     protected function _getEntityManager($config = null, $eventManager = null) {
         // NOTE: Functional tests use their own shared metadata cache, because


### PR DESCRIPTION
I came across this issue while attempting to implement an EntityManager Decorator to handle resetting the UoW and EntityManager. After doing so, I began receiving errors like
```
Argument 1 passed to Doctrine\ORM\Id\IdentityGenerator::generate() must be an instance of Doctrine\ORM\EntityManager, instance of MyEntityManager given ...
```
Where `MyEntityManager` implements `Doctrine\ORM\EntityManagerInterface`

## Files touched
1. lib/Doctrine/ORM/Id/AbstractIdGenerator.php
2. lib/Doctrine/ORM/Id/AssignedGenerator.php
3. lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
4. lib/Doctrine/ORM/Id/IdentityGenerator.php
5. lib/Doctrine/ORM/Id/SequenceGenerator.php
6. lib/Doctrine/ORM/Id/TableGenerator.php
7. lib/Doctrine/ORM/Id/UuidGenerator.php
8. tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php :: `class DDC2415Generator`
9. tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php :: `class CustomIdGenerator`
10. tests/Doctrine/Tests/OrmFunctionalTestCase.php