### PR TITLE
Allow DBAL 2.6 and common 2.8 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4",
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
-        "doctrine/dbal": ">=2.5-dev,<2.6-dev",
+        "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
         "doctrine/common": ">=2.5-dev,<2.8-dev",
         "doctrine/cache": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
         "doctrine/instantiator": "~1.0.1",
-        "doctrine/common": ">=2.5-dev,<2.8-dev",
+        "doctrine/common": ">=2.5-dev,<2.9-dev",
         "doctrine/cache": "~1.4",
         "symfony/console": "~2.5|~3.0"
     },


### PR DESCRIPTION
DBAL 2.6 is released but currently dependencies can't be resolved as ORM 2.5 does not allow DBAL 2.6 and ORM 2.6 is not relased yet.