### PR TITLE
Allow EntityGenerator to create PHP7 compliant methods

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -193,8 +193,6 @@ class EntityGenerator
         Type::SIMPLE_ARRAY  => 'array',
         Type::JSON_ARRAY    => 'array',
         Type::STRING        => 'string',
-        Type::BINARY        => 'resource',
-        Type::BLOB          => 'resource',
         Type::FLOAT         => 'float',
         Type::GUID          => 'string',
     );
@@ -661,6 +659,8 @@ public function __construct(<params>)
         if ($this->strictTypes) {
             return "\n".'declare(strict_types=1);'."\n";
         }
+
+        return '';
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1460,7 +1460,7 @@ public function __construct(<params>)
 
         $methodReturnType = null;
         if ($this->generateMethodsTypeHinting) {
-            $methodReturnType = $this->getMethodReturnType($metadata, $type, $variableType);
+            $methodReturnType = $this->getMethodReturnType($metadata, $type, $fieldName, $variableType);
 
             if (null === $methodTypeHint) {
                 $type = isset($this->typeHintingAlias[$variableType]) ? $this->typeHintingAlias[$variableType] : $variableType;
@@ -1964,16 +1964,24 @@ public function __construct(<params>)
     /**
      * @param ClassMetadataInfo $metadata
      * @param string            $type
+     * @param string            $fieldName
      * @param string            $variableType
      * @return string
      */
-    private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $variableType)
+    private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $fieldName, $variableType)
     {
         if (in_array($type, array('set', 'add'))) {
             return sprintf(': %s', $this->getClassName($metadata));
         }
 
         if ('get' === $type) {
+            if (
+                $metadata->isSingleValuedAssociation($fieldName) ||
+                (!$metadata->hasAssociation($fieldName) && $metadata->isNullable($fieldName))
+            ) {
+                return null;
+            }
+
             $type = isset($this->typeHintingAlias[$variableType]) ? $this->typeHintingAlias[$variableType] : $variableType;
             return sprintf(': %s', $type);
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1963,7 +1963,7 @@ public function __construct(<params>)
     private function getMethodReturnType(ClassMetadataInfo $metadata, $type, $fieldName, $variableType)
     {
         if (in_array($type, array('set', 'add'))) {
-            return sprintf(': %s', $this->getClassName($metadata));
+            return ': self';
         }
 
         if ('get' === $type) {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -624,10 +624,6 @@ public function __construct(<params>)
      */
     public function setStrictTypes($bool)
     {
-        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
-            throw new \InvalidArgumentException('Strict types mode is only available for PHP >= 7.0.0');
-        }
-
         $this->strictTypes = $bool;
     }
 
@@ -640,10 +636,6 @@ public function __construct(<params>)
      */
     public function setGenerateMethodsTypeHinting($bool)
     {
-        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
-            throw new \InvalidArgumentException('Scalar type hinting and method return types are only available for PHP >= 7.0.0');
-        }
-
         $this->generateMethodsTypeHinting = $bool;
     }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -148,6 +148,13 @@ class EntityGenerator
     protected $embeddablesImmutable = false;
 
     /**
+     * Whether or not to add PHP strict types.
+     *
+     * @var boolean
+     */
+    protected $strictTypes = false;
+
+    /**
      * Hash-map for handle types.
      *
      * @var array
@@ -212,7 +219,7 @@ class EntityGenerator
      */
     protected static $classTemplate =
 '<?php
-
+<strictTypes>
 <namespace>
 <useStatement>
 <entityAnnotation>
@@ -407,6 +414,7 @@ public function __construct(<params>)
     public function generateEntityClass(ClassMetadataInfo $metadata)
     {
         $placeHolders = [
+            '<strictTypes>',
             '<namespace>',
             '<useStatement>',
             '<entityAnnotation>',
@@ -415,6 +423,7 @@ public function __construct(<params>)
         ];
 
         $replacements = [
+            $this->generateEntityStrictTypes(),
             $this->generateEntityNamespace($metadata),
             $this->generateEntityUse(),
             $this->generateEntityDocBlock($metadata),
@@ -584,6 +593,22 @@ public function __construct(<params>)
     }
 
     /**
+     * Set whether or not to add PHP strict types.
+     *
+     * @param bool $bool
+     *
+     * @return void
+     */
+    public function setStrictTypes($bool)
+    {
+        if ($bool && version_compare(PHP_VERSION, '7.0.0', '<')) {
+            throw new \InvalidArgumentException('Strict types mode is only available for PHP >= 7.0.0');
+        }
+
+        $this->strictTypes = $bool;
+    }
+
+    /**
      * @param string $type
      *
      * @return string
@@ -595,6 +620,16 @@ public function __construct(<params>)
         }
 
         return $type;
+    }
+
+    /**
+     * @return string
+     */
+    protected function generateEntityStrictTypes()
+    {
+        if ($this->strictTypes) {
+            return "\n".'declare(strict_types=1);'."\n";
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1077,7 +1077,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
-        $this->assertEquals($authorClass, $reflMethod->getReturnType());
+        $this->assertNull($reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
         $this->assertEquals($metadata->name, $reflMethod->getReturnType());

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -34,6 +34,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
         $this->_generator->setStrictTypes(false);
+        $this->_generator->setGenerateMethodsTypeHinting(false);
         $this->_generator->setUpdateEntityIfExists(true);
         $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
@@ -1017,6 +1018,117 @@ class EntityGeneratorTest extends OrmTestCase
         }
 
         $this->_generator->setStrictTypes(true);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testGenerateMethodsTypeHintingWithNonCompatiblePHP()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+    }
+
+    public function testGenerateMethodsTypeHinting()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+
+        $metadata = $this->generateBookEntityFixture();
+        $this->loadEntityClass($metadata);
+
+        $reflClass = new \ReflectionClass($metadata->name);
+
+        $this->assertCount(5, $reflClass->getProperties());
+        $this->assertCount(13, $reflClass->getMethods());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getId');
+        $this->assertEquals('int', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setName');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals('string', $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getName');
+        $this->assertEquals('string', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setStatus');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals('string', $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getStatus');
+        $this->assertEquals('string', $reflMethod->getReturnType());
+
+        $authorClass = get_class(new EntityGeneratorAuthor());
+        $reflMethod = new \ReflectionMethod($metadata->name, 'setAuthor');
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals($authorClass, (string) $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
+        $this->assertEquals($authorClass, $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
+        $this->assertEquals($metadata->name, $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
+        $this->assertEquals('bool', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'getComments');
+        $this->assertEquals('Doctrine\Common\Collections\Collection', $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'loading');
+        $this->assertNull($reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, 'willBeRemoved');
+        $this->assertNull($reflMethod->getReturnType());
+    }
+
+    /**
+     * @dataProvider getEntityTypeAliasDataProvider
+     */
+    public function testEntityMethodTypeHintingAlias(array $field)
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
+        }
+
+        $this->_generator->setGenerateMethodsTypeHinting(true);
+
+        $metadata   = $this->generateEntityTypeFixture($field);
+        $path       = $this->_tmpDir . '/'. $this->_namespace . '/EntityType.php';
+
+        $this->assertFileExists($path);
+        require_once $path;
+
+        $type   = $field['phpType'];
+        if ('\\' === $type[0]) {
+            $type = substr($type, 1);
+        }
+
+        $name   = $field['fieldName'];
+        $getter = "get" . ucfirst($name);
+        $setter = "set" . ucfirst($name);
+
+        $reflMethod = new \ReflectionMethod($metadata->name, $setter);
+        $parameters = $reflMethod->getParameters();
+        $this->assertEquals(1, count($parameters));
+        $this->assertEquals($type, $parameters[0]->getType());
+        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+
+        $reflMethod = new \ReflectionMethod($metadata->name, $getter);
+        $this->assertEquals($type, (string) $reflMethod->getReturnType());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1031,7 +1031,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals('string', $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getName');
         $this->assertEquals('string', $reflMethod->getReturnType());
@@ -1040,7 +1040,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals('string', $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getStatus');
         $this->assertEquals('string', $reflMethod->getReturnType());
@@ -1050,13 +1050,13 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals($authorClass, (string) $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'getAuthor');
         $this->assertNull($reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
-        $this->assertEquals($metadata->name, $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
         $this->assertEquals('bool', $reflMethod->getReturnType());
@@ -1097,7 +1097,7 @@ class EntityGeneratorTest extends OrmTestCase
         $parameters = $reflMethod->getParameters();
         $this->assertEquals(1, count($parameters));
         $this->assertEquals($type, $parameters[0]->getType());
-        $this->assertEquals($metadata->getName(), $reflMethod->getReturnType());
+        $this->assertEquals('self', $reflMethod->getReturnType());
 
         $reflMethod = new \ReflectionMethod($metadata->name, $getter);
         $this->assertEquals($type, (string) $reflMethod->getReturnType());

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -33,6 +33,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->_generator->setGenerateAnnotations(true);
         $this->_generator->setGenerateStubMethods(true);
         $this->_generator->setRegenerateEntityIfExists(false);
+        $this->_generator->setStrictTypes(false);
         $this->_generator->setUpdateEntityIfExists(true);
         $this->_generator->setFieldVisibility(EntityGenerator::FIELD_VISIBLE_PROTECTED);
     }
@@ -1004,6 +1005,18 @@ class EntityGeneratorTest extends OrmTestCase
         $classNew = file_get_contents($path);
 
         $this->assertSame($classTest,$classNew);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testStrictTypesGenerationClassWithNonCompatiblePHP()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            $this->markTestSkipped('Strict mode is available in PHP > 7.0.0');
+        }
+
+        $this->_generator->setStrictTypes(true);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1008,30 +1008,6 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertSame($classTest,$classNew);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testStrictTypesGenerationClassWithNonCompatiblePHP()
-    {
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-            $this->markTestSkipped('Strict mode is available in PHP > 7.0.0');
-        }
-
-        $this->_generator->setStrictTypes(true);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGenerateMethodsTypeHintingWithNonCompatiblePHP()
-    {
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
-        }
-
-        $this->_generator->setGenerateMethodsTypeHinting(true);
-    }
-
     public function testGenerateMethodsTypeHinting()
     {
         if (version_compare(PHP_VERSION, '7.0.0', '<')) {
@@ -1100,10 +1076,6 @@ class EntityGeneratorTest extends OrmTestCase
      */
     public function testEntityMethodTypeHintingAlias(array $field)
     {
-        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
-            $this->markTestSkipped('Scalar type hinting and method return types are available in PHP >= 7.0.0');
-        }
-
         $this->_generator->setGenerateMethodsTypeHinting(true);
 
         $metadata   = $this->generateEntityTypeFixture($field);


### PR DESCRIPTION
I recreate the PR #5569 because I've delete the original fork and can't work on the PR anymore.

---

PHP files are in weak type-checking mode. Since PHP 7, strict type-checking mode is used for function calls and return statements in the the file.

This PR add support for generate class with are strict_types compliant.