### PR TITLE
[Parameter] Deprecate names starting or ending with a colon

### DIFF
--- a/lib/Doctrine/ORM/Query/Parameter.php
+++ b/lib/Doctrine/ORM/Query/Parameter.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query;
 
+use function preg_match;
+use function trigger_error;
 use function trim;
 
 /**
@@ -67,6 +69,10 @@ class Parameter
      */
     public function __construct($name, $value, $type = null)
     {
+        if (preg_match('/^:|:$/', $name)) {
+            @trigger_error('Starting or ending a parameter name with ":" is deprecated since 2.7 and will cause an error in 3.0', E_USER_DEPRECATED);
+        }
+
         $this->name          = trim($name, ':');
         $this->typeSpecified = $type !== null;
 

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Query;
+
+use Doctrine\ORM\Query\Parameter;
+use Doctrine\Tests\DoctrineTestCase;
+use Doctrine\Tests\VerifyDeprecations;
+
+final class ParameterTest extends DoctrineTestCase
+{
+    use VerifyDeprecations;
+
+    /**
+     * @test
+     * @group GH6880
+     */
+    public function deprecationMustBeTriggeredWhenUsingColonInParameterNames() : void
+    {
+        $this->expectDeprecationMessage('Starting or ending a parameter name with ":" is deprecated since 2.7 and will cause an error in 3.0');
+        new Parameter(':user_name', 'Testing');
+
+        $this->expectDeprecationMessage('Starting or ending a parameter name with ":" is deprecated since 2.7 and will cause an error in 3.0');
+        new Parameter('user_name:', 'Testing');
+
+        $this->expectDeprecationMessage('Starting or ending a parameter name with ":" is deprecated since 2.7 and will cause an error in 3.0');
+        new Parameter(':user_name:', 'Testing');
+    }
+}


### PR DESCRIPTION
As requested by @Majkl578 in https://github.com/doctrine/doctrine2/pull/5996

I wasn't able to make a test as I don't know how to test a deprecation message without the @expectedDeprecation annotation of the Symfony PHPUnit Bridge ^^