### PR TITLE
OrmTestCase: Always use full AnnotationReader, drop legacy versions

### DIFF
--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -4,7 +4,6 @@ namespace Doctrine\Tests;
 
 use Doctrine\Common\Annotations;
 use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\Version;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
@@ -58,43 +57,12 @@ abstract class OrmTestCase extends DoctrineTestCase
 
     /**
      * @param array $paths
-     * @param mixed $alias
      *
      * @return \Doctrine\ORM\Mapping\Driver\AnnotationDriver
      */
-    protected function createAnnotationDriver($paths = [], $alias = null)
+    protected function createAnnotationDriver($paths = [])
     {
-        if (version_compare(Version::VERSION, '3.0.0-DEV', '>=')) {
-            $reader = new Annotations\CachedReader(new Annotations\AnnotationReader(), new ArrayCache());
-        } else if (version_compare(Version::VERSION, '2.2.0-DEV', '>=')) {
-            // Register the ORM Annotations in the AnnotationRegistry
-            $reader = new Annotations\SimpleAnnotationReader();
-
-            $reader->addNamespace('Doctrine\ORM\Annotation');
-
-            $reader = new Annotations\CachedReader($reader, new ArrayCache());
-        } else if (version_compare(Version::VERSION, '2.1.0-BETA3-DEV', '>=')) {
-            $reader = new Annotations\AnnotationReader();
-
-            $reader->setIgnoreNotImportedAnnotations(true);
-            $reader->setEnableParsePhpImports(false);
-
-            if ($alias) {
-                $reader->setAnnotationNamespaceAlias('Doctrine\ORM\Annotation\\', $alias);
-            } else {
-                $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Annotation\\');
-            }
-
-            $reader = new Annotations\CachedReader(new Annotations\IndexedReader($reader), new ArrayCache());
-        } else {
-            $reader = new Annotations\AnnotationReader();
-
-            if ($alias) {
-                $reader->setAnnotationNamespaceAlias('Doctrine\ORM\Annotation\\', $alias);
-            } else {
-                $reader->setDefaultAnnotationNamespace('Doctrine\ORM\Annotation\\');
-            }
-        }
+        $reader = new Annotations\CachedReader(new Annotations\AnnotationReader(), new ArrayCache());
 
         Annotations\AnnotationRegistry::registerFile(__DIR__ . "/../../../lib/Doctrine/ORM/Annotation/DoctrineAnnotations.php");
 


### PR DESCRIPTION
Develop was failing locally due to class imports not being recognized. That's because SimpleAnnotationReader was in use rather than full AnnotationReader.
Also not sure why this was testing version of Common - annotations are separate package for a while now. :/
Dropped legacy setup & unused `$alias` parameter for `Doctrine\Tests\OrmTestCase#createAnnotationDriver()`.

cc @guilhermeblanco 