### PR TITLE
Fix OrderBy annotation with association

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -410,7 +410,16 @@ class SqlWalker implements TreeWalker
             $persister = $this->em->getUnitOfWork()->getEntityPersister($qComp['metadata']->name);
 
             foreach ($qComp['relation']['orderBy'] as $fieldName => $orientation) {
-                $columnName = $this->quoteStrategy->getColumnName($fieldName, $qComp['metadata'], $this->platform);
+                if ($qComp['metadata']->hasField($fieldName)) {
+                    $columnName = $this->quoteStrategy->getColumnName($fieldName, $qComp['metadata'], $this->platform);
+                } else {
+                    $columnName = $this->quoteStrategy->getJoinColumnName(
+                        $qComp['metadata']->associationMappings[$fieldName]['joinColumns'][0],
+                        $qComp['metadata'],
+                        $this->platform
+                    );
+                }
+
                 $tableName  = ($qComp['metadata']->isInheritanceTypeJoined())
                     ? $persister->getOwningTable($fieldName)
                     : $qComp['metadata']->getTableName();


### PR DESCRIPTION
According to SchemaValidator, the `@OrderBy` annotation can have either [a field name or an association name](https://github.com/doctrine/doctrine2/blob/43009682a49c9fa7fe1bacabf22a7230aa524e1f/lib/Doctrine/ORM/Tools/SchemaValidator.php#L231).

However if association is used it doesn't work correctly and the result is an `Undefined index` error in `DefaultQuoteStrategy::getColumnName()` - obviously since the association is not in `$classMetadata->fieldMappings`.

Of course some test is needed. But first I'd like to know how (if at all) to handle associations with more than one join column.