### PR TITLE
Added deprecation warnings for 2.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade to 2.7
+
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.6
 
 ## Minor BC BREAK: `Doctrine\ORM\Tools\Console\ConsoleRunner` is now final
@@ -29,11 +36,6 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - APCu extension (ext-apcu) will now be used instead of abandoned APC (ext-apc).
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
-
-## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
-
-Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
-It will be removed in 3.0.
 
 # Upgrade to 2.5
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,103 @@
 # Upgrade to 2.7
 
+## Deprecated code generators and related console commands
+ 
+These console commands have been deprecated:
+
+ * `orm:convert-mapping`
+ * `orm:generate:entities`
+ * `orm:generate-repositories`
+
+These classes have been deprecated:
+
+ * `Doctrine\ORM\Tools\EntityGenerator`
+ * `Doctrine\ORM\Tools\EntityRepositoryGenerator`
+
+Whole Doctrine\ORM\Tools\Export namespace with all its members have been deprecated as well.
+
+## Deprecated `Doctrine\ORM\Proxy\Proxy` marker interface
+
+Proxy objects in Doctrine 3.0 will no longer implement `Doctrine\ORM\Proxy\Proxy` nor
+`Doctrine\Common\Persistence\Proxy`: instead, they implement
+`ProxyManager\Proxy\GhostObjectInterface`.
+
+These related classes have been deprecated:
+
+ * `Doctrine\ORM\Proxy\ProxyFactory`
+ * `Doctrine\ORM\Proxy\Autoloader` - we suggest using the composer autoloader instead
+ 
+These methods have been deprecated:
+
+ * `Doctrine\ORM\Configuration#getAutoGenerateProxyClasses()`
+ * `Doctrine\ORM\Configuration#getProxyDir()`
+ * `Doctrine\ORM\Configuration#getProxyNamespace()`
+
+## Deprecated `Doctrine\ORM\Version`
+
+The `Doctrine\ORM\Version` class is now deprecated and will be removed in Doctrine 3.0:
+please refrain from checking the ORM version at runtime or use
+[Ocramius/PackageVersions](https://github.com/Ocramius/PackageVersions/).
+
+## Deprecated `EntityManager#merge()` and `EntityManager#detach()` methods
+
+Merge and detach semantics were a poor fit for the PHP "share-nothing" architecture.
+In addition to that, merging/detaching caused multiple issues with data integrity
+in the managed entity graph, which was constantly spawning more edge-case bugs/scenarios.
+
+The following API methods were therefore deprecated:
+
+* `EntityManager#merge()`
+* `EntityManager#detach()`
+* `UnitOfWork#merge()`
+* `UnitOfWork#detach()`
+
+Users are encouraged to migrate `EntityManager#detach()` calls to `EntityManager#clear()`.
+
+In order to maintain performance on batch processing jobs, it is endorsed to enable
+the second level cache (http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/second-level-cache.html)
+on entities that are frequently reused across multiple `EntityManager#clear()` calls.
+
+An alternative to `EntityManager#merge()` will not be provided by ORM 3.0, since the merging
+semantics should be part of the business domain rather than the persistence domain of an
+application. If your application relies heavily on CRUD-alike interactions and/or `PATCH`
+restful operations, you should look at alternatives such as [JMSSerializer](https://github.com/schmittjoh/serializer).
+
+## Extending `EntityManager` is deprecated
+
+Final keyword will be added to the `EntityManager::class` in Doctrine 3.0 in order to ensure that EntityManager
+ is not used as valid extension point. Valid extension point should be EntityManagerInterface.
+
+## Deprecated `EntityManager#flush($entity)` and `EntityManager#flush($entities)`
+
+If your code relies on single entity flushing optimisations via
+`EntityManager#flush($entity)`, the signature has been changed to
+`EntityManager#flush()`.
+
+Said API was affected by multiple data integrity bugs due to the fact
+that change tracking was being restricted upon a subset of the managed
+entities. The ORM cannot support committing subsets of the managed 
+entities while also guaranteeing data integrity, therefore this
+utility was removed.
+
+The `flush()` semantics will remain the same, but the change tracking will be performed
+on all entities managed by the unit of work, and not just on the provided
+`$entity` or `$entities`, as the parameter is now completely ignored.
+
+The same applies to `UnitOfWork#commit($entity)`, which will simply be
+`UnitOfWork#commit()`.
+
+If you would still like to perform batching operations over small `UnitOfWork`
+instances, it is suggested to follow these paths instead:
+
+ * eagerly use `EntityManager#clear()` in conjunction with a specific second level
+   cache configuration (see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/second-level-cache.html)
+ * use an explicit change tracking policy (see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/change-tracking-policies.html)
+
+## Deprecated `YAML` mapping drivers.
+
+If your code relies on `YamlDriver`  or `SimpleYamlDriver`, you **MUST** change to
+annotation or XML drivers instead.
+
 ## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
 
 Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,11 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
 
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "bin": ["bin/doctrine"],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-master": "2.7.x-dev"
         }
     },
     "archive": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "doctrine/coding-standard": "^1.0",
         "phpunit/phpunit": "^6.5",
         "squizlabs/php_codesniffer": "^3.2",
-        "symfony/yaml": "~3.4|~4.0"
+        "symfony/yaml": "~3.4|~4.0",
+        "symfony/phpunit-bridge": "^3.3|^4.0"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -70,6 +70,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Gets the directory where Doctrine generates any necessary proxy class files.
      *
      * @return string|null
+     *
+     * @deprecated
      */
     public function getProxyDir()
     {
@@ -82,6 +84,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Gets the strategy for automatically generating proxy classes.
      *
      * @return int Possible values are constants of Doctrine\Common\Proxy\AbstractProxyFactory.
+     *
+     * @deprecated
      */
     public function getAutoGenerateProxyClasses()
     {
@@ -107,6 +111,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Gets the namespace where proxy classes reside.
      *
      * @return string|null
+     *
+     * @deprecated
      */
     public function getProxyNamespace()
     {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -687,9 +687,6 @@ use Throwable;
 
     /**
      * {@inheritDoc}
-     *
-     * @todo Implementation need. This is necessary since $e2 = clone $e1; throws an E_FATAL when access anything on $e:
-     * Fatal error: Maximum function nesting level of '100' reached, aborting!
      */
     public function copy($entity, $deep = false)
     {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -353,6 +353,13 @@ use Throwable;
      */
     public function flush($entity = null)
     {
+        if (func_num_args() !== 0) {
+            @trigger_error(
+                'Calling ' . __METHOD__ . '() with any arguments to flush specific entities is deprecated and will not be supported in Doctrine 3.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->errorIfClosed();
 
         $this->unitOfWork->commit($entity);
@@ -652,9 +659,13 @@ use Throwable;
      * @return void
      *
      * @throws ORMInvalidArgumentException
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine 3.0.
      */
     public function detach($entity)
     {
+        @trigger_error('Method ' . __METHOD__ . '() is deprecated and will be removed in Doctrine 3.0.', E_USER_DEPRECATED);
+
         if ( ! is_object($entity)) {
             throw ORMInvalidArgumentException::invalidObject('EntityManager#detach()', $entity);
         }
@@ -673,9 +684,13 @@ use Throwable;
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine 3.0.
      */
     public function merge($entity)
     {
+        @trigger_error('Method ' . __METHOD__ . '() is deprecated and will be removed in Doctrine 3.0.', E_USER_DEPRECATED);
+
         if ( ! is_object($entity)) {
             throw ORMInvalidArgumentException::invalidObject('EntityManager#merge()', $entity);
         }
@@ -687,9 +702,13 @@ use Throwable;
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine 3.0.
      */
     public function copy($entity, $deep = false)
     {
+        @trigger_error('Method ' . __METHOD__ . '() is deprecated and will be removed in Doctrine 3.0.', E_USER_DEPRECATED);
+
         throw new \BadMethodCallException("Not implemented.");
     }
 

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -198,6 +198,8 @@ interface EntityManagerInterface extends ObjectManager
      * @return object The new entity.
      *
      * @throws \BadMethodCallException
+     *
+     * @deprecated This method is deprecated and will be removed in Doctrine 3.0.
      */
     public function copy($entity, $deep = false);
 

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -190,6 +190,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Creates a copy of the given entity. Can create a shallow or a deep copy.
      *
+     * @deprecated method will be removed in 3.0
+     *
      * @param object  $entity The entity to copy.
      * @param boolean $deep   FALSE for a shallow copy, TRUE for a deep copy.
      *

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -44,6 +44,11 @@ class YamlDriver extends FileDriver
      */
     public function __construct($locator, $fileExtension = self::DEFAULT_FILE_EXTENSION)
     {
+        @trigger_error(
+            'YAML mapping driver is deprecated and will be removed in Doctrine 3.0, please migrate to annotation or XML driver.',
+            E_USER_DEPRECATED
+        );
+
         parent::__construct($locator, $fileExtension);
     }
 

--- a/lib/Doctrine/ORM/Mapping/Version.php
+++ b/lib/Doctrine/ORM/Mapping/Version.php
@@ -22,6 +22,8 @@ namespace Doctrine\ORM\Mapping;
 /**
  * @Annotation
  * @Target("PROPERTY")
+ *
+ * @deprecated This class is deprecated and will be removed in Doctrine 3.0.
  */
 final class Version implements Annotation
 {

--- a/lib/Doctrine/ORM/Proxy/Proxy.php
+++ b/lib/Doctrine/ORM/Proxy/Proxy.php
@@ -26,6 +26,8 @@ use Doctrine\Common\Proxy\Proxy as BaseProxy;
  *
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
+ *
+ * @deprecated This class is deprecated and will be removed in Doctrine 3.0, proxies will no longer implement it.
  */
 interface Proxy extends BaseProxy
 {

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -37,6 +37,8 @@ use Doctrine\ORM\Utility\IdentifierFlattener;
  * @author Giorgio Sironi <piccoloprincipeazzurro@gmail.com>
  * @author Marco Pivetta  <ocramius@gmail.com>
  * @since 2.0
+ *
+ * @deprecated
  */
 class ProxyFactory extends AbstractProxyFactory
 {

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Command to convert a Doctrine 1 schema to a Doctrine 2 mapping file.
@@ -37,6 +38,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated This class is deprecated and will be removed in Doctrine 3.0.');
  */
 class ConvertDoctrine1SchemaCommand extends Command
 {
@@ -116,6 +119,9 @@ class ConvertDoctrine1SchemaCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $ui = new SymfonyStyle($input, $output);
+        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine 3.0.');
+
         // Process source directories
         $fromPaths = array_merge([$input->getArgument('from-path')], $input->getOption('from'));
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -38,6 +38,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated This class is deprecated and will be removed in Doctrine 3.0.');
  */
 class GenerateEntitiesCommand extends Command
 {
@@ -87,6 +89,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
+        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine 3.0.');
 
         $em = $this->getHelper('em')->getEntityManager();
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -37,6 +37,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated This class is deprecated and will be removed in Doctrine 3.0.');
  */
 class GenerateRepositoriesCommand extends Command
 {
@@ -59,6 +61,7 @@ class GenerateRepositoriesCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ui = new SymfonyStyle($input, $output);
+        $ui->warning('Command ' . $this->getName() . ' is deprecated and will be removed in Doctrine 3.0.');
 
         $em = $this->getHelper('em')->getEntityManager();
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -44,6 +44,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated
  */
 class EntityGenerator
 {
@@ -334,6 +336,8 @@ public function __construct(<params>)
      */
     public function __construct()
     {
+        @trigger_error(self::class . ' is deprecated and will be removed in Doctrine 3.0', E_USER_DEPRECATED);
+
         if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             $this->annotationsPrefix = 'ORM\\';
         }

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -31,6 +31,8 @@ use Doctrine\ORM\EntityRepository;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated
  */
 class EntityRepositoryGenerator
 {
@@ -51,6 +53,11 @@ class <className> extends <repositoryName>
 {
 }
 ';
+
+    public function __construct()
+    {
+        @trigger_error(self::class . ' is deprecated and will be removed in Doctrine 3.0', E_USER_DEPRECATED);
+    }
 
     /**
      * @param string $fullClassName

--- a/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
@@ -26,6 +26,8 @@ namespace Doctrine\ORM\Tools\Export;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 class ClassMetadataExporter
 {
@@ -39,6 +41,11 @@ class ClassMetadataExporter
         'php' => Driver\PhpExporter::class,
         'annotation' => Driver\AnnotationExporter::class
     ];
+
+    public function __construct()
+    {
+        @trigger_error(self::class . ' is deprecated and will be removed in Doctrine 3.0', E_USER_DEPRECATED);
+    }
 
     /**
      * Registers a new exporter driver class under a specified name.

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -29,6 +29,8 @@ use Doctrine\ORM\Tools\Export\ExportException;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 abstract class AbstractExporter
 {
@@ -57,6 +59,8 @@ abstract class AbstractExporter
      */
     public function __construct($dir = null)
     {
+        @trigger_error(static::class . ' is deprecated and will be removed in Doctrine 3.0', E_USER_DEPRECATED);
+
         $this->_outputDir = $dir;
     }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
@@ -28,6 +28,8 @@ use Doctrine\ORM\Tools\EntityGenerator;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 class AnnotationExporter extends AbstractExporter
 {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -27,6 +27,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 class PhpExporter extends AbstractExporter
 {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -28,6 +28,8 @@ use SimpleXMLElement;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 class XmlExporter extends AbstractExporter
 {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -28,6 +28,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Jonathan Wage <jonwage@gmail.com>
+ *
+ * @deprecated
  */
 class YamlExporter extends AbstractExporter
 {

--- a/lib/Doctrine/ORM/Tools/Export/ExportException.php
+++ b/lib/Doctrine/ORM/Tools/Export/ExportException.php
@@ -21,6 +21,9 @@ namespace Doctrine\ORM\Tools\Export;
 
 use Doctrine\ORM\ORMException;
 
+/**
+ * @deprecated
+ */
 class ExportException extends ORMException
 {
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1810,7 +1810,7 @@ class UnitOfWork implements PropertyChangedListener
      * @throws OptimisticLockException If the entity uses optimistic locking through a version
      *         attribute and the version check against the managed copy fails.
      *
-     * @todo Require active transaction!? OptimisticLockException may result in undefined state!?
+     * @deprecated
      */
     public function merge($entity)
     {
@@ -2000,6 +2000,8 @@ class UnitOfWork implements PropertyChangedListener
      * @param object $entity The entity to detach.
      *
      * @return void
+     *
+     * @deprecated
      */
     public function detach($entity)
     {

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -29,6 +29,8 @@ namespace Doctrine\ORM;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @deprecated
  */
 class Version
 {

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -35,7 +35,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.6.1-DEV';
+    const VERSION = '2.7.0-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,10 @@
         </exclude>
     </groups>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
   <php>
     <!-- "Real" test database -->
     <!-- uncomment, otherwise sqlite memory runs

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -69,6 +69,7 @@ class EntityManagerDecoratorTest extends TestCase
 
     /**
      * @dataProvider getMethodParameters
+     * @group legacy
      */
     public function testAllMethodCallsAreDelegatedToTheWrappedInstance($method, array $parameters)
     {

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -159,6 +159,7 @@ class EntityManagerTest extends OrmTestCase
 
     /**
      * @dataProvider dataMethodsAffectedByNoObjectArguments
+     * @group legacy
      */
     public function testThrowsExceptionOnNonObjectValues($methodName) {
         $this->expectException(ORMInvalidArgumentException::class);
@@ -181,6 +182,8 @@ class EntityManagerTest extends OrmTestCase
     /**
      * @dataProvider dataAffectedByErrorIfClosedException
      * @param string $methodName
+     *
+     * @group legacy
      */
     public function testAffectedByErrorIfClosedException($methodName)
     {
@@ -304,5 +307,54 @@ class EntityManagerTest extends OrmTestCase
         $this->_em->clear(null);
 
         $this->assertFalse($this->_em->contains($entity));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling Doctrine\ORM\EntityManager::flush() with any arguments to flush specific entities is deprecated and will not be supported in Doctrine 3.0.
+     */
+    public function testDeprecatedFlushWithArguments() : void
+    {
+        $entity = new Country(456, 'United Kingdom');
+        $this->_em->persist($entity);
+        $this->_em->flush($entity);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method Doctrine\ORM\EntityManager::merge() is deprecated and will be removed in Doctrine 3.0.
+     */
+    public function testDeprecatedMerge() : void
+    {
+        $entity = new Country(456, 'United Kingdom');
+        $this->_em->persist($entity);
+        $this->_em->merge($entity);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method Doctrine\ORM\EntityManager::detach() is deprecated and will be removed in Doctrine 3.0.
+     */
+    public function testDeprecatedDetach() : void
+    {
+        $entity = new Country(456, 'United Kingdom');
+        $this->_em->persist($entity);
+        $this->_em->detach($entity);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Method Doctrine\ORM\EntityManager::copy() is deprecated and will be removed in Doctrine 3.0.
+     */
+    public function testDeprecatedCopy() : void
+    {
+        $entity = new Country(456, 'United Kingdom');
+        $this->_em->persist($entity);
+
+        try {
+            $this->_em->copy($entity);
+        } catch (\BadMethodCallException $e) {
+            // do nothing
+        }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -499,7 +499,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($address);
 
         $this->_em->flush();
-        $this->_em->detach($address);
+        $this->_em->clear(CmsAddress::class);
 
         $this->assertFalse($this->_em->contains($address));
         $this->assertTrue($this->_em->contains($user));
@@ -873,6 +873,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $this->_em->find(get_class($user), $userId)->name);
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergePersistsNewEntities()
     {
         $user = new CmsUser();
@@ -896,6 +899,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(CmsUser::class, $user2);
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergeNonPersistedProperties()
     {
         $user = new CmsUser();
@@ -923,6 +929,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->assertEquals('active', $user2->status);
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergeThrowsExceptionIfEntityWithGeneratedIdentifierDoesNotExist()
     {
         $user = new CmsUser();
@@ -937,6 +946,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-634
+     * @group legacy
      */
     public function testOneToOneMergeSetNull()
     {
@@ -1044,6 +1054,9 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->assertEquals(UnitOfWork::STATE_DETACHED, $unitOfWork->getEntityState($address));
     }
 
+    /**
+     * @group legacy
+     */
     public function testFlushManyExplicitEntities()
     {
         $userA = new CmsUser;
@@ -1077,6 +1090,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushSingleManagedEntity()
     {
@@ -1098,6 +1112,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushSingleUnmanagedEntity()
     {
@@ -1114,6 +1129,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushSingleAndNewEntity()
     {
@@ -1141,6 +1157,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushAndCascadePersist()
     {
@@ -1168,6 +1185,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushSingleAndNoCascade()
     {
@@ -1195,6 +1213,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
      * @group DDC-720
      * @group DDC-1612
      * @group DDC-2267
+     * @group legacy
      */
     public function testFlushSingleNewEntityThenRemove()
     {
@@ -1217,6 +1236,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testProxyIsIgnored()
     {
@@ -1245,6 +1265,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-720
+     * @group legacy
      */
     public function testFlushSingleSaveOnlySingle()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -24,6 +24,9 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         parent::setUp();
     }
 
+    /**
+     * @group legacy
+     */
     public function testSimpleDetachMerge()
     {
         $user = new CmsUser;
@@ -46,6 +49,9 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->assertEquals('Roman B.', $user2->name);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSerializeUnserializeModifyMerge()
     {
         $user = new CmsUser;
@@ -126,6 +132,9 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->_em->flush();
     }
 
+    /**
+     * @group legacy
+     */
     public function testUninitializedLazyAssociationsAreIgnoredOnMerge()
     {
         $user = new CmsUser;
@@ -160,6 +169,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-822
+     * @group legacy
      */
     public function testUseDetachedEntityAsQueryParameter()
     {
@@ -185,6 +195,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-920
+     * @group legacy
      */
     public function testDetachManagedUnpersistedEntity()
     {
@@ -204,6 +215,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-1340
+     * @group legacy
      */
     public function testMergeArticleWrongVersion()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -944,6 +944,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-2478
+     * @group legacy
      */
     public function testMatchingCriteriaNullAssocComparison()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/MergeCompositeToOneKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeCompositeToOneKeyTest.php
@@ -26,6 +26,7 @@ class MergeCompositeToOneKeyTest extends OrmFunctionalTestCase
     /**
      * @group DDC-3378
      * @group 1176
+     * @group legacy
      */
     public function testMergingOfEntityWithCompositeIdentifierContainingToOneAssociation()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -29,6 +29,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      */
     public function testMergeDetachedUnInitializedProxy()
     {
@@ -49,6 +50,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      */
     public function testMergeUnserializedUnInitializedProxy()
     {
@@ -72,6 +74,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      */
     public function testMergeManagedProxy()
     {
@@ -87,6 +90,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      *
      * Bug discovered while working on DDC-2704 - merging towards un-initialized proxies does not initialize them,
      * causing merged data to be lost when they are actually initialized
@@ -116,6 +120,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      */
     public function testMergingProxyFromDifferentEntityManagerWithExistingManagedInstanceDoesNotReplaceInitializer()
     {
@@ -177,6 +182,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
      * @group DDC-1734
      * @group DDC-3368
      * @group #1172
+     * @group legacy
      */
     public function testMergingUnInitializedProxyDoesNotInitializeIt()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeSharedEntitiesTest.php
@@ -25,6 +25,9 @@ class MergeSharedEntitiesTest extends OrmFunctionalTestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergeSharedNewEntities()
     {
         $file    = new MSEFile;
@@ -38,6 +41,9 @@ class MergeSharedEntitiesTest extends OrmFunctionalTestCase
         $this->assertEquals($picture->file, $picture->otherFile, 'Identical entities must remain identical');
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergeSharedManagedEntities()
     {
         $file    = new MSEFile;
@@ -56,6 +62,9 @@ class MergeSharedEntitiesTest extends OrmFunctionalTestCase
         $this->assertEquals($picture->file, $picture->otherFile, 'Identical entities must remain identical');
     }
 
+    /**
+     * @group legacy
+     */
     public function testMergeSharedDetachedSerializedEntities()
     {
         $file    = new MSEFile;
@@ -78,6 +87,7 @@ class MergeSharedEntitiesTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-2704
+     * @group legacy
      */
     public function testMergeInheritedTransientPrivateProperties()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/MergeVersionedManyToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeVersionedManyToOneTest.php
@@ -21,6 +21,8 @@ class MergeVersionedManyToOneTest extends OrmFunctionalTestCase
     /**
      * This test case asserts that a detached and unmodified entity could be merge without firing
      * OptimisticLockException.
+     *
+     * @group legacy
      */
     public function testSetVersionOnCreate()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -83,7 +83,7 @@ class ProxiesLikeEntitiesTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(CmsUserProxy::class, $uninitializedProxy);
 
         $this->_em->persist($uninitializedProxy);
-        $this->_em->flush($uninitializedProxy);
+        $this->_em->flush();
         $this->assertFalse($uninitializedProxy->__isInitialized(), 'Proxy didn\'t get initialized during flush operations');
         $this->assertEquals($userId, $uninitializedProxy->getId());
         $this->_em->remove($uninitializedProxy);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -428,6 +428,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @group DDC-1519
+     * @group legacy
      */
     public function testMergeForeignKeyIdentifierEntity()
     {
@@ -435,7 +436,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $refRep = $this->_em->find(DDC117Reference::class, $idCriteria);
 
-        $this->_em->detach($refRep);
+        $this->_em->clear(DDC117Reference::class);
         $refRep = $this->_em->merge($refRep);
 
         $this->assertEquals($this->article1->id(), $refRep->source()->id());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1276Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1276Test.php
@@ -7,6 +7,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**
  * @group DDC-1276
+ * @group legacy
  */
 class DDC1276Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1383Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 /**
  * @group DDC-1383
+ * @group legacy
  */
 class DDC1383Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1392Test.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\UnitOfWork;
 
 /**
  * @group DDC-1392
+ * @group legacy
  */
 class DDC1392Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1509Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 /**
  * @group DDC-1509
+ * @group legacy
  */
 class DDC1509Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1594Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1594Test.php
@@ -6,6 +6,7 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 
 /**
  * @group DDC-1594
+ * @group legacy
  */
 class DDC1594Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1734Test.php
@@ -20,6 +20,7 @@ class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
      * This test is DDC-1734 minus the serialization, i.e. it works
      *
      * @group DDC-1734
+     * @group legacy
      */
     public function testMergeWorksOnNonSerializedProxies()
     {
@@ -50,6 +51,7 @@ class DDC1734Test extends \Doctrine\Tests\OrmFunctionalTestCase
      * - the entity is broken because it has no identifier and no field defined
      *
      * @group DDC-1734
+     * @group legacy
      */
     public function testMergeWorksOnSerializedProxies()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2106Test.php
@@ -26,7 +26,7 @@ class DDC2106Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $entity = new DDC2106Entity();
         $this->_em->persist($entity);
         $this->_em->flush();
-        $this->_em->detach($entity);
+        $this->_em->clear(DDC2106Entity::class);
         $entity = $this->_em->getRepository(DDC2106Entity::class)->findOneBy([]);
 
         // ... and a managed entity without id

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -10,6 +10,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
  * @group DDC-2230
+ * @group legacy
  */
 class DDC2230Test extends OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2409Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2409Test.php
@@ -8,6 +8,7 @@ use Doctrine\Tests\Models\CMS\CmsArticle;
 
 /**
  * @group DDC-2409
+ * @group legacy
  */
 class DDC2409Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -53,8 +54,8 @@ class DDC2409Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals(UnitOfWork::STATE_MANAGED, $uow->getEntityState($article));
         $this->assertEquals(UnitOfWork::STATE_NEW, $uow->getEntityState($user));
 
-        $em->detach($user);
-        $em->detach($article);
+        $em->clear(CmsUser::class);
+        $em->clear(CmsArticle::class);
 
         $userMerged     = $em->merge($user);
         $articleMerged  = $em->merge($article);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2645Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2645Test.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 /**
  * @group DDC-2645
+ * @group legacy
  */
 class DDC2645Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
@@ -45,7 +45,7 @@ class DDC2790Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // (and consequently also triggers preUpdate/postUpdate for the entity in question)
         $entity->name = 'Robin';
 
-        $this->_em->flush($entity);
+        $this->_em->flush();
 
         $qb = $this->_em->createQueryBuilder();
         $qb->from(get_class($entity), 'c');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php
@@ -40,7 +40,7 @@ class DDC2984Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $user->applyName('Alex');
 
         $this->_em->persist($user);
-        $this->_em->flush($user);
+        $this->_em->flush();
 
         $repository = $this->_em->getRepository(__NAMESPACE__ . "\DDC2984User");
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3699Test.php
@@ -18,6 +18,7 @@ class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @group DDC-3699
+     * @group legacy
      */
     public function testMergingParentClassFieldsDoesNotStopMergingScalarFieldsForToOneUninitializedAssociations()
     {
@@ -61,6 +62,7 @@ class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     /**
      * @group DDC-3699
+     * @group legacy
      */
     public function testMergingParentClassFieldsDoesNotStopMergingScalarFieldsForToManyUninitializedAssociations()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3711Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3711Test.php
@@ -9,6 +9,8 @@ use Doctrine\Tests\ORM\Mapping\YamlMappingDriverTest;
 
 /**
  * @author Marc Pantel <pantel.m@gmail.com>
+ *
+ * @group legacy
  */
 class DDC3711Test extends YamlMappingDriverTest
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC501Test.php
@@ -16,6 +16,8 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
  * @PHPUnit-Version 3.4.11
  *
  * @author markus
+ *
+ * @group legacy
  */
 class DDC501Test extends OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC518Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC518Test.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+/**
+ * @group legacy
+ */
 class DDC518Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC729Test.php
@@ -5,6 +5,9 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\PersistentCollection;
 
+/**
+ * @group legacy
+ */
 class DDC729Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     public function setUp()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC758Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC758Test.php
@@ -6,6 +6,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 
+/**
+ * @group legacy
+ */
 class DDC758Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -141,7 +141,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
 
         $person = new DDC93Person('Johannes', new DDC93Address('Moo', '12345', 'Karlsruhe', new DDC93Country('Germany')));
         $this->_em->persist($person);
-        $this->_em->flush($person);
+        $this->_em->flush();
 
         // SELECT
         $selectDql = "SELECT p FROM " . __NAMESPACE__ ."\\DDC93Person p WHERE p.address.city = :city AND p.address.country.name = :country";
@@ -184,7 +184,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
     {
         $person = new DDC93Person('Karl', new DDC93Address('Foo', '12345', 'Gosport', new DDC93Country('England')));
         $this->_em->persist($person);
-        $this->_em->flush($person);
+        $this->_em->flush();
         $this->_em->clear();
 
         // Prove that the entity was persisted correctly.
@@ -254,7 +254,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
     {
         $car = new DDC93Car(new DDC93Address('Foo', '12345', 'Asdf'));
         $this->_em->persist($car);
-        $this->_em->flush($car);
+        $this->_em->flush();
 
         $reloadedCar = $this->_em->find(DDC93Car::class, $car->id);
         $this->assertEquals($car, $reloadedCar);

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/YamlDriverTest.php
@@ -6,6 +6,7 @@ use \Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 
 /**
  * @group DDC-1418
+ * @group legacy
  */
 class YamlDriverTest extends AbstractDriverTest
 {

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -10,6 +10,9 @@ use Doctrine\Tests\Models\DirectoryTree\File;
 use Doctrine\Tests\Models\Generic\SerializationModel;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @group legacy
+ */
 class YamlMappingDriverTest extends AbstractMappingDriverTest
 {
     protected function _loadDriver()
@@ -76,6 +79,14 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
 
         $this->assertEquals(255, $nameField['length']);
         $this->assertEquals(255, $valueField['length']);
+    }
+
+    /**
+     * @expectedDeprecation YAML mapping driver is deprecated and will be removed in Doctrine 3.0, please migrate to annotation or XML driver.
+     */
+    public function testDeprecation() : void
+    {
+        $this->createClassMetadata(DDC2069Entity::class);
     }
 
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommandTest.php
@@ -7,6 +7,9 @@ use Doctrine\ORM\Tools\EntityGenerator;
 use Doctrine\Tests\OrmTestCase;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @group legacy
+ */
 class ConvertDoctrine1SchemaCommandTest extends OrmTestCase
 {
     public function testExecution()

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/GenerateRepositoriesCommandTest.php
@@ -14,6 +14,9 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
+/**
+ * @group legacy
+ */
 class GenerateRepositoriesCommandTest extends OrmFunctionalTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -39,6 +39,9 @@ class ConvertDoctrine1SchemaTest extends OrmTestCase
         return EntityManagerMock::create($conn, $config, $eventManager);
     }
 
+    /**
+     * @group legacy
+     */
     public function testTest()
     {
         if ( ! class_exists('Symfony\Component\Yaml\Yaml', true)) {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -13,6 +13,9 @@ use Doctrine\Tests\Models\DDC2372\DDC2372Admin;
 use Doctrine\Tests\Models\DDC2372\DDC2372User;
 use Doctrine\Tests\OrmTestCase;
 
+/**
+ * @group legacy
+ */
 class EntityGeneratorTest extends OrmTestCase
 {
 

--- a/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
@@ -11,6 +11,9 @@ use Doctrine\Tests\Models\DDC3231\DDC3231User1;
 use Doctrine\Tests\Models\DDC3231\DDC3231User2;
 use Doctrine\Tests\OrmTestCase;
 
+/**
+ * @group legacy
+ */
 class EntityRepositoryGeneratorTest extends OrmTestCase
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AnnotationClassMetadataExporterTest.php
@@ -11,6 +11,8 @@ namespace Doctrine\Tests\ORM\Tools\Export;
  * @link        http://www.phpdoctrine.org
  * @since       2.0
  * @version     $Revision$
+ *
+ * @group legacy
  */
 class AnnotationClassMetadataExporterTest extends AbstractClassMetadataExporterTest
 {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/PhpClassMetadataExporterTest.php
@@ -11,6 +11,8 @@ namespace Doctrine\Tests\ORM\Tools\Export;
  * @link        http://www.phpdoctrine.org
  * @since       2.0
  * @version     $Revision$
+ *
+ * @group legacy
  */
 class PhpClassMetadataExporterTest extends AbstractClassMetadataExporterTest
 {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/XmlClassMetadataExporterTest.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Tools\Export\Driver\XmlExporter;
  * @link        http://www.phpdoctrine.org
  * @since       2.0
  * @version     $Revision$
+ *
+ * @group legacy
  */
 class XmlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
 {

--- a/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/YamlClassMetadataExporterTest.php
@@ -11,6 +11,8 @@ namespace Doctrine\Tests\ORM\Tools\Export;
  * @link        http://www.phpdoctrine.org
  * @since       2.0
  * @version     $Revision$
+ *
+ * @group legacy
  */
 class YamlClassMetadataExporterTest extends AbstractClassMetadataExporterTest
 {

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -68,6 +68,9 @@ class SetupTest extends OrmTestCase
         $this->assertInstanceOf(XmlDriver::class, $config->getMetadataDriverImpl());
     }
 
+    /**
+     * @group legacy
+     */
     public function testYAMLConfiguration()
     {
         $config = Setup::createYAMLMetadataConfiguration([], true);

--- a/tests/travis/mariadb.travis.xml
+++ b/tests/travis/mariadb.travis.xml
@@ -39,6 +39,9 @@
             <group>locking_functional</group>
         </exclude>
     </groups>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
 </phpunit>
 

--- a/tests/travis/mysql.travis.xml
+++ b/tests/travis/mysql.travis.xml
@@ -39,6 +39,9 @@
             <group>locking_functional</group>
         </exclude>
     </groups>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
 </phpunit>
 

--- a/tests/travis/pgsql.travis.xml
+++ b/tests/travis/pgsql.travis.xml
@@ -42,5 +42,8 @@
             <group>locking_functional</group>
         </exclude>
     </groups>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
 </phpunit>

--- a/tests/travis/sqlite.travis.xml
+++ b/tests/travis/sqlite.travis.xml
@@ -26,5 +26,8 @@
          <group>locking_functional</group>
       </exclude>
     </groups>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 
 </phpunit>


### PR DESCRIPTION
Based on UPGRADE document for 3.0.

Deprecations added for:
* EntityManager::copy() method
* EntityManager::merge() method
* EntityManager::detach() method
* EntityManager::flush() calls with arguments
* YAML mapping driver
* Version class
* Proxy interface
* Configuration::getProxy*()
* ProxyFactory
* proxy Autoloader

I have not added any notes about mapping/metadata changes here because it's still pretty unstable.

Tests marked as `@legacy` use any of the deprecated methods.
Added explicit deprecation tests for deprecated methods.

~I'd like to get these into 2.6, there is no reason to delay it.~