### PR TITLE
[CS] Clean elses

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -50,10 +50,10 @@ class IterableResult implements \Iterator
     {
         if ($this->rewinded == true) {
             throw new HydrationException("Can only iterate a Result once.");
-        } else {
-            $this->current = $this->next();
-            $this->rewinded = true;
         }
+
+        $this->current = $this->next();
+        $this->rewinded = true;
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -30,9 +30,9 @@ class StatementArrayMock extends StatementMock
         $row = reset($this->result);
         if ($row) {
             return count($row);
-        } else {
-            return 0;
         }
+
+        return 0;
     }
 
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -791,7 +791,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             foreach ($last25queries as $i => $query) {
                 $params = array_map(
                     function($p) {
-                        if (is_object($p)) return get_class($p); else return var_export($p, true);
+                        return is_object($p) ? get_class($p) : var_export($p, true);
                     },
                     $query['params'] ?: []
                 );


### PR DESCRIPTION
I've cleaned up some `else`s when we've already returned something, like #6889, now on `develop` branch :put_litter_in_its_place:

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.