### PR TITLE
Allow installation of `doctrine/instantiator:^1.0.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-pdo": "*",
         "doctrine/collections": "~1.2",
         "doctrine/dbal": ">=2.5-dev,<2.7-dev",
-        "doctrine/instantiator": "~1.0.1",
+        "doctrine/instantiator": "^1.0.1",
         "doctrine/common": ">=2.5-dev,<2.9-dev",
         "doctrine/cache": "~1.4",
         "symfony/console": "~2.5|~3.0"


### PR DESCRIPTION
The current constraint prevents doctrine from being installed on PHP 7.1
```
  Problem 1
    - doctrine/instantiator 1.0.1 requires php ~5.3 -> your PHP version (7.1.6) does not satisfy that requirement.
    - doctrine/instantiator 1.0.3 requires php ~5.3 -> your PHP version (7.1.6) does not satisfy that requirement.
    - doctrine/instantiator 1.0.2 requires php ~5.3 -> your PHP version (7.1.6) does not satisfy that requirement.
    - Conclusion: don't install doctrine/orm v2.5.10
    - Conclusion: don't install doctrine/orm v2.5.9
    - Conclusion: don't install doctrine/orm v2.5.8
    - Conclusion: don't install doctrine/orm v2.5.7
    - Conclusion: don't install doctrine/orm v2.5.6
    - Conclusion: don't install doctrine/orm v2.5.5
    - Conclusion: don't install doctrine/orm v2.5.4
    - Conclusion: don't install doctrine/orm v2.5.3
    - Conclusion: don't install doctrine/orm v2.5.2
    - Conclusion: don't install doctrine/orm v2.5.1
    - Conclusion: don't install doctrine/orm v2.5.0
    - Conclusion: don't install doctrine/orm v2.5.0-RC2
    - Conclusion: don't install doctrine/orm v2.5.0-RC1
    - Conclusion: don't install doctrine/orm v2.5.0-beta1
    - Conclusion: don't install doctrine/orm v2.5.0-alpha2
    - Conclusion: don't install doctrine/orm v2.5.0-alpha1
    - Conclusion: don't install doctrine/orm 2.6.x-dev
    - Conclusion: remove doctrine/instantiator 1.1.0
    - Installation request for geosocio/core dev-develop -> satisfiable by geosocio/core[dev-develop].
    - Installation request for symfony/console (locked at v3.3.6, required as ^3.3) -> satisfiable by symfony/console[v3.3.6].
    - Installation request for symfony/yaml (locked at v3.3.6, required as ^3.3) -> satisfiable by symfony/yaml[v3.3.6].
    - Installation request for doctrine/orm ^2.5 -> satisfiable by doctrine/orm[2.5.x-dev, 2.6.x-dev, v2.5.0, v2.5.0-RC1, v2.5.0-RC2, v2.5.0-alpha1, v2.5.0-alpha2, v2.5.0-beta1, v2.5.1, v2.5.10, v2.5.2, v2.5.3, v2.5.4, v2.5.5, v2.5.6, v2.5.7, v2.5.8, v2.5.9].
    - Conclusion: don't install doctrine/instantiator 1.1.0
    - doctrine/orm 2.5.x-dev requires doctrine/instantiator ~1.0.1 -> satisfiable by doctrine/instantiator[1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.x-dev].
    - Can only install one of: doctrine/instantiator[1.0.5, 1.1.0].
    - Can only install one of: doctrine/instantiator[1.0.x-dev, 1.1.0].
    - Can only install one of: doctrine/instantiator[1.0.4, 1.1.0].
    - Installation request for doctrine/instantiator (locked at 1.1.0) -> satisfiable by doctrine/instantiator[1.1.0].
```