### PR TITLE
Require PHP 7.2, drop <7.2 in Composer & on Travis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1
+            version: 7.2
 
 before_commands:
     - "composer install --no-dev --prefer-source"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 7.1
   - 7.2
   - nightly
 
@@ -29,13 +28,6 @@ jobs:
       env: DB=mariadb
       addons:
         mariadb: 10.1
-
-    - stage: Test
-      env: DB=mysql MYSQL_VERSION=5.7
-      php: 7.1
-      before_script:
-        - ./tests/travis/install-mysql-$MYSQL_VERSION.sh
-      sudo: required
 
     - stage: Test
       env: DB=mysql MYSQL_VERSION=5.7

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-pdo": "*",
         "doctrine/collections": "^1.4",
         "doctrine/dbal": "dev-develop as 3.x-dev",


### PR DESCRIPTION
Targeting develop; closes #6529.

~How should I fix Scrutinizer (probably no 7.2 yet)? Is it even a blocker for _develop_?~ Oh cool, Scrutinizer doesn't seem to bother with develop. ^^