### PR TITLE
Revert "[3.0] Moved IdentifierGenerator to Property."

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -200,11 +200,50 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
     public $inheritanceType = InheritanceType::NONE;
 
     /**
+     * READ-ONLY: The Id generator type used by the class.
+     *
+     * @var string
+     */
+    public $generatorType = GeneratorType::NONE;
+
+    /**
      * READ-ONLY: The policy used for change-tracking on entities of this class.
      *
      * @var string
      */
     public $changeTrackingPolicy = ChangeTrackingPolicy::DEFERRED_IMPLICIT;
+
+    /**
+     * READ-ONLY: The definition of the identity generator of this class.
+     * In case of SEQUENCE generation strategy, the definition has the following structure:
+     * <code>
+     * array(
+     *     'sequenceName'   => 'name',
+     *     'allocationSize' => 20,
+     * )
+     * </code>
+     *
+     * In case of CUSTOM generation strategy, the definition has the following structure:
+     * <code>
+     * array(
+     *     'class' => 'ClassName',
+     * )
+     * </code>
+     *
+     * @var array
+     *
+     * @todo Remove!
+     */
+    public $generatorDefinition;
+
+    /**
+     * READ-ONLY: The ID generator used for generating IDs for this class.
+     *
+     * @var \Doctrine\ORM\Sequencing\Generator
+     *
+     * @todo Remove!
+     */
+    public $idGenerator;
 
     /**
      * READ-ONLY: The discriminator value of this class.
@@ -411,6 +450,7 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
             'name',
             'table',
             'rootEntityName',
+            'idGenerator', //TODO: Does not really need to be serialized. Could be moved to runtime.
         ]);
 
         // The rest of the metadata is only serialized if necessary.
@@ -429,6 +469,14 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
             $serialized[] = 'discriminatorMap';
             $serialized[] = 'parentClasses';
             $serialized[] = 'subClasses';
+        }
+
+        if ($this->generatorType !== GeneratorType::NONE) {
+            $serialized[] = 'generatorType';
+        }
+
+        if ($this->generatorDefinition) {
+            $serialized[] = "generatorDefinition";
         }
 
         if ($this->isMappedSuperclass) {
@@ -565,7 +613,7 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
             throw MappingException::identifierRequired($this->name);
         }
 
-        if ($this->isIdentifierComposite() && count($this->getGeneratedIdentifierProperties()) !== 0) {
+        if ($this->generatorType !== GeneratorType::NONE && $this->isIdentifierComposite()) {
             throw MappingException::compositeKeyAssignedIdGeneratorRequired($this->name);
         }
     }
@@ -1242,6 +1290,18 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
     }
 
     /**
+     * Sets the type of Id generator to use for the mapped class.
+     *
+     * @param int $generatorType
+     *
+     * @return void
+     */
+    public function setIdGeneratorType($generatorType)
+    {
+        $this->generatorType = $generatorType;
+    }
+
+    /**
      * Gets the name of the primary table.
      *
      * @return string
@@ -1571,28 +1631,6 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
         if ($inheritedProperty instanceof VersionFieldMetadata) {
             $this->versionProperty = $inheritedProperty;
         }
-    }
-
-    /**
-     * @return array<Property>
-     */
-    public function getIdentifierProperties(): array
-    {
-        return array_filter($this->properties, function (Property $property) : bool {
-            return $property instanceof FieldMetadata && $property->isPrimaryKey();
-        });
-    }
-
-    /**
-     * @return array<Property>
-     */
-    public function getGeneratedIdentifierProperties(): array
-    {
-        return array_filter($this->properties, function (Property $property) : bool {
-            return $property instanceof FieldMetadata
-                && $property->isPrimaryKey()
-                && $property->getIdentifierGeneratorType() !== GeneratorType::NONE;
-        });
     }
 
     /**
@@ -1944,6 +1982,51 @@ class ClassMetadata implements TableOwner, \Doctrine\Common\Persistence\Mapping\
     public function hasSqlResultSetMapping($name)
     {
         return isset($this->sqlResultSetMappings[$name]);
+    }
+
+    /**
+     * Sets the ID generator used to generate IDs for instances of this class.
+     *
+     * @param \Doctrine\ORM\Sequencing\Generator $generator
+     *
+     * @return void
+     */
+    public function setIdGenerator($generator)
+    {
+        $this->idGenerator = $generator;
+    }
+
+    /**
+     * Sets the generator definition for this class.
+     * For sequence definition, it must have the following structure:
+     *
+     * <code>
+     * array(
+     *     'sequenceName'   => 'name',
+     *     'allocationSize' => 20,
+     * )
+     * </code>
+     *
+     * For custom definition, it must have the following structure:
+     *
+     * <code>
+     * array(
+     *     'class'     => 'Path\To\ClassName',
+     *     'arguments' => [],
+     * )
+     * </code>
+     *
+     * @param array $definition
+     *
+     * @return void
+     */
+    public function setGeneratorDefinition(array $definition)
+    {
+        if ($this->generatorType === GeneratorType::SEQUENCE && ! isset($definition['sequenceName'])) {
+            throw MappingException::missingSequenceName($this->name);
+        }
+
+        $this->generatorDefinition = $definition;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -557,7 +557,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $strategy            = strtoupper($generatedValueAnnot->strategy);
             $idGeneratorType     = constant(sprintf('%s::%s', Mapping\GeneratorType::class, $strategy));
 
-            $fieldMetadata->setIdentifierGeneratorType($idGeneratorType);
+            $metadata->setIdGeneratorType($idGeneratorType);
         }
 
         // Check for CustomGenerator/SequenceGenerator/TableGenerator definition
@@ -565,7 +565,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             case isset($propertyAnnotations[Annotation\SequenceGenerator::class]):
                 $seqGeneratorAnnot = $propertyAnnotations[Annotation\SequenceGenerator::class];
 
-                $fieldMetadata->setIdentifierGeneratorDefinition([
+                $metadata->setGeneratorDefinition([
                     'sequenceName'   => $seqGeneratorAnnot->sequenceName,
                     'allocationSize' => $seqGeneratorAnnot->allocationSize,
                 ]);
@@ -575,7 +575,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             case isset($propertyAnnotations[Annotation\CustomIdGenerator::class]):
                 $customGeneratorAnnot = $propertyAnnotations[Annotation\CustomIdGenerator::class];
 
-                $fieldMetadata->setIdentifierGeneratorDefinition([
+                $metadata->setGeneratorDefinition([
                     'class'     => $customGeneratorAnnot->class,
                     'arguments' => $customGeneratorAnnot->arguments,
                 ]);

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -383,7 +383,7 @@ class DatabaseDriver implements MappingDriver
 
         // We need to check for the columns here, because we might have associations as id as well.
         if ($ids && count($primaryKeys) === 1) {
-            $ids[0]->setIdentifierGeneratorType(GeneratorType::AUTO);
+            $metadata->setIdGeneratorType(GeneratorType::AUTO);
         }
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -332,15 +332,14 @@ class XmlDriver extends FileDriver
                     : 'AUTO'
                 ;
 
-                $idGeneratorType = constant(sprintf('%s::%s', GeneratorType::class, strtoupper($strategy)));
-                $fieldMetadata->setIdentifierGeneratorType($idGeneratorType);
+                $metadata->setIdGeneratorType(constant(sprintf('%s::%s', GeneratorType::class, strtoupper($strategy))));
             }
 
             // Check for SequenceGenerator/TableGenerator definition
             if (isset($idElement->{'sequence-generator'})) {
                 $seqGenerator = $idElement->{'sequence-generator'};
 
-                $fieldMetadata->setIdentifierGeneratorDefinition(
+                $metadata->setGeneratorDefinition(
                     [
                         'sequenceName'   => (string) $seqGenerator['sequence-name'],
                         'allocationSize' => (string) $seqGenerator['allocation-size'],
@@ -349,7 +348,7 @@ class XmlDriver extends FileDriver
             } else if (isset($idElement->{'custom-id-generator'})) {
                 $customGenerator = $idElement->{'custom-id-generator'};
 
-                $fieldMetadata->setIdentifierGeneratorDefinition(
+                $metadata->setGeneratorDefinition(
                     [
                         'class'     => (string) $customGenerator['class'],
                         'arguments' => [],

--- a/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
@@ -132,6 +132,11 @@ class ClassMetadataExporter implements Exporter
             $lines[] = null;
         }
 
+        if (! $metadata->isIdentifierComposite()) {
+            $lines[] = $objectReference . '->setIdGeneratorType(Mapping\GeneratorType::' . strtoupper($metadata->generatorType) . ');';
+            $lines[] = null;
+        }
+
         if ($metadata->inheritanceType) {
             $lines[] = $objectReference . '->setInheritanceType(Mapping\InheritanceType::' . strtoupper($metadata->inheritanceType) . ');';
             $lines[] = null;

--- a/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
@@ -23,7 +23,6 @@ declare(strict_types = 1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\FieldMetadata;
-use Doctrine\ORM\Mapping\GeneratorType;
 
 class FieldMetadataExporter extends LocalColumnMetadataExporter
 {
@@ -36,22 +35,11 @@ class FieldMetadataExporter extends LocalColumnMetadataExporter
      */
     protected function exportInstantiation(FieldMetadata $metadata) : string
     {
-        $export = sprintf(
+        return sprintf(
             'new Mapping\FieldMetadata("%s", "%s", Type::getType("%s"));',
             $metadata->getName(),
             $metadata->getColumnName(),
             $metadata->getTypeName()
         );
-
-        if ($metadata->getIdentifierGeneratorType() !== GeneratorType::NONE) {
-            $export .= PHP_EOL;
-             $export .= sprintf(
-                 '%s->setIdentifierGeneratorType(Mapping\GeneratorType::%s);',
-                 self::VARIABLE,
-                 strtoupper($metadata->getIdentifierGeneratorType())
-             );
-        }
-
-        return $export;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/FieldMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMetadata.php
@@ -24,7 +24,6 @@ namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Reflection\ReflectionService;
-use Doctrine\ORM\Sequencing\Generator;
 
 class FieldMetadata extends LocalColumnMetadata implements Property
 {
@@ -37,14 +36,11 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     /** @var string */
     protected $name;
 
-    /** @var string */
+    /** @var int */
     protected $identifierGeneratorType = GeneratorType::NONE;
 
     /** @var array<string, mixed> */
     protected $identifierGeneratorDefinition = [];
-
-    /** @var Generator */
-    protected $identifierGenerator;
 
     /**
      * FieldMetadata constructor.
@@ -92,7 +88,7 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getIdentifierGeneratorType()
     {
@@ -102,7 +98,7 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     /**
      * @param int $identifierGeneratorType
      */
-    public function setIdentifierGeneratorType(string $identifierGeneratorType)
+    public function setIdentifierGeneratorType(int $identifierGeneratorType)
     {
         $this->identifierGeneratorType = $identifierGeneratorType;
     }
@@ -121,22 +117,6 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     public function setIdentifierGeneratorDefinition(array $identifierGeneratorDefinition)
     {
         $this->identifierGeneratorDefinition = $identifierGeneratorDefinition;
-    }
-
-    /**
-     * @return Generator
-     */
-    public function getIdentifierGenerator() : Generator
-    {
-        return $this->identifierGenerator;
-    }
-
-    /**
-     * @param Generator $identifierGenerator
-     */
-    public function setIdentifierGenerator(Generator $identifierGenerator)
-    {
-        $this->identifierGenerator = $identifierGenerator;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -93,7 +93,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         $postInsertIds  = [];
-        $idGenerator    = $this->class->getProperty($this->class->identifier[0])->getIdentifierGenerator();
+        $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
         $rootClass      = ($this->class->name !== $this->class->rootEntityName)
             ? $this->em->getClassMetadata($this->class->rootEntityName)
@@ -538,7 +538,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             if (
                 $this->class->name !== $this->class->rootEntityName ||
-                $property->getIdentifierGeneratorType() !== GeneratorType::IDENTITY ||
+                $this->class->generatorType !== GeneratorType::IDENTITY ||
                 $this->class->identifier[0] !== $name
             ) {
                 $columnName = $property->getColumnName();

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -112,6 +112,8 @@ EOT
                 [
                     $this->formatField('Discriminator value', $metadata->discriminatorValue),
                     $this->formatField('Discriminator map', $metadata->discriminatorMap),
+                    $this->formatField('Generator type', $metadata->generatorType),
+                    $this->formatField('Generator definition', $metadata->generatorDefinition),
                     $this->formatField('Table', ''),
                 ],
                 $this->formatTable($metadata->table),
@@ -331,11 +333,6 @@ EOT
         $output[] = $this->formatField('    isNullable', $this->formatValue($columnMetadata->isNullable()));
         $output[] = $this->formatField('    isUnique', $this->formatValue($columnMetadata->isUnique()));
         $output[] = $this->formatField('    options', $this->formatValue($columnMetadata->getOptions()));
-
-        if ($columnMetadata instanceof FieldMetadata) {
-            $output[] = $this->formatField('    Generator type', $this->formatValue($columnMetadata->getIdentifierGeneratorType()));
-            $output[] = $this->formatField('    Generator definition', $this->formatValue($columnMetadata->getIdentifierGeneratorDefinition()));
-        }
 
         return $output;
     }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
-use Doctrine\ORM\Mapping\Property;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 
@@ -1166,7 +1165,7 @@ public function __construct(<params>)
                     $methods[] = $code;
                 }
 
-                if (( ! $property->isPrimaryKey() || $property->getIdentifierGeneratorType() == GeneratorType::NONE) &&
+                if (( ! $property->isPrimaryKey() || $metadata->generatorType == GeneratorType::NONE) &&
                     ( ! $metadata->isEmbeddedClass || ! $this->embeddablesImmutable) &&
                     $code = $this->generateEntityStubMethod($metadata, 'set', $fieldName, $property->getTypeName(), $nullable)) {
                     $methods[] = $code;
@@ -1389,32 +1388,30 @@ public function __construct(<params>)
     }
 
     /**
-     * @param Property $metadata
+     * @param ClassMetadata $metadata
      *
      * @return string
      */
-    protected function generateIdentifierAnnotation(Property $metadata)
+    protected function generateIdentifierAnnotation(ClassMetadata $metadata)
     {
         $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'Id';
 
-        if ($metadata instanceof FieldMetadata) {
-            if ($generatorType = $this->getIdGeneratorTypeString($metadata->getIdentifierGeneratorType())) {
-                $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
+        if ($generatorType = $this->getIdGeneratorTypeString($metadata->generatorType)) {
+            $lines[] = $this->spaces.' * @' . $this->annotationsPrefix . 'GeneratedValue(strategy="' . $generatorType . '")';
+        }
+
+        if ($metadata->generatorDefinition) {
+            $generator = [];
+
+            if (isset($metadata->generatorDefinition['sequenceName'])) {
+                $generator[] = 'sequenceName="' . $metadata->generatorDefinition['sequenceName'] . '"';
             }
 
-            if ($metadata->getIdentifierGeneratorDefinition()) {
-                $generator = [];
-
-                if (isset($metadata->generatorDefinition['sequenceName'])) {
-                    $generator[] = 'sequenceName="' . $metadata->getIdentifierGeneratorDefinition()['sequenceName'] . '"';
-                }
-
-                if (isset($metadata->generatorDefinition['allocationSize'])) {
-                    $generator[] = 'allocationSize=' . $metadata->getIdentifierGeneratorDefinition()['allocationSize'];
-                }
-
-                $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'SequenceGenerator(' . implode(', ', $generator) . ')';
+            if (isset($metadata->generatorDefinition['allocationSize'])) {
+                $generator[] = 'allocationSize=' . $metadata->generatorDefinition['allocationSize'];
             }
+
+            $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'SequenceGenerator(' . implode(', ', $generator) . ')';
         }
 
         return implode(PHP_EOL, $lines);
@@ -1525,7 +1522,7 @@ public function __construct(<params>)
             $lines[] = $this->spaces . ' *';
 
             if ($association->isPrimaryKey()) {
-                $lines[] = $this->generateIdentifierAnnotation($association);
+                $lines[] = $this->generateIdentifierAnnotation($metadata);
             }
 
             $type = null;
@@ -1687,7 +1684,7 @@ public function __construct(<params>)
             $lines[] = $this->spaces . ' * @' . $this->annotationsPrefix . 'Column(' . implode(', ', $column) . ')';
 
             if ($propertyMetadata->isPrimaryKey()) {
-                $lines[] = $this->generateIdentifierAnnotation($propertyMetadata);
+                $lines[] = $this->generateIdentifierAnnotation($metadata);
             }
 
             if ($metadata->isVersioned() && $metadata->versionProperty->getName() === $propertyMetadata->getName()) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -22,7 +22,6 @@ namespace Doctrine\ORM\Tools\Export\Driver;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
-use Doctrine\ORM\Mapping\GeneratorType;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\JoinTableMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
@@ -143,6 +142,10 @@ class PhpExporter extends AbstractExporter
             }
         }
 
+        if (! $metadata->isIdentifierComposite()) {
+            $lines[] = '$metadata->setIdGeneratorType(Mapping\GeneratorType::' . $metadata->generatorType . ');';
+        }
+
         foreach ($metadata->getProperties() as $property) {
             if ($property instanceof FieldMetadata) {
                 $this->exportFieldMetadata($metadata, $property, $lines);
@@ -187,11 +190,6 @@ class PhpExporter extends AbstractExporter
         $lines[] = '$property->setPrimaryKey(' . $this->varExport($property->isPrimaryKey()) . ');';
         $lines[] = '$property->setNullable(' . $this->varExport($property->isNullable()) . ');';
         $lines[] = '$property->setUnique(' . $this->varExport($property->isUnique()) . ');';
-
-        if ($property->getIdentifierGeneratorType() !== GeneratorType::NONE) {
-            $lines[] = '$property->setIdentifierGeneratorType(Mapping\GeneratorType::' . $property->getIdentifierGeneratorType() . ');';
-        }
-
         $lines[] = null;
         $lines[] = '$metadata->addProperty($property);';
     }

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -205,12 +205,12 @@ class XmlExporter extends AbstractExporter
                     $idXml->addAttribute('length', $property->getLength());
                 }
 
-                if ($property->getIdentifierGeneratorType() !== GeneratorType::NONE) {
+                if ($metadata->generatorType) {
                     $generatorXml = $idXml->addChild('generator');
 
-                    $generatorXml->addAttribute('strategy', $property->getIdentifierGeneratorType());
+                    $generatorXml->addAttribute('strategy', $metadata->generatorType);
 
-                    $this->exportSequenceInformation($idXml, $property);
+                    $this->exportSequenceInformation($idXml, $metadata);
                 }
             }
         }
@@ -488,15 +488,15 @@ class XmlExporter extends AbstractExporter
      * Export sequence information (if available/configured) into the current identifier XML node
      *
      * @param \SimpleXMLElement $identifierXmlNode
-     * @param FieldMetadata     $metadata
+     * @param ClassMetadata     $metadata
      *
      * @return void
      */
-    private function exportSequenceInformation(\SimpleXMLElement $identifierXmlNode, FieldMetadata $metadata)
+    private function exportSequenceInformation(\SimpleXMLElement $identifierXmlNode, ClassMetadata $metadata)
     {
-        $sequenceDefinition = $metadata->getIdentifierGeneratorDefinition();
+        $sequenceDefinition = $metadata->generatorDefinition;
 
-        if (! ($metadata->getIdentifierGeneratorType() === GeneratorType::SEQUENCE && $sequenceDefinition)) {
+        if (! ($metadata->generatorType === GeneratorType::SEQUENCE && $sequenceDefinition)) {
             return;
         }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -338,17 +338,12 @@ class SchemaTool
 
             $processedClasses[$class->name] = true;
 
-            foreach ($class->getProperties() as $property) {
-                if (! $property instanceof FieldMetadata
-                    || $property->getIdentifierGeneratorType() !== GeneratorType::SEQUENCE
-                    || $class->name !== $class->rootEntityName) {
-                    continue;
-                }
-
-                $quotedName = $this->platform->quoteIdentifier($property->getIdentifierGeneratorDefinition()['sequenceName']);
+            if ($class->generatorType === GeneratorType::SEQUENCE && $class->name === $class->rootEntityName) {
+                $definition = $class->generatorDefinition;
+                $quotedName = $this->platform->quoteIdentifier($definition['sequenceName']);
 
                 if ( ! $schema->hasSequence($quotedName)) {
-                    $schema->createSequence($quotedName, $property->getIdentifierGeneratorDefinition()['allocationSize']);
+                    $schema->createSequence($quotedName, $definition['allocationSize']);
                 }
             }
 
@@ -498,7 +493,7 @@ class SchemaTool
             $options['customSchemaOptions'] = $fieldOptions;
         }
 
-        if ($fieldMetadata->getIdentifierGeneratorType() === GeneratorType::IDENTITY && $classMetadata->getIdentifierFieldNames() == [$fieldName]) {
+        if ($classMetadata->generatorType === GeneratorType::IDENTITY && $classMetadata->getIdentifierFieldNames() == [$fieldName]) {
             $options['autoincrement'] = true;
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -554,7 +554,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            if (( ! $property->isPrimaryKey() || ($property instanceof FieldMetadata && $property->getIdentifierGeneratorType() !== GeneratorType::IDENTITY))
+            if (( ! $class->isIdentifier($name) || $class->generatorType !== GeneratorType::IDENTITY)
                 && (! $class->isVersioned() || $name !== $class->versionProperty->getName())) {
                 $actualData[$name] = $value;
             }
@@ -836,24 +836,22 @@ class UnitOfWork implements PropertyChangedListener
             $this->listenersInvoker->invoke($class, Events::prePersist, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
         }
 
-        if (! $class->isIdentifierComposite()) {
-            $idField = $class->getSingleIdentifierFieldName();
-            $property = $class->getProperty($idField);
-            $idGen = $property->getIdentifierGenerator();
+        $idGen = $class->idGenerator;
 
-            if (! $idGen->isPostInsertGenerator()) {
-                $idValue = $idGen->generate($this->em, $entity);
+        if (! $idGen->isPostInsertGenerator()) {
+            $idValue = $idGen->generate($this->em, $entity);
 
-                if (! $idGen instanceof AssignedGenerator) {
-                    $platform = $this->em->getConnection()->getDatabasePlatform();
-                    $idValue = $property->getType()->convertToPHPValue($idValue, $platform);
-                    $idValue = [$idField => $idValue];
+            if (! $idGen instanceof AssignedGenerator) {
+                $idField  = $class->getSingleIdentifierFieldName();
+                $property = $class->getProperty($idField);
+                $platform = $this->em->getConnection()->getDatabasePlatform();
+                $idValue  = $property->getType()->convertToPHPValue($idValue, $platform);
+                $idValue  = [$idField => $idValue];
 
-                    $class->assignIdentifier($entity, $idValue);
-                }
-
-                $this->entityIdentifiers[$oid] = $idValue;
+                $class->assignIdentifier($entity, $idValue);
             }
+
+            $this->entityIdentifiers[$oid] = $idValue;
         }
 
         $this->entityStates[$oid] = self::STATE_MANAGED;
@@ -905,7 +903,7 @@ class UnitOfWork implements PropertyChangedListener
                     break;
 
                 case ($property instanceof FieldMetadata):
-                    if (! $property->isPrimaryKey() || $property->getIdentifierGeneratorType() !== GeneratorType::IDENTITY) {
+                    if (! $property->isPrimaryKey() || $class->generatorType !== GeneratorType::IDENTITY) {
                         $actualData[$name] = $property->getValue($entity);
                     }
 
@@ -1071,12 +1069,10 @@ class UnitOfWork implements PropertyChangedListener
             // Entity with this $oid after deletion treated as NEW, even if the $oid
             // is obtained by a new entity because the old one went out of scope.
             //$this->entityStates[$oid] = self::STATE_NEW;
-            if (! $class->isIdentifierComposite()) {
-                $identifierProperty = $class->getProperty($class->getSingleIdentifierFieldName());
-                if ($identifierProperty->getIdentifierGeneratorType() !== GeneratorType::NONE) {
-                    $property = $class->getProperty($class->getSingleIdentifierFieldName());
-                    $property->setValue($entity, null);
-                }
+            if ($class->generatorType !== GeneratorType::NONE) {
+                $property = $class->getProperty($class->getSingleIdentifierFieldName());
+
+                $property->setValue($entity, null);
             }
 
             if ($invoke !== ListenersInvoker::INVOKE_NONE) {
@@ -1439,7 +1435,7 @@ class UnitOfWork implements PropertyChangedListener
 
         $flatId = $this->identifierFlattener->flattenIdentifier($class, $id);
 
-        if (count($class->getGeneratedIdentifierProperties()) === 0) {
+        if ($class->generatorType === GeneratorType::NONE) {
             // Check for a version field, if available, to avoid a db lookup.
             if ($class->isVersioned()) {
                 return $class->versionProperty->getValue($entity)
@@ -1460,28 +1456,25 @@ class UnitOfWork implements PropertyChangedListener
             return self::STATE_NEW;
         }
 
-        foreach ($class->getGeneratedIdentifierProperties() as $property) {
-            if ($property->getIdentifierGeneratorType() !== GeneratorType::NONE
-                && $property->getIdentifierGenerator()->isPostInsertGenerator()) {
+        if ( ! $class->idGenerator->isPostInsertGenerator()) {
+            // if we have a pre insert generator we can't be sure that having an id
+            // really means that the entity exists. We have to verify this through
+            // the last resort: a db lookup
+
+            // Last try before db lookup: check the identity map.
+            if ($this->tryGetById($flatId, $class->rootEntityName)) {
                 return self::STATE_DETACHED;
             }
+
+            // db lookup
+            if ($this->getEntityPersister($class->name)->exists($entity)) {
+                return self::STATE_DETACHED;
+            }
+
+            return self::STATE_NEW;
         }
 
-        // if we have a pre insert generator we can't be sure that having an id
-        // really means that the entity exists. We have to verify this through
-        // the last resort: a db lookup
-
-        // Last try before db lookup: check the identity map.
-        if ($this->tryGetById($flatId, $class->rootEntityName)) {
-            return self::STATE_DETACHED;
-        }
-
-        // db lookup
-        if ($this->getEntityPersister($class->name)->exists($entity)) {
-            return self::STATE_DETACHED;
-        }
-
-        return self::STATE_NEW;
+        return self::STATE_DETACHED;
     }
 
     /**
@@ -1824,7 +1817,7 @@ class UnitOfWork implements PropertyChangedListener
                 if ($managedCopy === null) {
                     // If the identifier is ASSIGNED, it is NEW, otherwise an error
                     // since the managed entity was not found.
-                    if (count($class->getGeneratedIdentifierProperties()) !== 0) {
+                    if ($class->generatorType !== GeneratorType::NONE) {
                         throw EntityNotFoundException::fromClassNameAndIdentifier(
                             $class->getName(),
                             $this->identifierFlattener->flattenIdentifier($class, $id)

--- a/tests/Doctrine/Tests/Mocks/ClassMetadataMock.php
+++ b/tests/Doctrine/Tests/Mocks/ClassMetadataMock.php
@@ -10,4 +10,12 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 class ClassMetadataMock extends ClassMetadata
 {
     /* Mock API */
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setIdGeneratorType($type)
+    {
+        $this->generatorType = $type;
+    }
 }

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -56,8 +56,7 @@ class EntityPersisterMock extends BasicEntityPersister
     {
         $this->inserts[] = $entity;
 
-        if ($this->mockIdGeneratorType === GeneratorType::IDENTITY
-            || $this->class->getProperty($this->class->getSingleIdentifierFieldName())->getIdentifierGeneratorType() === GeneratorType::IDENTITY) {
+        if ($this->mockIdGeneratorType === GeneratorType::IDENTITY || $this->class->generatorType === GeneratorType::IDENTITY) {
             $id = $this->identityColumnValueCounter++;
 
             $this->postInsertIds[] = [

--- a/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
@@ -50,7 +50,6 @@ class DDC1476EntityWithDefaultFieldType
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('string'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -58,6 +57,8 @@ class DDC1476EntityWithDefaultFieldType
         $fieldMetadata->setType(Type::getType('string'));
 
         $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 
 }

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
@@ -88,7 +88,6 @@ class DDC3579User
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setColumnName('user_id');
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -107,5 +106,7 @@ class DDC3579User
         $association->setTargetEntity('DDC3579Group');
 
         $metadata->addProperty($association);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
@@ -38,7 +38,6 @@ class DDC5934BaseContract
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setColumnName('id');
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -47,5 +46,7 @@ class DDC5934BaseContract
         $association->setTargetEntity('DDC5934Member');
 
         $metadata->addProperty($association);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
@@ -26,7 +26,6 @@ class DDC869Payment
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -38,5 +37,6 @@ class DDC869Payment
         $metadata->isMappedSuperclass = true;
 
         $metadata->setCustomRepositoryClass(DDC869PaymentRepository::class);
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
@@ -20,9 +20,10 @@ class DDC889Class extends DDC889SuperClass
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
     }
 
 }

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
@@ -18,9 +18,9 @@ class DDC889SuperClass
     {
         $fieldMetadata = new Mapping\FieldMetadata('name');
         $fieldMetadata->setType(Type::getType('string'));
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
         $metadata->isMappedSuperclass = true;
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964User.php
@@ -115,7 +115,6 @@ class DDC964User
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setColumnName('user_id');
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -170,5 +169,7 @@ class DDC964User
         $association->setCascade(['persist', 'merge', 'detach']);
 
         $metadata->addProperty($association);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -22,7 +22,7 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
     {
         $address = $this->em->getClassMetadata(Models\CMS\CmsAddress::class);
 
-        self::assertEquals(1, $address->getProperty('id')->getIdentifierGeneratorDefinition['allocationSize']);
+        self::assertEquals(1, $address->generatorDefinition['allocationSize']);
     }
 
     public function testGetCreateSchemaSql()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2415Test.php
@@ -31,8 +31,6 @@ class DDC2415Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testTicket()
     {
-        $this->fail('FIXME');
-
         $parentMetadata  = $this->em->getClassMetadata(DDC2415ParentEntity::class);
         $childMetadata   = $this->em->getClassMetadata(DDC2415ChildEntity::class);
 
@@ -68,15 +66,17 @@ class DDC2415ParentEntity
 
         $fieldMetadata->setType(Type::getType('string'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
-        $fieldMetadata->setIdentifierGeneratorDefinition(
+
+        $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
+
+        $metadata->setGeneratorDefinition(
             [
                 'class'     => DDC2415Generator::class,
                 'arguments' => [],
             ]
         );
-
-        $metadata->addProperty($fieldMetadata);
 
         $metadata->isMappedSuperclass = true;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -20,7 +20,7 @@ class DDC3634Test extends OrmFunctionalTestCase
 
         $metadata = $this->em->getClassMetadata(DDC3634Entity::class);
 
-        if ( ! $metadata->getProperty('id')->getIdentifierGenerator()->isPostInsertGenerator()) {
+        if ( ! $metadata->idGenerator->isPostInsertGenerator()) {
             $this->markTestSkipped('Need a post-insert ID generator in order to make this test work correctly');
         }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -177,17 +177,13 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testEntitySequence($class)
     {
-        self::assertInternalType(
-            'array',
-            $class->getProperty('id')->getIdentifierGeneratorDefinition(),
-            'No Sequence Definition set on this driver.'
-        );
+        self::assertInternalType('array', $class->generatorDefinition, 'No Sequence Definition set on this driver.');
         self::assertEquals(
             [
                 'sequenceName'   => 'tablename_seq',
                 'allocationSize' => 100,
             ],
-            $class->getProperty('id')->getIdentifierGeneratorDefinition()
+            $class->generatorDefinition
         );
     }
 
@@ -195,13 +191,13 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     {
         $class = $this->createClassMetadata(Animal::class);
 
-        self::assertEquals(Mapping\GeneratorType::CUSTOM, $class->getProperty('id')->getIdentifierGeneratorType(), "Generator Type");
+        self::assertEquals(Mapping\GeneratorType::CUSTOM, $class->generatorType, "Generator Type");
         self::assertEquals(
             [
                 'class'     => 'stdClass',
                 'arguments' => [],
             ],
-            $class->getProperty('id')->getIdentifierGeneratorDefinition(),
+            $class->generatorDefinition,
             "Generator Definition"
         );
     }
@@ -321,7 +317,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertEquals('integer', $property->getTypeName());
         self::assertEquals(['id'], $class->identifier);
-        self::assertEquals(Mapping\GeneratorType::AUTO, $property->getIdentifierGeneratorType(), "ID-Generator is not GeneratorType::AUTO");
+        self::assertEquals(Mapping\GeneratorType::AUTO, $class->generatorType, "ID-Generator is not GeneratorType::AUTO");
 
         return $class;
     }
@@ -559,7 +555,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals('id', $idProperty->getColumnName());
         self::assertEquals('name', $nameProperty->getColumnName());
 
-        self::assertEquals(Mapping\GeneratorType::NONE, $idProperty->getIdentifierGeneratorType());
+        self::assertEquals(Mapping\GeneratorType::NONE, $class->generatorType);
     }
 
     /**
@@ -1290,6 +1286,13 @@ class User
         $metadata->addLifecycleCallback('doOtherStuffOnPrePersistToo', 'prePersist');
         $metadata->addLifecycleCallback('doStuffOnPostPersist', 'postPersist');
 
+        $metadata->setGeneratorDefinition(
+            [
+                'sequenceName'   => 'tablename_seq',
+                'allocationSize' => 100,
+            ]
+        );
+
         $metadata->addNamedQuery(
             [
                 'name' => 'all',
@@ -1301,13 +1304,6 @@ class User
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
         $fieldMetadata->setOptions(['foo' => 'bar', 'unsigned' => false]);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
-        $fieldMetadata->setIdentifierGeneratorDefinition(
-            [
-                'sequenceName'   => 'tablename_seq',
-                'allocationSize' => 100,
-            ]
-        );
 
         $metadata->addProperty($fieldMetadata);
 
@@ -1341,6 +1337,7 @@ class User
         $fieldMetadata->setType(Type::getType('integer'));
 
         $metadata->addProperty($fieldMetadata);
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
         $joinColumns = [];
 
@@ -1418,8 +1415,8 @@ abstract class Animal
 
     public static function loadMetadata(ClassMetadata $metadata)
     {
-        $metadata->getProperty('id')->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
-        $metadata->getProperty('id')->setIdentifierGeneratorDefinition(
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
+        $metadata->setGeneratorDefinition(
             [
                 'class'     => 'stdClass',
                 'arguments' => [],
@@ -1494,7 +1491,6 @@ class DDC1170Entity
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setColumnDefinition('INT unsigned NOT NULL');
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -1504,6 +1500,8 @@ class DDC1170Entity
         $fieldMetadata->setColumnDefinition('VARCHAR(255) NOT NULL');
 
         $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 
 }
@@ -1529,7 +1527,6 @@ class DDC807Entity
 
         $fieldMetadata->setType(Type::getType('string'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -1541,6 +1538,8 @@ class DDC807Entity
         $discrColumn->setColumnDefinition("ENUM('ONE','TWO')");
 
         $metadata->setDiscriminatorColumn($discrColumn);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 }
 
@@ -1610,10 +1609,10 @@ class SingleTableEntityNoDiscriminatorColumnMapping
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('string'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
 
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 }
 
@@ -1651,10 +1650,10 @@ class SingleTableEntityIncompleteDiscriminatorColumnMapping
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('string'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
         $metadata->addProperty($fieldMetadata);
 
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -149,10 +149,10 @@ class BasicInheritanceMappingTest extends OrmTestCase
         /* @var ClassMetadata $class */
         $class = $this->cmf->getMetadataFor(SuperclassEntity::class);
 
-        self::assertInstanceOf(SequenceGenerator::class, $class->getProperty('id')->getIdentifierGenerator());
+        self::assertInstanceOf(SequenceGenerator::class, $class->idGenerator);
         self::assertEquals(
             ['allocationSize' => 1, 'sequenceName' => 'foo'],
-            $class->getProperty('id')->getIdentifierGeneratorDefinition()
+            $class->generatorDefinition
         );
     }
 
@@ -165,10 +165,10 @@ class BasicInheritanceMappingTest extends OrmTestCase
         /* @var ClassMetadata $class */
         $class = $this->cmf->getMetadataFor(HierarchyD::class);
 
-        self::assertInstanceOf(SequenceGenerator::class, $class->getProperty('id')->getIdentifierGenerator());
+        self::assertInstanceOf(SequenceGenerator::class, $class->idGenerator);
         self::assertEquals(
             ['allocationSize' => 1, 'sequenceName' => 'foo'],
-            $class->getProperty('id')->getIdentifierGeneratorDefinition()
+            $class->generatorDefinition
         );
     }
 
@@ -181,10 +181,10 @@ class BasicInheritanceMappingTest extends OrmTestCase
         /* @var ClassMetadata $class */
         $class = $this->cmf->getMetadataFor(MediumSuperclassEntity::class);
 
-        self::assertInstanceOf(SequenceGenerator::class, $class->getProperty('id')->getIdentifierGenerator());
+        self::assertInstanceOf(SequenceGenerator::class, $class->idGenerator);
         self::assertEquals(
             ['allocationSize' => 1, 'sequenceName' => 'foo'],
-            $class->getProperty('id')->getIdentifierGeneratorDefinition()
+            $class->generatorDefinition
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -54,7 +54,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         // Prechecks
         self::assertEquals([], $cm1->parentClasses);
         self::assertEquals(Mapping\InheritanceType::NONE, $cm1->inheritanceType);
-        self::assertEquals(Mapping\GeneratorType::AUTO, $cm1->getProperty('id')->getIdentifierGgeneratorType());
+        self::assertEquals(Mapping\GeneratorType::AUTO, $cm1->generatorType);
         self::assertTrue($cm1->hasField('name'));
         self::assertCount(4, $cm1->getProperties()); // 2 fields + 2 associations
         self::assertEquals('group', $cm1->table->getName());
@@ -72,11 +72,12 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $cm1 = $this->createValidClassMetadata();
 
-        $cm1->getProperty('id')->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
-        $cm1->getProperty('id')->setIdentifierGeneratorDefinition([
+        $cm1->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
+
+        $cm1->generatorDefinition = [
             'class' => CustomIdGenerator::class,
             'arguments' => [],
-        ]);
+        ];
 
         $cmf = $this->createTestFactory();
 
@@ -84,19 +85,20 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $actual = $cmf->getMetadataFor($cm1->name);
 
-        self::assertEquals(Mapping\GeneratorType::CUSTOM, $actual->getProperty('id')->getIdentifierGeneratorType());
-        self::assertInstanceOf(CustomIdGenerator::class, $actual->getProperty('id')->getIdentifierGenerator());
+        self::assertEquals(Mapping\GeneratorType::CUSTOM, $actual->generatorType);
+        self::assertInstanceOf(CustomIdGenerator::class, $actual->idGenerator);
     }
 
     public function testGetMetadataFor_ThrowsExceptionOnUnknownCustomGeneratorClass()
     {
         $cm1 = $this->createValidClassMetadata();
 
-        $cm1->getProperty('id')->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
-        $cm1->getProperty('id')->setIdentifierGeneratorDefinition([
+        $cm1->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
+
+        $cm1->generatorDefinition = [
             'class' => 'NotExistingGenerator',
             'arguments' => [],
-        ]);
+        ];
 
         $cmf = $this->createTestFactory();
 
@@ -110,7 +112,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     public function testGetMetadataFor_ThrowsExceptionOnMissingCustomGeneratorDefinition()
     {
         $cm1 = $this->createValidClassMetadata();
-        $cm1->getProperty('id')->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
+        $cm1->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
         $cmf = $this->createTestFactory();
         $cmf->setMetadataForClass($cm1->name, $cm1);
         $this->expectException(ORMException::class);
@@ -292,7 +294,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $cm1->addProperty($fieldMetadata);
 
@@ -327,6 +328,9 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $association->setTargetEntity('TestEntity1');
 
         $cm1->addProperty($association);
+
+        // and an id generator type
+        $cm1->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
         return $cm1;
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1412,8 +1412,6 @@ class ClassMetadataTest extends OrmTestCase
      */
     public function testSetSequenceGeneratorThrowsExceptionWhenSequenceNameIsMissing()
     {
-        $this->fail('FIXME');
-
         $cm = new ClassMetadata(CMS\CmsUser::class);
 
         $cm->setIdGeneratorType(Mapping\GeneratorType::SEQUENCE);
@@ -1432,12 +1430,9 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $cm->getProperty('id')->setIdentifierGeneratorDefinition(['sequenceName' => 'foo', 'allocationSize' => 1]);
+        $cm->setGeneratorDefinition(['sequenceName' => 'foo', 'allocationSize' => 1]);
 
-        self::assertEquals(
-            ['sequenceName' => 'foo', 'allocationSize' => 1],
-            $cm->getProperty('id')->getIdentifierGeneratorDefinition()
-        );
+        self::assertEquals(['sequenceName' => 'foo', 'allocationSize' => 1], $cm->generatorDefinition);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Cache.City.php
@@ -14,6 +14,7 @@ $tableMetadata->setName('cache_city');
 $metadata->setTable($tableMetadata);
 $metadata->setInheritanceType(Mapping\InheritanceType::NONE);
 $metadata->setChangeTrackingPolicy(Mapping\ChangeTrackingPolicy::DEFERRED_IMPLICIT);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::IDENTITY);
 $metadata->setCache(
     new Mapping\CacheMetadata(
         Mapping\CacheUsage::READ_ONLY,
@@ -24,7 +25,6 @@ $metadata->setCache(
 $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::IDENTITY);
 
 $metadata->addProperty($fieldMetadata);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC1476.DDC1476EntityWithDefaultFieldType.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('string'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -16,3 +15,5 @@ $fieldMetadata = new Mapping\FieldMetadata('name');
 $fieldMetadata->setType(Type::getType('string'));
 
 $metadata->addProperty($fieldMetadata);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.ExplicitSchemaAndTable.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.ExplicitSchemaAndTable.php
@@ -10,11 +10,11 @@ $tableMetadata->setName('explicit_table');
 
 /* @var $metadata ClassMetadata */
 $metadata->setTable($tableMetadata);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
 $fieldMetadata = new Mapping\FieldMetadata('id');
 
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.SchemaAndTableInTableName.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC2825.SchemaAndTableInTableName.php
@@ -10,10 +10,10 @@ $tableMetadata->setName('implicit_table');
 
 /* @var $metadata ClassMetadata */
 $metadata->setTable($tableMetadata);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
 $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC3579.DDC3579User.php
@@ -9,7 +9,6 @@ $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setColumnName('user_id');
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -27,3 +26,5 @@ $association = new Mapping\ManyToManyAssociationMetadata('groups');
 $association->setTargetEntity('DDC3579Group');
 
 $metadata->addProperty($association);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC5934.DDC5934BaseContract.php
@@ -9,7 +9,6 @@ $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setColumnName('id');
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -18,3 +17,5 @@ $association = new Mapping\ManyToManyAssociationMetadata('members');
 $association->setTargetEntity('DDC5934Member');
 
 $metadata->addProperty($association);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC869.DDC869Payment.php
@@ -11,7 +11,6 @@ $metadata->isMappedSuperclass = true;
 $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -21,3 +20,4 @@ $fieldMetadata->setType(Type::getType('float'));
 $metadata->addProperty($fieldMetadata);
 
 $metadata->setCustomRepositoryClass(DDC869PaymentRepository::class);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC889.DDC889SuperClass.php
@@ -9,8 +9,8 @@ $metadata->isMappedSuperclass = true;
 
 $fieldMetadata = new Mapping\FieldMetadata('name');
 $fieldMetadata->setType(Type::getType('string'));
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 
 $metadata->setCustomRepositoryClass(DDC889SuperClass::class);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.DDC964.DDC964User.php
@@ -10,7 +10,6 @@ $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setColumnName('user_id');
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -65,3 +64,5 @@ $association->setInversedBy('user');
 $association->setCascade(['persist','merge','detach']);
 
 $metadata->addProperty($association);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.Animal.php
@@ -31,12 +31,14 @@ $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
 $fieldMetadata->setNullable(false);
 $fieldMetadata->setUnique(false);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::CUSTOM);
-$fieldMetadata->setIdentifierGeneratorDefinition(
+
+$metadata->addProperty($fieldMetadata);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::CUSTOM);
+
+$metadata->setGeneratorDefinition(
     [
         'class'     => 'stdClass',
         'arguments' => [],
     ]
 );
-
-$metadata->addProperty($fieldMetadata);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC1170Entity.php
@@ -9,7 +9,6 @@ $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setColumnDefinition('INT unsigned NOT NULL');
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -18,3 +17,5 @@ $fieldMetadata->setType(Type::getType('string'));
 $fieldMetadata->setColumnDefinition('VARCHAR(255) NOT NULL');
 
 $metadata->addProperty($fieldMetadata);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.DDC807Entity.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 $fieldMetadata = new Mapping\FieldMetadata('id');
 $fieldMetadata->setType(Type::getType('string'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::NONE);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -19,3 +18,5 @@ $discrColumn->setType(Type::getType('string'));
 $discrColumn->setColumnDefinition("ENUM('ONE','TWO')");
 
 $metadata->setDiscriminatorColumn($discrColumn);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::NONE);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -55,18 +55,18 @@ $metadata->addNamedQuery(
     ]
 );
 
-$fieldMetadata = new Mapping\FieldMetadata('id');
-
-$fieldMetadata->setType(Type::getType('integer'));
-$fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setOptions(['foo' => 'bar', 'unsigned' => false]);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
-$fieldMetadata->setIdentifierGeneratorDefinition(
+$metadata->setGeneratorDefinition(
     [
         'sequenceName'   => 'tablename_seq',
         'allocationSize' => 100,
     ]
 );
+
+$fieldMetadata = new Mapping\FieldMetadata('id');
+
+$fieldMetadata->setType(Type::getType('integer'));
+$fieldMetadata->setPrimaryKey(true);
+$fieldMetadata->setOptions(['foo' => 'bar', 'unsigned' => false]);
 
 $metadata->addProperty($fieldMetadata);
 
@@ -100,6 +100,8 @@ $versionFieldMetadata = new Mapping\VersionFieldMetadata('version');
 $versionFieldMetadata->setType(Type::getType('integer'));
 
 $metadata->addProperty($versionFieldMetadata);
+
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
 $joinColumns = [];
 

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -116,7 +116,6 @@ class EntityGeneratorTest extends OrmTestCase
         $fieldMetadata->setPrimaryKey(true);
         $fieldMetadata->setNullable(false);
         $fieldMetadata->setUnique(false);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -163,6 +162,7 @@ class EntityGeneratorTest extends OrmTestCase
 
         $metadata->addLifecycleCallback('loading', 'postLoad');
         $metadata->addLifecycleCallback('willBeRemoved', 'preRemove');
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
         foreach ($embeddedClasses as $fieldName => $embeddedClass) {
             $metadata->mapEmbedded(
@@ -193,7 +193,6 @@ class EntityGeneratorTest extends OrmTestCase
         $fieldMetadata->setPrimaryKey(true);
         $fieldMetadata->setNullable(false);
         $fieldMetadata->setUnique(false);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
         $metadata->addProperty($fieldMetadata);
 
@@ -203,6 +202,8 @@ class EntityGeneratorTest extends OrmTestCase
         $fieldMetadata->setUnique(false);
 
         $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 
         $this->generator->writeEntityClass($metadata, $this->tmpDir);
 
@@ -523,7 +524,7 @@ class EntityGeneratorTest extends OrmTestCase
         self::assertEquals($cm->getTableName(), $metadata->getTableName());
         self::assertEquals($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
         self::assertEquals($cm->identifier, $metadata->identifier);
-        self::assertEquals($cm->getProperty('id')->getIdentifierGenerator(), $metadata->getProperty('id')->getIdentifierGenerator());
+        self::assertEquals($cm->idGenerator, $metadata->idGenerator);
         self::assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
 //        self::assertEquals($cm->embeddedClasses, $metadata->embeddedClasses);
 //        self::assertEquals($cm->isEmbeddedClass, $metadata->isEmbeddedClass);
@@ -559,7 +560,7 @@ class EntityGeneratorTest extends OrmTestCase
         self::assertEquals($cm->getTableName(), $metadata->getTableName());
         self::assertEquals($cm->lifecycleCallbacks, $metadata->lifecycleCallbacks);
         self::assertEquals($cm->identifier, $metadata->identifier);
-        self::assertEquals($cm->getProperty('id')->getIdentifierGenerator(), $metadata->getProperty('id')->getIdentifierGenerator());
+        self::assertEquals($cm->idGenerator, $metadata->idGenerator);
         self::assertEquals($cm->customRepositoryClassName, $metadata->customRepositoryClassName);
 
 //        $isbn = $this->newInstance($embeddedMetadata);
@@ -621,15 +622,17 @@ class EntityGeneratorTest extends OrmTestCase
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::SEQUENCE);
-        $fieldMetadata->setIdentifierGeneratorDefinition(
+
+        $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::SEQUENCE);
+
+        $metadata->setGeneratorDefinition(
             [
                 'sequenceName'   => 'DDC1784_ID_SEQ',
                 'allocationSize' => 1,
             ]
         );
-
-        $metadata->addProperty($fieldMetadata);
 
         $this->generator->writeEntityClass($metadata, $this->tmpDir);
 
@@ -659,9 +662,10 @@ class EntityGeneratorTest extends OrmTestCase
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::SEQUENCE);
 
         $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::SEQUENCE);
 
         $joinTable = new Mapping\JoinTableMetadata();
         $joinTable->setName('unidade_centro_custo');

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -177,7 +177,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
 
         self::assertTrue($property->isPrimaryKey());
         self::assertEquals(['id'], $class->identifier);
-        self::assertEquals(GeneratorType::IDENTITY, $class->getProperty('id')->getIdentifierGeneratorType(), "Generator Type wrong");
+        self::assertEquals(GeneratorType::IDENTITY, $class->generatorType, "Generator Type wrong");
 
         return $class;
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -50,15 +50,17 @@ class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
         $fieldMetadata = new Mapping\FieldMetadata('id');
         $fieldMetadata->setType(Type::getType('integer'));
         $fieldMetadata->setPrimaryKey(true);
-        $fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::SEQUENCE);
-        $fieldMetadata->setIdentifierGeneratorDefinition(
+
+        $metadata->addProperty($fieldMetadata);
+
+        $metadata->setIdGeneratorType(Mapping\GeneratorType::SEQUENCE);
+
+        $metadata->setGeneratorDefinition(
             [
                 'sequenceName'   => 'seq_entity_test_id',
                 'allocationSize' => 5,
             ]
         );
-
-        $metadata->addProperty($fieldMetadata);
 
         $expectedFileContent = <<<'XML'
 <?xml version="1.0" encoding="utf-8"?>

--- a/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/php/Doctrine.Tests.ORM.Tools.Export.User.php
@@ -10,6 +10,7 @@ $tableMetadata->addOption('engine', 'MyISAM');
 $tableMetadata->addOption('foo', ['bar' => 'baz']);
 
 $metadata->setTable($tableMetadata);
+$metadata->setIdGeneratorType(Mapping\GeneratorType::AUTO);
 $metadata->setInheritanceType(Mapping\InheritanceType::NONE);
 $metadata->setChangeTrackingPolicy(Mapping\ChangeTrackingPolicy::DEFERRED_IMPLICIT);
 
@@ -22,7 +23,6 @@ $fieldMetadata = new Mapping\FieldMetadata('id');
 
 $fieldMetadata->setType(Type::getType('integer'));
 $fieldMetadata->setPrimaryKey(true);
-$fieldMetadata->setIdentifierGeneratorType(Mapping\GeneratorType::AUTO);
 
 $metadata->addProperty($fieldMetadata);
 


### PR DESCRIPTION
Reverts doctrine/doctrine2#6551

There's more work needed in order to merge a fully operation migration.