### PR TITLE
[CS] Standardize spaces around ternary operator

### DIFF
--- a/lib/Doctrine/ORM/Cache/Lock.php
+++ b/lib/Doctrine/ORM/Cache/Lock.php
@@ -30,7 +30,7 @@ class Lock
     public function __construct($value, $time = null)
     {
         $this->value = $value;
-        $this->time  = $time ? : time();
+        $this->time  = $time ?: time();
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
@@ -85,7 +85,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
      */
     public function referenceColumnName()
     {
-        return $this->case === CASE_UPPER ?  'ID' : 'id';
+        return $this->case === CASE_UPPER ? 'ID' : 'id';
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1585,7 +1585,7 @@ class SqlWalker implements TreeWalker
     public function walkNewObject($newObjectExpression, $newObjectResultAlias=null)
     {
         $sqlSelectExpressions = [];
-        $objIndex             = $newObjectResultAlias?:$this->newObjectCounter++;
+        $objIndex             = $newObjectResultAlias ?: $this->newObjectCounter++;
 
         foreach ($newObjectExpression->args as $argIndex => $e) {
             $resultAlias = $this->scalarResultCounter++;


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `ternary_operator_spaces`.