### PR TITLE
Remove reliance on Symfony\Component\Yaml deprecated constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,11 @@
         "doctrine/annotations": "~1.4",
         "symfony/console": "~3.0|~4.0"
     },
+    "conflict": {
+        "symfony/yaml": "<3.4"
+    },
     "require-dev": {
-        "symfony/yaml": "~3.0|~4.0",
+        "symfony/yaml": "~3.4|~4.0",
         "phpunit/phpunit": "^6.0"
     },
     "suggest": {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -806,10 +806,6 @@ class YamlDriver extends FileDriver
      */
     protected function loadMappingFile($file)
     {
-        if (defined(Yaml::class . '::PARSE_KEYS_AS_STRINGS')) {
-            return Yaml::parse(file_get_contents($file), Yaml::PARSE_KEYS_AS_STRINGS);
-        }
-
         return Yaml::parse(file_get_contents($file));
     }
 }


### PR DESCRIPTION
See https://travis-ci.org/doctrine/doctrine2/jobs/265260226#L546-L554 for reasons - constant is gone in 4.0, and that makes static analysis (obviously) crash.

