### PR TITLE
Allow called flush inside its postFlush event

### DIFF
--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -32,27 +32,210 @@ use Doctrine\ORM\EntityManagerInterface;
 class PostFlushEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManager
+     * @var \Doctrine\ORM\EntityManagerInterface
      */
     private $em;
 
     /**
-     * Constructor.
+     * Map of entity changes. Keys are object ids (spl_object_hash).
+     * Filled at the beginning of a commit of the UnitOfWork and cleaned at the end.
      *
-     * @param EntityManagerInterface $em
+     * @var array
      */
-    public function __construct(EntityManagerInterface $em)
-    {
+    private $entityChangeSets = [];
+
+    /**
+     * Map of entities that are scheduled for dirty checking at commit time.
+     * This is only used for entities with a change tracking policy of DEFERRED_EXPLICIT.
+     * Keys are object ids (spl_object_hash).
+     *
+     * @var array
+     */
+    private $scheduledForSynchronization = [];
+
+    /**
+     * A list of all pending entity insertions.
+     *
+     * @var array
+     */
+    private $entityInsertions = [];
+
+    /**
+     * A list of all pending entity updates.
+     *
+     * @var array
+     */
+    private $entityUpdates = [];
+
+    /**
+     * Any pending extra updates that have been scheduled by persisters.
+     *
+     * @var array
+     */
+    private $extraUpdates = [];
+    /**
+     * A list of all pending entity deletions.
+     *
+     * @var array
+     */
+    private $entityDeletions = [];
+
+    /**
+     * All pending collection deletions.
+     *
+     * @var array
+     */
+    private $collectionDeletions = [];
+
+    /**
+     * All pending collection updates.
+     *
+     * @var array
+     */
+    private $collectionUpdates = [];
+
+    /**
+     * List of collections visited during changeset calculation on a commit-phase of a UnitOfWork.
+     * At the end of the UnitOfWork all these collections will make new snapshots
+     * of their data.
+     *
+     * @var array
+     */
+    private $visitedCollections = [];
+
+    /**
+     * Orphaned entities that are scheduled for removal.
+     *
+     * @var array
+     */
+    private $orphanRemovals = [];
+
+    /**
+     * @param EntityManagerInterface $em
+     * @param array $entityInsertions
+     * @param array $entityUpdates
+     * @param array $entityDeletions
+     * @param array $extraUpdates
+     * @param array $entityChangeSets
+     * @param array $collectionUpdates
+     * @param array $collectionDeletions
+     * @param array $visitedCollections
+     * @param array $scheduledForSynchronization
+     * @param array $orphanRemovals
+     */
+    public function __construct(
+        EntityManagerInterface $em,
+        array $entityInsertions = [],
+        array $entityUpdates = [],
+        array $entityDeletions = [],
+        array $extraUpdates = [],
+        array $entityChangeSets = [],
+        array $collectionUpdates = [],
+        array $collectionDeletions = [],
+        array $visitedCollections = [],
+        array $scheduledForSynchronization = [],
+        array $orphanRemovals = []
+    ) {
         $this->em = $em;
+        $this->entityInsertions = $entityInsertions;
+        $this->entityUpdates = $entityUpdates;
+        $this->entityDeletions = $entityDeletions;
+        $this->extraUpdates = $extraUpdates;
+        $this->entityChangeSets = $entityChangeSets;
+        $this->collectionUpdates = $collectionUpdates;
+        $this->collectionDeletions = $collectionDeletions;
+        $this->visitedCollections = $visitedCollections;
+        $this->scheduledForSynchronization = $scheduledForSynchronization;
+        $this->orphanRemovals = $orphanRemovals;
     }
 
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManager
+     * @return \Doctrine\ORM\EntityManagerInterface
      */
-    public function getEntityManager()
+    public function getEntityManager(): EntityManagerInterface
     {
         return $this->em;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntityChangeSets(): array
+    {
+        return $this->entityChangeSets;
+    }
+
+    /**
+     * @return array
+     */
+    public function getScheduledForSynchronization(): array
+    {
+        return $this->scheduledForSynchronization;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntityInsertions(): array
+    {
+        return $this->entityInsertions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntityUpdates(): array
+    {
+        return $this->entityUpdates;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExtraUpdates(): array
+    {
+        return $this->extraUpdates;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntityDeletions(): array
+    {
+        return $this->entityDeletions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCollectionDeletions(): array
+    {
+        return $this->collectionDeletions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCollectionUpdates(): array
+    {
+        return $this->collectionUpdates;
+    }
+
+    /**
+     * @return array
+     */
+    public function getVisitedCollections(): array
+    {
+        return $this->visitedCollections;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOrphanRemovals(): array
+    {
+        return $this->orphanRemovals;
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -412,8 +412,19 @@ class UnitOfWork implements PropertyChangedListener
             $coll->takeSnapshot();
         }
 
-        $this->dispatchPostFlushEvent();
-
+        $event = new PostFlushEventArgs(
+            $this->em,
+            $this->entityInsertions,
+            $this->entityUpdates,
+            $this->entityDeletions,
+            $this->extraUpdates,
+            $this->entityChangeSets,
+            $this->collectionUpdates,
+            $this->collectionDeletions,
+            $this->visitedCollections,
+            $this->scheduledForSynchronization,
+            $this->orphanRemovals
+        );
         // Clear up
         $this->entityInsertions =
         $this->entityUpdates =
@@ -425,6 +436,8 @@ class UnitOfWork implements PropertyChangedListener
         $this->visitedCollections =
         $this->scheduledForSynchronization =
         $this->orphanRemovals = [];
+
+        $this->dispatchPostFlushEvent($event);
     }
 
     /**
@@ -3301,10 +3314,10 @@ class UnitOfWork implements PropertyChangedListener
         }
     }
 
-    private function dispatchPostFlushEvent()
+    private function dispatchPostFlushEvent(PostFlushEventArgs $event = null)
     {
         if ($this->evm->hasListeners(Events::postFlush)) {
-            $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
+            $this->evm->dispatchEvent(Events::postFlush, $event ?: new PostFlushEventArgs($this->em));
         }
     }
 


### PR DESCRIPTION
This PR related to https://github.com/doctrine/doctrine2/pull/1503 https://github.com/doctrine/doctrine2/pull/6590

I think it makes sense to allow this cases, because "why not" if end user can ensure that it does not cause to an infinite loop of recursion. In this PR moved dispatchPostFlushEvent method below clean up and added access to state of change set bypassing UOW.