### PR TITLE
Update table prefix docs

### DIFF
--- a/docs/en/cookbook/sql-table-prefixes.rst
+++ b/docs/en/cookbook/sql-table-prefixes.rst
@@ -41,7 +41,9 @@ appropriate autoloaders.
             $classMetadata = $eventArgs->getClassMetadata();
 
             if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
-                $classMetadata->setTableName($this->prefix . $classMetadata->getTableName());
+                $classMetadata->setPrimaryTable([
+                    'name' => $this->prefix . $classMetadata->getTableName()
+                ]);
             }
 
             foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {


### PR DESCRIPTION
Updated docs to remove deprecated setTableName() and replace it with setPrimaryTable()