### PR TITLE
[CS] Prefer `elseif` over `else if`

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -110,7 +110,7 @@ class ArrayHydrator extends AbstractHydrator
                     $first = reset($this->resultPointers);
                     // TODO: Exception if $key === null ?
                     $baseElement =& $this->resultPointers[$parent][key($first)];
-                } else if (isset($this->resultPointers[$parent])) {
+                } elseif (isset($this->resultPointers[$parent])) {
                     $baseElement =& $this->resultPointers[$parent];
                 } else {
                     unset($this->resultPointers[$dqlAlias]); // Ticket #1228
@@ -157,7 +157,7 @@ class ArrayHydrator extends AbstractHydrator
                         ( ! isset($baseElement[$relationAlias]))
                     ) {
                         $baseElement[$relationAlias] = null;
-                    } else if ( ! isset($baseElement[$relationAlias])) {
+                    } elseif ( ! isset($baseElement[$relationAlias])) {
                         $baseElement[$relationAlias] = $data;
                     }
                 }

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -183,7 +183,7 @@ class ObjectHydrator extends AbstractHydrator
             $this->uow->setOriginalEntityProperty($oid, $fieldName, $value);
 
             $this->initializedCollections[$oid . $fieldName] = $value;
-        } else if (
+        } elseif (
             isset($this->hints[Query::HINT_REFRESH]) ||
             (isset($this->hints['fetched'][$parentDqlAlias][$fieldName]) && ! $value->isInitialized())
         ) {
@@ -329,7 +329,7 @@ class ObjectHydrator extends AbstractHydrator
                 if ($this->rsm->isMixed && isset($this->rootAliases[$parentAlias])) {
                     $objectClass = $this->resultPointers[$parentAlias];
                     $parentObject = $objectClass[key($objectClass)];
-                } else if (isset($this->resultPointers[$parentAlias])) {
+                } elseif (isset($this->resultPointers[$parentAlias])) {
                     $parentObject = $this->resultPointers[$parentAlias];
                 } else {
                     // Parent object of relation not found, mark as not-fetched again
@@ -355,7 +355,7 @@ class ObjectHydrator extends AbstractHydrator
                         $collKey = $oid . $relationField;
                         if (isset($this->initializedCollections[$collKey])) {
                             $reflFieldValue = $this->initializedCollections[$collKey];
-                        } else if (! isset($this->existingCollections[$collKey])) {
+                        } elseif (! isset($this->existingCollections[$collKey])) {
                             $reflFieldValue = $this->initRelatedCollection($parentObject, $parentClass, $relationField, $parentAlias);
                         }
 
@@ -390,9 +390,9 @@ class ObjectHydrator extends AbstractHydrator
                             // Update result pointer
                             $this->resultPointers[$dqlAlias] = $reflFieldValue[$index];
                         }
-                    } else if ( ! $reflFieldValue) {
+                    } elseif ( ! $reflFieldValue) {
                         $reflFieldValue = $this->initRelatedCollection($parentObject, $parentClass, $relationField, $parentAlias);
-                    } else if ($reflFieldValue instanceof PersistentCollection && $reflFieldValue->isInitialized() === false) {
+                    } elseif ($reflFieldValue instanceof PersistentCollection && $reflFieldValue->isInitialized() === false) {
                         $reflFieldValue->setInitialized(true);
                     }
                 } else {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1253,7 +1253,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             // Revert what should not be allowed to change
             $property->setDeclaringClass($originalProperty->getDeclaringClass());
             $property->setPrimaryKey($originalProperty->isPrimaryKey());
-        } else if ($property instanceof AssociationMetadata) {
+        } elseif ($property instanceof AssociationMetadata) {
             // Unset all defined fieldNames prior to override
             if ($originalProperty instanceof ToOneAssociationMetadata && $originalProperty->isOwningSide()) {
                 foreach ($originalProperty->getJoinColumns() as $joinColumn) {
@@ -1272,7 +1272,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
 
             if ($originalProperty instanceof ToOneAssociationMetadata && $property->getJoinColumns()) {
                 $originalProperty->setJoinColumns($property->getJoinColumns());
-            } else if ($originalProperty instanceof ManyToManyAssociationMetadata && $property->getJoinTable()) {
+            } elseif ($originalProperty instanceof ManyToManyAssociationMetadata && $property->getJoinTable()) {
                 $originalProperty->setJoinTable($property->getJoinTable());
             }
 
@@ -1431,7 +1431,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             }
 
             $this->fieldNames[$property->getColumnName()] = $property->getName();
-        } else if ($inheritedProperty instanceof AssociationMetadata) {
+        } elseif ($inheritedProperty instanceof AssociationMetadata) {
             if ($declaringClass->isMappedSuperclass) {
                 $inheritedProperty->setSourceEntity($this->className);
             }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -253,7 +253,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     throw MappingException::missingDiscriminatorColumn($class->getClassName());
                 }
             }
-        } else if (($class->discriminatorMap || $class->discriminatorColumn) && $class->isMappedSuperclass && $class->isRootEntity()) {
+        } elseif (($class->discriminatorMap || $class->discriminatorColumn) && $class->isMappedSuperclass && $class->isRootEntity()) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
             throw MappingException::noInheritanceOnMappedSuperClass($class->getClassName());
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -54,7 +54,7 @@ class XmlDriver extends FileDriver
             if (isset($xmlRoot['read-only']) && $this->evaluateBoolean($xmlRoot['read-only'])) {
                 $metadata->asReadOnly();
             }
-        } else if ($xmlRoot->getName() === 'mapped-superclass') {
+        } elseif ($xmlRoot->getName() === 'mapped-superclass') {
             if (isset($xmlRoot['repository-class'])) {
                 $metadata->setCustomRepositoryClassName(
                     $metadata->fullyQualifiedClassName((string) $xmlRoot['repository-class'])
@@ -62,7 +62,7 @@ class XmlDriver extends FileDriver
             }
 
             $metadata->isMappedSuperclass = true;
-        } else if ($xmlRoot->getName() === 'embeddable') {
+        } elseif ($xmlRoot->getName() === 'embeddable') {
             $metadata->isEmbeddedClass = true;
         } else {
             throw Mapping\MappingException::classIsNotAValidEntityOrMappedSuperClass($className);
@@ -373,7 +373,7 @@ class XmlDriver extends FileDriver
 
                     if (isset($oneToOneElement->{'join-column'})) {
                         $joinColumns[] = $this->convertJoinColumnElementToJoinColumnMetadata($oneToOneElement->{'join-column'});
-                    } else if (isset($oneToOneElement->{'join-columns'})) {
+                    } elseif (isset($oneToOneElement->{'join-columns'})) {
                         foreach ($oneToOneElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
                             $joinColumns[] = $this->convertJoinColumnElementToJoinColumnMetadata($joinColumnElement);
                         }
@@ -444,7 +444,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($oneToManyElement['index-by'])) {
                     $association->setIndexedBy((string) $oneToManyElement['index-by']);
-                } else if (isset($oneToManyElement->{'index-by'})) {
+                } elseif (isset($oneToManyElement->{'index-by'})) {
                     throw new \InvalidArgumentException("<index-by /> is not a valid tag");
                 }
 
@@ -489,7 +489,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToOneElement->{'join-column'})) {
                     $joinColumns[] = $this->convertJoinColumnElementToJoinColumnMetadata($manyToOneElement->{'join-column'});
-                } else if (isset($manyToOneElement->{'join-columns'})) {
+                } elseif (isset($manyToOneElement->{'join-columns'})) {
                     foreach ($manyToOneElement->{'join-columns'}->{'join-column'} as $joinColumnElement) {
                         $joinColumns[] = $this->convertJoinColumnElementToJoinColumnMetadata($joinColumnElement);
                     }
@@ -540,7 +540,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToManyElement['mapped-by'])) {
                     $association->setMappedBy((string) $manyToManyElement['mapped-by']);
-                } else if (isset($manyToManyElement->{'join-table'})) {
+                } elseif (isset($manyToManyElement->{'join-table'})) {
                     if (isset($manyToManyElement['inversed-by'])) {
                         $association->setInversedBy((string) $manyToManyElement['inversed-by']);
                     }
@@ -591,7 +591,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToManyElement['index-by'])) {
                     $association->setIndexedBy((string) $manyToManyElement['index-by']);
-                } else if (isset($manyToManyElement->{'index-by'})) {
+                } elseif (isset($manyToManyElement->{'index-by'})) {
                     throw new \InvalidArgumentException("<index-by /> is not a valid tag");
                 }
 
@@ -959,12 +959,12 @@ class XmlDriver extends FileDriver
                 $entityName = (string) $entityElement['name'];
                 $result[$entityName] = $entityElement;
             }
-        } else if (isset($xmlElement->{'mapped-superclass'})) {
+        } elseif (isset($xmlElement->{'mapped-superclass'})) {
             foreach ($xmlElement->{'mapped-superclass'} as $mappedSuperClass) {
                 $className = (string) $mappedSuperClass['name'];
                 $result[$className] = $mappedSuperClass;
             }
-        } else if (isset($xmlElement->embeddable)) {
+        } elseif (isset($xmlElement->embeddable)) {
             foreach ($xmlElement->embeddable as $embeddableElement) {
                 $embeddableName = (string) $embeddableElement['name'];
                 $result[$embeddableName] = $embeddableElement;

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1080,7 +1080,7 @@ class BasicEntityPersister implements EntityPersister
 
             if ($property instanceof FieldMetadata) {
                 $value = $property->getValue($sourceEntity);
-            } else if ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 $property    = $sourceClass->getProperty($fieldName);
                 $targetClass = $this->em->getClassMetadata($property->getTargetEntity());
                 $value       = $property->getValue($sourceEntity);
@@ -1234,7 +1234,7 @@ class BasicEntityPersister implements EntityPersister
                 $orderByList[] = $tableAlias . '.' . $columnName . ' ' . $orientation;
 
                 continue;
-            } else if ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 if (! $property->isOwningSide()) {
                     throw ORMException::invalidFindByInverseAssociation($this->class->getClassName(), $fieldName);
                 }
@@ -1926,7 +1926,7 @@ class BasicEntityPersister implements EntityPersister
 
             if ($property instanceof FieldMetadata) {
                 $value = $property->getValue($sourceEntity);
-            } else if ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 $targetClass = $this->em->getClassMetadata($property->getTargetEntity());
                 $value       = $property->getValue($sourceEntity);
 

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -41,7 +41,7 @@ class SqlValueVisitor extends ExpressionVisitor
 
         if (($operator === Comparison::EQ || $operator === Comparison::IS) && $value === null) {
             return;
-        } else if ($operator === Comparison::NEQ && $value === null) {
+        } elseif ($operator === Comparison::NEQ && $value === null) {
             return;
         }
 

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -64,7 +64,7 @@ abstract class Node
             }
 
             $str .= str_repeat(' ', $ident) . ')';
-        } else if (is_array($obj)) {
+        } elseif (is_array($obj)) {
             $ident += 4;
             $str .= 'array(';
             $some = false;
@@ -77,7 +77,7 @@ abstract class Node
 
             $ident -= 4;
             $str .= ($some ? PHP_EOL . str_repeat(' ', $ident) : '') . ')';
-        } else if (is_object($obj)) {
+        } elseif (is_object($obj)) {
             $str .= 'instanceof(' . get_class($obj) . ')';
         } else {
             $str .= var_export($obj, true);

--- a/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
@@ -27,7 +27,7 @@ class SingleTableDeleteUpdateExecutor extends AbstractSqlExecutor
     {
         if ($AST instanceof AST\UpdateStatement) {
             $this->sqlStatements = $sqlWalker->walkUpdateStatement($AST);
-        } else if ($AST instanceof AST\DeleteStatement) {
+        } elseif ($AST instanceof AST\DeleteStatement) {
             $this->sqlStatements = $sqlWalker->walkDeleteStatement($AST);
         }
     }

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -600,7 +600,7 @@ class Expr
     {
         if (is_numeric($literal) && !is_string($literal)) {
             return (string) $literal;
-        } else if (is_bool($literal)) {
+        } elseif (is_bool($literal)) {
             return $literal ? "true" : "false";
         } else {
             return "'" . str_replace("'", "''", $literal) . "'";

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -945,7 +945,7 @@ class Parser
             $this->match(Lexer::T_FULLY_QUALIFIED_NAME);
 
             $schemaName = $this->lexer->token['value'];
-        } else if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+        } elseif ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
             $this->match(Lexer::T_IDENTIFIER);
 
             $schemaName = $this->lexer->token['value'];
@@ -3315,7 +3315,7 @@ class Parser
                 if ($this->lexer->isNextToken(Lexer::T_EQUALS)) {
                     $this->match(Lexer::T_EQUALS);
                     $operator .= '=';
-                } else if ($this->lexer->isNextToken(Lexer::T_GREATER_THAN)) {
+                } elseif ($this->lexer->isNextToken(Lexer::T_GREATER_THAN)) {
                     $this->match(Lexer::T_GREATER_THAN);
                     $operator .= '>';
                 }

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -457,9 +457,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
                 $class = $this->em->getClassMetadata($this->declaringClasses[$columnName]);
                 $field = $this->fieldMappings[$columnName];
                 $sql  .= $class->getProperty($field)->getColumnName();
-            } else if (isset($this->metaMappings[$columnName])) {
+            } elseif (isset($this->metaMappings[$columnName])) {
                 $sql .= $this->metaMappings[$columnName];
-            } else if (isset($this->discriminatorColumns[$dqlAlias])) {
+            } elseif (isset($this->discriminatorColumns[$dqlAlias])) {
                 $sql .= $this->discriminatorColumns[$dqlAlias];
             }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1035,7 +1035,7 @@ class SqlWalker implements TreeWalker
                 'table' => $targetTableName . ' ' . $targetTableAlias,
                 'condition' => implode(' AND ', $conditions),
             ];
-        } else if ($owningAssociation instanceof ManyToManyAssociationMetadata) {
+        } elseif ($owningAssociation instanceof ManyToManyAssociationMetadata) {
             // Join relation table
             $joinTable      = $owningAssociation->getJoinTable();
             $joinTableName  = $joinTable->getQuotedQualifiedName($this->platform);
@@ -1130,7 +1130,7 @@ class SqlWalker implements TreeWalker
         if ($indexBy) {
             // For Many-To-One or One-To-One associations this obviously makes no sense, but is ignored silently.
             $this->walkIndexBy($indexBy);
-        } else if ($association instanceof ToManyAssociationMetadata && $association->getIndexedBy()) {
+        } elseif ($association instanceof ToManyAssociationMetadata && $association->getIndexedBy()) {
             $this->rsm->addIndexBy($joinedDqlAlias, $association->getIndexedBy());
         }
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1492,7 +1492,7 @@ class QueryBuilder
                         $this->dqlParts[$part][$idx] = clone $element;
                     }
                 }
-            } else if (is_object($elements)) {
+            } elseif (is_object($elements)) {
                 $this->dqlParts[$part] = clone $elements;
             }
         }

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -330,7 +330,7 @@ EOT
 
             if ($property instanceof FieldMetadata) {
                 $output = array_merge($output, $this->formatColumn($property));
-            }  else if ($property instanceof AssociationMetadata) {
+            }  elseif ($property instanceof AssociationMetadata) {
                 // @todo guilhermeblanco Fix me! We are trying to iterate through an AssociationMetadata instance
                 foreach ($property as $field => $value) {
                     $output[] = $this->formatField(sprintf('    %s', $field), $this->formatValue($value));

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -113,7 +113,7 @@ class CountOutputWalker extends SqlWalker
                         $sqlIdentifier[$identifier] = $alias;
                     }
                 }
-            } else if ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 $joinColumns = $property->getJoinColumns();
                 $joinColumn  = reset($joinColumns);
 

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -528,7 +528,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
                         ];
                     }
                 }
-            } else if ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 $joinColumns = $property->getJoinColumns();
                 $joinColumn  = reset($joinColumns);
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -152,16 +152,16 @@ class SchemaValidator
                 $message = "The association %s#%s refers to the owning side property %s#%s which does not exist.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $mappedBy);
-            } else if ($targetAssociation instanceof FieldMetadata) {
+            } elseif ($targetAssociation instanceof FieldMetadata) {
                 $message = "The association %s#%s refers to the owning side property %s#%s which is not defined as association, but as field.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $mappedBy);
-            } else if ($targetAssociation->getInversedBy() === null) {
+            } elseif ($targetAssociation->getInversedBy() === null) {
                 $message = "The property %s#%s is on the inverse side of a bi-directional relationship, but the "
                     . "specified mappedBy association on the target-entity %s#%s does not contain the required 'inversedBy=\"%s\"' attribute.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $mappedBy, $fieldName);
-            } else if ($targetAssociation->getInversedBy() !== $fieldName) {
+            } elseif ($targetAssociation->getInversedBy() !== $fieldName) {
                 $message = "The mapping between %s#%s and %s#%s are inconsistent with each other.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $mappedBy);
@@ -176,16 +176,16 @@ class SchemaValidator
                 $message = "The association %s#%s refers to the inverse side property %s#%s which does not exist.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $inversedBy);
-            } else if ($targetAssociation instanceof FieldMetadata) {
+            } elseif ($targetAssociation instanceof FieldMetadata) {
                 $message = "The association %s#%s refers to the inverse side property %s#%s which is not defined as association, but as field.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $inversedBy);
-            } else if ($targetAssociation->getMappedBy() === null) {
+            } elseif ($targetAssociation->getMappedBy() === null) {
                 $message = "The property %s#%s is on the owning side of a bi-directional relationship, but the "
                     . "specified mappedBy association on the target-entity %s#%s does not contain the required 'inversedBy=\"%s\"' attribute.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $mappedBy, $fieldName);
-            } else if ($targetAssociation->getMappedBy() !== $fieldName) {
+            } elseif ($targetAssociation->getMappedBy() !== $fieldName) {
                 $message = "The mapping between %s#%s and %s#%s are inconsistent with each other.";
 
                 $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetEntity, $inversedBy);
@@ -197,11 +197,11 @@ class SchemaValidator
                     $message = "If association %s#%s is one-to-one, then the inversed side %s#%s has to be one-to-one as well.";
 
                     $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetMetadata->getClassName(), $inversedBy);
-                } else if ($association instanceof ManyToOneAssociationMetadata && ! $targetAssociation instanceof OneToManyAssociationMetadata) {
+                } elseif ($association instanceof ManyToOneAssociationMetadata && ! $targetAssociation instanceof OneToManyAssociationMetadata) {
                     $message = "If association %s#%s is many-to-one, then the inversed side %s#%s has to be one-to-many.";
 
                     $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetMetadata->getClassName(), $inversedBy);
-                } else if ($association instanceof ManyToManyAssociationMetadata && ! $targetAssociation instanceof ManyToManyAssociationMetadata) {
+                } elseif ($association instanceof ManyToManyAssociationMetadata && ! $targetAssociation instanceof ManyToManyAssociationMetadata) {
                     $message = "If association %s#%s is many-to-many, then the inversed side %s#%s has to be many-to-many as well.";
 
                     $ce[] = sprintf($message, $class->getClassName(), $fieldName, $targetMetadata->getClassName(), $inversedBy);
@@ -262,7 +262,7 @@ class SchemaValidator
 
                     $ce[] = sprintf($message, $joinTable->getName(), $class->getClassName(), $columnString);
                 }
-            } else if ($association instanceof ToOneAssociationMetadata) {
+            } elseif ($association instanceof ToOneAssociationMetadata) {
                 $identifierColumns = array_keys($targetMetadata->getIdentifierColumns($this->em));
                 $joinColumns       = $association->getJoinColumns();
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -611,7 +611,7 @@ class UnitOfWork implements PropertyChangedListener
 
                     if ($owner === null) { // cloned
                         $actualValue->setOwner($entity, $property);
-                    } else if ($owner !== $entity) { // no clone, we have to fix
+                    } elseif ($owner !== $entity) { // no clone, we have to fix
                         if (! $actualValue->isInitialized()) {
                             $actualValue->initialize(); // we have to do this otherwise the cols share state
                         }
@@ -932,7 +932,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($changeSet) {
             if (isset($this->entityChangeSets[$oid])) {
                 $this->entityChangeSets[$oid] = array_merge($this->entityChangeSets[$oid], $changeSet);
-            } else if ( ! isset($this->entityInsertions[$oid])) {
+            } elseif ( ! isset($this->entityInsertions[$oid])) {
                 $this->entityChangeSets[$oid] = $changeSet;
                 $this->entityUpdates[$oid]    = $entity;
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php
@@ -61,12 +61,12 @@ class DDC258Test extends OrmFunctionalTestCase
             if ($obj instanceof DDC258Class1) {
                 self::assertEquals('Foo', $obj->title);
                 self::assertEquals('Foo', $obj->description);
-            } else if ($obj instanceof DDC258Class2) {
+            } elseif ($obj instanceof DDC258Class2) {
                 self::assertSame($e2, $obj);
                 self::assertEquals('Bar', $obj->title);
                 self::assertEquals('Bar', $obj->description);
                 self::assertEquals('Bar', $obj->text);
-            } else if ($obj instanceof DDC258Class3) {
+            } elseif ($obj instanceof DDC258Class3) {
                 self::assertEquals('Baz', $obj->apples);
                 self::assertEquals('Baz', $obj->bananas);
             } else {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php
@@ -79,12 +79,12 @@ class DDC837Test extends \Doctrine\Tests\OrmFunctionalTestCase
             if ($obj instanceof DDC837Class1) {
                 self::assertEquals('Foo', $obj->title);
                 self::assertEquals('Foo', $obj->description);
-            } else if ($obj instanceof DDC837Class2) {
+            } elseif ($obj instanceof DDC837Class2) {
                 self::assertSame($e2, $obj);
                 self::assertEquals('Bar', $obj->title);
                 self::assertEquals('Bar', $obj->description);
                 self::assertEquals('Bar', $obj->text);
-            } else if ($obj instanceof DDC837Class3) {
+            } elseif ($obj instanceof DDC837Class3) {
                 self::assertEquals('Baz', $obj->apples);
                 self::assertEquals('Baz', $obj->bananas);
             } else {

--- a/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php
@@ -1031,7 +1031,7 @@ class ArrayHydratorTest extends HydrationTestCase
             if ($rowNum == 0) {
                 self::assertEquals(1, $row[0]['id']);
                 self::assertEquals('romanb', $row[0]['name']);
-            } else if ($rowNum == 1) {
+            } elseif ($rowNum == 1) {
                 self::assertEquals(2, $row[0]['id']);
                 self::assertEquals('jwage', $row[0]['name']);
             }
@@ -1077,7 +1077,7 @@ class ArrayHydratorTest extends HydrationTestCase
             if ($rowNum == 0) {
                 self::assertEquals(1, $row[0]['user']['id']);
                 self::assertEquals('romanb', $row[0]['user']['name']);
-            } else if ($rowNum == 1) {
+            } elseif ($rowNum == 1) {
                 self::assertEquals(2, $row[0]['user']['id']);
                 self::assertEquals('jwage', $row[0]['user']['name']);
             }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -652,7 +652,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         if (isset($GLOBALS['DOCTRINE_MARK_SQL_LOGS'])) {
             if (in_array(static::$sharedConn->getDatabasePlatform()->getName(), ["mysql", "postgresql"])) {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/');
-            } else if (static::$sharedConn->getDatabasePlatform()->getName() === "oracle") {
+            } elseif (static::$sharedConn->getDatabasePlatform()->getName() === "oracle") {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/ FROM dual');
             }
         }


### PR DESCRIPTION
As of yet there is a mixed usage of the two conditions `elseif` and `else if`.

Symfony prefers the former: the fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `elseif`.