### PR TITLE
parameter type guessing fails for identifier with custom type

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -386,7 +386,7 @@ final class Query extends AbstractQuery
             if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(StaticClassNameConverter::getClass($value))) {
                 $metadata = $this->em->getClassMetadata(StaticClassNameConverter::getClass($value));
                 if ($metadata->isIdentifierComposite()) {
-                    ORMInvalidArgumentException::invalidCompositeIdentifier();
+                    throw ORMInvalidArgumentException::invalidCompositeIdentifier();
                 }
                 $type = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -385,7 +385,7 @@ final class Query extends AbstractQuery
 
             if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(StaticClassNameConverter::getClass($value))) {
                 $metadata = $this->em->getClassMetadata(StaticClassNameConverter::getClass($value));
-                $type = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
+                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }
 
             $value = $this->processParameterValue($value);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
+use ProxyManager\Proxy\GhostObjectInterface;
 use function array_keys;
 use function array_values;
 use function count;
@@ -383,9 +384,12 @@ final class Query extends AbstractQuery
                 $value = array_keys(HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($value, $this->em));
             }
 
-            if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(get_class($value))) {
+            if (is_object($value) && (
+                    $this->em->getMetadataFactory()->hasMetadataFor(get_class($value))
+                    || $value instanceof GhostObjectInterface
+                )) {
                 $metadata = $this->em->getClassMetadata(get_class($value));
-                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
+                $type = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }
 
             $value = $this->processParameterValue($value);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -393,7 +393,7 @@ final class Query extends AbstractQuery
 
             $value = $this->processParameterValue($value);
             if ($type === null) {
-                $type  = $parameter->getValue() === $value
+                $type = $parameter->getValue() === $value
                     ? $parameter->getType()
                     : ParameterTypeInferer::inferType($value);
             }

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -385,7 +385,7 @@ final class Query extends AbstractQuery
 
             if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(get_class($value))) {
                 $metadata = $this->em->getClassMetadata(get_class($value));
-                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getType();
+                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }
 
             $value = $this->processParameterValue($value);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -19,11 +19,10 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
-use ProxyManager\Proxy\GhostObjectInterface;
+use Doctrine\ORM\Utility\StaticClassNameConverter;
 use function array_keys;
 use function array_values;
 use function count;
-use function get_class;
 use function in_array;
 use function is_object;
 use function ksort;
@@ -384,11 +383,8 @@ final class Query extends AbstractQuery
                 $value = array_keys(HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($value, $this->em));
             }
 
-            if (is_object($value) && (
-                    $this->em->getMetadataFactory()->hasMetadataFor(get_class($value))
-                    || $value instanceof GhostObjectInterface
-                )) {
-                $metadata = $this->em->getClassMetadata(get_class($value));
+            if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(StaticClassNameConverter::getClass($value))) {
+                $metadata = $this->em->getClassMetadata(StaticClassNameConverter::getClass($value));
                 $type = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }
 

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -385,7 +385,10 @@ final class Query extends AbstractQuery
 
             if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(StaticClassNameConverter::getClass($value))) {
                 $metadata = $this->em->getClassMetadata(StaticClassNameConverter::getClass($value));
-                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
+                if ($metadata->isIdentifierComposite()) {
+                    ORMInvalidArgumentException::invalidCompositeIdentifier();
+                }
+                $type = $metadata->getColumn($metadata->getIdentifier()[0])->getTypeName();
             }
 
             $value = $this->processParameterValue($value);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -22,7 +22,9 @@ use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
 use function array_keys;
 use function array_values;
 use function count;
+use function get_class;
 use function in_array;
+use function is_object;
 use function ksort;
 use function md5;
 use function reset;
@@ -367,6 +369,7 @@ final class Query extends AbstractQuery
             $key   = $parameter->getName();
             $value = $parameter->getValue();
             $rsm   = $this->getResultSetMapping();
+            $type  = null;
 
             if (! isset($paramMappings[$key])) {
                 throw QueryException::unknownParameter($key);
@@ -380,10 +383,17 @@ final class Query extends AbstractQuery
                 $value = array_keys(HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($value, $this->em));
             }
 
+            if (is_object($value) && $this->em->getMetadataFactory()->hasMetadataFor(get_class($value))) {
+                $metadata = $this->em->getClassMetadata(get_class($value));
+                $type     = $metadata->getColumn($metadata->getIdentifier()[0])->getType();
+            }
+
             $value = $this->processParameterValue($value);
-            $type  = $parameter->getValue() === $value
-                ? $parameter->getType()
-                : ParameterTypeInferer::inferType($value);
+            if ($type === null) {
+                $type  = $parameter->getValue() === $value
+                    ? $parameter->getType()
+                    : ParameterTypeInferer::inferType($value);
+            }
 
             foreach ($paramMappings[$key] as $position) {
                 $types[$position] = $type;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -31,7 +31,7 @@ class GH6443Test extends OrmFunctionalTestCase
         $entity     = new GH6443Post();
         $entity->id = 'Foo';
 
-        $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
+        $dql   = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
         $query = $this->em->createQuery($dql);
 
         // we do not know that the internal type is a rot13, so we can not add the type parameter here
@@ -58,7 +58,7 @@ class GH6443Test extends OrmFunctionalTestCase
         $metadata    = $this->em->getClassMetadata(GH6443Post::class);
         $entityProxy = $this->em->getProxyFactory()->getProxy($metadata, ['id' => 'Foo']);
 
-        $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
+        $dql   = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
         $query = $this->em->createQuery($dql);
 
         // we do not know that the internal type is a rot13, so we can not add the type parameter here
@@ -88,7 +88,7 @@ class GH6443Test extends OrmFunctionalTestCase
         $entity->id       = 'Foo';
         $entity->secondId = 'Bar';
 
-        $dql = 'SELECT entity FROM ' . GH6443CombinedIdentityEntity::class . ' entity WHERE entity = ?1';
+        $dql   = 'SELECT entity FROM ' . GH6443CombinedIdentityEntity::class . ' entity WHERE entity = ?1';
         $query = $this->em->createQuery($dql);
 
         // we set the entity as arameter
@@ -96,7 +96,6 @@ class GH6443Test extends OrmFunctionalTestCase
 
         // this is when the exception should be thrown
         $query->getResult();
-
     }
 
     /**
@@ -122,8 +121,8 @@ class GH6443Test extends OrmFunctionalTestCase
         parent::tearDown();
 
         $this->schemaTool->dropSchema([
-                $this->em->getClassMetadata(GH6443Post::class),
-                $this->em->getClassMetadata(GH6443CombinedIdentityEntity::class),
+            $this->em->getClassMetadata(GH6443Post::class),
+            $this->em->getClassMetadata(GH6443CombinedIdentityEntity::class),
         ]);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -82,7 +82,7 @@ class GH6443Test extends OrmFunctionalTestCase
      */
     public function testIssueWithCompositeIdentifier()
     {
-        self::expectException(ORMInvalidArgumentException::class);
+        $this->expectException(ORMInvalidArgumentException::class);
 
         $entity           = new GH6443CombinedIdentityEntity();
         $entity->id       = 'Foo';

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Logging\DebugStack;
@@ -33,7 +35,7 @@ class GH6443Test extends OrmFunctionalTestCase
         $entity->id = 'Foo';
 
         $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
-        $query = $this->_em->createQuery($dql);
+        $query = $this->em->createQuery($dql);
 
         // we do not know that the internal type is a rot13, so we can not add the type parameter here
         $query->setParameter(1, $entity);
@@ -59,11 +61,11 @@ class GH6443Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->sqlLogger = new DebugStack();
-        $this->_em->getConnection()->getConfiguration()->setSQLLogger($this->sqlLogger);
+        $this->em->getConnection()->getConfiguration()->setSQLLogger($this->sqlLogger);
 
 
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(GH6443Post::class),
+        $this->schemaTool->createSchema([
+            $this->em->getClassMetadata(GH6443Post::class),
         ]);
 
         $this->rot13Type = Type::getType('rot13');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -5,34 +5,29 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Logging\DebugStack;
-use Doctrine\ORM\Annotation as ORM;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Annotation as ORM;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use function count;
 
 /**
  * @group 6443
  */
 class GH6443Test extends OrmFunctionalTestCase
 {
-
-    /**
-     * @var Rot13Type
-     */
+    /** @var Rot13Type */
     private $rot13Type;
 
-    /**
-     * @var DebugStack
-     */
+    /** @var DebugStack */
     private $sqlLogger;
 
     /**
      * when having an entity, that has a non scalar identifier, the type will not be guessed / converted correctly
      */
-    public function testIssue()
+    public function testIssue() : void
     {
-
-        $entity = new GH6443Post();
+        $entity     = new GH6443Post();
         $entity->id = 'Foo';
 
         $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
@@ -59,8 +54,7 @@ class GH6443Test extends OrmFunctionalTestCase
      */
     public function testIssueWithProxyClass()
     {
-
-        $metadata = $this->em->getClassMetadata(GH6443Post::class);
+        $metadata    = $this->em->getClassMetadata(GH6443Post::class);
         $entityProxy = $this->em->getProxyFactory()->getProxy($metadata, ['id' => 'Foo']);
 
         $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
@@ -86,13 +80,12 @@ class GH6443Test extends OrmFunctionalTestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp(): void
+    protected function setUp() : void
     {
         parent::setUp();
 
         $this->sqlLogger = new DebugStack();
         $this->em->getConnection()->getConfiguration()->setSQLLogger($this->sqlLogger);
-
 
         $this->schemaTool->createSchema([
             $this->em->getClassMetadata(GH6443Post::class),
@@ -101,7 +94,7 @@ class GH6443Test extends OrmFunctionalTestCase
         $this->rot13Type = Type::getType('rot13');
     }
 
-    protected function tearDown(): void
+    protected function tearDown() : void
     {
         parent::tearDown();
 
@@ -109,7 +102,6 @@ class GH6443Test extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(GH6443Post::class),
         ]);
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\DbalTypes\Rot13Type;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group 6443
+ */
+class GH6443Test extends OrmFunctionalTestCase
+{
+
+    /**
+     * @var Rot13Type
+     */
+    private $rot13Type;
+
+    /**
+     * @var DebugStack
+     */
+    private $sqlLogger;
+
+    /**
+     * when having an entity, that has a non scalar identifier, the type will not be guessed / converted correctly
+     */
+    public function testIssue()
+    {
+
+        $entity = new GH6443Post();
+        $entity->id = 'Foo';
+
+        $dql = 'SELECT p FROM ' . GH6443Post::class . ' p WHERE p = ?1';
+        $query = $this->_em->createQuery($dql);
+
+        // we do not know that the internal type is a rot13, so we can not add the type parameter here
+        $query->setParameter(1, $entity);
+
+        // we do not need the result, but we need to execute it to log the SQL-Statement
+        $query->getResult();
+
+        $lastSql = $this->sqlLogger->queries[count($this->sqlLogger->queries)];
+
+        // the entity's identifier is of type "rot13" so the query parameter needs to be this type too
+        $this->assertSame(
+            $this->rot13Type->getName(),
+            $lastSql['types'][0],
+            "asserting that the entity's identifier type is correctly inferred"
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sqlLogger = new DebugStack();
+        $this->_em->getConnection()->getConfiguration()->setSQLLogger($this->sqlLogger);
+
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH6443Post::class),
+        ]);
+
+        $this->rot13Type = Type::getType('rot13');
+    }
+
+}
+
+/** @Entity */
+class GH6443Post
+{
+    /** @Id @Column(type="rot13") */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6443Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\ORM\Annotation as ORM;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -73,9 +74,14 @@ class GH6443Test extends OrmFunctionalTestCase
 
 }
 
-/** @Entity */
+/**
+ * @ORM\Entity
+ */
 class GH6443Post
 {
-    /** @Id @Column(type="rot13") */
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="rot13")
+     */
     public $id;
 }


### PR DESCRIPTION
Hi,

regarding #6443 this PR currenlty only adds a failing test case to discuss how one could improve type inferring.

The main part where things go wrong is here:
https://github.com/doctrine/doctrine2/blob/53245e8a73cb16d5e9ba35ffa5bbb15cc417bb9f/lib/Doctrine/ORM/Query.php#L406-L409

The reason is that `ParameterTypeInferer::inferType($value)` does not handle metadata and other information to detect the type.

I suggest to extend `ParameterTypeInferer` to take the class metadata into account, if it is available for the given parameter.

Are there any hints on this?
I'd try to create a first draft within the next days.