### PR TITLE
Fix metadata field order stability (failing test)

### DIFF
--- a/tests/Doctrine/Tests/Models/PropertyOrder/Admin.php
+++ b/tests/Doctrine/Tests/Models/PropertyOrder/Admin.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Doctrine\Tests\Models\PropertyOrder;
+
+/**
+ * @Entity
+ */
+class Admin extends User
+{
+    /**
+     * @Column(type="string")
+     */
+    public $email;
+}

--- a/tests/Doctrine/Tests/Models/PropertyOrder/Group.php
+++ b/tests/Doctrine/Tests/Models/PropertyOrder/Group.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Doctrine\Tests\Models\PropertyOrder;
+
+/**
+ * @Entity
+ */
+class Group
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/Models/PropertyOrder/User.php
+++ b/tests/Doctrine/Tests/Models/PropertyOrder/User.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\PropertyOrder;
+
+/**
+ * @Entity
+ */
+class User
+{
+    /**
+     * @Column(type="integer")
+     * @Id
+     */
+    public $id;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
+
+    /**
+     * @ManyToOne(targetEntity=Group::class)
+     */
+    public $group;
+}


### PR DESCRIPTION
A simplified, currently failing test case for #6502 .

Didn't find an easy way to fix this yet. The two paths to load the metadata are quite different and more drastic changes might break something else.

The test is more implementation specific than I'd like, but in practice the `reflFields` property is used directly.