### PR TITLE
Fix all risky tests

### DIFF
--- a/tests/Doctrine/Tests/DbalTypes/NegativeToPositiveType.php
+++ b/tests/Doctrine/Tests/DbalTypes/NegativeToPositiveType.php
@@ -7,12 +7,14 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class NegativeToPositiveType extends Type
 {
+    const NAME = 'negative_to_positive';
+
     /**
      * {@inheritdoc}
      */
     public function getName()
     {
-        return 'negative_to_positive';
+        return self::NAME;
     }
 
     /**

--- a/tests/Doctrine/Tests/DbalTypes/UpperCaseStringType.php
+++ b/tests/Doctrine/Tests/DbalTypes/UpperCaseStringType.php
@@ -7,12 +7,14 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class UpperCaseStringType extends StringType
 {
+    const NAME = 'upper_case_string';
+
     /**
      * {@inheritdoc}
      */
     public function getName()
     {
-        return 'upper_case_string';
+        return self::NAME;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -179,6 +179,8 @@ class ConfigurationTest extends TestCase
     {
         $this->setProductionSettings();
         $this->configuration->ensureProductionSettings();
+
+        $this->addToAssertionCount(1);
     }
 
     public function testEnsureProductionSettingsQueryCache()

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -740,11 +740,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $address->user = $user;
 
         $this->_em->persist($address);
-        // pretend we forgot to persist $user
-        try {
-            $this->_em->flush(); // should raise an exception
-            $this->fail();
-        } catch (\InvalidArgumentException $expected) {}
+
+        // flushing without persisting $user should raise an exception
+        $this->expectException(\InvalidArgumentException::class);
+        $this->_em->flush();
     }
 
     /**
@@ -774,11 +773,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $u2->name = "Benjamin E.";
         $u2->status = 'inactive';
         $address->user = $u2;
-        // pretend we forgot to persist $u2
-        try {
-            $this->_em->flush(); // should raise an exception
-            $this->fail();
-        } catch (\InvalidArgumentException $expected) {}
+
+        // flushing without persisting $u2 should raise an exception
+        $this->expectException(\InvalidArgumentException::class);
+        $this->_em->flush();
     }
 
     /**
@@ -797,11 +795,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $art->addComment($com);
 
         $this->_em->persist($art);
-        // pretend we forgot to persist $com
-        try {
-            $this->_em->flush(); // should raise an exception
-            $this->fail();
-        } catch (\InvalidArgumentException $expected) {}
+
+        // flushing without persisting $com should raise an exception
+        $this->expectException(\InvalidArgumentException::class);
+        $this->_em->flush();
     }
 
     public function testOneToOneOrphanRemoval()
@@ -933,10 +930,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $user->name = "Benjamin E.";
         $user->status = 'active';
         $user->id = 42;
-        try {
-            $this->_em->merge($user);
-            $this->fail();
-        } catch (EntityNotFoundException $enfe) {}
+
+        $this->expectException(EntityNotFoundException::class);
+        $this->_em->merge($user);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -727,7 +727,6 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
      */
     public function testNewAssociatedEntityDuringFlushThrowsException()
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $user = new CmsUser();
         $user->username = "beberlei";
         $user->name = "Benjamin E.";

--- a/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
@@ -47,6 +47,8 @@ class CascadeRemoveOrderTest extends OrmFunctionalTestCase
 
         $this->_em->remove($eOloaded);
         $this->_em->flush();
+
+        self::assertNull($this->_em->find(CascadeRemoveOrderEntityG::class, $eG->getId()));
     }
 
     public function testMany()
@@ -66,6 +68,10 @@ class CascadeRemoveOrderTest extends OrmFunctionalTestCase
 
         $this->_em->remove($eOloaded);
         $this->_em->flush();
+
+        self::assertNull($this->_em->find(CascadeRemoveOrderEntityG::class, $eG1->getId()));
+        self::assertNull($this->_em->find(CascadeRemoveOrderEntityG::class, $eG2->getId()));
+        self::assertNull($this->_em->find(CascadeRemoveOrderEntityG::class, $eG3->getId()));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
@@ -16,8 +16,8 @@ class CascadeRemoveOrderTest extends OrmFunctionalTestCase
 
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
-            $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
+                $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
+                $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
             ]
         );
     }
@@ -28,8 +28,8 @@ class CascadeRemoveOrderTest extends OrmFunctionalTestCase
 
         $this->_schemaTool->dropSchema(
             [
-            $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
-            $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
+                $this->_em->getClassMetadata(CascadeRemoveOrderEntityO::class),
+                $this->_em->getClassMetadata(CascadeRemoveOrderEntityG::class),
             ]
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -51,7 +51,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $entities = $query->getResult();
 
-        $this->assertEquals(2, count($entities));
+        $this->assertCount(2, $entities);
         $this->assertInstanceOf(CompanyPerson::class, $entities[0]);
         $this->assertInstanceOf(CompanyEmployee::class, $entities[1]);
         $this->assertTrue(is_numeric($entities[0]->getId()));
@@ -66,7 +66,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $entities = $query->getResult();
 
-        $this->assertEquals(1, count($entities));
+        $this->assertCount(1, $entities);
         $this->assertInstanceOf(CompanyEmployee::class, $entities[0]);
         $this->assertTrue(is_numeric($entities[0]->getId()));
         $this->assertEquals('Guilherme Blanco', $entities[0]->getName());
@@ -164,7 +164,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $query = $this->_em->createQuery('select p, s from ' . CompanyPerson::class . ' p join p.spouse s where p.name=\'Mary Smith\'');
 
         $result = $query->getResult();
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertInstanceOf(CompanyPerson::class, $result[0]);
         $this->assertEquals('Mary Smith', $result[0]->getName());
         $this->assertInstanceOf(CompanyEmployee::class, $result[0]->getSpouse());
@@ -182,8 +182,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $person1->addFriend($person2);
 
-        $this->assertEquals(1, count($person1->getFriends()));
-        $this->assertEquals(1, count($person2->getFriends()));
+        $this->assertCount(1, $person1->getFriends());
+        $this->assertCount(1, $person2->getFriends());
 
 
         $this->_em->persist($person1);
@@ -197,8 +197,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $query->setParameter(1, 'Roman');
 
         $result = $query->getResult();
-        $this->assertEquals(1, count($result));
-        $this->assertEquals(1, count($result[0]->getFriends()));
+        $this->assertCount(1, $result);
+        $this->assertCount(1, $result[0]->getFriends());
         $this->assertEquals('Roman', $result[0]->getName());
 
         $friends = $result[0]->getFriends();
@@ -226,7 +226,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $result = $q->getResult();
 
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertInstanceOf(CompanyOrganization::class, $result[0]);
         $this->assertNull($result[0]->getMainEvent());
 
@@ -235,7 +235,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(PersistentCollection::class, $events);
         $this->assertFalse($events->isInitialized());
 
-        $this->assertEquals(2, count($events));
+        $this->assertCount(2, $events);
         if ($events[0] instanceof CompanyAuction) {
             $this->assertInstanceOf(CompanyRaffle::class, $events[1]);
         } else {
@@ -259,7 +259,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $q->setParameter(1, $event1->getId());
 
         $result = $q->getResult();
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertInstanceOf(CompanyAuction::class, $result[0], sprintf("Is of class %s", get_class($result[0])));
 
         $this->_em->clear();
@@ -269,7 +269,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $result = $q->getResult();
 
-        $this->assertEquals(1, count($result));
+        $this->assertCount(1, $result);
         $this->assertInstanceOf(CompanyOrganization::class, $result[0]);
 
         $mainEvent = $result[0]->getMainEvent();
@@ -286,9 +286,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->createQuery('UPDATE ' . CompanyEmployee::class . ' AS p SET p.salary = 1')
                   ->execute();
 
-        $this->assertTrue(count($this->_em->createQuery(
-            'SELECT count(p.id) FROM Doctrine\Tests\Models\Company\CompanyEmployee p WHERE p.salary = 1')
-            ->getResult()) > 0);
+        $result = $this->_em->createQuery('SELECT count(p.id) FROM ' . CompanyEmployee::class . ' p WHERE p.salary = 1')
+                            ->getResult();
+
+        $this->assertGreaterThan(0, count($result));
     }
 
     /**
@@ -441,7 +442,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $manager = $this->_em->find(CompanyManager::class, $manager->getId());
-        $this->assertEquals(1, count($manager->getFriends()));
+
+        $this->assertCount(1, $manager->getFriends());
     }
 
     /**
@@ -481,12 +483,12 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $users = $repository->matching(new Criteria(
             Criteria::expr()->eq('department', 'IT')
         ));
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
 
         $repository = $this->_em->getRepository(CompanyManager::class);
         $users = $repository->matching(new Criteria(
             Criteria::expr()->eq('department', 'IT')
         ));
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -301,6 +301,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
                   ->setParameter(1, 'IT')
                   ->execute();
 
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -2,16 +2,16 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\Proxy;
-use Doctrine\Tests\Models\Company\CompanyPerson,
-    Doctrine\Tests\Models\Company\CompanyEmployee,
-    Doctrine\Tests\Models\Company\CompanyManager,
-    Doctrine\Tests\Models\Company\CompanyOrganization,
-    Doctrine\Tests\Models\Company\CompanyAuction,
-    Doctrine\Tests\Models\Company\CompanyRaffle;
-
-use Doctrine\Common\Collections\Criteria;
+use Doctrine\Tests\Models\Company\CompanyAuction;
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\Models\Company\CompanyEvent;
+use Doctrine\Tests\Models\Company\CompanyManager;
+use Doctrine\Tests\Models\Company\CompanyOrganization;
+use Doctrine\Tests\Models\Company\CompanyPerson;
+use Doctrine\Tests\Models\Company\CompanyRaffle;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -24,8 +24,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('company');
+
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
     }
 
     public function testCRUD()
@@ -47,7 +47,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select p from Doctrine\Tests\Models\Company\CompanyPerson p order by p.name desc");
+        $query = $this->_em->createQuery('select p from ' . CompanyPerson::class . ' p order by p.name desc');
 
         $entities = $query->getResult();
 
@@ -62,7 +62,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select p from Doctrine\Tests\Models\Company\CompanyEmployee p");
+        $query = $this->_em->createQuery('select p from ' . CompanyEmployee::class . ' p');
 
         $entities = $query->getResult();
 
@@ -80,7 +80,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("update Doctrine\Tests\Models\Company\CompanyEmployee p set p.name = ?1, p.department = ?2 where p.name='Guilherme Blanco' and p.salary = ?3");
+        $query = $this->_em->createQuery("update " . CompanyEmployee::class . " p set p.name = ?1, p.department = ?2 where p.name='Guilherme Blanco' and p.salary = ?3");
         $query->setParameter(1, 'NewName', 'string');
         $query->setParameter(2, 'NewDepartment');
         $query->setParameter(3, 100000);
@@ -88,12 +88,13 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $numUpdated = $query->execute();
         $this->assertEquals(1, $numUpdated);
 
-        $query = $this->_em->createQuery("delete from Doctrine\Tests\Models\Company\CompanyPerson p");
+        $query = $this->_em->createQuery('delete from ' . CompanyPerson::class . ' p');
         $numDeleted = $query->execute();
         $this->assertEquals(2, $numDeleted);
     }
 
-    public function testMultiLevelUpdateAndFind() {
+    public function testMultiLevelUpdateAndFind()
+    {
     	$manager = new CompanyManager;
         $manager->setName('Roman S. Borschel');
         $manager->setSalary(100000);
@@ -119,7 +120,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->assertTrue(is_numeric($manager->getId()));
     }
 
-    public function testFindOnBaseClass() {
+    public function testFindOnBaseClass()
+    {
         $manager = new CompanyManager;
         $manager->setName('Roman S. Borschel');
         $manager->setSalary(100000);
@@ -139,7 +141,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->assertTrue(is_numeric($person->getId()));
     }
 
-    public function testSelfReferencingOneToOne() {
+    public function testSelfReferencingOneToOne()
+    {
     	$manager = new CompanyManager;
         $manager->setName('John Smith');
         $manager->setSalary(100000);
@@ -155,16 +158,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->persist($manager);
         $this->_em->persist($wife);
-
         $this->_em->flush();
-
-        //var_dump($this->_em->getConnection()->fetchAll('select * from company_persons'));
-        //var_dump($this->_em->getConnection()->fetchAll('select * from company_employees'));
-        //var_dump($this->_em->getConnection()->fetchAll('select * from company_managers'));
-
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('select p, s from Doctrine\Tests\Models\Company\CompanyPerson p join p.spouse s where p.name=\'Mary Smith\'');
+        $query = $this->_em->createQuery('select p, s from ' . CompanyPerson::class . ' p join p.spouse s where p.name=\'Mary Smith\'');
 
         $result = $query->getResult();
         $this->assertEquals(1, count($result));
@@ -196,7 +193,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $query = $this->_em->createQuery('select p, f from Doctrine\Tests\Models\Company\CompanyPerson p join p.friends f where p.name=?1');
+        $query = $this->_em->createQuery('select p, f from ' . CompanyPerson::class . ' p join p.friends f where p.name=?1');
         $query->setParameter(1, 'Roman');
 
         $result = $query->getResult();
@@ -247,7 +244,6 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         }
     }
 
-
     public function testLazyLoading2()
     {
         $org = new CompanyOrganization;
@@ -259,16 +255,16 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $q = $this->_em->createQuery('select a from Doctrine\Tests\Models\Company\CompanyEvent a where a.id = ?1');
+        $q = $this->_em->createQuery('select a from ' . CompanyEvent::class . ' a where a.id = ?1');
         $q->setParameter(1, $event1->getId());
 
         $result = $q->getResult();
         $this->assertEquals(1, count($result));
-        $this->assertInstanceOf(CompanyAuction::class, $result[0], sprintf("Is of class %s",get_class($result[0])));
+        $this->assertInstanceOf(CompanyAuction::class, $result[0], sprintf("Is of class %s", get_class($result[0])));
 
         $this->_em->clear();
 
-        $q = $this->_em->createQuery('select a from Doctrine\Tests\Models\Company\CompanyOrganization a where a.id = ?1');
+        $q = $this->_em->createQuery('select a from ' . CompanyOrganization::class . ' a where a.id = ?1');
         $q->setParameter(1, $org->getId());
 
         $result = $q->getResult();
@@ -287,8 +283,8 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
      */
     public function testBulkUpdateIssueDDC368()
     {
-        $dql = 'UPDATE Doctrine\Tests\Models\Company\CompanyEmployee AS p SET p.salary = 1';
-        $this->_em->createQuery($dql)->execute();
+        $this->_em->createQuery('UPDATE ' . CompanyEmployee::class . ' AS p SET p.salary = 1')
+                  ->execute();
 
         $this->assertTrue(count($this->_em->createQuery(
             'SELECT count(p.id) FROM Doctrine\Tests\Models\Company\CompanyEmployee p WHERE p.salary = 1')
@@ -300,12 +296,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
      */
     public function testBulkUpdateNonScalarParameterDDC1341()
     {
-        $dql   = 'UPDATE Doctrine\Tests\Models\Company\CompanyEmployee AS p SET p.startDate = ?0 WHERE p.department = ?1';
-        $query = $this->_em->createQuery($dql)
-            ->setParameter(0, new \DateTime())
-            ->setParameter(1, 'IT');
-
-        $result = $query->execute();
+        $this->_em->createQuery('UPDATE ' . CompanyEmployee::class . ' AS p SET p.startDate = ?0 WHERE p.department = ?1')
+                  ->setParameter(0, new \DateTime())
+                  ->setParameter(1, 'IT')
+                  ->execute();
 
     }
 
@@ -314,8 +308,6 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
      */
     public function testDeleteJoinTableRecords()
     {
-        #$this->markTestSkipped('Nightmare! friends adds both ID 6-7 and 7-6 into two rows of the join table. How to detect this?');
-
         $employee1 = new CompanyEmployee();
         $employee1->setName('gblanco');
         $employee1->setSalary(0);
@@ -361,8 +353,9 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT m FROM Doctrine\Tests\Models\Company\CompanyManager m WHERE m.spouse = ?1";
-        $dqlManager = $this->_em->createQuery($dql)->setParameter(1, $person->getId())->getSingleResult();
+        $dqlManager = $this->_em->createQuery('SELECT m FROM ' . CompanyManager::class . ' m WHERE m.spouse = ?1')
+                                ->setParameter(1, $person->getId())
+                                ->getSingleResult();
 
         $this->assertEquals($manager->getId(), $dqlManager->getId());
         $this->assertEquals($person->getId(), $dqlManager->getSpouse()->getId());

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -23,7 +23,8 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         parent::setUp();
     }
 
-    public function testSimpleDetachMerge() {
+    public function testSimpleDetachMerge()
+    {
         $user = new CmsUser;
         $user->name = 'Roman';
         $user->username = 'romanb';
@@ -33,12 +34,9 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         // $user is now detached
-
         $this->assertFalse($this->_em->contains($user));
 
         $user->name = 'Roman B.';
-
-        //$this->assertEquals(UnitOfWork::STATE_DETACHED, $this->_em->getUnitOfWork()->getEntityState($user));
 
         $user2 = $this->_em->merge($user);
 
@@ -49,7 +47,6 @@ class DetachedEntityTest extends OrmFunctionalTestCase
 
     public function testSerializeUnserializeModifyMerge()
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $user = new CmsUser;
         $user->name = 'Guilherme';
         $user->username = 'gblanco';
@@ -173,7 +170,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->detach($user);
 
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = ?1";
+        $dql = 'SELECT u FROM ' . CmsUser::class . ' u WHERE u.id = ?1';
         $query = $this->_em->createQuery($dql);
         $query->setParameter(1, $user);
 
@@ -216,7 +213,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
 
         $this->_em->detach($article);
 
-        $sql = "UPDATE cms_articles SET version = version+1 WHERE id = " . $article->id;
+        $sql = 'UPDATE cms_articles SET version = version + 1 WHERE id = ' . $article->id;
         $this->_em->getConnection()->executeUpdate($sql);
 
         $this->expectException(OptimisticLockException::class);

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -113,14 +114,16 @@ class DetachedEntityTest extends OrmFunctionalTestCase
     {
         $ph = new CmsPhonenumber();
         $ph->phonenumber = '12345';
+
         $this->_em->persist($ph);
         $this->_em->flush();
         $this->_em->clear();
+
         $this->_em->persist($ph);
-        try {
-            $this->_em->flush();
-            $this->fail();
-        } catch (\Exception $expected) {}
+
+        // since it tries to insert the object twice (with the same PK)
+        $this->expectException(UniqueConstraintViolationException::class);
+        $this->_em->flush();
     }
 
     public function testUninitializedLazyAssociationsAreIgnoredOnMerge()

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -19,6 +19,7 @@ class LockTest extends OrmFunctionalTestCase
     {
         $this->useModelSet('cms');
         parent::setUp();
+
         $this->handles = [];
     }
 
@@ -26,7 +27,8 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockVersionedEntity() {
+    public function testLockVersionedEntity()
+    {
         $article = new CmsArticle();
         $article->text = "my article";
         $article->topic = "Hello";
@@ -41,7 +43,8 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockVersionedEntity_MismatchThrowsException() {
+    public function testLockVersionedEntity_MismatchThrowsException()
+    {
         $article = new CmsArticle();
         $article->text = "my article";
         $article->topic = "Hello";
@@ -58,7 +61,8 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockUnversionedEntity_ThrowsException() {
+    public function testLockUnversionedEntity_ThrowsException()
+    {
         $user = new CmsUser();
         $user->name = "foo";
         $user->status = "active";
@@ -76,11 +80,12 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockUnmanagedEntity_ThrowsException() {
+    public function testLockUnmanagedEntity_ThrowsException()
+    {
         $article = new CmsArticle();
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Entity Doctrine\Tests\Models\CMS\CmsArticle');
+        $this->expectExceptionMessage('Entity ' . CmsArticle::class);
 
         $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
     }
@@ -89,7 +94,8 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockPessimisticRead_NoTransaction_ThrowsException() {
+    public function testLockPessimisticRead_NoTransaction_ThrowsException()
+    {
         $article = new CmsArticle();
         $article->text = "my article";
         $article->topic = "Hello";
@@ -106,7 +112,8 @@ class LockTest extends OrmFunctionalTestCase
      * @group DDC-178
      * @group locking
      */
-    public function testLockPessimisticWrite_NoTransaction_ThrowsException() {
+    public function testLockPessimisticWrite_NoTransaction_ThrowsException()
+    {
         $article = new CmsArticle();
         $article->text = "my article";
         $article->topic = "Hello";
@@ -171,6 +178,7 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->_em->beginTransaction();
+
         try {
             $this->_em->lock($article, LockMode::PESSIMISTIC_READ);
             $this->_em->commit();
@@ -179,8 +187,9 @@ class LockTest extends OrmFunctionalTestCase
             throw $e;
         }
 
-        $query = array_pop( $this->_sqlLoggerStack->queries );
-        $query = array_pop( $this->_sqlLoggerStack->queries );
+        array_pop($this->_sqlLoggerStack->queries);
+        $query = array_pop($this->_sqlLoggerStack->queries);
+
         $this->assertContains($readLockSql, $query['sql']);
     }
 
@@ -189,13 +198,13 @@ class LockTest extends OrmFunctionalTestCase
      */
     public function testLockOptimisticNonVersionedThrowsExceptionInDQL()
     {
-        $dql = "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'";
+        $dql = "SELECT u FROM " . CmsUser::class . " u WHERE u.username = 'gblanco'";
 
         $this->expectException(OptimisticLockException::class);
         $this->expectExceptionMessage('The optimistic lock on an entity failed.');
 
-        $sql = $this->_em->createQuery($dql)->setHint(
-            Query::HINT_LOCK_MODE, LockMode::OPTIMISTIC
-        )->getSQL();
+        $this->_em->createQuery($dql)
+                  ->setHint(Query::HINT_LOCK_MODE, LockMode::OPTIMISTIC)
+                  ->getSQL();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -37,6 +37,8 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version);
+
+        $this->addToAssertionCount(1);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -178,6 +178,8 @@ class OptimisticTest extends OrmFunctionalTestCase
         $proxy = $this->_em->getReference(OptimisticStandard::class, $test->id);
 
         $this->_em->lock($proxy, LockMode::OPTIMISTIC, 1);
+
+        $this->addToAssertionCount(1);
     }
 
     public function testOptimisticTimestampSetsDefaultValue()

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -16,15 +16,16 @@ class OptimisticTest extends OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(OptimisticJoinedParent::class),
-                $this->_em->getClassMetadata(OptimisticJoinedChild::class),
-                $this->_em->getClassMetadata(OptimisticStandard::class),
-                $this->_em->getClassMetadata(OptimisticTimestamp::class)
+                    $this->_em->getClassMetadata(OptimisticJoinedParent::class),
+                    $this->_em->getClassMetadata(OptimisticJoinedChild::class),
+                    $this->_em->getClassMetadata(OptimisticStandard::class),
+                    $this->_em->getClassMetadata(OptimisticTimestamp::class)
                 ]
             );
         } catch (\Exception $e) {
             // Swallow all exceptions. We do not test the schema tool here.
         }
+
         $this->_conn = $this->_em->getConnection();
     }
 
@@ -168,7 +169,6 @@ class OptimisticTest extends OrmFunctionalTestCase
     public function testLockWorksWithProxy()
     {
         $test = new OptimisticStandard();
-
         $test->name = 'test';
 
         $this->_em->persist($test);

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -305,15 +305,6 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
     }
 
     /**
-     * @group DDC-980
-     */
-    public function testUpdateDeleteSizeSubselectQueries()
-    {
-        $this->_em->createQuery("DELETE Doctrine\Tests\Models\CMS\CmsUser u WHERE SIZE(u.groups) = 10")->execute();
-        $this->_em->createQuery("UPDATE Doctrine\Tests\Models\CMS\CmsUser u SET u.status = 'inactive' WHERE SIZE(u.groups) = 10")->execute();
-    }
-
-    /**
      * @group DDC-978
      */
     public function testClearAndResetCollection()

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -35,6 +35,7 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $this->useModelSet('cms');
         $this->useModelSet('company');
         parent::setUp();
+
         $this->platform = $this->_em->getConnection()->getDatabasePlatform();
     }
 
@@ -426,9 +427,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository(CmsUser::class);
 
-
         $result = $repository->createNativeNamedQuery('fetchIdAndUsernameWithResultClass')
-                        ->setParameter(1, 'FabioBatSilva')->getResult();
+                            ->setParameter(1, 'FabioBatSilva')
+                            ->getResult();
 
         $this->assertEquals(1, count($result));
         $this->assertInstanceOf(CmsUser::class, $result[0]);
@@ -439,9 +440,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
-
         $result = $repository->createNativeNamedQuery('fetchAllColumns')
-                        ->setParameter(1, 'FabioBatSilva')->getResult();
+                            ->setParameter(1, 'FabioBatSilva')
+                            ->getResult();
 
         $this->assertEquals(1, count($result));
         $this->assertInstanceOf(CmsUser::class, $result[0]);
@@ -468,19 +469,16 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $addr->zip      = 10827;
         $addr->city     = 'São Paulo';
 
-
         $user->setAddress($addr);
 
         $this->_em->persist($user);
         $this->_em->flush();
-
         $this->_em->clear();
 
-        $repository = $this->_em->getRepository(CmsUser::class);
-
-
-        $result = $repository->createNativeNamedQuery('fetchJoinedAddress')
-                        ->setParameter(1, 'FabioBatSilva')->getResult();
+        $result = $this->_em->getRepository(CmsUser::class)
+                            ->createNativeNamedQuery('fetchJoinedAddress')
+                            ->setParameter(1, 'FabioBatSilva')
+                            ->getResult();
 
         $this->assertEquals(1, count($result));
         $this->assertInstanceOf(CmsUser::class, $result[0]);

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -325,6 +325,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
     {
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata(CompanyFixContract::class, 'c');
+
+        self::assertSame(CompanyFixContract::class, $rsm->getClassName('c'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
@@ -16,15 +16,16 @@ class PersistentObjectTest extends OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
+
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(PersistentEntity::class),
+                    $this->_em->getClassMetadata(PersistentEntity::class),
                 ]
             );
         } catch (\Exception $e) {
-
         }
+
         PersistentObject::setObjectManager($this->_em);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
@@ -36,6 +36,8 @@ class PersistentObjectTest extends OrmFunctionalTestCase
 
         $this->_em->persist($entity);
         $this->_em->flush();
+
+        $this->addToAssertionCount(1);
     }
 
     public function testFind()

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -169,13 +169,29 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1 AND u.status = ?2')
                   ->setParameters($parameters)
                   ->getResult();
+
+        $extractValue = function (Parameter $parameter) {
+            return $parameter->getValue();
+        };
+
+        self::assertSame(
+            $parameters->map($extractValue)->toArray(),
+            $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['params']
+        );
     }
 
     public function testSetParametersBackwardsCompatible()
     {
+        $parameters = [1 => 'jwage', 2 => 'active'];
+
         $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1 AND u.status = ?2')
-                  ->setParameters([1 => 'jwage', 2 => 'active'])
+                  ->setParameters($parameters)
                   ->getResult();
+
+        self::assertSame(
+            array_values($parameters),
+            $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['params']
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -208,7 +208,7 @@ class QueryTest extends OrmFunctionalTestCase
         }
 
         $this->assertEquals(1, count($found));
-        $this->assertEquals(
+        $this->assertSame(
             [
                 [
                     [
@@ -256,8 +256,8 @@ class QueryTest extends OrmFunctionalTestCase
             $iteratedCount++;
         }
 
-        $this->assertEquals(["Doctrine 2", "Symfony 2"], $topics);
-        $this->assertEquals(2, $iteratedCount);
+        $this->assertSame(["Doctrine 2", "Symfony 2"], $topics);
+        $this->assertSame(2, $iteratedCount);
 
         $this->_em->flush();
         $this->_em->clear();
@@ -293,8 +293,8 @@ class QueryTest extends OrmFunctionalTestCase
             $iteratedCount++;
         }
 
-        $this->assertEquals(["Doctrine 2", "Symfony 2"], $topics);
-        $this->assertEquals(2, $iteratedCount);
+        $this->assertSame(["Doctrine 2", "Symfony 2"], $topics);
+        $this->assertSame(2, $iteratedCount);
 
         $this->_em->flush();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -26,6 +26,7 @@ class QueryTest extends OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('cms');
+
         parent::setUp();
     }
 
@@ -93,7 +94,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u join u.articles a ORDER BY a.topic");
+        $query = $this->_em->createQuery('select u, a from ' . CmsUser::class . ' u join u.articles a ORDER BY a.topic');
         $users = $query->getResult();
         $this->assertEquals(1, count($users));
         $this->assertInstanceOf(CmsUser::class, $users[0]);
@@ -112,7 +113,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = ?0');
+        $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.username = ?0');
         $q->setParameter(0, 'jwage');
         $user = $q->getSingleResult();
 
@@ -124,7 +125,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->expectException(QueryException::class);
         $this->expectExceptionMessage('Invalid parameter: token 2 is not defined in the query.');
 
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
+        $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1');
         $q->setParameter(2, 'jwage');
         $user = $q->getSingleResult();
     }
@@ -134,7 +135,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->expectException(QueryException::class);
         $this->expectExceptionMessage('Too many parameters: the query defines 1 parameters and you bound 2');
 
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
+        $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1');
         $q->setParameter(1, 'jwage');
         $q->setParameter(2, 'jwage');
 
@@ -146,38 +147,35 @@ class QueryTest extends OrmFunctionalTestCase
         $this->expectException(QueryException::class);
         $this->expectExceptionMessage('Too few parameters: the query defines 1 parameters but you only bound 0');
 
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1');
-
-        $user = $q->getSingleResult();
+        $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1')
+                  ->getSingleResult();
     }
 
     public function testInvalidInputParameterThrowsException()
     {
         $this->expectException(QueryException::class);
 
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?');
-        $q->setParameter(1, 'jwage');
-        $user = $q->getSingleResult();
+        $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?')
+                  ->setParameter(1, 'jwage')
+                  ->getSingleResult();
     }
 
     public function testSetParameters()
     {
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1 AND u.status = ?2');
-
         $parameters = new ArrayCollection();
         $parameters->add(new Parameter(1, 'jwage'));
         $parameters->add(new Parameter(2, 'active'));
 
-        $q->setParameters($parameters);
-        $users = $q->getResult();
+        $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1 AND u.status = ?2')
+                  ->setParameters($parameters)
+                  ->getResult();
     }
 
     public function testSetParametersBackwardsCompatible()
     {
-        $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = ?1 AND u.status = ?2');
-        $q->setParameters([1 => 'jwage', 2 => 'active']);
-
-        $users = $q->getResult();
+        $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1 AND u.status = ?2')
+                  ->setParameters([1 => 'jwage', 2 => 'active'])
+                  ->getResult();
     }
 
     /**
@@ -200,18 +198,29 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
         $articleId = $article1->id;
 
-        $query = $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a WHERE a.topic = ?1");
+        $query = $this->_em->createQuery('select a from ' . CmsArticle::class . ' a WHERE a.topic = ?1');
         $articles = $query->iterate(new ArrayCollection([new Parameter(1, 'Doctrine 2')]), Query::HYDRATE_ARRAY);
 
         $found = [];
+
         foreach ($articles AS $article) {
             $found[] = $article;
         }
+
         $this->assertEquals(1, count($found));
         $this->assertEquals(
             [
-            [['id' => $articleId, 'topic' => 'Doctrine 2', 'text' => 'This is an introduction to Doctrine 2.', 'version' => 1]]
-            ], $found);
+                [
+                    [
+                        'id'      => $articleId,
+                        'topic'   => 'Doctrine 2',
+                        'text'    => 'This is an introduction to Doctrine 2.',
+                        'version' => 1,
+                    ],
+                ],
+            ],
+            $found
+        );
     }
 
     public function testIterateResult_IterativelyBuildUpUnitOfWork()
@@ -230,11 +239,12 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a");
+        $query = $this->_em->createQuery('select a from ' . CmsArticle::class . ' a');
         $articles = $query->iterate();
 
         $iteratedCount = 0;
         $topics = [];
+
         foreach($articles AS $row) {
             $article = $row[0];
             $topics[] = $article->topic;
@@ -294,7 +304,7 @@ class QueryTest extends OrmFunctionalTestCase
      */
     public function testIterateResult_FetchJoinedCollection_ThrowsException()
     {
-        $query = $this->_em->createQuery("SELECT u, a FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.articles a");
+        $query = $this->_em->createQuery("SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.articles a");
         $articles = $query->iterate();
     }
 
@@ -360,7 +370,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $data = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u')
+        $data = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u')
                   ->setFirstResult(1)
                   ->setMaxResults(2)
                   ->getResult();
@@ -369,7 +379,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertEquals('gblanco1', $data[0]->username);
         $this->assertEquals('gblanco2', $data[1]->username);
 
-        $data = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u')
+        $data = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u')
                   ->setFirstResult(3)
                   ->setMaxResults(2)
                   ->getResult();
@@ -378,7 +388,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertEquals('gblanco3', $data[0]->username);
         $this->assertEquals('gblanco4', $data[1]->username);
 
-        $data = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u')
+        $data = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u')
                   ->setFirstResult(3)
                   ->setMaxResults(2)
                   ->getScalarResult();
@@ -472,13 +482,13 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $query = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = 'gblanco'");
+        $query = $this->_em->createQuery("select u from " . CmsUser::class . " u where u.username = 'gblanco'");
 
         $fetchedUser = $query->getOneOrNullResult();
         $this->assertInstanceOf(CmsUser::class, $fetchedUser);
         $this->assertEquals('gblanco', $fetchedUser->username);
 
-        $query = $this->_em->createQuery("select u.username from Doctrine\Tests\Models\CMS\CmsUser u where u.username = 'gblanco'");
+        $query = $this->_em->createQuery("select u.username from " . CmsUser::class . " u where u.username = 'gblanco'");
         $fetchedUsername = $query->getOneOrNullResult(Query::HYDRATE_SINGLE_SCALAR);
         $this->assertEquals('gblanco', $fetchedUsername);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -3,7 +3,11 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Tools\SchemaValidator;
+use Doctrine\Tests\DbalTypes\CustomIdObjectType;
+use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
+use Doctrine\Tests\DbalTypes\UpperCaseStringType;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\DBAL\Types\Type as DBALType;
 
 /**
  * Test the validity of all modelsets
@@ -12,26 +16,53 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class SchemaValidatorTest extends OrmFunctionalTestCase
 {
-    static public function dataValidateModelSets()
+    protected function setUp()
+    {
+        $this->registerType(CustomIdObjectType::class);
+        $this->registerType(UpperCaseStringType::class);
+        $this->registerType(NegativeToPositiveType::class);
+
+        parent::setUp();
+    }
+
+    /**
+     * @param string $className
+     *
+     * @throws \Doctrine\DBAL\DBALException
+     *
+     * @return void
+     */
+    private function registerType(string $className)
+    {
+        $type = constant($className . '::NAME');
+
+        if (DBALType::hasType($type)) {
+            DBALType::overrideType($type, $className);
+            return;
+        }
+
+        DBALType::addType($type, $className);
+    }
+
+    public static function dataValidateModelSets(): array
     {
         $modelSets = [];
-        foreach (self::$_modelSets as $modelSet => $classes) {
-            if ($modelSet == "customtype") {
-                continue;
-            }
-            $modelSets[] = [$modelSet];
+
+        foreach (array_keys(self::$_modelSets) as $modelSet) {
+            $modelSets[$modelSet] = [$modelSet];
         }
+
         return $modelSets;
     }
 
     /**
      * @dataProvider dataValidateModelSets
      */
-    public function testValidateModelSets($modelSet)
+    public function testValidateModelSets(string $modelSet)
     {
         $validator = new SchemaValidator($this->_em);
+        $classes   = [];
 
-        $classes = [];
         foreach (self::$_modelSets[$modelSet] as $className) {
             $classes[] = $this->_em->getClassMetadata($className);
         }
@@ -39,7 +70,7 @@ class SchemaValidatorTest extends OrmFunctionalTestCase
         foreach ($classes as $class) {
             $ce = $validator->validateClass($class);
 
-            $this->assertEquals(0, count($ce), "Invalid Modelset: " . $modelSet . " class " . $class->name . ": ". implode("\n", $ce));
+            $this->assertEmpty($ce, "Invalid Modelset: " . $modelSet . " class " . $class->name . ": ". implode("\n", $ce));
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -14,18 +14,17 @@ class SequenceGeneratorTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        if (!$this->_em->getConnection()->getDatabasePlatform()->supportsSequences()) {
+        if ( ! $this->_em->getConnection()->getDatabasePlatform()->supportsSequences()) {
             $this->markTestSkipped('Only working for Databases that support sequences.');
         }
 
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(SequenceEntity::class),
+                    $this->_em->getClassMetadata(SequenceEntity::class),
                 ]
             );
         } catch(\Exception $e) {
-
         }
     }
 
@@ -35,6 +34,7 @@ class SequenceGeneratorTest extends OrmFunctionalTestCase
             $e = new SequenceEntity();
             $this->_em->persist($e);
         }
+
         $this->_em->flush();
     }
 }
@@ -48,7 +48,7 @@ class SequenceEntity
      * @Id
      * @column(type="integer")
      * @GeneratedValue(strategy="SEQUENCE")
-     * @SequenceGenerator(allocationSize=5,sequenceName="person_id_seq")
+     * @SequenceGenerator(allocationSize=5, sequenceName="person_id_seq")
      */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -30,12 +30,13 @@ class SequenceGeneratorTest extends OrmFunctionalTestCase
 
     public function testHighAllocationSizeSequence()
     {
-        for ($i = 0; $i < 11; $i++) {
-            $e = new SequenceEntity();
-            $this->_em->persist($e);
+        for ($i = 0; $i < 11; ++$i) {
+            $this->_em->persist(new SequenceEntity());
         }
 
         $this->_em->flush();
+
+        self::assertCount(11, $this->_em->getRepository(SequenceEntity::class)->findAll());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -8,21 +8,20 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
  */
 class DDC1113Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
     public function setUp()
     {
         parent::setUp();
+
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC1113Engine::class),
-                $this->_em->getClassMetadata(DDC1113Vehicle::class),
-                $this->_em->getClassMetadata(DDC1113Car::class),
-                $this->_em->getClassMetadata(DDC1113Bus::class),
+                    $this->_em->getClassMetadata(DDC1113Engine::class),
+                    $this->_em->getClassMetadata(DDC1113Vehicle::class),
+                    $this->_em->getClassMetadata(DDC1113Car::class),
+                    $this->_em->getClassMetadata(DDC1113Bus::class),
                 ]
             );
         } catch (\Exception $e) {
-
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -42,8 +42,11 @@ class DDC1113Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->remove($bus);
         $this->_em->remove($car);
         $this->_em->flush();
-    }
 
+        self::assertEmpty($this->_em->getRepository(DDC1113Car::class)->findAll());
+        self::assertEmpty($this->_em->getRepository(DDC1113Bus::class)->findAll());
+        self::assertEmpty($this->_em->getRepository(DDC1113Engine::class)->findAll());
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -275,6 +275,8 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->persist($this->article1);
         $this->_em->flush();
+
+        self::assertSame($this->articleDetails, $this->_em->find(DDC117ArticleDetails::class, $this->article1));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -21,7 +21,8 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
     private $translation;
     private $articleDetails;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->useModelSet('ddc117');
         parent::setUp();
 
@@ -63,7 +64,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $dql = "SELECT r, s FROM Doctrine\Tests\Models\DDC117\DDC117Reference r JOIN r.source s WHERE r.source = ?1";
+        $dql = 'SELECT r, s FROM ' . DDC117Reference::class . ' r JOIN r.source s WHERE r.source = ?1';
         $dqlRef = $this->_em->createQuery($dql)->setParameter(1, 1)->getSingleResult();
 
         $this->assertInstanceOf(DDC117Reference::class, $mapRef);
@@ -73,7 +74,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $dql = "SELECT r, s FROM Doctrine\Tests\Models\DDC117\DDC117Reference r JOIN r.source s WHERE s.title = ?1";
+        $dql = 'SELECT r, s FROM ' . DDC117Reference::class . ' r JOIN r.source s WHERE s.title = ?1';
         $dqlRef = $this->_em->createQuery($dql)->setParameter(1, 'Foo')->getSingleResult();
 
         $this->assertInstanceOf(DDC117Reference::class, $dqlRef);
@@ -81,7 +82,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertInstanceOf(DDC117Article::class, $dqlRef->source());
         $this->assertSame($dqlRef, $this->_em->find(DDC117Reference::class, $idCriteria));
 
-        $dql = "SELECT r, s FROM Doctrine\Tests\Models\DDC117\DDC117Reference r JOIN r.source s WHERE s.title = ?1";
+        $dql = 'SELECT r, s FROM ' . DDC117Reference::class . ' r JOIN r.source s WHERE s.title = ?1';
         $dqlRef = $this->_em->createQuery($dql)->setParameter(1, 'Foo')->getSingleResult();
 
         $this->_em->contains($dqlRef);
@@ -265,12 +266,11 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testOneToOneCascadePersist()
     {
-        if (!$this->_em->getConnection()->getDatabasePlatform()->prefersSequences()) {
+        if ( ! $this->_em->getConnection()->getDatabasePlatform()->prefersSequences()) {
             $this->markTestSkipped('Test only works with databases that prefer sequences as ID strategy.');
         }
 
         $this->article1 = new DDC117Article("Foo");
-
         $this->articleDetails = new DDC117ArticleDetails($this->article1, "Very long text");
 
         $this->_em->persist($this->article1);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -47,6 +47,8 @@ class DDC1181Test extends OrmFunctionalTestCase
 
         $this->_em->remove($hotel);
         $this->_em->flush();
+
+        self::assertEmpty($this->_em->getRepository(DDC1181Booking::class)->findAll());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -11,9 +11,9 @@ class DDC1181Test extends OrmFunctionalTestCase
         parent::setUp();
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC1181Hotel::class),
-            $this->_em->getClassMetadata(DDC1181Booking::class),
-            $this->_em->getClassMetadata(DDC1181Room::class),
+                $this->_em->getClassMetadata(DDC1181Hotel::class),
+                $this->_em->getClassMetadata(DDC1181Booking::class),
+                $this->_em->getClassMetadata(DDC1181Room::class),
             ]
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -12,9 +12,9 @@ class DDC1209Test extends OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC1209_1::class),
-                $this->_em->getClassMetadata(DDC1209_2::class),
-                $this->_em->getClassMetadata(DDC1209_3::class)
+                    $this->_em->getClassMetadata(DDC1209_1::class),
+                    $this->_em->getClassMetadata(DDC1209_2::class),
+                    $this->_em->getClassMetadata(DDC1209_3::class)
                 ]
             );
         } catch(\Exception $e) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -26,8 +26,12 @@ class DDC1209Test extends OrmFunctionalTestCase
      */
     public function testIdentifierCanHaveCustomType()
     {
-        $this->_em->persist(new DDC1209_3());
+        $entity = new DDC1209_3();
+
+        $this->_em->persist($entity);
         $this->_em->flush();
+
+        self::assertSame($entity, $this->_em->find(DDC1209_3::class, $entity->date));
     }
 
     /**
@@ -36,14 +40,27 @@ class DDC1209Test extends OrmFunctionalTestCase
     public function testCompositeIdentifierCanHaveCustomType()
     {
         $future1 = new DDC1209_1();
-        $this->_em->persist($future1);
 
+        $this->_em->persist($future1);
         $this->_em->flush();
 
         $future2 = new DDC1209_2($future1);
-        $this->_em->persist($future2);
 
+        $this->_em->persist($future2);
         $this->_em->flush();
+
+        self::assertSame(
+            $future2,
+            $this->_em->find(
+                DDC1209_2::class,
+                [
+                    'future1'           => $future1,
+                    'starting_datetime' => $future2->starting_datetime,
+                    'during_datetime'   => $future2->during_datetime,
+                    'ending_datetime'   => $future2->ending_datetime,
+                ]
+            )
+        );
     }
 }
 
@@ -78,17 +95,19 @@ class DDC1209_2
      *  @Id
      *  @Column(type="datetime", nullable=false)
      */
-    private $starting_datetime;
+    public $starting_datetime;
+
     /**
      *  @Id
      *  @Column(type="datetime", nullable=false)
      */
-    private $during_datetime;
+    public $during_datetime;
+
     /**
      *  @Id
      *  @Column(type="datetime", nullable=false)
      */
-    private $ending_datetime;
+    public $ending_datetime;
 
     public function __construct(DDC1209_1 $future1)
     {
@@ -108,7 +127,7 @@ class DDC1209_3
      * @Id
      * @Column(type="datetime", name="somedate")
      */
-    private $date;
+    public $date;
 
     public function __construct()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 
@@ -13,6 +14,7 @@ class DDC1306Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         $this->useModelSet('cms');
+
         parent::setUp();
     }
 
@@ -25,7 +27,7 @@ class DDC1306Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($phone);
         $this->_em->flush();
 
-        $address = new \Doctrine\Tests\Models\CMS\CmsAddress();
+        $address = new CmsAddress();
         $address->city = "bonn";
         $address->country = "Germany";
         $address->street = "somestreet!";

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php
@@ -48,5 +48,8 @@ class DDC1306Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->remove($user->getAddress());
         $this->_em->remove($user);
         $this->_em->flush();
+
+        self::assertEmpty($this->_em->getRepository(CmsAddress::class)->findAll());
+        self::assertEmpty($this->_em->getRepository(CmsUser::class)->findAll());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
@@ -57,7 +57,11 @@ class DDC1400Test extends \Doctrine\Tests\OrmFunctionalTestCase
                   ->setParameter('activeUser', $user1)
                   ->getResult();
 
+        $queryCount = $this->getCurrentQueryCount();
+
         $this->_em->flush();
+
+        self::assertSame($queryCount, $this->getCurrentQueryCount(), 'No query should be executed during flush in this case');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php
@@ -14,9 +14,9 @@ class DDC1400Test extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC1400Article::class),
-                $this->_em->getClassMetadata(DDC1400User::class),
-                $this->_em->getClassMetadata(DDC1400UserState::class),
+                    $this->_em->getClassMetadata(DDC1400Article::class),
+                    $this->_em->getClassMetadata(DDC1400User::class),
+                    $this->_em->getClassMetadata(DDC1400UserState::class),
                 ]
             );
         } catch (\Exception $ignored) {
@@ -48,15 +48,14 @@ class DDC1400Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->persist($userState1);
         $this->_em->persist($userState2);
-
         $this->_em->flush();
         $this->_em->clear();
 
         $user1 = $this->_em->getReference(DDC1400User::class, $user1->id);
 
-        $q = $this->_em->createQuery("SELECT a, s FROM ".__NAMESPACE__."\DDC1400Article a JOIN a.userStates s WITH s.user = :activeUser");
-        $q->setParameter('activeUser', $user1);
-        $articles = $q->getResult();
+        $this->_em->createQuery('SELECT a, s FROM ' . DDC1400Article::class . ' a JOIN a.userStates s WITH s.user = :activeUser')
+                  ->setParameter('activeUser', $user1)
+                  ->getResult();
 
         $this->_em->flush();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -8,12 +8,11 @@ class DDC144Test extends OrmFunctionalTestCase
 {
     protected function setUp() {
         parent::setUp();
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
 
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC144FlowElement::class),
-            $this->_em->getClassMetadata(DDC144Operand::class),
+                $this->_em->getClassMetadata(DDC144FlowElement::class),
+                $this->_em->getClassMetadata(DDC144Operand::class),
             ]
         );
 
@@ -24,10 +23,10 @@ class DDC144Test extends OrmFunctionalTestCase
      */
     public function testIssue()
     {
-
         $operand = new DDC144Operand;
         $operand->property = 'flowValue';
         $operand->operandProperty = 'operandValue';
+
         $this->_em->persist($operand);
         $this->_em->flush();
 
@@ -41,23 +40,30 @@ class DDC144Test extends OrmFunctionalTestCase
  * @DiscriminatorColumn(type="string", name="discr")
  * @DiscriminatorMap({"flowelement" = "DDC144FlowElement", "operand" = "DDC144Operand"})
  */
-class DDC144FlowElement {
+class DDC144FlowElement
+{
     /**
      * @Id @Column(type="integer") @GeneratedValue
      * @var int
      */
     public $id;
+
     /** @Column */
     public $property;
 }
 
-abstract class DDC144Expression extends DDC144FlowElement {
-    abstract function method();
+abstract class DDC144Expression extends DDC144FlowElement
+{
+    abstract public function method();
 }
 
 /** @Entity @Table(name="ddc144_operands") */
-class DDC144Operand extends DDC144Expression {
+class DDC144Operand extends DDC144Expression
+{
     /** @Column */
     public $operandProperty;
-    function method() {}
+
+    public function method()
+    {
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -30,6 +30,7 @@ class DDC144Test extends OrmFunctionalTestCase
         $this->_em->persist($operand);
         $this->_em->flush();
 
+        self::assertSame($operand, $this->_em->find(DDC144Operand::class, $operand->id));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\UnitOfWork;
+
 /**
  * @group DDC-1454
  */
@@ -25,9 +27,9 @@ class DDC1454Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testFailingCase()
     {
         $pic = new DDC1454Picture();
-        $this->_em->getUnitOfWork()->getEntityState($pic);
-    }
 
+        self::assertSame(UnitOfWork::STATE_NEW, $this->_em->getUnitOfWork()->getEntityState($pic));
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
@@ -14,12 +14,11 @@ class DDC1454Test extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC1454File::class),
-                $this->_em->getClassMetadata(DDC1454Picture::class),
+                    $this->_em->getClassMetadata(DDC1454File::class),
+                    $this->_em->getClassMetadata(DDC1454Picture::class),
                 ]
             );
         } catch (\Exception $ignored) {
-
         }
     }
 
@@ -36,7 +35,6 @@ class DDC1454Test extends \Doctrine\Tests\OrmFunctionalTestCase
  */
 class DDC1454Picture extends DDC1454File
 {
-
 }
 
 /**
@@ -53,14 +51,16 @@ class DDC1454File
      */
     public $fileId;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->fileId = rand();
     }
 
     /**
      * Get fileId
      */
-    public function getFileId() {
+    public function getFileId()
+    {
         return $this->fileId;
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -36,6 +36,12 @@ class DDC1925Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->persist($product);
         $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var DDC1925Product $persistedProduct */
+        $persistedProduct = $this->_em->find(DDC1925Product::class, $product->getId());
+
+        self::assertEquals($user, $persistedProduct->getBuyers()->first());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -14,23 +14,25 @@ class DDC1925Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC1925User::class),
-            $this->_em->getClassMetadata(DDC1925Product::class),
+                $this->_em->getClassMetadata(DDC1925User::class),
+                $this->_em->getClassMetadata(DDC1925Product::class),
             ]
         );
 
         $user = new DDC1925User();
         $user->setTitle("Test User");
-        $this->_em->persist($user);
 
         $product = new DDC1925Product();
         $product->setTitle("Test product");
+
+        $this->_em->persist($user);
         $this->_em->persist($product);
         $this->_em->flush();
 
         $product->addBuyer($user);
 
-        $this->_em->getUnitOfWork()->computeChangeSets();
+        $this->_em->getUnitOfWork()
+                  ->computeChangeSets();
 
         $this->_em->persist($product);
         $this->_em->flush();
@@ -104,15 +106,7 @@ class DDC1925Product
     }
 
     /**
-     * @param string $buyers
-     */
-    public function setBuyers($buyers)
-    {
-        $this->buyers = $buyers;
-    }
-
-    /**
-     * @return string
+     * @return ArrayCollection
      */
     public function getBuyers()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -4,27 +4,31 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @group DDC-192
+ */
 class DDC192Test extends OrmFunctionalTestCase
 {
     public function testSchemaCreation()
     {
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC192User::class),
-            $this->_em->getClassMetadata(DDC192Phonenumber::class)
+                $this->_em->getClassMetadata(DDC192User::class),
+                $this->_em->getClassMetadata(DDC192Phonenumber::class)
             ]
         );
     }
 }
 
-
 /**
- * @Entity @Table(name="ddc192_users")
+ * @Entity
+ * @Table(name="ddc192_users")
  */
 class DDC192User
 {
     /**
-     * @Id @Column(name="id", type="integer")
+     * @Id
+     * @Column(name="id", type="integer")
      * @GeneratedValue(strategy="AUTO")
      */
     public $id;
@@ -37,12 +41,14 @@ class DDC192User
 
 
 /**
- * @Entity @Table(name="ddc192_phonenumbers")
+ * @Entity
+ * @Table(name="ddc192_phonenumbers")
  */
 class DDC192Phonenumber
 {
     /**
-     * @Id @Column(name="phone", type="string", length=40)
+     * @Id
+     * @Column(name="phone", type="string", length=40)
      */
     protected $phone;
 
@@ -54,14 +60,23 @@ class DDC192Phonenumber
     protected $User;
 
 
-    public function setPhone($value) { $this->phone = $value; }
+    public function setPhone($value)
+    {
+        $this->phone = $value;
+    }
 
-    public function getPhone() { return $this->phone; }
+    public function getPhone()
+    {
+        return $this->phone;
+    }
 
     public function setUser(User $user)
     {
         $this->User = $user;
     }
 
-    public function getUser() { return $this->User; }
+    public function getUser()
+    {
+        return $this->User;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -11,12 +12,21 @@ class DDC192Test extends OrmFunctionalTestCase
 {
     public function testSchemaCreation()
     {
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(DDC192User::class),
-                $this->_em->getClassMetadata(DDC192Phonenumber::class)
-            ]
-        );
+        $classes = [
+            $this->_em->getClassMetadata(DDC192User::class),
+            $this->_em->getClassMetadata(DDC192Phonenumber::class),
+        ];
+
+        $this->_schemaTool->createSchema($classes);
+
+        $tables = $this->_em->getConnection()
+                            ->getSchemaManager()
+                            ->listTableNames();
+
+        /** @var ClassMetadata $class */
+        foreach ($classes as $class) {
+            self::assertContains($class->getTableName(), $tables);
+        }
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
@@ -34,7 +34,8 @@ class DDC2106Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($entityWithoutId);
 
         $criteria = Criteria::create()->where(Criteria::expr()->eq('parent', $entityWithoutId));
-        $entity->children->matching($criteria)->count();
+
+        self::assertCount(0, $entity->children->matching($criteria));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
@@ -12,9 +12,10 @@ class DDC2106Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
+
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC2106Entity::class),
+                $this->_em->getClassMetadata(DDC2106Entity::class),
             ]
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -13,10 +13,11 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
+
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC2256User::class),
-            $this->_em->getClassMetadata(DDC2256Group::class)
+                $this->_em->getClassMetadata(DDC2256User::class),
+                $this->_em->getClassMetadata(DDC2256Group::class)
             ]
         );
     }
@@ -55,8 +56,7 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // Test ResultSetMappingBuilder.
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('MyNamespace:DDC2256User', 'u');
-        $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', ['id' => 'group_id', 'name' => 'group_name']
-        );
+        $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', ['id' => 'group_id', 'name' => 'group_name']);
 
         $this->_em->createNativeQuery($sql, $rsm)->getResult();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -51,14 +51,14 @@ class DDC2256Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $rsm->addFieldResult('g', 'group_id', 'id');
         $rsm->addFieldResult('g', 'group_name', 'name');
 
-        $this->_em->createNativeQuery($sql, $rsm)->getResult();
+        self::assertCount(1, $this->_em->createNativeQuery($sql, $rsm)->getResult());
 
         // Test ResultSetMappingBuilder.
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata('MyNamespace:DDC2256User', 'u');
         $rsm->addJoinedEntityFromClassMetadata('MyNamespace:DDC2256Group', 'g', 'u', 'group', ['id' => 'group_id', 'name' => 'group_name']);
 
-        $this->_em->createNativeQuery($sql, $rsm)->getResult();
+        self::assertCount(1, $this->_em->createNativeQuery($sql, $rsm)->getResult());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
@@ -49,6 +49,8 @@ class DDC2775Test extends OrmFunctionalTestCase
         $this->_em->remove($user);
         $this->_em->flush();
 
+        self::assertEmpty($this->_em->getRepository(Authorization::class)->findAll());
+
         // With the bug, the second flush throws an error because the cascade remove didn't work correctly
         $this->_em->flush();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php
@@ -17,10 +17,10 @@ class DDC2775Test extends OrmFunctionalTestCase
 
         $this->setUpEntitySchema(
             [
-            User::class,
-            Role::class,
-            AdminRole::class,
-            Authorization::class,
+                User::class,
+                Role::class,
+                AdminRole::class,
+                Authorization::class,
             ]
         );
     }
@@ -30,9 +30,8 @@ class DDC2775Test extends OrmFunctionalTestCase
      */
     public function testIssueCascadeRemove()
     {
-        $user = new User();
-
         $role = new AdminRole();
+        $user = new User();
         $user->addRole($role);
 
         $authorization = new Authorization();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
@@ -46,27 +46,17 @@ class DDC3170Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        try {
-            $this->_em->createQueryBuilder()
-                ->select('p')
-                ->from(DDC3170ProductJoined::class, 'p')
-                ->getQuery()
-                ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
-        } catch (HydrationException $e) // Thrown by SimpleObjectHydrator
-        {
-            $this->fail('Failed correct mapping of discriminator column when using simple object hydration and class table inheritance');
-        }
+        $this->_em->createQueryBuilder()
+                  ->select('p')
+                  ->from(DDC3170ProductJoined::class, 'p')
+                  ->getQuery()
+                  ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
 
-        try {
-            $this->_em->createQueryBuilder()
-                ->select('p')
-                ->from(DDC3170ProductSingleTable::class, 'p')
-                ->getQuery()
-                ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
-        } catch (HydrationException $e) // Thrown by SimpleObjectHydrator
-        {
-            $this->fail('Failed correct mapping of discriminator column when using simple object hydration and single table inheritance');
-        }
+        $this->_em->createQueryBuilder()
+                  ->select('p')
+                  ->from(DDC3170ProductSingleTable::class, 'p')
+                  ->getQuery()
+                  ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
@@ -46,17 +46,23 @@ class DDC3170Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $this->_em->createQueryBuilder()
+        $result = $this->_em->createQueryBuilder()
                   ->select('p')
                   ->from(DDC3170ProductJoined::class, 'p')
                   ->getQuery()
                   ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
 
-        $this->_em->createQueryBuilder()
+        self::assertCount(1, $result);
+        self::assertContainsOnly(DDC3170ProductJoined::class, $result);
+
+        $result = $this->_em->createQueryBuilder()
                   ->select('p')
                   ->from(DDC3170ProductSingleTable::class, 'p')
                   ->getQuery()
                   ->getResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
+
+        self::assertCount(1, $result);
+        self::assertContainsOnly(DDC3170ProductSingleTable::class, $result);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
@@ -38,10 +38,9 @@ class DDC3170Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testIssue()
     {
-        // $this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
-
         $productJoined = new DDC3170ProductJoined();
         $productSingleTable = new DDC3170ProductSingleTable();
+
         $this->_em->persist($productJoined);
         $this->_em->persist($productSingleTable);
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3711Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3711Test.php
@@ -26,6 +26,5 @@ class DDC3711Test extends YamlMappingDriverTest
 
         $this->assertEquals(['link_a_id1' => "id1", 'link_a_id2' => "id2"], $entityA->associationMappings['entityB']['relationToSourceKeyColumns']);
         $this->assertEquals(['link_b_id1' => "id1", 'link_b_id2' => "id2"], $entityA->associationMappings['entityB']['relationToTargetKeyColumns']);
-
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -44,8 +44,13 @@ class DDC3785Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $asset->getAttributes()
               ->removeElement($attribute1);
 
+        $idToBeRemoved = $attribute1->id;
+
         $this->_em->persist($asset);
         $this->_em->flush();
+
+        self::assertNull($this->_em->find(DDC3785_Attribute::class, $idToBeRemoved));
+        self::assertNotNull($this->_em->find(DDC3785_Attribute::class, $attribute2->id));
     }
 }
 
@@ -100,7 +105,7 @@ class DDC3785_Attribute
      * @Id @Column(type="integer")
      * @GeneratedValue
      */
-    private $id;
+    public $id;
 
     /** @Column(type = "string") */
     private $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -17,9 +17,9 @@ class DDC3785Test extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC3785_Asset::class),
-                $this->_em->getClassMetadata(DDC3785_AssetId::class),
-                $this->_em->getClassMetadata(DDC3785_Attribute::class)
+                    $this->_em->getClassMetadata(DDC3785_Asset::class),
+                    $this->_em->getClassMetadata(DDC3785_AssetId::class),
+                    $this->_em->getClassMetadata(DDC3785_Attribute::class)
                 ]
             );
         } catch(\Exception $e) {
@@ -31,15 +31,18 @@ class DDC3785Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testOwningValueObjectIdIsCorrectlyTransformedWhenRemovingOrphanedChildEntities()
     {
-    	$id = new DDC3785_AssetId("919609ba-57d9-4a13-be1d-d202521e858a");
-    	$attributes = [
-    		$attribute1 = new DDC3785_Attribute("foo1", "bar1"),
-    		$attribute2 = new DDC3785_Attribute("foo2", "bar2")
+        $id = new DDC3785_AssetId('919609ba-57d9-4a13-be1d-d202521e858a');
+
+        $attributes = [
+            $attribute1 = new DDC3785_Attribute('foo1', 'bar1'),
+            $attribute2 = new DDC3785_Attribute('foo2', 'bar2')
         ];
+
         $this->_em->persist($asset = new DDC3785_Asset($id, $attributes));
         $this->_em->flush();
 
-        $asset->getAttributes()->removeElement($attribute1);
+        $asset->getAttributes()
+              ->removeElement($attribute1);
 
         $this->_em->persist($asset);
         $this->_em->flush();
@@ -68,12 +71,12 @@ class DDC3785_Asset
 
     public function __construct(DDC3785_AssetId $id, $attributes = [])
     {
-    	$this->id = $id;
-    	$this->attributes = new ArrayCollection();
+        $this->id = $id;
+        $this->attributes = new ArrayCollection();
 
-    	foreach ($attributes as $attribute) {
-    		$this->attributes->add($attribute);
-    	}
+        foreach ($attributes as $attribute) {
+            $this->attributes->add($attribute);
+        }
     }
 
     public function getId()
@@ -83,7 +86,7 @@ class DDC3785_Asset
 
     public function getAttributes()
     {
-    	return $this->attributes;
+        return $this->attributes;
     }
 }
 
@@ -93,23 +96,23 @@ class DDC3785_Asset
  */
 class DDC3785_Attribute
 {
-	/**
+    /**
      * @Id @Column(type="integer")
      * @GeneratedValue
      */
-	private $id;
+    private $id;
 
-	/** @Column(type = "string") */
-	private $name;
+    /** @Column(type = "string") */
+    private $name;
 
-	/** @Column(type = "string") */
-	private $value;
+    /** @Column(type = "string") */
+    private $value;
 
-	public function __construct($name, $value)
-	{
-		$this->name = $name;
-		$this->value = $value;
-	}
+    public function __construct($name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
 }
 
 /** @Embeddable */
@@ -120,12 +123,12 @@ class DDC3785_AssetId
 
     public function __construct($id)
     {
-    	$this->id = $id;
+        $this->id = $id;
     }
 
     public function __toString()
     {
-    	return $this->id;
+        return $this->id;
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -78,7 +78,11 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $newCust = $this->_em->find(get_class($fkCust), $fkCust->id);
+        $expected = clone $fkCust;
+        // removing dynamic field (which is not persisted)
+        unset($expected->name);
+
+        self::assertEquals($expected, $this->_em->find(DDC522ForeignKeyTest::class, $fkCust->id));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -13,16 +13,16 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
+
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC522Customer::class),
-                $this->_em->getClassMetadata(DDC522Cart::class),
-                $this->_em->getClassMetadata(DDC522ForeignKeyTest::class)
+                    $this->_em->getClassMetadata(DDC522Customer::class),
+                    $this->_em->getClassMetadata(DDC522Cart::class),
+                    $this->_em->getClassMetadata(DDC522ForeignKeyTest::class)
                 ]
             );
         } catch(\Exception $e) {
-
         }
     }
 
@@ -43,8 +43,8 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->_em->clear();
 
-        $r = $this->_em->createQuery("select ca,c from ".get_class($cart)." ca join ca.customer c")
-                ->getResult();
+        $r = $this->_em->createQuery('select ca,c from ' . DDC522Cart::class . ' ca join ca.customer c')
+                       ->getResult();
 
         $this->assertInstanceOf(DDC522Cart::class, $r[0]);
         $this->assertInstanceOf(DDC522Customer::class, $r[0]->customer);
@@ -71,7 +71,7 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testJoinColumnWithNullSameNameAssociationField()
     {
         $fkCust = new DDC522ForeignKeyTest;
-        $fkCust->name = "name";
+        $fkCust->name = 'name';
         $fkCust->cart = null;
 
         $this->_em->persist($fkCust);
@@ -83,21 +83,27 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 /** @Entity */
-class DDC522Customer {
+class DDC522Customer
+{
     /** @Id @Column(type="integer") @GeneratedValue */
     public $id;
+
     /** @Column */
     public $name;
+
     /** @OneToOne(targetEntity="DDC522Cart", mappedBy="customer") */
     public $cart;
 }
 
 /** @Entity */
-class DDC522Cart {
+class DDC522Cart
+{
     /** @Id @Column(type="integer") @GeneratedValue */
     public $id;
+
     /** @Column(type="integer") */
     public $total;
+
     /**
      * @OneToOne(targetEntity="DDC522Customer", inversedBy="cart")
      * @JoinColumn(name="customer", referencedColumnName="id")
@@ -106,11 +112,14 @@ class DDC522Cart {
 }
 
 /** @Entity */
-class DDC522ForeignKeyTest {
+class DDC522ForeignKeyTest
+{
     /** @Id @Column(type="integer") @GeneratedValue */
     public $id;
+
     /** @Column(type="integer", name="cart_id", nullable=true) */
     public $cartId;
+
     /**
      * @OneToOne(targetEntity="DDC522Cart")
      * @JoinColumn(name="cart_id", referencedColumnName="id")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
@@ -23,6 +23,8 @@ class DDC588Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         // Following should not result in exception
         $this->_em->refresh($site);
+
+        $this->addToAssertionCount(1);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
@@ -7,9 +7,10 @@ class DDC588Test extends \Doctrine\Tests\OrmFunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
+
         $this->_schemaTool->createSchema(
             [
-            $this->_em->getClassMetadata(DDC588Site::class),
+                $this->_em->getClassMetadata(DDC588Site::class),
             ]
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -27,8 +27,8 @@ class DDC742Test extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC742User::class),
-                $this->_em->getClassMetadata(DDC742Comment::class)
+                    $this->_em->getClassMetadata(DDC742User::class),
+                    $this->_em->getClassMetadata(DDC742Comment::class)
                 ]
             );
         } catch(\Exception $e) {
@@ -64,9 +64,9 @@ class DDC742Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $user = $this->_em->find(get_class($user), $user->id);
-        $comment3 = $this->_em->find(get_class($comment3), $comment3->id);
-        $user->favoriteComments->add($comment3);
+        $user = $this->_em->find(DDC742User::class, $user->id);
+        $user->favoriteComments->add($this->_em->find(DDC742Comment::class, $comment3->id));
+
         $this->_em->flush();
     }
 }
@@ -86,11 +86,13 @@ class DDC742User
      * @var int
      */
     public $id;
+
     /**
      * @Column(length=100, type="string")
      * @var string
      */
     public $title;
+
     /**
      * @ManyToMany(targetEntity="DDC742Comment", cascade={"persist"}, fetch="EAGER")
      * @JoinTable(
@@ -99,7 +101,7 @@ class DDC742User
      *  inverseJoinColumns={@JoinColumn(name="comment_id", referencedColumnName="id")}
      * )
      *
-     * @var Doctrine\ORM\PersistentCollection
+     * @var \Doctrine\ORM\PersistentCollection
      */
     public $favoriteComments;
 }
@@ -119,6 +121,7 @@ class DDC742Comment
      * @var int
      */
     public $id;
+
     /**
      * @Column(length=100, type="string")
      * @var string

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -68,6 +68,7 @@ class DDC742Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user->favoriteComments->add($this->_em->find(DDC742Comment::class, $comment3->id));
 
         $this->_em->flush();
+        $this->addToAssertionCount(1);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -50,6 +50,9 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $like->word = 'test2';
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertEquals($like, $this->_em->find(DDC832Like::class, $like->id));
     }
 
     /**
@@ -61,8 +64,13 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($like);
         $this->_em->flush();
 
+        $idToBeRemoved = $like->id;
+
         $this->_em->remove($like);
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertNull($this->_em->find(DDC832Like::class, $idToBeRemoved));
     }
 
     /**
@@ -76,6 +84,9 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $index->name = 'asdf';
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertEquals($index, $this->_em->find(DDC832JoinedIndex::class, $index->id));
     }
 
     /**
@@ -87,8 +98,13 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($index);
         $this->_em->flush();
 
+        $idToBeRemoved = $index->id;
+
         $this->_em->remove($index);
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertNull($this->_em->find(DDC832JoinedIndex::class, $idToBeRemoved));
     }
 
     /**
@@ -102,6 +118,9 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $index->name = 'asdf';
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertEquals($index, $this->_em->find(DDC832JoinedTreeIndex::class, $index->id));
     }
 
     /**
@@ -113,8 +132,13 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->persist($index);
         $this->_em->flush();
 
+        $idToBeRemoved = $index->id;
+
         $this->_em->remove($index);
         $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertNull($this->_em->find(DDC832JoinedTreeIndex::class, $idToBeRemoved));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -7,22 +7,24 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
+
         $platform = $this->_em->getConnection()->getDatabasePlatform();
-        if ($platform->getName() == "oracle") {
+
+        if ($platform->getName() === 'oracle') {
             $this->markTestSkipped('Doesnt run on Oracle.');
         }
 
         $this->_em->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
+
         try {
             $this->_schemaTool->createSchema(
                 [
-                $this->_em->getClassMetadata(DDC832JoinedIndex::class),
-                $this->_em->getClassMetadata(DDC832JoinedTreeIndex::class),
-                $this->_em->getClassMetadata(DDC832Like::class),
+                    $this->_em->getClassMetadata(DDC832JoinedIndex::class),
+                    $this->_em->getClassMetadata(DDC832JoinedTreeIndex::class),
+                    $this->_em->getClassMetadata(DDC832Like::class),
                 ]
             );
         } catch(\Exception $e) {
-
         }
     }
 
@@ -30,6 +32,7 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         /* @var $sm \Doctrine\DBAL\Schema\AbstractSchemaManager */
         $platform = $this->_em->getConnection()->getDatabasePlatform();
+
         $sm = $this->_em->getConnection()->getSchemaManager();
         $sm->dropTable($platform->quoteIdentifier('TREE_INDEX'));
         $sm->dropTable($platform->quoteIdentifier('INDEX'));
@@ -41,11 +44,11 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableBasicUpdate()
     {
-        $like = new DDC832Like("test");
+        $like = new DDC832Like('test');
         $this->_em->persist($like);
         $this->_em->flush();
 
-        $like->word = "test2";
+        $like->word = 'test2';
         $this->_em->flush();
     }
 
@@ -54,7 +57,7 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableBasicRemove()
     {
-        $like = new DDC832Like("test");
+        $like = new DDC832Like('test');
         $this->_em->persist($like);
         $this->_em->flush();
 
@@ -67,11 +70,11 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableJoinedUpdate()
     {
-        $index = new DDC832JoinedIndex("test");
+        $index = new DDC832JoinedIndex('test');
         $this->_em->persist($index);
         $this->_em->flush();
 
-        $index->name = "asdf";
+        $index->name = 'asdf';
         $this->_em->flush();
     }
 
@@ -80,7 +83,7 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableJoinedRemove()
     {
-        $index = new DDC832JoinedIndex("test");
+        $index = new DDC832JoinedIndex('test');
         $this->_em->persist($index);
         $this->_em->flush();
 
@@ -93,11 +96,11 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableJoinedChildUpdate()
     {
-        $index = new DDC832JoinedTreeIndex("test", 1, 2);
+        $index = new DDC832JoinedTreeIndex('test', 1, 2);
         $this->_em->persist($index);
         $this->_em->flush();
 
-        $index->name = "asdf";
+        $index->name = 'asdf';
         $this->_em->flush();
     }
 
@@ -106,7 +109,7 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     public function testQuotedTableJoinedChildRemove()
     {
-        $index = new DDC832JoinedTreeIndex("test", 1, 2);
+        $index = new DDC832JoinedTreeIndex('test', 1, 2);
         $this->_em->persist($index);
         $this->_em->flush();
 
@@ -178,6 +181,7 @@ class DDC832JoinedTreeIndex extends DDC832JoinedIndex
 {
     /** @Column(type="integer") */
     public $lft;
+
     /** @Column(type="integer") */
     public $rgt;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\LockMode;
+use Doctrine\Tests\Models\Company\CompanyManager;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC933Test extends OrmFunctionalTestCase
@@ -9,6 +11,7 @@ class DDC933Test extends OrmFunctionalTestCase
     public function setUp()
     {
         $this->useModelSet('company');
+
         parent::setUp();
     }
 
@@ -17,9 +20,7 @@ class DDC933Test extends OrmFunctionalTestCase
      */
     public function testLockCTIClass()
     {
-        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger());
-
-        $manager = new \Doctrine\Tests\Models\Company\CompanyManager();
+        $manager = new CompanyManager();
         $manager->setName('beberlei');
         $manager->setSalary(1234);
         $manager->setTitle('Vice President of This Test');
@@ -29,7 +30,7 @@ class DDC933Test extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->_em->beginTransaction();
-        $this->_em->lock($manager, \Doctrine\DBAL\LockMode::PESSIMISTIC_READ);
+        $this->_em->lock($manager, LockMode::PESSIMISTIC_READ);
         $this->_em->rollback();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Tests\Models\Company\CompanyManager;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\Tests\TestUtil;
 
 class DDC933Test extends OrmFunctionalTestCase
 {
@@ -20,6 +21,10 @@ class DDC933Test extends OrmFunctionalTestCase
      */
     public function testLockCTIClass()
     {
+        if ($this->_em->getConnection()->getDatabasePlatform()->getName() === 'sqlite') {
+            self::markTestSkipped('It should not run on in-memory databases');
+        }
+
         $manager = new CompanyManager();
         $manager->setName('beberlei');
         $manager->setSalary(1234);
@@ -32,5 +37,33 @@ class DDC933Test extends OrmFunctionalTestCase
         $this->_em->beginTransaction();
         $this->_em->lock($manager, LockMode::PESSIMISTIC_READ);
         $this->_em->rollback();
+
+        // if lock hasn't been released we'd have an exception here
+        $this->assertManagerCanBeUpdatedOnAnotherConnection($manager->getId(), 'Master of This Test');
+    }
+
+    /**
+     * @param int    $id
+     * @param string $newName
+     *
+     * @return void
+     *
+     * @throws \Doctrine\Common\Persistence\Mapping\MappingException
+     * @throws \Doctrine\ORM\ORMException
+     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Doctrine\ORM\TransactionRequiredException
+     */
+    private function assertManagerCanBeUpdatedOnAnotherConnection(int $id, string $newName)
+    {
+        $em = $this->_getEntityManager(TestUtil::getConnection());
+
+        /** @var CompanyManager $manager */
+        $manager = $em->find(CompanyManager::class, $id);
+        $manager->setName($newName);
+
+        $em->flush();
+        $em->clear();
+
+        self::assertSame($newName, $em->find(CompanyManager::class, $id)->getName());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -145,6 +145,9 @@ class TypeTest extends OrmFunctionalTestCase
         $dateTimeDb = $this->_em->createQuery('SELECT d FROM Doctrine\Tests\Models\Generic\DateTimeModel d WHERE d.datetime = ?1')
                                 ->setParameter(1, $date, DBALType::DATETIME)
                                 ->getSingleResult();
+
+        $this->assertInstanceOf(\DateTime::class, $dateTimeDb->datetime);
+        $this->assertSame('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
     }
 
     public function testDqlQueryBuilderBindDateTimeInstance()
@@ -164,6 +167,9 @@ class TypeTest extends OrmFunctionalTestCase
                                  ->where('d.datetime = ?1')
                                  ->setParameter(1, $date, DBALType::DATETIME)
                                  ->getQuery()->getSingleResult();
+
+        $this->assertInstanceOf(\DateTime::class, $dateTimeDb->datetime);
+        $this->assertSame('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
     }
 
     public function testTime()

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -15,6 +15,7 @@ class TypeTest extends OrmFunctionalTestCase
     protected function setUp()
     {
         $this->useModelSet('generic');
+
         parent::setUp();
     }
 
@@ -28,7 +29,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT d FROM Doctrine\Tests\Models\Generic\DecimalModel d";
+        $dql = 'SELECT d FROM ' . DecimalModel::class . ' d';
         $decimal = $this->_em->createQuery($dql)->getSingleResult();
 
         $this->assertEquals(0.15, $decimal->decimal);
@@ -48,7 +49,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT b FROM Doctrine\Tests\Models\Generic\BooleanModel b WHERE b.booleanField = true";
+        $dql = 'SELECT b FROM ' . BooleanModel::class . ' b WHERE b.booleanField = true';
         $bool = $this->_em->createQuery($dql)->getSingleResult();
 
         $this->assertTrue($bool->booleanField);
@@ -58,7 +59,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT b FROM Doctrine\Tests\Models\Generic\BooleanModel b WHERE b.booleanField = false";
+        $dql = 'SELECT b FROM ' . BooleanModel::class . ' b WHERE b.booleanField = false';
         $bool = $this->_em->createQuery($dql)->getSingleResult();
 
         $this->assertFalse($bool->booleanField);
@@ -74,7 +75,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT s FROM Doctrine\Tests\Models\Generic\SerializationModel s";
+        $dql = 'SELECT s FROM ' . SerializationModel::class . ' s';
         $serialize = $this->_em->createQuery($dql)->getSingleResult();
 
         $this->assertEquals(["foo" => "bar", "bar" => "baz"], $serialize->array);
@@ -89,7 +90,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $dql = "SELECT s FROM Doctrine\Tests\Models\Generic\SerializationModel s";
+        $dql = 'SELECT s FROM ' . SerializationModel::class . ' s';
         $serialize = $this->_em->createQuery($dql)->getSingleResult();
 
         $this->assertInstanceOf('stdClass', $serialize->object);
@@ -106,7 +107,7 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTimeDb->date);
+        $this->assertInstanceOf(\DateTime::class, $dateTimeDb->date);
         $this->assertEquals('2009-10-01', $dateTimeDb->date->format('Y-m-d'));
     }
 
@@ -121,12 +122,12 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTimeDb->datetime);
+        $this->assertInstanceOf(\DateTime::class, $dateTimeDb->datetime);
         $this->assertEquals('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
 
-        $articles = $this->_em->getRepository( DateTimeModel::class )->findBy( ['datetime' => new \DateTime( "now" )]
-        );
-        $this->assertEquals( 0, count( $articles ) );
+        $articles = $this->_em->getRepository(DateTimeModel::class)
+                              ->findBy(['datetime' => new \DateTime()]);
+        $this->assertEquals(0, count($articles));
     }
 
     public function testDqlQueryBindDateTimeInstance()
@@ -175,7 +176,7 @@ class TypeTest extends OrmFunctionalTestCase
 
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
-        $this->assertInstanceOf('DateTime', $dateTime->time);
-        $this->assertEquals('19:27:20', $dateTime->time->format('H:i:s'));
+        $this->assertInstanceOf(\DateTime::class, $dateTimeDb->time);
+        $this->assertEquals('19:27:20', $dateTimeDb->time->format('H:i:s'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -32,8 +32,8 @@ class TypeTest extends OrmFunctionalTestCase
         $dql = 'SELECT d FROM ' . DecimalModel::class . ' d';
         $decimal = $this->_em->createQuery($dql)->getSingleResult();
 
-        $this->assertEquals(0.15, $decimal->decimal);
-        $this->assertEquals(0.1515, $decimal->highScale);
+        $this->assertSame('0.15', $decimal->decimal);
+        $this->assertSame('0.1515', $decimal->highScale);
     }
 
     /**
@@ -78,7 +78,7 @@ class TypeTest extends OrmFunctionalTestCase
         $dql = 'SELECT s FROM ' . SerializationModel::class . ' s';
         $serialize = $this->_em->createQuery($dql)->getSingleResult();
 
-        $this->assertEquals(["foo" => "bar", "bar" => "baz"], $serialize->array);
+        $this->assertSame(["foo" => "bar", "bar" => "baz"], $serialize->array);
     }
 
     public function testObject()
@@ -108,7 +108,7 @@ class TypeTest extends OrmFunctionalTestCase
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
         $this->assertInstanceOf(\DateTime::class, $dateTimeDb->date);
-        $this->assertEquals('2009-10-01', $dateTimeDb->date->format('Y-m-d'));
+        $this->assertSame('2009-10-01', $dateTimeDb->date->format('Y-m-d'));
     }
 
     public function testDateTime()
@@ -123,11 +123,12 @@ class TypeTest extends OrmFunctionalTestCase
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
         $this->assertInstanceOf(\DateTime::class, $dateTimeDb->datetime);
-        $this->assertEquals('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
+        $this->assertSame('2009-10-02 20:10:52', $dateTimeDb->datetime->format('Y-m-d H:i:s'));
 
         $articles = $this->_em->getRepository(DateTimeModel::class)
                               ->findBy(['datetime' => new \DateTime()]);
-        $this->assertEquals(0, count($articles));
+
+        $this->assertEmpty($articles);
     }
 
     public function testDqlQueryBindDateTimeInstance()
@@ -177,6 +178,6 @@ class TypeTest extends OrmFunctionalTestCase
         $dateTimeDb = $this->_em->find(DateTimeModel::class, $dateTime->id);
 
         $this->assertInstanceOf(\DateTime::class, $dateTimeDb->time);
-        $this->assertEquals('19:27:20', $dateTimeDb->time->format('H:i:s'));
+        $this->assertSame('19:27:20', $dateTimeDb->time->format('H:i:s'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\Tests\DbalTypes\NegativeToPositiveType;
+use Doctrine\Tests\DbalTypes\UpperCaseStringType;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\CustomType\CustomTypeUpperCase;
@@ -12,16 +14,16 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
 {
     protected function setUp()
     {
-        if (DBALType::hasType('upper_case_string')) {
-            DBALType::overrideType('upper_case_string', '\Doctrine\Tests\DbalTypes\UpperCaseStringType');
+        if (DBALType::hasType(UpperCaseStringType::NAME)) {
+            DBALType::overrideType(UpperCaseStringType::NAME, UpperCaseStringType::class);
         } else {
-            DBALType::addType('upper_case_string', '\Doctrine\Tests\DbalTypes\UpperCaseStringType');
+            DBALType::addType(UpperCaseStringType::NAME, UpperCaseStringType::class);
         }
 
-        if (DBALType::hasType('negative_to_positive')) {
-            DBALType::overrideType('negative_to_positive', '\Doctrine\Tests\DbalTypes\NegativeToPositiveType');
+        if (DBALType::hasType(NegativeToPositiveType::NAME)) {
+            DBALType::overrideType(NegativeToPositiveType::NAME, NegativeToPositiveType::class);
         } else {
-            DBALType::addType('negative_to_positive', '\Doctrine\Tests\DbalTypes\NegativeToPositiveType');
+            DBALType::addType(NegativeToPositiveType::NAME, NegativeToPositiveType::class);
         }
 
         $this->useModelSet('customtype');

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
@@ -66,7 +66,7 @@ class ScalarHydratorTest extends HydrationTestCase
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new ScalarHydrator($this->_em);
 
-        $result = $hydrator->hydrateAll($stmt, $rsm);
+        self::assertCount(1, $hydrator->hydrateAll($stmt, $rsm));
     }
 
     /**
@@ -96,6 +96,6 @@ class ScalarHydratorTest extends HydrationTestCase
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new ScalarHydrator($this->_em);
 
-        $result = $hydrator->hydrateAll($stmt, $rsm);
+        self::assertCount(1, $hydrator->hydrateAll($stmt, $rsm));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
@@ -37,8 +37,8 @@ class ScalarHydratorTest extends HydrationTestCase
 
         $result = $hydrator->hydrateAll($stmt, $rsm);
 
-        $this->assertTrue(is_array($result));
-        $this->assertEquals(2, count($result));
+        $this->assertInternalType('array', $result);
+        $this->assertCount(2, $result);
         $this->assertEquals('romanb', $result[0]['u_name']);
         $this->assertEquals(1, $result[0]['u_id']);
         $this->assertEquals('jwage', $result[1]['u_name']);

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use Doctrine\ORM\Internal\Hydration\ScalarHydrator;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -32,7 +33,7 @@ class ScalarHydratorTest extends HydrationTestCase
 
 
         $stmt = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ScalarHydrator($this->_em);
+        $hydrator = new ScalarHydrator($this->_em);
 
         $result = $hydrator->hydrateAll($stmt, $rsm);
 
@@ -63,7 +64,7 @@ class ScalarHydratorTest extends HydrationTestCase
         ];
 
         $stmt = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ScalarHydrator($this->_em);
+        $hydrator = new ScalarHydrator($this->_em);
 
         $result = $hydrator->hydrateAll($stmt, $rsm);
     }
@@ -93,7 +94,7 @@ class ScalarHydratorTest extends HydrationTestCase
         ];
 
         $stmt = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ScalarHydrator($this->_em);
+        $hydrator = new ScalarHydrator($this->_em);
 
         $result = $hydrator->hydrateAll($stmt, $rsm);
     }

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -72,17 +72,22 @@ class SingleScalarHydratorTest extends HydrationTestCase
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new SingleScalarHydrator($this->_em);
 
-        if ($name == 'result1') {
+        if ($name === 'result1') {
             $result = $hydrator->hydrateAll($stmt, $rsm);
             $this->assertEquals('romanb', $result);
-        } else if ($name == 'result2') {
+            return;
+        }
+
+        if ($name === 'result2') {
             $result = $hydrator->hydrateAll($stmt, $rsm);
             $this->assertEquals(1, $result);
-        } else if ($name == 'result3' || $name == 'result4') {
-            try {
-                $result = $hydrator->hydrateAll($stmt, $rsm);
-                $this->fail();
-            } catch (\Doctrine\ORM\NonUniqueResultException $e) {}
+
+            return;
+        }
+
+        if (in_array($name, ['result3', 'result4'], true)) {
+            $this->expectException(NonUniqueResultException::class);
+            $hydrator->hydrateAll($stmt, $rsm);
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -2,6 +2,8 @@
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use Doctrine\ORM\Internal\Hydration\SingleScalarHydrator;
+use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\Tests\Mocks\HydratorMockStatement;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\CMS\CmsUser;
@@ -9,48 +11,49 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 class SingleScalarHydratorTest extends HydrationTestCase
 {
     /** Result set provider for the HYDRATE_SINGLE_SCALAR tests */
-    public static function singleScalarResultSetProvider() {
+    public static function singleScalarResultSetProvider(): array
+    {
         return [
-          // valid
-          [
-              'name' => 'result1',
+            // valid
+            'valid' => [
+                'name'      => 'result1',
                 'resultSet' => [
-                  [
-                      'u__name' => 'romanb'
-                  ]
-                ]
-          ],
-          // valid
-          [
-              'name' => 'result2',
+                    [
+                        'u__name' => 'romanb',
+                    ],
+                ],
+            ],
+            // valid
+            [
+                'name'      => 'result2',
                 'resultSet' => [
-                  [
-                      'u__id' => '1'
-                  ]
-                ]
-          ],
-           // invalid
-           [
-               'name' => 'result3',
+                    [
+                        'u__id' => '1',
+                    ],
+                ],
+            ],
+            // invalid
+            [
+                'name'      => 'result3',
                 'resultSet' => [
-                  [
-                      'u__id' => '1',
-                      'u__name' => 'romanb'
-                  ]
-                ]
-           ],
-           // invalid
-           [
-               'name' => 'result4',
+                    [
+                        'u__id'   => '1',
+                        'u__name' => 'romanb',
+                    ],
+                ],
+            ],
+            // invalid
+            [
+                'name'      => 'result4',
                 'resultSet' => [
-                  [
-                      'u__id' => '1'
-                  ],
-                  [
-                      'u__id' => '2'
-                  ]
-                ]
-           ],
+                    [
+                        'u__id' => '1',
+                    ],
+                    [
+                        'u__id' => '2',
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -67,7 +70,7 @@ class SingleScalarHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__name', 'name');
 
         $stmt = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\SingleScalarHydrator($this->_em);
+        $hydrator = new SingleScalarHydrator($this->_em);
 
         if ($name == 'result1') {
             $result = $hydrator->hydrateAll($stmt, $rsm);

--- a/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php
@@ -22,19 +22,22 @@ class AssignedGeneratorTest extends OrmTestCase
         $this->_assignedGen = new AssignedGenerator;
     }
 
-    public function testThrowsExceptionIfIdNotAssigned()
+    /**
+     * @dataProvider entitiesWithoutId
+     */
+    public function testThrowsExceptionIfIdNotAssigned($entity)
     {
-        try {
-            $entity = new AssignedSingleIdEntity;
-            $this->_assignedGen->generate($this->_em, $entity);
-            $this->fail('Assigned generator did not throw exception even though ID was missing.');
-        } catch (ORMException $expected) {}
+        $this->expectException(ORMException::class);
 
-        try {
-            $entity = new AssignedCompositeIdEntity;
-            $this->_assignedGen->generate($this->_em, $entity);
-            $this->fail('Assigned generator did not throw exception even though ID was missing.');
-        } catch (ORMException $expected) {}
+        $this->_assignedGen->generate($this->_em, $entity);
+    }
+
+    public function entitiesWithoutId(): array
+    {
+        return [
+            'single'    => [new AssignedSingleIdEntity()],
+            'composite' => [new AssignedCompositeIdEntity()],
+        ];
     }
 
     public function testCorrectIdGeneration()

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -61,7 +61,7 @@ class HydrationCompleteHandlerTest extends TestCase
     }
 
     /**
-     * @dataProvider testGetValidListenerInvocationFlags
+     * @dataProvider invocationFlagProvider
      *
      * @param int $listenersFlag
      */
@@ -99,7 +99,7 @@ class HydrationCompleteHandlerTest extends TestCase
     }
 
     /**
-     * @dataProvider testGetValidListenerInvocationFlags
+     * @dataProvider invocationFlagProvider
      *
      * @param int $listenersFlag
      */
@@ -125,7 +125,7 @@ class HydrationCompleteHandlerTest extends TestCase
     }
 
     /**
-     * @dataProvider testGetValidListenerInvocationFlags
+     * @dataProvider invocationFlagProvider
      *
      * @param int $listenersFlag
      */
@@ -187,7 +187,7 @@ class HydrationCompleteHandlerTest extends TestCase
         $this->handler->hydrationComplete();
     }
 
-    public function testGetValidListenerInvocationFlags()
+    public function invocationFlagProvider()
     {
         return [
             [ListenersInvoker::INVOKE_LISTENERS],

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -68,17 +68,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         return $factory;
     }
 
-    public function testLoadMapping()
+    public function testEntityTableNameAndInheritance()
     {
-        return $this->createClassMetadata(User::class);
-    }
+        $class = $this->createClassMetadata(User::class);
 
-    /**
-     * @depends testLoadMapping
-     * @param ClassMetadata $class
-     */
-    public function testEntityTableNameAndInheritance($class)
-    {
         $this->assertEquals('cms_users', $class->getTableName());
         $this->assertEquals(ClassMetadata::INHERITANCE_TYPE_NONE, $class->inheritanceType);
 
@@ -274,14 +267,12 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     /**
      * @group #6129
      *
-     * @depends testLoadMapping
-     *
-     * @param ClassMetadata $class
-     *
      * @return ClassMetadata
      */
-    public function testBooleanValuesForOptionIsSetCorrectly(ClassMetadata $class)
+    public function testBooleanValuesForOptionIsSetCorrectly()
     {
+        $class = $this->createClassMetadata(User::class);
+
         $this->assertInternalType('bool', $class->fieldMappings['id']['options']['unsigned']);
         $this->assertFalse($class->fieldMappings['id']['options']['unsigned']);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -221,10 +221,11 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
 
         $em = $this->_getTestEntityManager();
         $em->getConfiguration()->setMetadataDriverImpl($annotationDriver);
+
         $factory = new ClassMetadataFactory();
         $factory->setEntityManager($em);
 
-        $cm = $factory->getMetadataFor(ChildEntity::class);
+        self::assertInstanceOf(ClassMetadata::class, $factory->getMetadataFor(ChildEntity::class));
     }
 
     public function testInvalidFetchOptionThrowsException()

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -32,7 +32,7 @@ class PHPMappingDriverTest extends AbstractMappingDriverTest
      */
     public function testinvalidEntityOrMappedSuperClassShouldMentionParentClasses()
     {
-        $this->createClassMetadata(DDC889Class::class);
+        self::assertInstanceOf(ClassMetadata::class, $this->createClassMetadata(DDC889Class::class));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -12,7 +12,6 @@ class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
         return new StaticPHPDriver(__DIR__ . DIRECTORY_SEPARATOR . 'php');
     }
 
-
     /**
      * All class with static::loadMetadata are entities for php driver
      *

--- a/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\Common\Persistence\Mapping\Driver\StaticPHPDriver;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\DDC889\DDC889Class;
 
 class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
@@ -19,7 +20,7 @@ class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
      */
     public function testinvalidEntityOrMappedSuperClassShouldMentionParentClasses()
     {
-        $this->createClassMetadata(DDC889Class::class);
+        self::assertInstanceOf(ClassMetadata::class, $this->createClassMetadata(DDC889Class::class));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Collections\ArrayCollection;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\Tests\Mocks\DriverConnectionMock;
 use Doctrine\Tests\Mocks\StatementArrayMock;
@@ -147,7 +148,8 @@ class QueryTest extends OrmTestCase
     public function testIterateWithDistinct()
     {
         $q = $this->_em->createQuery("SELECT DISTINCT u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
-        $q->iterate();
+
+        self::assertInstanceOf(IterableResult::class, $q->iterate());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -24,64 +24,28 @@ class SchemaValidatorTest extends OrmTestCase
         $this->validator = new SchemaValidator($this->em);
     }
 
-    public function testCmsModelSet()
+    /**
+     * @dataProvider modelSetProvider
+     */
+    public function testCmsModelSet(string $path)
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/CMS"
-            ]
-        );
+        $this->em->getConfiguration()
+                 ->getMetadataDriverImpl()
+                 ->addPaths([$path]);
+
         $this->validator->validateMapping();
     }
 
-    public function testCompanyModelSet()
+    public function modelSetProvider(): array
     {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/Company"
-            ]
-        );
-        $this->validator->validateMapping();
-    }
-
-    public function testECommerceModelSet()
-    {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/ECommerce"
-            ]
-        );
-        $this->validator->validateMapping();
-    }
-
-    public function testForumModelSet()
-    {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/Forum"
-            ]
-        );
-        $this->validator->validateMapping();
-    }
-
-    public function testNavigationModelSet()
-    {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/Navigation"
-            ]
-        );
-        $this->validator->validateMapping();
-    }
-
-    public function testRoutingModelSet()
-    {
-        $this->em->getConfiguration()->getMetadataDriverImpl()->addPaths(
-            [
-            __DIR__ . "/../../Models/Routing"
-            ]
-        );
-        $this->validator->validateMapping();
+        return [
+            'cms'        => [__DIR__ . '/../../Models/CMS'],
+            'company'    => [__DIR__ . '/../../Models/Company'],
+            'ecommerce'  => [__DIR__ . '/../../Models/ECommerce'],
+            'forum'      => [__DIR__ . '/../../Models/Forum'],
+            'navigation' => [__DIR__ . '/../../Models/Navigation'],
+            'routing'    => [__DIR__ . '/../../Models/Routing'],
+        ];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -33,7 +33,7 @@ class SchemaValidatorTest extends OrmTestCase
                  ->getMetadataDriverImpl()
                  ->addPaths([$path]);
 
-        $this->validator->validateMapping();
+        self::assertEmpty($this->validator->validateMapping());
     }
 
     public function modelSetProvider(): array

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -248,8 +248,12 @@ class UnitOfWorkTest extends OrmTestCase
         // Schedule user for update without changes
         $this->_unitOfWork->scheduleForUpdate($user);
 
+        self::assertNotEmpty($this->_unitOfWork->getScheduledEntityUpdates());
+
         // This commit should not raise an E_NOTICE
         $this->_unitOfWork->commit();
+
+        self::assertEmpty($this->_unitOfWork->getScheduledEntityUpdates());
     }
 
     /**

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as SqliteDriver;
 use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Types\Type;
@@ -674,12 +675,11 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     /**
      * Gets an EntityManager for testing purposes.
      *
-     * @param \Doctrine\ORM\Configuration   $config       The Configuration to pass to the EntityManager.
-     * @param \Doctrine\Common\EventManager $eventManager The EventManager to pass to the EntityManager.
+     * @return EntityManager
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @throws \Doctrine\ORM\ORMException
      */
-    protected function _getEntityManager($config = null, $eventManager = null) {
+    protected function _getEntityManager(Connection $connection = null) {
         // NOTE: Functional tests use their own shared metadata cache, because
         // the actual database platform used during execution has effect on some
         // metadata mapping behaviors (like the choice of the ID generation).
@@ -732,13 +732,17 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $this->isSecondLevelCacheEnabled = true;
         }
 
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
-            [
-            realpath(__DIR__ . '/Models/Cache'),
-            realpath(__DIR__ . '/Models/GeoNames')
-            ], true));
+        $config->setMetadataDriverImpl(
+            $config->newDefaultAnnotationDriver(
+                [
+                    realpath(__DIR__ . '/Models/Cache'),
+                    realpath(__DIR__ . '/Models/GeoNames')
+                ],
+                true
+            )
+        );
 
-        $conn = static::$_sharedConn;
+        $conn = $connection ?: static::$_sharedConn;
         $conn->getConfiguration()->setSQLLogger($this->_sqlLoggerStack);
 
         // get rid of more global state

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -106,7 +106,6 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\CMS\CmsArticle::class,
             Models\CMS\CmsComment::class,
         ],
-        'forum' => [],
         'company' => [
             Models\Company\CompanyPerson::class,
             Models\Company\CompanyEmployee::class,


### PR DESCRIPTION
This removes all risky warnings by either adding proper assertions or incrementing the assertion count (so we validate that `void` are not throwing any exceptions).

@mbeccati this should fix build as well 😉 