### PR TITLE
[CS] PHP constants and keywords should be lowercase

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
@@ -127,14 +127,14 @@ class DriverChain implements MappingDriver
         $driverClasses = [];
 
         /* @var $driver MappingDriver */
-        foreach ($this->drivers AS $namespace => $driver) {
+        foreach ($this->drivers as $namespace => $driver) {
             $oid = spl_object_hash($driver);
 
             if (!isset($driverClasses[$oid])) {
                 $driverClasses[$oid] = $driver->getAllClassNames();
             }
 
-            foreach ($driverClasses[$oid] AS $className) {
+            foreach ($driverClasses[$oid] as $className) {
                 if (strpos($className, $namespace) === 0) {
                     $classNames[$className] = true;
                 }
@@ -156,7 +156,7 @@ class DriverChain implements MappingDriver
     public function isTransient($className)
     {
         /* @var $driver MappingDriver */
-        foreach ($this->drivers AS $namespace => $driver) {
+        foreach ($this->drivers as $namespace => $driver) {
             if (strpos($className, $namespace) === 0) {
                 return $driver->isTransient($className);
             }

--- a/tests/Doctrine/Performance/ChangeSet/UnitOfWorkComputeChangesBench.php
+++ b/tests/Doctrine/Performance/ChangeSet/UnitOfWorkComputeChangesBench.php
@@ -58,7 +58,7 @@ final class UnitOfWorkComputeChangesBench
             throw new \LogicException('Unit of work should be clean at this stage');
         }
 
-        foreach ($this->users AS $user) {
+        foreach ($this->users as $user) {
             $user->status    = 'other';
             $user->username .= '++';
             $user->name      = str_replace('Mr.', 'Mrs.', $user->name);

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -203,7 +203,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
 
         // FIXME: Condition here is fugly.
         // NOTE: PostgreSQL and SQL SERVER do not support UNSIGNED integer
-        if ( ! $this->em->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform AND
+        if ( ! $this->em->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform and
              ! $this->em->getConnection()->getDatabasePlatform() instanceof SQLServerPlatform) {
             self::assertNotNull($metadata->getProperty('columnUnsigned'));
 

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -28,7 +28,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
 
         $metadatas = [];
 
-        foreach ($driver->getAllClassNames() AS $className) {
+        foreach ($driver->getAllClassNames() as $className) {
             $class = new ClassMetadata($className, $metadataBuildingContext);
 
             $driver->loadMetadataForClass($className, $class, $metadataBuildingContext);

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -100,7 +100,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         self::assertCount(3, $user->groups);
         self::assertFalse($user->groups->isInitialized());
 
-        foreach ($user->groups AS $group) { }
+        foreach ($user->groups as $group) { }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -132,7 +132,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        foreach ($user->groups AS $group) { }
+        foreach ($user->groups as $group) { }
 
         self::assertTrue($user->groups->isInitialized());
         self::assertCount(3, $user->groups);
@@ -208,7 +208,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         self::assertCount(1, $otherGroup);
         self::assertFalse($user->groups->isInitialized());
 
-        foreach ($user->groups AS $group) { }
+        foreach ($user->groups as $group) { }
 
         self::assertTrue($user->groups->isInitialized());
         self::assertCount(3, $user->groups);
@@ -225,7 +225,7 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        foreach ($user->groups AS $group) { }
+        foreach ($user->groups as $group) { }
 
         $someGroups = $user->groups->slice(0, 2);
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php
@@ -152,7 +152,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
         $groups = $user->groups->toArray();
         $user->groups->clear();
 
-        foreach ($groups AS $group) {
+        foreach ($groups as $group) {
             $user->groups[] = $group;
         }
 
@@ -232,7 +232,7 @@ class ManyToManyBasicAssociationTest extends OrmFunctionalTestCase
     {
         $user = $this->addCmsUserGblancoWithGroups(2);
 
-        foreach ($user->getGroups() AS $group) {
+        foreach ($user->getGroups() as $group) {
             $this->em->remove($group);
         }
         $this->em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
@@ -23,7 +23,7 @@ class OneToManyUnidirectionalAssociationTest extends OrmFunctionalTestCase
 
         $locations = ["Berlin", "Bonn", "Brasilia", "Atlanta"];
 
-        foreach ($locations AS $locationName) {
+        foreach ($locations as $locationName) {
             $location = new RoutingLocation();
             $location->name = $locationName;
             $this->em->persist($location);

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php
@@ -21,7 +21,7 @@ class OrderedCollectionTest extends OrmFunctionalTestCase
 
         $locations = ["Berlin", "Bonn", "Brasilia", "Atlanta"];
 
-        foreach ($locations AS $locationName) {
+        foreach ($locations as $locationName) {
             $location = new RoutingLocation();
             $location->name = $locationName;
             $this->em->persist($location);

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -221,7 +221,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         $found = [];
 
-        foreach ($articles AS $article) {
+        foreach ($articles as $article) {
             $found[] = $article;
         }
 
@@ -263,7 +263,7 @@ class QueryTest extends OrmFunctionalTestCase
         $iteratedCount = 0;
         $topics = [];
 
-        foreach($articles AS $row) {
+        foreach($articles as $row) {
             $article = $row[0];
             $topics[] = $article->topic;
 
@@ -302,7 +302,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         $iteratedCount = 0;
         $topics = [];
-        foreach($articles AS $row) {
+        foreach($articles as $row) {
             $article  = $row[0];
             $topics[] = $article->topic;
 
@@ -497,7 +497,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         self::assertCount(10, $articles);
 
-        foreach ($articles AS $article) {
+        foreach ($articles as $article) {
             self::assertNotInstanceOf(GhostObjectInterface::class, $article);
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -66,7 +66,7 @@ class DDC214Test extends OrmFunctionalTestCase
     public function assertCreatedSchemaNeedsNoUpdates($classes)
     {
         $classMetadata = [];
-        foreach ($classes AS $class) {
+        foreach ($classes as $class) {
             $classMetadata[] = $this->em->getClassMetadata($class);
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -109,7 +109,7 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
 
         $dropSequenceSQLs = 0;
 
-        foreach ($sql AS $stmt) {
+        foreach ($sql as $stmt) {
             if (strpos($stmt, "DROP SEQUENCE") === 0) {
                 $dropSequenceSQLs++;
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -118,7 +118,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertGreaterThan(0, $refs, "Has to contain at least one Reference.");
 
-        foreach ($refs AS $ref) {
+        foreach ($refs as $ref) {
             self::assertInstanceOf(DDC117Reference::class, $ref, "Contains only Reference instances.");
             self::assertTrue($this->em->contains($ref), "Contains Reference in the IdentityMap.");
         }
@@ -166,7 +166,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertCount(1, $this->article1->references());
 
-        foreach ($this->article1->references() AS $this->reference) {
+        foreach ($this->article1->references() as $this->reference) {
             self::assertInstanceOf(DDC117Reference::class, $this->reference);
             self::assertSame($this->article1, $this->reference->source());
         }
@@ -180,7 +180,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertCount(1, $this->article1->references());
 
-        foreach ($this->article1->references() AS $this->reference) {
+        foreach ($this->article1->references() as $this->reference) {
             self::assertInstanceOf(DDC117Reference::class, $this->reference);
             self::assertSame($this->article1, $this->reference->source());
         }
@@ -407,7 +407,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         /* @var $article1 DDC117Article */
         $article1 = $this->em->find(get_class($this->article1), $this->article1->id());
-        foreach ($article1->getTranslations() AS $translation) {
+        foreach ($article1->getTranslations() as $translation) {
             $editor->reviewingTranslations[] = $translation;
         }
 
@@ -416,7 +416,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $article2->addTranslation("de", "Vanille-Krapferl"); // omnomnom
         $article2->addTranslation("fr", "Sorry can't speak french!");
 
-        foreach ($article2->getTranslations() AS $translation) {
+        foreach ($article2->getTranslations() as $translation) {
             $this->em->persist($translation); // otherwise persisting the editor won't work, reachability!
             $editor->reviewingTranslations[] = $translation;
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -53,7 +53,7 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(2, $user->articles);
         self::assertFalse($user->articles->isInitialized());
 
-        foreach ($user->articles AS $article) { }
+        foreach ($user->articles as $article) { }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -67,7 +67,7 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(2, $user->references);
         self::assertFalse($user->references->isInitialized());
 
-        foreach ($user->references AS $reference) { }
+        foreach ($user->references as $reference) { }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -81,7 +81,7 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(3, $user->cars);
         self::assertFalse($user->cars->isInitialized());
 
-        foreach ($user->cars AS $reference) { }
+        foreach ($user->cars as $reference) { }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -68,7 +68,7 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $appointments = $this->em->createQuery("SELECT a FROM " . __NAMESPACE__ . "\DDC633Appointment a")->getResult();
 
-        foreach ($appointments AS $eagerAppointment) {
+        foreach ($appointments as $eagerAppointment) {
             self::assertInstanceOf(GhostObjectInterface::class, $eagerAppointment->patient);
             self::assertTrue($eagerAppointment->patient->isProxyInitialized(), "Proxy should already be initialized due to eager loading!");
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -64,12 +64,12 @@ class DDC719Group extends Entity {
 	 * 		inverseJoinColumns={@ORM\JoinColumn(name="child_id", referencedColumnName="id")}
 	 * )
 	 */
-	protected $children = NULL;
+	protected $children = null;
 
 	/**
 	 * @ORM\ManyToMany(targetEntity="DDC719Group", mappedBy="children")
 	 */
-	protected $parents = NULL;
+	protected $parents = null;
 
 	/**
 	 * construct

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -89,7 +89,7 @@ class DisableFetchJoinTreeWalker extends \Doctrine\ORM\Query\TreeWalkerAdapter
      */
     public function walkSelectClause($selectClause)
     {
-        foreach ($selectClause->selectExpressions AS $key => $selectExpr) {
+        foreach ($selectClause->selectExpressions as $key => $selectExpr) {
             /* @var $selectExpr \Doctrine\ORM\Query\AST\SelectExpression */
             if ($selectExpr->expression == "c") {
                 unset($selectClause->selectExpressions[$key]);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -45,7 +45,7 @@ class DDC992Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $child = $this->em->getRepository(get_class($role))->find($child->roleID);
         self::assertCount(1, $child->extends);
-        foreach ($child->extends AS $parent) {
+        foreach ($child->extends as $parent) {
             self::assertEquals($role->getRoleID(), $parent->getRoleID());
         }
     }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -47,7 +47,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         try {
             $query = $this->em->createQuery($dqlToBeTested);
 
-            foreach ($queryParams AS $name => $value) {
+            foreach ($queryParams as $name => $value) {
                 $query->setParameter($name, $value);
             }
 
@@ -56,7 +56,7 @@ class SelectSqlGenerationTest extends OrmTestCase
                 ->useQueryCache(false)
             ;
 
-            foreach ($queryHints AS $name => $value) {
+            foreach ($queryHints as $name => $value) {
                 $query->setHint($name, $value);
             }
 
@@ -84,7 +84,7 @@ class SelectSqlGenerationTest extends OrmTestCase
 
         $query = $this->em->createQuery($dqlToBeTested);
 
-        foreach ($queryParams AS $name => $value) {
+        foreach ($queryParams as $name => $value) {
             $query->setParameter($name, $value);
         }
 
@@ -93,7 +93,7 @@ class SelectSqlGenerationTest extends OrmTestCase
             ->useQueryCache(false)
         ;
 
-        foreach ($queryHints AS $name => $value) {
+        foreach ($queryHints as $name => $value) {
             $query->setHint($name, $value);
         }
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -748,8 +748,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         // get rid of more global state
         $evm = $conn->getEventManager();
 
-        foreach ($evm->getListeners() AS $event => $listeners) {
-            foreach ($listeners AS $listener) {
+        foreach ($evm->getListeners() as $event => $listeners) {
+            foreach ($listeners as $listener) {
                 $evm->removeEventListener([$event], $listener);
             }
         }
@@ -759,7 +759,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($GLOBALS['db_event_subscribers'])) {
-            foreach (explode(",", $GLOBALS['db_event_subscribers']) AS $subscriberClass) {
+            foreach (explode(",", $GLOBALS['db_event_subscribers']) as $subscriberClass) {
                 $subscriberInstance = new $subscriberClass();
                 $evm->addEventSubscriber($subscriberInstance);
             }
@@ -803,7 +803,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $trace = $e->getTrace();
             $traceMsg = "";
 
-            foreach($trace AS $part) {
+            foreach($trace as $part) {
                 if(isset($part['file'])) {
                     if(strpos($part['file'], "PHPUnit/") !== false) {
                         // Beginning with PHPUnit files we don't print the trace anymore.


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `lowercase_constants` and `lowercase_keywords`.