### PR TITLE
[CS] Exactly one line-feed at end-of-file

### DIFF
--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -93,4 +93,3 @@ class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
         return $this->metadataBuildingContext;
     }
 }
-

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -106,4 +106,3 @@ class SqlExpressionVisitor extends ExpressionVisitor
         return '?';
     }
 }
-

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -67,4 +67,3 @@ class ConcatFunction extends FunctionNode
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }
-

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -558,4 +558,3 @@ class ResultSetMapping
         return $this;
     }
 }
-

--- a/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
@@ -48,4 +48,3 @@ class BigIntegerIdentityGenerator implements Generator
         return true;
     }
 }
-

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -84,4 +84,3 @@ class CountWalker extends TreeWalkerAdapter
         $AST->orderByClause = null;
     }
 }
-

--- a/tests/Doctrine/Performance/ChangeSet/UnitOfWorkComputeChangesBench.php
+++ b/tests/Doctrine/Performance/ChangeSet/UnitOfWorkComputeChangesBench.php
@@ -70,4 +70,3 @@ final class UnitOfWorkComputeChangesBench
         $this->unitOfWork->computeChangeSets();
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinArrayHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinArrayHydrationPerformanceBench.php
@@ -92,4 +92,3 @@ final class MixedQueryFetchJoinArrayHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinFullObjectHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinFullObjectHydrationPerformanceBench.php
@@ -81,4 +81,3 @@ final class MixedQueryFetchJoinFullObjectHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinPartialObjectHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinPartialObjectHydrationPerformanceBench.php
@@ -93,4 +93,3 @@ final class MixedQueryFetchJoinPartialObjectHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/SimpleQueryArrayHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/SimpleQueryArrayHydrationPerformanceBench.php
@@ -79,4 +79,3 @@ final class SimpleQueryArrayHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/SimpleQueryFullObjectHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/SimpleQueryFullObjectHydrationPerformanceBench.php
@@ -72,4 +72,3 @@ final class SimpleQueryFullObjectHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/SimpleQueryPartialObjectHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/SimpleQueryPartialObjectHydrationPerformanceBench.php
@@ -80,4 +80,3 @@ final class SimpleQueryPartialObjectHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
     }
 }
-

--- a/tests/Doctrine/Performance/Hydration/SimpleQueryScalarHydrationPerformanceBench.php
+++ b/tests/Doctrine/Performance/Hydration/SimpleQueryScalarHydrationPerformanceBench.php
@@ -79,4 +79,3 @@ final class SimpleQueryScalarHydrationPerformanceBench
         $this->hydrator->hydrateAll($this->stmt, $this->rsm);
     }
 }
-

--- a/tests/Doctrine/Performance/LazyLoading/ProxyInitializationTimeBench.php
+++ b/tests/Doctrine/Performance/LazyLoading/ProxyInitializationTimeBench.php
@@ -84,4 +84,3 @@ final class ProxyInitializationTimeBench
         }
     }
 }
-

--- a/tests/Doctrine/Performance/LazyLoading/ProxyInstantiationTimeBench.php
+++ b/tests/Doctrine/Performance/LazyLoading/ProxyInstantiationTimeBench.php
@@ -53,4 +53,3 @@ final class ProxyInstantiationTimeBench
         }
     }
 }
-

--- a/tests/Doctrine/Tests/Models/CMS/CmsEmployee.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsEmployee.php
@@ -49,4 +49,3 @@ class CmsEmployee
         return $this->spouse;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
@@ -51,4 +51,3 @@ class CmsGroup
         return $this->users;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/CMS/CmsTag.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTag.php
@@ -49,4 +49,3 @@ class CmsTag
         return $this->users;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyPerson.php
@@ -130,4 +130,3 @@ class CompanyPerson
         }
     }
 }
-

--- a/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
+++ b/tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php
@@ -66,4 +66,3 @@ class DDC3579Group
         return $this->admins;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/DDC6412/DDC6412File.php
+++ b/tests/Doctrine/Tests/Models/DDC6412/DDC6412File.php
@@ -22,4 +22,3 @@ class DDC6412File
      */
     public $name;
 }
-

--- a/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
+++ b/tests/Doctrine/Tests/Models/DDC964/DDC964Group.php
@@ -66,4 +66,3 @@ class DDC964Group
         return $this->users;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/Forum/ForumEntry.php
+++ b/tests/Doctrine/Tests/Models/Forum/ForumEntry.php
@@ -28,4 +28,3 @@ class ForumEntry
         return $this->topic;
     }
 }
-

--- a/tests/Doctrine/Tests/Models/Navigation/NavUser.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavUser.php
@@ -29,4 +29,3 @@ class NavUser
         $this->name = $name;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/HydrationCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/HydrationCacheTest.php
@@ -88,4 +88,3 @@ class HydrationCacheTest extends OrmFunctionalTestCase
         self::assertEquals($c, $this->getCurrentQueryCount(), "Should not execute query. Its cached!");
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
@@ -189,4 +189,3 @@ class NotifyGroup extends NotifyBaseEntity
         return $this->users;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -162,4 +162,3 @@ class QueryCacheTest extends OrmFunctionalTestCase
         $users = $query->getResult();
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php
@@ -96,4 +96,3 @@ class DDC1113Engine
     /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
     public $id;
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php
@@ -113,4 +113,3 @@ class DDC1238User
         $this->name = $name;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -43,4 +43,3 @@ class DDC1360DoubleQuote
     /** @ORM\Id @ORM\GeneratedValue @ORM\Column(type="integer") */
     public $id;
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1436Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1436Test.php
@@ -91,4 +91,3 @@ class DDC1436Page
         $this->parent = $parent;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php
@@ -122,4 +122,3 @@ class DDC1643Test extends \Doctrine\Tests\OrmFunctionalTestCase
         self::assertCount(3, $user1->groups);
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php
@@ -68,4 +68,3 @@ class DDC1685Test extends \Doctrine\Tests\OrmFunctionalTestCase
         }
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -130,4 +130,3 @@ class DDC211Group
         return $this->users;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php
@@ -81,4 +81,3 @@ class DDC2230Address implements NotifyPropertyChanged
         $this->listener = $listener;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2256Test.php
@@ -118,4 +118,3 @@ class DDC2256Group
         $this->users = new \Doctrine\Common\Collections\ArrayCollection();
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2780Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2780Test.php
@@ -95,4 +95,3 @@ class DDC2780Project
         $this->users = new ArrayCollection();
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php
@@ -70,4 +70,3 @@ class DDC3160OnFlushListener
         }
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php
@@ -158,4 +158,3 @@ class DDC345Membership
         $this->updated = new \DateTime;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php
@@ -76,4 +76,3 @@ class DDC371Parent
     /** @ORM\OneToMany(targetEntity=DDC371Child::class, mappedBy="parent") */
     public $children;
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -82,4 +82,3 @@ class DDC422Contact
     /** @ORM\Id @ORM\Column(type="integer") @ORM\GeneratedValue */
     public $id;
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php
@@ -98,4 +98,3 @@ class DisableFetchJoinTreeWalker extends \Doctrine\ORM\Query\TreeWalkerAdapter
         }
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -449,4 +449,3 @@ class RelationType
         return $this->relations;
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Sequencing/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Sequencing/SequenceGeneratorTest.php
@@ -56,4 +56,3 @@ class SequenceGeneratorTest extends OrmTestCase
         }
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -89,4 +89,3 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         );
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
@@ -60,4 +60,3 @@ class CountOutputWalkerTest extends PaginationTestCase
         );
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php
@@ -74,4 +74,3 @@ class CountWalkerTest extends PaginationTestCase
         $query->getSQL();
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -452,4 +452,3 @@ ORDER BY b.id DESC'
         );
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -144,4 +144,3 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         );
     }
 }
-

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -163,4 +163,3 @@ class WhereInWalkerTest extends PaginationTestCase
         );
     }
 }
-

--- a/tests/Doctrine/Tests/TestInit.php
+++ b/tests/Doctrine/Tests/TestInit.php
@@ -26,4 +26,3 @@ if ( ! file_exists(__DIR__ . '/Proxies') && ! mkdir(__DIR__ . '/Proxies')) {
 if ( ! file_exists(__DIR__ . '/ORM/Proxy/generated') &&  ! mkdir(__DIR__ . '/ORM/Proxy/generated')) {
     throw new \Exception('Could not create ' . __DIR__ . '/ORM/Proxy/generated Folder.');
 }
-


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `single_blank_line_at_eof`.