### PR TITLE
Supply default values for optional values in sequence mapping if omitted by driver.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3003,13 +3003,21 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function setSequenceGeneratorDefinition(array $definition)
     {
-        if ( ! isset($definition['sequenceName'])) {
+        if ( ! isset($definition['sequenceName']) || trim($definition['sequenceName']) === '') {
             throw MappingException::missingSequenceName($this->name);
         }
 
         if ($definition['sequenceName'][0] == '`') {
             $definition['sequenceName']   = trim($definition['sequenceName'], '`');
             $definition['quoted'] = true;
+        }
+
+        if ( ! isset($definition['allocationSize']) || trim($definition['allocationSize']) === '') {
+            $definition['allocationSize'] = '1';
+        }
+
+        if ( ! isset($definition['initialValue']) || trim($definition['initialValue']) === '') {
+            $definition['initialValue'] = '1';
         }
 
         $this->sequenceGeneratorDefinition = $definition;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6682Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6682Test.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Doctrine\Test\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH6682Test extends OrmFunctionalTestCase
+{
+    /**
+     * @group 6682
+     */
+    public function testIssue() : void
+    {
+        $parsedDefinition = [
+            'sequenceName'   => 'test_sequence',
+            'allocationSize' => '',
+            'initialValue'   => '',
+        ];
+
+        $classMetadataInfo = new ClassMetadataInfo('test_entity');
+        $classMetadataInfo->setSequenceGeneratorDefinition($parsedDefinition);
+
+        self::assertSame(
+            ['sequenceName' => 'test_sequence', 'allocationSize' => '1', 'initialValue' => '1'],
+            $classMetadataInfo->sequenceGeneratorDefinition
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1188,15 +1188,19 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-2662
+     * @group 6682
      */
-    public function testQuotedSequenceName()
+    public function testQuotedSequenceName() : void
     {
         $cm = new ClassMetadata(CMS\CmsUser::class);
-        $cm->initializeReflection(new RuntimeReflectionService());
 
+        $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setSequenceGeneratorDefinition(['sequenceName' => '`foo`']);
 
-        $this->assertEquals(['sequenceName' => 'foo', 'quoted' => true], $cm->sequenceGeneratorDefinition);
+        self::assertSame(
+            ['sequenceName' => 'foo', 'quoted' => true, 'allocationSize' => '1', 'initialValue' => '1'],
+            $cm->sequenceGeneratorDefinition
+        );
     }
 
     /**


### PR DESCRIPTION
Fix #6682
~~Cannot figure out how to get XML to run properly from Ticket directory as in contributor guide. If this is a strict requirement will try again.~~ Figured out.