### PR TITLE
Not all fields are present when getting the original data for an entity.

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/UnknownTicketTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/UnknownTicketTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Tweet\Tweet;
+use Doctrine\Tests\Models\Tweet\User;
+
+class UnknownTicketTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function testCompleteOriginalData()
+    {
+        $this->useModelSet('tweet');
+        parent::setUp();
+
+        $tweet1 = new Tweet();
+        $tweet1->content = 'foobar';
+
+        $user = new User();
+        $user->name = 'Marco';
+        $user->addTweet($tweet1);
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        // This should contain all fields now
+        $originalData1 = $this->_em->getUnitOfWork()->getOriginalEntityData($user);
+
+        // Change only one of the non-associating fields
+        $user->name = 'Polo';
+
+        $this->_em->flush();
+
+        // This should still contain all fields
+        $originalData2 = $this->_em->getUnitOfWork()->getOriginalEntityData($user);
+
+        $this->assertSame(array_keys($originalData1), array_keys($originalData2));
+    }
+}


### PR DESCRIPTION
In some cases not all fields are present in the array returned by `UnitOfWork::getOriginalEntityData()`. It will filter out non-owning association when updating a scalar field.

Is this intended behavior?

See the PR unit test for a test case. I would expect the keys to be the same in both cases but this is not true. My guess it because of [this `continue` in the UoW](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/UnitOfWork.php#L625).

Result of the added test case:
```
1) Doctrine\Tests\ORM\Functional\Ticket\UnknownTicketTest::testCompleteOriginalData
Failed asserting that Array &0 (
    0 => 'name'
) is identical to Array &0 (
    0 => 'name'
    1 => 'tweets'
    2 => 'userLists'
    3 => 'id'
).
```