### PR TITLE
Setup: Switch Apc -> Apcu and Memcache -> Memcached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
       env: DB=none STATIC_ANALYSIS
       install: travis_retry composer update --prefer-dist --prefer-stable
       before_script:
+        - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
       script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,6 +21,15 @@ Method `Doctrine\ORM\Query\Parser#overwriteInternalDQLFunctionNotAllowed()` was
 removed because of the choice to allow users to overwrite internal functions, ie
 `AVG`, `SUM`, `COUNT`, `MIN` and `MAX`. [#6500](https://github.com/doctrine/doctrine2/pull/6500)
 
+## PHP 7.1 is now required
+
+Doctrine 2.6 now requires PHP 7.1 or newer.
+
+As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Configuration() was changed:
+- APCu extension (ext-apcu) will now be used instead of abandoned APC (ext-apc).
+- Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
+- XCache support was dropped as it doesn't work with PHP 7.
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -165,19 +165,16 @@ class Setup
             return new ArrayCache();
         }
 
-        if (extension_loaded('apc')) {
-            return new \Doctrine\Common\Cache\ApcCache();
+        if (extension_loaded('apcu')) {
+            return new \Doctrine\Common\Cache\ApcuCache();
         }
 
-        if (ini_get('xcache.cacher')) {
-            return new \Doctrine\Common\Cache\XcacheCache();
-        }
 
-        if (extension_loaded('memcache')) {
-            $memcache = new \Memcache();
-            $memcache->connect('127.0.0.1');
+        if (extension_loaded('memcached')) {
+            $memcache = new \Memcached();
+            $memcache->addServer('127.0.0.1', 11211);
 
-            $cache = new \Doctrine\Common\Cache\MemcacheCache();
+            $cache = new \Doctrine\Common\Cache\MemcachedCache();
             $cache->setMemcache($memcache);
 
             return $cache;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,3 @@ parameters:
     earlyTerminatingMethodCalls:
         Doctrine\ORM\Query\Parser:
             - syntaxError
-    ignoreErrors:
-        # Memcache does not exist on PHP 7
-        - '#Instantiated class Memcache not found#'


### PR DESCRIPTION
Quick fix for 2.6 release.
Without this change it would be impossible to autoconfigure APC/Memcache since previous extensions do not exist anymore in 7.1 world [1][2]. Removed XCache, never upgraded to PHP 7 [3].

Marked as BC break, but it's really not one since those extensions wouldn't just work - this is actually _broken_ by requiring PHP 7.1.

[1] https://pecl.php.net/package-changelog.php?package=APC&release=3.1.13
[2] https://pecl.php.net/package-changelog.php?package=memcache&release=3.0.8
[3] https://xcache.lighttpd.net/