### PR TITLE
[CS] PHPDoc: remove empty lines at start/end

### DIFF
--- a/lib/Doctrine/ORM/Mapping/CacheUsage.php
+++ b/lib/Doctrine/ORM/Mapping/CacheUsage.php
@@ -32,7 +32,6 @@ final class CacheUsage
 
     /**
      * Will break upon instantiation.
-     *
      */
     private function __construct()
     {

--- a/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
@@ -40,7 +40,6 @@ final class ChangeTrackingPolicy
 
     /**
      * Will break upon instantiation.
-     *
      */
     private function __construct()
     {

--- a/lib/Doctrine/ORM/Mapping/FetchMode.php
+++ b/lib/Doctrine/ORM/Mapping/FetchMode.php
@@ -35,7 +35,6 @@ final class FetchMode
 
     /**
      * Will break upon instantiation.
-     *
      */
     private function __construct()
     {

--- a/lib/Doctrine/ORM/Mapping/GeneratorType.php
+++ b/lib/Doctrine/ORM/Mapping/GeneratorType.php
@@ -61,7 +61,6 @@ final class GeneratorType
 
     /**
      * Will break upon instantiation.
-     *
      */
     private function __construct()
     {

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -41,7 +41,6 @@ final class InheritanceType
 
     /**
      * Will break upon instantiation.
-     *
      */
     private function __construct()
     {

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -87,7 +87,6 @@ class ORMException extends Exception
     }
 
     /**
-     *
      * @param string $class
      * @param string $association
      * @param string $given

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -163,7 +163,6 @@ class QueryBuilder
     }
 
     /**
-     *
      * Enable/disable second level query (result) caching for this query.
      *
      * @param boolean $cacheable

--- a/tests/Doctrine/Tests/Models/Navigation/NavTour.php
+++ b/tests/Doctrine/Tests/Models/Navigation/NavTour.php
@@ -33,7 +33,6 @@ class NavTour
      *          @ORM\JoinColumn(name="poi_lat", referencedColumnName="nav_lat")
      *      }
      * )
-     *
      */
     private $pois;
 

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -168,7 +168,6 @@ class Lemma
     private $id;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="lemma_name", unique=true, length=255)
      */
@@ -185,7 +184,6 @@ class Lemma
     }
 
     /**
-     *
      * @return int
      */
     public function getId()
@@ -194,7 +192,6 @@ class Lemma
     }
 
     /**
-     *
      * @param string $lemma
      * @return void
      */
@@ -204,7 +201,6 @@ class Lemma
     }
 
     /**
-     *
      * @return string
      */
     public function getLemma()
@@ -235,7 +231,6 @@ class Lemma
     }
 
     /**
-     *
      * @return kateglo\application\helpers\collections\ArrayCollection
      */
     public function getTypes()
@@ -253,7 +248,6 @@ class Type
     const CLASS_NAME = __CLASS__;
 
     /**
-     *
      * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", name="type_id")
@@ -262,14 +256,12 @@ class Type
     private $id;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="type_name", unique=true)
      */
     private $type;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="type_abbreviation", unique=true)
      */
@@ -291,7 +283,6 @@ class Type
     }
 
     /**
-     *
      * @return int
      */
     public function getId()
@@ -300,7 +291,6 @@ class Type
     }
 
     /**
-     *
      * @param string $type
      * @return void
      */
@@ -310,7 +300,6 @@ class Type
     }
 
     /**
-     *
      * @return string
      */
     public function getType()
@@ -319,7 +308,6 @@ class Type
     }
 
     /**
-     *
      * @param string $abbreviation
      * @return void
      */
@@ -329,7 +317,6 @@ class Type
     }
 
     /**
-     *
      * @return string
      */
     public function getAbbreviation()
@@ -338,7 +325,6 @@ class Type
     }
 
     /**
-     *
      * @param kateglo\application\models\Lemma $lemma
      * @return void
      */
@@ -351,7 +337,6 @@ class Type
     }
 
     /**
-     *
      * @param kateglo\application\models\Lemma $lemma
      * @return void
      */
@@ -365,7 +350,6 @@ class Type
     }
 
     /**
-     *
      * @return kateglo\application\helpers\collections\ArrayCollection
      */
     public function getCategories()
@@ -411,7 +395,6 @@ class Phrase
     }
 
     /**
-     *
      * @param Definition $definition
      * @return void
      */
@@ -447,7 +430,6 @@ class Phrase
     }
 
     /**
-     *
      * @param PhraseType $type
      * @return void
      */
@@ -457,7 +439,6 @@ class Phrase
     }
 
     /**
-     *
      * @return PhraseType
      */
     public function getType()
@@ -466,7 +447,6 @@ class Phrase
     }
 
     /**
-     *
      * @return ArrayCollection
      */
     public function getDefinitions()
@@ -562,7 +542,6 @@ class PhraseType
     }
 
     /**
-     *
      * @return ArrayCollection
      */
     public function getPhrases()

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -90,7 +90,6 @@ abstract class OJTIC_Pet
     public $id;
 
     /**
-     *
      * @ORM\Column
      */
     public $name;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php
@@ -66,7 +66,6 @@ class DDC1250ClientHistory
 }
 
 /**
- *
 Entities\ClientsHistory:
 type: entity
 table: clients_history
@@ -91,6 +90,4 @@ targetEntity: Entities\ClientsHistory
 mappedBy: declinedClientsHistory
 lifecycleCallbacks: { }
 repositoryClass: Entities\ClientsHistoryRepository
-
-
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
@@ -131,7 +131,6 @@ class DDC2138UserFollowedStructure extends DDC2138UserFollowedObject
     }
 
     /**
-     *
      * @return User
      */
     public function getUser()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
@@ -274,7 +274,6 @@ class DDC2602BiographyField
 
     /**
      * Constructor.
-     *
      */
     public function __construct()
     {
@@ -326,7 +325,6 @@ class DDC2602FieldSelection
 
     /**
      * Constructor.
-     *
      */
     public function __construct()
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -37,7 +37,6 @@ class DDC698Test extends \Doctrine\Tests\OrmFunctionalTestCase
 }
 
 /**
- *
  * @ORM\Table(name="Roles")
  * @ORM\Entity
  */
@@ -46,21 +45,16 @@ class DDC698Role
     /**
      *  @ORM\Id @ORM\Column(name="roleID", type="integer")
      *  @ORM\GeneratedValue(strategy="AUTO")
-     *
      */
     protected $roleID;
 
     /**
      * @ORM\Column(name="name", type="string", length=45)
-     *
-     *
      */
     protected $name;
 
     /**
      * @ORM\Column(name="shortName", type="string", length=45)
-     *
-     *
      */
     protected $shortName;
 
@@ -76,7 +70,6 @@ class DDC698Role
 
 
 /**
- *
  * @ORM\Table(name="Privileges")
  * @ORM\Entity()
  */
@@ -85,14 +78,11 @@ class DDC698Privilege
     /**
      *  @ORM\Id  @ORM\Column(name="privilegeID", type="integer")
      *  @ORM\GeneratedValue(strategy="AUTO")
-     *
      */
     protected $privilegeID;
 
     /**
      * @ORM\Column(name="name", type="string", length=45)
-     *
-     *
      */
     protected $name;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php
@@ -117,7 +117,6 @@ class Lemma
     private $id;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="lemma_name", unique=true, length=255)
      */
@@ -138,7 +137,6 @@ class Lemma
 
 
     /**
-     *
      * @return int
      */
     public function getId()
@@ -147,7 +145,6 @@ class Lemma
     }
 
     /**
-     *
      * @param string $lemma
      * @return void
      */
@@ -157,7 +154,6 @@ class Lemma
     }
 
     /**
-     *
      * @return string
      */
     public function getLemma()
@@ -167,7 +163,6 @@ class Lemma
 
 
     /**
-     *
      * @param Relation $relation
      * @return void
      */
@@ -178,7 +173,6 @@ class Lemma
     }
 
     /**
-     *
      * @param Relation $relation
      * @return void
      */
@@ -192,7 +186,6 @@ class Lemma
     }
 
     /**
-     *
      * @return kateglo\application\utilities\collections\ArrayCollection
      */
     public function getRelations()
@@ -202,7 +195,6 @@ class Lemma
 }
 
 /**
- *
  * @ORM\Entity
  * @ORM\Table(name="relation")
  */
@@ -240,7 +232,6 @@ class Relation
     private $type;
 
     /**
-     *
      * @param Lemma $parent
      * @return void
      */
@@ -250,7 +241,6 @@ class Relation
     }
 
     /**
-     *
      * @return Phrase
      */
     public function getParent()
@@ -259,7 +249,6 @@ class Relation
     }
 
     /**
-     *
      * @return void
      */
     public function removeParent()
@@ -273,7 +262,6 @@ class Relation
     }
 
     /**
-     *
      * @param Lemma $child
      * @return void
      */
@@ -283,7 +271,6 @@ class Relation
     }
 
     /**
-     *
      * @return Lemma
      */
     public function getChild()
@@ -292,7 +279,6 @@ class Relation
     }
 
     /**
-     *
      * @param RelationType $type
      * @return void
      */
@@ -302,7 +288,6 @@ class Relation
     }
 
     /**
-     *
      * @return RelationType
      */
     public function getType()
@@ -311,7 +296,6 @@ class Relation
     }
 
     /**
-     *
      * @return void
      */
     public function removeType()
@@ -326,7 +310,6 @@ class Relation
 }
 
 /**
- *
  * @ORM\Entity
  * @ORM\Table(name="relation_type")
  */
@@ -335,7 +318,6 @@ class RelationType
     const CLASS_NAME = __CLASS__;
 
     /**
-     *
      * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", name="relation_type_id")
@@ -344,14 +326,12 @@ class RelationType
     private $id;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="relation_type_name", unique=true, length=255)
      */
     private $type;
 
     /**
-     *
      * @var string
      * @ORM\Column(type="string", name="relation_type_abbreviation", unique=true, length=255)
      */
@@ -369,7 +349,6 @@ class RelationType
     }
 
     /**
-     *
      * @return int
      */
     public function getId()
@@ -378,7 +357,6 @@ class RelationType
     }
 
     /**
-     *
      * @param string $type
      * @return void
      */
@@ -388,7 +366,6 @@ class RelationType
     }
 
     /**
-     *
      * @return string
      */
     public function getType()
@@ -397,7 +374,6 @@ class RelationType
     }
 
     /**
-     *
      * @param string $abbreviation
      * @return void
      */
@@ -407,7 +383,6 @@ class RelationType
     }
 
     /**
-     *
      * @return string
      */
     public function getAbbreviation()
@@ -416,7 +391,6 @@ class RelationType
     }
 
     /**
-     *
      * @param Relation $relation
      * @return void
      */
@@ -427,7 +401,6 @@ class RelationType
     }
 
     /**
-     *
      * @param Relation $relation
      * @return void
      */
@@ -441,7 +414,6 @@ class RelationType
     }
 
     /**
-     *
      * @return kateglo\application\utilities\collections\ArrayCollection
      */
     public function getRelations()

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -96,7 +96,6 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
     }
 
     /**
-     *
      * @param ClassMetadata $class
      */
     public function testEntityIndexes()


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `phpdoc_trim`.