### PR TITLE
Fix syntax error when join unrelated entity with discriminator entity

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -902,15 +902,17 @@ class SqlWalker implements TreeWalker
             $this->query->getHint(Query::HINT_LOCK_MODE)
         );
 
-        if ($class->isInheritanceTypeJoined()) {
-            if ($buildNestedJoins) {
-                $sql = '(' . $sql . $this->_generateClassTableInheritanceJoins($class, $dqlAlias) . ')';
-            } else {
-                $sql .= $this->_generateClassTableInheritanceJoins($class, $dqlAlias);
-            }
+        if ( ! $class->isInheritanceTypeJoined()) {
+            return $sql;
         }
 
-        return $sql;
+        $classTableInheritanceJoins = $this->_generateClassTableInheritanceJoins($class, $dqlAlias);
+
+        if ( ! $buildNestedJoins) {
+            return $sql . $classTableInheritanceJoins;
+        }
+
+        return $classTableInheritanceJoins === '' ? $sql : '(' . $sql . $classTableInheritanceJoins . ')';
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -205,6 +205,11 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT e FROM Doctrine\Tests\Models\Company\CompanyEmployee e LEFT JOIN Doctrine\Tests\Models\Company\CompanyManager m WITH e.id = m.id',
             'SELECT c0_.id AS id_0, c0_.name AS name_1, c1_.salary AS salary_2, c1_.department AS department_3, c1_.startDate AS startDate_4, c0_.discr AS discr_5 FROM company_employees c1_ INNER JOIN company_persons c0_ ON c1_.id = c0_.id LEFT JOIN (company_managers c2_ INNER JOIN company_employees c4_ ON c2_.id = c4_.id INNER JOIN company_persons c3_ ON c2_.id = c3_.id) ON (c0_.id = c3_.id)'
         );
+
+        $this->assertSqlGeneration(
+            'SELECT c FROM Doctrine\Tests\Models\Company\CompanyContract c JOIN c.salesPerson s LEFT JOIN Doctrine\Tests\Models\Company\CompanyEvent e WITH s.id = e.id',
+            'SELECT c0_.id AS id_0, c0_.completed AS completed_1, c0_.fixPrice AS fixPrice_2, c0_.hoursWorked AS hoursWorked_3, c0_.pricePerHour AS pricePerHour_4, c0_.maxPrice AS maxPrice_5, c0_.discr AS discr_6 FROM company_contracts c0_ INNER JOIN company_employees c1_ ON c0_.salesPerson_id = c1_.id LEFT JOIN company_persons c2_ ON c1_.id = c2_.id LEFT JOIN company_events c3_ ON (c2_.id = c3_.id) WHERE c0_.discr IN (\'fix\', \'flexible\', \'flexultra\')'
+        );
     }
 
     public function testSupportsSelectWithCollectionAssociationJoin()


### PR DESCRIPTION
When joining a unrelated entity with a discriminator the join contains the table name and alias in brackets which is a syntax error (at least in SQL Server).

Exmaple:

```sql
SELECT
  c
FROM
  Doctrine\Tests\Models\Company\CompanyContract c
JOIN
  c.salesPerson s
LEFT JOIN
  Doctrine\Tests\Models\Company\CompanyEvent e WITH s.id = e.id
```
Results in:
```sql
SELECT
  c0_.id AS id_0,
  c0_.completed AS completed_1,
  c0_.fixPrice AS fixPrice_2,
  c0_.hoursWorked AS hoursWorked_3,
  c0_.pricePerHour AS pricePerHour_4,
  c0_.maxPrice AS maxPrice_5,
  c0_.discr AS discr_6
FROM
  company_contracts c0_
INNER JOIN
  company_employees c1_ ON c0_.salesPerson_id = c1_.id
LEFT JOIN
  company_persons c2_ ON c1_.id = c2_.id
LEFT JOIN
  (company_events c3_) ON (c2_.id = c3_.id)
WHERE
  c0_.discr IN ('fix', 'flexible', 'flexultra')
```

After the fix it results in:
```sql
SELECT
  c0_.id AS id_0,
  c0_.completed AS completed_1,
  c0_.fixPrice AS fixPrice_2,
  c0_.hoursWorked AS hoursWorked_3,
  c0_.pricePerHour AS pricePerHour_4,
  c0_.maxPrice AS maxPrice_5,
  c0_.discr AS discr_6
FROM
  company_contracts c0_
INNER JOIN
  company_employees c1_ ON c0_.salesPerson_id = c1_.id
LEFT JOIN
  company_persons c2_ ON c1_.id = c2_.id
LEFT JOIN
  company_events c3_ ON (c2_.id = c3_.id)
WHERE
  c0_.discr IN ('fix', 'flexible', 'flexultra')
```

I have created #6811 PR for backporting this to the 2.5 branch as well.
