### PR TITLE
[CS] One blank line after namespace declaration

### DIFF
--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Doctrine\ORM;
+
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
+
 use Doctrine\ORM\Mapping\AssociationMetadata;
 
 use Doctrine\ORM\Query\AST\PathExpression;

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
-
 /**
  * Simple statement mock that returns result based on array.
  * Doesn't support fetch modes

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
+
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use ProxyManager\Proxy\GhostObjectInterface;

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
+
 use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\QueryException;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Tests\Models\Company\CompanyFlexContract;
 use Doctrine\Tests\Models\Company\CompanyManager;

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Query;
+
 use Doctrine\Tests\OrmTestCase;
 
 /**


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `blank_line_after_namespace`.