### PR TITLE
Replace spl_object_hash() with more efficient spl_object_id()

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -54,7 +54,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
 
         $this->persister->delete($collection);
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = $key;
+        $this->queuedCache['delete'][spl_object_id($collection)] = $key;
     }
 
     /**
@@ -78,14 +78,14 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
             ($this->association instanceof ToManyAssociationMetadata && $this->association->getOrderBy())) {
             $this->persister->update($collection);
 
-            $this->queuedCache['delete'][spl_object_hash($collection)] = $key;
+            $this->queuedCache['delete'][spl_object_id($collection)] = $key;
 
             return;
         }
 
         $this->persister->update($collection);
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = [
+        $this->queuedCache['update'][spl_object_id($collection)] = [
             'key'   => $key,
             'list'  => $collection
         ];

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -90,7 +90,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = [
+        $this->queuedCache['delete'][spl_object_id($collection)] = [
             'key'   => $key,
             'lock'  => $lock
         ];
@@ -118,7 +118,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = [
+        $this->queuedCache['update'][spl_object_id($collection)] = [
             'key'   => $key,
             'lock'  => $lock
         ];

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -172,7 +172,7 @@ class ObjectHydrator extends AbstractHydrator
         /** @var ToManyAssociationMetadata $association */
         $association = $class->getProperty($fieldName);
         $value       = $association->getValue($entity);
-        $oid         = spl_object_hash($entity);
+        $oid         = spl_object_id($entity);
 
         if (! $value instanceof PersistentCollection) {
             $value = $association->wrap($entity, $value, $this->em);
@@ -343,7 +343,7 @@ class ObjectHydrator extends AbstractHydrator
                     continue;
                 }
 
-                $oid = spl_object_hash($parentObject);
+                $oid = spl_object_id($parentObject);
 
                 // Check the type of the relation (many or single-valued)
                 if (! ($association instanceof ToOneAssociationMetadata)) {
@@ -421,7 +421,7 @@ class ObjectHydrator extends AbstractHydrator
                                         $inverseAssociation->setValue($element, $parentObject);
 
                                         $this->uow->setOriginalEntityProperty(
-                                            spl_object_hash($element),
+                                            spl_object_id($element),
                                             $inverseAssociation->getName(),
                                             $parentObject
                                         );
@@ -434,7 +434,7 @@ class ObjectHydrator extends AbstractHydrator
                                 $inverseAssociation->setValue($element, $parentObject);
 
                                 $this->uow->setOriginalEntityProperty(
-                                    spl_object_hash($element),
+                                    spl_object_id($element),
                                     $mappedBy,
                                     $parentObject
                                 );

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -308,7 +308,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
      */
     public function __toString()
     {
-        return __CLASS__ . '@' . spl_object_hash($this);
+        return __CLASS__ . '@' . spl_object_id($this);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
@@ -128,7 +128,7 @@ class DriverChain implements MappingDriver
 
         /* @var $driver MappingDriver */
         foreach ($this->drivers as $namespace => $driver) {
-            $oid = spl_object_hash($driver);
+            $oid = spl_object_id($driver);
 
             if (!isset($driverClasses[$oid])) {
                 $driverClasses[$oid] = $driver->getAllClassNames();

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -249,7 +249,7 @@ class ORMInvalidArgumentException extends \InvalidArgumentException
      */
     private static function objToStr($obj) : string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj).'@'.spl_object_hash($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj).'@'.spl_object_id($obj);
     }
 
     /**

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -160,7 +160,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             $inversedAssociation->setValue($element, $this->owner);
 
             $this->em->getUnitOfWork()->setOriginalEntityProperty(
-                spl_object_hash($element), $this->backRefFieldName, $this->owner
+                spl_object_id($element), $this->backRefFieldName, $this->owner
             );
         }
     }
@@ -187,7 +187,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             $inversedAssociation->setValue($element, $this->owner);
 
             $this->em->getUnitOfWork()->setOriginalEntityProperty(
-                spl_object_hash($element), $this->backRefFieldName, $this->owner
+                spl_object_id($element), $this->backRefFieldName, $this->owner
             );
         }
     }
@@ -243,8 +243,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $collectionItems = $this->collection->toArray();
 
         return \array_values(\array_diff_key(
-            \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot),
-            \array_combine(\array_map('spl_object_hash', $collectionItems), $collectionItems)
+            \array_combine(\array_map('spl_object_id', $this->snapshot), $this->snapshot),
+            \array_combine(\array_map('spl_object_id', $collectionItems), $collectionItems)
         ));
     }
 
@@ -259,8 +259,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         $collectionItems = $this->collection->toArray();
 
         return \array_values(\array_diff_key(
-            \array_combine(\array_map('spl_object_hash', $collectionItems), $collectionItems),
-            \array_combine(\array_map('spl_object_hash', $this->snapshot), $this->snapshot)
+            \array_combine(\array_map('spl_object_id', $collectionItems), $collectionItems),
+            \array_combine(\array_map('spl_object_id', $this->snapshot), $this->snapshot)
         ));
     }
 
@@ -722,7 +722,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * @param object[] $newObjects
      *
-     * Note: the only reason why this entire looping/complexity is performed via `spl_object_hash`
+     * Note: the only reason why this entire looping/complexity is performed via `spl_object_id`
      *       is because we want to prevent using `array_udiff()`, which is likely to cause very
      *       high overhead (complexity of O(n^2)). `array_diff_key()` performs the operation in
      *       core, which is faster than using a callback for comparisons
@@ -730,8 +730,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     private function restoreNewObjectsInDirtyCollection(array $newObjects) : void
     {
         $loadedObjects               = $this->collection->toArray();
-        $newObjectsByOid             = \array_combine(\array_map('spl_object_hash', $newObjects), $newObjects);
-        $loadedObjectsByOid          = \array_combine(\array_map('spl_object_hash', $loadedObjects), $loadedObjects);
+        $newObjectsByOid             = \array_combine(\array_map('spl_object_id', $newObjects), $newObjects);
+        $loadedObjectsByOid          = \array_combine(\array_map('spl_object_id', $loadedObjects), $loadedObjects);
         $newObjectsThatWereNotLoaded = \array_diff_key($newObjectsByOid, $loadedObjectsByOid);
 
         if ($newObjectsThatWereNotLoaded) {

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -26,7 +26,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName)
     {
-        $repositoryHash = $entityManager->getClassMetadata($entityName)->getClassName() . spl_object_hash($entityManager);
+        $repositoryHash = $entityManager->getClassMetadata($entityName)->getClassName() . spl_object_id($entityManager);
 
         if (isset($this->repositoryList[$repositoryHash])) {
             return $this->repositoryList[$repositoryHash];

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -79,7 +79,7 @@ class DebugUnitOfWorkListener
             fwrite($fh, "Class: ". $className . "\n");
 
             foreach ($map as $entity) {
-                fwrite($fh, " Entity: " . $this->getIdString($entity, $uow) . " " . spl_object_hash($entity)."\n");
+                fwrite($fh, " Entity: " . $this->getIdString($entity, $uow) . " " . spl_object_id($entity)."\n");
                 fwrite($fh, "  Associations:\n");
 
                 $cm = $em->getClassMetadata($className);
@@ -104,7 +104,7 @@ class DebugUnitOfWorkListener
                             fwrite($fh, "[PROXY] ");
                         }
 
-                        fwrite($fh, $this->getIdString($value, $uow) . " " . spl_object_hash($value) . "\n");
+                        fwrite($fh, $this->getIdString($value, $uow) . " " . spl_object_id($value) . "\n");
                     } else {
                         $initialized = !($value instanceof PersistentCollection) || $value->isInitialized();
 
@@ -112,13 +112,13 @@ class DebugUnitOfWorkListener
                             fwrite($fh, "[INITIALIZED] " . $this->getType($value). " " . count($value) . " elements\n");
 
                             foreach ($value as $obj) {
-                                fwrite($fh, "    " . $this->getIdString($obj, $uow) . " " . spl_object_hash($obj)."\n");
+                                fwrite($fh, "    " . $this->getIdString($obj, $uow) . " " . spl_object_id($obj)."\n");
                             }
                         } else {
                             fwrite($fh, "[PROXY] " . $this->getType($value) . " unknown element size\n");
 
                             foreach ($value->unwrap() as $obj) {
-                                fwrite($fh, "    " . $this->getIdString($obj, $uow) . " " . spl_object_hash($obj)."\n");
+                                fwrite($fh, "    " . $this->getIdString($obj, $uow) . " " . spl_object_id($obj)."\n");
                             }
                         }
                     }

--- a/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
+++ b/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
@@ -35,7 +35,7 @@ class UnitOfWorkMock extends UnitOfWork
      */
     public function & getEntityChangeSet($entity)
     {
-        $oid = spl_object_hash($entity);
+        $oid = spl_object_id($entity);
 
         if (isset($this->mockDataChangeSets[$oid])) {
             return $this->mockDataChangeSets[$oid];


### PR DESCRIPTION
Simple function name replacement.
 spl_object_id() returns numeric id instead of string hash so it's a simple win, both memory and time-wise.