### PR TITLE
getRepository actually returns ObjectRepository

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -709,7 +709,7 @@ use Throwable;
      *
      * @param string $entityName The name of the entity.
      *
-     * @return \Doctrine\ORM\EntityRepository The repository class.
+     * @return \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository The repository class.
      */
     public function getRepository($entityName)
     {


### PR DESCRIPTION
Because the `repositoryFactory` in `EntityManager` must implement the `RepositoryFactory` interface. `RepositoryFactory`'s `getRepository` method advertises that it returns an instance of `\Doctrine\Common\Persistence\ObjectRepository`.

I've kept the `EntityRepository` return as an or, because in practice, people still expect the remaining functions from `EntityManager` (like `createQueryBuilder`) on the response.

cc/ @weaverryan