### PR TITLE
Typehint EntityManagerInterface only

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 3.0
 
+## BC Break: ``EntityManagerInterface`` is now used instead of ``EntityManager`` in typehints
+
+`Sequencing\Generator#generate()` now takes ``EntityManagerInterface`` as its first argument instead of ``EntityManager``. If you have any custom generators, please update your code accordingly.
+
 ## BC Break: Removed `EntityManager#flush($entity)` and `EntityManager#flush($entities)`
 
 If your code relies on single entity flushing optimisations via

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -264,7 +264,7 @@ abstract class AbstractQuery
     /**
      * Retrieves the associated EntityManager of this Query instance.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class DefaultEntityHydrator implements EntityHydrator
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -31,7 +31,7 @@ class EntityRepository implements ObjectRepository, Selectable
     protected $entityName;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
@@ -43,8 +43,8 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Initializes a new <tt>EntityRepository</tt>.
      *
-     * @param EntityManager         $em    The EntityManager to use.
-     * @param Mapping\ClassMetadata $class The class descriptor.
+     * @param EntityManagerInterface $em    The EntityManager to use.
+     * @param Mapping\ClassMetadata  $class The class descriptor.
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {
@@ -249,7 +249,7 @@ class EntityRepository implements ObjectRepository, Selectable
     }
 
     /**
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     protected function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -30,7 +30,7 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -35,7 +35,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -36,7 +36,7 @@ class OnFlushEventArgs extends EventArgs
     /**
      * Retrieve associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class PostFlushEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
@@ -34,7 +34,7 @@ class PostFlushEventArgs extends EventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class PreFlushEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
@@ -34,7 +34,7 @@ class PreFlushEventArgs extends EventArgs
     }
 
     /**
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -35,7 +35,7 @@ class FilterCollection
     /**
      * The EntityManager that "owns" this FilterCollection instance.
      *
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -122,7 +122,7 @@ class Parser
     /**
      * The EntityManager.
      *
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
@@ -227,7 +227,7 @@ class Parser
     /**
      * Gets the EntityManager used by the parser.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -83,7 +83,7 @@ class SqlWalker implements TreeWalker
     private $parserResult;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
@@ -196,7 +196,7 @@ class SqlWalker implements TreeWalker
     /**
      * Gets the EntityManager used by the walker.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -262,7 +262,7 @@ class QueryBuilder
     /**
      * Gets the associated EntityManager for this query builder.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -35,7 +35,7 @@ class BigIntegerIdentityGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return (string) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Sequencing/Generator.php
+++ b/lib/Doctrine/ORM/Sequencing/Generator.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 interface Generator
 {
     /**
      * Generates an identifier for an entity.
      *
-     * @param EntityManager $em
-     * @param object        $entity
+     * @param EntityManagerInterface $em
+     * @param object                 $entity
      *
      * @return \Generator
      */
-    public function generate(EntityManager $em, $entity);
+    public function generate(EntityManagerInterface $em, $entity);
 
     /**
      * Gets whether this generator is a post-insert generator which means that

--- a/lib/Doctrine/ORM/Sequencing/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/IdentityGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that obtains IDs from special "identity" columns. These are columns
@@ -35,7 +35,7 @@ class IdentityGenerator implements Generator
     /**
      * {@inheritDoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return (int) $em->getConnection()->lastInsertId($this->sequenceName);
     }

--- a/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Serializable;
 
 /**
@@ -54,7 +54,7 @@ class SequenceGenerator implements Generator, Serializable
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         if ($this->maxValue === null || $this->nextValue == $this->maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Sequencing/TableGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/TableGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Id generator that uses a single-row database table and a hi/lo algorithm.
@@ -57,7 +57,7 @@ class TableGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         if ($this->maxValue === null || $this->nextValue === $this->maxValue) {
             // Allocate new values

--- a/lib/Doctrine/ORM/Sequencing/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/UuidGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Represents an ID generator that uses the database UUID expression
@@ -17,7 +17,7 @@ class UuidGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         $conn = $em->getConnection();
         $sql = 'SELECT ' . $conn->getDatabasePlatform()->getGuidExpression();

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -39,7 +39,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /* @var $entityManager \Doctrine\ORM\EntityManager */
+        /* @var $entityManager \Doctrine\ORM\EntityManagerInterface */
         $entityManager = $this->getHelper('em')->getEntityManager();
 
         $entityClassNames = $entityManager->getConfiguration()

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -38,7 +38,7 @@ abstract class AbstractCommand extends Command
     {
         $emHelper = $this->getHelper('em');
 
-        /* @var $em \Doctrine\ORM\EntityManager */
+        /* @var $em \Doctrine\ORM\EntityManagerInterface */
         $em = $emHelper->getEntityManager();
 
         $metadatas = $em->getMetadataFactory()->getAllMetadata();

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -59,7 +59,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
     private $maxResults;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\EventListener;
 
 use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\CacheMetadata;
 use Doctrine\ORM\Mapping\CacheUsage;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -57,10 +57,10 @@ class CacheMetadataListener
     }
 
     /**
-     * @param ClassMetadata $metadata
-     * @param EntityManager $em
+     * @param ClassMetadata          $metadata
+     * @param EntityManagerInterface $em
      */
-    protected function enableCaching(ClassMetadata $metadata, EntityManager $em)
+    protected function enableCaching(ClassMetadata $metadata, EntityManagerInterface $em)
     {
         if ($this->isVisited($metadata)) {
             return; // Already handled in the past

--- a/tests/Doctrine/Tests/Mocks/SequenceMock.php
+++ b/tests/Doctrine/Tests/Mocks/SequenceMock.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Sequencing\SequenceGenerator;
 
 /**
@@ -20,7 +20,7 @@ class SequenceMock extends SequenceGenerator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return $this->sequenceNumber++;
     }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -41,7 +41,7 @@ class DefaultCacheFactoryTest extends OrmTestCase
     private $factory;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
@@ -25,7 +25,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
     private $structure;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -36,7 +36,7 @@ class DefaultQueryCacheTest extends OrmTestCase
     private $queryCache;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Cache\Persister\Collection\AbstractCollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
@@ -32,7 +32,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     protected $collectionPersister;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
@@ -67,15 +67,15 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
     ];
 
     /**
-     * @param EntityManager       $em
-     * @param CollectionPersister $persister
-     * @param Region              $region
-     * @param AssociationMetadata $association
+     * @param EntityManagerInterface $em
+     * @param CollectionPersister    $persister
+     * @param Region                 $region
+     * @param AssociationMetadata    $association
      *
      * @return AbstractCollectionPersister
      */
     abstract protected function createPersister(
-        EntityManager $em,
+        EntityManagerInterface $em,
         CollectionPersister $persister,
         Region $region,
         AssociationMetadata $association

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\NonStrictReadWriteCachedCollectionPersister;
@@ -19,7 +19,7 @@ class NonStrictReadWriteCachedCollectionPersisterTest extends AbstractCollection
      * {@inheritdoc}
      */
     protected function createPersister(
-        EntityManager $em,
+        EntityManagerInterface $em,
         CollectionPersister $persister,
         Region $region,
         AssociationMetadata $association

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Cache\Persister\Collection\ReadOnlyCachedCollectionPersister;
@@ -19,7 +19,7 @@ class ReadOnlyCachedCollectionPersisterTest extends AbstractCollectionPersisterT
      * {@inheritdoc}
      */
     protected function createPersister(
-        EntityManager $em,
+        EntityManagerInterface $em,
         CollectionPersister $persister,
         Region $region,
         AssociationMetadata $association

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\ORM\Cache\CollectionCacheKey;
@@ -35,7 +35,7 @@ class ReadWriteCachedCollectionPersisterTest extends AbstractCollectionPersister
      * {@inheritdoc}
      */
     protected function createPersister(
-        EntityManager $em,
+        EntityManagerInterface $em,
         CollectionPersister $persister,
         Region $region,
         AssociationMetadata $association

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
@@ -36,7 +36,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     protected $entityPersister;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 
@@ -88,14 +88,14 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
     ];
 
     /**
-     * @param \Doctrine\ORM\EntityManager                     $em
+     * @param \Doctrine\ORM\EntityManagerInterface            $em
      * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister
      * @param \Doctrine\ORM\Cache\Region                      $region
      * @param \Doctrine\ORM\Mapping\ClassMetadata             $metadata
      *
      * @return \Doctrine\ORM\Cache\Persister\Entity\AbstractEntityPersister
      */
-    abstract protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata);
+    abstract protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata);
 
     protected function setUp()
     {

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Cache\EntityCacheEntry;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersister;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\Tests\Models\Cache\Country;
@@ -21,7 +21,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     /**
      * {@inheritdoc}
      */
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
     {
         return new NonStrictReadWriteCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
@@ -19,7 +19,7 @@ class ReadOnlyCachedEntityPersisterTest extends AbstractEntityPersisterTest
     /**
      * {@inheritdoc}
      */
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
     {
         return new ReadOnlyCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php
@@ -6,9 +6,9 @@ namespace Doctrine\Tests\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\Region;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\EntityCacheKey;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Models\Cache\Country;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
@@ -34,7 +34,7 @@ class ReadWriteCachedEntityPersisterTest extends AbstractEntityPersisterTest
     /**
      * {@inheritdoc}
      */
-    protected function createPersister(EntityManager $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
+    protected function createPersister(EntityManagerInterface $em, EntityPersister $persister, Region $region, ClassMetadata $metadata)
     {
         return new ReadWriteCachedEntityPersister($persister, $region, $em, $metadata);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
@@ -233,7 +234,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
     /**
      * @param SQLLogger $logger
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     private function createEntityManager(SQLLogger $logger)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\ORM\Query\Filter\SQLFilter;
@@ -201,7 +201,7 @@ class SQLFilterTest extends OrmFunctionalTestCase
     protected function getMockEntityManager()
     {
         // Setup connection mock
-        $em = $this->getMockBuilder(EntityManager::class)
+        $em = $this->getMockBuilder(EntityManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
@@ -39,7 +39,7 @@ class DDC1509Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $picture->setThumbnail($thumbnail);
 
 
-        /* @var $em \Doctrine\ORM\EntityManager */
+        /* @var $em \Doctrine\ORM\EntityManagerInterface */
         $em = $this->em;
         $em->persist($picture);
         $em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -8,7 +8,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\MappingDriver;
@@ -28,7 +28,7 @@ class DDC2359Test extends DoctrineTestCase
     {
         $mockDriver      = $this->createMock(MappingDriver::class);
         $mockMetadata    = $this->createMock(ClassMetadata::class);
-        $entityManager   = $this->createMock(EntityManager::class);
+        $entityManager   = $this->createMock(EntityManagerInterface::class);
 
         /* @var $metadataFactory \Doctrine\ORM\Mapping\ClassMetadataFactory|\PHPUnit_Framework_MockObject_MockObject */
         $metadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -5,7 +5,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Sequencing\Generator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
@@ -47,7 +47,7 @@ final class GH5804Generator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity)
+    public function generate(EntityManagerInterface $em, $entity)
     {
         return 'test5804';
     }

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -24,7 +24,7 @@ use Doctrine\Tests\Models\Legacy\LegacyUserReference;
 class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -56,10 +56,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     }
 
     /**
-     * @param \Doctrine\ORM\EntityManager $entityClassName
+     * @param \Doctrine\ORM\EntityManagerInterface $entityClassName
      * @return \Doctrine\ORM\Mapping\ClassMetadataFactory
      */
-    protected function createClassMetadataFactory(EntityManager $em = null)
+    protected function createClassMetadataFactory(EntityManagerInterface $em = null)
     {
         $driver     = $this->loadDriver();
         $em         = $em ?: $this->getTestEntityManager();

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
@@ -430,7 +429,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $classMetadataFactory = new ClassMetadataFactory();
 
-        /* @var $entityManager EntityManager */
+        /* @var EntityManagerInterface EntityManager */
         $entityManager        = $this->createMock(EntityManagerInterface::class);
 
         $classMetadataFactory->setEntityManager($entityManager);
@@ -523,7 +522,7 @@ class CustomIdGenerator implements Generator
     /**
      * {@inheritdoc}
      */
-    public function generate(EntityManager $em, $entity): \Generator
+    public function generate(EntityManagerInterface $em, $entity): \Generator
     {
     }
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
@@ -20,7 +20,7 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
     protected $persister;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -18,7 +18,7 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
     protected $persister;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -23,7 +23,7 @@ class BasicEntityPersisterTypeValueSqlTest extends OrmTestCase
     protected $persister;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -16,7 +16,7 @@ use Doctrine\Tests\OrmTestCase;
 class FilterCollectionTest extends OrmTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -6,8 +6,7 @@ namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Collections\ArrayCollection;
-
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
@@ -18,7 +17,7 @@ use Doctrine\Tests\OrmTestCase;
 
 class QueryTest extends OrmTestCase
 {
-    /** @var EntityManager */
+    /** @var EntityManagerInterface */
     protected $em = null;
 
     protected function setUp()

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -28,7 +28,7 @@ use Doctrine\Tests\OrmTestCase;
 class QueryBuilderTest extends OrmTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Sequencing/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Sequencing/SequenceGeneratorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Sequencing;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Sequencing\SequenceGenerator;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Mocks\StatementArrayMock;
@@ -13,7 +13,7 @@ use Doctrine\Tests\OrmTestCase;
 class SequenceGeneratorTest extends OrmTestCase
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $entityManager;
 

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\OrmTestCase;
 class AttachEntityListenersListenerTest extends OrmTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\OrmTestCase;
 class ResolveTargetEntityListenerTest extends OrmTestCase
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Tools;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\Tests\OrmTestCase;
 
 class SchemaValidatorTest extends OrmTestCase
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $em = null;
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\DbalTypes\Rot13Type;
@@ -50,7 +51,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     protected static $sharedConn;
 
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     protected $em;
 
@@ -670,7 +671,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     /**
      * Gets an EntityManager for testing purposes.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      *
      * @throws \Doctrine\ORM\ORMException
      */

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -84,7 +84,7 @@ abstract class OrmTestCase extends DoctrineTestCase
      * @param \Doctrine\Common\EventManager|null $eventManager
      * @param bool                               $withSharedMetadata
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
     protected function getTestEntityManager($conn = null, $conf = null, $eventManager = null, $withSharedMetadata = true)
     {


### PR DESCRIPTION
Few signature changes (Generators), otherwise mostly just fixes for incorrect `@var`/`@return` where EntityManagerInterfcace is already used.

Relates to #6596.