### PR TITLE
EntityManager::getReference() can return null

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -150,7 +150,7 @@ interface EntityManagerInterface extends ObjectManager
      * @param string $entityName The name of the entity type.
      * @param mixed  $id         The entity identifier.
      *
-     * @return object The entity reference.
+     * @return object|null The entity reference.
      *
      * @throws ORMException
      */


### PR DESCRIPTION
When the requested class has subclasses, a proxy cannot be returned, and the entity has to be loaded from the DB to figure out its actual class:

https://github.com/doctrine/doctrine2/blob/13f838f8bed021cc67e564ec1ff6e994a1a499a8/lib/Doctrine/ORM/EntityManager.php#L498-L500

Because `find()` is used, if the entity doesn't exist, `EntityManager::getReference()` therefore returns `null`.

I think that either:

- the return type of `EntityManagerInterface::getReference()` should be `object|null`
- or `EntityManager::getReference()` should throw an `ORMException` when the id doesn't exist

This is a PR for the first proposal, but if you prefer the second approach (BC break?) I can change the PR.