### PR TITLE
#6638 #6648 one-to-one association being refreshed even if not built by the hydrator or having `HINT_REFRESH` set

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -90,7 +90,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
 
         /* @var $entityEntries \Doctrine\ORM\Cache\EntityCacheEntry[] */
         foreach ($entityEntries as $index => $entityEntry) {
-            $list[$index] = $this->uow->createEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
+            [$list[$index]] = $this->uow->getOrCreateEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
         }
 
         array_walk($list, function($entity, $index) use ($collection) {

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -185,14 +185,14 @@ class DefaultEntityHydrator implements EntityHydrator
                 return null;
             }
 
-            $data[$name] = $this->uow->createEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), $hints);
+            [$data[$name]] = $this->uow->getOrCreateEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), $hints);
         }
 
         if ($entity !== null) {
             $this->uow->registerManaged($entity, $key->identifier, $data);
         }
 
-        $result = $this->uow->createEntity($entry->class, $data, $hints);
+        [$result] = $this->uow->getOrCreateEntity($entry->class, $data, $hints);
 
         $this->uow->hydrationComplete();
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -137,7 +137,7 @@ class DefaultQueryCache implements QueryCache
             }
 
             if ( ! $hasRelation) {
-                $result[$index]  = $this->uow->createEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
+                [$result[$index]] = $this->uow->getOrCreateEntity($entityEntry->class, $entityEntry->resolveAssociationEntries($this->em), self::$hints);
 
                 continue;
             }
@@ -162,7 +162,7 @@ class DefaultQueryCache implements QueryCache
                         return null;
                     }
 
-                    $data[$name] = $this->uow->createEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), self::$hints);
+                    [$data[$name]] = $this->uow->getOrCreateEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), self::$hints);
 
                     if ($this->cacheLogger !== null) {
                         $this->cacheLogger->entityCacheHit($assocRegion->getName(), $assocKey);
@@ -196,7 +196,7 @@ class DefaultQueryCache implements QueryCache
                         return null;
                     }
 
-                    $element = $this->uow->createEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), self::$hints);
+                    [$element] = $this->uow->getOrCreateEntity($assocEntry->class, $assocEntry->resolveAssociationEntries($this->em), self::$hints);
 
                     $collection->hydrateSet($assocIndex, $element);
 
@@ -229,7 +229,7 @@ class DefaultQueryCache implements QueryCache
                 }
             }
 
-            $result[$index] = $this->uow->createEntity($entityEntry->class, $data, self::$hints);
+            [$result[$index]] = $this->uow->getOrCreateEntity($entityEntry->class, $data, self::$hints);
         }
 
         $this->uow->hydrationComplete();

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -103,7 +103,7 @@ abstract class AbstractHydrator
         $this->_em            = $em;
         $this->_platform      = $em->getConnection()->getDatabasePlatform();
         $this->_uow           = $em->getUnitOfWork();
-        $this->_metadataCache = new LazyPropertyMap([$em->getMetadataFactory(), 'getMetadataFor']);
+        $this->_metadataCache = new LazyPropertyMap([$em, 'getClassMetadata']);
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -100,10 +100,10 @@ abstract class AbstractHydrator
      */
     public function __construct(EntityManagerInterface $em)
     {
-        $this->_em       = $em;
-        $this->_platform = $em->getConnection()->getDatabasePlatform();
-        $this->_uow      = $em->getUnitOfWork();
-        $this->_metadataCache = new LazyPropertyMap([$em, 'getClassMetadata']);
+        $this->_em            = $em;
+        $this->_platform      = $em->getConnection()->getDatabasePlatform();
+        $this->_uow           = $em->getUnitOfWork();
+        $this->_metadataCache = new LazyPropertyMap([$em->getMetadataFactory(), 'getMetadataFor']);
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -67,7 +67,7 @@ abstract class AbstractHydrator
     /**
      * Local ClassMetadata cache to avoid going to the EntityManager all the time.
      *
-     * @var array
+     * @var ClassMetadata[] indexed by class name
      */
     protected $_metadataCache = [];
 

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -22,7 +22,6 @@ namespace Doctrine\ORM\Internal\Hydration;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
-use Doctrine\ORM\Internal\Hydration\Cache\LazyPropertyMap;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use PDO;
 
@@ -68,9 +67,9 @@ abstract class AbstractHydrator
     /**
      * Local ClassMetadata cache to avoid going to the EntityManager all the time.
      *
-     * @var ClassMetadata[]|LazyPropertyMap indexed by class name
+     * @var array
      */
-    protected $_metadataCache;
+    protected $_metadataCache = [];
 
     /**
      * The cache used during row-by-row hydration.
@@ -103,7 +102,6 @@ abstract class AbstractHydrator
         $this->_em            = $em;
         $this->_platform      = $em->getConnection()->getDatabasePlatform();
         $this->_uow           = $em->getUnitOfWork();
-        $this->_metadataCache = new LazyPropertyMap([$em, 'getClassMetadata']);
     }
 
     /**
@@ -214,7 +212,7 @@ abstract class AbstractHydrator
         $this->_stmt          = null;
         $this->_rsm           = null;
         $this->_cache         = [];
-        $this->_metadataCache = new LazyPropertyMap([$this->_em, 'getClassMetadata']);
+        $this->_metadataCache = [];
 
         $this
             ->_em
@@ -385,8 +383,7 @@ abstract class AbstractHydrator
         switch (true) {
             // NOTE: Most of the times it's a field mapping, so keep it first!!!
             case (isset($this->_rsm->fieldMappings[$key])):
-                /* @var $classMetadata ClassMetadata */
-                $classMetadata = $this->_metadataCache->{$this->_rsm->declaringClasses[$key]};
+                $classMetadata = $this->getClassMetadata($this->_rsm->declaringClasses[$key]);
                 $fieldName     = $this->_rsm->fieldMappings[$key];
                 $fieldMapping  = $classMetadata->fieldMappings[$fieldName];
                 $ownerMap      = $this->_rsm->columnOwnerMap[$key];
@@ -441,7 +438,7 @@ abstract class AbstractHydrator
                     : null;
 
                 // Cache metadata fetch
-                $this->_metadataCache->{$this->_rsm->aliasMap[$dqlAlias]};
+                $this->getClassMetadata($this->_rsm->aliasMap[$dqlAlias]);
 
                 return $this->_cache[$key] = [
                     'isIdentifier' => isset($this->_rsm->isIdentifierColumn[$dqlAlias][$key]),
@@ -455,6 +452,22 @@ abstract class AbstractHydrator
         // this column is a left over, maybe from a LIMIT query hack for example in Oracle or DB2
         // maybe from an additional column that has not been defined in a NativeQuery ResultSetMapping.
         return null;
+    }
+
+    /**
+     * Retrieve ClassMetadata associated to entity class name.
+     *
+     * @param string $className
+     *
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    protected function getClassMetadata($className)
+    {
+        if ( ! isset($this->_metadataCache[$className])) {
+            $this->_metadataCache[$className] = $this->_em->getClassMetadata($className);
+        }
+
+        return $this->_metadataCache[$className];
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -130,7 +130,7 @@ class ArrayHydrator extends AbstractHydrator
                 }
 
                 $relationAlias = $this->_rsm->relationMap[$dqlAlias];
-                $parentClass   = $this->_metadataCache[$this->_rsm->aliasMap[$parent]];
+                $parentClass   = $this->_metadataCache->{$this->_rsm->aliasMap[$parent]};
                 $relation      = $parentClass->associationMappings[$relationAlias];
 
                 // Check the type of the relation (many or single-valued)

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -130,7 +130,7 @@ class ArrayHydrator extends AbstractHydrator
                 }
 
                 $relationAlias = $this->_rsm->relationMap[$dqlAlias];
-                $parentClass   = $this->_metadataCache->{$this->_rsm->aliasMap[$parent]};
+                $parentClass   = $this->_metadataCache[$this->_rsm->aliasMap[$parent]];
                 $relation      = $parentClass->associationMappings[$relationAlias];
 
                 // Check the type of the relation (many or single-valued)

--- a/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration\Cache;
+
+/**
+ * Concept taken from ocramius/lazy-map
+ *
+ * @link https://github.com/Ocramius/LazyMap/blob/1.0.0/src/LazyMap/CallbackLazyMap.php
+ */
+final class LazyPropertyMap
+{
+    public function __construct(callable $instantiate)
+    {
+        $this->{__CLASS__ . "\0callback"} = $instantiate;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        $this->$name = ($this->{__CLASS__ . "\0callback"})($name);
+
+        return $this->$name;
+    }
+}

--- a/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Internal\Hydration\Cache;
  * Concept taken from ocramius/lazy-map
  *
  * @link https://github.com/Ocramius/LazyMap/blob/1.0.0/src/LazyMap/CallbackLazyMap.php
+ * @internal do not use: internal class only
  */
 final class LazyPropertyMap
 {

--- a/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/Cache/LazyPropertyMap.php
@@ -13,7 +13,10 @@ final class LazyPropertyMap
 {
     public function __construct(callable $instantiate)
     {
-        $this->{__CLASS__ . "\0callback"} = $instantiate;
+        // Note: the reason why we use dynamic access to create a private-ish property is
+        //       that we do not want this property to be statically defined. If that
+        //       happens, then a consumer of `__get` may access it, and that's no good
+        $this->{self::class . "\0callback"} = $instantiate;
     }
 
     /**
@@ -23,7 +26,7 @@ final class LazyPropertyMap
      */
     public function __get(string $name)
     {
-        $this->$name = ($this->{__CLASS__ . "\0callback"})($name);
+        $this->$name = ($this->{self::class . "\0callback"})($name);
 
         return $this->$name;
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -332,11 +332,11 @@ class ObjectHydrator extends AbstractHydrator
         /* @var $metadata ClassMetadata */
         $metadata       = $this->_metadataCache->{$className};
         $rootEntityName = $metadata->rootEntityName;
-        /* @var $idColumns string[] of column names, indexed by field name */
+        /* @var $idColumns string[] */
         $idColumns      = [];
 
         foreach ($metadata->identifier as $idFieldName) {
-            $idColumns[$idFieldName] = isset($metadata->associationMappings[$idFieldName])
+            $idColumns[] = isset($metadata->associationMappings[$idFieldName])
                 ? $metadata->associationMappings[$idFieldName]['joinColumns'][0]['name']
                 : $idFieldName;
         }
@@ -355,7 +355,7 @@ class ObjectHydrator extends AbstractHydrator
                 $idHashData[] = $data[$idColumn];
             }
 
-            return $this->_uow->tryGetByIdHash(implode(' ', $idHashData), $rootEntityName) ?: null;
+            return $this->_uow->tryGetByIdHash(\implode(' ', $idHashData), $rootEntityName) ?: null;
         };
     }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -296,7 +296,10 @@ class ObjectHydrator extends AbstractHydrator
 
         // If the entity is not existing in the UnitOfWork, then we
         // are the one creating it: let's track the object hash to
-        // allow writing to it
+        // allow writing to it. Note that we discard `$managedEntity`
+        // anyway, as we need to call `createEntity` with the data
+        // in any case to allow refreshing proxy information, for
+        // example
         if (! $managedEntity) {
             $entity = $this->_uow->createEntity($className, $data, $this->_hints);
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -49,7 +49,7 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * @var object[] indexed by oid
      */
-    private $createdEntities = [];
+    private $trackedWritableEntities = [];
 
     /**
      * @var array
@@ -303,7 +303,7 @@ class ObjectHydrator extends AbstractHydrator
         if (! $managedEntity) {
             $entity = $this->_uow->createEntity($className, $data, $this->_hints);
 
-            $this->createdEntities[\spl_object_hash($entity)] = true;
+            $this->trackedWritableEntities[\spl_object_hash($entity)] = true;
 
             return $entity;
         }
@@ -313,7 +313,7 @@ class ObjectHydrator extends AbstractHydrator
         // If the entity is not created by us, we can only consider
         // it to be created in here if it's a non-initialized proxy
         if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
-            $this->createdEntities[\spl_object_hash($entity)] = true;
+            $this->trackedWritableEntities[\spl_object_hash($entity)] = true;
         }
 
         return $entity;
@@ -490,7 +490,7 @@ class ObjectHydrator extends AbstractHydrator
                     // PATH B: Single-valued association
                     $reflFieldValue = $reflField->getValue($parentObject);
 
-                    if (isset($this->createdEntities[$oid]) || isset($this->_hints[Query::HINT_REFRESH])) {
+                    if (isset($this->trackedWritableEntities[$oid]) || isset($this->_hints[Query::HINT_REFRESH])) {
                         // we only need to take action if `$parentObject` was not built or is not to be refreshed by this hydrator,
                         if (isset($nonemptyComponents[$dqlAlias])) {
                             $element = $this->getEntity($data, $dqlAlias);

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -292,27 +292,9 @@ class ObjectHydrator extends AbstractHydrator
 
         $this->_hints['fetchAlias'] = $dqlAlias;
 
-        $managedEntity = ($this->entityTryGetCallbacksByEntityName->{$className})($data);
+        [$entity, $writable] = $this->_uow->getOrCreateEntity($className, $data, $this->_hints);
 
-        // If the entity is not existing in the UnitOfWork, then we
-        // are the one creating it: let's track the object hash to
-        // allow writing to it. Note that we discard `$managedEntity`
-        // anyway, as we need to call `createEntity` with the data
-        // in any case to allow refreshing proxy information, for
-        // example
-        if (! $managedEntity) {
-            $entity = $this->_uow->createEntity($className, $data, $this->_hints);
-
-            $this->trackedWritableEntities[\spl_object_hash($entity)] = true;
-
-            return $entity;
-        }
-
-        $entity = $this->_uow->createEntity($className, $data, $this->_hints);
-
-        // If the entity is not created by us, we can only consider
-        // it to be created in here if it's a non-initialized proxy
-        if ($entity instanceof Proxy && ! $entity->__isInitialized()) {
+        if ($writable) {
             $this->trackedWritableEntities[\spl_object_hash($entity)] = true;
         }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -43,7 +43,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             throw new \RuntimeException("Cannot use SimpleObjectHydrator with a ResultSetMapping that contains scalar mappings.");
         }
 
-        $this->class = $this->getClassMetadata(reset($this->_rsm->aliasMap));
+        $this->class = $this->_metadataCache->{reset($this->_rsm->aliasMap)};
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -142,8 +142,8 @@ class SimpleObjectHydrator extends AbstractHydrator
             $this->registerManaged($this->class, $this->_hints[Query::HINT_REFRESH_ENTITY], $data);
         }
 
-        $uow    = $this->_em->getUnitOfWork();
-        $entity = $uow->createEntity($entityName, $data, $this->_hints);
+        $uow      = $this->_em->getUnitOfWork();
+        [$entity] = $uow->getOrCreateEntity($entityName, $data, $this->_hints);
 
         $result[] = $entity;
 

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -43,7 +43,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             throw new \RuntimeException("Cannot use SimpleObjectHydrator with a ResultSetMapping that contains scalar mappings.");
         }
 
-        $this->class = $this->_metadataCache->{reset($this->_rsm->aliasMap)};
+        $this->class = $this->getClassMetadata(reset($this->_rsm->aliasMap));
     }
 
     /**

--- a/tests/Doctrine/Performance/Hydration/Cache/LazyPropertyMapBench.php
+++ b/tests/Doctrine/Performance/Hydration/Cache/LazyPropertyMapBench.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Doctrine\Performance\Hydration\Cache;
+
+use Doctrine\ORM\Internal\Hydration\Cache\LazyPropertyMap;
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use stdClass;
+
+/**
+ * @BeforeMethods({"init"})
+ */
+final class LazyPropertyMapBench
+{
+    /**
+     * @var callable
+     */
+    private $initializer;
+
+    /**
+     * LazyPropertyMap
+     */
+    private $lazyMap;
+
+    /**
+     * @var array
+     */
+    private $array;
+
+    /**
+     * @var int
+     */
+    private $currentKey = 0;
+
+    public function init() : void
+    {
+        $this->initializer = function (string $name) : stdClass {
+            return (object) [$name => true];
+        };
+        $this->lazyMap     = new LazyPropertyMap($this->initializer);
+        $this->array       = [
+            'initialized' => ($this->initializer)('initialized'),
+        ];
+
+        $this->lazyMap->initialized;
+    }
+
+    public function benchInitializedPropertyAccess() : stdClass
+    {
+        $key = 'initialized';
+
+        return $this->lazyMap->$key;
+    }
+
+    public function benchInitializedArrayKeyAccess() : stdClass
+    {
+        $key = 'initialized';
+
+        return $this->array[$key] ?? $this->array[$key] = ($this->initializer)($key);
+    }
+
+    public function benchUninitializedPropertyAccess() : stdClass
+    {
+        $key = 'key' . $this->currentKey++;
+
+        return $this->lazyMap->$key;
+    }
+
+    public function benchUninitializedArrayAccess() : stdClass
+    {
+        $key = 'key' . $this->currentKey++;
+
+        return $this->array[$key] ?? $this->array[$key] = ($this->initializer)($key);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
@@ -9,27 +9,38 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
  * Functional tests for orphan removal with one to many association.
+ *
+ * @group DDC-3644
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * Note: this test is not necessarily to be run in a separate process, but another set of
+ *       tests (which we cannot isolate) is causing it to fail during SQLite schema mutations.
+ *       This is likely due to a separate process causing explicit rollbacks, and this process
+ *       not expecting those to happen in the same transaction boundaries. DDL is not
+ *       transactional in SQLite, so that's possibly going to fix the test when it supports
+ *       that.
+ *
+ * @link http://sqlite.1065341.n5.nabble.com/Table-locked-why-td27245.html
+ * @link http://technosophos.com/2009/05/28/sqlite-database-table-locked-errors-pdo.html
+ * @link https://www.sqlite.org/cvstrac/wiki?p=DatabaseIsLocked
+ * @link https://github.com/doctrine/doctrine2/pull/6649#issuecomment-325130196
  */
 class DDC3644Test extends OrmFunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
-        $this->setUpEntitySchema(
-            [
+        $this->setUpEntitySchema([
             DDC3644User::class,
             DDC3644Address::class,
             DDC3644Animal::class,
             DDC3644Pet::class,
-            ]
-        );
+        ]);
     }
 
-    /**
-     * @group DDC-3644
-     */
-    public function testIssueWithRegularEntity()
+    public function testIssueWithRegularEntity() : void
     {
         // Define initial dataset
         $current   = new DDC3644Address('Sao Paulo, SP, Brazil');
@@ -78,10 +89,7 @@ class DDC3644Test extends OrmFunctionalTestCase
         $this->assertCount(1, $addresses);
     }
 
-    /**
-     * @group DDC-3644
-     */
-    public function testIssueWithJoinedEntity()
+    public function testIssueWithJoinedEntity() : void
     {
         // Define initial dataset
         $actual = new DDC3644Pet('Catharina');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH6638Test extends OrmFunctionalTestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH6638Customer::class),
+            $this->_em->getClassMetadata(GH6638Cart::class),
+        ]);
+    }
+
+    public function testFetchingOfOneToOneRelations() : void
+    {
+        $initialCustomer = new GH6638Customer();
+
+        $initialCart = new GH6638Cart();
+        $initialCustomer->cart = $initialCart;
+        $initialCart->customer = $initialCustomer;
+
+        $this->_em->persist($initialCustomer);
+        $this->_em->persist($initialCart);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(GH6638Customer::class);
+
+        $customer = $repository->find($initialCustomer->id);
+
+        $this->assertInstanceOf(GH6638Cart::class, $customer->cart);
+
+        $customer->cart = null;
+
+        $this->assertNull($customer->cart);
+
+        $repository->findBy(['id' => $initialCustomer->id]);
+
+        $this->assertNull($customer->cart);
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH6638Customer
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="GH6638Cart", mappedBy="customer")
+     */
+    public $cart;
+}
+
+/**
+ * @Entity
+ */
+class GH6638Cart
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="GH6638Customer", inversedBy="cart")
+     * @JoinColumn()
+     */
+    public $customer;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -45,39 +45,34 @@ final class GH6638Test extends OrmFunctionalTestCase
     }
 }
 
-/**
- * @Entity
- */
+/** @Entity */
 class GH6638Customer
 {
-    /**
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
-    /**
-     * @OneToOne(targetEntity="GH6638Cart", mappedBy="customer")
-     */
+    /** @OneToOne(targetEntity=GH6638Cart::class, mappedBy="customer") */
     public $cart;
+
+    public function __construct()
+    {
+        $this->id = uniqid(self::class, true);
+    }
 }
 
-/**
- * @Entity
- */
+/** @Entity */
 class GH6638Cart
 {
-    /**
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
-     */
+    /** @Id @Column(type="string") @GeneratedValue(strategy="NONE") */
     public $id;
 
     /**
-     * @OneToOne(targetEntity="GH6638Customer", inversedBy="cart")
-     * @JoinColumn()
+     * @OneToOne(targetEntity=GH6638Customer::class, inversedBy="cart")
      */
     public $customer;
+
+    public function __construct()
+    {
+        $this->id = uniqid(self::class, true);
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -41,15 +41,15 @@ final class GH6638Test extends OrmFunctionalTestCase
 
         $customer = $repository->find($initialCustomer->id);
 
-        $this->assertInstanceOf(GH6638Cart::class, $customer->cart);
+        self::assertInstanceOf(GH6638Cart::class, $customer->cart);
 
         $customer->cart = null;
 
-        $this->assertNull($customer->cart);
+        self::assertNull($customer->cart);
 
         $repository->findBy(['id' => $initialCustomer->id]);
 
-        $this->assertNull($customer->cart);
+        self::assertNull($customer->cart);
     }
 
     public function testFindOneByDoesNotReHydrateAssociation() : void
@@ -69,15 +69,15 @@ final class GH6638Test extends OrmFunctionalTestCase
 
         $customer = $repository->find($initialCustomer->id);
 
-        $this->assertInstanceOf(GH6638Cart::class, $customer->cart);
+        self::assertInstanceOf(GH6638Cart::class, $customer->cart);
 
         $customer->cart = null;
 
-        $this->assertNull($customer->cart);
+        self::assertNull($customer->cart);
 
         $repository->findOneBy(['id' => $initialCustomer->id]);
 
-        $this->assertNull($customer->cart);
+        self::assertNull($customer->cart);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -5,6 +5,10 @@ namespace Doctrine\Tests\Functional\Ticket;
 use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+/**
+ * @group #6638
+ * @group #6648
+ */
 final class GH6638Test extends OrmFunctionalTestCase
 {
     public function setUp() : void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\Functional\Ticket;
 
+use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 final class GH6638Test extends OrmFunctionalTestCase
@@ -10,17 +11,20 @@ final class GH6638Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(GH6638Customer::class),
-            $this->_em->getClassMetadata(GH6638Cart::class),
-        ]);
+        try {
+            $this->_schemaTool->createSchema([
+                $this->_em->getClassMetadata(GH6638Customer::class),
+                $this->_em->getClassMetadata(GH6638Cart::class),
+            ]);
+        } catch (ToolsException $ignored) {
+        }
     }
 
     public function testFetchingOfOneToOneRelations() : void
     {
         $initialCustomer = new GH6638Customer();
+        $initialCart     = new GH6638Cart();
 
-        $initialCart = new GH6638Cart();
         $initialCustomer->cart = $initialCart;
         $initialCart->customer = $initialCustomer;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6638Test.php
@@ -24,7 +24,7 @@ final class GH6638Test extends OrmFunctionalTestCase
         }
     }
 
-    public function testFetchingOfOneToOneRelations() : void
+    public function testFindByDoesNotReHydrateAssociation() : void
     {
         $initialCustomer = new GH6638Customer();
         $initialCart     = new GH6638Cart();
@@ -48,6 +48,34 @@ final class GH6638Test extends OrmFunctionalTestCase
         $this->assertNull($customer->cart);
 
         $repository->findBy(['id' => $initialCustomer->id]);
+
+        $this->assertNull($customer->cart);
+    }
+
+    public function testFindOneByDoesNotReHydrateAssociation() : void
+    {
+        $initialCustomer = new GH6638Customer();
+        $initialCart     = new GH6638Cart();
+
+        $initialCustomer->cart = $initialCart;
+        $initialCart->customer = $initialCustomer;
+
+        $this->_em->persist($initialCustomer);
+        $this->_em->persist($initialCart);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(GH6638Customer::class);
+
+        $customer = $repository->find($initialCustomer->id);
+
+        $this->assertInstanceOf(GH6638Cart::class, $customer->cart);
+
+        $customer->cart = null;
+
+        $this->assertNull($customer->cart);
+
+        $repository->findOneBy(['id' => $initialCustomer->id]);
 
         $this->assertNull($customer->cart);
     }

--- a/tests/Doctrine/Tests/ORM/Internal/Cache/LazyPropertyMapTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/Cache/LazyPropertyMapTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LazyMapTest;
+
+use Doctrine\ORM\Internal\Hydration\Cache\LazyPropertyMap;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * @link https://github.com/Ocramius/LazyMap/blob/1.0.0/tests/LazyMapTest/CallbackLazyMapTest.php
+ *
+ * @covers \Doctrine\ORM\Internal\Hydration\Cache\LazyPropertyMap
+ */
+class LazyPropertyMapTest extends TestCase
+{
+    /**
+     * @var \LazyMap\CallbackLazyMap
+     */
+    protected $lazyMap;
+
+    /**
+     * @var callable|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $callback;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->callback = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
+        $this->lazyMap  = new LazyPropertyMap($this->callback);
+    }
+
+    public function testDirectPropertyAccess()
+    {
+        $count = 0;
+        $this
+            ->callback
+            ->expects(self::exactly(3))
+            ->method('__invoke')
+            ->will(self::returnCallback(function ($name) use (& $count) {
+                $count += 1;
+
+                return $name . ' - ' . $count;
+            }));
+
+        $this->assertSame('foo - 1', $this->lazyMap->foo);
+        $this->assertSame('bar - 2', $this->lazyMap->bar);
+        $this->assertSame('baz\\tab - 3', $this->lazyMap->{'baz\\tab'});
+    }
+}


### PR DESCRIPTION
Fixes #6638
Fixes #6648 

This patch is just a first stab at the issue: the `ObjectHydrator` is massively broken because of this bug, and the idea is that we need to internally cache whether an object is BUILT in the current `ObjectHydrator`, or whether it already exists as a loaded and managed entity in the `UnitOfWork`.

This has to happen before calling `createEntity()` on the `UnitOfWork`, or else information is lost.