### PR TITLE
[CS] Require explicit visibility

### DIFF
--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -45,7 +45,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSelectStatement(AST\SelectStatement $AST);
+    public function walkSelectStatement(AST\SelectStatement $AST);
 
     /**
      * Walks down a SelectClause AST node, thereby generating the appropriate SQL.
@@ -54,7 +54,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSelectClause($selectClause);
+    public function walkSelectClause($selectClause);
 
     /**
      * Walks down a FromClause AST node, thereby generating the appropriate SQL.
@@ -63,7 +63,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkFromClause($fromClause);
+    public function walkFromClause($fromClause);
 
     /**
      * Walks down a FunctionNode AST node, thereby generating the appropriate SQL.
@@ -72,7 +72,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkFunction($function);
+    public function walkFunction($function);
 
     /**
      * Walks down an OrderByClause AST node, thereby generating the appropriate SQL.
@@ -81,7 +81,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkOrderByClause($orderByClause);
+    public function walkOrderByClause($orderByClause);
 
     /**
      * Walks down an OrderByItem AST node, thereby generating the appropriate SQL.
@@ -90,7 +90,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkOrderByItem($orderByItem);
+    public function walkOrderByItem($orderByItem);
 
     /**
      * Walks down a HavingClause AST node, thereby generating the appropriate SQL.
@@ -99,7 +99,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkHavingClause($havingClause);
+    public function walkHavingClause($havingClause);
 
     /**
      * Walks down a Join AST node and creates the corresponding SQL.
@@ -108,7 +108,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkJoin($join);
+    public function walkJoin($join);
 
     /**
      * Walks down a SelectExpression AST node and generates the corresponding SQL.
@@ -117,7 +117,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSelectExpression($selectExpression);
+    public function walkSelectExpression($selectExpression);
 
     /**
      * Walks down a QuantifiedExpression AST node, thereby generating the appropriate SQL.
@@ -126,7 +126,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkQuantifiedExpression($qExpr);
+    public function walkQuantifiedExpression($qExpr);
 
     /**
      * Walks down a Subselect AST node, thereby generating the appropriate SQL.
@@ -135,7 +135,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSubselect($subselect);
+    public function walkSubselect($subselect);
 
     /**
      * Walks down a SubselectFromClause AST node, thereby generating the appropriate SQL.
@@ -144,7 +144,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSubselectFromClause($subselectFromClause);
+    public function walkSubselectFromClause($subselectFromClause);
 
     /**
      * Walks down a SimpleSelectClause AST node, thereby generating the appropriate SQL.
@@ -153,7 +153,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSimpleSelectClause($simpleSelectClause);
+    public function walkSimpleSelectClause($simpleSelectClause);
 
     /**
      * Walks down a SimpleSelectExpression AST node, thereby generating the appropriate SQL.
@@ -162,7 +162,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSimpleSelectExpression($simpleSelectExpression);
+    public function walkSimpleSelectExpression($simpleSelectExpression);
 
     /**
      * Walks down an AggregateExpression AST node, thereby generating the appropriate SQL.
@@ -171,7 +171,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkAggregateExpression($aggExpression);
+    public function walkAggregateExpression($aggExpression);
 
     /**
      * Walks down a GroupByClause AST node, thereby generating the appropriate SQL.
@@ -180,7 +180,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkGroupByClause($groupByClause);
+    public function walkGroupByClause($groupByClause);
 
     /**
      * Walks down a GroupByItem AST node, thereby generating the appropriate SQL.
@@ -189,7 +189,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkGroupByItem($groupByItem);
+    public function walkGroupByItem($groupByItem);
 
     /**
      * Walks down an UpdateStatement AST node, thereby generating the appropriate SQL.
@@ -198,7 +198,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkUpdateStatement(AST\UpdateStatement $AST);
+    public function walkUpdateStatement(AST\UpdateStatement $AST);
 
     /**
      * Walks down a DeleteStatement AST node, thereby generating the appropriate SQL.
@@ -207,7 +207,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkDeleteStatement(AST\DeleteStatement $AST);
+    public function walkDeleteStatement(AST\DeleteStatement $AST);
 
     /**
      * Walks down a DeleteClause AST node, thereby generating the appropriate SQL.
@@ -216,7 +216,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkDeleteClause(AST\DeleteClause $deleteClause);
+    public function walkDeleteClause(AST\DeleteClause $deleteClause);
 
     /**
      * Walks down an UpdateClause AST node, thereby generating the appropriate SQL.
@@ -225,7 +225,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkUpdateClause($updateClause);
+    public function walkUpdateClause($updateClause);
 
     /**
      * Walks down an UpdateItem AST node, thereby generating the appropriate SQL.
@@ -234,7 +234,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkUpdateItem($updateItem);
+    public function walkUpdateItem($updateItem);
 
     /**
      * Walks down a WhereClause AST node, thereby generating the appropriate SQL.
@@ -244,7 +244,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkWhereClause($whereClause);
+    public function walkWhereClause($whereClause);
 
     /**
      * Walk down a ConditionalExpression AST node, thereby generating the appropriate SQL.
@@ -253,7 +253,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkConditionalExpression($condExpr);
+    public function walkConditionalExpression($condExpr);
 
     /**
      * Walks down a ConditionalTerm AST node, thereby generating the appropriate SQL.
@@ -262,7 +262,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkConditionalTerm($condTerm);
+    public function walkConditionalTerm($condTerm);
 
     /**
      * Walks down a ConditionalFactor AST node, thereby generating the appropriate SQL.
@@ -271,7 +271,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkConditionalFactor($factor);
+    public function walkConditionalFactor($factor);
 
     /**
      * Walks down a ConditionalPrimary AST node, thereby generating the appropriate SQL.
@@ -280,7 +280,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkConditionalPrimary($primary);
+    public function walkConditionalPrimary($primary);
 
     /**
      * Walks down an ExistsExpression AST node, thereby generating the appropriate SQL.
@@ -289,7 +289,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkExistsExpression($existsExpr);
+    public function walkExistsExpression($existsExpr);
 
     /**
      * Walks down a CollectionMemberExpression AST node, thereby generating the appropriate SQL.
@@ -298,7 +298,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkCollectionMemberExpression($collMemberExpr);
+    public function walkCollectionMemberExpression($collMemberExpr);
 
     /**
      * Walks down an EmptyCollectionComparisonExpression AST node, thereby generating the appropriate SQL.
@@ -307,7 +307,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkEmptyCollectionComparisonExpression($emptyCollCompExpr);
+    public function walkEmptyCollectionComparisonExpression($emptyCollCompExpr);
 
     /**
      * Walks down a NullComparisonExpression AST node, thereby generating the appropriate SQL.
@@ -316,7 +316,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkNullComparisonExpression($nullCompExpr);
+    public function walkNullComparisonExpression($nullCompExpr);
 
     /**
      * Walks down an InExpression AST node, thereby generating the appropriate SQL.
@@ -325,7 +325,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkInExpression($inExpr);
+    public function walkInExpression($inExpr);
 
     /**
      * Walks down an InstanceOfExpression AST node, thereby generating the appropriate SQL.
@@ -334,7 +334,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkInstanceOfExpression($instanceOfExpr);
+    public function walkInstanceOfExpression($instanceOfExpr);
 
     /**
      * Walks down a literal that represents an AST node, thereby generating the appropriate SQL.
@@ -343,7 +343,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkLiteral($literal);
+    public function walkLiteral($literal);
 
     /**
      * Walks down a BetweenExpression AST node, thereby generating the appropriate SQL.
@@ -352,7 +352,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkBetweenExpression($betweenExpr);
+    public function walkBetweenExpression($betweenExpr);
 
     /**
      * Walks down a LikeExpression AST node, thereby generating the appropriate SQL.
@@ -361,7 +361,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkLikeExpression($likeExpr);
+    public function walkLikeExpression($likeExpr);
 
     /**
      * Walks down a StateFieldPathExpression AST node, thereby generating the appropriate SQL.
@@ -370,7 +370,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkStateFieldPathExpression($stateFieldPathExpression);
+    public function walkStateFieldPathExpression($stateFieldPathExpression);
 
     /**
      * Walks down a ComparisonExpression AST node, thereby generating the appropriate SQL.
@@ -379,7 +379,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkComparisonExpression($compExpr);
+    public function walkComparisonExpression($compExpr);
 
     /**
      * Walks down an InputParameter AST node, thereby generating the appropriate SQL.
@@ -388,7 +388,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkInputParameter($inputParam);
+    public function walkInputParameter($inputParam);
 
     /**
      * Walks down an ArithmeticExpression AST node, thereby generating the appropriate SQL.
@@ -397,7 +397,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkArithmeticExpression($arithmeticExpr);
+    public function walkArithmeticExpression($arithmeticExpr);
 
     /**
      * Walks down an ArithmeticTerm AST node, thereby generating the appropriate SQL.
@@ -406,7 +406,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkArithmeticTerm($term);
+    public function walkArithmeticTerm($term);
 
     /**
      * Walks down a StringPrimary that represents an AST node, thereby generating the appropriate SQL.
@@ -415,7 +415,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkStringPrimary($stringPrimary);
+    public function walkStringPrimary($stringPrimary);
 
     /**
      * Walks down an ArithmeticFactor that represents an AST node, thereby generating the appropriate SQL.
@@ -424,7 +424,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkArithmeticFactor($factor);
+    public function walkArithmeticFactor($factor);
 
     /**
      * Walks down an SimpleArithmeticExpression AST node, thereby generating the appropriate SQL.
@@ -433,7 +433,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkSimpleArithmeticExpression($simpleArithmeticExpr);
+    public function walkSimpleArithmeticExpression($simpleArithmeticExpr);
 
     /**
      * Walks down a PathExpression AST node, thereby generating the appropriate SQL.
@@ -442,7 +442,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkPathExpression($pathExpr);
+    public function walkPathExpression($pathExpr);
 
     /**
      * Walks down a ResultVariable that represents an AST node, thereby generating the appropriate SQL.
@@ -451,7 +451,7 @@ interface TreeWalker
      *
      * @return string The SQL.
      */
-    function walkResultVariable($resultVariable);
+    public function walkResultVariable($resultVariable);
 
     /**
      * Gets an executor that can be used to execute the result of this walker.
@@ -460,5 +460,5 @@ interface TreeWalker
      *
      * @return Exec\AbstractSqlExecutor
      */
-    function getExecutor($AST);
+    public function getExecutor($AST);
 }

--- a/tests/Doctrine/Tests/Mocks/CacheKeyMock.php
+++ b/tests/Doctrine/Tests/Mocks/CacheKeyMock.php
@@ -16,7 +16,7 @@ class CacheKeyMock extends CacheKey
     /**
      * @param string $hash The string hash that represent this cache key
      */
-    function __construct($hash)
+    public function __construct($hash)
     {
         $this->hash = $hash;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php
@@ -537,7 +537,7 @@ class LifecycleCallbackCascader
 class LifecycleCallbackParentEntity
 {
     /** @ORM\PrePersist */
-    function doStuff()
+    public function doStuff()
     {
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -98,7 +98,7 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertEquals('SELECT u FROM ' . __NAMESPACE__ . '\DDC1335User u INDEX BY u.email', $dql);
     }
 
-    public function  testIndexWithJoin()
+    public function testIndexWithJoin()
     {
         $builder = $this->em->createQueryBuilder();
         $builder->select('u','p')

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -109,28 +109,28 @@ class DDC1690Parent extends NotifyBaseEntity
     /** @ORM\OneToOne(targetEntity=DDC1690Child::class) */
     private $child;
 
-    function getId()
+    public function getId()
     {
         return $this->id;
     }
 
-    function getName()
+    public function getName()
     {
         return $this->name;
     }
 
-    function setName($name)
+    public function setName($name)
     {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    function setChild($child)
+    public function setChild($child)
     {
         $this->child = $child;
     }
 
-    function getChild()
+    public function getChild()
     {
         return $this->child;
     }
@@ -148,28 +148,28 @@ class DDC1690Child extends NotifyBaseEntity
     /** @ORM\OneToOne(targetEntity=DDC1690Parent::class, mappedBy="child") */
     private $parent;
 
-    function getId()
+    public function getId()
     {
         return $this->id;
     }
 
-    function getName()
+    public function getName()
     {
         return $this->name;
     }
 
-    function setName($name)
+    public function setName($name)
     {
         $this->onPropertyChanged('name', $this->name, $name);
         $this->name = $name;
     }
 
-    function setParent($parent)
+    public function setParent($parent)
     {
         $this->parent = $parent;
     }
 
-    function getParent()
+    public function getParent()
     {
         return $this->parent;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -76,7 +76,7 @@ class DDC2230Address implements NotifyPropertyChanged
     public $listener;
 
     /** {@inheritDoc} */
-    function addPropertyChangedListener(PropertyChangedListener $listener)
+    public function addPropertyChangedListener(PropertyChangedListener $listener)
     {
         $this->listener = $listener;
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php
@@ -178,7 +178,7 @@ class DDC618Book
     /** @ORM\ManyToOne(targetEntity=DDC618Author::class, inversedBy="books") */
     public $author;
 
-    function __construct($title, $author)
+    public function __construct($title, $author)
     {
         $this->title = $title;
         $this->author = $author;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5762Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5762Test.php
@@ -150,7 +150,7 @@ class GH5762DriverRide
      */
     public $car;
 
-    function __construct(GH5762Driver $driver, GH5762Car $car)
+    public function __construct(GH5762Driver $driver, GH5762Car $car)
     {
         $this->driver = $driver;
         $this->car = $car;

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -734,7 +734,7 @@ class NotifyChangedEntity implements NotifyPropertyChanged
     /** @ORM\OneToMany(targetEntity=NotifyChangedRelatedItem::class, mappedBy="owner") */
     private $items;
 
-    public function  __construct()
+    public function __construct()
     {
         $this->items = new ArrayCollection;
     }


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `visibility` on `methods`.