### PR TITLE
Case insensitive like

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "doctrine/orm",
+    "name": "okoehler/orm",
     "type": "library",
     "description": "Object-Relational-Mapper for PHP",
     "keywords": ["orm", "database"],

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
-        "doctrine/collections": "^1.4",
+        "doctrine/collections": "dev-master",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
@@ -24,6 +24,12 @@
         "doctrine/annotations": "~1.4",
         "symfony/console": "~3.0|~4.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/okoehler/collections"
+        }
+    ],
     "require-dev": {
         "symfony/yaml": "~3.0|~4.0",
         "phpunit/phpunit": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "okoehler/orm",
+    "name": "doctrine/orm",
     "type": "library",
     "description": "Object-Relational-Mapper for PHP",
     "keywords": ["orm", "database"],
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
-        "doctrine/collections": "dev-master",
+        "doctrine/collections": "^1.4",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": "^2.7.1",
@@ -24,12 +24,6 @@
         "doctrine/annotations": "~1.4",
         "symfony/console": "~3.0|~4.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/okoehler/collections"
-        }
-    ],
     "require-dev": {
         "symfony/yaml": "~3.0|~4.0",
         "phpunit/phpunit": "^6.0"

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -97,6 +97,7 @@ class BasicEntityPersister implements EntityPersister
         Comparison::IN          => 'IN (%s)',
         Comparison::NIN         => 'NOT IN (%s)',
         Comparison::CONTAINS    => 'LIKE %s',
+        Comparison::CONTAINS_CI => 'LIKE LOWER(%s)',
         Comparison::STARTS_WITH => 'LIKE %s',
         Comparison::ENDS_WITH   => 'LIKE %s',
     ];
@@ -1614,6 +1615,10 @@ class BasicEntityPersister implements EntityPersister
                     $selectedColumns[] = $column . ' IS NOT NULL';
 
                     continue;
+                }
+
+                if ($comparison === Comparison::CONTAINS_CI) {
+                    $column = 'LOWER(' . $column . ')';
                 }
 
                 $selectedColumns[] = $column . ' ' . sprintf(self::$comparisonMap[$comparison], $placeholder);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -97,7 +97,7 @@ class BasicEntityPersister implements EntityPersister
         Comparison::IN          => 'IN (%s)',
         Comparison::NIN         => 'NOT IN (%s)',
         Comparison::CONTAINS    => 'LIKE %s',
-        Comparison::CONTAINS_CI => 'LIKE %s',
+        Comparison::ICONTAINS   => 'LIKE %s',
         Comparison::STARTS_WITH => 'LIKE %s',
         Comparison::ENDS_WITH   => 'LIKE %s',
     ];
@@ -1617,7 +1617,7 @@ class BasicEntityPersister implements EntityPersister
                     continue;
                 }
 
-                if ($comparison === Comparison::CONTAINS_CI) {
+                if ($comparison === Comparison::ICONTAINS) {
                     $column = $this->platform->getLowerExpression($column);
                 }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -97,7 +97,7 @@ class BasicEntityPersister implements EntityPersister
         Comparison::IN          => 'IN (%s)',
         Comparison::NIN         => 'NOT IN (%s)',
         Comparison::CONTAINS    => 'LIKE %s',
-        Comparison::CONTAINS_CI => 'LIKE LOWER(%s)',
+        Comparison::CONTAINS_CI => 'LIKE %s',
         Comparison::STARTS_WITH => 'LIKE %s',
         Comparison::ENDS_WITH   => 'LIKE %s',
     ];
@@ -1618,7 +1618,7 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 if ($comparison === Comparison::CONTAINS_CI) {
-                    $column = 'LOWER(' . $column . ')';
+                    $column = $this->platform->getLowerExpression($column);
                 }
 
                 $selectedColumns[] = $column . ' ' . sprintf(self::$comparisonMap[$comparison], $placeholder);

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -113,6 +113,7 @@ class SqlValueVisitor extends ExpressionVisitor
 
         switch ($comparison->getOperator()) {
             case Comparison::CONTAINS:
+            case Comparison::CONTAINS_CI:
                 return "%{$value}%";
 
             case Comparison::STARTS_WITH:

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -113,8 +113,10 @@ class SqlValueVisitor extends ExpressionVisitor
 
         switch ($comparison->getOperator()) {
             case Comparison::CONTAINS:
-            case Comparison::ICONTAINS:
                 return "%{$value}%";
+
+            case Comparison::ICONTAINS:
+                return '%' . mb_strtolower($value) . '%';
 
             case Comparison::STARTS_WITH:
                 return "{$value}%";

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -113,7 +113,7 @@ class SqlValueVisitor extends ExpressionVisitor
 
         switch ($comparison->getOperator()) {
             case Comparison::CONTAINS:
-            case Comparison::CONTAINS_CI:
+            case Comparison::ICONTAINS:
                 return "%{$value}%";
 
             case Comparison::STARTS_WITH:

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -186,8 +186,8 @@ class QueryExpressionVisitor extends ExpressionVisitor
                 $this->parameters[] = $parameter;
 
                 return $this->expr->like($field, $placeholder);
-            case Comparison::CONTAINS_CI:
-                $parameter->setValue('%' . strtolower($parameter->getValue()) . '%', $parameter->getType());
+            case Comparison::ICONTAINS:
+                $parameter->setValue('%' . mb_strtolower($parameter->getValue()) . '%', $parameter->getType());
                 $this->parameters[] = $parameter;
 
                 return $this->expr->like($field, $placeholder);

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -182,6 +182,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
 
                 return $this->expr->neq($field, $placeholder);
             case Comparison::CONTAINS:
+            case Comparison::CONTAINS_CI:
                 $parameter->setValue('%' . $parameter->getValue() . '%', $parameter->getType());
                 $this->parameters[] = $parameter;
 

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -182,8 +182,12 @@ class QueryExpressionVisitor extends ExpressionVisitor
 
                 return $this->expr->neq($field, $placeholder);
             case Comparison::CONTAINS:
-            case Comparison::CONTAINS_CI:
                 $parameter->setValue('%' . $parameter->getValue() . '%', $parameter->getType());
+                $this->parameters[] = $parameter;
+
+                return $this->expr->like($field, $placeholder);
+            case Comparison::CONTAINS_CI:
+                $parameter->setValue('%' . strtolower($parameter->getValue()) . '%', $parameter->getType());
                 $this->parameters[] = $parameter;
 
                 return $this->expr->like($field, $placeholder);

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php
@@ -183,4 +183,34 @@ class EntityRepositoryCriteriaTest extends OrmFunctionalTestCase
 
         $this->assertFalse($tweets->isInitialized());
     }
+
+    public function testCanIContainsWithoutLoadingCollection()
+    {
+        $user = new User();
+        $user->name = 'Marco';
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $tweet = new Tweet();
+        $tweet->author = $user;
+        $tweet->content = 'Criteria is awesome';
+        $this->_em->persist($tweet);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        $criteria = new Criteria();
+        $criteria->andWhere($criteria->expr()->iContains('content', 'criteria'));
+
+        $user   = $this->_em->find(User::class, $user->id);
+        $tweets = $user->tweets->matching($criteria);
+
+        $this->assertInstanceOf(LazyCriteriaCollection::class, $tweets);
+        $this->assertFalse($tweets->isInitialized());
+
+        $tweets->contains($tweet);
+        $this->assertTrue($tweets->contains($tweet));
+
+        $this->assertFalse($tweets->isInitialized());
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -910,6 +910,22 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->assertEquals(2, count($users));
     }
 
+    public function testMatchingCriteriaIContainsComparison()
+    {
+        $this->loadFixture();
+
+        $repository = $this->_em->getRepository(CmsUser::class);
+
+        $users = $repository->matching(new Criteria(Criteria::expr()->iContains('name', 'foobar')));
+        $this->assertEquals(0, count($users));
+
+        $users = $repository->matching(new Criteria(Criteria::expr()->iContains('name', 'rOm')));
+        $this->assertEquals(1, count($users));
+
+        $users = $repository->matching(new Criteria(Criteria::expr()->iContains('status', 'DEV')));
+        $this->assertEquals(2, count($users));
+    }
+
     public function testMatchingCriteriaStartsWithComparison()
     {
         $this->loadFixture();

--- a/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php
@@ -67,6 +67,7 @@ class QueryExpressionVisitorTest extends TestCase
             [$cb->notIn('field', ['value']), $qb->notIn('o.field', ':field'), new Parameter('field', ['value'])],
 
             [$cb->contains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')],
+            [$cb->iContains('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value%')],
 
             [$cb->startsWith('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', 'value%')],
             [$cb->endsWith('field', 'value'), $qb->like('o.field', ':field'), new Parameter('field', '%value')],


### PR DESCRIPTION
This pull request adds Comparison::ICONTAINS to create a case insensitive like. 

Existing case sensitive like
`fieldname LIKE %value%`

New case insensitive like
`LOWER(fieldname) LIKE (%value%)`
with value converted to lowercase by php, and fieldname surrounded by platforms lower function. 

UnitTests will run if you use [this version of doctrine collections](https://github.com/okoehler/collections/tree/6de7e7ce5e3b0f5d50b5152366efbb9e721db212). See doctrine collections [PR#123](https://github.com/doctrine/collections/pull/123)
