### PR TITLE
ManyToManyPersister should detect columnName

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -237,15 +237,18 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         $parameters = $this->expandCriteriaParameters($criteria);
+        $targetClass  = $this->em->getClassMetadata($mapping['targetEntity']);
 
         foreach ($parameters as $parameter) {
             list($name, $value) = $parameter;
+
+            $name = $targetClass->getColumnName($name);
+
             $whereClauses[]     = sprintf('te.%s = ?', $name);
             $params[]           = $value;
         }
 
         $mapping      = $collection->getMapping();
-        $targetClass  = $this->em->getClassMetadata($mapping['targetEntity']);
         $tableName    = $this->quoteStrategy->getTableName($targetClass, $this->platform);
         $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $ownerMetadata, $this->platform);
         $onConditions = $this->getOnConditionSQL($mapping);


### PR DESCRIPTION
Hey guys,

I recently realized that if you want to apply a criteria on a `PersistentCollection` by using the `ManyToManyPersister`, the criteria MUST contain the field name relating to the database.

Since we are always using property names, I got some error on ManyToMany (SQL Error: Missing fieldname).

I just wanted to add the `ClassMetadata::getColumnName` logic to the `ManyToManyPersister::loadCriteria` method so if someone applied the property name, it maps to the expected column name.

This was already applied in `master`: [ManyToManyPersister.php#L263](https://github.com/doctrine/doctrine2/blob/74c48c201dc5284688210872fdb546897de8eba9/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php#L263
)
Would love to see this in some of the next minor releases.