### PR TITLE
#6815 Pass the dicriminator column's "fieldName" config to ClassMetadata

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -250,6 +250,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                             'name'             => $discrColumnAnnot->name,
                             'type'             => $discrColumnAnnot->type ?: 'string',
                             'length'           => $discrColumnAnnot->length ?: 255,
+                            'fieldName'        => $discrColumnAnnot->fieldName,
                             'columnDefinition' => $discrColumnAnnot->columnDefinition,
                         ]
                     );

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -175,6 +175,7 @@ class XmlDriver extends FileDriver
                             'name' => isset($discrColumn['name']) ? (string) $discrColumn['name'] : null,
                             'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
                             'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : 255,
+                            'fieldName' => isset($discrColumnAnnot['field-name']) ? (string) $discrColumn['field-name'] : null,
                             'columnDefinition' => isset($discrColumn['column-definition']) ? (string) $discrColumn['column-definition'] : null
                         ]
                     );

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -184,6 +184,7 @@ class YamlDriver extends FileDriver
                             'name' => isset($discrColumn['name']) ? (string) $discrColumn['name'] : null,
                             'type' => isset($discrColumn['type']) ? (string) $discrColumn['type'] : 'string',
                             'length' => isset($discrColumn['length']) ? (string) $discrColumn['length'] : 255,
+                            'fieldName' => isset($discrColumnAnnot['fieldName']) ? (string) $discrColumn['fieldName'] : null,
                             'columnDefinition' => isset($discrColumn['columnDefinition']) ? (string) $discrColumn['columnDefinition'] : null
                         ]
                     );

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6815Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6815Test.php
@@ -1,0 +1,58 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-6815
+ */
+class GH6815Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH6815Entity::class),
+            $this->_em->getClassMetadata(GH6815SubClass1::class),
+            $this->_em->getClassMetadata(GH6815SubClass2::class),
+        ]);
+    }
+
+    /**
+     * Verifies that the configured field name of the discriminator column
+     * has been mapped to the class metadata object
+     */
+    public function testIssue() : void
+    {
+        $classMetadata = $this->_em->getClassMetadata(GH6815Entity::class);
+
+        $this->assertArrayHasKey('fieldName', $classMetadata->discriminatorColumn);
+        $this->assertEquals("discriminatorField", $classMetadata->discriminatorColumn['fieldName']);
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({"ONE" = "GH6815SubClass1", "TWO" = "GH6815SubClass2"})
+ * @DiscriminatorColumn(name = "dtype", fieldName = "discriminatorField")
+ */
+abstract class GH6815Entity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue(strategy="NONE")
+     **/
+    public $id;
+}
+
+/** @Entity */
+class GH6815SubClass1 extends GH6815Entity {}
+
+/** @Entity */
+class GH6815SubClass2 extends GH6815Entity {}


### PR DESCRIPTION
Fix for #6815 

I fixed this for Annotation, Xml and Yaml drivers, however the test works for the Annotation driver only, as I failed to get the `OrmFunctionalTestCase` working with the other drivers.