### PR TITLE
Removed the final comment on EntityManager.php

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -60,7 +60,7 @@ use Doctrine\Common\Util\ClassUtils;
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  */
-/* final */class EntityManager implements EntityManagerInterface
+class EntityManager implements EntityManagerInterface
 {
     /**
      * The used Configuration.


### PR DESCRIPTION
Removed the comment for "final class keyword" on EntityManager to avoid ambiguity. The commit to put this into comment was made in early 2013 but does not talk about why the final was commented. Though i really wanted to add a final back but i am assuming there must be a reason for it.