### PR TITLE
Throw exception when APCu cache is used by cli commands

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/AbstractCommand.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
+
+use Symfony\Component\Console\Command\Command;
+use Doctrine\Common\Cache;
+
+/**
+ * AbstractCommand to clear cache of the various cache drivers.
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.5
+ */
+abstract class AbstractCommand extends Command
+{
+    /**
+     * @param object $cacheDriver
+     *
+     * @throws \LogicException
+     */
+    protected function checkCacheDriverType($cacheDriver)
+    {
+        if ($cacheDriver instanceof Cache\ApcCache) {
+            $name = 'APC';
+        } elseif ($cacheDriver instanceof Cache\ApcuCache) {
+            $name = 'APCu';
+        } elseif ($cacheDriver instanceof Cache\XcacheCache) {
+            $name = 'XCache';
+        }
+
+        if (isset($name)) {
+            throw new \LogicException(sprintf(
+                'Cannot clear %s Cache from Console, '
+                    . 'its shared in the Webserver memory and not accessible from the CLI.',
+                $name
+            ));
+        }
+    }
+}

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -19,12 +19,9 @@
 
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the metadata cache of the various cache drivers.
@@ -36,7 +33,7 @@ use Doctrine\Common\Cache\XcacheCache;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class MetadataCommand extends Command
+class MetadataCommand extends AbstractCommand
 {
     /**
      * {@inheritdoc}
@@ -87,14 +84,7 @@ EOT
             throw new \InvalidArgumentException('No Metadata cache driver is configured on given EntityManager.');
         }
 
-        if ($cacheDriver instanceof ApcCache) {
-            throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
-
-        if ($cacheDriver instanceof XcacheCache) {
-            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
-
+        $this->checkCacheDriverType($cacheDriver);
 
         $output->writeln('Clearing ALL Metadata cache entries');
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -19,12 +19,9 @@
 
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the query cache of the various cache drivers.
@@ -36,7 +33,7 @@ use Doctrine\Common\Cache\XcacheCache;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class QueryCommand extends Command
+class QueryCommand extends AbstractCommand
 {
     /**
      * {@inheritdoc}
@@ -87,12 +84,7 @@ EOT
             throw new \InvalidArgumentException('No Query cache driver is configured on given EntityManager.');
         }
 
-        if ($cacheDriver instanceof ApcCache) {
-            throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
-        if ($cacheDriver instanceof XcacheCache) {
-            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
+        $this->checkCacheDriverType($cacheDriver);
 
         $output->write('Clearing ALL Query cache entries' . PHP_EOL);
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -19,12 +19,9 @@
 
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Doctrine\Common\Cache\ApcCache;
-use Doctrine\Common\Cache\XcacheCache;
 
 /**
  * Command to clear the result cache of the various cache drivers.
@@ -36,7 +33,7 @@ use Doctrine\Common\Cache\XcacheCache;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-class ResultCommand extends Command
+class ResultCommand extends AbstractCommand
 {
     /**
      * {@inheritdoc}
@@ -87,13 +84,7 @@ EOT
             throw new \InvalidArgumentException('No Result cache driver is configured on given EntityManager.');
         }
 
-        if ($cacheDriver instanceof ApcCache) {
-            throw new \LogicException("Cannot clear APC Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
-
-        if ($cacheDriver instanceof XcacheCache) {
-            throw new \LogicException("Cannot clear XCache Cache from Console, its shared in the Webserver memory and not accessible from the CLI.");
-        }
+        $this->checkCacheDriverType($cacheDriver);
 
         $output->writeln('Clearing ALL Result cache entries');
 

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Tools\Console\Command;
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\CollectionRegionCommand;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group DDC-2183
  */
-class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
+class CollectionRegionCommandTest extends OrmFunctionalTestCase
 {
     /**
      * @var \Symfony\Component\Console\Application

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/EntityRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/EntityRegionCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Tools\Console\Command;
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\EntityRegionCommand;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @group DDC-2183
  */
-class ClearCacheEntityRegionCommandTest extends OrmFunctionalTestCase
+class EntityRegionCommandTest extends OrmFunctionalTestCase
 {
     /**
      * @var \Symfony\Component\Console\Application

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
+
+use Doctrine\Common\Cache;
+use Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Application;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class MetadataCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Application
+     */
+    private $application;
+
+    /**
+     * @var \Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand
+     */
+    private $command;
+
+    protected function setUp()
+    {
+        $this->enableSecondLevelCache();
+        parent::setUp();
+
+        $this->application = new Application();
+        $this->command     = new MetadataCommand();
+
+        $this->application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($this->_em)]));
+
+        $this->application->add($this->command);
+    }
+
+    public function testFlush()
+    {
+        $command    = $this->application->find('orm:clear-cache:metadata');
+        $tester     = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+
+        $expected = <<<'EOT'
+Clearing ALL Metadata cache entries
+Successfully flushed cache entries.
+
+EOT;
+
+        $this->assertEquals($expected, $tester->getDisplay());
+    }
+
+    /**
+     * @param string $cacheClassName
+     * @param string $cacheName
+     *
+     * @dataProvider dataProviderForTestFlushWithNoAccessToCacheException
+     */
+    public function testFlushWithNoAccessToCacheException($cacheClassName, $cacheName)
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Cannot clear %s Cache from Console, its shared in the Webserver memory and not accessible from the CLI.',
+            $cacheName
+        ));
+
+        /* @var $cache Cache\Cache|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->createMock($cacheClassName);
+
+        $this->_em->getConfiguration()->setMetadataCacheImpl($cache);
+
+        $command = $this->application->find('orm:clear-cache:metadata');
+        $tester = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestFlushWithNoAccessToCacheException()
+    {
+        return [
+            [
+                Cache\ApcCache::class,
+                'APC',
+            ],
+            [
+                Cache\XcacheCache::class,
+                'XCache',
+            ],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Application;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @covers \Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand<extended>
+ */
 class MetadataCommandTest extends OrmFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/MetadataCommandTest.php
@@ -95,6 +95,10 @@ EOT;
                 'APC',
             ],
             [
+                Cache\ApcuCache::class,
+                'APCu',
+            ],
+            [
                 Cache\XcacheCache::class,
                 'XCache',
             ],

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Application;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @covers \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand<extended>
+ */
 class QueryCommandTest extends OrmFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
+
+use Doctrine\Common\Cache;
+use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Application;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class QueryCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Application
+     */
+    private $application;
+
+    /**
+     * @var \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand
+     */
+    private $command;
+
+    protected function setUp()
+    {
+        $this->enableSecondLevelCache();
+        parent::setUp();
+
+        $this->application = new Application();
+        $this->command     = new QueryCommand();
+
+        $this->application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($this->_em)]));
+
+        $this->application->add($this->command);
+    }
+
+    public function testFlush()
+    {
+        $command    = $this->application->find('orm:clear-cache:query');
+        $tester     = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+
+        $expected = <<<'EOT'
+Clearing ALL Query cache entries
+Successfully flushed cache entries.
+
+EOT;
+
+        $this->assertEquals($expected, $tester->getDisplay());
+    }
+
+    /**
+     * @param string $cacheClassName
+     * @param string $cacheName
+     *
+     * @dataProvider dataProviderForTestFlushWithNoAccessToCacheException
+     */
+    public function testFlushWithNoAccessToCacheException($cacheClassName, $cacheName)
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Cannot clear %s Cache from Console, its shared in the Webserver memory and not accessible from the CLI.',
+            $cacheName
+        ));
+
+        /* @var $cache Cache\Cache|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->createMock($cacheClassName);
+
+        $this->_em->getConfiguration()->setQueryCacheImpl($cache);
+
+        $command = $this->application->find('orm:clear-cache:query');
+        $tester = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestFlushWithNoAccessToCacheException()
+    {
+        return [
+            [
+                Cache\ApcCache::class,
+                'APC',
+            ],
+            [
+                Cache\XcacheCache::class,
+                'XCache',
+            ],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryCommandTest.php
@@ -95,6 +95,10 @@ EOT;
                 'APC',
             ],
             [
+                Cache\ApcuCache::class,
+                'APCu',
+            ],
+            [
                 Cache\XcacheCache::class,
                 'XCache',
             ],

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/QueryRegionCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctrine\Tests\ORM\Tools\Console\Command;
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Tools\Console\Command\ClearCache\QueryRegionCommand;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -12,7 +12,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 /**
  * @group DDC-2183
  */
-class ClearCacheQueryRegionCommandTest extends OrmFunctionalTestCase
+class QueryRegionCommandTest extends OrmFunctionalTestCase
 {
     /**
      * @var \Symfony\Component\Console\Application

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Application;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @covers \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand<extended>
+ */
 class ResultCommandTest extends OrmFunctionalTestCase
 {
     /**
@@ -33,6 +36,28 @@ class ResultCommandTest extends OrmFunctionalTestCase
         $this->application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($this->_em)]));
 
         $this->application->add($this->command);
+    }
+
+    public function testFlush()
+    {
+        $this->_em->getConfiguration()->setResultCacheImpl(new Cache\ArrayCache());
+
+        $command    = $this->application->find('orm:clear-cache:result');
+        $tester     = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+
+        $expected = <<<'EOT'
+Clearing ALL Result cache entries
+Successfully flushed cache entries.
+
+EOT;
+
+        $this->assertEquals($expected, $tester->getDisplay());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command\ClearCache;
+
+use Doctrine\Common\Cache;
+use Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Application;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class ResultCommandTest extends OrmFunctionalTestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Application
+     */
+    private $application;
+
+    /**
+     * @var \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand
+     */
+    private $command;
+
+    protected function setUp()
+    {
+        $this->enableSecondLevelCache();
+        parent::setUp();
+
+        $this->application = new Application();
+        $this->command     = new ResultCommand();
+
+        $this->application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($this->_em)]));
+
+        $this->application->add($this->command);
+    }
+
+    /**
+     * @param string $cacheClassName
+     * @param string $cacheName
+     *
+     * @dataProvider dataProviderForTestFlushWithNoAccessToCacheException
+     */
+    public function testFlushWithNoAccessToCacheException($cacheClassName, $cacheName)
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Cannot clear %s Cache from Console, its shared in the Webserver memory and not accessible from the CLI.',
+            $cacheName
+        ));
+
+        /* @var $cache Cache\Cache|\PHPUnit_Framework_MockObject_MockObject */
+        $cache = $this->createMock($cacheClassName);
+
+        $this->_em->getConfiguration()->setResultCacheImpl($cache);
+
+        $command = $this->application->find('orm:clear-cache:result');
+        $tester = new CommandTester($command);
+        $tester->execute(
+            [
+                'command' => $command->getName(),
+                '--flush'   => true,
+            ], ['decorated' => false]
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderForTestFlushWithNoAccessToCacheException()
+    {
+        return [
+            [
+                Cache\ApcCache::class,
+                'APC',
+            ],
+            [
+                Cache\XcacheCache::class,
+                'XCache',
+            ],
+        ];
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCache/ResultCommandTest.php
@@ -75,6 +75,10 @@ class ResultCommandTest extends OrmFunctionalTestCase
                 'APC',
             ],
             [
+                Cache\ApcuCache::class,
+                'APCu',
+            ],
+            [
                 Cache\XcacheCache::class,
                 'XCache',
             ],


### PR DESCRIPTION
It isn't possible to access the APCu cache (same behaviour as APC and XCache) from cli.
The commands (MetadataCommand, QueryCommand and ResultCommand) don't throw an exception when APCu cache is used.

**Changes**
- Created a AbstractCommand with one method to check the $cacheDriver and throws a \LogicException for APC, APCu and XCache.
- Created unittests for MetadataCommand, QueryCommand and ResultCommand.
- Moved RegionCache unittests to the corresponding namespace.
