### PR TITLE
Update QueryBuilder docblock to reflect correct type of bound parameter type

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -526,7 +526,7 @@ class QueryBuilder
      *
      * @param string|integer $key   The parameter position or name.
      * @param mixed          $value The parameter value.
-     * @param string|null    $type  PDO::PARAM_* or \Doctrine\DBAL\Types\Type::* constant
+     * @param string|integer|null    $type  PDO::PARAM_* or \Doctrine\DBAL\Types\Type::* constant
      *
      * @return self
      */


### PR DESCRIPTION
Hello,

thank you very much for your work, it's awesome!
I found a minor error in PHPDOC for method setParameter. Argument "type" can be a string or null but can be also an int if it comes from \PDO::PARAM_*. So I've changed typehint "string" into "mixed".