### PR TITLE
Fix double spacing in "cascade persist missing" exception message

### DIFF
--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -93,7 +93,7 @@ class ORMInvalidArgumentException extends \InvalidArgumentException
             . $assoc['sourceEntity'] . "#" . $assoc['fieldName'] . "' that was not"
             . " configured to cascade persist operations for entity: " . self::objToStr($entry) . "."
             . " To solve this issue: Either explicitly call EntityManager#persist()"
-            . " on this unknown entity or configure cascade persist "
+            . " on this unknown entity or configure cascade persist"
             . " this association in the mapping for example @ManyToOne(..,cascade={\"persist\"})."
             . (method_exists($entry, '__toString') ? "": " If you cannot find out which entity causes the problem"
             . " implement '" . $assoc['targetEntity'] . "#__toString()' to get a clue."));


### PR DESCRIPTION
This is an absolute minor style improvement that concerns wrong double spacing on string concatenation.