### PR TITLE
Fix Mock Implementations.

### DIFF
--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -109,7 +109,6 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
      */
     public function execute($params = null)
     {
-
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -30,13 +30,12 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
     /**
      * Fetches all rows from the result set.
      *
-     * @param int|null   $fetchStyle
-     * @param int|null   $columnIndex
+     * @param null       $fetchMode
+     * @param null       $fetchArgument
      * @param array|null $ctorArgs
-     *
      * @return array
      */
-    public function fetchAll($fetchStyle = null, $columnIndex = null, array $ctorArgs = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         return $this->_resultSet;
     }
@@ -55,7 +54,7 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchStyle = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         $current = current($this->_resultSet);
         next($this->_resultSet);
@@ -108,8 +107,9 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function execute($params = [])
+    public function execute($params = null)
     {
+
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -30,8 +30,8 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
     /**
      * Fetches all rows from the result set.
      *
-     * @param null       $fetchMode
-     * @param null       $fetchArgument
+     * @param int|null   $fetchMode
+     * @param int|null   $fetchArgument
      * @param array|null $ctorArgs
      * @return array
      */

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -34,12 +34,12 @@ class StatementArrayMock extends StatementMock
         }
     }
 
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
         return $this->_result;
     }
 
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         $current = current($this->_result);
         next($this->_result);

--- a/tests/Doctrine/Tests/Mocks/StatementMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementMock.php
@@ -75,14 +75,14 @@ class StatementMock implements \IteratorAggregate, Statement
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchMode = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
     {
     }
 


### PR DESCRIPTION
The implementations were not using the correct function signatures. Caused some failures, but easily resolved.