### PR TITLE
Fix parameter name comparison in AbstractQuery regarding different types (fixes #6699)

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -321,14 +321,14 @@ abstract class AbstractQuery
     public function getParameter($key)
     {
         $filteredParameters = $this->parameters->filter(
-            function ($parameter) use ($key)
-            {
-                // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+            function (Query\Parameter $parameter) use ($key) : bool {
+                $parameterName = $parameter->getName();
+
+                return $key === $parameterName || (string) $key === (string) $parameterName;
             }
         );
 
-        return count($filteredParameters) ? $filteredParameters->first() : null;
+        return ! $filteredParameters->isEmpty() ? $filteredParameters->first() : null;
     }
 
     /**
@@ -369,17 +369,10 @@ abstract class AbstractQuery
      */
     public function setParameter($key, $value, $type = null)
     {
-        $filteredParameters = $this->parameters->filter(
-            function ($parameter) use ($key)
-            {
-                // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
-            }
-        );
+        $existingParameter = $this->getParameter($key);
 
-        if (count($filteredParameters)) {
-            $parameter = $filteredParameters->first();
-            $parameter->setValue($value, $type);
+        if ($existingParameter !== null) {
+            $existingParameter->setValue($value, $type);
 
             return $this;
         }

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -532,26 +532,15 @@ class QueryBuilder
      */
     public function setParameter($key, $value, $type = null)
     {
-        $filteredParameters = $this->parameters->filter(
-            function ($parameter) use ($key)
-            {
-                /* @var Query\Parameter $parameter */
-                // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
-            }
-        );
+        $existingParameter = $this->getParameter($key);
 
-        if (count($filteredParameters)) {
-            /* @var Query\Parameter $parameter */
-            $parameter = $filteredParameters->first();
-            $parameter->setValue($value, $type);
+        if ($existingParameter !== null) {
+            $existingParameter->setValue($value, $type);
 
             return $this;
         }
 
-        $parameter = new Query\Parameter($key, $value, $type);
-
-        $this->parameters->add($parameter);
+        $this->parameters->add(new Query\Parameter($key, $value, $type));
 
         return $this;
     }
@@ -614,15 +603,14 @@ class QueryBuilder
     public function getParameter($key)
     {
         $filteredParameters = $this->parameters->filter(
-            function ($parameter) use ($key)
-            {
-                /* @var Query\Parameter $parameter */
-                // Must not be identical because of string to integer conversion
-                return ($key == $parameter->getName());
+            function (Query\Parameter $parameter) use ($key) : bool {
+                $parameterName = $parameter->getName();
+
+                return $key === $parameterName || (string) $key === (string) $parameterName;
             }
         );
 
-        return count($filteredParameters) ? $filteredParameters->first() : null;
+        return ! $filteredParameters->isEmpty() ? $filteredParameters->first() : null;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6699Test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group 6699
+ */
+final class GH6699Test extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        $this->useModelSet('cms');
+
+        parent::setUp();
+    }
+
+    public function testMixedParametersWithZeroNumber() : void
+    {
+        $query = $this->_em->createQueryBuilder()
+                           ->select('u')
+                           ->from(CmsUser::class, 'u')
+                           ->andWhere('u.username = :username')
+                           ->andWhere('u.id = ?0')
+                           ->getQuery();
+
+        $query->setParameter('username', 'bar');
+        $query->setParameter(0, 0);
+
+        $query->execute();
+
+        self::assertCount(2, $query->getParameters());
+        self::assertSame(0, $query->getParameter(0)->getValue());
+        self::assertSame('bar', $query->getParameter('username')->getValue());
+    }
+
+    public function testMixedParametersWithZeroNumberOnQueryBuilder() : void
+    {
+        $query = $this->_em->createQueryBuilder()
+                           ->select('u')
+                           ->from(CmsUser::class, 'u')
+                           ->andWhere('u.username = :username')
+                           ->andWhere('u.id = ?0')
+                           ->setParameter('username', 'bar')
+                           ->setParameter(0, 0)
+                           ->getQuery();
+
+        $query->execute();
+
+        self::assertCount(2, $query->getParameters());
+        self::assertSame(0, $query->getParameter(0)->getValue());
+        self::assertSame('bar', $query->getParameter('username')->getValue());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\Mocks\DriverConnectionMock;
 use Doctrine\Tests\Mocks\StatementArrayMock;
 use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmTestCase;
 
 class QueryTest extends OrmTestCase
@@ -302,5 +303,67 @@ class QueryTest extends OrmTestCase
         $this->expectException(QueryException::class);
         $this->expectExceptionMessage('Subquery');
         $query->getSQL();
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testGetParameterTypeJuggling() : void
+    {
+        $query = $this->_em->createQuery('select u from ' . CmsUser::class . ' u where u.id = ?0');
+
+        $query->setParameter(0, 0);
+
+        self::assertCount(1, $query->getParameters());
+        self::assertSame(0, $query->getParameter(0)->getValue());
+        self::assertSame(0, $query->getParameter('0')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithNameZeroIsNotOverridden() : void
+    {
+        $query = $this->_em->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
+
+        $query->setParameter(0, 0);
+        $query->setParameter('name', 'Doctrine');
+
+        self::assertCount(2, $query->getParameters());
+        self::assertSame(0, $query->getParameter('0')->getValue());
+        self::assertSame('Doctrine', $query->getParameter('name')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithNameZeroDoesNotOverrideAnotherParameter() : void
+    {
+        $query = $this->_em->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
+
+        $query->setParameter('name', 'Doctrine');
+        $query->setParameter(0, 0);
+
+        self::assertCount(2, $query->getParameters());
+        self::assertSame(0, $query->getParameter(0)->getValue());
+        self::assertSame('Doctrine', $query->getParameter('name')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithTypeJugglingWorks() : void
+    {
+        $query = $this->_em->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
+
+        $query->setParameter('0', 1);
+        $query->setParameter('name', 'Doctrine');
+        $query->setParameter(0, 2);
+        $query->setParameter('0', 3);
+
+        self::assertCount(2, $query->getParameters());
+        self::assertSame(3, $query->getParameter(0)->getValue());
+        self::assertSame(3, $query->getParameter('0')->getValue());
+        self::assertSame('Doctrine', $query->getParameter('name')->getValue());
     }
 }

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -1158,4 +1158,81 @@ class QueryBuilderTest extends OrmTestCase
 
         $this->assertEquals(['u', 'g'], $aliases);
     }
+
+    /**
+     * @group 6699
+     */
+    public function testGetParameterTypeJuggling() : void
+    {
+        $builder = $this->_em->createQueryBuilder()
+                             ->select('u')
+                             ->from(CmsUser::class, 'u')
+                             ->where('u.id = ?0');
+
+        $builder->setParameter(0, 0);
+
+        self::assertCount(1, $builder->getParameters());
+        self::assertSame(0, $builder->getParameter(0)->getValue());
+        self::assertSame(0, $builder->getParameter('0')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithNameZeroIsNotOverridden() : void
+    {
+        $builder = $this->_em->createQueryBuilder()
+                             ->select('u')
+                             ->from(CmsUser::class, 'u')
+                             ->where('u.id != ?0')
+                             ->andWhere('u.username = :name');
+
+        $builder->setParameter(0, 0);
+        $builder->setParameter('name', 'Doctrine');
+
+        self::assertCount(2, $builder->getParameters());
+        self::assertSame(0, $builder->getParameter('0')->getValue());
+        self::assertSame('Doctrine', $builder->getParameter('name')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithNameZeroDoesNotOverrideAnotherParameter() : void
+    {
+        $builder = $this->_em->createQueryBuilder()
+                             ->select('u')
+                             ->from(CmsUser::class, 'u')
+                             ->where('u.id != ?0')
+                             ->andWhere('u.username = :name');
+
+        $builder->setParameter('name', 'Doctrine');
+        $builder->setParameter(0, 0);
+
+        self::assertCount(2, $builder->getParameters());
+        self::assertSame(0, $builder->getParameter(0)->getValue());
+        self::assertSame('Doctrine', $builder->getParameter('name')->getValue());
+    }
+
+    /**
+     * @group 6699
+     */
+    public function testSetParameterWithTypeJugglingWorks() : void
+    {
+        $builder = $this->_em->createQueryBuilder()
+                             ->select('u')
+                             ->from(CmsUser::class, 'u')
+                             ->where('u.id != ?0')
+                             ->andWhere('u.username = :name');
+
+        $builder->setParameter('0', 1);
+        $builder->setParameter('name', 'Doctrine');
+        $builder->setParameter(0, 2);
+        $builder->setParameter('0', 3);
+
+        self::assertCount(2, $builder->getParameters());
+        self::assertSame(3, $builder->getParameter(0)->getValue());
+        self::assertSame(3, $builder->getParameter('0')->getValue());
+        self::assertSame('Doctrine', $builder->getParameter('name')->getValue());
+    }
 }


### PR DESCRIPTION
AbstractQuery::setParameter() uses weak comparison to compare parameter names and decide whether to update existing or add new parameter. AbstractQuery::getParameter() does so as well.
This is problematic for parameter named `0` since strings are downcasted to `0` as well, making it incorrectly assume that i.e. the `0` and `"foo"` are the same parameter.
In most cases, cast is not needed and we would ideally want to prevent it, thus added identity check first and only if it fails, string cast comparison is attempted.

Fixes #6699.