### PR TITLE
[CS] Remove trailing whitespace at the end of blank lines

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -31,7 +31,7 @@ class SingleScalarHydrator extends AbstractHydrator
         if ($numRows > 1) {
             throw new NonUniqueResultException('The query returned multiple rows. Change the query or use a different result function like getScalarResult().');
         }
-        
+
         if (count($data[key($data)]) > 1) {
             throw new NonUniqueResultException('The query returned a row containing multiple columns. Change the query or use a different result function like getScalarResult().');
         }

--- a/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
@@ -103,7 +103,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     {
         return $this->classToTableName($sourceEntity) . '_' . $this->classToTableName($targetEntity);
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -112,7 +112,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
         return $this->classToTableName($entityName) . '_' .
                 ($referencedColumnName ?: $this->referenceColumnName());
     }
-    
+
     /**
      * @param string $string
      *

--- a/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
@@ -18,12 +18,12 @@ class JoinVariableDeclaration extends Node
      * @var Join 
      */
     public $join;
-    
+
     /**
      * @var IndexBy|null 
      */
     public $indexBy;
-    
+
     /**
      * Constructor.
      * 

--- a/tests/Doctrine/Tests/DbalFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/DbalFunctionalTestCase.php
@@ -24,7 +24,7 @@ class DbalFunctionalTestCase extends DbalTestCase
     protected function resetSharedConn()
     {
         $this->sharedFixture['conn'] = null;
-        
+
         self::$sharedConn = null;
     }
 
@@ -35,10 +35,10 @@ class DbalFunctionalTestCase extends DbalTestCase
     {
         if (isset($this->sharedFixture['conn'])) {
             $this->conn = $this->sharedFixture['conn'];
-            
+
             return;
         }
-        
+
         if (! isset(self::$sharedConn)) {
             self::$sharedConn = TestUtil::getConnection();
         }

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddressListener.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddressListener.php
@@ -17,7 +17,7 @@ class CmsAddressListener
     {
         $this->calls[__FUNCTION__][] = func_get_args();
     }
-    
+
     public function preUpdate()
     {
         $this->calls[__FUNCTION__][] = func_get_args();

--- a/tests/Doctrine/Tests/Models/DDC6412/DDC6412File.php
+++ b/tests/Doctrine/Tests/Models/DDC6412/DDC6412File.php
@@ -16,7 +16,7 @@ class DDC6412File
      * @ORM\GeneratedValue
      */
     public $id;
-    
+
     /**
      * @ORM\Column(length=50, name="file_name")
      */

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php
@@ -34,7 +34,7 @@ class LegacyArticle
      * @ORM\JoinColumn(name="iUserId", referencedColumnName="iUserId")
      */
     public $user;
-    
+
     public function setAuthor(LegacyUser $author)
     {
         $this->user = $author;

--- a/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
+++ b/tests/Doctrine/Tests/Models/Legacy/LegacyUser.php
@@ -48,7 +48,7 @@ class LegacyUser
      *      )
      */
     public $cars;
-    
+
     public function __construct()
     {
         $this->articles = new ArrayCollection;

--- a/tests/Doctrine/Tests/Models/Taxi/Car.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Car.php
@@ -33,7 +33,7 @@ class Car
      * @ORM\OneToMany(targetEntity=PaidRide::class, mappedBy="car")
      */
     private $carRides;
-    
+
     public function getBrand()
     {
         return $this->brand;

--- a/tests/Doctrine/Tests/Models/Taxi/Driver.php
+++ b/tests/Doctrine/Tests/Models/Taxi/Driver.php
@@ -33,7 +33,7 @@ class Driver
      * @ORM\OneToMany(targetEntity=PaidRide::class, mappedBy="driver")
      */
     private $driverRides;
-    
+
     public function getId()
     {
         return $this->id;

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -358,7 +358,7 @@ class Type
     public function removeLEmma(Lemma $lemma)
     {
         $removed = $this->lemmas->removeElement($lemma);
-        
+
         if ($removed !== null) {
             $removed->removeType($this);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php
@@ -32,7 +32,7 @@ class SecondLevelCacheConcurrentTest extends SecondLevelCacheAbstractTest
     protected function setUp()
     {
         $this->enableSecondLevelCache();
-        
+
         parent::setUp();
 
         $this->cacheFactory = new CacheFactorySecondLevelCacheConcurrentTest($this->getSharedSecondLevelCacheDriverImpl());

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php
@@ -14,7 +14,7 @@ class DDC1300Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->schemaTool->createSchema(
             [
                 $this->em->getClassMetadata(DDC1300Foo::class),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php
@@ -20,11 +20,11 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function setUp()
     {
         $this->useModelSet('legacy');
-        
+
         parent::setUp();
 
         $class = $this->em->getClassMetadata(Models\Legacy\LegacyUser::class);
-        
+
         $class->getProperty('articles')->setFetchMode(FetchMode::EXTRA_LAZY);
         $class->getProperty('references')->setFetchMode(FetchMode::EXTRA_LAZY);
         $class->getProperty('cars')->setFetchMode(FetchMode::EXTRA_LAZY);
@@ -37,7 +37,7 @@ class DDC1301Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::tearDown();
 
         $class = $this->em->getClassMetadata(Models\Legacy\LegacyUser::class);
-        
+
         $class->getProperty('articles')->setFetchMode(FetchMode::LAZY);
         $class->getProperty('references')->setFetchMode(FetchMode::LAZY);
         $class->getProperty('cars')->setFetchMode(FetchMode::LAZY);

--- a/tests/Doctrine/Tests/ORM/Mapping/EntityListenerResolverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/EntityListenerResolverTest.php
@@ -76,7 +76,7 @@ class EntityListenerResolverTest extends OrmTestCase
 
         self::assertInstanceOf($className1, $obj1);
         self::assertInstanceOf($className2, $obj2);
-        
+
         self::assertSame($obj1, $this->resolver->resolve($className1));
         self::assertSame($obj2, $this->resolver->resolve($className2));
 
@@ -84,7 +84,7 @@ class EntityListenerResolverTest extends OrmTestCase
 
         self::assertInstanceOf($className1, $this->resolver->resolve($className1));
         self::assertInstanceOf($className2, $this->resolver->resolve($className2));
-        
+
         self::assertNotSame($obj1, $this->resolver->resolve($className1));
         self::assertNotSame($obj2, $this->resolver->resolve($className2));
     }


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `no_whitespace_in_blank_line`.