### PR TITLE
#6217 #6284 when hydrating an entity with a composite primary key that is both an `EAGER` and a `LAZY` association and also cached, the `DefaultQueryCache` tries to pass L2 cache implementation detail objects to the `UnitOfWork` 

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -92,13 +92,13 @@ class DefaultQueryCache implements QueryCache
             return null;
         }
 
-        $entry = $this->region->get($key);
+        $cacheEntry = $this->region->get($key);
 
-        if ( ! $entry instanceof QueryCacheEntry) {
+        if ( ! $cacheEntry instanceof QueryCacheEntry) {
             return null;
         }
 
-        if ( ! $this->validator->isValid($key, $entry)) {
+        if ( ! $this->validator->isValid($key, $cacheEntry)) {
             $this->region->evict($key);
 
             return null;
@@ -117,11 +117,11 @@ class DefaultQueryCache implements QueryCache
             return new EntityCacheKey($cm->rootEntityName, $entry['identifier']);
         };
 
-        $cacheKeys = new CollectionCacheEntry(array_map($generateKeys, $entry->result));
+        $cacheKeys = new CollectionCacheEntry(array_map($generateKeys, $cacheEntry->result));
         $entries   = $region->getMultiple($cacheKeys);
 
         // @TODO - move to cache hydration component
-        foreach ($entry->result as $index => $entry) {
+        foreach ($cacheEntry->result as $index => $entry) {
             $entityEntry = is_array($entries) && array_key_exists($index, $entries) ? $entries[$index] : null;
 
             if ($entityEntry === null) {
@@ -210,6 +210,25 @@ class DefaultQueryCache implements QueryCache
                 $collection->setInitialized(true);
             }
 
+            foreach ($data as $fieldName => $unCachedAssociationData) {
+                // In some scenarios, such as EAGER+ASSOCIATION+ID+CACHE, the
+                // cache key information in `$cacheEntry` will not contain details
+                // for fields that are associations.
+                //
+                // This means that `$data` keys for some associations that may
+                // actually not be cached will not be converted to actual association
+                // data, yet they contain L2 cache AssociationCacheEntry objects.
+                //
+                // We need to unwrap those associations into proxy references,
+                // since we don't have actual data for them except for identifiers.
+                if ($unCachedAssociationData instanceof AssociationCacheEntry) {
+                    $data[$fieldName] = $this->em->getReference(
+                        $unCachedAssociationData->class,
+                        $unCachedAssociationData->identifier
+                    );
+                }
+            }
+
             $result[$index] = $this->uow->createEntity($entityEntry->class, $data, self::$hints);
         }
 
@@ -246,7 +265,6 @@ class DefaultQueryCache implements QueryCache
         $data        = [];
         $entityName  = reset($rsm->aliasMap);
         $rootAlias   = key($rsm->aliasMap);
-        $hasRelation = ( ! empty($rsm->relationMap));
         $persister   = $this->uow->getEntityPersister($entityName);
 
         if ( ! ($persister instanceof CachedPersister)) {
@@ -258,8 +276,6 @@ class DefaultQueryCache implements QueryCache
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
             $entityKey                      = new EntityCacheKey($entityName, $identifier);
-            $data[$index]['identifier']     = $identifier;
-            $data[$index]['associations']   = [];
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail
@@ -268,9 +284,8 @@ class DefaultQueryCache implements QueryCache
                 }
             }
 
-            if ( ! $hasRelation) {
-                continue;
-            }
+            $data[$index]['identifier']   = $identifier;
+            $data[$index]['associations'] = [];
 
             // @TODO - move to cache hydration components
             foreach ($rsm->relationMap as $alias => $name) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -29,7 +29,6 @@ use ReflectionClass;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\ClassLoader;
 use Doctrine\ORM\Cache\CacheException;
-use Doctrine\ORM\Cache\AssociationCacheEntry;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata
@@ -715,14 +714,11 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getIdentifierValues($entity)
     {
-        if ($entity instanceof AssociationCacheEntry) {
-            throw new \InvalidArgumentException('WTF DUDE: ' . $entity->class . ' - ' . \serialize($entity->identifier));
-        }
         if ($this->isIdentifierComposite) {
             $id = [];
 
             foreach ($this->identifier as $idField) {
-                $value = $this->getIndentifierValue($entity, $idField);
+                $value = $this->reflFields[$idField]->getValue($entity);
 
                 if (null !== $value) {
                     $id[$idField] = $value;
@@ -733,22 +729,13 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         $id = $this->identifier[0];
-        $value = $this->getIndentifierValue($entity, $id);
+        $value = $this->reflFields[$id]->getValue($entity);
 
         if (null === $value) {
             return [];
         }
 
         return [$id => $value];
-    }
-
-    private function getIndentifierValue($entity, $id)
-    {
-        if ($entity instanceof AssociationCacheEntry) {
-             return $entity->identifier[$id];
-        }
-
-        return $this->reflFields[$id]->getValue($entity);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -715,6 +715,9 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function getIdentifierValues($entity)
     {
+        if ($entity instanceof AssociationCacheEntry) {
+            throw new \InvalidArgumentException('WTF DUDE: ' . $entity->class . ' - ' . \serialize($entity->identifier));
+        }
         if ($this->isIdentifierComposite) {
             $id = [];
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -29,6 +29,7 @@ use ReflectionClass;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\ClassLoader;
 use Doctrine\ORM\Cache\CacheException;
+use Doctrine\ORM\Cache\AssociationCacheEntry;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata
@@ -718,7 +719,7 @@ class ClassMetadataInfo implements ClassMetadata
             $id = [];
 
             foreach ($this->identifier as $idField) {
-                $value = $this->reflFields[$idField]->getValue($entity);
+                $value = $this->getIndentifierValue($entity, $idField);
 
                 if (null !== $value) {
                     $id[$idField] = $value;
@@ -729,13 +730,22 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         $id = $this->identifier[0];
-        $value = $this->reflFields[$id]->getValue($entity);
+        $value = $this->getIndentifierValue($entity, $id);
 
         if (null === $value) {
             return [];
         }
 
         return [$id => $value];
+    }
+
+    private function getIndentifierValue($entity, $id)
+    {
+        if ($entity instanceof AssociationCacheEntry) {
+             return $entity->identifier[$id];
+        }
+
+        return $this->reflFields[$id]->getValue($entity);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -1,0 +1,162 @@
+<?php
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH6217Test extends OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        $this->enableSecondLevelCache();
+
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(GH6217User::class),
+                $this->_em->getClassMetadata(GH6217Profile::class),
+                $this->_em->getClassMetadata(GH6217Category::class),
+                $this->_em->getClassMetadata(GH6217UserProfile::class),
+            ]
+        );
+    }
+
+    /**
+     * @group 6217
+     */
+    public function testRetrievingCacheShouldNotThrowUndefinedIndexException()
+    {
+        $user = new GH6217User(1, 'user 1');
+        $profile = new GH6217Profile(1);
+        $category = new GH6217Category(1, 'category 1');
+        $userProfile = new GH6217UserProfile($user, $profile, $category);
+
+        $this->_em->persist($category);
+        $this->_em->persist($user);
+        $this->_em->persist($profile);
+        $this->_em->persist($userProfile);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(GH6217UserProfile::class);
+        $filters = ['user' => 1, 'category' => 1];
+
+        $this->assertCount(1, $repository->findBy($filters));
+        $queryCount = $this->getCurrentQueryCount();
+
+        $this->_em->clear();
+
+        $this->assertCount(1, $repository->findBy($filters));
+        $this->assertEquals($queryCount, $this->getCurrentQueryCount());
+    }
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH6217User
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @Column(type="string", length=60, unique=true)
+     *
+     * @var string
+     */
+    public $username;
+
+    public function __construct(int $id, string $username)
+    {
+        $this->id = $id;
+        $this->username = $username;
+    }
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH6217Profile
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH6217Category
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+}
+
+/**
+ * @Entity
+ * @Cache(usage="NONSTRICT_READ_WRITE")
+ */
+class GH6217UserProfile
+{
+    /**
+     * @Id
+     * @Cache("NONSTRICT_READ_WRITE")
+     * @ManyToOne(targetEntity="GH6217User")
+     * @JoinColumn(nullable=false)
+     *
+     * @var GH6217User
+     */
+    public $user;
+
+    /**
+     * @Id
+     * @Cache("NONSTRICT_READ_WRITE")
+     * @ManyToOne(targetEntity="GH6217Profile", fetch="EAGER")
+     *
+     * @var GH6217Profile
+     */
+    public $profile;
+
+    /**
+     * @Id
+     * @Cache("NONSTRICT_READ_WRITE")
+     * @ManyToOne(targetEntity="GH6217Category", fetch="EAGER")
+     *
+     * @var GH6217Category
+     */
+    public $category;
+
+    public function __construct(GH6217User $user, GH6217Profile $profile, GH6217Category $category)
+    {
+        $this->user = $user;
+        $this->profile = $profile;
+        $this->category = $category;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -35,17 +35,17 @@ final class GH6217Test extends OrmFunctionalTestCase
         $repository = $this->_em->getRepository(GH6217FetchedEntity::class);
         $filters    = ['eager' => $eager->id];
 
-        $this->assertCount(1, $repository->findBy($filters));
+        self::assertCount(1, $repository->findBy($filters));
         $queryCount = $this->getCurrentQueryCount();
 
         /* @var $found GH6217FetchedEntity[] */
         $found = $repository->findBy($filters);
 
-        $this->assertCount(1, $found);
-        $this->assertInstanceOf(GH6217FetchedEntity::class, $found[0]);
-        $this->assertSame($lazy->id, $found[0]->lazy->id);
-        $this->assertSame($eager->id, $found[0]->eager->id);
-        $this->assertEquals($queryCount, $this->getCurrentQueryCount(), 'No queries were executed in `findBy`');
+        self::assertCount(1, $found);
+        self::assertInstanceOf(GH6217FetchedEntity::class, $found[0]);
+        self::assertSame($lazy->id, $found[0]->lazy->id);
+        self::assertSame($eager->id, $found[0]->eager->id);
+        self::assertEquals($queryCount, $this->getCurrentQueryCount(), 'No queries were executed in `findBy`');
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -51,19 +51,10 @@ final class GH6217Test extends OrmFunctionalTestCase
     }
 }
 
-/**
- * @Entity
- * @Cache(usage="NONSTRICT_READ_WRITE")
- */
+/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217User
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()
@@ -75,13 +66,7 @@ class GH6217User
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Profile
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()
@@ -90,19 +75,10 @@ class GH6217Profile
     }
 }
 
-/**
- * @Entity
- * @Cache(usage="NONSTRICT_READ_WRITE")
- */
+/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Category
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()
@@ -111,37 +87,16 @@ class GH6217Category
     }
 }
 
-/**
- * @Entity
- * @Cache(usage="NONSTRICT_READ_WRITE")
- */
+/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217UserProfile
 {
-    /**
-     * @Id
-     * @Cache("NONSTRICT_READ_WRITE")
-     * @ManyToOne(targetEntity="GH6217User")
-     *
-     * @var GH6217User
-     */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217User::class) */
     public $user;
 
-    /**
-     * @Id
-     * @Cache("NONSTRICT_READ_WRITE")
-     * @ManyToOne(targetEntity="GH6217Profile", fetch="EAGER")
-     *
-     * @var GH6217Profile
-     */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Profile::class) */
     public $profile;
 
-    /**
-     * @Id
-     * @Cache("NONSTRICT_READ_WRITE")
-     * @ManyToOne(targetEntity="GH6217Category", fetch="EAGER")
-     *
-     * @var GH6217Category
-     */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Category::class) */
     public $category;
 
     public function __construct(GH6217User $user, GH6217Profile $profile, GH6217Category $category)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -26,9 +26,9 @@ final class GH6217Test extends OrmFunctionalTestCase
      */
     public function testRetrievingCacheShouldNotThrowUndefinedIndexException()
     {
-        $user = new GH6217User(1);
+        $user = new GH6217User();
         $profile = new GH6217Profile();
-        $category = new GH6217Category(1);
+        $category = new GH6217Category();
         $userProfile = new GH6217UserProfile($user, $profile, $category);
 
         $this->_em->persist($category);
@@ -39,7 +39,7 @@ final class GH6217Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository(GH6217UserProfile::class);
-        $filters = ['user' => 1, 'category' => 1];
+        $filters = ['user' => $user->id, 'category' => $category->id];
 
         $this->assertCount(1, $repository->findBy($filters));
         $queryCount = $this->getCurrentQueryCount();
@@ -59,15 +59,16 @@ class GH6217User
 {
     /**
      * @Id
-     * @Column(type="integer")
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
      *
-     * @var int
+     * @var string
      */
     public $id;
 
-    public function __construct(int $id)
+    public function __construct()
     {
-        $this->id = $id;
+        $this->id = uniqid(self::class, true);
     }
 }
 
@@ -97,15 +98,16 @@ class GH6217Category
 {
     /**
      * @Id
-     * @Column(type="integer")
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
      *
-     * @var int
+     * @var string
      */
     public $id;
 
-    public function __construct(int $id)
+    public function __construct()
     {
-        $this->id = $id;
+        $this->id = uniqid(self::class, true);
     }
 }
 
@@ -119,7 +121,6 @@ class GH6217UserProfile
      * @Id
      * @Cache("NONSTRICT_READ_WRITE")
      * @ManyToOne(targetEntity="GH6217User")
-     * @JoinColumn(nullable=false)
      *
      * @var GH6217User
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -54,7 +54,13 @@ final class GH6217Test extends OrmFunctionalTestCase
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217User
 {
-    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     *
+     * @var string
+     */
     public $id;
 
     public function __construct()
@@ -66,7 +72,13 @@ class GH6217User
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Profile
 {
-    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     *
+     * @var string
+     */
     public $id;
 
     public function __construct()
@@ -78,7 +90,13 @@ class GH6217Profile
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Category
 {
-    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
+    /**
+     * @Id
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     *
+     * @var string
+     */
     public $id;
 
     public function __construct()
@@ -93,10 +111,10 @@ class GH6217UserProfile
     /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217User::class) */
     public $user;
 
-    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Profile::class) */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Profile::class, fetch="EAGER") */
     public $profile;
 
-    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Category::class) */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Category::class, fetch="EAGER") */
     public $category;
 
     public function __construct(GH6217User $user, GH6217Profile $profile, GH6217Category $category)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -36,14 +36,20 @@ final class GH6217Test extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository(GH6217UserProfile::class);
-        $filters = ['user' => $user->id, 'category' => $category->id];
+        $filters    = ['category' => $category->id];
 
         $this->assertCount(1, $repository->findBy($filters));
         $queryCount = $this->getCurrentQueryCount();
 
         $this->_em->clear();
 
-        $this->assertCount(1, $repository->findBy($filters));
+        /* @var $found GH6217UserProfile[] */
+        $found = $repository->findBy($filters);
+
+        $this->assertCount(1, $found);
+        $this->assertInstanceOf(GH6217UserProfile::class, $found[0]);
+        $this->assertSame($user->id, $found[0]->user->id);
+        $this->assertSame($category->id, $found[0]->category->id);
         $this->assertEquals($queryCount, $this->getCurrentQueryCount());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -11,19 +11,17 @@ final class GH6217Test extends OrmFunctionalTestCase
 
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(GH6217LazyEntity::class),
-                $this->_em->getClassMetadata(GH6217EagerEntity::class),
-                $this->_em->getClassMetadata(GH6217FetchedEntity::class),
-            ]
-        );
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH6217LazyEntity::class),
+            $this->_em->getClassMetadata(GH6217EagerEntity::class),
+            $this->_em->getClassMetadata(GH6217FetchedEntity::class),
+        ]);
     }
 
     /**
      * @group 6217
      */
-    public function testRetrievingCacheShouldNotThrowUndefinedIndexException()
+    public function testLoadingOfSecondLevelCacheOnEagerAssociations()
     {
         $user = new GH6217LazyEntity();
         $category = new GH6217EagerEntity();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -15,16 +15,15 @@ final class GH6217Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(GH6217LazyEntity::class),
-            $this->_em->getClassMetadata(GH6217EagerEntity::class),
+            $this->_em->getClassMetadata(GH6217AssociatedEntity::class),
             $this->_em->getClassMetadata(GH6217FetchedEntity::class),
         ]);
     }
 
     public function testLoadingOfSecondLevelCacheOnEagerAssociations() : void
     {
-        $lazy = new GH6217LazyEntity();
-        $eager = new GH6217EagerEntity();
+        $lazy = new GH6217AssociatedEntity();
+        $eager = new GH6217AssociatedEntity();
         $fetched = new GH6217FetchedEntity($lazy, $eager);
 
         $this->_em->persist($eager);
@@ -63,7 +62,7 @@ class GH6217LazyEntity
 }
 
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
-class GH6217EagerEntity
+class GH6217AssociatedEntity
 {
     /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
@@ -77,13 +76,13 @@ class GH6217EagerEntity
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217FetchedEntity
 {
-    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217LazyEntity::class) */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217AssociatedEntity::class) */
     public $lazy;
 
-    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217EagerEntity::class, fetch="EAGER") */
+    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217AssociatedEntity::class, fetch="EAGER") */
     public $eager;
 
-    public function __construct(GH6217LazyEntity $lazy, GH6217EagerEntity $eager)
+    public function __construct(GH6217AssociatedEntity $lazy, GH6217AssociatedEntity $eager)
     {
         $this->lazy  = $lazy;
         $this->eager = $eager;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -14,7 +14,6 @@ final class GH6217Test extends OrmFunctionalTestCase
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(GH6217User::class),
-                $this->_em->getClassMetadata(GH6217Profile::class),
                 $this->_em->getClassMetadata(GH6217Category::class),
                 $this->_em->getClassMetadata(GH6217UserProfile::class),
             ]
@@ -27,13 +26,11 @@ final class GH6217Test extends OrmFunctionalTestCase
     public function testRetrievingCacheShouldNotThrowUndefinedIndexException()
     {
         $user = new GH6217User();
-        $profile = new GH6217Profile();
         $category = new GH6217Category();
-        $userProfile = new GH6217UserProfile($user, $profile, $category);
+        $userProfile = new GH6217UserProfile($user, $category);
 
         $this->_em->persist($category);
         $this->_em->persist($user);
-        $this->_em->persist($profile);
         $this->_em->persist($userProfile);
         $this->_em->flush();
         $this->_em->clear();
@@ -64,18 +61,6 @@ class GH6217User
 }
 
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
-class GH6217Profile
-{
-    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
-    public $id;
-
-    public function __construct()
-    {
-        $this->id = uniqid(self::class, true);
-    }
-}
-
-/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Category
 {
     /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
@@ -93,16 +78,12 @@ class GH6217UserProfile
     /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217User::class) */
     public $user;
 
-    /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Profile::class, fetch="EAGER") */
-    public $profile;
-
     /** @Id @Cache("NONSTRICT_READ_WRITE") @ManyToOne(targetEntity=GH6217Category::class, fetch="EAGER") */
     public $category;
 
-    public function __construct(GH6217User $user, GH6217Profile $profile, GH6217Category $category)
+    public function __construct(GH6217User $user, GH6217Category $category)
     {
         $this->user = $user;
-        $this->profile = $profile;
         $this->category = $category;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -54,13 +54,7 @@ final class GH6217Test extends OrmFunctionalTestCase
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217User
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()
@@ -72,13 +66,7 @@ class GH6217User
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Profile
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()
@@ -90,13 +78,7 @@ class GH6217Profile
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Category
 {
-    /**
-     * @Id
-     * @Column(type="string")
-     * @GeneratedValue(strategy="NONE")
-     *
-     * @var string
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     public function __construct()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -50,18 +50,6 @@ final class GH6217Test extends OrmFunctionalTestCase
 }
 
 /** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
-class GH6217LazyEntity
-{
-    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
-    public $id;
-
-    public function __construct()
-    {
-        $this->id = uniqid(self::class, true);
-    }
-}
-
-/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217AssociatedEntity
 {
     /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -26,9 +26,9 @@ final class GH6217Test extends OrmFunctionalTestCase
      */
     public function testRetrievingCacheShouldNotThrowUndefinedIndexException()
     {
-        $user = new GH6217User(1, 'user 1');
-        $profile = new GH6217Profile(1);
-        $category = new GH6217Category(1, 'category 1');
+        $user = new GH6217User(1);
+        $profile = new GH6217Profile();
+        $category = new GH6217Category(1);
         $userProfile = new GH6217UserProfile($user, $profile, $category);
 
         $this->_em->persist($category);
@@ -65,37 +65,27 @@ class GH6217User
      */
     public $id;
 
-    /**
-     * @Column(type="string", length=60, unique=true)
-     *
-     * @var string
-     */
-    public $username;
-
-    public function __construct(int $id, string $username)
+    public function __construct(int $id)
     {
         $this->id = $id;
-        $this->username = $username;
     }
 }
 
-/**
- * @Entity
- * @Cache(usage="NONSTRICT_READ_WRITE")
- */
+/** @Entity @Cache(usage="NONSTRICT_READ_WRITE") */
 class GH6217Profile
 {
     /**
      * @Id
-     * @Column(type="integer")
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
      *
-     * @var int
+     * @var string
      */
     public $id;
 
-    public function __construct(int $id)
+    public function __construct()
     {
-        $this->id = $id;
+        $this->id = uniqid(self::class, true);
     }
 }
 


### PR DESCRIPTION
Fixes #6217
Fixes #6284

This is a proper version of #6284, fixing the deeper problem.

Basically, what is happening is that you have a L2 cached entity class like following:

```php
class A
{
    /** @Id @ManyToOne(targetEntity=b) */
    private $b;
    /** @Id @ManyToOne(targetEntity=c)*/
    private $c;
}
```

And a DQL query like following:

```sql
SELECT a, b
FROM A a
JOIN a.b b
```

The L2 cache for `A.c` won't have any information to cache, but it will still contain the identifier for `A.c`. This means that for that association, a `AssociationCacheEntry` exists anyway, but no definition in the `QueryCacheEntry` on how to process it.

I also tried fixing the problem on the other side (where the `QueryCacheEntry` is produced, rather than consumed), but overfitting it when no association data is actually available causes empty `AssociationCacheEntry` objects to be hydrated into empty entities (really bad!).

This is just a shotgun patch to fix the problem by iterating over all possible association fields, so if you have any better ideas, please do let me know.