### PR TITLE
Fix invalid sql generated for CTI JOINs when INNER JOIN'ing with a `WITH` clause

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
@@ -33,10 +33,7 @@ class GH6464Test extends OrmFunctionalTestCase
      */
     public function testIssue()
     {
-
-        $qb = $this->_em->createQueryBuilder();
-
-        $query = $qb
+        $query = $this->_em->createQueryBuilder()
             ->select('p', 'a')
             ->from(GH6464Post::class, 'p')
             ->innerJoin(GH6464Author::class, 'a', 'WITH', 'p.authorId = a.id')
@@ -61,12 +58,6 @@ class GH6464Post
 
     /** @Column(type="integer") */
     public $authorId;
-
-    /** @Column(length=100) */
-    public $title;
-
-    /** @Column(type="text") */
-    public $text;
 }
 
 /**
@@ -84,6 +75,4 @@ abstract class GH6464User
 /** @Entity */
 class GH6464Author extends GH6464User
 {
-    /** @Column(length=50) */
-    public $displayName;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-6464
+ */
+class GH6464Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(GH6464Post::class),
+                $this->_em->getClassMetadata(GH6464User::class),
+                $this->_em->getClassMetadata(GH6464Author::class),
+            ]
+        );
+    }
+
+    /**
+     * Verifies that SqlWalker generates valid SQL for an INNER JOIN to CTI table
+     *
+     * SqlWalker needs to generate nested INNER JOIN statements, otherwise there would be INNER JOIN
+     * statements without an ON clause, which are valid on e.g. MySQL but rejected by PostgreSQL.
+     */
+    public function testIssue()
+    {
+
+        $qb = $this->_em->createQueryBuilder();
+
+        $query = $qb
+            ->select('p', 'a')
+            ->from(GH6464Post::class, 'p')
+            ->innerJoin(GH6464Author::class, 'a', 'WITH', 'p.authorId = a.id')
+            ->getQuery();
+
+        $this->assertNotRegExp(
+            '/INNER JOIN \w+ \w+ INNER JOIN/',
+            $query->getSQL(),
+            'As of GH-6464, every INNER JOIN should have an ON clause, which is missing here'
+        );
+
+        // Query shouldn't yield a result, yet it shouldn't crash (anymore)
+        $this->assertEquals([], $query->getResult());
+    }
+}
+
+/** @Entity */
+class GH6464Post
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @Column(type="integer") */
+    public $authorId;
+
+    /** @Column(length=100) */
+    public $title;
+
+    /** @Column(type="text") */
+    public $text;
+}
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"author" = "GH6464Author"})
+ */
+abstract class GH6464User
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+}
+
+/** @Entity */
+class GH6464Author extends GH6464User
+{
+    /** @Column(length=50) */
+    public $displayName;
+}

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -198,12 +198,12 @@ class SelectSqlGenerationTest extends OrmTestCase
     {
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e JOIN Doctrine\Tests\Models\Company\CompanyManager m WITH e.id = m.id',
-            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id INNER JOIN company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id AND (c0_.id = c3_.id)'
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id INNER JOIN (company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id) ON (c0_.id = c3_.id)'
         );
 
         $this->assertSqlGeneration(
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyManager m WITH e.id = m.id',
-            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id ON (c0_.id = c3_.id)'
+            'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN (company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id) ON (c0_.id = c3_.id)'
         );
     }
 
@@ -2211,7 +2211,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         // the where clause when not joining onto that table
         $this->assertSqlGeneration(
             'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c LEFT JOIN Doctrine\Tests\Models\Company\CompanyEmployee e WITH e.id = c.salesPerson WHERE c.completed = true',
-            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ LEFT JOIN company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id ON (c2_.id = c0_.salesPerson_id) WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
+            "SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ LEFT JOIN (company_employees c1_ INNER JOIN company_persons c2_ ON c1_.id = c2_.id) ON (c2_.id = c0_.salesPerson_id) WHERE (c0_.completed = 1) AND c0_.discr IN ('fix', 'flexible', 'flexultra')"
         );
     }
 


### PR DESCRIPTION
See #6464 for a detailed example of the problem.

For a query like 

```php
$qb
            ->select('p', 'a')
            ->from(GH6464Post::class, 'p')
            ->innerJoin(GH6464Author::class, 'a', 'WITH', 'p.authorId = a.id')
            ->getQuery();
```

... where `GH6464Author` is a CTI entity, the sql generation currently generates two JOINs (correct) and attaches both join conditions to the latter JOIN. This works with MySQL and SQLite, however fails on PostgreSQL.

This patch

* adds a functional test case that actually tries to run such a query
* applies a fix to `SqlWalker` that makes it output a nested JOIN
* adapts test cases in `SelectSqlGenerationTest` to reflect the change (and make those SQL statements valid -- on PostgreSQL)




