### PR TITLE
Fix return value of `PersistentCollection#removeElement()` for extra-lazy collections: should be `bool`

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -373,11 +373,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
 
-            if ($persister->removeElement($this, $element)) {
-                return $element;
-            }
-
-            return null;
+            return $persister->removeElement($this, $element);
         }
 
         $removed = parent::removeElement($element);

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -640,7 +640,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $group      = $this->_em->find(CmsGroup::class, $this->groupId);
         $queryCount = $this->getCurrentQueryCount();
 
-        $user->groups->removeElement($group);
+        $this->assertTrue($user->groups->removeElement($group));
 
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Removing a persisted entity should cause one query to be executed.");
         $this->assertFalse($user->groups->isInitialized(), "Post-Condition: Collection is not initialized.");

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -645,6 +645,8 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $this->assertEquals($queryCount + 1, $this->getCurrentQueryCount(), "Removing a persisted entity should cause one query to be executed.");
         $this->assertFalse($user->groups->isInitialized(), "Post-Condition: Collection is not initialized.");
 
+        $this->assertFalse($user->groups->removeElement($group), "Removing an already removed element returns false");
+
         // Test Many to Many removal with Entity state as new
         $group = new CmsGroup();
         $group->name = "A New group!";


### PR DESCRIPTION
Fixes #5745.

As indicated in the ticket, calling `removeElement` on an uninitialized collection that uses the extra_lazy fetch mode does not return a bool, breaking the contract specified in the collection interface. This PR changes `removeElement` to return a bool value in those cases as well.