### PR TITLE
Ensure `ObjectManagerAware` and `EntityManagerAware` are correctly handled by UoW load/refresh

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use Doctrine\Common\EventManager;
-use Doctrine\Common\Persistence\ObjectManagerAware;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\LockMode;
@@ -534,10 +533,6 @@ final class EntityManager implements EntityManagerInterface
         $entity = $this->proxyFactory->getProxy($class, $id);
 
         $this->unitOfWork->registerManaged($entity, $sortedId, []);
-
-        if ($entity instanceof ObjectManagerAware) {
-            $entity->injectObjectManager($this, $class);
-        }
 
         if ($entity instanceof EntityManagerAware) {
             $entity->injectEntityManager($this, $class);

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use Doctrine\Common\EventManager;
+use Doctrine\Common\Persistence\ObjectManagerAware;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\LockMode;
@@ -533,6 +534,14 @@ final class EntityManager implements EntityManagerInterface
         $entity = $this->proxyFactory->getProxy($class, $id);
 
         $this->unitOfWork->registerManaged($entity, $sortedId, []);
+
+        if ($entity instanceof ObjectManagerAware) {
+            $entity->injectObjectManager($this, $class);
+        }
+
+        if ($entity instanceof EntityManagerAware) {
+            $entity->injectEntityManager($this, $class);
+        }
 
         return $entity;
     }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\NotifyPropertyChanged;
-use Doctrine\Common\Persistence\ObjectManagerAware;
 use Doctrine\Common\PropertyChangedListener;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Instantiator\Instantiator;
@@ -2103,10 +2102,6 @@ class UnitOfWork implements PropertyChangedListener
             $entity->injectEntityManager($this->em, $class);
         }
 
-        if ($entity instanceof ObjectManagerAware) {
-            $entity->injectObjectManager($this->em, $class);
-        }
-
         return $entity;
     }
 
@@ -2159,11 +2154,6 @@ class UnitOfWork implements PropertyChangedListener
                     || (isset($hints[Query::HINT_REFRESH_ENTITY]) && $hints[Query::HINT_REFRESH_ENTITY] !== $entity)) {
                     return $entity;
                 }
-            }
-
-            // inject ObjectManager upon refresh.
-            if ($entity instanceof ObjectManagerAware) {
-                $entity->injectObjectManager($this->em, $class);
             }
 
             // inject EntityManager upon refresh.

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2103,6 +2103,10 @@ class UnitOfWork implements PropertyChangedListener
             $entity->injectEntityManager($this->em, $class);
         }
 
+        if ($entity instanceof ObjectManagerAware) {
+            $entity->injectObjectManager($this->em, $class);
+        }
+
         return $entity;
     }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2162,6 +2162,11 @@ class UnitOfWork implements PropertyChangedListener
                 $entity->injectObjectManager($this->em, $class);
             }
 
+            // inject EntityManager upon refresh.
+            if ($entity instanceof EntityManagerAware) {
+                $entity->injectEntityManager($this->em, $class);
+            }
+
             $this->originalEntityData[$oid] = $data;
         } else {
             $entity = $this->newInstance($class);

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Annotation as ORM;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
- * Test that Doctrine ORM correctly works with the ObjectManagerAware and PersistentObject
+ * Test that Doctrine ORM correctly works with the EntityManagerAware and PersistentObject
  * classes from Common.
  *
  * @group DDC-1448

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -38,6 +38,7 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertInstanceOf(GhostObjectInterface::class, $y1ref);
         self::assertInstanceOf(DDC2231EntityY::class, $y1ref);
+        self::assertInstanceOf(EntityManagerAware::class, $y1ref);
         self::assertFalse($y1ref->isProxyInitialized());
 
         $y1ref->initializeProxy();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -63,6 +63,7 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertInstanceOf(DDC2231EntityManagerAwareEntity::class, $emAware);
         self::assertInstanceOf(EntityManagerAware::class, $emAware);
         self::assertFalse($emAware->isProxyInitialized());
+        self::assertSame($this->em, $emAware->em);
 
         $emAware->initializeProxy();
 
@@ -95,10 +96,11 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertInstanceOf(DDC2231ObjectManagerAwareEntity::class, $omAware);
         self::assertInstanceOf(ObjectManagerAware::class, $omAware);
         self::assertFalse($omAware->isProxyInitialized());
+        self::assertSame($this->em, $omAware->om);
 
         $omAware->initializeProxy();
 
-        self::assertSame($this->em, $omAware->em);
+        self::assertSame($this->em, $omAware->om);
     }
 
     public function testInjectObjectManagerInFetchedInstance()
@@ -112,7 +114,7 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertInstanceOf(DDC2231ObjectManagerAwareEntity::class, $omAware);
         self::assertInstanceOf(ObjectManagerAware::class, $omAware);
         self::assertNotInstanceOf(GhostObjectInterface::class, $omAware);
-        self::assertSame($this->em, $omAware->em);
+        self::assertSame($this->em, $omAware->om);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php
@@ -4,54 +4,44 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata as CommonMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectManagerAware;
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\EntityManagerAware;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\ToolsException;
+use Doctrine\Tests\OrmFunctionalTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;
 
 /**
  * @group DDC-2231
  */
-class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
+final class DDC2231Test extends OrmFunctionalTestCase
 {
     /**
      * @var DDC2231EntityManagerAwareEntity
      */
     private $persistedEntityManagerAwareEntity;
 
-    /**
-     * @var DDC2231ObjectManagerAwareEntity
-     */
-    private $persistedObjectManagerAwareEntity;
-
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
         try {
             $this->schemaTool->createSchema([
                 $this->em->getClassMetadata(DDC2231EntityManagerAwareEntity::class),
-                $this->em->getClassMetadata(DDC2231ObjectManagerAwareEntity::class),
             ]);
         } catch (ToolsException $ignored) {
             // ignore - schema already exists
         }
 
         $this->persistedEntityManagerAwareEntity = new DDC2231EntityManagerAwareEntity();
-        $this->persistedObjectManagerAwareEntity = new DDC2231ObjectManagerAwareEntity();
 
         $this->em->persist($this->persistedEntityManagerAwareEntity);
-        $this->em->persist($this->persistedObjectManagerAwareEntity);
         $this->em->flush();
         $this->em->clear();
     }
 
-    public function testInjectEntityManagerInProxyIfInitializedInUow()
+    public function testInjectEntityManagerInProxyIfInitializedInUow() : void
     {
         /* @var $emAware DDC2231EntityManagerAwareEntity|GhostObjectInterface */
         $emAware = $this->em->getReference(
@@ -70,7 +60,7 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertSame($this->em, $emAware->em);
     }
 
-    public function testInjectEntityManagerInFetchedInstance()
+    public function testInjectEntityManagerInFetchedInstance() : void
     {
         /* @var $emAware DDC2231EntityManagerAwareEntity */
         $emAware = $this->em->find(
@@ -83,41 +73,7 @@ class DDC2231Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertNotInstanceOf(GhostObjectInterface::class, $emAware);
         self::assertSame($this->em, $emAware->em);
     }
-
-    public function testInjectObjectManagerInProxyIfInitializedInUow()
-    {
-        /* @var $omAware DDC2231ObjectManagerAwareEntity|GhostObjectInterface */
-        $omAware = $this->em->getReference(
-            DDC2231ObjectManagerAwareEntity::class,
-            $this->persistedObjectManagerAwareEntity->id
-        );
-
-        self::assertInstanceOf(GhostObjectInterface::class, $omAware);
-        self::assertInstanceOf(DDC2231ObjectManagerAwareEntity::class, $omAware);
-        self::assertInstanceOf(ObjectManagerAware::class, $omAware);
-        self::assertFalse($omAware->isProxyInitialized());
-        self::assertSame($this->em, $omAware->om);
-
-        $omAware->initializeProxy();
-
-        self::assertSame($this->em, $omAware->om);
-    }
-
-    public function testInjectObjectManagerInFetchedInstance()
-    {
-        /* @var $omAware DDC2231ObjectManagerAwareEntity */
-        $omAware = $this->em->find(
-            DDC2231ObjectManagerAwareEntity::class,
-            $this->persistedObjectManagerAwareEntity->id
-        );
-
-        self::assertInstanceOf(DDC2231ObjectManagerAwareEntity::class, $omAware);
-        self::assertInstanceOf(ObjectManagerAware::class, $omAware);
-        self::assertNotInstanceOf(GhostObjectInterface::class, $omAware);
-        self::assertSame($this->em, $omAware->om);
-    }
 }
-
 
 /** @ORM\Entity */
 class DDC2231EntityManagerAwareEntity implements EntityManagerAware
@@ -131,21 +87,5 @@ class DDC2231EntityManagerAwareEntity implements EntityManagerAware
     public function injectEntityManager(EntityManagerInterface $entityManager, ClassMetadata $classMetadata) : void
     {
         $this->em = $entityManager;
-    }
-}
-
-
-/** @ORM\Entity */
-class DDC2231ObjectManagerAwareEntity implements ObjectManagerAware
-{
-    /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
-    public $id;
-
-    /** @var ObjectManager|null */
-    public $om;
-
-    public function injectObjectManager(ObjectManager $objectManager, CommonMetadata $classMetadata) : void
-    {
-        $this->om = $objectManager;
     }
 }


### PR DESCRIPTION
Couple things here:

 * [x] tests fail because `Doctrine\Common\Persistence\ClassMetadata` is no longer an ancestor of the ORM metadata
 * [x] since lazy-loading is now performed on a per-property fashion, the assertion that the `om` and `em` fields are `null` before lazy-loading seems wrong. `getReference` should inject the `EntityManager` instance

@guilhermeblanco feedback needed on the above, then I can continue on this :-)