### PR TITLE
#6573 multiple "NEW" operator syntax

### DIFF
--- a/tests/Doctrine/Tests/Models/DDC6573/DDC6573Currency.php
+++ b/tests/Doctrine/Tests/Models/DDC6573/DDC6573Currency.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC6573;
+
+class DDC6573Currency
+{
+    /**
+     * Currency code.
+     *
+     * @var string
+     */
+    private $code;
+
+    public function __construct($code)
+    {
+        if (!is_string($code)) {
+            throw new \InvalidArgumentException('Currency code should be string');
+        }
+
+        $this->code = $code;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC6573/DDC6573Item.php
+++ b/tests/Doctrine/Tests/Models/DDC6573/DDC6573Item.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC6573;
+
+/**
+ * @Entity
+ * @Table(name="ddc6573_items")
+ */
+class DDC6573Item
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /**
+     * @Column(type="string", length=255)
+     */
+    public $name;
+
+    /**
+     * @Column(type="string")
+     */
+    public $priceAmount;
+
+    /**
+     * @Column(type="string", length=3)
+     */
+    public $priceCurrency;
+
+    /**
+     * @param $name
+     * @param DDC6573Money $price
+     */
+    public function __construct($name, DDC6573Money $price)
+    {
+        $this->name = $name;
+        $this->priceAmount = $price->getAmount();
+        $this->priceCurrency = $price->getCurrency()->getCode();
+    }
+
+    /**
+     * @return DDC6573Money
+     */
+    public function getPrice()
+    {
+        return new DDC6573Money($this->priceAmount, new DDC6573Currency($this->priceCurrency));
+    }
+}

--- a/tests/Doctrine/Tests/Models/DDC6573/DDC6573Money.php
+++ b/tests/Doctrine/Tests/Models/DDC6573/DDC6573Money.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\Models\DDC6573;
+
+class DDC6573Money
+{
+    /**
+     * @var string
+     */
+    private $amount;
+
+    /**
+     * @var DDC6573Currency
+     */
+    private $currency;
+
+    /**
+     * @param int|string $amount   Amount, expressed in the smallest units of $currency (eg cents)
+     * @param DDC6573Currency   $currency
+     *
+     * @throws \InvalidArgumentException If amount is not integer
+     */
+    public function __construct($amount, DDC6573Currency $currency)
+    {
+        if (filter_var($amount, FILTER_VALIDATE_INT) === false) {
+            throw new \InvalidArgumentException('Amount must be an integer(ish) value');
+        }
+
+        $this->amount = (string) $amount;
+        $this->currency = $currency;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return DDC6573Currency
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6573Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6573Test.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\DDC6573\DDC6573Currency;
+use Doctrine\Tests\Models\DDC6573\DDC6573Item;
+use Doctrine\Tests\Models\DDC6573\DDC6573Money;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6573
+ */
+class DDC6573Test extends OrmFunctionalTestCase
+{
+    /**
+     * @var DDC6573Item[]
+     */
+    private $fixtures;
+
+    protected function setUp()
+    {
+        $this->useModelSet('ddc6573');
+        parent::setUp();
+
+        $this->loadFixtures();
+    }
+
+    public function provideDataForHydrationMode()
+    {
+        return [
+            [Query::HYDRATE_ARRAY],
+            [Query::HYDRATE_OBJECT],
+        ];
+    }
+
+    private function loadFixtures()
+    {
+        $item1 = new DDC6573Item('Plate', new DDC6573Money('5', new DDC6573Currency('GBP')));
+        $item2 = new DDC6573Item('Teapot', new DDC6573Money(10, new DDC6573Currency('GBP')));
+        $item3 = new DDC6573Item('Iron', new DDC6573Money('50', new DDC6573Currency('GBP')));
+
+        $this->_em->persist($item1);
+        $this->_em->persist($item2);
+        $this->_em->persist($item3);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $this->fixtures = [$item1, $item2, $item3];
+    }
+
+    /**
+     * @dataProvider provideDataForHydrationMode
+     */
+    public function testShouldSupportsMultipleNewOperator($hydrationMode)
+    {
+        $this->markTestSkipped('Feature does not exist.');
+
+        $dql = "
+            SELECT
+                new Doctrine\Tests\Models\DDC6573\DDC6573Money(
+                    i.priceAmount,
+                    new Doctrine\Tests\Models\DDC6573\DDC6573Currency(i.priceCurrency)
+                )
+            FROM
+                Doctrine\Tests\Models\DDC6573\DDC6573Item i
+            ORDER BY
+                i.priceAmount";
+
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getResult($hydrationMode);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(DDC6573Money::class, $result[0]);
+        $this->assertInstanceOf(DDC6573Money::class, $result[1]);
+        $this->assertInstanceOf(DDC6573Money::class, $result[2]);
+
+        $this->assertEquals($this->fixtures[0]->getPrice(), $result[0]);
+        $this->assertEquals($this->fixtures[1]->getPrice(), $result[1]);
+        $this->assertEquals($this->fixtures[2]->getPrice(), $result[2]);
+    }
+
+    /**
+     * @dataProvider provideDataForHydrationMode
+     */
+    public function testShouldSupportsMultipleNewOperatorWithHiddenKeyword($hydrationMode)
+    {
+        $this->markTestSkipped('Feature does not exist.');
+
+        $dql = "
+            SELECT
+                new Doctrine\Tests\Models\DDC6573\DDC6573Currency(i.priceCurrency) as HIDDEN currency,
+                new Doctrine\Tests\Models\DDC6573\DDC6573Money(
+                    i.priceAmount,
+                    currency
+                )
+            FROM
+                Doctrine\Tests\Models\DDC6573\DDC6573Item i
+            ORDER BY
+                i.priceAmount";
+
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getResult($hydrationMode);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(DDC6573Money::class, $result[0]);
+        $this->assertInstanceOf(DDC6573Money::class, $result[1]);
+        $this->assertInstanceOf(DDC6573Money::class, $result[2]);
+
+        $this->assertEquals($this->fixtures[0]->getPrice(), $result[0]);
+        $this->assertEquals($this->fixtures[1]->getPrice(), $result[1]);
+        $this->assertEquals($this->fixtures[2]->getPrice(), $result[2]);
+    }
+
+    public function testShouldSupportsMultipleNewOperatorWithFunctionApplied()
+    {
+        $this->markTestSkipped('Feature does not exist.');
+
+        $dql = "
+            SELECT
+                new Doctrine\Tests\Models\DDC6573\DDC6573Money(
+                  sum(i.priceAmount),
+                  new Doctrine\Tests\Models\DDC6573\DDC6573Currency('GBP')
+                )
+            FROM
+                Doctrine\Tests\Models\DDC6573\DDC6573Item i
+            ORDER BY
+                i.priceAmount";
+
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getScalarResult();
+
+        $this->assertEquals(new DDC6573Money('65', new DDC6573Currency('GBP')), $result[0]);
+    }
+
+    /**
+     * @dataProvider provideDataForHydrationMode
+     */
+    public function testShouldSupportsBasicUsage($hydrationMode)
+    {
+        $dql = "
+            SELECT
+                new Doctrine\Tests\Models\DDC6573\DDC6573Currency(
+                    i.priceCurrency
+                )
+            FROM
+                Doctrine\Tests\Models\DDC6573\DDC6573Item i
+            ORDER BY
+                i.priceAmount";
+
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getResult($hydrationMode);
+
+        $this->assertCount(3, $result);
+
+        $this->assertInstanceOf(DDC6573Currency::class, $result[0]);
+        $this->assertInstanceOf(DDC6573Currency::class, $result[1]);
+        $this->assertInstanceOf(DDC6573Currency::class, $result[2]);
+
+        $this->assertEquals($this->fixtures[0]->getPrice()->getCurrency(), $result[0]);
+        $this->assertEquals($this->fixtures[1]->getPrice()->getCurrency(), $result[1]);
+        $this->assertEquals($this->fixtures[2]->getPrice()->getCurrency(), $result[2]);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6573Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6573Test.php
@@ -55,8 +55,6 @@ class DDC6573Test extends OrmFunctionalTestCase
      */
     public function testShouldSupportsMultipleNewOperator($hydrationMode)
     {
-        $this->markTestSkipped('Feature does not exist.');
-
         $dql = "
             SELECT
                 new Doctrine\Tests\Models\DDC6573\DDC6573Money(
@@ -87,8 +85,6 @@ class DDC6573Test extends OrmFunctionalTestCase
      */
     public function testShouldSupportsMultipleNewOperatorWithHiddenKeyword($hydrationMode)
     {
-        $this->markTestSkipped('Feature does not exist.');
-
         $dql = "
             SELECT
                 new Doctrine\Tests\Models\DDC6573\DDC6573Currency(i.priceCurrency) as HIDDEN currency,
@@ -117,8 +113,6 @@ class DDC6573Test extends OrmFunctionalTestCase
 
     public function testShouldSupportsMultipleNewOperatorWithFunctionApplied()
     {
-        $this->markTestSkipped('Feature does not exist.');
-
         $dql = "
             SELECT
                 new Doctrine\Tests\Models\DDC6573\DDC6573Money(

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -312,6 +312,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue5989\Issue5989Employee::class,
             Models\Issue5989\Issue5989Manager::class,
         ],
+        'ddc6573' => [
+            Models\DDC6573\DDC6573Item::class,
+        ],
     ];
 
     /**
@@ -594,6 +597,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM issue5989_persons');
             $conn->executeUpdate('DELETE FROM issue5989_employees');
             $conn->executeUpdate('DELETE FROM issue5989_managers');
+        }
+
+        if (isset($this->_usedModelSets['ddc6573'])) {
+            $conn->executeUpdate('DELETE FROM ddc6573_items');
         }
 
         $this->_em->clear();


### PR DESCRIPTION
In some cases, it will be good to use multiple `NewObjectExpression`.

For example, I used [money](https://github.com/moneyphp/money) library for money calculations and I would like to return the price of each item in my bucket as a `Money` value object.

```
            SELECT
                new Doctrine\Tests\Models\DDC6573\DDC6573Money(
                    i.priceAmount,
                    new Doctrine\Tests\Models\DDC6573\DDC6573Currency(i.priceCurrency)
                )
            FROM
                Doctrine\Tests\Models\DDC6573\DDC6573Item i
```

See: #6573 

Right now I committed the only test.


