### PR TITLE
[CS] Standardize docblock asterisks

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php
@@ -106,7 +106,7 @@ class DDC2575Root
 
     /**
      * @ORM\OneToOne(targetEntity="DDC2575A", mappedBy="rootRelation")
-     **/
+     */
     public $aRelation;
 
     public function __construct($id, $value = 0)

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1214,7 +1214,7 @@ class User
      * @ORM\Column(type="integer", options={"foo": "bar", "unsigned": false})
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\SequenceGenerator(sequenceName="tablename_seq", allocationSize=100)
-     **/
+     */
     public $id;
 
     /**
@@ -1475,7 +1475,7 @@ class DDC1170Entity
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="NONE")
      * @ORM\Column(type="integer", columnDefinition = "INT unsigned NOT NULL")
-     **/
+     */
     private $id;
 
     /**
@@ -1513,7 +1513,7 @@ class DDC807Entity
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="NONE")
-     **/
+     */
     public $id;
 }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -132,7 +132,7 @@ class QueryTest extends OrmTestCase
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     **/
+     */
     public function testIterateWithNoDistinctAndWrongSelectClause()
     {
         $q = $this->em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
@@ -141,7 +141,7 @@ class QueryTest extends OrmTestCase
 
     /**
      * @expectedException Doctrine\ORM\Query\QueryException
-     **/
+     */
     public function testIterateWithNoDistinctAndWithValidSelectClause()
     {
         $q = $this->em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `phpdoc_opening_closing`