### PR TITLE
Ensure that `AbstractHydrator#hydrateAll()` detaches the hydrator from the event manager

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -143,6 +143,9 @@ abstract class AbstractHydrator
         $this->_rsm   = $resultSetMapping;
         $this->_hints = $hints;
 
+        $evm = $this->_em->getEventManager();
+        $evm->addEventListener(array(Events::onClear), $this);
+
         $this->prepare();
 
         $result = $this->hydrateAllData();

--- a/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -52,6 +52,17 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
             ->method('removeEventListener')
             ->with([Events::onClear], $mockAbstractHydrator);
 
+        $mockEventManager
+            ->expects(self::at(2))
+            ->method('addEventListener')
+            ->with([Events::onClear], $mockAbstractHydrator);
+
+        $mockEventManager
+            ->expects(self::at(3))
+            ->method('removeEventListener')
+            ->with([Events::onClear], $mockAbstractHydrator);
+
         iterator_to_array($mockAbstractHydrator->iterate($mockStatement, $mockResultMapping));
+        $mockAbstractHydrator->hydrateAll($mockStatement, $mockResultMapping);
     }
 }


### PR DESCRIPTION
I think someone overlooked hydrateAll() method and edited only iterate(). https://github.com/doctrine/doctrine2/pull/1515

As a result an event listener is not added which can cause problems if EventManager implementation does not check for existence of a listener upon its removal.

In my case it causes E_NOTICE (undefined index) because of https://github.com/Kdyby/Events/blob/master/src/Events/EventManager.php#L198

If my PR should be altered (commit message, etc.) please let me know.