### PR TITLE
#6759 showstopper one-to-one inverse not being loaded with correct identifier restrictions when defining `joinColumn`

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -802,8 +802,6 @@ class BasicEntityPersister implements EntityPersister
                 );
             }
 
-            // unset the old value and set the new sql aliased value here. By definition
-            // unset($identifier[$targetKeyColumn] works here with how UnitOfWork::createEntity() calls this method.
             $computedIdentifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
                 $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -792,6 +792,8 @@ class BasicEntityPersister implements EntityPersister
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
         $owningAssoc = $targetClass->getAssociationMapping($assoc['mappedBy']);
 
+        $computedIdentifier = [];
+
         // TRICKY: since the association is specular source and target are flipped
         foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
             if ( ! isset($sourceClass->fieldNames[$sourceKeyColumn])) {
@@ -802,13 +804,11 @@ class BasicEntityPersister implements EntityPersister
 
             // unset the old value and set the new sql aliased value here. By definition
             // unset($identifier[$targetKeyColumn] works here with how UnitOfWork::createEntity() calls this method.
-            $identifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
+            $computedIdentifier[$targetClass->getFieldForColumn($targetKeyColumn)] =
                 $sourceClass->reflFields[$sourceClass->fieldNames[$sourceKeyColumn]]->getValue($sourceEntity);
-
-            unset($identifier[$targetKeyColumn]);
         }
 
-        $targetEntity = $this->load($identifier, null, $assoc);
+        $targetEntity = $this->load($computedIdentifier, null, $assoc);
 
         if ($targetEntity !== null) {
             $targetClass->setFieldValue($targetEntity, $assoc['mappedBy'], $sourceEntity);

--- a/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/InverseSide.php
+++ b/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/InverseSide.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToOneInverseSideLoad;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @Entity()
+ * @Table(name="one_to_one_inverse_side_load_inverse")
+ */
+class InverseSide
+{
+    /**
+     * @Id()
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity=OwningSide::class, mappedBy="inverse")
+     */
+    public $owning;
+}

--- a/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/OwningSide.php
+++ b/tests/Doctrine/Tests/Models/OneToOneInverseSideLoad/OwningSide.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\OneToOneInverseSideLoad;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @Entity()
+ * @Table(name="one_to_one_inverse_side_load_owning")
+ */
+class OwningSide
+{
+    /**
+     * @Id()
+     * @Column(type="string")
+     * @GeneratedValue(strategy="NONE")
+     */
+    public $id;
+
+    /**
+     * Owning side
+     *
+     * @OneToOne(targetEntity=InverseSide::class, inversedBy="owning")
+     * @JoinColumn(nullable=false, name="inverse")
+     */
+    public $inverse;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
@@ -26,7 +26,7 @@ class OneToOneInverseSideLoadAfterDqlQueryTest extends OrmFunctionalTestCase
     }
 
     /**
-     * @group #6759
+     * @group 6759
      */
     public function testInverseSideOneToOneLoadedAfterDqlQuery(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class OneToOneInverseSideLoadAfterDqlQueryTest extends OrmFunctionalTestCase
+{
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $schemaTool = new SchemaTool($this->_em);
+        try {
+            $schemaTool->createSchema(
+                [
+                    $this->_em->getClassMetadata(Bus::class),
+                    $this->_em->getClassMetadata(BusOwner::class),
+                ]
+            );
+        } catch(\Exception $e) {}
+    }
+
+    public function testInverseSideOneToOneLoadedAfterDqlQuery(): void
+    {
+        $owner = new BusOwner('Alexander');
+        $bus = new Bus($owner);
+
+        $this->_em->persist($bus);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $bus = $this->_em->createQueryBuilder()
+            ->select('to')
+            ->from(BusOwner::class, 'to')
+            ->andWhere('to.id = :id')
+            ->setParameter('id', $owner->id)
+            ->getQuery()
+            ->getResult();
+
+        $this->assertSQLEquals(
+            "SELECT b0_.id AS id_0, b0_.name AS name_1 FROM BusOwner b0_ WHERE b0_.id = ?",
+            $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery - 1]['sql']
+        );
+
+        $this->assertSQLEquals(
+            "SELECT t0.id AS id_1, t0.owner AS owner_2 FROM Bus t0 WHERE t0.owner = ?",
+            $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['sql']
+        );
+    }
+
+}
+
+
+/**
+ * @Entity
+ */
+class Bus
+{
+    /**
+     * @id @column(type="integer") @generatedValue
+     * @var int
+     */
+    public $id;
+    /**
+     * Owning side
+     * @OneToOne(targetEntity="BusOwner", inversedBy="bus", cascade={"persist"})
+     * @JoinColumn(nullable=false, name="owner")
+     */
+    public $owner;
+
+    public function __construct(BusOwner $owner)
+    {
+        $this->owner = $owner;
+    }
+
+}
+
+/**
+ * @Entity
+ */
+class BusOwner
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /** @column(type="string") */
+    public $name;
+    /**
+     * Inverse side
+     * @OneToOne(targetEntity="Bus", mappedBy="owner")
+     */
+    public $bus;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function setBus(Bus $t)
+    {
+        $this->bus = $t;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
@@ -1,112 +1,70 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\ToolsException;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\InverseSide;
+use Doctrine\Tests\Models\OneToOneInverseSideLoad\OwningSide;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class OneToOneInverseSideLoadAfterDqlQueryTest extends OrmFunctionalTestCase
 {
-
     protected function setUp()
     {
         parent::setUp();
 
         try {
             $this->_schemaTool->createSchema([
-                $this->_em->getClassMetadata(Bus::class),
-                $this->_em->getClassMetadata(BusOwner::class),
+                $this->_em->getClassMetadata(OwningSide::class),
+                $this->_em->getClassMetadata(InverseSide::class),
             ]);
         } catch(ToolsException $e) {
             // ignored
         }
     }
 
+    /**
+     * @group #6759
+     */
     public function testInverseSideOneToOneLoadedAfterDqlQuery(): void
     {
-        $owner = new BusOwner('Alexander');
-        $bus = new Bus($owner);
+        $owner   = new OwningSide();
+        $inverse = new InverseSide();
 
-        $this->_em->persist($bus);
+        $owner->id       = 'owner';
+        $inverse->id     = 'inverse';
+        $owner->inverse  = $inverse;
+        $inverse->owning = $owner;
+
+        $this->_em->persist($owner);
+        $this->_em->persist($inverse);
         $this->_em->flush();
         $this->_em->clear();
 
-        $bus = $this
+        /* @var $fetchedInverse InverseSide */
+        $fetchedInverse = $this
             ->_em
             ->createQueryBuilder()
-            ->select('to')
-            ->from(BusOwner::class, 'to')
-            ->andWhere('to.id = :id')
-            ->setParameter('id', $owner->id)
+            ->select('inverse')
+            ->from(InverseSide::class, 'inverse')
+            ->andWhere('inverse.id = :id')
+            ->setParameter('id', 'inverse')
             ->getQuery()
-            ->getResult();
+            ->getSingleResult();
+
+        self::assertInstanceOf(InverseSide::class, $fetchedInverse);
+        self::assertInstanceOf(OwningSide::class, $fetchedInverse->owning);
 
         $this->assertSQLEquals(
-            'SELECT b0_.id AS id_0, b0_.name AS name_1 FROM BusOwner b0_ WHERE b0_.id = ?',
+            'select o0_.id as id_0 from one_to_one_inverse_side_load_inverse o0_ where o0_.id = ?',
             $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery - 1]['sql']
         );
 
         $this->assertSQLEquals(
-            'SELECT t0.id AS id_1, t0.owner AS owner_2 FROM Bus t0 WHERE t0.owner = ?',
+            'select t0.id as id_1, t0.inverse as inverse_2 from one_to_one_inverse_side_load_owning t0 WHERE t0.inverse = ?',
             $this->_sqlLoggerStack->queries[$this->_sqlLoggerStack->currentQuery]['sql']
         );
-    }
-
-}
-
-
-/**
- * @Entity
- */
-class Bus
-{
-    /**
-     * @id @column(type="integer") @generatedValue
-     * @var int
-     */
-    public $id;
-    /**
-     * Owning side
-     * @OneToOne(targetEntity="BusOwner", inversedBy="bus", cascade={"persist"})
-     * @JoinColumn(nullable=false, name="owner")
-     */
-    public $owner;
-
-    public function __construct(BusOwner $owner)
-    {
-        $this->owner = $owner;
-    }
-
-}
-
-/**
- * @Entity
- */
-class BusOwner
-{
-    /**
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue
-     */
-    public $id;
-
-    /** @column(type="string") */
-    public $name;
-    /**
-     * Inverse side
-     * @OneToOne(targetEntity="Bus", mappedBy="owner")
-     */
-    public $bus;
-
-    public function __construct($name)
-    {
-        $this->name = $name;
-    }
-
-    public function setBus(Bus $t)
-    {
-        $this->bus = $t;
     }
 }


### PR DESCRIPTION
Fixes #6759