### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "doctrine/instantiator": "^1.0.1",
         "doctrine/common": ">=2.5-dev,<2.9-dev",
         "doctrine/cache": "~1.4",
-        "symfony/console": "~2.5|~3.0"
+        "symfony/console": "~2.5|~3.0|~4.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0|~4.0",
         "phpunit/phpunit": "~4.0"
     },
     "suggest": {


### PR DESCRIPTION
@nicolas-grekas added support for Symfony 4.0, but only on the master branch, which is yet to be released. As Symfony 4 will start to be in beta really soon now (next week), having support for it in Doctrine 2.5 is critical.

I know that's a lot to ask, but is it possible to merge this PR and release 2.5.12?

Thank you a lot for your help on this one.
