### PR TITLE
[CS] No alias functions

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -39,7 +39,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
      */
     private function getCacheSize(ArrayCache $cache)
     {
-        return sizeof($this->cacheDataReflection->getValue($cache));
+        return count($this->cacheDataReflection->getValue($cache));
     }
 
 

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -39,7 +39,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
      */
     private function getCacheSize(ArrayCache $cache)
     {
-        return sizeof($this->cacheDataReflection->getValue($cache));
+        return count($this->cacheDataReflection->getValue($cache));
     }
 
     public function testResultCache()


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `no_alias_functions`.