### PR TITLE
Allow arithmetic expressions within IN operator

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1712,7 +1712,7 @@ Literal Values
 .. code-block:: php
 
     Literal     ::= string | char | integer | float | boolean
-    InParameter ::= Literal | InputParameter
+    InParameter ::= ArithmeticExpression | InputParameter
 
 Input Parameter
 ~~~~~~~~~~~~~~~

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2759,7 +2759,7 @@ class Parser
     }
 
     /**
-     * InParameter ::= Literal | InputParameter
+     * InParameter ::= ArithmeticExpression | InputParameter
      *
      * @return AST\InputParameter|AST\Literal
      */
@@ -2769,7 +2769,7 @@ class Parser
             return $this->InputParameter();
         }
 
-        return $this->Literal();
+        return $this->ArithmeticExpression();
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2106,7 +2106,7 @@ class SqlWalker implements TreeWalker
     {
         return $inParam instanceof AST\InputParameter
             ? $this->walkInputParameter($inParam)
-            : $this->walkLiteral($inParam);
+            : $this->walkArithmeticExpression($inParam);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -643,6 +643,17 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
+    public function testCustomFunctionWithinInExpression() : void
+    {
+        $this->entityManager->getConfiguration()->addCustomStringFunction('FOO', MyAbsFunction::class);
+        $this->assertSqlGeneration(
+            "SELECT u FROM Doctrine\Tests\Models\Forum\ForumUser u WHERE u.username IN (FOO('Lo'), 'Lo', :name)",
+            <<<'SQL'
+SELECT f0_.id AS id_0, f0_.username AS username_1 FROM forum_users f0_ WHERE f0_.username IN (ABS('Lo'), 'Lo', ?)
+SQL
+        );
+    }
+
     public function testSupportsConcatFunctionForMysqlAndPostgresql(): void
     {
         $connMock    = $this->entityManager->getConnection();


### PR DESCRIPTION
In some cases it is necessary to use not only scalar values or subselects within IN-conditions, but also own functions. 

With Oracle databases, the following is then possible:

DQL:
`SELECT u FROM User WHERE u.name IN ( CUSTOM_DQL_FUNCTION() );`

SQL:
`SELECT * FROM user WHERE name IN ( SELECT * FROM TABLE(ORACLE_PLSQL_FUNCTION()) );`


Another example which is also possible now:

DQL:
`[...] WHERE field IN ( CUSTOM_DQL_GET_ID('Foo'), CUSTOM_ESCAPE('Bar') )`

SQL:
`[...] WHERE field IN ( (SELECT id FROM settings WHERE name = 'Foo'), [...] )`
