### PR TITLE
Use stable packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,10 @@ jobs:
       install: travis_retry composer update --prefer-dist --prefer-lowest
 
     - stage: Test
-      env: DB=sqlite DEPENDENCIES=stable
-      install: travis_retry composer update --prefer-dist --prefer-stable
+      env: DB=sqlite STABILITY=dev
+      install:
+        - composer config minimum-stability $STABILITY
+        - travis_retry composer update --prefer-dist
 
     - stage: Test
       env: DB=sqlite COVERAGE
@@ -91,6 +93,7 @@ jobs:
 
   allow_failures:
     - php: nightly
+    - env: DB=sqlite STABILITY=dev
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ jobs:
       install: travis_retry composer update --prefer-dist --prefer-lowest
 
     - stage: Test
-      env: DB=sqlite STABILITY=dev
+      if: type = cron
+      env: DB=sqlite
       install:
-        - composer config minimum-stability $STABILITY
+        - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
 
     - stage: Test
@@ -93,7 +94,6 @@ jobs:
 
   allow_failures:
     - php: nightly
-    - env: DB=sqlite STABILITY=dev
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
 
     - stage: Test
       if: type = cron
-      env: DB=sqlite
+      env: DB=sqlite DEV_DEPENDENCIES
       install:
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         {"name": "Jonathan Wage", "email": "jonwage@gmail.com"},
         {"name": "Marco Pivetta", "email": "ocramius@gmail.com"}
     ],
-    "minimum-stability": "dev",
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
This will make it easier to contribute. It will also make reviews safer
since you will be able to tell if a PR is reponsible for a broken build
or not. Catching errors early is still possible by having a look at
allowed failures.