### PR TITLE
#6499 commit order must consider non-nullability of join columns as prioritised over nullable join columns

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1154,7 +1154,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $joinColumns = reset($assoc['joinColumns']);
 
-                $calc->addDependency($targetClass->name, $class->name, (int)empty($joinColumns['nullable']));
+                $calc->addDependency($targetClass->name, $class->name, (int) ! ( ! isset($joinColumns['nullable']) || $joinColumns['nullable'] === true));
 
                 // If the target class has mapped subclasses, these share the same dependency.
                 if ( ! $targetClass->subClasses) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6499
+ */
+class DDC6499Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+            $this->_em->getClassMetadata(DDC6499A::class),
+            $this->_em->getClassMetadata(DDC6499B::class),
+            ]
+        );
+    }
+
+    /**
+     * Test for the bug described in issue #6499.
+     */
+    public function testIssue()
+    {
+        $a = new DDC6499A();
+        $this->_em->persist($a);
+
+        $b = new DDC6499B();
+        $a->setB($b);
+        $this->_em->persist($b);
+
+        $this->_em->flush();
+
+        // Issue #6499 will result in a Integrity constraint violation before reaching this point
+        $this->assertEquals(true, true);
+    }
+}
+
+/** @Entity */
+class DDC6499A
+{
+    /**
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="DDC6499B", mappedBy="a", cascade={"persist", "remove"}, orphanRemoval=true)
+     */
+    private $bs;
+
+    /**
+     * @OneToOne(targetEntity="DDC6499B", cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     */
+    private $b;
+
+    /**
+     * DDC6499A constructor.
+     */
+    public function __construct()
+    {
+        $this->bs = new ArrayCollection();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return DDC6499B[]|ArrayCollection
+     */
+    public function getBs()
+    {
+        return $this->bs;
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function addB(DDC6499B $b)
+    {
+        if ($this->bs->contains($b)) return;
+
+        $this->bs->add($b);
+
+        // Update owning side
+        $b->setA($this);
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function removeB(DDC6499B $b)
+    {
+        if (!$this->bs->contains($b)) return;
+
+        $this->bs->removeElement($b);
+
+        // Not updating owning side due to orphan removal
+    }
+
+    /**
+     * @return DDC6499B
+     */
+    public function getB()
+    {
+        return $this->b;
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function setB(DDC6499B $b)
+    {
+        $this->b = $b;
+    }
+}
+
+/** @Entity */
+class DDC6499B
+{
+    /**
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     */
+    private $id;
+
+    /**
+     * @ManyToOne(targetEntity="DDC6499A", inversedBy="bs", cascade={"persist"})
+     */
+    private $a;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return DDC6499A
+     */
+    public function getA()
+    {
+        return $this->a;
+    }
+
+    /**
+     * @param DDC6499A $a
+     */
+    public function setA(DDC6499A $a)
+    {
+        $this->a = $a;
+    }
+}


### PR DESCRIPTION
As suggested by @lcobucci, I created a PR with a minimal test example.

While working on the test example I looked into the code and found the (probable) cause for this issue and proposed a fix for it in a second commit.

The issue seems to originate from the part of the code in UnitOfWork which calculates the weight for new dependencies in the graph based on whether or not the `nullable` clause on join columns is set and to which value.

In particular the part `(int)empty($joinColumns['nullable'])` which to me seems incorrect. With the current implementation in `master` the case where the `nullable` property on the join column is set to false (so, the relation is mandatory) yields the same weight as when the `nullable` property is not defined. But when the `nullable` property is not defined, the documention states that the default would be `nullable === true`.

Below, you find a simple truth table breakdown of the specific part of the code (for the possible values for `$joinColumns['nullable']`.

| `(int)` 	| `empty`	| `( $joinColumns['nullable'] )` 	|
|-------	|-------	|------------------------------	|
| 0     	| false 	| true                         	|
| 1     	| true  	| false                        	|
| 1     	| true  	| unset/null/etc.              	|

I tried to keep the (in-line) fix as compact as possible. All test keep running and the added test for this issue also succeeds after applying the fix. Before applying the fix, it throws a ConstraintViolationException and tries to insert null for a mandatory foreign key.

Since I'm not completely familiar with the codebase, please look into whether this does not influence other parts of the code. If there's anything I can do to assist, let me know.