### PR TITLE
Allow Symfony 4.x console component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/console": "~2.5|~3.0"
     },
     "require-dev": {
-        "symfony/yaml": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0|~4.0",
         "phpunit/phpunit": "~4.0"
     },
     "suggest": {


### PR DESCRIPTION
Symfony Flex ORM-pack does not work as Doctrine ORM 2.5.11 requires Console 3.x component.

This is an issue at least when using the Symfony Flex ORM pack, issue here: https://github.com/symfony/orm-pack/issues/6