### PR TITLE
Add Type::GUID to $typeAlias list in EntityGenerator

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -164,6 +164,7 @@ class EntityGenerator
         Type::TEXT          => 'string',
         Type::BLOB          => 'string',
         Type::DECIMAL       => 'string',
+        Type::GUID          => 'string',
         Type::JSON_ARRAY    => 'array',
         Type::SIMPLE_ARRAY  => 'array',
         Type::BOOLEAN       => 'bool',

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1086,6 +1086,14 @@ class EntityGeneratorTest extends OrmTestCase
             ],
             [
                 [
+                    'fieldName' => 'guid',
+                    'phpType' => 'string',
+                    'dbType' => 'guid',
+                    'value' => '00000000-0000-0000-0000-000000000001'
+                ]
+            ],
+            [
+                [
                 'fieldName' => 'decimal',
                 'phpType' => 'string',
                 'dbType' => 'decimal',


### PR DESCRIPTION
Right now, when generating entities, a column of type 'guid' will generate the following PHPDoc:

```
/**
 * Get id
 *
 * @return guid
 */
public function getId() {...}
```

Since guid is not a valid PHP type, this throws a warning in PHPStorm, and I assume most IDEs.

Adding the type to the type alias list fixes the problem.