### PR TITLE
[CS] One black line after opening tag

### DIFF
--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Event;

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;

--- a/lib/Doctrine/ORM/Query/AST/LikeExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/LikeExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;

--- a/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Event;

--- a/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;

--- a/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Doctrine\Tests\Functional\Ticket;
 
 use Doctrine\ORM\Annotation as ORM;

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `blank_line_after_opening_tag`.