### PR TITLE
Drop explicit conflict with stable symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "doctrine/annotations": "~1.4",
         "symfony/console": "~3.0|~4.0"
     },
-    "conflict": {
-        "symfony/yaml": "<3.4"
-    },
     "require-dev": {
         "symfony/yaml": "~3.4|~4.0",
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
As per discussion in #6639, conflict with versions below 3.4
of the YAML component is superfluous, previous versions
would work just fine even with bb994b9e70.

Closes #6639.
Partially reverts #6630 (conflict added in 40515472c1).