### PR TITLE
Updating `Query#$_maxResults` to allow for `null` (no limit)

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -163,7 +163,7 @@ final class Query extends AbstractQuery
     /**
      * The maximum number of results to return (the "limit").
      *
-     * @var integer
+     * @var integer|null
      */
     private $_maxResults = null;
 
@@ -628,7 +628,7 @@ final class Query extends AbstractQuery
     /**
      * Sets the maximum number of results to retrieve (the "limit").
      *
-     * @param integer $maxResults
+     * @param integer|null $maxResults
      *
      * @return Query This query object.
      */
@@ -644,7 +644,7 @@ final class Query extends AbstractQuery
      * Gets the maximum number of results the query object was set to retrieve (the "limit").
      * Returns NULL if {@link setMaxResults} was not applied to this query.
      *
-     * @return integer Maximum number of results.
+     * @return integer|null Maximum number of results.
      */
     public function getMaxResults()
     {

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -107,7 +107,7 @@ class QueryBuilder
     /**
      * The maximum number of results to retrieve.
      *
-     * @var integer
+     * @var integer|null
      */
     private $_maxResults = null;
 
@@ -653,7 +653,7 @@ class QueryBuilder
     /**
      * Sets the maximum number of results to retrieve (the "limit").
      *
-     * @param integer $maxResults The maximum number of results to retrieve.
+     * @param integer|null $maxResults The maximum number of results to retrieve.
      *
      * @return self
      */
@@ -668,7 +668,7 @@ class QueryBuilder
      * Gets the maximum number of results the query object was set to retrieve (the "limit").
      * Returns NULL if {@link setMaxResults} was not applied to this query builder.
      *
-     * @return integer Maximum number of results.
+     * @return integer|null Maximum number of results.
      */
     public function getMaxResults()
     {

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -136,7 +136,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         $fromRoot        = reset($from);
 
         if ($query instanceof Query
-            && $query->getMaxResults()
+            && null !== $query->getMaxResults()
             && $AST->orderByClause
             && count($fromRoot->joins)) {
             // Check each orderby item.


### PR DESCRIPTION
I am using PHPStan level 7 in a project I am working on. This pull request means I will be able to remove [one of my PHPStan ignore rules](https://github.com/bbc/programmes-pages-service/pull/164/files#diff-e4ce1df0d2ca17a9d91544a50ace127aR10).