### PR TITLE
Travis: Moved coverage stage back to Code Quality group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
 
-    - stage: Test
+    - stage: Code Quality
       env: DB=sqlite COVERAGE
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}


### PR DESCRIPTION
Was moved as part of  #6896, probably accidentally. It slows Test stage from 2-3min to 7-8min. If that was intentional, feel free to close right away. 😊 

(Getting tired of these false positives on Scrutinizer... 😢 )