### PR TITLE
[Bug] Fix compatibility with PHP >= 7.0 in v2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 env:
   - DB=mysql
   - DB=pgsql

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -848,8 +848,8 @@ class QueryBuilder
      */
     public function andWhere($where)
     {
-        $where = $this->getDQLPart('where');
         $args  = func_get_args();
+        $where = $this->getDQLPart('where');
 
         if ($where instanceof Expr\Andx) {
             $where->addMultiple($args);
@@ -879,8 +879,8 @@ class QueryBuilder
      */
     public function orWhere($where)
     {
-        $where = $this->getDqlPart('where');
         $args  = func_get_args();
+        $where = $this->getDqlPart('where');
 
         if ($where instanceof Expr\Orx) {
             $where->addMultiple($args);
@@ -956,8 +956,8 @@ class QueryBuilder
      */
     public function andHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Andx) {
             $having->addMultiple($args);
@@ -978,8 +978,8 @@ class QueryBuilder
      */
     public function orHaving($having)
     {
-        $having = $this->getDqlPart('having');
         $args   = func_get_args();
+        $having = $this->getDqlPart('having');
 
         if ($having instanceof Expr\Orx) {
             $having->addMultiple($args);


### PR DESCRIPTION
**Not sure if it is related with [this BC break](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified) but the QueryBuilder from doctrine/orm `2.3` is not working normally with PHP `>= 7.0`.**

If `func_get_args` is not called first, it returns

```
array(1) {
  [0]=>
  NULL
}
```

instead of (when it's called first):

```
array(1) {
  [0]=>
  string(19) "e.name LIKE :e_name"
}
```

**[It seems it was fixed for HHVM from `2.4`](https://github.com/doctrine/doctrine2/commit/dbbe7a4be5d5f84632ce9a2401b88d59afff1a05#diff-6e1fe274092a9dc90ad2f6728df45c6a), but it's still a problem in `2.3` with PHP `>= 7.0`.**
**This should be fixed, or the support for `>= 7.0` should be dropped in `2.3`.**

I added PHP versions `5.5`, `5.6`, `7.0` and `7.1` in Travis Matrix, since the current requirement for PHP is `>=5.3.2` and versions above `5.4` are not tested right now.