### PR TITLE
Deprecation of EntityManager copy method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade to 2.7
+
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.6
 
 ## Minor BC BREAK: `Doctrine\ORM\Tools\Console\ConsoleRunner` is now final
@@ -29,11 +36,6 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - APCu extension (ext-apcu) will now be used instead of abandoned APC (ext-apc).
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
-
-## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
-
-Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
-It will be removed in 3.0.
 
 # Upgrade to 2.5
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,11 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
 
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -687,9 +687,6 @@ use Throwable;
 
     /**
      * {@inheritDoc}
-     *
-     * @todo Implementation need. This is necessary since $e2 = clone $e1; throws an E_FATAL when access anything on $e:
-     * Fatal error: Maximum function nesting level of '100' reached, aborting!
      */
     public function copy($entity, $deep = false)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -190,6 +190,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Creates a copy of the given entity. Can create a shallow or a deep copy.
      *
+     * @deprecated method will be removed in 3.0
+     *
      * @param object  $entity The entity to copy.
      * @param boolean $deep   FALSE for a shallow copy, TRUE for a deep copy.
      *


### PR DESCRIPTION
To follow @alcaeus' procedure mentioned in #6794, I create this PR to deprecate the method `EntityManagerInterface::copy()` on the master branch.