### PR TITLE
Disallow orphan removal attribute on many-to-one

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -540,7 +540,6 @@
     </xs:sequence>
     <xs:attribute name="target-entity" type="xs:string" use="required" />
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:anyAttribute namespace="##other"/>


### PR DESCRIPTION
It only makes sense for collections, and there is no collection here.
Plus the docs do not say it is supported.
See
http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/working-with-associations.html#orphan-removal