### PR TITLE
Added DiscriminatorValue annotation

### DIFF
--- a/docs/en/cookbook/decorator-pattern.rst
+++ b/docs/en/cookbook/decorator-pattern.rst
@@ -27,6 +27,7 @@ concrete subclasses, ``ConcreteComponent`` and ``ConcreteDecorator``.
      * @Entity
      * @InheritanceType("SINGLE_TABLE")
      * @DiscriminatorColumn(name="discr", type="string")
+     * @DiscriminatorValue(value="discr-column-value")
      * @DiscriminatorMap({"cc" = "Test\Component\ConcreteComponent", 
         "cd" = "Test\Decorator\ConcreteDecorator"})
      */

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -246,6 +246,11 @@ class ClassMetadataBuilder
         return $this;
     }
 
+    public function setDiscriminatorValue($value, $className)
+    {
+        $this->cm->setDiscriminatorValue($value, $className);
+    }
+
     /**
      * Adds a subclass to this inheritance hierarchy.
      *

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2773,6 +2773,25 @@ class ClassMetadataInfo implements ClassMetadata
         }
     }
 
+    public function setDiscriminatorValue($value, $className)
+    {
+        $discrVal = '';
+        if (isset($value->value)) {
+            $discrVal = $value->value;
+        }
+        if (!is_string($discrVal)) {
+            throw MappingException::invalidDiscriminatorValue($this->name);
+        }
+        $this->discriminatorValue = $discrVal;
+
+        $discrMapKey = array_search($className, $this->discriminatorMap);
+        if ($discrMapKey === false) {
+            throw MappingException::invalidClassInMap($className);
+        }
+        $this->discriminatorMap[$discrVal] = $className;
+        unset($this->discriminatorMap[$discrMapKey]);
+    }
+
     /**
      * Sets the discriminator values used by this class.
      * Used for JOINED and SINGLE_TABLE inheritance mapping strategies.

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorValue.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorValue.php
@@ -1,0 +1,14 @@
+<?php
+namespace Doctrine\ORM\Mapping;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class DiscriminatorValue implements Annotation
+{
+    /**
+     * @var string
+     */
+    public $value;
+}

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -183,6 +183,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                         'fields'                => [],
                         'entityClass'           => $entityResultAnnot->entityClass,
                         'discriminatorColumn'   => $entityResultAnnot->discriminatorColumn,
+                        'discriminatorValue'    => $entityResultAnnot->discriminatorValue,
                     ];
 
                     foreach ($entityResultAnnot->fields as $fieldResultAnnot) {
@@ -263,6 +264,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     $metadata->setDiscriminatorMap($discrMapAnnot->value);
                 }
             }
+        }
+
+        // Sets custom Discriminator value from within a child class
+        if (isset($classAnnotations[Mapping\DiscriminatorValue::class])) {
+            $metadata->setDiscriminatorValue($classAnnotations[Mapping\DiscriminatorValue::class], $className);
         }
 
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -132,6 +132,7 @@ class XmlDriver extends FileDriver
                             'fields'                => [],
                             'entityClass'           => (string) $entityElement['entity-class'],
                             'discriminatorColumn'   => isset($entityElement['discriminator-column']) ? (string) $entityElement['discriminator-column'] : null,
+                            'discriminatorValue'    => isset($entityElement['discriminator-value']) ? (string) $entityElement['discriminator-value'] : null,
                         ];
 
                         foreach ($entityElement as $fieldElement) {
@@ -191,6 +192,11 @@ class XmlDriver extends FileDriver
                     $metadata->setDiscriminatorMap($map);
                 }
             }
+        }
+
+        // Sets custom Discriminator value from within a child class
+        if (isset($xmlRoot->{'discriminator-value'})) {
+            $metadata->setDiscriminatorValue($xmlRoot->{'discriminator-value'}, $className);
         }
 
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -138,6 +138,7 @@ class YamlDriver extends FileDriver
                             'fields'                => [],
                             'entityClass'           => isset($entityResultElement['entityClass']) ? $entityResultElement['entityClass'] : null,
                             'discriminatorColumn'   => isset($entityResultElement['discriminatorColumn']) ? $entityResultElement['discriminatorColumn'] : null,
+                            'discriminatorValue'    => isset($entityResultElement['discriminatorValue']) ? $entityResultElement['discriminatorValue'] : null,
                         ];
 
                         if (isset($entityResultElement['fieldResult'])) {
@@ -198,6 +199,10 @@ class YamlDriver extends FileDriver
             }
         }
 
+        // Sets custom Discriminator value from within a child class
+        if (isset($element['discriminatorValue'])) {
+            $metadata->setDiscriminatorValue($element['discriminatorValue'], $className);
+        }
 
         // Evaluate changeTrackingPolicy
         if (isset($element['changeTrackingPolicy'])) {

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -482,6 +482,13 @@ class MappingException extends \Doctrine\ORM\ORMException
         );
     }
 
+    public static function invalidClassInMap($className)
+    {
+        return new self(
+            "'$className' is not present in the discriminator map"
+        );
+    }
+
     /**
      * @param string $className
      * @param array  $entries
@@ -529,6 +536,11 @@ class MappingException extends \Doctrine\ORM\ORMException
     public static function invalidDiscriminatorColumnType($className, $type)
     {
         return new self("Discriminator column type on entity class '$className' is not allowed to be '$type'. 'string' or 'integer' type variables are suggested!");
+    }
+
+    public static function invalidDiscriminatorValue($className)
+    {
+        return new self("Discriminator value on entity class '$className' should be a valud 'string'");
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -214,6 +214,11 @@ class ResultSetMapping
         return $this;
     }
 
+    public function setDiscriminatorValue($value, $discrColumn)
+    {
+        $this->columnOwnerMap[$discrColumn] = $value;
+    }
+
     /**
      * Sets a field to use for indexing an entity result or joined entity result.
      *

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -66,6 +66,10 @@ class PhpExporter extends AbstractExporter
             $lines[] = '$metadata->setDiscriminatorColumn(' . $this->_varExport($metadata->discriminatorColumn) . ');';
         }
 
+        if ($metadata->discriminatorValue) {
+            $lines[] = '$metadata->setDiscriminatorValue(' . $metadata->discriminatorValue . ', ' . $metadata->getName() . ');';
+        }
+
         if ($metadata->discriminatorMap) {
             $lines[] = '$metadata->setDiscriminatorMap(' . $this->_varExport($metadata->discriminatorMap) . ');';
         }

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -140,6 +140,7 @@ abstract class CompanyContract
             'type' => 'string',
             ]
         );
+        $metadata->setDiscriminatorValue('test-discr-value', $metadata->getName());
 
         $metadata->mapField(
             [

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -811,6 +811,7 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addJoinedEntityResult(DDC3899FixContract::class, 'c', 'u', 'contracts');
         $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('id'), 'id');
         $rsm->setDiscriminatorColumn('c', $this->platform->getSQLResultCasing('discr'));
+        $rsm->setDiscriminatorValue('test-discr-value', DDC3899User::class);
 
         $selectClause = $rsm->generateSelectClause(['u' => 'u1', 'c' => 'c1']);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.Company.CompanyContract.php
@@ -10,6 +10,7 @@ $metadata->setDiscriminatorColumn(
     'type' => 'string',
     ]
 );
+$metadata->setDiscriminatorValue('custom-discr-colum-value', $metadata->name);
 
 $metadata->mapField(
     [


### PR DESCRIPTION
Added Hibernate's DiscriminatorValue in Doctrine so that this value
could be set via the child Entities rather than in the DiscrminiatorMap
in the main class. The benefit of this is when an entity in Bundle A
extends BaseEntity in Bundle B and you want to add a new Entity in
a new Bundle C you would not have to make any changes in the Core
Bundle A.