### PR TITLE
Allow internal functions to be overridden.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,17 @@
+# Upgrade to 2.6
+
+## Minor BC BREAK: removed `Doctrine\ORM\Query\Parser#isInternalFunction`
+
+Method `Doctrine\ORM\Query\Parser#isInternalFunction` was removed because 
+the distinction between internal function and user defined DQL was removed.
+[#6500](https://github.com/doctrine/doctrine2/pull/6500)
+
+## Minor BC BREAK: removed `Doctrine\ORM\ORMException#overwriteInternalDQLFunctionNotAllowed`
+
+Method `Doctrine\ORM\Query\Parser#overwriteInternalDQLFunctionNotAllowed` was 
+removed because of the choice to allow users to overwrite internal functions, ie
+`AVG`, `SUM`, `COUNT`, `MIN` and `MAX`. [#6500](https://github.com/doctrine/doctrine2/pull/6500)
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -425,10 +425,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addCustomStringFunction($name, $className)
     {
-        if (Query\Parser::isInternalFunction($name)) {
-            throw ORMException::overwriteInternalDQLFunctionNotAllowed($name);
-        }
-
         $this->_attributes['customStringFunctions'][strtolower($name)] = $className;
     }
 
@@ -483,10 +479,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addCustomNumericFunction($name, $className)
     {
-        if (Query\Parser::isInternalFunction($name)) {
-            throw ORMException::overwriteInternalDQLFunctionNotAllowed($name);
-        }
-
         $this->_attributes['customNumericFunctions'][strtolower($name)] = $className;
     }
 
@@ -541,10 +533,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function addCustomDatetimeFunction($name, $className)
     {
-        if (Query\Parser::isInternalFunction($name)) {
-            throw ORMException::overwriteInternalDQLFunctionNotAllowed($name);
-        }
-
         $this->_attributes['customDatetimeFunctions'][strtolower($name)] = $className;
     }
 

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -420,8 +420,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string|callable $className Class name or a callable that returns the function.
      *
      * @return void
-     *
-     * @throws ORMException
      */
     public function addCustomStringFunction($name, $className)
     {
@@ -474,8 +472,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string|callable $className Class name or a callable that returns the function.
      *
      * @return void
-     *
-     * @throws ORMException
      */
     public function addCustomNumericFunction($name, $className)
     {
@@ -528,8 +524,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string|callable $className Class name or a callable that returns the function.
      *
      * @return void
-     *
-     * @throws ORMException
      */
     public function addCustomDatetimeFunction($name, $className)
     {

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -324,16 +324,6 @@ class ORMException extends Exception
     }
 
     /**
-     * @param string $functionName
-     *
-     * @return ORMException
-     */
-    public static function overwriteInternalDQLFunctionNotAllowed($functionName)
-    {
-        return new self("It is not allowed to overwrite internal function '$functionName' in the DQL parser through user-defined functions.");
-    }
-
-    /**
      * @return ORMException
      */
     public static function cantUseInOperatorOnCompositeKeys()

--- a/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
@@ -29,7 +29,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-class AvgFunction extends FunctionNode
+final class AvgFunction extends FunctionNode
 {
     /**
      * @var AggregateExpression

--- a/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
@@ -26,8 +26,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 /**
  * "AVG" "(" ["DISTINCT"] StringPrimary ")"
  *
- * @link    www.doctrine-project.org
- * @since   2.0
+ * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
 class AvgFunction extends FunctionNode
@@ -35,12 +34,12 @@ class AvgFunction extends FunctionNode
     /**
      * @var AggregateExpression
      */
-    public $aggregateExpression;
+    private $aggregateExpression;
 
     /**
      * @inheritDoc
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }
@@ -48,7 +47,7 @@ class AvgFunction extends FunctionNode
     /**
      * @inheritDoc
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * "AVG" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Mathew Davies <thepixeldeveloper@icloud.com>
+ */
+class AvgFunction extends FunctionNode
+{
+    /**
+     * @var AggregateExpression
+     */
+    public $aggregateExpression;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->aggregateExpression->dispatch($sqlWalker);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(Parser $parser)
+    {
+        $this->aggregateExpression = $parser->AggregateExpression();
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * "COUNT" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Mathew Davies <thepixeldeveloper@icloud.com>
+ */
+class CountFunction extends FunctionNode
+{
+    /**
+     * @var AggregateExpression
+     */
+    public $aggregateExpression;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->aggregateExpression->dispatch($sqlWalker);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(Parser $parser)
+    {
+        $this->aggregateExpression = $parser->AggregateExpression();
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -29,7 +29,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-class CountFunction extends FunctionNode
+final class CountFunction extends FunctionNode
 {
     /**
      * @var AggregateExpression

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -26,8 +26,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 /**
  * "COUNT" "(" ["DISTINCT"] StringPrimary ")"
  *
- * @link    www.doctrine-project.org
- * @since   2.0
+ * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
 class CountFunction extends FunctionNode
@@ -35,12 +34,12 @@ class CountFunction extends FunctionNode
     /**
      * @var AggregateExpression
      */
-    public $aggregateExpression;
+    private $aggregateExpression;
 
     /**
      * @inheritDoc
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }
@@ -48,7 +47,7 @@ class CountFunction extends FunctionNode
     /**
      * @inheritDoc
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
@@ -26,8 +26,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 /**
  * "MAX" "(" ["DISTINCT"] StringPrimary ")"
  *
- * @link    www.doctrine-project.org
- * @since   2.0
+ * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
 class MaxFunction extends FunctionNode
@@ -35,12 +34,12 @@ class MaxFunction extends FunctionNode
     /**
      * @var AggregateExpression
      */
-    public $aggregateExpression;
+    private $aggregateExpression;
 
     /**
      * @inheritDoc
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }
@@ -48,7 +47,7 @@ class MaxFunction extends FunctionNode
     /**
      * @inheritDoc
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
@@ -29,7 +29,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-class MaxFunction extends FunctionNode
+final class MaxFunction extends FunctionNode
 {
     /**
      * @var AggregateExpression

--- a/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * "MAX" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Mathew Davies <thepixeldeveloper@icloud.com>
+ */
+class MaxFunction extends FunctionNode
+{
+    /**
+     * @var AggregateExpression
+     */
+    public $aggregateExpression;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->aggregateExpression->dispatch($sqlWalker);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(Parser $parser)
+    {
+        $this->aggregateExpression = $parser->AggregateExpression();
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
@@ -29,7 +29,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-class MinFunction extends FunctionNode
+final class MinFunction extends FunctionNode
 {
     /**
      * @var AggregateExpression

--- a/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * "MIN" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Mathew Davies <thepixeldeveloper@icloud.com>
+ */
+class MinFunction extends FunctionNode
+{
+    /**
+     * @var AggregateExpression
+     */
+    public $aggregateExpression;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->aggregateExpression->dispatch($sqlWalker);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(Parser $parser)
+    {
+        $this->aggregateExpression = $parser->AggregateExpression();
+    }
+}

--- a/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
@@ -26,8 +26,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 /**
  * "MIN" "(" ["DISTINCT"] StringPrimary ")"
  *
- * @link    www.doctrine-project.org
- * @since   2.0
+ * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
 class MinFunction extends FunctionNode
@@ -35,12 +34,12 @@ class MinFunction extends FunctionNode
     /**
      * @var AggregateExpression
      */
-    public $aggregateExpression;
+    private $aggregateExpression;
 
     /**
      * @inheritDoc
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }
@@ -48,7 +47,7 @@ class MinFunction extends FunctionNode
     /**
      * @inheritDoc
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
@@ -29,7 +29,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-class SumFunction extends FunctionNode
+final class SumFunction extends FunctionNode
 {
     /**
      * @var AggregateExpression

--- a/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
@@ -26,8 +26,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
 /**
  * "SUM" "(" ["DISTINCT"] StringPrimary ")"
  *
- * @link    www.doctrine-project.org
- * @since   2.0
+ * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
 class SumFunction extends FunctionNode
@@ -35,12 +34,12 @@ class SumFunction extends FunctionNode
     /**
      * @var AggregateExpression
      */
-    public $aggregateExpression;
+    private $aggregateExpression;
 
     /**
      * @inheritDoc
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }
@@ -48,7 +47,7 @@ class SumFunction extends FunctionNode
     /**
      * @inheritDoc
      */
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }

--- a/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Query\AST\Functions;
+
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\AST\AggregateExpression;
+
+/**
+ * "SUM" "(" ["DISTINCT"] StringPrimary ")"
+ *
+ * @link    www.doctrine-project.org
+ * @since   2.0
+ * @author  Mathew Davies <thepixeldeveloper@icloud.com>
+ */
+class SumFunction extends FunctionNode
+{
+    /**
+     * @var AggregateExpression
+     */
+    public $aggregateExpression;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return $this->aggregateExpression->dispatch($sqlWalker);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function parse(Parser $parser)
+    {
+        $this->aggregateExpression = $parser->AggregateExpression();
+    }
+}

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -3377,7 +3377,7 @@ class Parser
         $funcName = strtolower($token['value']);
 
         $customFunctionDeclaration = $this->CustomFunctionDeclaration();
-        
+
         // Check for custom functions functions first!
         switch (true) {
             case $customFunctionDeclaration !== null:

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -3376,8 +3376,13 @@ class Parser
         $token = $this->lexer->lookahead;
         $funcName = strtolower($token['value']);
 
-        // Check for built-in functions first!
+        $customFunctionDeclaration = $this->CustomFunctionDeclaration();
+        
+        // Check for custom functions functions first!
         switch (true) {
+            case $customFunctionDeclaration !== null:
+                return $customFunctionDeclaration;
+            
             case (isset(self::$_STRING_FUNCTIONS[$funcName])):
                 return $this->FunctionsReturningStrings();
 
@@ -3388,7 +3393,7 @@ class Parser
                 return $this->FunctionsReturningDatetime();
 
             default:
-                return $this->CustomFunctionDeclaration();
+                $this->syntaxError('known function', $token);
         }
     }
 
@@ -3416,7 +3421,7 @@ class Parser
                 return $this->CustomFunctionsReturningDatetime();
 
             default:
-                $this->syntaxError('known function', $token);
+                return null;
         }
     }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1579,16 +1579,6 @@ class SqlWalker implements TreeWalker
                 $sql .= $this->walkPathExpression($expr);
                 break;
 
-            case ($expr instanceof AST\Functions\AvgFunction):
-            case ($expr instanceof AST\Functions\CountFunction):
-            case ($expr instanceof AST\Functions\MaxFunction):
-            case ($expr instanceof AST\Functions\MinFunction):
-            case ($expr instanceof AST\Functions\SumFunction):
-                $alias = $simpleSelectExpression->fieldIdentificationVariable ?: $this->scalarResultCounter++;
-
-                $sql .= $expr->dispatch($this) . ' AS dctrn__' . $alias;
-                break;
-
             case ($expr instanceof AST\Subselect):
                 $alias = $simpleSelectExpression->fieldIdentificationVariable ?: $this->scalarResultCounter++;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1579,10 +1579,14 @@ class SqlWalker implements TreeWalker
                 $sql .= $this->walkPathExpression($expr);
                 break;
 
-            case ($expr instanceof AST\AggregateExpression):
+            case ($expr instanceof AST\Functions\AvgFunction):
+            case ($expr instanceof AST\Functions\CountFunction):
+            case ($expr instanceof AST\Functions\MaxFunction):
+            case ($expr instanceof AST\Functions\MinFunction):
+            case ($expr instanceof AST\Functions\SumFunction):
                 $alias = $simpleSelectExpression->fieldIdentificationVariable ?: $this->scalarResultCounter++;
 
-                $sql .= $this->walkAggregateExpression($expr) . ' AS dctrn__' . $alias;
+                $sql .= $expr->dispatch($this) . ' AS dctrn__' . $alias;
                 break;
 
             case ($expr instanceof AST\Subselect):

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -265,8 +265,6 @@ class ConfigurationTest extends TestCase
         $this->assertSame(null, $this->configuration->getCustomStringFunction('NonExistingFunction'));
         $this->configuration->setCustomStringFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomStringFunction('OtherFunctionName'));
-        $this->expectException(ORMException::class);
-        $this->configuration->addCustomStringFunction('concat', __CLASS__);
     }
 
     public function testAddGetCustomNumericFunction()
@@ -276,8 +274,6 @@ class ConfigurationTest extends TestCase
         $this->assertSame(null, $this->configuration->getCustomNumericFunction('NonExistingFunction'));
         $this->configuration->setCustomNumericFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomNumericFunction('OtherFunctionName'));
-        $this->expectException(ORMException::class);
-        $this->configuration->addCustomNumericFunction('abs', __CLASS__);
     }
 
     public function testAddGetCustomDatetimeFunction()
@@ -287,8 +283,6 @@ class ConfigurationTest extends TestCase
         $this->assertSame(null, $this->configuration->getCustomDatetimeFunction('NonExistingFunction'));
         $this->configuration->setCustomDatetimeFunctions(['OtherFunctionName' => __CLASS__]);
         $this->assertSame(__CLASS__, $this->configuration->getCustomDatetimeFunction('OtherFunctionName'));
-        $this->expectException(ORMException::class);
-        $this->configuration->addCustomDatetimeFunction('date_add', __CLASS__);
     }
 
     public function testAddGetCustomHydrationMode()

--- a/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
@@ -94,12 +94,12 @@ class CustomCount extends FunctionNode
      */
     private $aggregateExpression;
 
-    public function parse(Parser $parser)
+    public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
     }
 
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         return $this->aggregateExpression->dispatch($sqlWalker);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php
@@ -58,12 +58,11 @@ class CustomFunctionsTest extends OrmFunctionalTestCase
 
         $this->_em->getConfiguration()->addCustomStringFunction('COUNT', 'Doctrine\Tests\ORM\Functional\CustomCount');
 
-        $query = $this->_em->createQuery('SELECT COUNT(u.id) FROM Doctrine\Tests\Models\CMS\CmsUser u');
+        $query = $this->_em->createQuery('SELECT COUNT(DISTINCT u.id) FROM Doctrine\Tests\Models\CMS\CmsUser u');
 
-        $users = $query->getResult();
+        $usersCount = $query->getSingleScalarResult();
 
-        $this->assertEquals(1, count($users));
-        $this->assertSame($user, $users[0]);
+        $this->assertEquals(1, $usersCount);
     }
 }
 
@@ -91,20 +90,17 @@ class NoOp extends FunctionNode
 class CustomCount extends FunctionNode
 {
     /**
-     * @var PathExpression
+     * @var Query\AST\AggregateExpression
      */
-    private $field;
+    private $aggregateExpression;
 
     public function parse(Parser $parser)
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
-        $this->field = $parser->StringExpression();
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $this->aggregateExpression = $parser->AggregateExpression();
     }
 
     public function getSql(SqlWalker $sqlWalker)
     {
-        return $this->field->dispatch($sqlWalker);
+        return $this->aggregateExpression->dispatch($sqlWalker);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1031,7 +1031,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     {
         $this->assertSqlGeneration(
             "SELECT u.name, (SELECT COUNT(p.phonenumber) FROM Doctrine\Tests\Models\CMS\CmsPhonenumber p WHERE p.phonenumber = 1234) pcount FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.name = 'jon'",
-            "SELECT c0_.name AS name_0, (SELECT COUNT(c1_.phonenumber) AS dctrn__1 FROM cms_phonenumbers c1_ WHERE c1_.phonenumber = 1234) AS sclr_1 FROM cms_users c0_ WHERE c0_.name = 'jon'"
+            "SELECT c0_.name AS name_0, (SELECT COUNT(c1_.phonenumber) AS sclr_2 FROM cms_phonenumbers c1_ WHERE c1_.phonenumber = 1234) AS sclr_1 FROM cms_users c0_ WHERE c0_.name = 'jon'"
         );
     }
 
@@ -1198,7 +1198,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     {
         $this->assertSqlGeneration(
             "SELECT u.name, (SELECT COUNT(cfc.id) total FROM Doctrine\Tests\Models\Company\CompanyFixContract cfc) as cfc_count FROM Doctrine\Tests\Models\CMS\CmsUser u",
-            "SELECT c0_.name AS name_0, (SELECT COUNT(c1_.id) AS dctrn__total FROM company_contracts c1_ WHERE c1_.discr IN ('fix')) AS sclr_1 FROM cms_users c0_"
+            "SELECT c0_.name AS name_0, (SELECT COUNT(c1_.id) AS sclr_2 FROM company_contracts c1_ WHERE c1_.discr IN ('fix')) AS sclr_1 FROM cms_users c0_"
         );
     }
 
@@ -1750,7 +1750,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
         $this->assertSqlGeneration(
             'SELECT u1 FROM Doctrine\Tests\Models\CMS\CmsUser u1 WHERE COUNT(u1.id) = ( SELECT SUM(u2.id) FROM Doctrine\Tests\Models\CMS\CmsUser u2 )',
-            'SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 FROM cms_users c0_ WHERE COUNT(c0_.id) = (SELECT SUM(c1_.id) AS dctrn__1 FROM cms_users c1_)'
+            'SELECT c0_.id AS id_0, c0_.status AS status_1, c0_.username AS username_2, c0_.name AS name_3 FROM cms_users c0_ WHERE COUNT(c0_.id) = (SELECT SUM(c1_.id) AS sclr_4 FROM cms_users c1_)'
         );
         $this->assertSqlGeneration(
             'SELECT u1 FROM Doctrine\Tests\Models\CMS\CmsUser u1 WHERE COUNT(u1.id) <= ( SELECT SUM(u2.id) + COUNT(u2.email) FROM Doctrine\Tests\Models\CMS\CmsUser u2 )',

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -330,7 +330,7 @@ ORDER BY b.id DESC'
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0 FROM (SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS dctrn__1 FROM BlogPost b1_) = 1)) dctrn_result ORDER BY id_0 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT b0_.id AS id_0, b0_.author_id AS author_id_1, b0_.category_id AS category_id_2 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS sclr_3 FROM BlogPost b1_) = 1)) dctrn_result ORDER BY id_0 DESC',
             $query->getSQL()
         );
     }
@@ -346,7 +346,7 @@ ORDER BY b.id DESC'
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0, MIN(sclr_1) AS dctrn_minrownum FROM (SELECT b0_.id AS id_0, ROW_NUMBER() OVER(ORDER BY b0_.id DESC) AS sclr_1, b0_.author_id AS author_id_2, b0_.category_id AS category_id_3 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS dctrn__1 FROM BlogPost b1_) = 1)) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
+            'SELECT DISTINCT id_0, MIN(sclr_1) AS dctrn_minrownum FROM (SELECT b0_.id AS id_0, ROW_NUMBER() OVER(ORDER BY b0_.id DESC) AS sclr_1, b0_.author_id AS author_id_2, b0_.category_id AS category_id_3 FROM BlogPost b0_ WHERE ((SELECT COUNT(b1_.id) AS sclr_4 FROM BlogPost b1_) = 1)) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
             $query->getSQL()
         );
     }
@@ -390,7 +390,7 @@ ORDER BY b.id DESC'
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2 FROM Author a0_) dctrn_result ORDER BY sclr_2 DESC',
+            'SELECT DISTINCT id_0 FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS sclr_3 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2 FROM Author a0_) dctrn_result ORDER BY sclr_2 DESC',
             $query->getSQL()
         );
     }
@@ -415,7 +415,7 @@ ORDER BY b.id DESC'
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
         $this->assertEquals(
-            'SELECT DISTINCT id_0, MIN(sclr_3) AS dctrn_minrownum FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS dctrn__2 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS sclr_3 FROM Author a0_) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
+            'SELECT DISTINCT id_0, MIN(sclr_4) AS dctrn_minrownum FROM (SELECT a0_.id AS id_0, a0_.name AS name_1, (SELECT MIN(m1_.title) AS sclr_3 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS sclr_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS sclr_5 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS sclr_4 FROM Author a0_) dctrn_result GROUP BY id_0 ORDER BY dctrn_minrownum ASC',
             $query->getSQL()
         );
     }
@@ -440,7 +440,7 @@ ORDER BY b.id DESC'
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
         $this->assertEquals(
-            'SELECT DISTINCT ID_0, MIN(SCLR_3) AS dctrn_minrownum FROM (SELECT a0_.id AS ID_0, a0_.name AS NAME_1, (SELECT MIN(m1_.title) AS dctrn__1 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS SCLR_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS dctrn__2 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS SCLR_3 FROM Author a0_) dctrn_result GROUP BY ID_0 ORDER BY dctrn_minrownum ASC',
+            'SELECT DISTINCT ID_0, MIN(SCLR_4) AS dctrn_minrownum FROM (SELECT a0_.id AS ID_0, a0_.name AS NAME_1, (SELECT MIN(m1_.title) AS SCLR_3 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) AS SCLR_2, ROW_NUMBER() OVER(ORDER BY (SELECT MIN(m1_.title) AS SCLR_5 FROM MyBlogPost m1_ WHERE m1_.author_id = a0_.id) DESC) AS SCLR_4 FROM Author a0_) dctrn_result GROUP BY ID_0 ORDER BY dctrn_minrownum ASC',
             $query->getSQL()
         );
     }


### PR DESCRIPTION
Background
------------

This came about because we're writing a driver for [PrestoDB](https://prestodb.io) and wanted to implement windowing for the aggregate functions. This is fine for anything new, but we struggled when trying to add windowing support for count, avg, etc ... 

> All Aggregate Functions can be used as window functions by adding the OVER clause. The aggregate function is computed for each row over the rows within the current row’s window frame.

Source: [6.15. Window Functions — Presto 0.178 Documentation](https://prestodb.io/docs/current/functions/window.html)

Solution
--------

Obvious solution for us was to have the ability to override the internal aggregate functions. We moved the internal aggregate functions into the `$_NUMERIC_FUNCTIONS` property so they can be overridden; They were handled as a special case before.

The only part we weren't sure of was the `dctrn` alias used: https://github.com/SamKnows/doctrine2/pull/1/files#diff-0c8825d1265a66bb8b20f3d99c276961 

If that doesn't matter and we can go with `sclr`, then this is another path that can be removed.

Thoughts? 

PS. First big PR for the Doctrine internals 👍 