### PR TITLE
[CS] Remove useless semicolon statements

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Collections\ArrayCollection;;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\DBAL\Cache\QueryCacheProfile;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -664,7 +664,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
 
             if ($property->getType()->canRequireSQLConversion()) {
                 throw MappingException::sqlConversionNotAllowedForPrimaryKeyProperties($property);
-            };
+            }
 
             if (! in_array($fieldName, $this->identifier)) {
                 $this->identifier[] = $fieldName;

--- a/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
@@ -628,7 +628,7 @@ class NewAnnotationDriver implements MappingDriver
         if ($isPrimaryKey) {
             if ($fieldMetadata->getType()->canRequireSQLConversion()) {
                 throw Mapping\MappingException::sqlConversionNotAllowedForPrimaryKeyProperties($className, $fieldMetadata);
-            };
+            }
 
             $fieldMetadata->setPrimaryKey(true);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -698,7 +698,7 @@ class PaginationTest extends OrmFunctionalTestCase
     public function populate()
     {
         $groups = [];
-        for ($j = 0; $j < 3; $j++) {;
+        for ($j = 0; $j < 3; $j++) {
             $group = new CmsGroup();
             $group->name = "group$j";
             $groups[] = $group;

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -87,7 +87,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         self::assertEquals('United States of America', $person->address->country->name);
 
         // 4. check deleting works
-        $personId = $person->id;;
+        $personId = $person->id;
         $this->em->remove($person);
         $this->em->flush();
 


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `no_empty_statement`.