### PR TITLE
Fix applying target column options on foreign key columns

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -439,19 +439,7 @@ class SchemaTool
             $options['columnDefinition'] = $mapping['columnDefinition'];
         }
 
-        if (isset($mapping['options'])) {
-            $knownOptions = array('comment', 'unsigned', 'fixed', 'default');
-
-            foreach ($knownOptions as $knownOption) {
-                if (array_key_exists($knownOption, $mapping['options'])) {
-                    $options[$knownOption] = $mapping['options'][$knownOption];
-
-                    unset($mapping['options'][$knownOption]);
-                }
-            }
-
-            $options['customSchemaOptions'] = $mapping['options'];
-        }
+        $this->gatherColumnOptions($options, $mapping);
 
         if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == array($mapping['fieldName'])) {
             $options['autoincrement'] = true;
@@ -661,9 +649,7 @@ class SchemaTool
                     $columnOptions['notnull'] = !$joinColumn['nullable'];
                 }
 
-                if (isset($fieldMapping['options'])) {
-                    $columnOptions['options'] = $fieldMapping['options'];
-                }
+                $this->gatherColumnOptions($columnOptions, $fieldMapping);
 
                 if ($fieldMapping['type'] == "string" && isset($fieldMapping['length'])) {
                     $columnOptions['length'] = $fieldMapping['length'];
@@ -870,5 +856,22 @@ class SchemaTool
         }
 
         return $schemaDiff->toSql($this->platform);
+    }
+
+    private function gatherColumnOptions(array &$options, array $mapping)
+    {
+        if (isset($mapping['options'])) {
+            $knownOptions = array('comment', 'unsigned', 'fixed', 'default');
+
+            foreach ($knownOptions as $knownOption) {
+                if (array_key_exists($knownOption, $mapping['options'])) {
+                    $options[$knownOption] = $mapping['options'][$knownOption];
+
+                    unset($mapping['options'][$knownOption]);
+                }
+            }
+
+            $options['customSchemaOptions'] = $mapping['options'];
+        }
     }
 }

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -34,7 +34,7 @@ class HydratorMockStatement implements \IteratorAggregate, \Doctrine\DBAL\Driver
      *
      * @return array
      */
-    public function fetchAll($fetchStyle = null, $columnIndex = null, array $ctorArgs = null)
+    public function fetchAll($fetchStyle = null, $columnIndex = null, $ctorArgs = null)
     {
         return $this->_resultSet;
     }
@@ -53,7 +53,7 @@ class HydratorMockStatement implements \IteratorAggregate, \Doctrine\DBAL\Driver
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchStyle = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
         $current = current($this->_resultSet);
         next($this->_resultSet);

--- a/tests/Doctrine/Tests/Mocks/StatementMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementMock.php
@@ -73,14 +73,14 @@ class StatementMock implements \IteratorAggregate, \Doctrine\DBAL\Driver\Stateme
     /**
      * {@inheritdoc}
      */
-    public function fetch($fetchStyle = null)
+    public function fetch($fetchStyle = null, $cursorOrientation = \PDO::FETCH_ORI_NEXT, $cursorOffset = 0)
     {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function fetchAll($fetchStyle = null)
+    public function fetchAll($fetchStyle = null, $fetchArgument = null, $ctorArgs = null)
     {
     }
 

--- a/tests/Doctrine/Tests/Models/Forum/ForumCategory.php
+++ b/tests/Doctrine/Tests/Models/Forum/ForumCategory.php
@@ -9,7 +9,7 @@ namespace Doctrine\Tests\Models\Forum;
 class ForumCategory
 {
     /**
-     * @Column(type="integer")
+     * @Column(type="guid", options={"fixed":true, "collation":"latin1_bin", "foo":"bar"})
      * @Id
      */
     private $id;

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -54,13 +54,18 @@ class EntityManagerDecoratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters)
     {
+        $returnedValue = null;
+
         $stub = $this->wrapped
             ->expects($this->once())
             ->method($method)
-            ->will($this->returnValue('INNER VALUE FROM ' . $method));
+            ->willReturnCallback(function () use ($method, &$returnedValue) {
+                $returnedValue = 'INNER VALUE FROM '.$method;
+            });
 
         call_user_func_array(array($stub, 'with'), $parameters);
+        call_user_func_array(array($this->decorator, $method), $parameters);
 
-        $this->assertSame('INNER VALUE FROM ' . $method, call_user_func_array(array($this->decorator, $method), $parameters));
+        $this->assertSame('INNER VALUE FROM ' . $method, $returnedValue);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -72,6 +72,39 @@ class SchemaToolTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals($customColumnDef, $table->getColumn('avatar_id')->getColumnDefinition());
     }
 
+    public function testPassColumnOptionsToJoinColumn()
+    {
+        $em = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $category = $em->getClassMetadata('Doctrine\Tests\Models\Forum\ForumCategory');
+        $board = $em->getClassMetadata('Doctrine\Tests\Models\Forum\ForumBoard');
+
+        $classes = array($category, $board);
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        $this->assertTrue($schema->hasTable('forum_categories'));
+        $this->assertTrue($schema->hasTable('forum_boards'));
+
+        $tableCategory = $schema->getTable('forum_categories');
+        $tableBoard = $schema->getTable('forum_boards');
+
+        $this->assertTrue($tableBoard->hasColumn('category_id'));
+
+        $this->assertSame(
+            $tableCategory->getColumn('id')->getFixed(),
+            $tableBoard->getColumn('category_id')->getFixed(),
+            'Target and source columns have different value of option `fixed`'
+        );
+
+        $this->assertEquals(
+            $tableCategory->getColumn('id')->getCustomSchemaOptions(),
+            $tableBoard->getColumn('category_id')->getCustomSchemaOptions(),
+            'Target and source columns have different schema options'
+        );
+    }
+
     /**
      * @group DDC-283
      */


### PR DESCRIPTION
Fixes doctrine/dbal#2811
Similar PR: #6830 

Tobion's PR fixes only applying of collation, which is not enough. This fix applies all options from target column to make type of source and target columns equal.

P.S.
Sorry for my terrible english.