### PR TITLE
NewObjectExpression: Allows use of nested new operators

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -293,6 +293,29 @@ abstract class AbstractHydrator
             }
         }
 
+        foreach ($this->rsm->nestedNewObjectArguments as $objIndex => ['ownerIndex' => $ownerIndex, 'argIndex' => $argIndex]) {
+            $newObject = $rowData['newObjects'][$objIndex];
+            unset($rowData['newObjects'][$objIndex]);
+
+            $class  = $newObject['class'];
+            $args   = $newObject['args'];
+            $obj    = $class->newInstanceArgs($args);
+
+            $rowData['newObjects'][$ownerIndex]['args'][$argIndex] = $obj;
+        }
+
+
+        if (isset($rowData['newObjects'])) {
+            foreach ($rowData['newObjects'] as $objIndex => $newObject) {
+                $class  = $newObject['class'];
+                $args   = $newObject['args'];
+                $obj    = $class->newInstanceArgs($args);
+
+                $rowData['newObjects'][$objIndex]['obj'] = $obj;
+            }
+        }
+
+
         return $rowData;
     }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -309,6 +309,7 @@ abstract class AbstractHydrator
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
                 $class  = $newObject['class'];
                 $args   = $newObject['args'];
+                ksort($args);
                 $obj    = $class->newInstanceArgs($args);
 
                 $rowData['newObjects'][$objIndex]['obj'] = $obj;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -233,9 +233,8 @@ class ArrayHydrator extends AbstractHydrator
             $onlyOneRootAlias = $scalarCount === 0 && count($rowData['newObjects']) === 1;
 
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
-                $class = $newObject['class'];
-                $args  = $newObject['args'];
-                $obj   = $class->newInstanceArgs($args);
+                $args   = $newObject['args'];
+                $obj    = $newObject['obj'];
 
                 if ($onlyOneRootAlias || \count($args) === $scalarCount) {
                     $result[$resultKey] = $obj;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -532,12 +532,11 @@ class ObjectHydrator extends AbstractHydrator
                 $resultKey = $this->resultCounter - 1;
             }
 
+
             $hasNoScalars = ! (isset($rowData['scalars']) && $rowData['scalars']);
 
             foreach ($rowData['newObjects'] as $objIndex => $newObject) {
-                $class = $newObject['class'];
-                $args  = $newObject['args'];
-                $obj   = $class->newInstanceArgs($args);
+                $obj = $newObject['obj'];
 
                 if ($hasNoScalars && \count($rowData['newObjects']) === 1) {
                     $result[$resultKey] = $obj;

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1873,6 +1873,12 @@ class Parser
             return $expression;
         }
 
+        if ($token['type'] === Lexer::T_NEW) {
+            $expression = $this->NewObjectExpression();
+
+            return $expression;
+        }
+
         return $this->ScalarExpression();
     }
 

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -148,6 +148,13 @@ class ResultSetMapping
     public $newObjectMappings = [];
 
     /**
+     * Maps last argument for new objects in order to initiate object construction
+     *
+     * @var array
+     */
+    public $nestedNewObjectArguments = [];
+
+    /**
      * Maps metadata parameter names to the metadata attribute.
      *
      * @var mixed[]
@@ -554,5 +561,24 @@ class ResultSetMapping
         }
 
         return $this;
+    }
+
+    public function addNewObjectAsArgument($alias, $objOwner, $objOwnerIdx)
+    {
+        $owner = [
+            'ownerIndex' => $objOwner,
+            'argIndex' => $objOwnerIdx,
+        ];
+
+        if (!isset($this->nestedNewObjectArguments[$owner['ownerIndex']])) {
+            $this->nestedNewObjectArguments[$alias] = $owner;
+
+            return;
+        }
+
+        $this->nestedNewObjectArguments = array_merge(
+            [$alias => $owner],
+            $this->nestedNewObjectArguments
+        );
     }
 }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -71,6 +71,13 @@ class SqlWalker implements TreeWalker
     private $newObjectCounter = 0;
 
     /**
+     * Contains nesting levels of new objects arguments
+     *
+     * @var array of newObject indexes
+     */
+    private $newObjectStack = [];
+
+    /**
      * @var ParserResult
      */
     private $parserResult;
@@ -1578,7 +1585,14 @@ class SqlWalker implements TreeWalker
     public function walkNewObject($newObjectExpression, $newObjectResultAlias = null)
     {
         $sqlSelectExpressions = [];
-        $objIndex             = $newObjectResultAlias ?: $this->newObjectCounter++;
+
+        $objOwner = $objOwnerIdx = null;
+        if (!empty($this->newObjectStack)) {
+            [$objOwner, $objOwnerIdx] = end($this->newObjectStack);
+            $objIndex = "$objOwner:$objOwnerIdx";
+        } else {
+            $objIndex = $newObjectResultAlias ?: $this->newObjectCounter++;
+        }
 
         foreach ($newObjectExpression->args as $argIndex => $e) {
             $resultAlias = $this->scalarResultCounter++;
@@ -1587,7 +1601,10 @@ class SqlWalker implements TreeWalker
 
             switch (true) {
                 case ($e instanceof AST\NewObjectExpression):
+                    array_push($this->newObjectStack, [$objIndex, $argIndex]);
                     $sqlSelectExpressions[] = $e->dispatch($this);
+                    array_pop($this->newObjectStack);
+
                     break;
 
                 case ($e instanceof AST\Subselect):
@@ -1630,6 +1647,10 @@ class SqlWalker implements TreeWalker
                 'objIndex'  => $objIndex,
                 'argIndex'  => $argIndex,
             ];
+
+            if ($objOwner) {
+                $this->rsm->addNewObjectAsArgument($objIndex, $objOwner, $objOwnerIdx);
+            }
         }
 
         return implode(', ', $sqlSelectExpressions);

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1648,7 +1648,7 @@ class SqlWalker implements TreeWalker
                 'argIndex'  => $argIndex,
             ];
 
-            if ($objOwner) {
+            if ($objOwner !== null) {
                 $this->rsm->addNewObjectAsArgument($objIndex, $objOwner, $objOwnerIdx);
             }
         }

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -297,4 +297,21 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
 
         self::assertTrue($this->rsm->hasIndexBy('lu'));
     }
+
+    public function testNewObjectNestedArgumentsDeepestLeavesShouldComeFirst()
+    {
+        $this->rsm->addNewObjectAsArgument('objALevel2', 'objALevel1', 0);
+        $this->rsm->addNewObjectAsArgument('objALevel3', 'objALevel2', 1);
+        $this->rsm->addNewObjectAsArgument('objBLevel3', 'objBLevel2', 0);
+        $this->rsm->addNewObjectAsArgument('objBLevel2', 'objBLevel1', 1);
+
+        $expectedArgumentMapping = [
+            'objALevel3' => ['ownerIndex' => 'objALevel2', 'argIndex' => 1],
+            'objALevel2' => ['ownerIndex' => 'objALevel1', 'argIndex' => 0],
+            'objBLevel3' => ['ownerIndex' => 'objBLevel2', 'argIndex' => 0],
+            'objBLevel2' => ['ownerIndex' => 'objBLevel1', 'argIndex' => 1],
+        ];
+
+        $this->assertEquals($expectedArgumentMapping, $this->rsm->nestedNewObjectArguments);
+    }
 }


### PR DESCRIPTION
Covers #4687, #6573

This PR adds ability to use aggregation of DTOs as query result:

```php
$dql = '
    SELECT
        new UserDTO(
           u.id,
           u.name,
           new AddressDTO(
                address.country,
                address.city,
                address.street,
                address.postcode
           )
        )
    FROM User u
    JOIN u.location address
';
```

Use cases:

 - reporting and aggregations results
 - read-only queries
