### PR TITLE
Make test suite compatible with PHP 7.2

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -27,7 +27,7 @@ class DefaultRegionTest extends AbstractRegionTest
 
     public function testSharedRegion()
     {
-        if ( ! extension_loaded('apc') || false === @apc_cache_info()) {
+        if ( ! extension_loaded('apc') || ! is_array(@apc_cache_info("user"))) {
             $this->markTestSkipped('The ' . __CLASS__ .' requires the use of APC');
         }
 

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php
@@ -28,7 +28,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
     {
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty($persister, 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -50,7 +50,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
         $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty($persister, 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -87,7 +87,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
         $entry     = new EntityCacheEntry(Country::CLASSNAME, array('id'=>1, 'name'=>'Foo'));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty($persister, 'queuedCache');
 
         $property->setAccessible(true);
 
@@ -115,7 +115,7 @@ class NonStrictReadWriteCachedEntityPersisterTest extends AbstractEntityPersiste
         $entity    = new Country("Foo");
         $persister = $this->createPersisterDefault();
         $key       = new EntityCacheKey(Country::CLASSNAME, array('id'=>1));
-        $property  = new \ReflectionProperty('Doctrine\ORM\Cache\Persister\Entity\ReadWriteCachedEntityPersister', 'queuedCache');
+        $property  = new \ReflectionProperty($persister, 'queuedCache');
 
         $property->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -129,6 +129,7 @@ class QueryCacheTest extends \Doctrine\Tests\OrmFunctionalTestCase
                     ->will($this->returnValue( 10 ));
 
         $parserResultMock = $this->getMock('Doctrine\ORM\Query\ParserResult');
+        $parserResultMock->method('getParameterMappings')->willReturn(array());
         $parserResultMock->expects($this->once())
                          ->method('getSqlExecutor')
                          ->will($this->returnValue($sqlExecMock));


### PR DESCRIPTION
With PHP 7.2:

```
There was 1 error:
1) Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCache_HitDoesNotSaveParserResult
count(): Parameter must be an array or an object that implements Countable
/builddir/build/BUILDROOT/php-doctrine-orm-2.5.11-1.fc28.noarch/usr/share/php/Doctrine/ORM/Query.php:306
/builddir/build/BUILDROOT/php-doctrine-orm-2.5.11-1.fc28.noarch/usr/share/php/Doctrine/ORM/AbstractQuery.php:969
/builddir/build/BUILDROOT/php-doctrine-orm-2.5.11-1.fc28.noarch/usr/share/php/Doctrine/ORM/AbstractQuery.php:924
/builddir/build/BUILDROOT/php-doctrine-orm-2.5.11-1.fc28.noarch/usr/share/php/Doctrine/ORM/AbstractQuery.php:727
/builddir/build/BUILD/doctrine2-249b737094f1e7cba4f0a8d19acf5be6cf3ed504/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php:148

```

And, since 7.1

```
There were 4 errors:

1) Doctrine\Tests\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersisterTest::testTransactionRollBackShouldClearQueue
ReflectionException: Given object is not an instance of the class this property was declared in

/work/GIT/doctrine2/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php:40

2) Doctrine\Tests\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersisterTest::testInsertTransactionCommitShouldPutCache
ReflectionException: Given object is not an instance of the class this property was declared in

/work/GIT/doctrine2/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php:77

3) Doctrine\Tests\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersisterTest::testUpdateTransactionCommitShouldPutCache
ReflectionException: Given object is not an instance of the class this property was declared in

/work/GIT/doctrine2/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php:106

4) Doctrine\Tests\ORM\Cache\Persister\Entity\NonStrictReadWriteCachedEntityPersisterTest::testDeleteTransactionCommitShouldEvictCache
ReflectionException: Given object is not an instance of the class this property was declared in

/work/GIT/doctrine2/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php:134

```