### PR TITLE
6661: Improve timezone handling documentation

### DIFF
--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -67,8 +67,8 @@ The problem is simple. Not a single database vendor saves the timezone, only the
 However with frequent daylight saving and political timezone changes you can have a UTC offset that moves
 in different offset directions depending on the real location.
 
-The solution for this dilemma seems simple. Don't use timezones with DateTime and Doctrine 2. However there are 2 workarounds
-that even allows correct date-time handling with timezones depending on your use case:
+The solution for this dilemma seems simple: don't use timezones with DateTime(Immutable) and Doctrine 2. However there are some
+workarounds that allow correct date-time handling with timezones depending on your use case:
 
 1a. Don't convert DateTimes to UTC
 1b. Always convert any DateTime instance to UTC

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -84,9 +84,13 @@ But as soon as you are handling datetimes that are more than a few days in advan
 Handling DateTimes with timezone-informations
 _____________________________________________
 
-Say we have an international calendaring application where users can add events that occur at different places worldwide and therefore at different timezones. To determine the exact time an event will happen means to save both the local time of the event and the timezone the event will happen in.
+Say we have an international calendaring application where users can add events that occur at different places
+worldwide and therefore at different timezones. To determine the exact date and time an event will happen means to save
+both the local time of the event and the timezone the event will happen in.
 
-Using the defalt DateTimeType will store the DateTime in the local time but without the timezone information. Therefore we need to store the timezone information as well and also need to provide a way to get the datetime back from the database with the correct timezone-information.
+Using the default datetime-type will store the datetime in the local time but without the timezone information.
+Therefore we need to store the timezone information as well and also need to provide a way to get the datetime
+back from the database with the correct timezone-information.
 
 To be able to transform these values back into their real timezone we have to save the timezone in a separate field of the entity requiring timezoned datetimes:
 

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -185,7 +185,7 @@ An alternative would be to use a post-processing lifecycle event to recreate the
             $this->timezone = $eventDateTime->getTimeZone()->getName();
         }
 
-        /** @PostLoad */
+        /** @ORM\PostLoad */
         public function correctTimezone(): void
         {
             $this->eventDateTime = new DateTimeImmutable(

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -80,7 +80,9 @@ Wait: **What? Shall we convert to UTC or not?**
 
 That depends on what kind of DateTimes you are handling! When you are handling current dates like log-entries or
 datetimes that are within one or two days of the current date, you can - and even should - convert them to UTC.
-But as soon as you are handling datetimes that are more than a few days in advance (or back) you should **not** convert them to UTC but instead keep them in their local timezone. Why? You might want to read up on `why not to convert a datetime to a timestamp<https://andreas.heigl.org/2016/12/22/why-not-to-convert-a-datetime-to-timestamp/>`_
+But as soon as you are handling datetimes that are more than a few days in advance (or back) you should **not**
+convert them to UTC but instead keep them in their local timezone. Why? You might want to read up on
+`why not to convert a datetime to a timestamp<https://andreas.heigl.org/2016/12/22/why-not-to-convert-a-datetime-to-timestamp/>`_
 
 Handling DateTimes with timezone-informations
 _____________________________________________
@@ -136,14 +138,24 @@ field of the entity requiring timezoned datetimes:
             $this->timezone = $eventDateTime->getTimeZone()->getName();
         }
 
+        /**
+         * During hydration $this->eventDateTime will set with a new DateTimeImmutable instance with the servers
+         * default timezone. So when getting the eventDateTime for the first time after hydration we need to
+         * make sure that the correct timezone is set. Therefore we reset the property with a correctly created
+         * DateTimeImmutable object.
+         *
+         * DBALTypes sadly currently can not take care of this during hydration due to the fact that they are not
+         * allowing to access multiple fields.
+         */
         public function getEventDateTime()
         {
-            if (!$this->localized) {
+            if ($this->localized === false) {
 
                 $this->eventDateTime = new DateTimeImmutable(
                     $this->eventDateTime->format('Y-m-d H:i:s'),
-                    new \DateTimeZone($this->timezone)
+                    new DateTimeZone($this->timezone)
                 );
+                $this->localized = true;
             }
             return $this->eventDateTime;
         }

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -188,11 +188,15 @@ An alternative would be to use a post-processing lifecycle event to recreate the
         /** @ORM\PostLoad */
         public function correctTimezone(): void
         {
-            $this->eventDateTime = new DateTimeImmutable(
+            $correctEntity = new DateTimeImmutable(
                 $this->eventDateTime->format('Y-m-d H:i:s'),
                 new DateTimeZone($this->timezone)
             );
+
+            $this->eventDateTime->setTimezone(new DateTimezone($this->timezone))
+                                ->modify($correctEntity->format('Y-m-d H:i:s'));
         }
+
 
         public function getEventDateTime(): DateTimeImmutable
         {

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -237,7 +237,7 @@ requiring timezoned datetimes:
          */
         private $localized = false;
 
-        public function __construct(\DateTime $createDate)
+        public function __construct(\DateTimeImmutable $createDate)
         {
             $this->localized = true;
             $this->created = $createDate;

--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -119,7 +119,7 @@ To be able to transform these values back into their real timezone we have to sa
         {
             $this->localized = true;
             $this->eventDateTime = $eventDateTime;
-            $this->timezone = $$eventDateTime->getTimeZone()->getName();
+            $this->timezone = $eventDateTime->getTimeZone()->getName();
         }
 
         public function getEventDateTime()

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
     <testsuites>
         <testsuite name="Doctrine ORM Test Suite">
             <directory>./tests/Doctrine/Tests/ORM</directory>
+            <directory>./tests/Doctrine/Tests/Examples</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/Doctrine/Tests/Examples/DateTimeExampleTest.php
+++ b/tests/Doctrine/Tests/Examples/DateTimeExampleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Doctrine\Tests\Examples;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmTestCase;
+
+class DateTimeExampleTest extends OrmTestCase
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->entityManager = $this->getTestEntityManager(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $schemaTool = new SchemaTool($this->entityManager);
+
+        $cmf = $this->entityManager->getMetadataFactory();
+        $classes = $cmf->getMetadataFor(DateTimeInstance::class);
+
+        $schemaTool->dropDatabase();
+        $schemaTool->createSchema([$classes]);
+    }
+
+    public function testDateTimeWithTimezoneExample(): void
+    {
+        $entity = new DateTimeInstance(
+            new DateTimeImmutable('2021-09-30 12:00:00', new DateTimeZone('Europe/Busingen')),
+            1
+        );
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $this->entityManager->clear();
+        $this->entityManager->getUnitOfWork()->clear();
+
+        $newEntity = $this->entityManager->find(DateTimeInstance::class, 1);
+        $this->entityManager->getUnitOfWork()->computeChangeSets();
+        $this->assertEmpty($this->entityManager->getUnitOfWork()->getEntityChangeSet($newEntity));
+        $this->assertEquals('Europe/Busingen', $newEntity->getEventDateTime()->getTimezone()->getName());
+        $this->assertEquals('2021-09-30 12:00:00', $newEntity->getEventDateTime()->format('Y-m-d H:i:s'));
+
+        $newEntity->convertToUtc();
+
+        $this->entityManager->getUnitOfWork()->computeChangeSets();
+        $this->assertNotEmpty($this->entityManager->getUnitOfWork()->getEntityChangeSet($newEntity));
+    }
+}

--- a/tests/Doctrine/Tests/Examples/DateTimeInstance.php
+++ b/tests/Doctrine/Tests/Examples/DateTimeInstance.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Examples;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimezone;
+
+/**
+ * @\Doctrine\ORM\Mapping\Entity
+ * @\Doctrine\ORM\Mapping\HasLifecycleCallbacks
+ */
+class DateTimeInstance
+{
+    /**
+     * @\Doctrine\ORM\Mapping\Id
+     * @\Doctrine\ORM\Mapping\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @\Doctrine\ORM\Mapping\Column(type="datetime")
+     * @var DateTimeImmutable
+     */
+    private $eventDateTime;
+
+    /** @\Doctrine\ORM\Mapping\Column(type="string") */
+    private $timezone;
+
+    public function __construct(DateTimeInterface $eventDateTime, int $id)
+    {
+        $this->id = $id;
+        $this->eventDateTime = $eventDateTime;
+        $this->timezone = $eventDateTime->getTimeZone()->getName();
+    }
+
+    /** @\Doctrine\ORM\Mapping\PostLoad */
+    public function correctTimezone(): void
+    {
+        $correctEntity = new DateTimeImmutable(
+            $this->eventDateTime->format('Y-m-d H:i:s'),
+            new DateTimeZone($this->timezone)
+        );
+
+        $this->eventDateTime->setTimezone(new DateTimezone($this->timezone))->modify($correctEntity->format('Y-m-d H:i:s'));
+    }
+
+    public function convertToUtc(): void
+    {
+        $this->eventDateTime = clone $this->eventDateTime->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    public function getEventDateTime(): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromMutable($this->eventDateTime);
+    }
+}


### PR DESCRIPTION
This commit alters the page to better handle datetimes with timezones. The result will store the datetime with the local date as datetime-value and the timezone as string-value. That way the database-specific ways of doing datetime arithmentics with timezones (see examples for [MySQL](https://andreas.heigl.org/2016/04/18/timezones-and-mysql/) and [Postgres](https://andreas.heigl.org/2016/05/29/timezones-and-postgresql/)) are still possible, the datetime will not be prone to errors due to timezone-changes between creation and the actual datetime and still the application will be able to use a generic datetime-object that can then be converted to a local timezone of the current user.