### PR TITLE
Fixes #4252 Cascading refresh to lazy loaded assocations

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2216,12 +2216,12 @@ class UnitOfWork implements PropertyChangedListener
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 
+        $this->cascadeRefresh($entity, $visited);
+
         $this->getEntityPersister($class->name)->refresh(
             array_combine($class->getIdentifierFieldNames(), $this->entityIdentifiers[$oid]),
             $entity
         );
-
-        $this->cascadeRefresh($entity, $visited);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH4252Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH4252Test.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @group GH-4252
+ */
+class GH4252Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(GH4252City::class),
+            $this->_em->getClassMetadata(GH4252Resident::class),
+            $this->_em->getClassMetadata(GH4252Address::class),
+        ));
+    }
+
+    public function testIssue()
+    {
+        $city = new GH4252City([new GH4252Resident([new GH4252Address()])]);
+
+        $this->_em->persist($city);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var GH4252City $city */
+        $city = $this->_em->find(GH4252City::class, $city->getId());
+        $city->setFlag(false);
+        /** @var GH4252Resident $resident */
+        $resident = $city->getResidents()->first();
+        $resident->setFlag(false);
+        /** @var GH4252Address $address */
+        $address = $resident->getAddresses()->first();
+        $address->setFlag(false);
+
+        $this->_em->refresh($city);
+
+        $resident = $city->getResidents()->first();
+        $address = $resident->getAddresses()->first();
+
+        $this->assertTrue($city->getFlag());
+        $this->assertTrue($resident->getFlag());
+        $this->assertTrue($address->getFlag());
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH4252City
+{
+    /**
+     * @var int
+     * @Id @Column(type="integer") @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var bool
+     * @Column(type="boolean")
+     */
+    private $flag;
+
+    /**
+     * @var GH4252Resident[]|Collection
+     *
+     * @OneToMany(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH4252Resident", mappedBy="city", cascade={"persist","refresh"})
+     */
+    private $residents;
+
+    public function __construct(array $residents)
+    {
+        $this->residents = new ArrayCollection();
+        foreach ($residents as $resident) {
+            $this->residents->add($resident);
+            $resident->setCity($this);
+        }
+        $this->flag = true;
+    }
+
+    public function getId() : int
+    {
+        return $this->id;
+    }
+
+    public function getFlag() : bool
+    {
+        return $this->flag;
+    }
+
+    public function setFlag(bool $flag) : void
+    {
+        $this->flag = $flag;
+    }
+
+    public function getResidents() : Collection
+    {
+        return $this->residents;
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH4252Resident
+{
+    /**
+     * @var int
+     * @Id @Column(type="integer") @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var GH4252City
+     * @ManyToOne(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH4252City", inversedBy="residents")
+     */
+    private $city;
+
+    /**
+     * @var bool
+     * @Column(type="boolean")
+     */
+    private $flag;
+
+    /**
+     * @var GH4252Address[]|Collection
+     *
+     * @ManyToMany(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH4252Address", fetch="EXTRA_LAZY", cascade={"persist","refresh"})
+     */
+    private $addresses;
+
+    public function __construct(array $addresses)
+    {
+        $this->addresses = new ArrayCollection();
+        foreach ($addresses as $address) {
+            $this->addresses->add($address);
+        }
+        $this->flag = true;
+    }
+
+    public function getId() : int
+    {
+        return $this->id;
+    }
+
+    public function getCity() : GH4252City
+    {
+        return $this->city;
+    }
+
+    public function setCity(GH4252City $city) : void
+    {
+        $this->city = $city;
+    }
+
+    public function getFlag() : bool
+    {
+        return $this->flag;
+    }
+
+    public function setFlag(bool $flag) : void
+    {
+        $this->flag = $flag;
+    }
+
+    public function getAddresses() : Collection
+    {
+        return $this->addresses;
+    }
+}
+
+/** @Entity */
+class GH4252Address
+{
+    /**
+     * @var int
+     * @Id @Column(type="integer") @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @var bool
+     * @Column(type="boolean")
+     */
+    private $flag;
+
+    public function __construct()
+    {
+        $this->flag = true;
+    }
+
+    public function getId() : int
+    {
+        return $this->id;
+    }
+
+    public function getFlag() : bool
+    {
+        return $this->flag;
+    }
+
+    public function setFlag(bool $flag) : void
+    {
+        $this->flag = $flag;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH4252Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH4252Test.php
@@ -1,27 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function assert;
 
 /**
  * @group GH-4252
  */
-class GH4252Test extends \Doctrine\Tests\OrmFunctionalTestCase
+class GH4252Test extends OrmFunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(array(
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(GH4252City::class),
             $this->_em->getClassMetadata(GH4252Resident::class),
             $this->_em->getClassMetadata(GH4252Address::class),
-        ));
+        ]);
     }
 
-    public function testIssue()
+    public function testIssue(): void
     {
         $city = new GH4252City([new GH4252Resident([new GH4252Address()])]);
 
@@ -29,20 +41,20 @@ class GH4252Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        /** @var GH4252City $city */
         $city = $this->_em->find(GH4252City::class, $city->getId());
+        assert($city instanceof GH4252City);
         $city->setFlag(false);
-        /** @var GH4252Resident $resident */
         $resident = $city->getResidents()->first();
+        assert($resident instanceof GH4252Resident);
         $resident->setFlag(false);
-        /** @var GH4252Address $address */
         $address = $resident->getAddresses()->first();
+        assert($address instanceof GH4252Address);
         $address->setFlag(false);
 
         $this->_em->refresh($city);
 
         $resident = $city->getResidents()->first();
-        $address = $resident->getAddresses()->first();
+        $address  = $resident->getAddresses()->first();
 
         $this->assertTrue($city->getFlag());
         $this->assertTrue($resident->getFlag());
@@ -57,7 +69,9 @@ class GH4252City
 {
     /**
      * @var int
-     * @Id @Column(type="integer") @GeneratedValue
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
      */
     private $id;
 
@@ -69,7 +83,6 @@ class GH4252City
 
     /**
      * @var GH4252Resident[]|Collection
-     *
      * @OneToMany(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH4252Resident", mappedBy="city", cascade={"persist","refresh"})
      */
     private $residents;
@@ -81,25 +94,26 @@ class GH4252City
             $this->residents->add($resident);
             $resident->setCity($this);
         }
+
         $this->flag = true;
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getFlag() : bool
+    public function getFlag(): bool
     {
         return $this->flag;
     }
 
-    public function setFlag(bool $flag) : void
+    public function setFlag(bool $flag): void
     {
         $this->flag = $flag;
     }
 
-    public function getResidents() : Collection
+    public function getResidents(): Collection
     {
         return $this->residents;
     }
@@ -130,7 +144,6 @@ class GH4252Resident
 
     /**
      * @var GH4252Address[]|Collection
-     *
      * @ManyToMany(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH4252Address", fetch="EXTRA_LAZY", cascade={"persist","refresh"})
      */
     private $addresses;
@@ -141,35 +154,36 @@ class GH4252Resident
         foreach ($addresses as $address) {
             $this->addresses->add($address);
         }
+
         $this->flag = true;
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getCity() : GH4252City
+    public function getCity(): GH4252City
     {
         return $this->city;
     }
 
-    public function setCity(GH4252City $city) : void
+    public function setCity(GH4252City $city): void
     {
         $this->city = $city;
     }
 
-    public function getFlag() : bool
+    public function getFlag(): bool
     {
         return $this->flag;
     }
 
-    public function setFlag(bool $flag) : void
+    public function setFlag(bool $flag): void
     {
         $this->flag = $flag;
     }
 
-    public function getAddresses() : Collection
+    public function getAddresses(): Collection
     {
         return $this->addresses;
     }
@@ -180,7 +194,9 @@ class GH4252Address
 {
     /**
      * @var int
-     * @Id @Column(type="integer") @GeneratedValue
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
      */
     private $id;
 
@@ -195,17 +211,17 @@ class GH4252Address
         $this->flag = true;
     }
 
-    public function getId() : int
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getFlag() : bool
+    public function getFlag(): bool
     {
         return $this->flag;
     }
 
-    public function setFlag(bool $flag) : void
+    public function setFlag(bool $flag): void
     {
         $this->flag = $flag;
     }


### PR DESCRIPTION
Fixes #4252
Closes #1218

### Bug description

Refreshing an entity resets toMany (extra) lazy loaded associations to an empty collection before the refresh operation is cascaded to its underlying associations. Meaning objects that should be refreshed stay unrefreshed in the UoW.

### Fix

The fix simply cascades the operation to its associations before refreshing the current entity.
