### PR TITLE
onFlush and postFlush Entity Listeners

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -53,6 +53,8 @@
       <xs:enumeration value="preRemove"/>
       <xs:enumeration value="postRemove"/>
       <xs:enumeration value="postLoad"/>
+      <xs:enumeration value="onFlush"/>
+      <xs:enumeration value="postFlush"/>
       <xs:enumeration value="preFlush"/>
     </xs:restriction>
   </xs:simpleType>

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -42,7 +42,9 @@ class EntityListenerBuilder
         Events::preUpdate   => true,
         Events::postUpdate  => true,
         Events::postLoad    => true,
-        Events::preFlush    => true
+        Events::preFlush    => true,
+        Events::onFlush     => true,
+        Events::postFlush   => true
     ];
 
     /**

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -244,8 +244,8 @@ class CmsAddress
         $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CmsAddressListener', 'preRemove');
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CmsAddressListener', 'preFlush');
-        $metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CmsAddressListener', 'onFlushHandler');
-        $metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CmsAddressListener', 'postFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CmsAddressListener', 'onFlush');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CmsAddressListener', 'postFlush');
         $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CmsAddressListener', 'postLoad');
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -244,6 +244,8 @@ class CmsAddress
         $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CmsAddressListener', 'preRemove');
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CmsAddressListener', 'preFlush');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CmsAddressListener', 'onFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CmsAddressListener', 'postFlushHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CmsAddressListener', 'postLoad');
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddressListener.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddressListener.php
@@ -41,6 +41,16 @@ class CmsAddressListener
         $this->calls[__FUNCTION__][] = func_get_args();
     }
 
+    public function onFlush()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
+
+    public function postFlush()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
+
     public function preFlush()
     {
         $this->calls[__FUNCTION__][] = func_get_args();

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -175,6 +175,8 @@ abstract class CompanyContract
         $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CompanyContractListener', 'preRemoveHandler');
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CompanyContractListener', 'preFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CompanyContractListener', 'onFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CompanyContractListener', 'postFlushHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CompanyContractListener', 'postLoadHandler');
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyContractListener.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContractListener.php
@@ -14,6 +14,8 @@ class CompanyContractListener
     public $preRemoveCalls;
 
     public $preFlushCalls;
+    public $onFlushCalls;
+    public $postFlushCalls;
 
     public $postLoadCalls;
 
@@ -71,6 +73,22 @@ class CompanyContractListener
     public function preFlushHandler(CompanyContract $contract)
     {
         $this->preFlushCalls[] = func_get_args();
+    }
+
+    /**
+     * @OnFlush
+     */
+    public function onFlushHandler(CompanyContract $contract)
+    {
+        $this->onFlushCalls[] = func_get_args();
+    }
+
+    /**
+     * @PostFlush
+     */
+    public function postFlushHandler(CompanyContract $contract)
+    {
+        $this->postFlushCalls[] = func_get_args();
     }
 
     /**

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
@@ -48,6 +48,8 @@ class CompanyFlexUltraContract extends CompanyFlexContract
         $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CompanyContractListener', 'preRemoveHandler');
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CompanyContractListener', 'preFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CompanyContractListener', 'onFlushHandler');
+        $metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CompanyContractListener', 'postFlushHandler');
         $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CompanyContractListener', 'postLoadHandler');
 
         $metadata->addEntityListener(\Doctrine\ORM\Events::prePersist, 'CompanyFlexUltraContractListener', 'prePersistHandler1');

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\Tests\Models\Company\CompanyContractListener;
@@ -44,6 +46,38 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->assertSame($fix, $this->listener->preFlushCalls[0][0]);
         $this->assertInstanceOf(CompanyFixContract::class, $this->listener->preFlushCalls[0][0]);
         $this->assertInstanceOf(PreFlushEventArgs::class, $this->listener->preFlushCalls[0][1]);
+    }
+
+    public function testOnFlushListeners()
+    {
+        $fix = new CompanyFixContract();
+        $fix->setFixPrice(2000);
+
+        $this->listener->onFlushCalls  = [];
+
+        $this->_em->persist($fix);
+        $this->_em->flush();
+
+        $this->assertCount(1,$this->listener->onFlushCalls);
+        $this->assertSame($fix, $this->listener->onFlushCalls[0][0]);
+        $this->assertInstanceOf(CompanyFixContract::class, $this->listener->onFlushCalls[0][0]);
+        $this->assertInstanceOf(OnFlushEventArgs::class, $this->listener->onFlushCalls[0][1]);
+    }
+
+    public function testPostFlushListeners()
+    {
+        $fix = new CompanyFixContract();
+        $fix->setFixPrice(2000);
+
+        $this->listener->postFlushCalls  = [];
+
+        $this->_em->persist($fix);
+        $this->_em->flush();
+
+        $this->assertCount(1,$this->listener->postFlushCalls);
+        $this->assertSame($fix, $this->listener->postFlushCalls[0][0]);
+        $this->assertInstanceOf(CompanyFixContract::class, $this->listener->postFlushCalls[0][0]);
+        $this->assertInstanceOf(PostFlushEventArgs::class, $this->listener->postFlushCalls[0][1]);
     }
 
     public function testPostLoadListeners()

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -940,6 +940,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertArrayHasKey(Events::postRemove, $metadata->entityListeners);
         $this->assertArrayHasKey(Events::preRemove, $metadata->entityListeners);
         $this->assertArrayHasKey(Events::postLoad, $metadata->entityListeners);
+        $this->assertArrayHasKey(Events::onFlush, $metadata->entityListeners);
+        $this->assertArrayHasKey(Events::postFlush, $metadata->entityListeners);
         $this->assertArrayHasKey(Events::preFlush, $metadata->entityListeners);
 
         $this->assertCount(1, $metadata->entityListeners[Events::postPersist]);
@@ -949,6 +951,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertCount(1, $metadata->entityListeners[Events::postRemove]);
         $this->assertCount(1, $metadata->entityListeners[Events::preRemove]);
         $this->assertCount(1, $metadata->entityListeners[Events::postLoad]);
+        $this->assertCount(1, $metadata->entityListeners[Events::onFlush]);
+        $this->assertCount(1, $metadata->entityListeners[Events::postFlush]);
         $this->assertCount(1, $metadata->entityListeners[Events::preFlush]);
 
         $postPersist = $metadata->entityListeners[Events::postPersist][0];
@@ -958,6 +962,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $postRemove  = $metadata->entityListeners[Events::postRemove][0];
         $preRemove   = $metadata->entityListeners[Events::preRemove][0];
         $postLoad    = $metadata->entityListeners[Events::postLoad][0];
+        $onFlush    = $metadata->entityListeners[Events::onFlush][0];
+        $postFlush    = $metadata->entityListeners[Events::postFlush][0];
         $preFlush    = $metadata->entityListeners[Events::preFlush][0];
 
 
@@ -968,6 +974,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(CmsAddressListener::class, $postRemove['class']);
         $this->assertEquals(CmsAddressListener::class, $preRemove['class']);
         $this->assertEquals(CmsAddressListener::class, $postLoad['class']);
+        $this->assertEquals(CmsAddressListener::class, $onFlush['class']);
+        $this->assertEquals(CmsAddressListener::class, $postFlush['class']);
         $this->assertEquals(CmsAddressListener::class, $preFlush['class']);
 
         $this->assertEquals(Events::postPersist, $postPersist['method']);
@@ -977,6 +985,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(Events::postRemove, $postRemove['method']);
         $this->assertEquals(Events::preRemove, $preRemove['method']);
         $this->assertEquals(Events::postLoad, $postLoad['method']);
+        $this->assertEquals(Events::onFlush, $onFlush['method']);
+        $this->assertEquals(Events::postFlush, $postFlush['method']);
         $this->assertEquals(Events::preFlush, $preFlush['method']);
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsAddress.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.CMS.CmsAddress.php
@@ -123,5 +123,8 @@ $metadata->addEntityListener(Events::preUpdate, 'CmsAddressListener', 'preUpdate
 $metadata->addEntityListener(Events::postRemove, 'CmsAddressListener', 'postRemove');
 $metadata->addEntityListener(Events::preRemove, 'CmsAddressListener', 'preRemove');
 
+$metadata->addEntityListener(Events::onFlush, 'CmsAddressListener', 'onFlush');
+$metadata->addEntityListener(Events::postFlush, 'CmsAddressListener', 'postFlush');
+
 $metadata->addEntityListener(Events::preFlush, 'CmsAddressListener', 'preFlush');
 $metadata->addEntityListener(Events::postLoad, 'CmsAddressListener', 'postLoad');

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
@@ -44,5 +44,7 @@ $metadata->addEntityListener(\Doctrine\ORM\Events::preUpdate, 'CompanyContractLi
 $metadata->addEntityListener(\Doctrine\ORM\Events::postRemove, 'CompanyContractListener', 'postRemoveHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CompanyContractListener', 'preRemoveHandler');
 
+$metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CompanyContractListener', 'onFlushHandler');
+$metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CompanyContractListener', 'postFlushHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CompanyContractListener', 'preFlushHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CompanyContractListener', 'postLoadHandler');

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.php
@@ -16,6 +16,8 @@ $metadata->addEntityListener(\Doctrine\ORM\Events::preUpdate, 'CompanyContractLi
 $metadata->addEntityListener(\Doctrine\ORM\Events::postRemove, 'CompanyContractListener', 'postRemoveHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::preRemove, 'CompanyContractListener', 'preRemoveHandler');
 
+$metadata->addEntityListener(\Doctrine\ORM\Events::onFlush, 'CompanyContractListener', 'onFlushHandler');
+$metadata->addEntityListener(\Doctrine\ORM\Events::postFlush, 'CompanyContractListener', 'postFlushHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::preFlush, 'CompanyContractListener', 'preFlushHandler');
 $metadata->addEntityListener(\Doctrine\ORM\Events::postLoad, 'CompanyContractListener', 'postLoadHandler');
 

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyContract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyContract.dcm.xml
@@ -15,6 +15,9 @@
 
         <entity-listeners>
             <entity-listener class="CompanyContractListener">
+                <lifecycle-callback type="onFlush"      method="onFlushHandler"/>
+                <lifecycle-callback type="postFlush"      method="postFlushHandler"/>
+
                 <lifecycle-callback type="preFlush"      method="preFlushHandler"/>
                 <lifecycle-callback type="postLoad"      method="postLoadHandler"/>
                 

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.xml
@@ -9,8 +9,8 @@
 
         <entity-listeners>
             <entity-listener class="CompanyContractListener">
-                <lifecycle-callback type="onFlush"      method="onFlushHandler"/>
-                <lifecycle-callback type="postFlush"      method="postFlushHandler"/>
+                <lifecycle-callback type="onFlush"       method="onFlushHandler"/>
+                <lifecycle-callback type="postFlush"     method="postFlushHandler"/>
 
                 <lifecycle-callback type="preFlush"      method="preFlushHandler"/>
                 <lifecycle-callback type="postLoad"      method="postLoadHandler"/>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.xml
@@ -9,6 +9,9 @@
 
         <entity-listeners>
             <entity-listener class="CompanyContractListener">
+                <lifecycle-callback type="onFlush"      method="onFlushHandler"/>
+                <lifecycle-callback type="postFlush"      method="postFlushHandler"/>
+
                 <lifecycle-callback type="preFlush"      method="preFlushHandler"/>
                 <lifecycle-callback type="postLoad"      method="postLoadHandler"/>
 

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Company.CompanyContract.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Company.CompanyContract.dcm.yml
@@ -10,6 +10,9 @@ Doctrine\Tests\Models\Company\CompanyContract:
   entityListeners:
     CompanyContractListener:
 
+      onFlush: [onFlushHandler]
+      postFlush: [postFlushHandler]
+
       preFlush: [preFlushHandler]
       postLoad: [postLoadHandler]
 

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.Company.CompanyFlexUltraContract.dcm.yml
@@ -4,6 +4,9 @@ Doctrine\Tests\Models\Company\CompanyFlexUltraContract:
   entityListeners:
     CompanyContractListener:
       
+      onFlush: [onFlushHandler]
+      postFlush: [postFlushHandler]
+
       preFlush: [preFlushHandler]
       postLoad: [postLoadHandler]
 


### PR DESCRIPTION
Simply check if an onFlush or postFlush entity listener is subscribed
for the current class in the entity manager during dispatch.

This is a followup to #6345, #5822, and #5582.