### PR TITLE
Fix DDC2632.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -465,11 +465,21 @@ class DatabaseDriver implements MappingDriver
                 $associationMapping['id'] = true;
             }
 
-            for ($i = 0; $i < count($fkColumns); $i++) {
-                $associationMapping['joinColumns'][] = array(
+
+            for ($i = 0; $i < count($fkColumns); $i++){
+                $associationMappingParameters = array(
                     'name'                 => $fkColumns[$i],
-                    'referencedColumnName' => $fkForeignColumns[$i],
+                    'referencedColumnName' => $fkForeignColumns[$i]
                 );
+
+
+                $columns = $foreignKey->getLocalTable()->getColumns();
+                foreach  ($columns as $column) {
+                    if(strtolower($column->getName()) === strtolower($fkColumns[$i]) && $column->getNotNull() === true) {
+                        $associationMappingParameters['nullable'] = false;
+                    }
+                }
+                $associationMapping['joinColumns'][] = $associationMappingParameters;
             }
 
             // Here we need to check if $fkColumns are the same as $primaryKeys

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -305,7 +305,6 @@ class XmlExporter extends AbstractExporter
                     $cascadeXml->addChild($type);
                 }
             }
-
             if (isset($associationMapping['joinTable']) && $associationMapping['joinTable']) {
                 $joinTableXml = $associationMappingXml->addChild('join-table');
                 $joinTableXml->addAttribute('name', $associationMapping['joinTable']['name']);
@@ -316,6 +315,10 @@ class XmlExporter extends AbstractExporter
                     $joinColumnXml->addAttribute('name', $joinColumn['name']);
                     $joinColumnXml->addAttribute('referenced-column-name', $joinColumn['referencedColumnName']);
 
+					if(isset($joinColumn['nullable'])){
+
+						$joinColumnXml->addAttribute('nullable', $joinColumn['nullable']);
+					}
                     if (isset($joinColumn['onDelete'])) {
                         $joinColumnXml->addAttribute('on-delete', $joinColumn['onDelete']);
                     }

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -124,6 +124,7 @@ class YamlExporter extends AbstractExporter
         }
 
         foreach ($metadata->associationMappings as $name => $associationMapping) {
+
             $cascade = array();
 
             if ($associationMapping['isCascadeRemove']) {
@@ -165,10 +166,13 @@ class YamlExporter extends AbstractExporter
             if ($associationMapping['type'] & ClassMetadataInfo::TO_ONE) {
                 $joinColumns = $associationMapping['isOwningSide'] ? $associationMapping['joinColumns'] : [];
                 $newJoinColumns = array();
-
                 foreach ($joinColumns as $joinColumn) {
                     $newJoinColumns[$joinColumn['name']]['referencedColumnName'] = $joinColumn['referencedColumnName'];
 
+					if(isset($joinColumn['nullable'])){
+
+						$newJoinColumns[$joinColumn['name']]['nullable'] = $joinColumn['nullable'];
+					}
                     if (isset($joinColumn['onDelete'])) {
                         $newJoinColumns[$joinColumn['name']]['onDelete'] = $joinColumn['onDelete'];
                     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2632Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2632Test.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Tools\Export\Driver\YamlExporter;
+use Doctrine\Tests\ORM\Functional\DatabaseDriverTestCase;
+
+
+/**
+ * @group DDC-2632
+ */
+class DDC2632Test extends  DatabaseDriverTestCase
+
+{
+
+    protected function _getType()
+    {
+        if (!class_exists('Symfony\Component\Yaml\Yaml', true)) {
+            $this->markTestSkipped('Please install Symfony YAML Component into the include path of your PHP installation.');
+        }
+
+        return 'yaml';
+    }
+
+    /**
+     * @var \Doctrine\DBAL\Schema\AbstractSchemaManager
+     */
+    protected $_sm = null;
+
+    public function setUp()
+    {
+        //  $this->useModelSet('cms');
+        parent::setUp();
+
+        $this->_sm = $this->_em->getConnection()->getSchemaManager();
+    }
+
+    /**
+     * @group DDC-2632
+     */
+    public function testFKDefaultValueOptionExport() {
+        $exporter = new YamlExporter();
+
+        //var_dump($this->_em->getConnection()->getDatabasePlatform());
+
+
+        if (!$this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $user = new \Doctrine\DBAL\Schema\Table("ddc2059_user");
+        $user->addColumn('id', 'integer', array('notnull' => true));
+        $user->setPrimaryKey(array('id'));
+        $project = new \Doctrine\DBAL\Schema\Table("ddc2059_project");
+        $project->addColumn('id', 'integer', array('notnull' => false));
+        $project->addColumn('user_id', 'integer', array('notnull' => true));
+        //$project->addColumn('user', 'string');
+        $project->setPrimaryKey(array('id'),true);
+
+        $project->addForeignKeyConstraint('ddc2059_user', array('user_id'), array('id'),array(),'fk');
+
+        $this->_sm->dropAndCreateTable($user);
+        $this->_sm->dropAndCreateTable($project);
+
+        $metadata = $this->extractClassMetadata(array("Ddc2059User", "Ddc2059Project"));
+
+        $expetedResult =  "joinColumns:"
+            . "user_id:"
+            . "referencedColumnName:id"
+            . "nullable:false";
+
+        $this->assertContains($expetedResult,$string = trim(preg_replace('/\s+/', '',preg_replace('/\t/', '', $exporter->exportClassMetadata($metadata['Ddc2059Project'])))));
+
+    }
+
+}


### PR DESCRIPTION
This fix DDC2632 problem. I generate de nullable field for the foreingkey in the case you are using the tool to generate an xml or yml form a database.

To run the test you need to use a database that supports foreing keys like mysql.

When this PR gets closed I fix this problem for master branch.