### PR TITLE
[CS] Remove unused use statements

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Query\ResultSetMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\PersistentCollection;
 use Doctrine\Common\Proxy\Proxy;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Query;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use PDO;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * The ArrayHydrator produces a nested array "graph" that is often (not always)

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
-use Doctrine\ORM\Event\PostLoadEventDispatcher;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;

--- a/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\ORM\Mapping;
 
 class ClassMetadataExporter implements Exporter

--- a/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
@@ -6,7 +6,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\FieldMetadata;
-use Doctrine\ORM\Mapping\GeneratorType;
 
 class FieldMetadataExporter extends LocalColumnMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/FieldMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMetadata.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Reflection\ReflectionService;
-use Doctrine\ORM\Sequencing\Generator;
 
 /**
  * Class FieldMetadata

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Persisters\Entity;
 
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
 
 /**

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
-use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -8,8 +8,6 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\GeneratorType;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
-use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Query\AST;
-use Doctrine\ORM\Utility\PersisterHelper;
 use Throwable;
 
 /**

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Query\ParameterTypeInferer;
-use Doctrine\ORM\Utility\PersisterHelper;
 use Throwable;
 
 /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Query;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\InheritanceType;

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Persistence\Proxy;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 use Doctrine\ORM\Query\AST\SelectStatement;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\TreeWalkerAdapter;

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -7,7 +7,6 @@ namespace Doctrine\ORM\Tools;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Mapping\AssociationMetadata;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
-use Doctrine\ORM\Query\QueryException;
 
 /**
  * The PersisterHelper contains logic to infer binding types which is used in

--- a/tests/Doctrine/Performance/Mock/NonProxyLoadingUnitOfWork.php
+++ b/tests/Doctrine/Performance/Mock/NonProxyLoadingUnitOfWork.php
@@ -6,7 +6,6 @@ namespace Doctrine\Performance\Mock;
 
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\UnitOfWork;
-use Doctrine\Tests\ORM\Performance\PersisterMock;
 
 /**
  * An unit of work mock that prevents lazy-loading of proxies

--- a/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityPersisterMock.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Mocks;
 
 use Doctrine\Common\Collections\Criteria;
-use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\GeneratorType;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 
 /**

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\Models\CMS;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\Mapping;
-use Doctrine\Tests\Models\CMS\CmsAddressListener;
 
 /**
  * CmsAddress

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/Cache/City.php
+++ b/tests/Doctrine/Tests/Models/Cache/City.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\Cache;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Cache

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\Models\Company;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\Mapping;
-use Doctrine\Tests\Models\Company\CompanyContractListener;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
@@ -6,9 +6,6 @@ namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
-use Doctrine\Tests\Models\Company\CompanyContractListener;
-use Doctrine\Tests\Models\Company\CompanyFlexUltraContractListener;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * Description of CompanyPerson

--- a/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
+++ b/tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\DDC1476;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity()

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC1590;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\Tests\Models\DDC1590\DDC1590Entity;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC2825/ExplicitSchemaAndTable.php
+++ b/tests/Doctrine/Tests/Models/DDC2825/ExplicitSchemaAndTable.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC2825;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC2825/SchemaAndTableInTableName.php
+++ b/tests/Doctrine/Tests/Models/DDC2825/SchemaAndTableInTableName.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC2825;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * Quoted column name to check that sequence names are

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579Admin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC3579;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\Models\DDC3579;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\MappedSuperClass

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934BaseContract.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\Models\DDC5934;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC5934/DDC5934Contract.php
+++ b/tests/Doctrine/Tests/Models/DDC5934/DDC5934Contract.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC5934;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\MappedSuperclass(repositoryClass="Doctrine\Tests\Models\DDC869\DDC869PaymentRepository")

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Class.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 use Doctrine\DBAL\Types\Type;
 
 class DDC889Class extends DDC889SuperClass

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\DDC889;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\MappedSuperclass

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Models\DDC964;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping;
 
 /**
  * @ORM\Entity

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Util\Debug;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\Tests\Models\Navigation\NavCountry;

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMetadata;

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsGroup;

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\Models\ECommerce\ECommerceCategory;
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Query;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
@@ -6,8 +6,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * Tests a self referential many-to-many association mapping (from a model to the same model, without inheritance).

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php
@@ -7,8 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * Tests a unidirectional many-to-many association mapping (without inheritance).

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\ECommerce\ECommerceCategory;
 use Doctrine\Tests\OrmFunctionalTestCase;

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceCustomer;

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSingleTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSingleTableInheritanceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\OneToOneSingleTableInheritance\Cat;
 use Doctrine\Tests\Models\OneToOneSingleTableInheritance\LitterBox;
 use Doctrine\Tests\Models\OneToOneSingleTableInheritance\Pet;

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Mapping\AssociationMapping;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;

--- a/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php
@@ -12,7 +12,6 @@ use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsTag;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\Models\CMS\CmsUser as CmsUserProxy;
 use ProxyManager\Configuration;
 use ProxyManager\Proxy\GhostObjectInterface;
 

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
 use Doctrine\DBAL\Schema\Comparator;
-use Doctrine\ORM\Tools;
 use Doctrine\Tests\Models;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Mapping\CacheMetadata;
 use Doctrine\ORM\Mapping\CacheUsage;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Tests\Mocks\ConcurrentRegionMock;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\TimestampRegionMock;

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\Models\Cache\State;
 use Doctrine\Tests\Models\Cache\Travel;
-use Doctrine\ORM\Mapping\ClassMetadata;
 
 /**
  * @group DDC-2183

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\Tests\Models;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Util\Debug;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\CMS\CmsGroup;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Internal\Hydration\HydrationException;
 
 /**
  * @group DDC-2306

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\DBAL\Types\Type as DBALType;
-use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\Tests\Models\Generic\BooleanModel;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Tests\Models\Generic\DecimalModel;

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\ValueConversionType;
 
-use Doctrine\Tests\Models;
 use Doctrine\Tests\Models\ValueConversionType as Entity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -29,7 +29,6 @@ use Doctrine\Tests\Models\Hydration\EntityWithArrayDefaultArrayValueM2M;
 use Doctrine\Tests\Models\Hydration\SimpleEntity;
 use ProxyManager\Configuration;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
-use ProxyManager\Proxy\GhostObjectInterface;
 
 class ObjectHydratorTest extends HydrationTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Mapping\TransientMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\MappingException;
-use Doctrine\ORM\Sequencing\SequenceGenerator;
 use Doctrine\Tests\Models\DDC869\DDC869ChequePayment;
 use Doctrine\Tests\Models\DDC869\DDC869CreditCardPayment;
 use Doctrine\Tests\Models\DDC869\DDC869Payment;

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -29,7 +29,6 @@ use Doctrine\Tests\Models\DDC964\DDC964Guest;
 use Doctrine\Tests\Models\Routing\RoutingLeg;
 use Doctrine\Tests\OrmTestCase;
 use DoctrineGlobal_Article;
-use SebastianBergmann\Environment\Runtime;
 
 require_once __DIR__ . '/../../Models/Global/GlobalNamespaceModel.php';
 

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Mapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
-use Doctrine\ORM\Reflection\RuntimeReflectionService;
 use Doctrine\Tests\Models\DDC117\DDC117Translation;
 use Doctrine\Tests\Models\DDC3293\DDC3293User;
 use Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed;

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Tests\Models\CustomType\CustomTypeChild;
-use Doctrine\Tests\Models\CustomType\CustomTypeFriend;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\Generic\NonAlphaColumnsEntity;
 use Doctrine\Tests\OrmTestCase;

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -9,7 +9,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\Common\NotifyPropertyChanged;
 use Doctrine\Common\PropertyChangedListener;
 use Doctrine\ORM\Annotation as ORM;
-use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataBuildingContext;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -20,7 +20,6 @@ use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\DbalTypes\Rot13Type;
 use Doctrine\Tests\EventListener\CacheMetadataListener;
-use Doctrine\Tests\Models;
 use PHPUnit\Framework\AssertionFailedError;
 
 /**

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Proxy\Factory\ProxyFactory;
-use Doctrine\Tests\Mocks;
 
 /**
  * Base testcase class for all ORM testcases.


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `no_unused_imports`.

NOTE: I am confident of PHP-CS-Fixer tool, at the time of writing is a stable and reliable coding-standard fixer. `no_unused_imports` already accounts annotations and doesn't strip related imports.
But if you prefer to test this PR against a functioning travis, ping me as soon as you fix it and I'll rebase this PR.