### PR TITLE
Use new analyser on scrutinizer-ci

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,19 @@
 build:
-    environment:
-        php:
-            version: 7.1
+    nodes:
+        analysis:
+            environment:
+                php:
+                    version: 7.1
+            cache:
+                disabled: false
+                directories:
+                    - ~/.composer/cache
+
+            project_setup:
+                override: true
+            tests:
+                override:
+                    - php-scrutinizer-run
 
 before_commands:
     - "composer install --no-dev --prefer-source"
@@ -17,8 +29,6 @@ filter:
 
 build_failure_conditions:
     - 'elements.rating(<= C).new.exists'                        # No new classes/methods with a rating of C or worse allowed
-    - 'issues.label("coding-style").new.exists'                 # No new coding style issues allowed
     - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection
-    - 'patches.label("Doc Comments").new.exists'                # No new doc comments patches allowed
     - 'patches.label("Unused Use Statements").new.exists'       # No new unused imports patches allowed


### PR DESCRIPTION
Also preventing from running the tests (because that's already done on Travis-CI) and simplifying the build failure conditions.