### PR TITLE
Use Generators instead of AppendIterator for properties iteration

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
@@ -108,11 +108,13 @@ abstract class ComponentMetadata
     }
 
     /**
-     * @return \ArrayIterator
+     * @return iterable
      */
-    public function getDeclaredPropertiesIterator() : \ArrayIterator
+    public function getDeclaredPropertiesIterator() : iterable
     {
-        return new \ArrayIterator($this->declaredProperties);
+        foreach ($this->declaredProperties as $name => $property) {
+            yield $name => $property;
+        }
     }
 
     /**
@@ -159,22 +161,15 @@ abstract class ComponentMetadata
     }
 
     /**
-     * @return \Iterator
+     * @return iterable
      */
-    public function getPropertiesIterator() : \Iterator
+    public function getPropertiesIterator() : iterable
     {
-        $declaredPropertiesIterator = $this->getDeclaredPropertiesIterator();
-
-        if (! $this->parent) {
-            return $declaredPropertiesIterator;
+        if ($this->parent) {
+            yield from $this->parent->getPropertiesIterator();
         }
 
-        $iterator = new \AppendIterator();
-
-        $iterator->append($this->parent->getPropertiesIterator());
-        $iterator->append($declaredPropertiesIterator);
-
-        return $iterator;
+        yield from $this->getDeclaredPropertiesIterator();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -68,7 +68,7 @@ class DDC599Test extends \Doctrine\Tests\OrmFunctionalTestCase
     {
         $class = $this->em->getClassMetadata(DDC599Subitem::class);
 
-        self::assertArrayHasKey('children', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('children', iterator_to_array($class->getDeclaredPropertiesIterator()));
         self::assertContains('remove', $class->getProperty('children')->getCascade());
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -366,7 +366,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testOwningOneToOneAssociation($class)
     {
-        self::assertArrayHasKey('address', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('address', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $association = $class->getProperty('address');
 
@@ -384,7 +384,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testInverseOneToManyAssociation($class)
     {
-        self::assertArrayHasKey('phonenumbers', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('phonenumbers', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $association = $class->getProperty('phonenumbers');
 
@@ -406,7 +406,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
      */
     public function testManyToManyAssociationWithCascadeAll($class)
     {
-        self::assertArrayHasKey('groups', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('groups', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $association = $class->getProperty('groups');
 
@@ -806,8 +806,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $guestMetadata  = $factory->getMetadataFor(DDC964Guest::class);
 
         // assert groups association mappings
-        self::assertArrayHasKey('groups', $guestMetadata->getDeclaredPropertiesIterator());
-        self::assertArrayHasKey('groups', $adminMetadata->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('groups', iterator_to_array($guestMetadata->getDeclaredPropertiesIterator()));
+        self::assertArrayHasKey('groups', iterator_to_array($adminMetadata->getDeclaredPropertiesIterator()));
 
         $guestGroups = $guestMetadata->getProperty('groups');
         $adminGroups = $adminMetadata->getProperty('groups');
@@ -843,8 +843,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals('admingroup_id', $adminGroupsInverseJoinColumn->getColumnName());
 
         // assert address association mappings
-        self::assertArrayHasKey('address', $guestMetadata->getDeclaredPropertiesIterator());
-        self::assertArrayHasKey('address', $adminMetadata->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('address', iterator_to_array($guestMetadata->getDeclaredPropertiesIterator()));
+        self::assertArrayHasKey('address', iterator_to_array($adminMetadata->getDeclaredPropertiesIterator()));
 
         $guestAddress = $guestMetadata->getProperty('address');
         $adminAddress = $adminMetadata->getProperty('address');
@@ -879,7 +879,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $adminMetadata  = $factory->getMetadataFor(DDC3579Admin::class);
 
         // assert groups association mappings
-        self::assertArrayHasKey('groups', $adminMetadata->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('groups', iterator_to_array($adminMetadata->getDeclaredPropertiesIterator()));
 
         $adminGroups = $adminMetadata->getProperty('groups');
 
@@ -895,7 +895,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         // check override metadata
         $contractMetadata = $this->createClassMetadataFactory()->getMetadataFor(DDC5934Contract::class);
 
-        self::assertArrayHasKey('members', $contractMetadata->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('members', iterator_to_array($contractMetadata->getDeclaredPropertiesIterator()));
 
         $contractMembers = $contractMetadata->getProperty('members');
 
@@ -1095,7 +1095,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals(Mapping\CacheUsage::READ_ONLY, $class->getCache()->getUsage());
         self::assertEquals('doctrine_tests_models_cache_city', $class->getCache()->getRegion());
 
-        self::assertArrayHasKey('state', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('state', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $stateAssociation = $class->getProperty('state');
 
@@ -1103,7 +1103,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals(Mapping\CacheUsage::READ_ONLY, $stateAssociation->getCache()->getUsage());
         self::assertEquals('doctrine_tests_models_cache_city__state', $stateAssociation->getCache()->getRegion());
 
-        self::assertArrayHasKey('attractions', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('attractions', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $attractionsAssociation = $class->getProperty('attractions');
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -149,11 +149,11 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $factory->setEntityManager($em);
 
         $classPage = $factory->getMetadataFor(File::class);
-        self::assertArrayHasKey('parentDirectory', $classPage->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('parentDirectory', iterator_to_array($classPage->getDeclaredPropertiesIterator()));
         self::assertEquals(File::class, $classPage->getProperty('parentDirectory')->getSourceEntity());
 
         $classDirectory = $factory->getMetadataFor(Directory::class);
-        self::assertArrayHasKey('parentDirectory', $classDirectory->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('parentDirectory', iterator_to_array($classDirectory->getDeclaredPropertiesIterator()));
         self::assertEquals(Directory::class, $classDirectory->getProperty('parentDirectory')->getSourceEntity());
     }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -70,7 +70,7 @@ class BasicInheritanceMappingTest extends OrmTestCase
         self::assertNotNull($class->getProperty('transient'));
         self::assertInstanceOf(TransientMetadata::class, $class->getProperty('transient'));
 
-        self::assertArrayHasKey('mappedRelated1', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('mappedRelated1', iterator_to_array($class->getDeclaredPropertiesIterator()));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -66,7 +66,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $class = $factory->getMetadataFor(DDC117Translation::class);
 
         self::assertEquals(['language', 'article'], $class->identifier);
-        self::assertArrayHasKey('article', $class->getDeclaredPropertiesIterator());
+        self::assertArrayHasKey('article', iterator_to_array($class->getDeclaredPropertiesIterator()));
 
         $association = $class->getProperty('article');
 

--- a/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php
@@ -50,7 +50,7 @@ class ResolveTargetEntityListenerTest extends OrmTestCase
         $evm->addEventSubscriber($this->listener);
 
         $cm   = $this->factory->getMetadataFor(ResolveTargetEntity::class);
-        $meta = $cm->getDeclaredPropertiesIterator();
+        $meta = iterator_to_array($cm->getDeclaredPropertiesIterator());
 
         self::assertSame(TargetEntity::class, $meta['manyToMany']->getTargetEntity());
         self::assertSame(ResolveTargetEntity::class, $meta['manyToOne']->getTargetEntity());


### PR DESCRIPTION
As discussed on Slack, AppendIterator doesn't work with inheritance depth >2, would have to be flattened somehow or FlattenIterator been created. Generators solve this issue in a cleaner way.

Tests with assertArrayHasKey had to be adjusted (some of them should probably use `hasProperty()` instead), strange it worked with AppendIterator. :)