### PR TITLE
Verify that the `fileLockRegionDirectory` passed to the `DefaultCacheFactory` cannot be empty

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -210,7 +210,10 @@ class DefaultCacheFactory implements CacheFactory
 
         if ($cache['usage'] === ClassMetadata::CACHE_USAGE_READ_WRITE) {
 
-            if ( ! $this->fileLockRegionDirectory) {
+            if (
+                '' === $this->fileLockRegionDirectory ||
+                null === $this->fileLockRegionDirectory
+            ) {
                 throw new \LogicException(
                     'If you want to use a "READ_WRITE" cache an implementation of "Doctrine\ORM\Cache\ConcurrentRegion" is required, ' .
                     'The default implementation provided by doctrine is "Doctrine\ORM\Cache\Region\FileLockRegion" if you want to use it please provide a valid directory, DefaultCacheFactory#setFileLockRegionDirectory(). '

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -275,6 +275,24 @@ class DefaultCacheFactoryTest extends OrmTestCase
         );
     }
 
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage If you want to use a "READ_WRITE" cache an implementation of "Doctrine\ORM\Cache\ConcurrentRegion" is required, The default implementation provided by doctrine is "Doctrine\ORM\Cache\Region\FileLockRegion" if you want to use it please provide a valid directory
+     */
+    public function testInvalidFileLockRegionDirectoryExceptionWithEmptyString()
+    {
+        $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());
+
+        $factory->setFileLockRegionDirectory('');
+
+        $factory->getRegion(
+            [
+                'usage'   => ClassMetadata::CACHE_USAGE_READ_WRITE,
+                'region'  => 'foo'
+            ]
+        );
+    }
+
     public function testBuildsNewNamespacedCacheInstancePerRegionInstance()
     {
         $factory = new DefaultCacheFactory($this->regionsConfig, $this->getSharedSecondLevelCacheDriverImpl());


### PR DESCRIPTION
The expression $this->fileLockRegionDirectory of type string|null is loosely compared to false; this is ambiguous if the string can be empty. You might want to explicitly use === null instead.