### PR TITLE
[Docs] Type::convertToDatabaseValue is always called

### DIFF
--- a/docs/en/cookbook/custom-mapping-types.rst
+++ b/docs/en/cookbook/custom-mapping-types.rst
@@ -49,8 +49,6 @@ you wish. Here is an example skeleton of such a custom type class:
 
     The following assumptions are applied to mapping types by the ORM:
 
-    -  If the value of the field is *NULL* the method
-       ``convertToDatabaseValue()`` is not called.
     -  The ``UnitOfWork`` never passes values to the database convert
        method that did not change in the request.
     -  The ``UnitOfWork`` internally assumes that entity identifiers are


### PR DESCRIPTION
Custom types documentation includes a false statement that `Type::convertToDatabaseValue` is not called for NULL values.

According to [DBAL issue](https://github.com/doctrine/dbal/issues/2896) this looks like expected behavior so it would be great to remove misleading line from ORM docs.