### PR TITLE
Fixing setResultCacheProfile when handling null profile

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -521,7 +521,7 @@ abstract class AbstractQuery
      */
     public function setResultCacheProfile(QueryCacheProfile $profile = null)
     {
-        if ( ! $profile->getResultCacheDriver()) {
+        if ($profile !== null && ! $profile->getResultCacheDriver()) {
             $resultCacheDriver = $this->_em->getConfiguration()->getResultCacheImpl();
             $profile = $profile->setResultCacheDriver($resultCacheDriver);
         }


### PR DESCRIPTION
Just bumping https://github.com/doctrine/doctrine2/pull/5842

Here is the code I'd like to use:

``` php
$tasks = $em
    ->createQuery('SELECT wt FROM Something wt')
    ->setHint(Query::HINT_LOCK_MODE, LockMode::PESSIMISTIC_WRITE)
    ->useResultCache(false)
    ->setHydrationCacheProfile(null)
    ->getResult()
;
```

Here is the result:

```
PHP Fatal error:  Call to a member function getResultCacheDriver() on a non-object in /xxx/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php on line XXX
```

Here is the workaround we're using:

``` php
class DisabledCache implements Cache
{
    function fetch($id)
    {
        return false;
    }

    function contains($id)
    {
        return false;
    }

    function save($id, $data, $lifeTime = 0)
    {
        return true;
    }

    function delete($id)
    {
        return true;
    }

    function getStats()
    {
        return null;
    }
}

$tasks = $em
    ->createQuery('SELECT wt FROM Something wt')
    ->setHint(Query::HINT_LOCK_MODE, LockMode::PESSIMISTIC_WRITE)
    ->useResultCache(false)
    ->setHydrationCacheProfile(new QueryCacheProfile(0, 'disabled', new DisabledCache))
    ->getResult()
;
```
