### PR TITLE
Clean elses

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -617,9 +617,9 @@ class Expr
             return (string) $literal;
         } else if (is_bool($literal)) {
             return $literal ? "true" : "false";
-        } else {
-            return "'" . str_replace("'", "''", $literal) . "'";
         }
+
+        return "'" . str_replace("'", "''", $literal) . "'";
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/DriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverMock.php
@@ -48,9 +48,9 @@ class DriverMock implements Driver
     {
         if ($this->_schemaManagerMock == null) {
             return new SchemaManagerMock($conn);
-        } else {
-            return $this->_schemaManagerMock;
         }
+
+        return $this->_schemaManagerMock;
     }
 
     /* MOCK API */

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -53,9 +53,9 @@ class StatementArrayMock extends StatementMock
         if ($current) {
             next($this->_result);
             return reset($current);
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     public function rowCount()


### PR DESCRIPTION
I've cleaned up some `else`s when we've already returned something :put_litter_in_its_place: 