### PR TITLE
Replacing direct `quote` model-set schema creation with actually existing model-set setup

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
@@ -2,8 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Tests\Models\Quote\Group;
-use Doctrine\Tests\Models\Quote\Phone;
 use Doctrine\Tests\Models\Quote\User;
 use Doctrine\Tests\Models\Quote\Address;
 
@@ -13,21 +11,11 @@ use Doctrine\Tests\Models\Quote\Address;
  */
 class DDC142Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp() : void
     {
-        parent::setUp();
+        $this->useModelSet('quote');
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                $this->_em->getClassMetadata(User::class),
-                $this->_em->getClassMetadata(Group::class),
-                $this->_em->getClassMetadata(Phone::class),
-                $this->_em->getClassMetadata(Address::class),
-                ]
-            );
-        } catch(\Exception $e) {
-        }
+        parent::setUp();
     }
 
     public function testCreateRetrieveUpdateDelete()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
@@ -2,10 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Tests\Models\Quote\Address;
 use Doctrine\Tests\Models\Quote\Group;
-use Doctrine\Tests\Models\Quote\Phone;
-use Doctrine\Tests\Models\Quote\User;
 
 /**
  * @group DDC-1845
@@ -13,22 +10,11 @@ use Doctrine\Tests\Models\Quote\User;
  */
 class DDC1843Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
-    protected function setUp()
+    protected function setUp() : void
     {
-        parent::setUp();
+        $this->useModelSet('quote');
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                $this->_em->getClassMetadata(User::class),
-                $this->_em->getClassMetadata(Group::class),
-                $this->_em->getClassMetadata(Phone::class),
-                $this->_em->getClassMetadata(Address::class),
-                ]
-            );
-        } catch(\Exception $e) {
-        }
+        parent::setUp();
     }
 
     public function testCreateRetrieveUpdateDelete()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Tests\Models\Quote\Address;
 use Doctrine\Tests\Models\Quote\Group;
 use Doctrine\Tests\Models\Quote\User;
 
@@ -18,20 +17,11 @@ class DDC1885Test extends \Doctrine\Tests\OrmFunctionalTestCase
      */
     private $user;
 
-    protected function setUp()
+    protected function setUp() : void
     {
-        parent::setUp();
+        $this->useModelSet('quote');
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                $this->_em->getClassMetadata(User::class),
-                $this->_em->getClassMetadata(Group::class),
-                $this->_em->getClassMetadata(Address::class),
-                ]
-            );
-        } catch(\Exception $e) {
-        }
+        parent::setUp();
 
         $user           = new User();
         $user->name     = "FabioBatSilva";

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6402Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6402Test.php
@@ -5,8 +5,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Tests\Models\Quote\Address;
 use Doctrine\Tests\Models\Quote\City;
 use Doctrine\Tests\Models\Quote\FullAddress;
-use Doctrine\Tests\Models\Quote\Group;
-use Doctrine\Tests\Models\Quote\Phone;
 use Doctrine\Tests\Models\Quote\User;
 use Doctrine\Tests\OrmFunctionalTestCase;
 


### PR DESCRIPTION
This was causing random test failures due to the schema tool raising exceptions while running completely unrelated tests or just a subset of the test suite.