### PR TITLE
[CS] Heredoc to Nowdoc

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -35,7 +35,7 @@ class CollectionRegionCommand extends Command
         ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.');
 
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear a second-level cache collection regions for an associated Entity Manager.
 It is possible to delete/invalidate all collection region, a specific collection region or flushes the cache provider.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -34,7 +34,7 @@ class EntityRegionCommand extends Command
         ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.');
 
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear a second-level cache entity region for an associated Entity Manager.
 It is possible to delete/invalidate all entity region, a specific entity region or flushes the cache provider.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -40,7 +40,7 @@ class MetadataCommand extends Command
             ]
         );
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear the metadata cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -40,7 +40,7 @@ class QueryCommand extends Command
             ]
         );
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear the query cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -33,7 +33,7 @@ class QueryRegionCommand extends Command
         ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.');
 
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear a second-level cache query region for an associated Entity Manager.
 It is possible to delete/invalidate all query region, a specific query region or flushes the cache provider.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -40,7 +40,7 @@ class ResultCommand extends Command
             ]
         );
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command is meant to clear the result cache of associated Entity Manager.
 It is possible to invalidate all cache entries at once - called delete -, or flushes the cache provider
 instance completely.

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -39,7 +39,7 @@ class EnsureProductionSettingsCommand extends Command
                 )
             ]
         )
-        ->setHelp(<<<EOT
+        ->setHelp(<<<'EOT'
 Verify that Doctrine is properly configured for a production environment.
 EOT
         );

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -44,7 +44,7 @@ class GenerateProxiesCommand extends Command
                 ),
             ]
         )
-        ->setHelp(<<<EOT
+        ->setHelp(<<<'EOT'
 Generates proxy classes for entity classes.
 EOT
         );

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -26,7 +26,7 @@ class InfoCommand extends Command
         $this
             ->setName('orm:info')
             ->setDescription('Show basic information about all mapped entities')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The <info>%command.name%</info> shows basic information about which
 entities exist and possibly if their mapping information contains errors or
 not.

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -36,7 +36,7 @@ final class MappingDescribeCommand extends Command
             ->setName('orm:mapping:describe')
             ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
             ->setDescription('Display information about mapped objects')
-            ->setHelp(<<<EOT
+            ->setHelp(<<<'EOT'
 The %command.full_name% command describes the metadata for the given full or partial entity class name.
 
     <info>%command.full_name%</info> My\Namespace\Entity\MyEntity

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -57,7 +57,7 @@ class RunDqlCommand extends Command
                 )
             ]
         )
-        ->setHelp(<<<EOT
+        ->setHelp(<<<'EOT'
 Executes arbitrary DQL directly from the command line.
 EOT
         );

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -39,14 +39,14 @@ class CreateCommand extends AbstractCommand
                 )
             ]
         )
-        ->setHelp(<<<EOT
+        ->setHelp(<<<'EOT'
 Processes the schema and either create it directly on EntityManager Storage Connection or generate the SQL output.
 
 <comment>Hint:</comment> If you have a database with tables that should not be managed
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    \$config->setFilterSchemaAssetsExpression(\$regexp);
+    $config->setFilterSchemaAssetsExpression($regexp);
 EOT
         );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -47,7 +47,7 @@ class DropCommand extends AbstractCommand
                 ),
             ]
         )
-        ->setHelp(<<<EOT
+        ->setHelp(<<<'EOT'
 Processes the schema and either drop the database schema of EntityManager Storage Connection or generate the SQL output.
 Beware that the complete database is dropped by this command, even tables that are not relevant to your metadata model.
 
@@ -55,7 +55,7 @@ Beware that the complete database is dropped by this command, even tables that a
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    \$config->setFilterSchemaAssetsExpression(\$regexp);
+    $config->setFilterSchemaAssetsExpression($regexp);
 EOT
         );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -56,7 +56,7 @@ class UpdateCommand extends AbstractCommand
             ]
         );
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(<<<'EOT'
 The <info>%command.name%</info> command generates the SQL needed to
 synchronize the database schema with the current mapping metadata of the
 default entity manager.
@@ -84,7 +84,7 @@ described by any metadata.
 by the ORM, you can use a DBAL functionality to filter the tables and sequences down
 on a global level:
 
-    \$config->setFilterSchemaAssetsExpression(\$regexp);
+    $config->setFilterSchemaAssetsExpression($regexp);
 EOT
         );
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -44,7 +44,7 @@ class ValidateSchemaCommand extends Command
             'Skip checking if the mapping is in sync with the database'
         )
         ->setHelp(
-            <<<EOT
+            <<<'EOT'
 'Validate that the mapping files are correct and in sync with the database.'
 EOT
         );


### PR DESCRIPTION
Nowdocs aren't parsed, so the developer immediately knows that they don't cointain interpreted variable; hence are faster to read and maintain.

The porting was done with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rules `escape_implicit_backslashes` and `heredoc_to_nowdoc`, so only heredocs - even with dollar signs and backslashes - eligible to the change were fixed.