### PR TITLE
[CS] Properties must not be explicitly initialized with null

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -31,7 +31,7 @@ class IterableResult implements \Iterator
     /**
      * @var object|null
      */
-    private $current = null;
+    private $current;
 
     /**
      * @param \Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator

--- a/lib/Doctrine/ORM/Mapping/AssociationMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMetadata.php
@@ -54,7 +54,7 @@ class AssociationMetadata implements Property
     private $orphanRemoval = false;
 
     /** @var null|CacheMetadata */
-    private $cache = null;
+    private $cache;
 
     /**
      * AssociationMetadata constructor.

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -32,7 +32,7 @@ class DatabaseDriver implements MappingDriver
     /**
      * @var array|null
      */
-    private $tables = null;
+    private $tables;
 
     /**
      * @var array

--- a/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
@@ -26,7 +26,7 @@ abstract class EntityClassMetadata extends ComponentMetadata
     /**
      * @var null|Property The field which is used for versioning in optimistic locking (if any).
      */
-    protected $declaredVersion = null;
+    protected $declaredVersion;
 
     /**
      * Whether this class describes the mapping of a read-only class.

--- a/lib/Doctrine/ORM/PersistentObject.php
+++ b/lib/Doctrine/ORM/PersistentObject.php
@@ -53,7 +53,7 @@ abstract class PersistentObject implements EntityManagerAware
     /**
      * @var ClassMetadata|null
      */
-    private $cm = null;
+    private $cm;
 
     /**
      * Sets the entity manager responsible for all persistent object base classes.

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -129,7 +129,7 @@ final class Query extends AbstractQuery
      *
      * @var string
      */
-    private $dql = null;
+    private $dql;
 
     /**
      * The parser result that holds DQL => SQL information.
@@ -143,14 +143,14 @@ final class Query extends AbstractQuery
      *
      * @var integer
      */
-    private $firstResult = null;
+    private $firstResult;
 
     /**
      * The maximum number of results to return (the "limit").
      *
      * @var integer|null
      */
-    private $maxResults = null;
+    private $maxResults;
 
     /**
      * The cache driver used for caching queries.

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -20,9 +20,9 @@ use Doctrine\ORM\Query\QueryException;
  */
 class DateAddFunction extends FunctionNode
 {
-    public $firstDateExpression = null;
-    public $intervalExpression = null;
-    public $unit = null;
+    public $firstDateExpression;
+    public $intervalExpression;
+    public $unit;
 
     /**
      * @override

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -29,7 +29,7 @@ class SubstringFunction extends FunctionNode
     /**
      * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression|null
      */
-    public $secondSimpleArithmeticExpression = null;
+    public $secondSimpleArithmeticExpression;
 
     /**
      * @override

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -25,7 +25,7 @@ class GeneralCaseExpression extends Node
     /**
      * @var mixed
      */
-    public $elseScalarExpression = null;
+    public $elseScalarExpression;
 
     /**
      * @param array $whenClauses

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -18,12 +18,12 @@ class IdentificationVariableDeclaration extends Node
     /**
      * @var RangeVariableDeclaration|null
      */
-    public $rangeVariableDeclaration = null;
+    public $rangeVariableDeclaration;
 
     /**
      * @var IndexBy|null
      */
-    public $indexBy = null;
+    public $indexBy;
 
     /**
      * @var array

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -18,7 +18,7 @@ class IndexBy extends Node
     /**
      * @var PathExpression
      */
-    public $simpleStateFieldPathExpression = null;
+    public $simpleStateFieldPathExpression;
 
     /**
      * @param PathExpression $simpleStateFieldPathExpression

--- a/lib/Doctrine/ORM/Query/AST/Join.php
+++ b/lib/Doctrine/ORM/Query/AST/Join.php
@@ -28,12 +28,12 @@ class Join extends Node
     /**
      * @var Node|null
      */
-    public $joinAssociationDeclaration = null;
+    public $joinAssociationDeclaration;
 
     /**
      * @var ConditionalExpression|null
      */
-    public $conditionalExpression = null;
+    public $conditionalExpression;
 
     /**
      * @param int  $joinType

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -20,7 +20,7 @@ class SimpleCaseExpression extends Node
     /**
      * @var PathExpression
      */
-    public $caseOperand = null;
+    public $caseOperand;
 
     /**
      * @var array
@@ -30,7 +30,7 @@ class SimpleCaseExpression extends Node
     /**
      * @var mixed
      */
-    public $elseScalarExpression = null;
+    public $elseScalarExpression;
 
     /**
      * @param PathExpression $caseOperand

--- a/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
@@ -20,12 +20,12 @@ class SimpleWhenClause extends Node
     /**
      * @var mixed
      */
-    public $caseScalarExpression = null;
+    public $caseScalarExpression;
 
     /**
      * @var mixed
      */
-    public $thenScalarExpression = null;
+    public $thenScalarExpression;
 
     /**
      * @param mixed $caseScalarExpression

--- a/lib/Doctrine/ORM/Query/AST/WhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhenClause.php
@@ -20,12 +20,12 @@ class WhenClause extends Node
     /**
      * @var ConditionalExpression
      */
-    public $caseConditionExpression = null;
+    public $caseConditionExpression;
 
     /**
      * @var mixed
      */
-    public $thenScalarExpression = null;
+    public $thenScalarExpression;
 
     /**
      * @param ConditionalExpression $caseConditionExpression

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -87,14 +87,14 @@ class QueryBuilder
      *
      * @var integer
      */
-    private $firstResult = null;
+    private $firstResult;
 
     /**
      * The maximum number of results to retrieve.
      *
      * @var integer|null
      */
-    private $maxResults = null;
+    private $maxResults;
 
     /**
      * Keeps root entity alias names for join entities.

--- a/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
@@ -37,7 +37,7 @@ class SequenceGenerator implements Generator, Serializable
     /**
      * @var int|null
      */
-    private $maxValue = null;
+    private $maxValue;
 
     /**
      * Initializes a new sequence generator.

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
@@ -31,13 +31,13 @@ abstract class DDC3597Root
      * @var \DateTime
      * @ORM\Column(name="created_at", type="datetime", nullable=false)
      */
-    protected $createdAt = null;
+    protected $createdAt;
 
     /**
      * @var \DateTime
      * @ORM\Column(name="updated_at", type="datetime", nullable=false)
      */
-    protected $updatedAt = null;
+    protected $updatedAt;
 
     /**
      * Set createdAt

--- a/tests/Doctrine/Tests/Models/Routing/RoutingRouteBooking.php
+++ b/tests/Doctrine/Tests/Models/Routing/RoutingRouteBooking.php
@@ -27,7 +27,7 @@ class RoutingRouteBooking
     /**
      * @ORM\Column(type="string")
      */
-    public $passengerName = null;
+    public $passengerName;
 
     public function getPassengerName()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -15,7 +15,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
     /**
      * @var \Doctrine\DBAL\Schema\AbstractSchemaManager
      */
-    protected $sm = null;
+    protected $sm;
 
     public function setUp()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class GearmanLockTest extends OrmFunctionalTestCase
 {
-    private $gearman = null;
+    private $gearman;
     private $maxRunTime = 0;
     private $articleId;
 

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -32,7 +32,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class NativeQueryTest extends OrmFunctionalTestCase
 {
-    private $platform = null;
+    private $platform;
 
     protected function setUp()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -238,18 +238,18 @@ class DDC1080FooBar
      * @ORM\JoinColumn(name="fooID", referencedColumnName="fooID")
      * @ORM\Id
      */
-    protected $foo = null;
+    protected $foo;
     /**
      * @ORM\ManyToOne(targetEntity="DDC1080Bar")
      * @ORM\JoinColumn(name="barID", referencedColumnName="barID")
      * @ORM\Id
      */
-    protected $bar = null;
+    protected $bar;
     /**
      * @var int orderNr
      * @ORM\Column(name="orderNr", type="integer", nullable=false)
      */
-    protected $orderNr = null;
+    protected $orderNr;
 
     /**
      * Retrieve the foo property

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -57,19 +57,19 @@ class DDC1300Foo
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Id
      */
-    public $fooID = null;
+    public $fooID;
 
     /**
      * @var string fooReference
      * @ORM\Column(name="fooReference", type="string", nullable=true, length=45)
      */
-    public $fooReference = null;
+    public $fooReference;
 
     /**
      * @ORM\OneToMany(targetEntity="DDC1300FooLocale", mappedBy="foo",
      * cascade={"persist"})
      */
-    public $fooLocaleRefFoo = null;
+    public $fooLocaleRefFoo;
 
     /**
      * Constructor
@@ -95,19 +95,19 @@ class DDC1300FooLocale
      * @ORM\JoinColumn(name="fooID", referencedColumnName="fooID")
      * @ORM\Id
      */
-    public $foo = null;
+    public $foo;
 
     /**
      * @var string locale
      * @ORM\Column(name="locale", type="string", nullable=false, length=5)
      * @ORM\Id
      */
-    public $locale = null;
+    public $locale;
 
     /**
      * @var string title
      * @ORM\Column(name="title", type="string", nullable=true, length=150)
      */
-    public $title = null;
+    public $title;
 
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php
@@ -48,7 +48,7 @@ class DDC588Site
     /**
      * @ORM\Column(type="string", length=45)
      */
-    protected $name = null;
+    protected $name;
 
     public function __construct($name = '')
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -64,12 +64,12 @@ class DDC719Group extends Entity {
 	 * 		inverseJoinColumns={@ORM\JoinColumn(name="child_id", referencedColumnName="id")}
 	 * )
 	 */
-	protected $children = null;
+	protected $children;
 
 	/**
 	 * @ORM\ManyToMany(targetEntity="DDC719Group", mappedBy="children")
 	 */
-	protected $parents = null;
+	protected $parents;
 
 	/**
 	 * construct

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -18,7 +18,7 @@ use Doctrine\Tests\OrmTestCase;
 class QueryTest extends OrmTestCase
 {
     /** @var EntityManagerInterface */
-    protected $em = null;
+    protected $em;
 
     protected function setUp()
     {

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -14,12 +14,12 @@ class SchemaValidatorTest extends OrmTestCase
     /**
      * @var EntityManagerInterface
      */
-    private $em = null;
+    private $em;
 
     /**
      * @var SchemaValidator
      */
-    private $validator = null;
+    private $validator;
 
     public function setUp()
     {

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -56,7 +56,7 @@ abstract class OrmTestCase extends DoctrineTestCase
     /**
      * @var \Doctrine\Common\Cache\Cache|null
      */
-    protected $secondLevelCacheDriverImpl = null;
+    protected $secondLevelCacheDriverImpl;
 
     /**
      * @param array $paths


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `no_null_property_initialization`.

Ref: https://github.com/doctrine/doctrine2/pull/6917#issuecomment-353032273