### PR TITLE
Correctly process entities bound to query parameters, conver them to their identifier values when their metadata is not yet available in-memory

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -19,10 +19,11 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Util\ClassUtils;
+use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 
+use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
@@ -419,17 +420,16 @@ abstract class AbstractQuery
 
         if (is_object($value)) {
             try {
-                $this->_em->getMetadataFactory()->getMetadataFor(ClassUtils::getClass($value));
-            } catch (\Exception $e) {
-
-            }
-
-            if (!isset($e)) {
                 $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
 
                 if ($value === null) {
                     throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
                 }
+            } catch (MappingException $e) {
+                // The object is not a mapped entity but we still want its processed value so we have to continue code
+                // execution
+            } catch (ORMMappingException $e) {
+
             }
         }
 

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -417,11 +417,19 @@ abstract class AbstractQuery
             return $value;
         }
 
-        if (is_object($value) && $this->_em->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($value))) {
-            $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
+        if (is_object($value)) {
+            try {
+                $this->_em->getMetadataFactory()->getMetadataFor(ClassUtils::getClass($value));
+            } catch (\Exception $e) {
 
-            if ($value === null) {
-                throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+            }
+
+            if (!isset($e)) {
+                $value = $this->_em->getUnitOfWork()->getSingleIdentifierValue($value);
+
+                if ($value === null) {
+                    throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
+                }
             }
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -870,8 +870,9 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testProcessParameterValueWithObjects()
     {
-        $query  = $this->_em->createQuery();
+        $query = $this->_em->createQuery();
 
+        // non-mapped class
         $dt = new \DateTime();
         $this->assertSame(
             $dt,
@@ -887,6 +888,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         $this->assertEquals(true, $this->_em->getMetadataFactory()->hasMetadataFor(CmsUser::class));
 
+        // non-loaded metadata
         $this->assertEquals(
             $user->getId(),
             $query->processParameterValue($user)
@@ -895,6 +897,7 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->getMetadataFactory()->setMetadataFor(CmsUser::class, null);
         $this->assertEquals(false, $this->_em->getMetadataFactory()->hasMetadataFor(CmsUser::class));
 
+        // loaded metadata
         $this->assertEquals(
             $user->getId(),
             $query->processParameterValue($user)

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -867,4 +867,37 @@ class QueryTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(CmsUser::class, $users[2]);
         $this->assertNull($users[3]);
     }
+
+    public function testProcessParameterValueWithObjects()
+    {
+        $query  = $this->_em->createQuery();
+
+        $dt = new \DateTime();
+        $this->assertSame(
+            $dt,
+            $query->processParameterValue($dt)
+        );
+
+        $user = new CmsUser();
+        $user->name = 'Thomas';
+        $user->username = 'fancyweb';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->assertEquals(true, $this->_em->getMetadataFactory()->hasMetadataFor(CmsUser::class));
+
+        $this->assertEquals(
+            $user->getId(),
+            $query->processParameterValue($user)
+        );
+
+        $this->_em->getMetadataFactory()->setMetadataFor(CmsUser::class, null);
+        $this->assertEquals(false, $this->_em->getMetadataFactory()->hasMetadataFor(CmsUser::class));
+
+        $this->assertEquals(
+            $user->getId(),
+            $query->processParameterValue($user)
+        );
+    }
 }


### PR DESCRIPTION
Fixed issue : https://github.com/doctrine/doctrine2/issues/6073

Better late than never :-)