### PR TITLE
[CS] Phpdoc (and related) blocks indentation

### DIFF
--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -58,7 +58,7 @@ class CacheConfiguration
      */
     public function getCacheLogger()
     {
-         return $this->cacheLogger;
+        return $this->cacheLogger;
     }
 
     /**
@@ -100,7 +100,7 @@ class CacheConfiguration
             );
         }
 
-         return $this->queryValidator;
+        return $this->queryValidator;
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/CacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/CacheEntry.php
@@ -17,5 +17,4 @@ namespace Doctrine\ORM\Cache;
  */
 interface CacheEntry
 {
-
 }

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -31,9 +31,9 @@ class DefaultCache implements Cache
      */
     private $uow;
 
-     /**
-      * @var \Doctrine\ORM\Cache\CacheFactory
-      */
+    /**
+     * @var \Doctrine\ORM\Cache\CacheFactory
+     */
     private $cacheFactory;
 
     /**
@@ -273,12 +273,12 @@ class DefaultCache implements Cache
         return $this->queryCaches[$regionName];
     }
 
-     /**
-      * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata   The entity metadata.
-      * @param mixed                               $identifier The entity identifier.
-      *
-      * @return \Doctrine\ORM\Cache\EntityCacheKey
-      */
+    /**
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata   The entity metadata.
+     * @param mixed                               $identifier The entity identifier.
+     *
+     * @return \Doctrine\ORM\Cache\EntityCacheKey
+     */
     private function buildEntityCacheKey(ClassMetadata $metadata, $identifier)
     {
         if (! is_array($identifier)) {
@@ -322,5 +322,4 @@ class DefaultCache implements Cache
 
         return [$metadata->identifier[0] => $identifier];
     }
-
 }

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -23,9 +23,9 @@ use ProxyManager\Proxy\GhostObjectInterface;
  */
 class DefaultQueryCache implements QueryCache
 {
-     /**
-      * @var \Doctrine\ORM\EntityManagerInterface
-      */
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
     private $em;
 
     /**

--- a/lib/Doctrine/ORM/Cache/LockException.php
+++ b/lib/Doctrine/ORM/Cache/LockException.php
@@ -13,5 +13,4 @@ namespace Doctrine\ORM\Cache;
  */
 class LockException extends CacheException
 {
-
 }

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
@@ -41,12 +41,12 @@ interface CacheLogger
      */
     public function entityCacheMiss($regionName, EntityCacheKey $key);
 
-     /**
-      * Log an entity put into second level cache.
-      *
-      * @param string                                 $regionName The name of the cache region.
-      * @param \Doctrine\ORM\Cache\CollectionCacheKey $key        The cache key of the collection.
-      */
+    /**
+     * Log an entity put into second level cache.
+     *
+     * @param string                                 $regionName The name of the cache region.
+     * @param \Doctrine\ORM\Cache\CollectionCacheKey $key        The cache key of the collection.
+     */
     public function collectionCachePut($regionName, CollectionCacheKey $key);
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -25,9 +25,9 @@ use Doctrine\ORM\Utility\StaticClassNameConverter;
  */
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
-     /**
-      * @var \Doctrine\ORM\UnitOfWork
-      */
+    /**
+     * @var \Doctrine\ORM\UnitOfWork
+     */
     protected $uow;
 
     /**
@@ -55,9 +55,9 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
      */
     protected $association;
 
-     /**
-      * @var array
-      */
+    /**
+     * @var array
+     */
     protected $queuedCache = [];
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -73,7 +73,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
         $ownerId   = $this->uow->getEntityIdentifier($collection->getOwner());
         $key       = new CollectionCacheKey($this->sourceEntity->getRootClassName(), $fieldName, $ownerId);
 
-       // Invalidate non initialized collections OR ordered collection
+        // Invalidate non initialized collections OR ordered collection
         if (($isDirty && ! $isInitialized) ||
             ($this->association instanceof ToManyAssociationMetadata && $this->association->getOrderBy())) {
             $this->persister->update($collection);

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
@@ -15,9 +15,9 @@ use Doctrine\ORM\Utility\StaticClassNameConverter;
  */
 class ReadOnlyCachedCollectionPersister extends NonStrictReadWriteCachedCollectionPersister
 {
-     /**
-      * {@inheritdoc}
-      */
+    /**
+     * {@inheritdoc}
+     */
     public function update(PersistentCollection $collection)
     {
         if ($collection->isDirty() && $collection->getSnapshot()) {

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -50,9 +50,9 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     protected $class;
 
-     /**
-      * @var array
-      */
+    /**
+     * @var array
+     */
     protected $queuedCache = [];
 
     /**

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -42,5 +42,4 @@ class OnFlushEventArgs extends EventArgs
     {
         return $this->em;
     }
-
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -278,7 +278,7 @@ abstract class AbstractHydrator
 
                     // If there are field name collisions in the child class, then we need
                     // to only hydrate if we are looking at the correct discriminator value
-                    if(
+                    if (
                         isset($cacheKeyInfo['discriminatorColumn'],$data[$cacheKeyInfo['discriminatorColumn']]) &&
                         // Note: loose comparison required. See https://github.com/doctrine/doctrine2/pull/6304#issuecomment-323294442
                         $data[$cacheKeyInfo['discriminatorColumn']] != $cacheKeyInfo['discriminatorValue']

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -54,7 +54,7 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
     public function resolve($className)
     {
         if (isset($this->instances[$className = trim($className, '\\')])) {
-           return $this->instances[$className];
+            return $this->instances[$className];
         }
 
         return $this->instances[$className] = new $className();

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -322,7 +322,7 @@ class XmlDriver extends FileDriver
                     // Check for SequenceGenerator/TableGenerator definition
                     if (isset($idElement->{'sequence-generator'})) {
                         $seqGenerator = $idElement->{'sequence-generator'};
-            $idGeneratorDefinition = [
+                        $idGeneratorDefinition = [
                             'sequenceName' => (string) $seqGenerator['sequence-name'],
                             'allocationSize' => (string) $seqGenerator['allocation-size'],
                         ];
@@ -770,7 +770,6 @@ class XmlDriver extends FileDriver
             } else {
                 $array[] = $value;
             }
-
         }
 
         return $array;

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -38,7 +38,6 @@ class MappingException extends \Doctrine\ORM\ORMException
             'No identifier/primary key specified for Entity "%s". Every Entity must have an identifier/primary key.',
             $entityName
         ));
-
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -127,9 +127,9 @@ class OneToManyPersister extends AbstractCollectionPersister
         return (bool) $persister->count($criteria);
     }
 
-     /**
-      * {@inheritdoc}
-      */
+    /**
+     * {@inheritdoc}
+     */
     public function contains(PersistentCollection $collection, $element)
     {
         if ( ! $this->isValidEntityState($element)) {

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1806,7 +1806,6 @@ class BasicEntityPersister implements EntityPersister
 
                     $columns[] = $joinTableName . '.' . $quotedColumnName;
                 }
-
             } else {
                 if (! $owningAssociation->isOwningSide()) {
                     throw ORMException::invalidFindByInverseAssociation($this->class->getClassName(), $field);
@@ -2163,9 +2162,9 @@ class BasicEntityPersister implements EntityPersister
 
         // if one of the join columns is nullable, return left join
         foreach ($association->getJoinColumns() as $joinColumn) {
-             if (! $joinColumn->isNullable()) {
-                 continue;
-             }
+            if (! $joinColumn->isNullable()) {
+                continue;
+            }
 
             return 'LEFT JOIN';
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -36,7 +36,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
         $columnList[] = parent::getSelectColumnsSQL();
 
-         // Append discriminator column
+        // Append discriminator column
         $discrColumn      = $this->class->discriminatorColumn;
         $discrTableAlias  = $this->getSQLTableAlias($discrColumn->getTableName());
         $discrColumnName  = $discrColumn->getColumnName();

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -82,7 +82,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
             $expressionList[] = $this->dispatch($child);
         }
 
-        switch($expr->getType()) {
+        switch ($expr->getType()) {
             case CompositeExpression::TYPE_AND:
                 return '(' . implode(' AND ', $expressionList) . ')';
 

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -736,9 +736,9 @@ final class Query extends AbstractQuery
         );
     }
 
-     /**
-      * {@inheritdoc}
-      */
+    /**
+     * {@inheritdoc}
+     */
     protected function getHash()
     {
         return sha1(parent::getHash(). '-'. $this->firstResult . '-' . $this->maxResults);

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -33,7 +33,6 @@ class LocateFunction extends FunctionNode
      */
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
-
         return $sqlWalker->getConnection()->getDatabasePlatform()->getLocateExpression(
             $sqlWalker->walkStringPrimary($this->secondStringPrimary), // its the other way around in platform
             $sqlWalker->walkStringPrimary($this->firstStringPrimary),

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -99,7 +99,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
             $expressionList[] = $this->dispatch($child);
         }
 
-        switch($expr->getType()) {
+        switch ($expr->getType()) {
             case CompositeExpression::TYPE_AND:
                 return new Expr\Andx($expressionList);
 
@@ -116,15 +116,14 @@ class QueryExpressionVisitor extends ExpressionVisitor
      */
     public function walkComparison(Comparison $comparison)
     {
-
         if ( ! isset($this->queryAliases[0])) {
             throw new QueryException('No aliases are set before invoking walkComparison().');
         }
 
         $field = $this->queryAliases[0] . '.' . $comparison->getField();
 
-        foreach($this->queryAliases as $alias) {
-            if(strpos($comparison->getField() . '.', $alias . '.') === 0) {
+        foreach ($this->queryAliases as $alias) {
+            if (strpos($comparison->getField() . '.', $alias . '.') === 0) {
                 $field = $comparison->getField();
                 break;
             }

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -222,7 +222,9 @@ class ResultSetMapping
         $found = false;
 
         foreach (array_merge($this->metaMappings, $this->fieldMappings) as $columnName => $columnFieldName) {
-            if ( ! ($columnFieldName === $fieldName && $this->columnOwnerMap[$columnName] === $alias)) continue;
+            if ( ! ($columnFieldName === $fieldName && $this->columnOwnerMap[$columnName] === $alias)) {
+                continue;
+            }
 
             $this->addIndexByColumn($alias, $columnName);
             $found = true;

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -306,7 +306,6 @@ class ResultSetMappingBuilder extends ResultSetMapping
                         $this->addJoinedEntityResult($association->getTargetEntity(), $joinAlias, $rootAlias, $fieldName);
                     }
                 }
-
             }
         }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -308,7 +308,6 @@ class SqlWalker implements TreeWalker
     public function getSQLColumnAlias()
     {
         return $this->platform->getSQLResultCasing('c' . $this->aliasCounter++);
-
     }
 
     /**

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -103,11 +103,11 @@ class QueryBuilder
      */
     private $joinRootAliases = [];
 
-     /**
-      * Whether to use second level cache, if available.
-      *
-      * @var boolean
-      */
+    /**
+     * Whether to use second level cache, if available.
+     *
+     * @var boolean
+     */
     protected $cacheable = false;
 
     /**
@@ -1285,16 +1285,15 @@ class QueryBuilder
 
         if ($criteria->getOrderings()) {
             foreach ($criteria->getOrderings() as $sort => $order) {
-
                 $hasValidAlias = false;
-                foreach($allAliases as $alias) {
-                    if(strpos($sort . '.', $alias . '.') === 0) {
+                foreach ($allAliases as $alias) {
+                    if (strpos($sort . '.', $alias . '.') === 0) {
                         $hasValidAlias = true;
                         break;
                     }
                 }
 
-                if(!$hasValidAlias) {
+                if (!$hasValidAlias) {
                     $sort = $allAliases[0] . '.' . $sort;
                 }
 
@@ -1344,7 +1343,7 @@ class QueryBuilder
      */
     private function getDQLForDelete()
     {
-         return 'DELETE'
+        return 'DELETE'
               . $this->getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
               . $this->getReducedDQLQueryPart('where', ['pre' => ' WHERE '])
               . $this->getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
@@ -1355,7 +1354,7 @@ class QueryBuilder
      */
     private function getDQLForUpdate()
     {
-         return 'UPDATE'
+        return 'UPDATE'
               . $this->getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
               . $this->getReducedDQLQueryPart('set', ['pre' => ' SET ', 'separator' => ', '])
               . $this->getReducedDQLQueryPart('where', ['pre' => ' WHERE '])

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -320,12 +320,11 @@ EOT
 
             if ($property instanceof FieldMetadata) {
                 $output = array_merge($output, $this->formatColumn($property));
-            }  elseif ($property instanceof AssociationMetadata) {
+            } elseif ($property instanceof AssociationMetadata) {
                 // @todo guilhermeblanco Fix me! We are trying to iterate through an AssociationMetadata instance
                 foreach ($property as $field => $value) {
                     $output[] = $this->formatField(sprintf('    %s', $field), $this->formatValue($value));
                 }
-
             }
         }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -230,7 +230,6 @@ class SchemaTool
                                 ['onDelete' => 'CASCADE']
                             );
                         }
-
                     }
 
                     $table->setPrimaryKey($pkColumns);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1713,7 +1713,6 @@ class UnitOfWork implements PropertyChangedListener
             default:
                 throw new UnexpectedValueException("Unexpected entity state: $entityState." . self::objToStr($entity));
         }
-
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/CacheEntryMock.php
+++ b/tests/Doctrine/Tests/Mocks/CacheEntryMock.php
@@ -11,5 +11,4 @@ use Doctrine\ORM\Cache\CacheEntry;
  */
 class CacheEntryMock extends \ArrayObject implements CacheEntry
 {
-
 }

--- a/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php
@@ -167,7 +167,6 @@ class ConcurrentRegionMock implements ConcurrentRegion
         $this->throwException(__FUNCTION__);
 
         if (isset($this->locks[$key->hash])) {
-
             if ($lock !== null && $this->locks[$key->hash]->value === $lock->value) {
                 return $this->region->put($key, $entry);
             }

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -48,7 +48,9 @@ class HydratorMockStatement implements \IteratorAggregate, Statement
     public function fetchColumn($columnNumber = 0)
     {
         $row = current($this->resultSet);
-        if ( ! is_array($row)) return false;
+        if ( ! is_array($row)) {
+            return false;
+        }
         $val = array_shift($row);
         return $val !== null ? $val : false;
     }

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -102,27 +102,33 @@ class CmsAddress
      */
     public $user;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getUser() {
+    public function getUser()
+    {
         return $this->user;
     }
 
-    public function getCountry() {
+    public function getCountry()
+    {
         return $this->country;
     }
 
-    public function getZipCode() {
+    public function getZipCode()
+    {
         return $this->zip;
     }
 
-    public function getCity() {
+    public function getCity()
+    {
         return $this->city;
     }
 
-    public function setUser(CmsUser $user) {
+    public function setUser(CmsUser $user)
+    {
         if ($this->user !== $user) {
             $this->user = $user;
             $user->setAddress($this);

--- a/tests/Doctrine/Tests/Models/CMS/CmsArticle.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsArticle.php
@@ -42,11 +42,13 @@ class CmsArticle
      */
     public $version;
 
-    public function setAuthor(CmsUser $author) {
+    public function setAuthor(CmsUser $author)
+    {
         $this->user = $author;
     }
 
-    public function addComment(CmsComment $comment) {
+    public function addComment(CmsComment $comment)
+    {
         $this->comments[] = $comment;
         $comment->setArticle($this);
     }

--- a/tests/Doctrine/Tests/Models/CMS/CmsComment.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsComment.php
@@ -32,11 +32,13 @@ class CmsComment
      */
     public $article;
 
-    public function setArticle(CmsArticle $article) {
+    public function setArticle(CmsArticle $article)
+    {
         $this->article = $article;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         return __CLASS__."[id=".$this->id."]";
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsEmail.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsEmail.php
@@ -30,23 +30,28 @@ class CmsEmail
      */
     public $user;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getEmail() {
+    public function getEmail()
+    {
         return $this->email;
     }
 
-    public function setEmail($email) {
+    public function setEmail($email)
+    {
         $this->email = $email;
     }
 
-    public function getUser() {
+    public function getUser()
+    {
         return $this->user;
     }
 
-    public function setUser(CmsUser $user) {
+    public function setUser(CmsUser $user)
+    {
         $this->user = $user;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsEmployee.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsEmployee.php
@@ -34,15 +34,18 @@ class CmsEmployee
      */
     private $spouse;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function getSpouse() {
+    public function getSpouse()
+    {
         return $this->spouse;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
@@ -31,19 +31,23 @@ class CmsGroup
      */
     public $users;
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function addUser(CmsUser $user) {
+    public function addUser(CmsUser $user)
+    {
         $this->users[] = $user;
     }
 
-    public function getUsers() {
+    public function getUsers()
+    {
         return $this->users;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsPhonenumber.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsPhonenumber.php
@@ -22,11 +22,13 @@ class CmsPhonenumber
      */
     public $user;
 
-    public function setUser(CmsUser $user) {
+    public function setUser(CmsUser $user)
+    {
         $this->user = $user;
     }
 
-    public function getUser() {
+    public function getUser()
+    {
         return $this->user;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsTag.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTag.php
@@ -29,19 +29,23 @@ class CmsTag
      */
     public $users;
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function addUser(CmsUser $user) {
+    public function addUser(CmsUser $user)
+    {
         $this->users[] = $user;
     }
 
-    public function getUsers() {
+    public function getUsers()
+    {
         return $this->users;
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -178,26 +178,31 @@ class CmsUser
 
     public $nonPersistedPropertyObject;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->phonenumbers = new ArrayCollection;
         $this->articles = new ArrayCollection;
         $this->groups = new ArrayCollection;
         $this->tags = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getStatus() {
+    public function getStatus()
+    {
         return $this->status;
     }
 
-    public function getUsername() {
+    public function getUsername()
+    {
         return $this->username;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
@@ -206,39 +211,47 @@ class CmsUser
      *
      * @param CmsPhonenumber $phone
      */
-    public function addPhonenumber(CmsPhonenumber $phone) {
+    public function addPhonenumber(CmsPhonenumber $phone)
+    {
         $this->phonenumbers[] = $phone;
         $phone->setUser($this);
     }
 
-    public function getPhonenumbers() {
+    public function getPhonenumbers()
+    {
         return $this->phonenumbers;
     }
 
-    public function addArticle(CmsArticle $article) {
+    public function addArticle(CmsArticle $article)
+    {
         $this->articles[] = $article;
         $article->setAuthor($this);
     }
 
-    public function addGroup(CmsGroup $group) {
+    public function addGroup(CmsGroup $group)
+    {
         $this->groups[] = $group;
         $group->addUser($this);
     }
 
-    public function getGroups() {
+    public function getGroups()
+    {
         return $this->groups;
     }
 
-    public function addTag(CmsTag $tag) {
+    public function addTag(CmsTag $tag)
+    {
         $this->tags[] = $tag;
         $tag->addUser($this);
     }
 
-    public function getTags() {
+    public function getTags()
+    {
         return $this->tags;
     }
 
-    public function removePhonenumber($index) {
+    public function removePhonenumber($index)
+    {
         if (isset($this->phonenumbers[$index])) {
             $ph = $this->phonenumbers[$index];
             unset($this->phonenumbers[$index]);
@@ -248,9 +261,13 @@ class CmsUser
         return false;
     }
 
-    public function getAddress() { return $this->address; }
+    public function getAddress()
+    {
+        return $this->address;
+    }
 
-    public function setAddress(CmsAddress $address) {
+    public function setAddress(CmsAddress $address)
+    {
         if ($this->address !== $address) {
             $this->address = $address;
             $address->setUser($this);
@@ -260,9 +277,13 @@ class CmsUser
     /**
      * @return CmsEmail
      */
-    public function getEmail() { return $this->email; }
+    public function getEmail()
+    {
+        return $this->email;
+    }
 
-    public function setEmail(CmsEmail $email = null) {
+    public function setEmail(CmsEmail $email = null)
+    {
         if ($this->email !== $email) {
             $this->email = $email;
 

--- a/tests/Doctrine/Tests/Models/Cache/City.php
+++ b/tests/Doctrine/Tests/Models/Cache/City.php
@@ -33,16 +33,16 @@ class City
      */
     protected $state;
 
-     /**
-      * @ORM\ManyToMany(targetEntity="Travel", mappedBy="visitedCities")
-      */
+    /**
+     * @ORM\ManyToMany(targetEntity="Travel", mappedBy="visitedCities")
+     */
     public $travels;
 
-     /**
-      * @ORM\Cache
-      * @ORM\OrderBy({"name" = "ASC"})
-      * @ORM\OneToMany(targetEntity="Attraction", mappedBy="city")
-      */
+    /**
+     * @ORM\Cache
+     * @ORM\OrderBy({"name" = "ASC"})
+     * @ORM\OneToMany(targetEntity="Attraction", mappedBy="city")
+     */
     public $attractions;
 
     public function __construct($name, State $state = null)

--- a/tests/Doctrine/Tests/Models/Cache/Token.php
+++ b/tests/Doctrine/Tests/Models/Cache/Token.php
@@ -96,5 +96,4 @@ class Token
     {
         return $this->complexAction;
     }
-
 }

--- a/tests/Doctrine/Tests/Models/Cache/Traveler.php
+++ b/tests/Doctrine/Tests/Models/Cache/Traveler.php
@@ -38,7 +38,7 @@ class Traveler
      * @ORM\Cache
      * @ORM\OneToOne(targetEntity="TravelerProfile")
      */
-     protected $profile;
+    protected $profile;
 
     /**
      * @param string $name

--- a/tests/Doctrine/Tests/Models/Company/CompanyAuction.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyAuction.php
@@ -17,11 +17,13 @@ class CompanyAuction extends CompanyEvent
      */
     private $data;
 
-    public function setData($data) {
+    public function setData($data)
+    {
         $this->data = $data;
     }
 
-    public function getData() {
+    public function getData()
+    {
         return $this->data;
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyCar.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyCar.php
@@ -23,15 +23,18 @@ class CompanyCar
      */
     private $brand;
 
-    public function __construct($brand = null) {
+    public function __construct($brand = null)
+    {
         $this->brand = $brand;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getBrand() {
+    public function getBrand()
+    {
         return $this->title;
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyEmployee.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyEmployee.php
@@ -37,27 +37,33 @@ class CompanyEmployee extends CompanyPerson
      */
     public $soldContracts;
 
-    public function getSalary() {
+    public function getSalary()
+    {
         return $this->salary;
     }
 
-    public function setSalary($salary) {
+    public function setSalary($salary)
+    {
         $this->salary = $salary;
     }
 
-    public function getDepartment() {
+    public function getDepartment()
+    {
         return $this->department;
     }
 
-    public function setDepartment($dep) {
+    public function setDepartment($dep)
+    {
         $this->department = $dep;
     }
 
-    public function getStartDate() {
+    public function getStartDate()
+    {
         return $this->startDate;
     }
 
-    public function setStartDate($date) {
+    public function setStartDate($date)
+    {
         $this->startDate = $date;
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyEvent.php
@@ -12,29 +12,32 @@ use Doctrine\ORM\Annotation as ORM;
  * @ORM\DiscriminatorColumn(name="event_type", type="string")
  * @ORM\DiscriminatorMap({"auction"="CompanyAuction", "raffle"="CompanyRaffle"})
  */
-abstract class CompanyEvent {
-   /**
-    * @ORM\Id @ORM\Column(type="integer")
-    * @ORM\GeneratedValue
-    */
+abstract class CompanyEvent
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     private $id;
 
     /**
      * @ORM\ManyToOne(targetEntity="CompanyOrganization", inversedBy="events", cascade={"persist"})
      * @ORM\JoinColumn(name="org_id", referencedColumnName="id")
      */
-     private $organization;
+    private $organization;
 
-     public function getId() {
-         return $this->id;
-     }
+    public function getId()
+    {
+        return $this->id;
+    }
 
-     public function getOrganization() {
-         return $this->organization;
-     }
+    public function getOrganization()
+    {
+        return $this->organization;
+    }
 
-     public function setOrganization(CompanyOrganization $org) {
-         $this->organization = $org;
-     }
-
+    public function setOrganization(CompanyOrganization $org)
+    {
+        $this->organization = $org;
+    }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyManager.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyManager.php
@@ -28,19 +28,23 @@ class CompanyManager extends CompanyEmployee
      */
     public $managedContracts;
 
-    public function getTitle() {
+    public function getTitle()
+    {
         return $this->title;
     }
 
-    public function setTitle($title) {
+    public function setTitle($title)
+    {
         $this->title = $title;
     }
 
-    public function getCar() {
+    public function getCar()
+    {
         return $this->car;
     }
 
-    public function setCar(CompanyCar $car) {
+    public function setCar(CompanyCar $car)
+    {
         $this->car = $car;
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyOrganization.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyOrganization.php
@@ -10,27 +10,31 @@ use Doctrine\ORM\Annotation as ORM;
  * @ORM\Entity
  * @ORM\Table(name="company_organizations")
  */
-class CompanyOrganization {
-   /**
-    * @ORM\Id @ORM\Column(type="integer")
-    * @ORM\GeneratedValue(strategy="AUTO")
-    */
-   private $id;
+class CompanyOrganization
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
 
     /**
      * @ORM\OneToMany(targetEntity="CompanyEvent", mappedBy="organization", cascade={"persist"}, fetch="EXTRA_LAZY")
      */
     public $events;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getEvents() {
+    public function getEvents()
+    {
         return $this->events;
     }
 
-    public function addEvent(CompanyEvent $event) {
+    public function addEvent(CompanyEvent $event)
+    {
         $this->events[] = $event;
         $event->setOrganization($this);
     }
@@ -41,11 +45,13 @@ class CompanyOrganization {
      */
     private $mainevent;
 
-    public function getMainEvent() {
+    public function getMainEvent()
+    {
         return $this->mainevent;
     }
 
-    public function setMainEvent($event) {
+    public function setMainEvent($event)
+    {
         $this->mainevent = $event;
     }
 }

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -84,38 +84,46 @@ class CompanyPerson
      */
     private $friends;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->friends = new \Doctrine\Common\Collections\ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return  $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getSpouse() {
+    public function getSpouse()
+    {
         return $this->spouse;
     }
 
-    public function getFriends() {
+    public function getFriends()
+    {
         return $this->friends;
     }
 
-    public function addFriend(CompanyPerson $friend) {
+    public function addFriend(CompanyPerson $friend)
+    {
         if ( ! $this->friends->contains($friend)) {
             $this->friends->add($friend);
             $friend->addFriend($this);
         }
     }
 
-    public function setSpouse(CompanyPerson $spouse) {
+    public function setSpouse(CompanyPerson $spouse)
+    {
         if ($spouse !== $this->spouse) {
             $this->spouse = $spouse;
             $this->spouse->setSpouse($this);

--- a/tests/Doctrine/Tests/Models/Company/CompanyRaffle.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyRaffle.php
@@ -15,11 +15,13 @@ class CompanyRaffle extends CompanyEvent
     /** @ORM\Column */
     private $data;
 
-    public function setData($data) {
+    public function setData($data)
+    {
         $this->data = $data;
     }
 
-    public function getData() {
+    public function getData()
+    {
         return $this->data;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590User.php
@@ -16,5 +16,4 @@ class DDC1590User extends DDC1590Entity
      * @ORM\Column(type="string", length=255)
      */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC3231/DDC3231User1.php
+++ b/tests/Doctrine/Tests/Models/DDC3231/DDC3231User1.php
@@ -23,5 +23,4 @@ class DDC3231User1
      * @ORM\Column(type="string", length=255)
      */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC3231/DDC3231User1NoNamespace.php
+++ b/tests/Doctrine/Tests/Models/DDC3231/DDC3231User1NoNamespace.php
@@ -21,5 +21,4 @@ class DDC3231User1NoNamespace
      * @ORM\Column(type="string", length=255)
      */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC3231/DDC3231User2.php
+++ b/tests/Doctrine/Tests/Models/DDC3231/DDC3231User2.php
@@ -23,5 +23,4 @@ class DDC3231User2
      * @ORM\Column(type="string", length=255)
      */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC3231/DDC3231User2NoNamespace.php
+++ b/tests/Doctrine/Tests/Models/DDC3231/DDC3231User2NoNamespace.php
@@ -21,5 +21,4 @@ class DDC3231User2NoNamespace
      * @ORM\Column(type="string", length=255)
      */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
@@ -65,6 +65,5 @@ class DDC3579Group
     {
         return $this->admins;
     }
-
 }
 

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Image.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Image.php
@@ -24,7 +24,8 @@ class DDC3597Image extends DDC3597Media
     /**
      * @param string $distributionHash
      */
-    public function __construct($distributionHash) {
+    public function __construct($distributionHash)
+    {
         parent::__construct($distributionHash);
         $this->dimension = new DDC3597Dimension();
     }
@@ -32,7 +33,8 @@ class DDC3597Image extends DDC3597Media
     /**
      * @return DDC3597Dimension
      */
-    public function getDimension() {
+    public function getDimension()
+    {
         return $this->dimension;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Media.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Media.php
@@ -34,42 +34,48 @@ abstract class DDC3597Media extends DDC3597Root
      */
     private $format;
 
-    public function __construct($distributionHash) {
+    public function __construct($distributionHash)
+    {
         $this->distributionHash = $distributionHash;
     }
 
     /**
      * @return string
      */
-    public function getDistributionHash() {
+    public function getDistributionHash()
+    {
         return $this->distributionHash;
     }
 
     /**
      * @return int
      */
-    public function getSize() {
+    public function getSize()
+    {
         return $this->size;
     }
 
     /**
      * @param int $size
      */
-    public function setSize($size) {
+    public function setSize($size)
+    {
         $this->size = $size;
     }
 
     /**
      * @return string
      */
-    public function getFormat() {
+    public function getFormat()
+    {
         return $this->format;
     }
 
     /**
      * @param string $format
      */
-    public function setFormat($format) {
+    public function setFormat($format)
+    {
         $this->format = $format;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php
@@ -44,7 +44,8 @@ abstract class DDC3597Root
      *
      * @ORM\PrePersist
      */
-    public function prePersist() {
+    public function prePersist()
+    {
         $this->updatedAt = $this->createdAt = new \DateTime();
     }
 
@@ -53,14 +54,16 @@ abstract class DDC3597Root
      *
      * @ORM\PreUpdate
      */
-    public function preUpdate() {
+    public function preUpdate()
+    {
         $this->updatedAt = new \DateTime();
     }
 
     /**
      * @return int
      */
-    public function getId() {
+    public function getId()
+    {
         return (int)$this->id;
     }
 
@@ -68,14 +71,16 @@ abstract class DDC3597Root
     /**
      * @return \DateTime
      */
-    public function getCreatedAt() {
+    public function getCreatedAt()
+    {
         return $this->createdAt;
     }
 
     /**
      * @return \DateTime
      */
-    public function getUpdatedAt() {
+    public function getUpdatedAt()
+    {
         return $this->updatedAt;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3597/Embeddable/DDC3597Dimension.php
+++ b/tests/Doctrine/Tests/Models/DDC3597/Embeddable/DDC3597Dimension.php
@@ -25,7 +25,8 @@ class DDC3597Dimension
      */
     private $height;
 
-    public function __construct($width = 0, $height = 0) {
+    public function __construct($width = 0, $height = 0)
+    {
         $this->setWidth($width);
         $this->setHeight($height);
     }
@@ -33,28 +34,32 @@ class DDC3597Dimension
     /**
      * @return int
      */
-    public function getWidth() {
+    public function getWidth()
+    {
         return $this->width;
     }
 
     /**
      * @param int $width
      */
-    public function setWidth($width) {
+    public function setWidth($width)
+    {
         $this->width = (int)$width;
     }
 
     /**
      * @return int
      */
-    public function getHeight() {
+    public function getHeight()
+    {
         return $this->height;
     }
 
     /**
      * @param int $height
      */
-    public function setHeight($height) {
+    public function setHeight($height)
+    {
         $this->height = (int)$height;
     }
 }

--- a/tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityB.php
+++ b/tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityB.php
@@ -74,5 +74,4 @@ class DDC3711EntityB
     {
         $this->entityA[] = $entityA;
     }
-
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753DefaultRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753DefaultRepository.php
@@ -15,5 +15,4 @@ class DDC753DefaultRepository extends EntityRepository
     {
         return true;
     }
-
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithCustomRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithCustomRepository.php
@@ -21,5 +21,4 @@ class DDC753EntityWithCustomRepository
 
     /** @ORM\Column(type="string") */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithDefaultCustomRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithDefaultCustomRepository.php
@@ -20,5 +20,4 @@ class DDC753EntityWithDefaultCustomRepository
 
     /** @ORM\Column(type="string") */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithInvalidRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753EntityWithInvalidRepository.php
@@ -20,5 +20,4 @@ class DDC753EntityWithInvalidRepository
 
     /** @ORM\Column(type="string") */
     protected $name;
-
 }

--- a/tests/Doctrine/Tests/Models/DDC753/DDC753InvalidRepository.php
+++ b/tests/Doctrine/Tests/Models/DDC753/DDC753InvalidRepository.php
@@ -6,5 +6,4 @@ namespace Doctrine\Tests\Models\DDC753;
 
 class DDC753InvalidRepository
 {
-
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Address.php
@@ -122,5 +122,4 @@ class DDC964Address
     {
         $this->street = $street;
     }
-
 }

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
@@ -65,6 +65,5 @@ class DDC964Group
     {
         return $this->users;
     }
-
 }
 

--- a/tests/Doctrine/Tests/Models/ECommerce/ECommerceCart.php
+++ b/tests/Doctrine/Tests/Models/ECommerce/ECommerceCart.php
@@ -48,26 +48,31 @@ class ECommerceCart
         $this->products = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getPayment() {
+    public function getPayment()
+    {
         return $this->payment;
     }
 
-    public function setPayment($payment) {
+    public function setPayment($payment)
+    {
         $this->payment = $payment;
     }
 
-    public function setCustomer(ECommerceCustomer $customer) {
+    public function setCustomer(ECommerceCustomer $customer)
+    {
         if ($this->customer !== $customer) {
             $this->customer = $customer;
             $customer->setCart($this);
         }
     }
 
-    public function removeCustomer() {
+    public function removeCustomer()
+    {
         if ($this->customer !== null) {
             $customer = $this->customer;
             $this->customer = null;
@@ -75,7 +80,8 @@ class ECommerceCart
         }
     }
 
-    public function getCustomer() {
+    public function getCustomer()
+    {
         return $this->customer;
     }
 
@@ -84,11 +90,13 @@ class ECommerceCart
         return $this->products;
     }
 
-    public function addProduct(ECommerceProduct $product) {
+    public function addProduct(ECommerceProduct $product)
+    {
         $this->products[] = $product;
     }
 
-    public function removeProduct(ECommerceProduct $product) {
+    public function removeProduct(ECommerceProduct $product)
+    {
         return $this->products->removeElement($product);
     }
 }

--- a/tests/Doctrine/Tests/Models/ECommerce/ECommerceCustomer.php
+++ b/tests/Doctrine/Tests/Models/ECommerce/ECommerceCustomer.php
@@ -43,15 +43,18 @@ class ECommerceCustomer
      */
     private $mentor;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
@@ -64,11 +67,13 @@ class ECommerceCustomer
     }
 
     /* Does not properly maintain the bidirectional association! */
-    public function brokenSetCart(ECommerceCart $cart) {
+    public function brokenSetCart(ECommerceCart $cart)
+    {
         $this->cart = $cart;
     }
 
-    public function getCart() {
+    public function getCart()
+    {
         return $this->cart;
     }
 

--- a/tests/Doctrine/Tests/Models/ECommerce/ECommerceFeature.php
+++ b/tests/Doctrine/Tests/Models/ECommerce/ECommerceFeature.php
@@ -33,23 +33,28 @@ class ECommerceFeature
      */
     private $product;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getDescription() {
+    public function getDescription()
+    {
         return $this->description;
     }
 
-    public function setDescription($description) {
+    public function setDescription($description)
+    {
         $this->description = $description;
     }
 
-    public function setProduct(ECommerceProduct $product) {
+    public function setProduct(ECommerceProduct $product)
+    {
         $this->product = $product;
     }
 
-    public function removeProduct() {
+    public function removeProduct()
+    {
         if ($this->product !== null) {
             $product = $this->product;
             $this->product = null;
@@ -57,7 +62,8 @@ class ECommerceFeature
         }
     }
 
-    public function getProduct() {
+    public function getProduct()
+    {
         return $this->product;
     }
 }

--- a/tests/Doctrine/Tests/Models/Forum/ForumCategory.php
+++ b/tests/Doctrine/Tests/Models/Forum/ForumCategory.php
@@ -30,7 +30,8 @@ class ForumCategory
      */
     public $boards;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 }

--- a/tests/Doctrine/Tests/Models/Forum/ForumEntry.php
+++ b/tests/Doctrine/Tests/Models/Forum/ForumEntry.php
@@ -23,7 +23,8 @@ class ForumEntry
      */
     public $topic;
 
-    public function &getTopicByReference() {
+    public function &getTopicByReference()
+    {
         return $this->topic;
     }
 }

--- a/tests/Doctrine/Tests/Models/Forum/ForumUser.php
+++ b/tests/Doctrine/Tests/Models/Forum/ForumUser.php
@@ -29,19 +29,23 @@ class ForumUser
      */
     public $avatar;
 
-    public function getId() {
-    	return $this->id;
+    public function getId()
+    {
+        return $this->id;
     }
 
-    public function getUsername() {
-    	return $this->username;
+    public function getUsername()
+    {
+        return $this->username;
     }
 
-    public function getAvatar() {
-    	return $this->avatar;
+    public function getAvatar()
+    {
+        return $this->avatar;
     }
 
-    public function setAvatar(ForumAvatar $avatar) {
-    	$this->avatar = $avatar;
+    public function setAvatar(ForumAvatar $avatar)
+    {
+        $this->avatar = $avatar;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
@@ -35,7 +35,7 @@ class LegacyArticle
      */
     public $user;
     
-    public function setAuthor(LegacyUser $author) 
+    public function setAuthor(LegacyUser $author)
     {
         $this->user = $author;
     }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyCar.php
@@ -34,11 +34,13 @@ class LegacyCar
         return $this->description;
     }
 
-    public function addUser(LegacyUser $user) {
+    public function addUser(LegacyUser $user)
+    {
         $this->users[] = $user;
     }
 
-    public function getUsers() {
+    public function getUsers()
+    {
         return $this->users;
     }
 }

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
@@ -56,15 +56,18 @@ class LegacyUser
         $this->cars = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getUsername() {
+    public function getUsername()
+    {
         return $this->username;
     }
 
-    public function addArticle(LegacyArticle $article) {
+    public function addArticle(LegacyArticle $article)
+    {
         $this->articles[] = $article;
         $article->setAuthor($this);
     }
@@ -79,12 +82,14 @@ class LegacyUser
         return $this->references;
     }
 
-    public function addCar(LegacyCar $car) {
+    public function addCar(LegacyCar $car)
+    {
         $this->cars[] = $car;
         $car->addUser($this);
     }
 
-    public function getCars() {
+    public function getCars()
+    {
         return $this->cars;
     }
 }

--- a/tests/Doctrine/Tests/Models/Navigation/NavCountry.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavCountry.php
@@ -29,15 +29,18 @@ class NavCountry
      */
     private $pois;
 
-    public function __construct($name) {
+    public function __construct($name)
+    {
         $this->name = $name;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 }

--- a/tests/Doctrine/Tests/Models/Navigation/NavPhotos.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavPhotos.php
@@ -33,20 +33,24 @@ class NavPhotos
      */
     private $file;
 
-    public function __construct($poi, $file) {
+    public function __construct($poi, $file)
+    {
         $this->poi = $poi;
         $this->file = $file;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getPointOfInterest() {
+    public function getPointOfInterest()
+    {
         return $this->poi;
     }
 
-    public function getFile() {
+    public function getFile()
+    {
         return $this->file;
     }
 }

--- a/tests/Doctrine/Tests/Models/Navigation/NavPointOfInterest.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavPointOfInterest.php
@@ -34,16 +34,16 @@ class NavPointOfInterest
      */
     private $country;
 
-     /**
-      * @ORM\ManyToMany(targetEntity="NavUser", cascade={"persist"})
-      * @ORM\JoinTable(name="navigation_pois_visitors",
-      *      inverseJoinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
-      *      joinColumns={
-      *          @ORM\JoinColumn(name="poi_long", referencedColumnName="nav_long"),
-      *          @ORM\JoinColumn(name="poi_lat", referencedColumnName="nav_lat")
-      *      }
-      * )
-      */
+    /**
+     * @ORM\ManyToMany(targetEntity="NavUser", cascade={"persist"})
+     * @ORM\JoinTable(name="navigation_pois_visitors",
+     *      inverseJoinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id")},
+     *      joinColumns={
+     *          @ORM\JoinColumn(name="poi_long", referencedColumnName="nav_long"),
+     *          @ORM\JoinColumn(name="poi_lat", referencedColumnName="nav_lat")
+     *      }
+     * )
+     */
     private $visitors;
 
     public function __construct($lat, $long, $name, $country)
@@ -55,19 +55,23 @@ class NavPointOfInterest
         $this->visitors = new \Doctrine\Common\Collections\ArrayCollection;
     }
 
-    public function getLong() {
+    public function getLong()
+    {
         return $this->long;
     }
 
-    public function getLat() {
+    public function getLat()
+    {
         return $this->lat;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function getCountry() {
+    public function getCountry()
+    {
         return $this->country;
     }
 

--- a/tests/Doctrine/Tests/Models/Quote/Address.php
+++ b/tests/Doctrine/Tests/Models/Quote/Address.php
@@ -33,7 +33,8 @@ class Address
      */
     public $user;
 
-    public function setUser(User $user) {
+    public function setUser(User $user)
+    {
         if ($this->user !== $user) {
             $this->user = $user;
             $user->setAddress($this);

--- a/tests/Doctrine/Tests/Models/Quote/User.php
+++ b/tests/Doctrine/Tests/Models/Quote/User.php
@@ -77,7 +77,8 @@ class User
         return $this->groups;
     }
 
-    public function setAddress(Address $address) {
+    public function setAddress(Address $address)
+    {
         if ($this->address !== $address) {
             $this->address = $address;
             $address->setUser($this);

--- a/tests/Doctrine/Tests/Models/Taxi/Car.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Car.php
@@ -34,7 +34,7 @@ class Car
      */
     private $carRides;
     
-    public function getBrand() 
+    public function getBrand()
     {
         return $this->brand;
     }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php
@@ -381,5 +381,4 @@ class DefaultCacheFactoryTest extends OrmTestCase
 
         self::assertInstanceOf(DefaultMultiGetRegion::class, $barRegion);
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -254,5 +254,4 @@ class DefaultCacheTest extends OrmTestCase
 
         self::assertEquals(['id'=>$identifier], $method->invoke($this->cache, $metadata, $identifier));
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
@@ -80,5 +80,4 @@ class DefaultCollectionHydratorTest extends OrmFunctionalTestCase
         self::assertEquals(UnitOfWork::STATE_MANAGED, $this->em->getUnitOfWork()->getEntityState($collection[0]));
         self::assertEquals(UnitOfWork::STATE_MANAGED, $this->em->getUnitOfWork()->getEntityState($collection[1]));
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
@@ -195,5 +195,4 @@ class DefaultEntityHydratorTest extends OrmTestCase
             $cache->data
         );
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -663,7 +663,6 @@ class DefaultQueryCacheTest extends OrmTestCase
 
         self::assertFalse($this->queryCache->put($key, $rsm, $result));
     }
-
 }
 
 class CacheFactoryDefaultQueryCacheTest extends Cache\DefaultCacheFactory

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -111,8 +111,7 @@ final class SharedArrayCache extends ArrayCache
 {
     public function createChild(): Cache
     {
-        return new class ($this) extends CacheProvider
-        {
+        return new class ($this) extends CacheProvider {
             /**
              * @var ArrayCache
              */

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -164,7 +164,8 @@ class EntityManagerTest extends OrmTestCase
     /**
      * @dataProvider dataMethodsAffectedByNoObjectArguments
      */
-    public function testThrowsExceptionOnNonObjectValues($methodName) {
+    public function testThrowsExceptionOnNonObjectValues($methodName)
+    {
         $this->expectException(ORMInvalidArgumentException::class);
         $this->expectExceptionMessage('EntityManager#' . $methodName . '() expects parameter 1 to be an entity object, NULL given.');
 

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -16,7 +16,8 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class AdvancedAssociationTest extends OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
 
         try {
@@ -154,7 +155,7 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
  * @ORM\Entity
  * @ORM\Table(name="lemma")
  */
-class Lemma 
+class Lemma
 {
     const CLASS_NAME = __CLASS__;
 
@@ -206,7 +207,8 @@ class Lemma
      *
      * @return string
      */
-    public function getLemma(){
+    public function getLemma()
+    {
         return $this->lemma;
     }
 
@@ -246,7 +248,7 @@ class Lemma
  * @ORM\Entity
  * @ORM\Table(name="type")
  */
-class Type 
+class Type
 {
     const CLASS_NAME = __CLASS__;
 
@@ -376,7 +378,7 @@ class Type
  * @ORM\Entity
  * @ORM\Table(name="phrase")
  */
-class Phrase 
+class Phrase
 {
     const CLASS_NAME = __CLASS__;
 
@@ -477,7 +479,7 @@ class Phrase
  * @ORM\Entity
  * @ORM\Table(name="phrase_type")
  */
-class PhraseType 
+class PhraseType
 {
     const CLASS_NAME = __CLASS__;
 
@@ -567,7 +569,6 @@ class PhraseType
     {
         return $this->phrases;
     }
-
 }
 
 /**
@@ -621,7 +622,7 @@ class Definition
         return $this->phrase;
     }
 
-    public function removePhrase() 
+    public function removePhrase()
     {
         if ($this->phrase !== null) {
             /*@var $phrase kateglo\application\models\Phrase */

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -637,7 +637,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
         $user->setAddress($address);
 
-        $this->em->transactional(function($em) use($user) {
+        $this->em->transactional(function($em) use ($user) {
             $em->persist($user);
         });
         $this->em->clear();

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -103,7 +103,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
     public function testMultiLevelUpdateAndFind()
     {
-    	$manager = new CompanyManager;
+        $manager = new CompanyManager;
         $manager->setName('Roman S. Borschel');
         $manager->setSalary(100000);
         $manager->setDepartment('IT');
@@ -151,7 +151,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
     public function testSelfReferencingOneToOne()
     {
-    	$manager = new CompanyManager;
+        $manager = new CompanyManager;
         $manager->setName('John Smith');
         $manager->setSalary(100000);
         $manager->setDepartment('IT');

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php
@@ -87,25 +87,29 @@ class ClassTableInheritanceTest2 extends OrmFunctionalTestCase
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({"parent" = "CTIParent", "child" = "CTIChild"})
  */
-class CTIParent {
-   /**
-    * @ORM\Id @ORM\Column(type="integer")
-    * @ORM\GeneratedValue(strategy="AUTO")
-    */
+class CTIParent
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
     private $id;
 
     /** @ORM\OneToOne(targetEntity="CTIRelated", mappedBy="ctiParent") */
     private $related;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getRelated() {
+    public function getRelated()
+    {
         return $this->related;
     }
 
-    public function setRelated($related) {
+    public function setRelated($related)
+    {
         $this->related = $related;
         $related->setCTIParent($this);
     }
@@ -114,24 +118,27 @@ class CTIParent {
 /**
  * @ORM\Entity @ORM\Table(name="cti_children")
  */
-class CTIChild extends CTIParent {
-   /**
-    * @ORM\Column(type="string")
-    */
+class CTIChild extends CTIParent
+{
+    /**
+     * @ORM\Column(type="string")
+     */
     private $data;
 
-    public function getData() {
+    public function getData()
+    {
         return $this->data;
     }
 
-    public function setData($data) {
+    public function setData($data)
+    {
         $this->data = $data;
     }
-
 }
 
 /** @ORM\Entity */
-class CTIRelated {
+class CTIRelated
+{
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
@@ -144,15 +151,18 @@ class CTIRelated {
      */
     private $ctiParent;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getCTIParent() {
+    public function getCTIParent()
+    {
         return $this->ctiParent;
     }
 
-    public function setCTIParent($ctiParent) {
+    public function setCTIParent($ctiParent)
+    {
         $this->ctiParent = $ctiParent;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -32,7 +32,8 @@ class DefaultValuesTest extends OrmFunctionalTestCase
     /**
      * @group non-cacheable
      */
-    public function testSimpleDetachMerge() {
+    public function testSimpleDetachMerge()
+    {
         $user = new DefaultValueUser;
         $user->name = 'romanb';
         $this->em->persist($user);
@@ -113,7 +114,10 @@ class DefaultValueUser
      */
     public $address;
 
-    public function getId() {return $this->id;}
+    public function getId()
+    {
+        return $this->id;
+    }
 }
 
 /**
@@ -155,5 +159,8 @@ class DefaultValueAddress
      */
     public $user;
 
-    public function getUser() {return $this->user;}
+    public function getUser()
+    {
+        return $this->user;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -308,7 +308,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
     /**
      * @expectedException \Doctrine\ORM\ORMException
      */
-    public function testExceptionIsThrownWhenCallingFindByWithoutParameter() {
+    public function testExceptionIsThrownWhenCallingFindByWithoutParameter()
+    {
         $this->em->getRepository(CmsUser::class)
                   ->findByStatus();
     }
@@ -316,7 +317,8 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
     /**
      * @expectedException \Doctrine\ORM\ORMException
      */
-    public function testExceptionIsThrownWhenUsingInvalidFieldName() {
+    public function testExceptionIsThrownWhenUsingInvalidFieldName()
+    {
         $this->em->getRepository(CmsUser::class)
                   ->findByThisFieldDoesNotExist('testvalue');
     }
@@ -435,13 +437,13 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindOneByOrderBy()
     {
-    	$this->loadFixture();
+        $this->loadFixture();
 
-    	$repos = $this->em->getRepository(CmsUser::class);
-    	$userAsc = $repos->findOneBy([], ["username" => "ASC"]);
-    	$userDesc = $repos->findOneBy([], ["username" => "DESC"]);
+        $repos = $this->em->getRepository(CmsUser::class);
+        $userAsc = $repos->findOneBy([], ["username" => "ASC"]);
+        $userDesc = $repos->findOneBy([], ["username" => "DESC"]);
 
-    	self::assertNotSame($userAsc, $userDesc);
+        self::assertNotSame($userAsc, $userDesc);
     }
 
     /**
@@ -639,7 +641,6 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         self::assertEquals($this->em->getConfiguration()->getDefaultRepositoryClassName(), DDC753DefaultRepository::class);
         $this->em->getConfiguration()->setDefaultRepositoryClassName(EntityRepository::class);
         self::assertEquals($this->em->getConfiguration()->getDefaultRepositoryClassName(), EntityRepository::class);
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -99,7 +99,8 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         self::assertCount(3, $user->groups);
         self::assertFalse($user->groups->isInitialized());
 
-        foreach ($user->groups as $group) { }
+        foreach ($user->groups as $group) {
+        }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -131,7 +132,8 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        foreach ($user->groups as $group) { }
+        foreach ($user->groups as $group) {
+        }
 
         self::assertTrue($user->groups->isInitialized());
         self::assertCount(3, $user->groups);
@@ -207,7 +209,8 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         self::assertCount(1, $otherGroup);
         self::assertFalse($user->groups->isInitialized());
 
-        foreach ($user->groups as $group) { }
+        foreach ($user->groups as $group) {
+        }
 
         self::assertTrue($user->groups->isInitialized());
         self::assertCount(3, $user->groups);
@@ -224,7 +227,8 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId);
         $queryCount = $this->getCurrentQueryCount();
 
-        foreach ($user->groups as $group) { }
+        foreach ($user->groups as $group) {
+        }
 
         $someGroups = $user->groups->slice(0, 2);
 
@@ -1060,7 +1064,6 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $this->groupname = $group1->name;
         $this->topic = $article1->topic;
         $this->phonenumber = $phonenumber1->phonenumber;
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php
@@ -83,7 +83,6 @@ class OnFlushListener
         $uow = $em->getUnitOfWork();
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
-
             if ($entity instanceof CmsUser) {
                 // Adds a phonenumber to every newly persisted CmsUser ...
 
@@ -109,7 +108,6 @@ class OnFlushListener
 
                 var_dump($old);
             }*/
-
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php
@@ -10,12 +10,10 @@ use Doctrine\Tests\Models\CompositeKeyInheritance\JoinedChildClass;
 
 class JoinedTableCompositeKeyTest extends OrmFunctionalTestCase
 {
-
     public function setUp()
     {
         $this->useModelSet('compositekeyinheritance');
         parent::setUp();
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -387,20 +387,39 @@ DQL;
 }
 
 /** @ORM\Entity @ORM\HasLifecycleCallbacks */
-class LifecycleCallbackTestUser {
+class LifecycleCallbackTestUser
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
     /** @ORM\Column(type="string") */
     private $value;
     /** @ORM\Column(type="string") */
     private $name;
-    public function getId() {return $this->id;}
-    public function getValue() {return $this->value;}
-    public function setValue($value) {$this->value = $value;}
-    public function getName() {return $this->name;}
-    public function setName($name) {$this->name = $name;}
+    public function getId()
+    {
+        return $this->id;
+    }
+    public function getValue()
+    {
+        return $this->value;
+    }
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+    public function getName()
+    {
+        return $this->name;
+    }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
     /** @ORM\PreUpdate */
-    public function testCallback() {$this->value = 'Hello World';}
+    public function testCallback()
+    {
+        $this->value = 'Hello World';
+    }
 }
 
 /**
@@ -433,37 +452,44 @@ class LifecycleCallbackTestEntity
      */
     public $cascader;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getValue() {
+    public function getValue()
+    {
         return $this->value;
     }
 
     /** @ORM\PrePersist */
-    public function doStuffOnPrePersist() {
+    public function doStuffOnPrePersist()
+    {
         $this->prePersistCallbackInvoked = true;
     }
 
     /** @ORM\PostPersist */
-    public function doStuffOnPostPersist() {
+    public function doStuffOnPostPersist()
+    {
         $this->postPersistCallbackInvoked = true;
     }
 
     /** @ORM\PostLoad */
-    public function doStuffOnPostLoad() {
+    public function doStuffOnPostLoad()
+    {
         $this->postLoadCallbackInvoked = true;
         $this->postLoadCascaderNotNull = isset($this->cascader);
     }
 
     /** @ORM\PreUpdate */
-    public function doStuffOnPreUpdate() {
+    public function doStuffOnPreUpdate()
+    {
         $this->value = 'changed from preUpdate callback!';
     }
 
     /** @ORM\PreFlush */
-    public function doStuffOnPreFlush() {
+    public function doStuffOnPreFlush()
+    {
         $this->preFlushCallbackInvoked = true;
     }
 }
@@ -495,26 +521,30 @@ class LifecycleCallbackCascader
     }
 
     /** @ORM\PostLoad */
-    public function doStuffOnPostLoad() {
+    public function doStuffOnPostLoad()
+    {
         $this->postLoadCallbackInvoked = true;
         $this->postLoadEntitiesCount = count($this->entities);
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 }
 
 /** @ORM\MappedSuperclass @ORM\HasLifecycleCallbacks */
-class LifecycleCallbackParentEntity {
+class LifecycleCallbackParentEntity
+{
     /** @ORM\PrePersist */
-    function doStuff() {
-
+    function doStuff()
+    {
     }
 }
 
 /** @ORM\Entity @ORM\Table(name="lc_cb_childentity") */
-class LifecycleCallbackChildEntity extends LifecycleCallbackParentEntity {
+class LifecycleCallbackChildEntity extends LifecycleCallbackParentEntity
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -26,7 +26,7 @@ class LockAgentWorker
         $worker->addFunction("dqlWithLock", [$lockAgent, "dqlWithLock"]);
         $worker->addFunction('lock', [$lockAgent, 'lock']);
 
-        while($worker->work()) {
+        while ($worker->work()) {
             if ($worker->returnCode() != GEARMAN_SUCCESS) {
                 echo "return_code: " . $worker->returnCode() . "\n";
                 break;

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -232,7 +232,6 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         self::assertNotNull($caughtException, "No OptimisticLockingException was thrown");
         self::assertSame($test, $caughtException->getEntity());
-
     }
 
     /**
@@ -261,9 +260,7 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         self::assertNotNull($caughtException, "No OptimisticLockingException was thrown");
         self::assertSame($test, $caughtException->getEntity());
-
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
@@ -93,14 +93,17 @@ class NotifyPolicyTest extends OrmFunctionalTestCase
     }
 }
 
-class NotifyBaseEntity implements NotifyPropertyChanged {
+class NotifyBaseEntity implements NotifyPropertyChanged
+{
     public $listeners = [];
 
-    public function addPropertyChangedListener(PropertyChangedListener $listener) {
+    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    {
         $this->listeners[] = $listener;
     }
 
-    protected function onPropertyChanged($propName, $oldValue, $newValue) {
+    protected function onPropertyChanged($propName, $oldValue, $newValue)
+    {
         if ($this->listeners) {
             foreach ($this->listeners as $listener) {
                 $listener->propertyChanged($this, $propName, $oldValue, $newValue);
@@ -110,7 +113,8 @@ class NotifyBaseEntity implements NotifyPropertyChanged {
 }
 
 /** @ORM\Entity @ORM\ChangeTrackingPolicy("NOTIFY") */
-class NotifyUser extends NotifyBaseEntity {
+class NotifyUser extends NotifyBaseEntity
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
 
@@ -120,30 +124,36 @@ class NotifyUser extends NotifyBaseEntity {
     /** @ORM\ManyToMany(targetEntity="NotifyGroup") */
     private $groups;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->groups = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    public function getGroups() {
+    public function getGroups()
+    {
         return $this->groups;
     }
 }
 
 /** @ORM\Entity */
-class NotifyGroup extends NotifyBaseEntity {
+class NotifyGroup extends NotifyBaseEntity
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
 
@@ -153,24 +163,29 @@ class NotifyGroup extends NotifyBaseEntity {
     /** @ORM\ManyToMany(targetEntity="NotifyUser", mappedBy="groups") */
     private $users;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->users = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    public function getUsers() {
+    public function getUsers()
+    {
         return $this->users;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -32,7 +32,8 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->secondFeature->setDescription('Annotations examples');
     }
 
-    public function testSavesAOneToManyAssociationWithCascadeSaveSet() {
+    public function testSavesAOneToManyAssociationWithCascadeSaveSet()
+    {
         $this->product->addFeature($this->firstFeature);
         $this->product->addFeature($this->secondFeature);
         $this->em->persist($this->product);
@@ -50,7 +51,8 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         self::assertCount(0, $this->product->getFeatures());
     }
 
-    public function testDoesNotSaveAnInverseSideSet() {
+    public function testDoesNotSaveAnInverseSideSet()
+    {
         $this->product->brokenAddFeature($this->firstFeature);
         $this->em->persist($this->product);
         $this->em->flush();
@@ -234,7 +236,8 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->em->clear();
     }
 
-    public function assertFeatureForeignKeyIs($value, ECommerceFeature $feature) {
+    public function assertFeatureForeignKeyIs($value, ECommerceFeature $feature)
+    {
         $foreignKey = $this->em->getConnection()->executeQuery(
             'SELECT product_id FROM ecommerce_features WHERE id=?',
             [$feature->getId()]

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -29,7 +29,8 @@ class OneToManySelfReferentialAssociationTest extends OrmFunctionalTestCase
         $this->secondChild->setName('Php books');
     }
 
-    public function testSavesAOneToManyAssociationWithCascadeSaveSet() {
+    public function testSavesAOneToManyAssociationWithCascadeSaveSet()
+    {
         $this->parent->addChild($this->firstChild);
         $this->parent->addChild($this->secondChild);
         $this->em->persist($this->parent);
@@ -48,7 +49,8 @@ class OneToManySelfReferentialAssociationTest extends OrmFunctionalTestCase
         self::assertCount(0, $this->parent->getChildren());
     }
 
-    public function testDoesNotSaveAnInverseSideSet() {
+    public function testDoesNotSaveAnInverseSideSet()
+    {
         $this->parent->brokenAddChild($this->firstChild);
         $this->em->persist($this->parent);
         $this->em->flush();
@@ -116,7 +118,8 @@ class OneToManySelfReferentialAssociationTest extends OrmFunctionalTestCase
         $this->em->clear();
     }
 
-    public function assertForeignKeyIs($value, ECommerceCategory $child) {
+    public function assertForeignKeyIs($value, ECommerceCategory $child)
+    {
         $foreignKey = $this->em->getConnection()->executeQuery('SELECT parent_id FROM ecommerce_categories WHERE id=?', [$child->getId()])->fetchColumn();
         self::assertEquals($value, $foreignKey);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php
@@ -78,7 +78,7 @@ class OneToManyUnidirectionalAssociationTest extends OrmFunctionalTestCase
         try {
             // exception depending on the underlying Database Driver
             $this->em->flush();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $exceptionThrown = true;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -28,7 +28,8 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->cart->setPayment('Credit card');
     }
 
-    public function testSavesAOneToOneAssociationWithCascadeSaveSet() {
+    public function testSavesAOneToOneAssociationWithCascadeSaveSet()
+    {
         $this->customer->setCart($this->cart);
         $this->em->persist($this->customer);
         $this->em->flush();
@@ -36,7 +37,8 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
         self::assertCartForeignKeyIs($this->customer->getId());
     }
 
-    public function testDoesNotSaveAnInverseSideSet() {
+    public function testDoesNotSaveAnInverseSideSet()
+    {
         $this->customer->brokenSetCart($this->cart);
         $this->em->persist($this->customer);
         $this->em->flush();
@@ -67,7 +69,8 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
         self::assertEquals('paypal', $customer->getCart()->getPayment());
     }
 
-    public function testLazyLoadsObjectsOnTheOwningSide() {
+    public function testLazyLoadsObjectsOnTheOwningSide()
+    {
         $this->createFixture();
         $metadata = $this->em->getClassMetadata(ECommerceCart::class);
         $metadata->getProperty('customer')->setFetchMode(FetchMode::LAZY);
@@ -145,7 +148,8 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->em->clear();
     }
 
-    public function assertCartForeignKeyIs($value) {
+    public function assertCartForeignKeyIs($value)
+    {
         $foreignKey = $this->em->getConnection()->executeQuery('SELECT customer_id FROM ecommerce_carts WHERE id=?', [$this->cart->getId()])->fetchColumn();
         self::assertEquals($value, $foreignKey);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -29,7 +29,8 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(TrainOrder::class),
                 ]
             );
-        } catch(\Exception $e) {}
+        } catch (\Exception $e) {
+        }
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php
@@ -20,7 +20,7 @@ class OneToOneInverseSideLoadAfterDqlQueryTest extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(OwningSide::class),
                 $this->em->getClassMetadata(InverseSide::class),
             ]);
-        } catch(ToolsException $e) {
+        } catch (ToolsException $e) {
             // ignored
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -32,7 +32,8 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
         $this->mentor->setName('Obi-wan Kenobi');
     }
 
-    public function testSavesAOneToOneAssociationWithCascadeSaveSet() {
+    public function testSavesAOneToOneAssociationWithCascadeSaveSet()
+    {
         $this->customer->setMentor($this->mentor);
         $this->em->persist($this->customer);
         $this->em->flush();
@@ -122,7 +123,8 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
         self::assertEquals('Obi-wan Kenobi', $customer->getMentor()->getName());
     }
 
-    public function assertForeignKeyIs($value) {
+    public function assertForeignKeyIs($value)
+    {
         $foreignKey = $this->em->getConnection()->executeQuery('SELECT mentor_id FROM ecommerce_customers WHERE id=?', [$this->customer->getId()])->fetchColumn();
         self::assertEquals($value, $foreignKey);
     }
@@ -147,7 +149,8 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
 /**
  * @ORM\Entity
  */
-class MultiSelfReference {
+class MultiSelfReference
+{
     /** @ORM\Id @ORM\GeneratedValue(strategy="AUTO") @ORM\Column(type="integer") */
     private $id;
     /**
@@ -161,9 +164,24 @@ class MultiSelfReference {
      */
     private $other2;
 
-    public function getId() {return $this->id;}
-    public function setOther1($other1) {$this->other1 = $other1;}
-    public function getOther1() {return $this->other1;}
-    public function setOther2($other2) {$this->other2 = $other2;}
-    public function getOther2() {return $this->other2;}
+    public function getId()
+    {
+        return $this->id;
+    }
+    public function setOther1($other1)
+    {
+        $this->other1 = $other1;
+    }
+    public function getOther1()
+    {
+        return $this->other1;
+    }
+    public function setOther2($other2)
+    {
+        $this->other2 = $other2;
+    }
+    public function getOther2()
+    {
+        return $this->other2;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -29,7 +29,8 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->shipping->setDays('5');
     }
 
-    public function testSavesAOneToOneAssociationWithCascadeSaveSet() {
+    public function testSavesAOneToOneAssociationWithCascadeSaveSet()
+    {
         $this->product->setShipping($this->shipping);
         $this->em->persist($this->product);
         $this->em->flush();
@@ -60,7 +61,8 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
         self::assertEquals(1, $product->getShipping()->getDays());
     }
 
-    public function testLazyLoadsObjects() {
+    public function testLazyLoadsObjects()
+    {
         $this->createFixture();
         $metadata = $this->em->getClassMetadata(ECommerceProduct::class);
         $metadata->getProperty('shipping')->setFetchMode(FetchMode::LAZY);
@@ -73,7 +75,8 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
         self::assertEquals(1, $product->getShipping()->getDays());
     }
 
-    public function testDoesNotLazyLoadObjectsIfConfigurationDoesNotAllowIt() {
+    public function testDoesNotLazyLoadObjectsIfConfigurationDoesNotAllowIt()
+    {
         $this->createFixture();
 
         $query = $this->em->createQuery('select p from Doctrine\Tests\Models\ECommerce\ECommerceProduct p');
@@ -99,7 +102,8 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
         $this->em->clear();
     }
 
-    public function assertForeignKeyIs($value) {
+    public function assertForeignKeyIs($value)
+    {
         $foreignKey = $this->em->getConnection()->executeQuery(
             'SELECT shipping_id FROM ecommerce_products WHERE id=?',
             [$this->product->getId()]

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -125,7 +125,6 @@ abstract class OJTIC_Pet
  */
 class OJTIC_Cat extends OJTIC_Pet
 {
-
 }
 
 /**
@@ -133,5 +132,4 @@ class OJTIC_Cat extends OJTIC_Pet
  */
 class OJTIC_Dog extends OJTIC_Pet
 {
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -735,7 +735,7 @@ class PaginationTest extends OrmFunctionalTestCase
             $company->logo->image_width = 100 + $i;
             $company->logo->image_height = 100 + $i;
             $company->logo->company = $company;
-            for($j=0;$j<3;$j++) {
+            for ($j=0;$j<3;$j++) {
                 $department = new Department();
                 $department->name = "name$i$j";
                 $department->company = $company;

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
@@ -22,7 +22,6 @@ class PersistentCollectionTest extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(PersistentCollectionContent::class),
             ]);
         } catch (\Exception $e) {
-
         }
 
         PersistentObject::setEntityManager($this->em);

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -263,7 +263,7 @@ class QueryTest extends OrmFunctionalTestCase
         $iteratedCount = 0;
         $topics = [];
 
-        foreach($articles as $row) {
+        foreach ($articles as $row) {
             $article = $row[0];
             $topics[] = $article->topic;
 
@@ -302,7 +302,7 @@ class QueryTest extends OrmFunctionalTestCase
 
         $iteratedCount = 0;
         $topics = [];
-        foreach($articles as $row) {
+        foreach ($articles as $row) {
             $article  = $row[0];
             $topics[] = $article->topic;
 

--- a/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php
@@ -24,7 +24,7 @@ class ReadOnlyTest extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(ReadOnlyEntity::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -19,12 +19,13 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class ResultCacheTest extends OrmFunctionalTestCase
 {
-   /**
-    * @var \ReflectionProperty
-    */
+    /**
+     * @var \ReflectionProperty
+     */
     private $cacheDataReflection;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->cacheDataReflection = new \ReflectionProperty(ArrayCache::class, "data");
         $this->cacheDataReflection->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -108,7 +108,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
         // Two enabled filters
         self::assertCount(2, $em->getFilters()->getEnabledFilters());
-
     }
 
     public function testEntityManagerDisableFilter()
@@ -316,7 +315,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $metadata = new ClassMetadata('MyEntity\NoSoftDeleteNewsItem', $metadataBuildingContext);
 
         self::assertEquals('', $filter->addFilterConstraint($metadata, 't1_'));
-
     }
 
     public function testSQLFilterToString()
@@ -493,7 +491,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
         // We get one user after enabling the filter
         self::assertCount(1, $query->getResult());
-
     }
 
     public function testWhereFilter()
@@ -1002,7 +999,6 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
     public function testOneToMany_ExtraLazySliceWithFilterOnSTI()
     {
-
         $this->loadCompanySingleTableInheritanceFixtureData();
 
         $manager = $this->em->find(CompanyManager::class, $this->managerId);

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -71,7 +71,7 @@ class DDC214Test extends OrmFunctionalTestCase
 
         try {
             $this->schemaTool->createSchema($classMetadata);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             // was already created
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -11,7 +11,8 @@ use Doctrine\Tests\Models;
 
 class MySqlSchemaToolTest extends OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
         if ($this->em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
             $this->markTestSkipped('The ' . __CLASS__ .' requires the use of mysql.');
@@ -91,7 +92,6 @@ class MySqlSchemaToolTest extends OrmFunctionalTestCase
 
         self::assertCount(0, $sql);
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php
@@ -48,7 +48,6 @@ class SecondLevelCacheCompositePrimaryKeyWithAssociationsTest extends OrmFunctio
         $this->em->flush();
         $this->em->clear();
         $this->evictRegions();
-
     }
 
     public function testFindByReturnsCachedEntity()

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php
@@ -156,5 +156,4 @@ class SecondLevelCacheCriteriaTest extends SecondLevelCacheAbstractTest
         self::assertInstanceOf(Collection::class, $matching);
         self::assertCount(1, $matching);
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -243,6 +243,5 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         $queryCount = $this->getCurrentQueryCount();
         self::assertEquals(0, $entity->getVisitedCities()->count());
         self::assertEquals($queryCount, $this->getCurrentQueryCount());
-
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php
@@ -316,7 +316,6 @@ class SecondLevelCacheOneToManyTest extends SecondLevelCacheAbstractTest
 
         self::assertEquals(0, $entity->getCities()->count());
         self::assertEquals($queryCount, $this->getCurrentQueryCount());
-
     }
 
     public function testOneToManyCount()

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -804,7 +804,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->secondLevelCacheLogger->clearStats();
         $this->em->clear();
 
-        $getHash = function(AbstractQuery $query){
+        $getHash = function(AbstractQuery $query) {
             $method = new \ReflectionMethod($query, 'getHash');
             $method->setAccessible(true);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php
@@ -37,7 +37,6 @@ class SecondLevelCacheRepositoryTest extends SecondLevelCacheAbstractTest
         self::assertEquals(2, $this->secondLevelCacheLogger->getHitCount());
         self::assertEquals(0, $this->secondLevelCacheLogger->getMissCount());
         self::assertEquals(2, $this->secondLevelCacheLogger->getRegionHitCount($this->getEntityRegion(Country::class)));
-
     }
 
     public function testRepositoryCacheFindAll()

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php
@@ -199,9 +199,9 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
     {
         $listener = new ListenerSecondLevelCacheTest(
             [
-                Events::postFlush => function(){
-            throw new \RuntimeException('post flush failure');
-        }
+                Events::postFlush => function() {
+                    throw new \RuntimeException('post flush failure');
+                }
             ]
         );
 
@@ -233,9 +233,9 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
 
         $listener = new ListenerSecondLevelCacheTest(
             [
-                Events::postUpdate => function(){
-            throw new \RuntimeException('post update failure');
-        }
+                Events::postUpdate => function() {
+                    throw new \RuntimeException('post update failure');
+                }
             ]
         );
 
@@ -280,8 +280,7 @@ class SecondLevelCacheTest extends SecondLevelCacheAbstractTest
         $this->em->clear();
 
         $listener = new ListenerSecondLevelCacheTest([
-            Events::postRemove => function()
-            {
+            Events::postRemove => function() {
                 throw new \RuntimeException('post remove failure');
             }
         ]);

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -28,7 +28,7 @@ class SequenceGeneratorTest extends OrmFunctionalTestCase
                     $this->em->getClassMetadata(SequenceEntity::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php
@@ -10,12 +10,10 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 class SingleTableCompositeKeyTest extends OrmFunctionalTestCase
 {
-
     public function setUp()
     {
         $this->useModelSet('compositekeyinheritance');
         parent::setUp();
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php
@@ -146,7 +146,6 @@ class DDC1080Foo
     {
         $this->fooBars = $fooBars;
     }
-
 }
 /**
  * @ORM\Entity
@@ -224,7 +223,6 @@ class DDC1080Bar
     {
         $this->fooBars = $fooBars;
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -71,7 +71,6 @@ class DDC1113Vehicle
 
     /** @ORM\OneToOne(targetEntity="DDC1113Engine", cascade={"persist", "remove"}) */
     public $engine;
-
 }
 
 /**
@@ -79,7 +78,6 @@ class DDC1113Vehicle
  */
 class DDC1113Car extends DDC1113Vehicle
 {
-
 }
 
 /**
@@ -87,7 +85,6 @@ class DDC1113Car extends DDC1113Vehicle
  */
 class DDC1113Bus extends DDC1113Vehicle
 {
-
 }
 
 /**
@@ -98,6 +95,5 @@ class DDC1113Engine
 
     /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
     public $id;
-
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -125,7 +125,6 @@ class DDC1163ProxyHolder
     {
         return $this->specialProduct;
     }
-
 }
 
 /**
@@ -149,7 +148,6 @@ abstract class DDC1163Product
     {
         return $this->id;
     }
-
 }
 
 /**
@@ -171,7 +169,6 @@ class DDC1163SpecialProduct extends DDC1163Product
     {
         $this->subclassProperty = $value;
     }
-
 }
 
 /**
@@ -216,5 +213,4 @@ class DDC1163Tag
     {
         $this->product = $product;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -222,7 +222,7 @@ class DDC117Test extends \Doctrine\Tests\OrmFunctionalTestCase
         try {
             // exception depending on the underlying Database Driver
             $this->em->flush();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $exceptionThrown = true;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -68,7 +68,6 @@ class DDC1181Hotel
      * @var Booking[]
      */
     public $bookings;
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php
@@ -66,7 +66,8 @@ class DDC1193Test extends OrmFunctionalTestCase
 }
 
 /** @ORM\Entity */
-class DDC1193Company {
+class DDC1193Company
+{
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue
@@ -75,11 +76,11 @@ class DDC1193Company {
 
     /** @ORM\OneToOne(targetEntity="DDC1193Person", cascade={"persist", "remove"}) */
     public $member;
-
 }
 
 /** @ORM\Entity */
-class DDC1193Person {
+class DDC1193Person
+{
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue
@@ -93,11 +94,11 @@ class DDC1193Person {
 }
 
 /** @ORM\Entity */
-class DDC1193Account {
+class DDC1193Account
+{
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue
      */
     public $id;
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php
@@ -20,7 +20,7 @@ class DDC1209Test extends OrmFunctionalTestCase
                     $this->em->getClassMetadata(DDC1209_3::class)
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php
@@ -21,8 +21,7 @@ class DDC1225Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1225_TestEntity2::class),
                 ]
             );
-        } catch(\PDOException $e) {
-
+        } catch (\PDOException $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php
@@ -23,8 +23,7 @@ class DDC1228Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1228Profile::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -21,8 +21,7 @@ class DDC1238Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1238User::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
@@ -20,8 +20,7 @@ class DDC1250Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1250ClientHistory::class),
                 ]
             );
-        } catch(\PDOException $e) {
-
+        } catch (\PDOException $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -81,7 +81,6 @@ class DDC1300Foo
     {
         $this->fooLocaleRefFoo = new \Doctrine\Common\Collections\ArrayCollection();
     }
-
 }
 
 /**
@@ -109,5 +108,4 @@ class DDC1300FooLocale
      * @ORM\Column(name="title", type="string", nullable=true, length=150)
      */
     public $title;
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -52,7 +52,8 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(2, $user->articles);
         self::assertFalse($user->articles->isInitialized());
 
-        foreach ($user->articles as $article) { }
+        foreach ($user->articles as $article) {
+        }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -66,7 +67,8 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(2, $user->references);
         self::assertFalse($user->references->isInitialized());
 
-        foreach ($user->references as $reference) { }
+        foreach ($user->references as $reference) {
+        }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }
@@ -80,7 +82,8 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(3, $user->cars);
         self::assertFalse($user->cars->isInitialized());
 
-        foreach ($user->cars as $reference) { }
+        foreach ($user->cars as $reference) {
+        }
 
         self::assertEquals($queryCount + 2, $this->getCurrentQueryCount(), "Expecting two queries to be fired for count, then iteration.");
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -22,7 +22,7 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 ]
             );
             $this->loadFixture();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 
@@ -148,7 +148,6 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->em->flush();
         $this->em->clear();
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1404Test.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Annotation as ORM;
  */
 class DDC1404Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
     protected function setUp()
     {
         parent::setUp();
@@ -59,7 +58,6 @@ class DDC1404Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $this->em->flush();
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php
@@ -22,7 +22,6 @@ class DDC142Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testCreateRetrieveUpdateDelete()
     {
-
         $user           = new User;
         $user->name     = 'FabioBatSilva';
         $this->em->persist($user);
@@ -75,5 +74,4 @@ class DDC142Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertNull($this->em->find(User::class, $id));
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php
@@ -11,7 +11,6 @@ use Doctrine\ORM\Annotation as ORM;
  */
 class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
     protected function setUp()
     {
         parent::setUp();
@@ -25,7 +24,6 @@ class DDC1430Test extends \Doctrine\Tests\OrmFunctionalTestCase
             );
             $this->loadFixtures();
         } catch (\Exception $exc) {
-
         }
     }
 
@@ -313,5 +311,4 @@ class DDC1430OrderProduct
     {
         $this->value = $value;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php
@@ -19,7 +19,6 @@ class DDC144Test extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC144Operand::class),
             ]
         );
-
     }
 
     /**
@@ -66,7 +65,8 @@ abstract class DDC144Expression extends DDC144FlowElement
 }
 
 /** @ORM\Entity @ORM\Table(name="ddc144_operands") */
-class DDC144Operand extends DDC144Expression {
+class DDC144Operand extends DDC144Expression
+{
     /** @ORM\Column */
     public $operandProperty;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php
@@ -68,5 +68,4 @@ class DDC1454File
     {
         return $this->fileId;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php
@@ -22,8 +22,7 @@ class DDC1461Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1461User::class)
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
@@ -107,7 +107,6 @@ class DDC1654Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         $comments = $this->em->getRepository(DDC1654Comment::class)->findAll();
         self::assertCount(0, $comments);
-
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php
@@ -25,7 +25,7 @@ class DDC1655Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC1655Baz::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->fail($e->getMessage() . PHP_EOL . $e->getTraceAsString());
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php
@@ -10,7 +10,8 @@ class DDC168Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
     protected $oldMetadata;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->useModelSet('company');
 
         parent::setUp();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -11,7 +11,8 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
         try {
             $this->schemaTool->createSchema(
@@ -77,16 +78,19 @@ class DDC1690Test extends \Doctrine\Tests\OrmFunctionalTestCase
     }
 }
 
-class NotifyBaseEntity implements NotifyPropertyChanged {
+class NotifyBaseEntity implements NotifyPropertyChanged
+{
     public $listeners = [];
 
-    public function addPropertyChangedListener(PropertyChangedListener $listener) {
+    public function addPropertyChangedListener(PropertyChangedListener $listener)
+    {
         if (! \in_array($listener, $this->listeners, true)) {
             $this->listeners[] = $listener;
         }
     }
 
-    protected function onPropertyChanged($propName, $oldValue, $newValue) {
+    protected function onPropertyChanged($propName, $oldValue, $newValue)
+    {
         foreach ($this->listeners as $listener) {
             $listener->propertyChanged($this, $propName, $oldValue, $newValue);
         }
@@ -94,7 +98,8 @@ class NotifyBaseEntity implements NotifyPropertyChanged {
 }
 
 /** @ORM\Entity @ORM\ChangeTrackingPolicy("NOTIFY") */
-class DDC1690Parent extends NotifyBaseEntity {
+class DDC1690Parent extends NotifyBaseEntity
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
 
@@ -104,30 +109,36 @@ class DDC1690Parent extends NotifyBaseEntity {
     /** @ORM\OneToOne(targetEntity="DDC1690Child") */
     private $child;
 
-    function getId() {
+    function getId()
+    {
         return $this->id;
     }
 
-    function getName() {
+    function getName()
+    {
         return $this->name;
     }
 
-    function setName($name) {
+    function setName($name)
+    {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    function setChild($child) {
+    function setChild($child)
+    {
         $this->child = $child;
     }
 
-    function getChild() {
+    function getChild()
+    {
         return $this->child;
     }
 }
 
 /** @ORM\Entity */
-class DDC1690Child extends NotifyBaseEntity {
+class DDC1690Child extends NotifyBaseEntity
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
 
@@ -137,24 +148,29 @@ class DDC1690Child extends NotifyBaseEntity {
     /** @ORM\OneToOne(targetEntity="DDC1690Parent", mappedBy="child") */
     private $parent;
 
-    function getId() {
+    function getId()
+    {
         return $this->id;
     }
 
-    function getName() {
+    function getName()
+    {
         return $this->name;
     }
 
-    function setName($name) {
+    function setName($name)
+    {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    function setParent($parent) {
+    function setParent($parent)
+    {
         $this->parent = $parent;
     }
 
-    function getParent() {
+    function getParent()
+    {
         return $this->parent;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1707Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1707Test.php
@@ -26,7 +26,6 @@ class DDC1707Test extends OrmFunctionalTestCase
                 ]
             );
         } catch (\Exception $ignored) {
-
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php
@@ -92,7 +92,6 @@ class DDC1719Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertNull($e1);
         self::assertNull($e2);
     }
-
 }
 
 /**
@@ -121,5 +120,4 @@ class DDC1719SimpleEntity
     {
         $this->value = $value;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php
@@ -21,7 +21,6 @@ class DDC1843Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testCreateRetrieveUpdateDelete()
     {
-
         $e1 = new Group('Parent Bar 1');
         $e2 = new Group('Parent Foo 2');
 
@@ -123,5 +122,4 @@ class DDC1843Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertNull($e3);
         self::assertNull($e4);
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php
@@ -35,7 +35,6 @@ class DDC1885Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->em->persist($user);
         $this->em->flush();
         $this->em->clear();
-
     }
 
     public function testCreateRetrieveUpdateDelete()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php
@@ -101,7 +101,6 @@ class DDC2012Item
  */
 class DDC2012ItemPerson extends DDC2012Item
 {
-
 }
 
 class DDC2012TsVectorType extends Type

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -32,7 +32,6 @@ class DDC211Test extends OrmFunctionalTestCase
 
         $groupNames = ['group 1', 'group 2', 'group 3', 'group 4'];
         foreach ($groupNames as $name) {
-
             $group = new DDC211Group;
             $group->setName($name);
             $this->em->persist($group);
@@ -46,7 +45,6 @@ class DDC211Test extends OrmFunctionalTestCase
         }
 
         self::assertEquals(4, $user->getGroups()->count());
-
     }
 }
 
@@ -78,13 +76,20 @@ class DDC211User
      */
     protected $groups;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->groups = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
-    public function setName($name) { $this->name = $name; }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 
-    public function getGroups() { return $this->groups; }
+    public function getGroups()
+    {
+        return $this->groups;
+    }
 }
 
 /**
@@ -110,12 +115,19 @@ class DDC211Group
      */
     protected $users;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->users = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
-    public function setName($name) { $this->name = $name; }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
 
-    public function getUsers() { return $this->users; }
+    public function getUsers()
+    {
+        return $this->users;
+    }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
@@ -199,7 +199,6 @@ class DDC2138UserFollowedUser extends DDC2138UserFollowedObject
     {
         return $this->followedUser;
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -25,7 +25,8 @@ class DDC2230Test extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC2230User::class),
                 $this->em->getClassMetadata(DDC2230Address::class),
             ]);
-        } catch (ToolsException $e) {}
+        } catch (ToolsException $e) {
+        }
     }
 
     public function testNotifyTrackingCalledOnProxyInitialization()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2252Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2252Test.php
@@ -145,7 +145,8 @@ class DDC2252MerchantAccount
  * @ORM\Entity
  * @ORM\Table(name="ddc2252_user_account")
  */
-class DDC2252User {
+class DDC2252User
+{
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php
@@ -106,7 +106,8 @@ class DDC2306User
     public $zone;
 
     /** Constructor */
-    public function __construct() {
+    public function __construct()
+    {
         $this->addresses = new ArrayCollection();
     }
 }
@@ -128,7 +129,8 @@ class DDC2306Address
     public $zone;
 
     /** Constructor */
-    public function __construct() {
+    public function __construct()
+    {
         $this->users = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php
@@ -84,7 +84,8 @@ class DDC2346Foo
     public $bars;
 
     /** Constructor */
-    public function __construct() {
+    public function __construct()
+    {
         $this->bars = new ArrayCollection();
     }
 }
@@ -110,5 +111,4 @@ class DDC2346Bar
  */
 class DDC2346Baz extends DDC2346Bar
 {
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php
@@ -62,7 +62,6 @@ class DDC237Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertNotSame($z, $z2);
         self::assertSame($z2->y, $x2->y);
         self::assertInstanceOf(GhostObjectInterface::class, $z2->y);
-
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
@@ -114,7 +114,6 @@ class DDC2575Root
         $this->id = $id;
         $this->sampleField = $value;
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php
@@ -94,7 +94,6 @@ class DDC2579Entity
         $this->assoc = $assoc;
         $this->value = $value;
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php
@@ -27,7 +27,7 @@ class DDC2660Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC2660CustomerOrder::class)
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php
@@ -26,7 +26,7 @@ class DDC2692Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC2692Foo::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return;
         }
         $this->em->clear();
@@ -58,12 +58,14 @@ class DDC2692Foo
     public $id;
 }
 
-class DDC2692Listener implements EventSubscriber {
-
-    public function getSubscribedEvents() {
+class DDC2692Listener implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
         return [\Doctrine\ORM\Events::preFlush];
     }
 
-    public function preFlush(PreFlushEventArgs $args) {
+    public function preFlush(PreFlushEventArgs $args)
+    {
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2759Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2759Test.php
@@ -27,7 +27,7 @@ class DDC2759Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC2759MetadataCategory::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             return;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php
@@ -71,8 +71,7 @@ class OnFlushListener
         $updates = $uow->getScheduledEntityUpdates();
 
         $undelete = array_intersect_key($deletions, $updates);
-        foreach ($undelete as $d)
-        {
+        foreach ($undelete as $d) {
             $em->persist($d);
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php
@@ -81,7 +81,6 @@ abstract class DDC279EntityXAbstract
      * @ORM\Column(type="string")
      */
     public $data;
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
@@ -187,7 +187,6 @@ class DDC2862Driver
     {
         return $this->userProfile;
     }
-
 }
 
 /**
@@ -238,5 +237,4 @@ class DDC2862User
     {
         return $this->name;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php
@@ -22,8 +22,7 @@ class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC2895::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -49,7 +48,6 @@ class DDC2895Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $ddc2895 = $this->em->find(get_class($ddc2895), $ddc2895->id);
 
         self::assertNotNull($ddc2895->getLastModified());
-
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
@@ -16,7 +16,8 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class DDC3160Test extends OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->useModelSet('cms');
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC331Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC331Test.php
@@ -11,7 +11,8 @@ namespace Doctrine\Tests\ORM\Functional\Ticket;
  */
 class DDC331Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->useModelSet('company');
         parent::setUp();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php
@@ -19,7 +19,8 @@ class DDC353Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC353Picture::class),
                 ]
             );
-        } catch(\Exception $ignored) {}
+        } catch (\Exception $ignored) {
+        }
     }
 
     public function testWorkingCase()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3582Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3582Test.php
@@ -49,7 +49,10 @@ class DDC3582Embeddable1
     /** @ORM\Embedded(class="DDC3582Embeddable2") @var DDC3582Embeddable2 */
     public $embeddable2;
 
-    public function __construct() { $this->embeddable2 = new DDC3582Embeddable2(); }
+    public function __construct()
+    {
+        $this->embeddable2 = new DDC3582Embeddable2();
+    }
 }
 
 /** @ORM\Embeddable */
@@ -58,7 +61,10 @@ class DDC3582Embeddable2
     /** @ORM\Embedded(class="DDC3582Embeddable3") @var DDC3582Embeddable3 */
     public $embeddable3;
 
-    public function __construct() { $this->embeddable3 = new DDC3582Embeddable3(); }
+    public function __construct()
+    {
+        $this->embeddable3 = new DDC3582Embeddable3();
+    }
 }
 
 /** @ORM\Embeddable */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3597Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3597Test.php
@@ -11,9 +11,10 @@ use Doctrine\Tests\Models\DDC3597\DDC3597Root;
 /**
  * @group DDC-117
  */
-class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase {
-
-    protected function setUp() {
+class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
         parent::setUp();
         $this->schemaTool->createSchema(
             [
@@ -27,7 +28,8 @@ class DDC3597Test extends \Doctrine\Tests\OrmFunctionalTestCase {
     /**
      * @group DDC-3597
      */
-    public function testSaveImageEntity() {
+    public function testSaveImageEntity()
+    {
         $imageEntity = new DDC3597Image('foobar');
         $imageEntity->setFormat('JPG');
         $imageEntity->setSize(123);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -14,9 +14,9 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 /**
  * @group DDC-3634
  */
-class DDC3634Test extends OrmFunctionalTestCase 
+class DDC3634Test extends OrmFunctionalTestCase
 {
-    protected function setUp() 
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -56,7 +56,8 @@ class DDC371Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 /** @ORM\Entity */
-class DDC371Child {
+class DDC371Child
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
     /** @ORM\Column(type="string") */
@@ -66,7 +67,8 @@ class DDC371Child {
 }
 
 /** @ORM\Entity */
-class DDC371Parent {
+class DDC371Parent
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     private $id;
     /** @ORM\Column(type="string") */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -25,7 +25,7 @@ class DDC3785Test extends \Doctrine\Tests\OrmFunctionalTestCase
                     $this->em->getClassMetadata(DDC3785_Attribute::class)
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 
@@ -106,17 +106,17 @@ class DDC3785_Asset
  */
 class DDC3785_Attribute
 {
-	/**
-	 * @ORM\Id @ORM\Column(type="integer")
-	 * @ORM\GeneratedValue
-	 */
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     public $id;
 
-	/** @ORM\Column(type = "string") */
-	private $name;
+    /** @ORM\Column(type = "string") */
+    private $name;
 
-	/** @ORM\Column(type = "string") */
-	private $value;
+    /** @ORM\Column(type = "string") */
+    private $value;
 
     public function __construct($name, $value)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php
@@ -18,8 +18,7 @@ class DDC381Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC381Entity::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -61,6 +60,5 @@ class DDC381Entity
 
     public function getOtherMethod()
     {
-
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -52,13 +52,15 @@ class DDC422Test extends \Doctrine\Tests\OrmFunctionalTestCase
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  * @ORM\DiscriminatorMap({"guest" = "DDC422Guest", "customer" = "DDC422Customer"})
  */
-class DDC422Guest {
+class DDC422Guest
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     public $id;
 }
 
 /** @ORM\Entity */
-class DDC422Customer extends DDC422Guest {
+class DDC422Customer extends DDC422Guest
+{
     /**
      * @ORM\ManyToMany(targetEntity="DDC422Contact", cascade={"persist","remove"})
      * @ORM\JoinTable(name="ddc422_customers_contacts",
@@ -68,13 +70,15 @@ class DDC422Customer extends DDC422Guest {
      */
     public $contacts;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->contacts = new \Doctrine\Common\Collections\ArrayCollection;
     }
 }
 
 /** @ORM\Entity */
-class DDC422Contact {
+class DDC422Contact
+{
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
@@ -34,7 +34,8 @@ class DDC425Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 /** @ORM\Entity */
-class DDC425Entity {
+class DDC425Entity
+{
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Annotation as ORM;
 
 class DDC440Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
     protected function setUp()
     {
         parent::setUp();
@@ -79,7 +78,6 @@ class DDC440Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $originalData = $uw->getOriginalEntityData($p2);
         self::assertEquals($phone2->getNumber(), $originalData['number']);
     }
-
 }
 
 /**
@@ -139,7 +137,6 @@ class DDC440Phone
     {
         $this->id = $value;
     }
-
 }
 
 /**
@@ -174,7 +171,6 @@ class DDC440Client
 
     public function __construct()
     {
-
     }
 
     public function setName($value)
@@ -217,5 +213,4 @@ class DDC440Client
     {
         $this->id = $value;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php
@@ -37,7 +37,8 @@ class DDC493Test extends \Doctrine\Tests\OrmFunctionalTestCase
  * @ORM\DiscriminatorColumn(name="discr", type="string")
  * @ORM\DiscriminatorMap({"distributor" = "DDC493Distributor", "customer" = "DDC493Customer"})
  */
-class DDC493Customer {
+class DDC493Customer
+{
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
@@ -49,13 +50,13 @@ class DDC493Customer {
      * @ORM\JoinColumn(name="contact", referencedColumnName="id")
      */
     public $contact;
-
 }
 
 /**
  * @ORM\Entity
  */
-class DDC493Distributor extends DDC493Customer {
+class DDC493Distributor extends DDC493Customer
+{
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php
@@ -54,7 +54,8 @@ class DDC512Test extends OrmFunctionalTestCase
 /**
  * @ORM\Entity
  */
-class DDC512Customer {
+class DDC512Customer
+{
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php
@@ -63,7 +63,8 @@ class DDC513Item
 /**
  * @ORM\Entity
  */
-class DDC513Price {
+class DDC513Price
+{
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php
@@ -25,7 +25,7 @@ class DDC522Test extends \Doctrine\Tests\OrmFunctionalTestCase
                     $this->em->getClassMetadata(DDC522ForeignKeyTest::class)
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php
@@ -18,7 +18,8 @@ class DDC599Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC599Subitem::class),
                 $this->em->getClassMetadata(DDC599Child::class),
             ]);
-        } catch (\Exception $ignored) {}
+        } catch (\Exception $ignored) {
+        }
     }
 
     public function testCascadeRemoveOnInheritanceHierarchy()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -40,8 +40,7 @@ class DDC618Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
             $this->em->flush();
             $this->em->clear();
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php
@@ -36,7 +36,6 @@ class DDC6303Test extends OrmFunctionalTestCase
             'a' => new DDC6303ChildA('a', 'authorized'),
             'b' => new DDC6303ChildB('b', ['accepted', 'authorized']),
         ]);
-
     }
 
     public function testEmptyValuesInJoinedInheritance() : void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php
@@ -19,8 +19,7 @@ class DDC633Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC633Appointment::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -87,7 +86,6 @@ class DDC633Appointment
      * @ORM\OneToOne(targetEntity="DDC633Patient", inversedBy="appointment", fetch="EAGER")
      */
     public $patient;
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php
@@ -17,8 +17,7 @@ class DDC656Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC656Entity::class)
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -66,19 +65,23 @@ class DDC656Entity
      */
     public $specificationId;
 
-    public function getName() {
+    public function getName()
+    {
         return $this->name;
     }
 
-    public function setName($name) {
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
-    public function setType($type) {
+    public function setType($type)
+    {
         $this->type = $type;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -18,8 +18,7 @@ class DDC698Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC698Privilege::class)
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -44,38 +43,37 @@ class DDC698Test extends \Doctrine\Tests\OrmFunctionalTestCase
  */
 class DDC698Role
 {
-	/**
-	 *  @ORM\Id @ORM\Column(name="roleID", type="integer")
-	 *  @ORM\GeneratedValue(strategy="AUTO")
-	 *
-	 */
-	protected $roleID;
+    /**
+     *  @ORM\Id @ORM\Column(name="roleID", type="integer")
+     *  @ORM\GeneratedValue(strategy="AUTO")
+     *
+     */
+    protected $roleID;
 
-	/**
-	 * @ORM\Column(name="name", type="string", length=45)
-	 *
-	 *
-	 */
-	protected $name;
+    /**
+     * @ORM\Column(name="name", type="string", length=45)
+     *
+     *
+     */
+    protected $name;
 
-	/**
-	 * @ORM\Column(name="shortName", type="string", length=45)
-	 *
-	 *
-	 */
-	protected $shortName;
+    /**
+     * @ORM\Column(name="shortName", type="string", length=45)
+     *
+     *
+     */
+    protected $shortName;
 
 
 
-	/**
-	 * @ORM\ManyToMany(targetEntity="DDC698Privilege", inversedBy="roles")
-	 * @ORM\JoinTable(name="RolePrivileges",
-	 *     joinColumns={@ORM\JoinColumn(name="roleID", referencedColumnName="roleID")},
-	 *     inverseJoinColumns={@ORM\JoinColumn(name="privilegeID", referencedColumnName="privilegeID")}
-	 * )
-	 */
-	protected $privilege;
-
+    /**
+     * @ORM\ManyToMany(targetEntity="DDC698Privilege", inversedBy="roles")
+     * @ORM\JoinTable(name="RolePrivileges",
+     *     joinColumns={@ORM\JoinColumn(name="roleID", referencedColumnName="roleID")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="privilegeID", referencedColumnName="privilegeID")}
+     * )
+     */
+    protected $privilege;
 }
 
 
@@ -86,22 +84,22 @@ class DDC698Role
  */
 class DDC698Privilege
 {
-	/**
-	 *  @ORM\Id  @ORM\Column(name="privilegeID", type="integer")
-	 *  @ORM\GeneratedValue(strategy="AUTO")
-	 *
-	 */
-	protected $privilegeID;
+    /**
+     *  @ORM\Id  @ORM\Column(name="privilegeID", type="integer")
+     *  @ORM\GeneratedValue(strategy="AUTO")
+     *
+     */
+    protected $privilegeID;
 
-	/**
-	 * @ORM\Column(name="name", type="string", length=45)
-	 *
-	 *
-	 */
-	protected $name;
+    /**
+     * @ORM\Column(name="name", type="string", length=45)
+     *
+     *
+     */
+    protected $name;
 
-	/**
-	 * @ORM\ManyToMany(targetEntity="DDC698Role", mappedBy="privilege")
-	 */
-	protected $roles;
+    /**
+     * @ORM\ManyToMany(targetEntity="DDC698Role", mappedBy="privilege")
+     */
+    protected $roles;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -43,76 +43,104 @@ class Entity
      */
     protected $id;
 
-    public function getId() { return $this->id; }
+    public function getId()
+    {
+        return $this->id;
+    }
 }
 
 /**
  * @ORM\Entity
  * @ORM\Table(name="groups")
  */
-class DDC719Group extends Entity {
+class DDC719Group extends Entity
+{
     /** @ORM\Column(type="string", nullable=false) */
     protected $name;
 
-	/** @ORM\Column(type="string", nullable=true) */
-	protected $description;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected $description;
 
-	/**
-	 * @ORM\ManyToMany(targetEntity="DDC719Group", inversedBy="parents")
-	 * @ORM\JoinTable(name="groups_groups",
-	 * 		joinColumns={@ORM\JoinColumn(name="parent_id", referencedColumnName="id")},
-	 * 		inverseJoinColumns={@ORM\JoinColumn(name="child_id", referencedColumnName="id")}
-	 * )
-	 */
-	protected $children;
+    /**
+     * @ORM\ManyToMany(targetEntity="DDC719Group", inversedBy="parents")
+     * @ORM\JoinTable(name="groups_groups",
+     * 		joinColumns={@ORM\JoinColumn(name="parent_id", referencedColumnName="id")},
+     * 		inverseJoinColumns={@ORM\JoinColumn(name="child_id", referencedColumnName="id")}
+     * )
+     */
+    protected $children;
 
-	/**
-	 * @ORM\ManyToMany(targetEntity="DDC719Group", mappedBy="children")
-	 */
-	protected $parents;
+    /**
+     * @ORM\ManyToMany(targetEntity="DDC719Group", mappedBy="children")
+     */
+    protected $parents;
 
-	/**
-	 * construct
-	 */
-	public function __construct() {
-		parent::__construct();
+    /**
+     * construct
+     */
+    public function __construct()
+    {
+        parent::__construct();
 
-		$this->channels = new ArrayCollection();
-		$this->children = new ArrayCollection();
-		$this->parents = new ArrayCollection();
-	}
+        $this->channels = new ArrayCollection();
+        $this->children = new ArrayCollection();
+        $this->parents = new ArrayCollection();
+    }
 
-	/**
-	 * adds group as new child
-	 *
-	 * @param Group $child
-	 */
-	public function addGroup(Group $child) {
+    /**
+     * adds group as new child
+     *
+     * @param Group $child
+     */
+    public function addGroup(Group $child)
+    {
         if ( ! $this->children->contains($child)) {
             $this->children->add($child);
             $child->addGroup($this);
         }
-	}
+    }
 
-	/**
-	 * adds channel as new child
-	 *
-	 * @param Channel $child
-	 */
-	public function addChannel(Channel $child) {
+    /**
+     * adds channel as new child
+     *
+     * @param Channel $child
+     */
+    public function addChannel(Channel $child)
+    {
         if ( ! $this->channels->contains($child)) {
             $this->channels->add($child);
         }
-	}
+    }
 
-	/**
-	 * getter & setter
-	 */
-	public function getName() { return $this->name; }
-	public function setName($name) { $this->name = $name; }
-	public function getDescription() { return $this->description; }
-	public function setDescription($description) { $this->description = $description; }
-	public function getChildren() { return $this->children; }
-	public function getParents() { return $this->parents; }
-	public function getChannels() { return $this->channels; }
+    /**
+     * getter & setter
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+    public function getDescription()
+    {
+        return $this->description;
+    }
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+    public function getChildren()
+    {
+        return $this->children;
+    }
+    public function getParents()
+    {
+        return $this->parents;
+    }
+    public function getChannels()
+    {
+        return $this->channels;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php
@@ -19,8 +19,7 @@ class DDC735Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC735Review::class)
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -34,7 +34,7 @@ class DDC742Test extends \Doctrine\Tests\OrmFunctionalTestCase
                     $this->em->getClassMetadata(DDC742Comment::class)
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
 
         // make sure classes will be deserialized from caches

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php
@@ -66,7 +66,7 @@ class DDC767Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
             $this->em->flush();
             $this->em->commit();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->em->rollback();
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -28,7 +28,7 @@ class DDC832Test extends \Doctrine\Tests\OrmFunctionalTestCase
                     $this->em->getClassMetadata(DDC832Like::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php
@@ -10,7 +10,6 @@ use ProxyManager\Proxy\GhostObjectInterface;
 
 class DDC881Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
-
     protected function setUp()
     {
         parent::setUp();
@@ -24,7 +23,6 @@ class DDC881Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 ]
             );
         } catch (\Exception $e) {
-
         }
     }
 
@@ -97,7 +95,6 @@ class DDC881Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertInstanceOf(PersistentCollection::class, $numbers[0]->getCalls());
         self::assertTrue($numbers[0]->getCalls()->isInitialized());
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -19,8 +19,7 @@ class DDC960Test extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC960Child::class)
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -23,8 +23,7 @@ class DDC992Test extends \Doctrine\Tests\OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC992Child::class),
                 ]
             );
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
     }
 
@@ -142,7 +141,8 @@ class DDC992Role
      */
     public $extends;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->extends = new ArrayCollection;
         $this->extendedBy = new ArrayCollection;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
@@ -40,9 +40,9 @@ class Ticket2481Test extends \Doctrine\Tests\OrmFunctionalTestCase
  */
 class Ticket2481Product
 {
-  /**
-   * @ORM\Id @ORM\Column(type="integer")
-   * @ORM\GeneratedValue(strategy="AUTO")
-   */
-  public $id;
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -11,7 +11,8 @@ use Doctrine\ORM\Annotation as ORM;
  *
  * @author robo
  */
-class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase {
+class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
     protected function setUp()
     {
         parent::setUp();
@@ -90,13 +91,12 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase {
         self::assertInstanceOf(Lemma::class, $lemma);
         $relations = $lemma->getRelations();
 
-        foreach($relations as $relation) {
+        foreach ($relations as $relation) {
             self::assertInstanceOf(Relation::class, $relation);
             self::assertTrue($relation->getType()->getType() != '');
         }
 
         $this->em->clear();
-
     }
 }
 
@@ -104,8 +104,8 @@ class AdvancedAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase {
  * @ORM\Entity
  * @ORM\Table(name="lemma")
  */
-class Lemma {
-
+class Lemma
+{
     const CLASS_NAME = __CLASS__;
 
     /**
@@ -130,7 +130,8 @@ class Lemma {
      */
     private $relations;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->types = new \Doctrine\Common\Collections\ArrayCollection();
         $this->relations = new \Doctrine\Common\Collections\ArrayCollection();
     }
@@ -140,7 +141,8 @@ class Lemma {
      *
      * @return int
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -149,7 +151,8 @@ class Lemma {
      * @param string $lemma
      * @return void
      */
-    public function setLemma($lemma) {
+    public function setLemma($lemma)
+    {
         $this->lemma = $lemma;
     }
 
@@ -157,7 +160,8 @@ class Lemma {
      *
      * @return string
      */
-    public function getLemma() {
+    public function getLemma()
+    {
         return $this->lemma;
     }
 
@@ -167,7 +171,8 @@ class Lemma {
      * @param Relation $relation
      * @return void
      */
-    public function addRelation(Relation $relation) {
+    public function addRelation(Relation $relation)
+    {
         $this->relations[] = $relation;
         $relation->setParent($this);
     }
@@ -177,7 +182,8 @@ class Lemma {
      * @param Relation $relation
      * @return void
      */
-    public function removeRelation(Relation $relation) {
+    public function removeRelation(Relation $relation)
+    {
         /*@var $removed Relation */
         $removed = $this->relations->removeElement($relation);
         if ($removed !== null) {
@@ -189,10 +195,10 @@ class Lemma {
      *
      * @return kateglo\application\utilities\collections\ArrayCollection
      */
-    public function getRelations() {
+    public function getRelations()
+    {
         return $this->relations;
     }
-
 }
 
 /**
@@ -200,8 +206,8 @@ class Lemma {
  * @ORM\Entity
  * @ORM\Table(name="relation")
  */
-class Relation {
-
+class Relation
+{
     const CLASS_NAME = __CLASS__;
 
     /**
@@ -238,7 +244,8 @@ class Relation {
      * @param Lemma $parent
      * @return void
      */
-    public function setParent(Lemma $parent) {
+    public function setParent(Lemma $parent)
+    {
         $this->parent = $parent;
     }
 
@@ -246,7 +253,8 @@ class Relation {
      *
      * @return Phrase
      */
-    public function getParent() {
+    public function getParent()
+    {
         return $this->parent;
     }
 
@@ -254,7 +262,8 @@ class Relation {
      *
      * @return void
      */
-    public function removeParent() {
+    public function removeParent()
+    {
         if ($this->lemma !== null) {
             /*@var $phrase Lemma */
             $lemma = $this->parent;
@@ -268,7 +277,8 @@ class Relation {
      * @param Lemma $child
      * @return void
      */
-    public function setChild(Lemma $child) {
+    public function setChild(Lemma $child)
+    {
         $this->child = $child;
     }
 
@@ -276,7 +286,8 @@ class Relation {
      *
      * @return Lemma
      */
-    public function getChild() {
+    public function getChild()
+    {
         return $this->child;
     }
 
@@ -285,7 +296,8 @@ class Relation {
      * @param RelationType $type
      * @return void
      */
-    public function setType(RelationType $type) {
+    public function setType(RelationType $type)
+    {
         $this->type = $type;
     }
 
@@ -293,7 +305,8 @@ class Relation {
      *
      * @return RelationType
      */
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
@@ -301,7 +314,8 @@ class Relation {
      *
      * @return void
      */
-    public function removeType() {
+    public function removeType()
+    {
         if ($this->type !== null) {
             /*@var $phrase RelationType */
             $type = $this->type;
@@ -316,8 +330,8 @@ class Relation {
  * @ORM\Entity
  * @ORM\Table(name="relation_type")
  */
-class RelationType {
-
+class RelationType
+{
     const CLASS_NAME = __CLASS__;
 
     /**
@@ -349,7 +363,8 @@ class RelationType {
      */
     private $relations;
 
-    public function __construct() {
+    public function __construct()
+    {
         $relations = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
@@ -357,7 +372,8 @@ class RelationType {
      *
      * @return int
      */
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
@@ -366,7 +382,8 @@ class RelationType {
      * @param string $type
      * @return void
      */
-    public function setType($type) {
+    public function setType($type)
+    {
         $this->type = $type;
     }
 
@@ -374,7 +391,8 @@ class RelationType {
      *
      * @return string
      */
-    public function getType() {
+    public function getType()
+    {
         return $this->type;
     }
 
@@ -383,7 +401,8 @@ class RelationType {
      * @param string $abbreviation
      * @return void
      */
-    public function setAbbreviation($abbreviation) {
+    public function setAbbreviation($abbreviation)
+    {
         $this->abbreviation = $abbreviation;
     }
 
@@ -391,7 +410,8 @@ class RelationType {
      *
      * @return string
      */
-    public function getAbbreviation() {
+    public function getAbbreviation()
+    {
         return $this->abbreviation;
     }
 
@@ -400,7 +420,8 @@ class RelationType {
      * @param Relation $relation
      * @return void
      */
-    public function addRelation(Relation $relation) {
+    public function addRelation(Relation $relation)
+    {
         $this->relations[] = $relation;
         $relation->setType($this);
     }
@@ -410,7 +431,8 @@ class RelationType {
      * @param Relation $relation
      * @return void
      */
-    public function removeRelation(Relation $relation) {
+    public function removeRelation(Relation $relation)
+    {
         /*@var $removed Relation */
         $removed = $this->relations->removeElement($relation);
         if ($removed !== null) {
@@ -422,7 +444,8 @@ class RelationType {
      *
      * @return kateglo\application\utilities\collections\ArrayCollection
      */
-    public function getRelations() {
+    public function getRelations()
+    {
         return $this->relations;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
@@ -55,7 +55,6 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
      */
     public function testUpperCaseStringTypeWhenColumnNameIsDefined()
     {
-
         $entity = new CustomTypeUpperCase();
         $entity->lowerCaseString        = 'Some Value';
         $entity->namedLowerCaseString   = 'foo';

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -32,7 +32,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
                 $this->em->getClassMetadata(DDC3027Dog::class),
                 ]
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -205,9 +205,9 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         self::assertEquals(CmsEmail::class, $rsm->getDeclaringClass('email_id'));
     }
 
-        /**
-         * @group DDC-1663
-         */
+    /**
+     * @group DDC-1663
+     */
     public function testAddNamedNativeQueryResultSetMappingWithoutFields()
     {
         $cm = new ClassMetadata(CmsUser::class, $this->metadataBuildingContext);

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -707,7 +707,6 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $countMapping = $class->getSqlResultSetMapping('mapping-count');
 
         self::assertEquals(['name'=>'count'], $countMapping['columns'][0]);
-
     }
 
     /**
@@ -821,7 +820,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertEquals($guestGroups->getFetchMode(), $adminGroups->getFetchMode());
         self::assertEquals($guestGroups->getCascade(), $adminGroups->getCascade());
 
-         // assert not override attributes
+        // assert not override attributes
         $guestGroupsJoinTable          = $guestGroups->getJoinTable();
         $guestGroupsJoinColumns        = $guestGroupsJoinTable->getJoinColumns();
         $guestGroupsJoinColumn         = reset($guestGroupsJoinColumns);
@@ -1265,7 +1264,8 @@ class User
     /**
      * @ORM\PrePersist
      */
-    public function doOtherStuffOnPrePersistToo() {
+    public function doOtherStuffOnPrePersistToo()
+    {
     }
 
     /**
@@ -1273,7 +1273,6 @@ class User
      */
     public function doStuffOnPostPersist()
     {
-
     }
 
     public static function loadMetadata(ClassMetadata $metadata)
@@ -1498,7 +1497,6 @@ class DDC1170Entity
     {
         return $this->value;
     }
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -304,7 +304,6 @@ class AnnotationParent
      */
     public function postLoad()
     {
-
     }
 
     /**
@@ -312,7 +311,6 @@ class AnnotationParent
      */
     public function preUpdate()
     {
-
     }
 }
 
@@ -322,7 +320,6 @@ class AnnotationParent
  */
 class AnnotationChild extends AnnotationParent
 {
-
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -27,7 +27,8 @@ class BasicInheritanceMappingTest extends OrmTestCase
     /**
      * {@inheritDoc}
      */
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->cmf = new ClassMetadataFactory();
 
         $this->cmf->setEntityManager($this->getTestEntityManager());
@@ -191,7 +192,8 @@ class BasicInheritanceMappingTest extends OrmTestCase
     }
 }
 
-class TransientBaseClass {
+class TransientBaseClass
+{
     private $transient1;
     private $transient2;
 }
@@ -206,7 +208,8 @@ class EntitySubClass extends TransientBaseClass
 }
 
 /** @ORM\MappedSuperclass */
-class MappedSuperclassBase {
+class MappedSuperclassBase
+{
     /** @ORM\Column(type="integer") */
     private $mapped1;
     /** @ORM\Column(type="string") */
@@ -218,10 +221,13 @@ class MappedSuperclassBase {
     private $mappedRelated1;
     private $transient;
 }
-class MappedSuperclassRelated1 {}
+class MappedSuperclassRelated1
+{
+}
 
 /** @ORM\Entity */
-class EntitySubClass2 extends MappedSuperclassBase {
+class EntitySubClass2 extends MappedSuperclassBase
+{
     /** @ORM\Id @ORM\Column(type="integer") */
     private $id;
     /** @ORM\Column(type="string") */
@@ -231,7 +237,8 @@ class EntitySubClass2 extends MappedSuperclassBase {
 /**
  * @ORM\MappedSuperclass
  */
-class MappedSuperclassBaseIndex {
+class MappedSuperclassBaseIndex
+{
     /** @ORM\Column(type="string") */
     private $mapped1;
     /** @ORM\Column(type="string") */

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -1291,7 +1291,7 @@ class ClassMetadataTest extends OrmTestCase
         $association->setCascade(['invalid']);
 
         $cm->addProperty($association);
-     }
+    }
 
     /**
      * @group DDC-964

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -177,11 +177,11 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
             'Doctrine.Tests.Models.DDC889.DDC889Class.dcm'
         ];
 
-        $list = array_filter($list, function($item) use ($invalid){
+        $list = array_filter($list, function($item) use ($invalid) {
             return ! in_array(pathinfo($item, PATHINFO_FILENAME), $invalid);
         });
 
-        return array_map(function($item){
+        return array_map(function($item) {
             return [$item];
         }, $list);
     }

--- a/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php
@@ -202,9 +202,7 @@ class SecondLevelCacheTest extends OrmFunctionalTestCase
         $startFind  = microtime(true);
 
         for ($i = 0; $i < $times; $i++) {
-
             foreach ($states as $state) {
-
                 $state = $em->find(State::class, $state->getId());
 
                 foreach ($state->getCities() as $city) {

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
@@ -38,7 +38,6 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
         $this->em->getClassMetadata(Admin1AlternateName::class);
 
         $this->persister = new BasicEntityPersister($this->em, $this->em->getClassMetadata(Admin1AlternateName::class));
-
     }
 
     public function testExpandParametersWillExpandCompositeEntityKeys()

--- a/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php
@@ -357,5 +357,4 @@ class ProxyFactoryTest extends OrmTestCase
 
 abstract class AbstractClass
 {
-
 }

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -24,7 +24,8 @@ class DeleteSqlGenerationTest extends OrmTestCase
 {
     private $em;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->em = $this->getTestEntityManager();
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -233,7 +233,7 @@ class ExprTest extends OrmTestCase
      */
     public function testLiteralExprProperlyQuotesStrings()
     {
-       self::assertEquals("'00010001'", (string) $this->expr->literal('00010001'));
+        self::assertEquals("'00010001'", (string) $this->expr->literal('00010001'));
     }
 
     public function testGreaterThanOrEqualToExpr()
@@ -266,11 +266,13 @@ class ExprTest extends OrmTestCase
         self::assertEquals('u.id IS NOT NULL', (string) $this->expr->isNotNull('u.id'));
     }
 
-    public function testIsInstanceOfExpr() {
+    public function testIsInstanceOfExpr()
+    {
         self::assertEquals('u INSTANCE OF Doctrine\Tests\Models\Company\CompanyEmployee', (string) $this->expr->isInstanceOf('u', CompanyEmployee::class));
     }
 
-    public function testIsMemberOfExpr() {
+    public function testIsMemberOfExpr()
+    {
         self::assertEquals(':groupId MEMBER OF u.groups', (string) $this->expr->isMemberOf(':groupId', 'u.groups'));
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php
@@ -59,7 +59,7 @@ class LanguageRecognitionTest extends OrmTestCase
         $query->setDQL($dql);
 
         foreach ($hints as $key => $value) {
-        	$query->setHint($key, $value);
+            $query->setHint($key, $value);
         }
 
         $parser = new Query\Parser($query);

--- a/tests/Doctrine/Tests/ORM/Query/LexerTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/LexerTest.php
@@ -11,7 +11,8 @@ class LexerTest extends OrmTestCase
 {
     //private $lexer;
 
-    protected function setUp() {
+    protected function setUp()
+    {
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -12,7 +12,6 @@ use PDO;
 
 class ParameterTypeInfererTest extends OrmTestCase
 {
-
     public function providerParameterTypeInferer()
     {
         $data = [

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -1237,7 +1237,6 @@ class SelectSqlGenerationTest extends OrmTestCase
         }
 
         self::assertTrue($exceptionThrown);
-
     }
 
     public function testSubSelectAliasesFromOuterQuery()
@@ -1662,9 +1661,9 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
-     /**
-      * @group DDC-1430
-      */
+    /**
+     * @group DDC-1430
+     */
     public function testGroupByAllFieldsWhenObjectHasForeignKeys()
     {
         $this->assertSqlGeneration(
@@ -1742,7 +1741,8 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
-    public function testSupportsParenthesisExpressionInSubSelect() {
+    public function testSupportsParenthesisExpressionInSubSelect()
+    {
         $this->assertSqlGeneration(
             'SELECT u.id, (SELECT (1000*SUM(subU.id)/SUM(subU.id)) FROM Doctrine\Tests\Models\CMS\CmsUser subU where subU.id = u.id) AS subSelect FROM Doctrine\Tests\Models\CMS\CmsUser u',
             'SELECT t0."id" AS c0, (SELECT (1000 * SUM(t1."id") / SUM(t1."id")) FROM "cms_users" t1 WHERE t1."id" = t0."id") AS c1 FROM "cms_users" t0'
@@ -2004,9 +2004,9 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
-   /**
-    * @group DDC-1845
-    */
+    /**
+     * @group DDC-1845
+     */
     public function testQuotedWalkJoinVariableDeclaration()
     {
         $this->assertSqlGeneration(
@@ -2040,9 +2040,9 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
-   /**
-    * @group DDC-2208
-    */
+    /**
+     * @group DDC-2208
+     */
     public function testCaseThenParameterArithmeticExpression()
     {
         $this->assertSqlGeneration(
@@ -2130,15 +2130,15 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT t0.[id] AS c0 FROM [cms_users] t0 WHERE (t0.[name] + t0.[status] + \'s\') = ?'
     	);
 
-    	$this->assertSqlGeneration(
+        $this->assertSqlGeneration(
             'SELECT CONCAT(u.id, u.name, u.status) FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = ?1',
             'SELECT (t0.[id] + t0.[name] + t0.[status]) AS c0 FROM [cms_users] t0 WHERE t0.[id] = ?'
     	);
     }
 
-     /**
-      * @group DDC-2188
-      */
+    /**
+     * @group DDC-2188
+     */
     public function testArithmeticPriority()
     {
         $this->assertSqlGeneration(
@@ -2437,5 +2437,4 @@ class DDC1474Entity
     {
         $this->value = $value;
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php
@@ -20,7 +20,8 @@ class UpdateSqlGenerationTest extends OrmTestCase
 {
     private $em;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         if (DBALType::hasType('negative_to_positive')) {
             DBALType::overrideType('negative_to_positive', NegativeToPositiveType::class);
         } else {

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -760,7 +760,6 @@ class QueryBuilderTest extends OrmTestCase
            ->where($expr->gt('u.id', $expr->all('select a.id from Doctrine\Tests\Models\CMS\CmsArticle a')));
 
         self::assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id > ALL(select a.id from Doctrine\Tests\Models\CMS\CmsArticle a)');
-
     }
 
     public function testMultipleIsolatedQueryConstruction()

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -116,7 +116,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
     /**
      * Arbitrary Join
      */
-     public function testLimitSubqueryWithArbitraryJoin()
+    public function testLimitSubqueryWithArbitraryJoin()
     {
         $dql        = 'SELECT p, c FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p JOIN Doctrine\Tests\ORM\Tools\Pagination\Category c WITH p.category = c';
         $query      = $this->entityManager->createQuery($dql);

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -127,7 +127,7 @@ class UnitOfWorkTest extends OrmTestCase
 
         // should have an id
         self::assertInternalType('numeric', $user->id);
-}
+    }
 
     /**
      * Tests a scenario where a save() operation is cascaded from a ForumUser
@@ -734,30 +734,36 @@ class NotifyChangedEntity implements NotifyPropertyChanged
     /** @ORM\OneToMany(targetEntity="NotifyChangedRelatedItem", mappedBy="owner") */
     private $items;
 
-    public function  __construct() {
+    public function  __construct()
+    {
         $this->items = new ArrayCollection;
     }
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getItems() {
+    public function getItems()
+    {
         return $this->items;
     }
 
-    public function setTransient($value) {
+    public function setTransient($value)
+    {
         if ($value != $this->transient) {
             $this->onPropertyChanged('transient', $this->transient, $value);
             $this->transient = $value;
         }
     }
 
-    public function getData() {
+    public function getData()
+    {
         return $this->data;
     }
 
-    public function setData($data) {
+    public function setData($data)
+    {
         if ($data != $this->data) {
             $this->onPropertyChanged('data', $this->data, $data);
             $this->data = $data;
@@ -769,7 +775,8 @@ class NotifyChangedEntity implements NotifyPropertyChanged
         $this->listeners[] = $listener;
     }
 
-    protected function onPropertyChanged($propName, $oldValue, $newValue) {
+    protected function onPropertyChanged($propName, $oldValue, $newValue)
+    {
         if ($this->listeners) {
             foreach ($this->listeners as $listener) {
                 $listener->propertyChanged($this, $propName, $oldValue, $newValue);
@@ -791,15 +798,18 @@ class NotifyChangedRelatedItem
     /** @ORM\ManyToOne(targetEntity="NotifyChangedEntity", inversedBy="items") */
     private $owner;
 
-    public function getId() {
+    public function getId()
+    {
         return $this->id;
     }
 
-    public function getOwner() {
+    public function getOwner()
+    {
         return $this->owner;
     }
 
-    public function setOwner($owner) {
+    public function setOwner($owner)
+    {
         $this->owner = $owner;
     }
 }

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -402,7 +402,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $conn->executeUpdate('DELETE FROM RoutingLocation');
         }
 
-        if(isset($this->usedModelSets['navigation'])) {
+        if (isset($this->usedModelSets['navigation'])) {
             $conn->executeUpdate('DELETE FROM navigation_tour_pois');
             $conn->executeUpdate('DELETE FROM navigation_photos');
             $conn->executeUpdate('DELETE FROM navigation_pois');
@@ -802,9 +802,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $trace = $e->getTrace();
             $traceMsg = "";
 
-            foreach($trace as $part) {
-                if(isset($part['file'])) {
-                    if(strpos($part['file'], "PHPUnit/") !== false) {
+            foreach ($trace as $part) {
+                if (isset($part['file'])) {
+                    if (strpos($part['file'], "PHPUnit/") !== false) {
                         // Beginning with PHPUnit files we don't print the trace anymore.
                         break;
                     }


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `braces` - partial:

1. Unaligned DocBlocks
1. Unaligned non-empty class opening with DocBlocks
1. Unaligned properties with DocBlocks
1. Unaligned non-empty methods with DocBlocks
1. Unaligned single-line comments
1. Tab indentations (only found in tests)
1. A bunch of unaligned closing braces

Reference: https://github.com/doctrine/doctrine2/pull/6924#discussion_r158002055