### PR TITLE
Remove copy() method from EntityManager

### DIFF
--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -152,14 +152,6 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritdoc}
      */
-    public function copy($entity, $deep = false)
-    {
-        return $this->wrapped->copy($entity, $deep);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function lock($entity, $lockMode, $lockVersion = null)
     {
         return $this->wrapped->lock($entity, $lockMode, $lockVersion);

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -696,17 +696,6 @@ final class EntityManager implements EntityManagerInterface
 
     /**
      * {@inheritDoc}
-     *
-     * @todo Implementation need. This is necessary since $e2 = clone $e1; throws an E_FATAL when access anything on $e:
-     * Fatal error: Maximum function nesting level of '100' reached, aborting!
-     */
-    public function copy($entity, $deep = false)
-    {
-        throw new \BadMethodCallException("Not implemented.");
-    }
-
-    /**
-     * {@inheritDoc}
      */
     public function lock($entity, $lockMode, $lockVersion = null)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -184,18 +184,6 @@ interface EntityManagerInterface extends ObjectManager
     public function close();
 
     /**
-     * Creates a copy of the given entity. Can create a shallow or a deep copy.
-     *
-     * @param object  $entity The entity to copy.
-     * @param boolean $deep   FALSE for a shallow copy, TRUE for a deep copy.
-     *
-     * @return object The new entity.
-     *
-     * @throws \BadMethodCallException
-     */
-    public function copy($entity, $deep = false);
-
-    /**
      * Acquire a lock on the given entity.
      *
      * @param object   $entity

--- a/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
+++ b/tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php
@@ -179,14 +179,6 @@ class NonProxyLoadingEntityManager implements EntityManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function copy($entity, $deep = false)
-    {
-        return $this->realEntityManager->copy($entity, $deep);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function lock($entity, $lockMode, $lockVersion = null) : void
     {
         $this->realEntityManager->lock($entity, $lockMode, $lockVersion);


### PR DESCRIPTION
The method `EntityManager::copy()` is a pretty old addition to Doctrine and never got any functionality, which is why I created this PR to remove this method from the `EntityManager`.

Because I had to remove this method from `EntityManagerInterface` too, I consider this a BC break. Even though the original `EntityManager` never got any functionality for copy, a user may have created a custom entity manager for a project, that uses a custom implementation of copy.

Questions:
* Do we need tests for the removal of a method?
* Do we need a deprecation PR as an in between step?