### PR TITLE
Initial PHPStan integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 script:
   - ENABLE_SECOND_LEVEL_CACHE=0 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml $PHPUNIT_FLAGS
   - ENABLE_SECOND_LEVEL_CACHE=1 ./vendor/bin/phpunit -v -c tests/travis/$DB.travis.xml --exclude-group performance,non-cacheable,locking_functional
+  - if [[ $PHPSTAN = 1 ]]; then vendor/bin/phpstan analyse -l 0 lib; fi
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.0' && $DB = 'sqlite' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
@@ -75,6 +76,10 @@ matrix:
       dist: trusty
       group: edge # until the next update
       env: DB=sqlite
+    - php: 7
+      env: PHPSTAN=1
+    - php: 7.1
+      env: PHPSTAN=1
 
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.3|~3.0",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "phpstan/phpstan": "^0.7"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -514,10 +514,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     public function offsetSet($offset, $value)
     {
         if ( ! isset($offset)) {
-            return $this->add($value);
+            $this->add($value);
         }
 
-        return $this->set($offset, $value);
+        $this->set($offset, $value);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -738,7 +738,7 @@ final class Query extends AbstractQuery
             ->getName();
 
         return md5(
-            $this->getDql() . serialize($this->_hints) .
+            $this->getDQL() . serialize($this->_hints) .
             '&platform=' . $platform .
             ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
             '&firstResult=' . $this->_firstResult . '&maxResult=' . $this->_maxResults .

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1504,7 +1504,7 @@ class Parser
         $glimpse = $this->lexer->glimpse();
 
         switch (true) {
-            case ($this->isFunction($peek)):
+            case ($this->isFunction()):
                 $expr = $this->FunctionDeclaration();
                 break;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1761,7 +1761,7 @@ class SqlWalker implements TreeWalker
     public function walkWhereClause($whereClause)
     {
         $condSql  = null !== $whereClause ? $this->walkConditionalExpression($whereClause->conditionalExpression) : '';
-        $discrSql = $this->_generateDiscriminatorColumnConditionSql($this->rootAliases);
+        $discrSql = $this->_generateDiscriminatorColumnConditionSQL($this->rootAliases);
 
         if ($this->em->hasFilters()) {
             $filterClauses = [];


### PR DESCRIPTION
This is a starting point to begin using static analysis in Doctrine ORM codebase. [PHPStan](https://github.com/phpstan/phpstan) is already used by doctrine/common and doctrine/annotations so I think it's logical that the ORM repo starts using it too :)

The build will now fail, I wasn't sure what to do about this one error:

```
 ------ ------------------------------------------------------------------------------------------
  Line   lib/Doctrine/ORM/Query/ResultSetMapping.php
 ------ ------------------------------------------------------------------------------------------
  456    Return typehint of method Doctrine\ORM\Query\ResultSetMapping::getRelation() has invalid
         type Doctrine\ORM\Query\AssociationMapping.
 ------ ------------------------------------------------------------------------------------------
```

The method has no tests and no usage in the project, so I'm really not sure what it's supposed to return.

After you merge this, I can spread the analysis to tests and also increase the level of the analysis to find more errors.