### PR TITLE
[CS] Add curly braces to indirect variables

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -302,6 +302,6 @@ class EntityRepository implements ObjectRepository, Selectable
             throw ORMException::invalidMagicCall($this->entityName, $fieldName, $method . $by);
         }
 
-        return $this->$method([$fieldName => $arguments[0]], ...array_slice($arguments, 1));
+        return $this->{$method}([$fieldName => $arguments[0]], ...array_slice($arguments, 1));
     }
 }

--- a/lib/Doctrine/ORM/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ORM/Event/ListenersInvoker.php
@@ -84,7 +84,7 @@ class ListenersInvoker
     {
         if ($invoke & self::INVOKE_CALLBACKS) {
             foreach ($metadata->lifecycleCallbacks[$eventName] as $callback) {
-                $entity->$callback($event);
+                $entity->{$callback}($event);
             }
         }
 
@@ -94,7 +94,7 @@ class ListenersInvoker
                 $method     = $listener['method'];
                 $instance   = $this->resolver->resolve($class);
 
-                $instance->$method($entity, $event);
+                $instance->{$method}($entity, $event);
             }
         }
 

--- a/lib/Doctrine/ORM/PersistentObject.php
+++ b/lib/Doctrine/ORM/PersistentObject.php
@@ -120,7 +120,7 @@ abstract class PersistentObject implements EntityManagerAware
 
         switch (true) {
             case ($property instanceof FieldMetadata && ! $property->isPrimaryKey()):
-                $this->$field = $args[0];
+                $this->{$field} = $args[0];
                 break;
 
             case ($property instanceof ToOneAssociationMetadata):
@@ -130,7 +130,7 @@ abstract class PersistentObject implements EntityManagerAware
                     throw new \InvalidArgumentException("Expected persistent object of type '".$targetClassName."'");
                 }
 
-                $this->$field = $args[0];
+                $this->{$field} = $args[0];
                 $this->completeOwningSide($property, $args[0]);
                 break;
         }
@@ -157,7 +157,7 @@ abstract class PersistentObject implements EntityManagerAware
             throw new \BadMethodCallException("no field with name '".$field."' exists on '".$this->cm->getClassName()."'");
         }
 
-        return $this->$field;
+        return $this->{$field};
     }
 
     /**
@@ -181,7 +181,7 @@ abstract class PersistentObject implements EntityManagerAware
         $targetProperty   = $targetMetadata->getProperty($mappedByField);
         $setterMethodName = ($targetProperty instanceof ToManyAssociationMetadata ? 'add' : 'set') . $mappedByField;
 
-        $targetObject->$setterMethodName($this);
+        $targetObject->{$setterMethodName}($this);
     }
 
     /**
@@ -215,11 +215,11 @@ abstract class PersistentObject implements EntityManagerAware
             throw new \InvalidArgumentException("Expected persistent object of type '".$targetClassName."'");
         }
 
-        if (! ($this->$field instanceof Collection)) {
-            $this->$field = new ArrayCollection($this->$field ?: []);
+        if (! ($this->{$field} instanceof Collection)) {
+            $this->{$field} = new ArrayCollection($this->{$field} ?: []);
         }
 
-        $this->$field->add($args[0]);
+        $this->{$field}->add($args[0]);
 
         $this->completeOwningSide($property, $args[0]);
 

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -169,7 +169,7 @@ class EntityManagerTest extends OrmTestCase
         $this->expectException(ORMInvalidArgumentException::class);
         $this->expectExceptionMessage('EntityManager#' . $methodName . '() expects parameter 1 to be an entity object, NULL given.');
 
-        $this->em->$methodName(null);
+        $this->em->{$methodName}(null);
     }
 
     static public function dataAffectedByErrorIfClosedException()
@@ -192,7 +192,7 @@ class EntityManagerTest extends OrmTestCase
         $this->expectExceptionMessage('closed');
 
         $this->em->close();
-        $this->em->$methodName(new \stdClass());
+        $this->em->{$methodName}(new \stdClass());
     }
 
     public function dataToBeReturnedByTransactional()

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -131,7 +131,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(9, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "0", $result[0]->$checkField);
+        self::assertEquals($checkField . "0", $result[0]->{$checkField});
     }
 
     private function iterateWithOrderAscWithLimit($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
@@ -147,7 +147,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(3, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "0", $result[0]->$checkField);
+        self::assertEquals($checkField . "0", $result[0]->{$checkField});
     }
 
     private function iterateWithOrderAscWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
@@ -163,7 +163,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(3, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "3", $result[0]->$checkField);
+        self::assertEquals($checkField . "3", $result[0]->{$checkField});
     }
 
     private function iterateWithOrderDesc($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
@@ -176,7 +176,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(9, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "8", $result[0]->$checkField);
+        self::assertEquals($checkField . "8", $result[0]->{$checkField});
     }
 
     private function iterateWithOrderDescWithLimit($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
@@ -191,7 +191,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(3, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "8", $result[0]->$checkField);
+        self::assertEquals($checkField . "8", $result[0]->{$checkField});
     }
 
     private function iterateWithOrderDescWithLimitAndOffset($useOutputWalkers, $fetchJoinCollection, $baseDql, $checkField)
@@ -206,7 +206,7 @@ class PaginationTest extends OrmFunctionalTestCase
         $iter = $paginator->getIterator();
         self::assertCount(3, $iter);
         $result = iterator_to_array($iter);
-        self::assertEquals($checkField . "5", $result[0]->$checkField);
+        self::assertEquals($checkField . "5", $result[0]->{$checkField});
     }
 
     /**


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `explicit_indirect_variable`.

Add curly braces to indirect variables to make them clear to understand.