### PR TITLE
Introduce EntityRepositoryInterface, ancestor for custom repositories

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -411,7 +411,7 @@ implementations.
 Default Repository (***OPTIONAL***)
 -----------------------------------
 
-Specifies the FQCN of a subclass of the EntityRepository.
+Specifies the FQCN of a class implementing EntityRepositoryInterface.
 That will be available for all entities without a custom repository class.
 
 .. code-block:: php
@@ -421,7 +421,7 @@ That will be available for all entities without a custom repository class.
     $config->getDefaultRepositoryClassName();
 
 The default value is ``Doctrine\ORM\EntityRepository``.
-Any repository class must be a subclass of EntityRepository otherwise you got an ORMException
+Any repository class must implement EntityRepositoryInterface otherwise you got an ORMException
 
 Setting up the Console
 ----------------------

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -377,8 +377,8 @@ the persistence of all classes marked as entities.
 
 Optional attributes:
 
--  **repositoryClass**: Specifies the FQCN of a subclass of the
-   EntityRepository. Use of repositories for entities is encouraged to keep
+-  **repositoryClass**: Specifies the FQCN of a class implementing the
+   EntityRepositoryInterface. Use of repositories for entities is encouraged to keep
    specialized DQL and SQL operations separated from the Model/Domain
    Layer.
 -  **readOnly**: (>= 2.1) Specifies that this entity is marked as read only and not
@@ -799,7 +799,7 @@ The @MappedSuperclass annotation cannot be used in conjunction with
 
 Optional attributes:
 
--  **repositoryClass**: (>= 2.2) Specifies the FQCN of a subclass of the EntityRepository.
+-  **repositoryClass**: (>= 2.2) Specifies the FQCN of a class implementing the EntityRepositoryInterface.
    That will be inherited for all subclasses of that Mapped Superclass.
 
 Example:

--- a/docs/en/reference/working-with-associations.rst
+++ b/docs/en/reference/working-with-associations.rst
@@ -362,7 +362,7 @@ the details inside the classes can be challenging.
 This will however always initialize the collection, with all the
 performance penalties given the size. In some scenarios of large
 collections it might even be a good idea to completely hide the
-read access behind methods on the EntityRepository.
+read access behind methods on the EntityRepositoryInterface.
 
 There is no single, best way for association management. It greatly
 depends on the requirements of your concrete domain model as well

--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -562,7 +562,7 @@ following:
 ``EntityManager#getRepository($entityName)`` returns a repository
 object which provides many ways to retrieve entities of the
 specified type. By default, the repository instance is of type
-``Doctrine\ORM\EntityRepository``. You can also use custom
+``Doctrine\ORM\EntityRepositoryInterface``. You can also use custom
 repository classes as shown later.
 
 By Simple Conditions
@@ -594,7 +594,7 @@ You can also load by owning side associations through the repository:
     $number = $em->find('MyProject\Domain\Phonenumber', 1234);
     $user = $em->getRepository('MyProject\Domain\User')->findOneBy(array('phone' => $number->getId()));
 
-The ``EntityRepository#findBy()`` method additionally accepts orderings, limit and offset as second to fourth parameters:
+The ``EntityRepositoryInterface#findBy()`` method additionally accepts orderings, limit and offset as second to fourth parameters:
 
 .. code-block:: php
 
@@ -609,7 +609,7 @@ If you pass an array of values Doctrine will convert the query into a WHERE fiel
     $users = $em->getRepository('MyProject\Domain\User')->findBy(array('age' => array(20, 30, 40)));
     // translates roughly to: SELECT * FROM users WHERE age IN (20, 30, 40)
 
-An EntityRepository also provides a mechanism for more concise
+An EntityRepositoryInterface also provides a mechanism for more concise
 calls through its use of ``__call``. Thus, the following two
 examples are equivalent:
 
@@ -707,7 +707,7 @@ Custom Repositories
 ~~~~~~~~~~~~~~~~~~~
 
 By default the EntityManager returns a default implementation of
-``Doctrine\ORM\EntityRepository`` when you call
+``Doctrine\ORM\EntityRepositoryInterface`` when you call
 ``EntityManager#getRepository($entityClass)``. You can overwrite
 this behaviour by specifying the class name of your own Entity
 Repository in the Annotation, XML or YAML metadata. In large

--- a/docs/en/reference/xml-mapping.rst
+++ b/docs/en/reference/xml-mapping.rst
@@ -200,7 +200,7 @@ Optional attributes:
 -  **table** - The Table-Name to be used for this entity. Otherwise the
    Unqualified Class-Name is used by default.
 -  **repository-class** - The fully qualified class-name of an
-   alternative ``Doctrine\ORM\EntityRepository`` implementation to be
+   alternative ``Doctrine\ORM\EntityRepositoryInterface`` implementation to be
    used with this entity.
 -  **inheritance-type** - The type of inheritance, defaults to none. A
    more detailed description follows in the

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -1425,8 +1425,8 @@ example querying for all closed bugs:
         // do stuff
     }
 
-Compared to DQL these query methods are falling short of functionality very fast.
-Doctrine offers you a convenient way to extend the functionalities of the default ``EntityRepository``
+Compared to DQL these query methods are falling short of functionality very fast. Doctrine offers
+you a convenient way to extend the functionalities of the default ``EntityRepositoryInterface``
 and put all the specialized DQL query logic on it. For this you have to create a subclass
 of ``Doctrine\ORM\EntityRepository``, in our case a ``BugRepository`` and group all
 the previously discussed query functionality in it:
@@ -1515,7 +1515,7 @@ we have to adjust the metadata slightly.
           type: entity
           repositoryClass: BugRepository
 
-Now we can remove our query logic in all the places and instead use them through the EntityRepository.
+Now we can remove our query logic in all the places and instead use them through the repository.
 As an example here is the code of the first use case "List of Bugs":
 
 .. code-block:: php

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -588,13 +588,13 @@ class Configuration extends DBALConfiguration
      *
      * @since 2.2
      *
-     * @throws ORMException If not is a \Doctrine\Common\Persistence\ObjectRepository implementation
+     * @throws ORMException If not is a \Doctrine\ORM\EntityRepositoryInterface implementation
      */
     public function setDefaultRepositoryClassName(string $repositoryClassName) : void
     {
         $reflectionClass = new \ReflectionClass($repositoryClassName);
 
-        if ( ! $reflectionClass->implementsInterface(ObjectRepository::class)) {
+        if ( ! $reflectionClass->implementsInterface(EntityRepositoryInterface::class)) {
             throw ORMException::invalidEntityRepository($repositoryClassName);
         }
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -717,7 +717,7 @@ final class EntityManager implements EntityManagerInterface
      *
      * @param string $entityName The name of the entity.
      *
-     * @return \Doctrine\Common\Persistence\ObjectRepository|\Doctrine\ORM\EntityRepository The repository class.
+     * @return EntityRepositoryInterface The repository class.
      */
     public function getRepository($entityName)
     {

--- a/lib/Doctrine/ORM/EntityRepositoryInterface.php
+++ b/lib/Doctrine/ORM/EntityRepositoryInterface.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\Query\ResultSetMappingBuilder;
+
+interface EntityRepositoryInterface extends ObjectRepository, Selectable
+{
+    /**
+     * Creates a new QueryBuilder instance that is prepopulated for this entity name.
+     *
+     * @param string $alias
+     * @param string $indexBy The index for the from.
+     *
+     * @return QueryBuilder
+     */
+    public function createQueryBuilder($alias, $indexBy = null) : QueryBuilder;
+
+    /**
+     * Creates a new result set mapping builder for this entity.
+     * The column naming strategy is "INCREMENT".
+     *
+     * @param string $alias
+     *
+     * @return ResultSetMappingBuilder
+     */
+    public function createResultSetMappingBuilder($alias) : ResultSetMappingBuilder;
+
+    /**
+     * Creates a new Query instance based on a predefined metadata named query.
+     *
+     * @param string $queryName
+     *
+     * @return Query
+     */
+    public function createNamedQuery($queryName) : Query;
+
+    /**
+     * Creates a native SQL query.
+     *
+     * @param string $queryName
+     *
+     * @return NativeQuery
+     */
+    public function createNativeNamedQuery($queryName) : NativeQuery;
+
+    /**
+     * Clears the repository, causing all managed entities to become detached.
+     *
+     * @return void
+     */
+    public function clear() : void;
+
+    /**
+     * Finds an entity by its primary key / identifier.
+     *
+     * @param mixed $id The identifier.
+     * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                              or NULL if no specific lock mode should be used
+     *                              during the search.
+     * @param int|null $lockVersion The lock version.
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
+     */
+    public function find($id, $lockMode = null, $lockVersion = null) : ?object;
+
+    /**
+     * Finds all entities in the repository.
+     *
+     * @return object[] The entities.
+     */
+    public function findAll() : array;
+
+    /**
+     * Finds entities by a set of criteria.
+     *
+     * @param mixed[]  $criteria
+     * @param string[] $orderBy
+     * @param int|null $limit
+     * @param int|null $offset
+     *
+     * @return object[] The objects.
+     *
+     * @todo guilhermeblanco Change orderBy to use a blank array by default (requires Common\Persistence change).
+     */
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null) : array;
+
+    /**
+     * Finds a single entity by a set of criteria.
+     *
+     * @param string[] $criteria
+     * @param string[] $orderBy
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
+     */
+    public function findOneBy(array $criteria, array $orderBy = []) : ?object;
+
+    /**
+     * Counts entities by a set of criteria.
+     *
+     * @param Criteria[] $criteria
+     *
+     * @return int The cardinality of the objects that match the given criteria.
+     *
+     * @todo Add this method to `ObjectRepository` interface in the next major release
+     */
+    public function count(array $criteria) : int;
+
+    public function getClassName() : string;
+
+    /**
+     * Select all elements from a selectable that match the expression and
+     * return a new collection containing these elements.
+     */
+    public function matching(Criteria $criteria) : Collection;
+}

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -280,7 +280,7 @@ class ORMException extends Exception
      */
     public static function invalidEntityRepository($className)
     {
-        return new self("Invalid repository class '".$className."'. It must be a Doctrine\Common\Persistence\ObjectRepository.");
+        return new self("Invalid repository class '" . $className . "'. It must be a " . EntityRepositoryInterface::class . '.');
     }
 
     /**

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepositoryInterface;
 
 /**
  * This factory is used to create default repository objects for entities at runtime.
@@ -17,14 +18,14 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * The list of EntityRepository instances.
      *
-     * @var \Doctrine\Common\Persistence\ObjectRepository[]
+     * @var \Doctrine\ORM\EntityRepositoryInterface[]
      */
     private $repositoryList = [];
 
     /**
      * {@inheritdoc}
      */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    public function getRepository(EntityManagerInterface $entityManager, string $entityName) : EntityRepositoryInterface
     {
         $repositoryHash = $entityManager->getClassMetadata($entityName)->getClassName() . spl_object_id($entityManager);
 
@@ -38,12 +39,10 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * Create a new repository instance for an entity class.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string                               $entityName    The name of the entity.
-     *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @param EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                 $entityName    The name of the entity.
      */
-    private function createRepository(EntityManagerInterface $entityManager, $entityName)
+    private function createRepository(EntityManagerInterface $entityManager, string $entityName) : EntityRepositoryInterface
     {
         /* @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
         $metadata            = $entityManager->getClassMetadata($entityName);

--- a/lib/Doctrine/ORM/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/RepositoryFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepositoryInterface;
 
 /**
  * Interface for entity repository factory.
@@ -17,10 +18,8 @@ interface RepositoryFactory
     /**
      * Gets the repository for an entity class.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string                               $entityName    The name of the entity.
-     *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @param EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                 $entityName    The name of the entity.
      */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName);
+    public function getRepository(EntityManagerInterface $entityManager, string $entityName) : EntityRepositoryInterface;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -646,7 +646,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
     /**
      * @group DDC-753
      * @expectedException Doctrine\ORM\ORMException
-     * @expectedExceptionMessage Invalid repository class 'Doctrine\Tests\Models\DDC753\DDC753InvalidRepository'. It must be a Doctrine\Common\Persistence\ObjectRepository.
+     * @expectedExceptionMessage Invalid repository class 'Doctrine\Tests\Models\DDC753\DDC753InvalidRepository'. It must be a Doctrine\ORM\EntityRepositoryInterface.
      */
     public function testSetDefaultRepositoryInvalidClassError()
     {


### PR DESCRIPTION
Introducing a common ancestor for custom repositories.
Currently there is a slight mess, some pieces of code only specify ObjectRepository which:
a) is insufficient since it's missing Selectable;
b) is incorrect since following code expects EntityRepository.

I've taken the opportunity to also add return types to the interface and default repository. Also  updated some phpDocs - specialized `array` and removed duplicate information.

This change should not affect 99.9% of user code since almost everyone extends EntityRepository, but allows 1% to use custom repositories in fancier way.

TODO:
* [ ] constructor should be part of the interface or made parameterless
* [ ] make Scrutinizer happy