### PR TITLE
[CS] Method argument space: no space before comma, at least one space after

### DIFF
--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -201,7 +201,7 @@ class FileLockRegion implements ConcurrentRegion
     {
         // The check below is necessary because on some platforms glob returns false
         // when nothing matched (even though no errors occurred)
-        $filenames = glob(sprintf("%s/*.%s" , $this->directory, self::LOCK_EXTENSION));
+        $filenames = glob(sprintf("%s/*.%s", $this->directory, self::LOCK_EXTENSION));
 
         if ($filenames) {
             foreach ($filenames as $filename) {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1412,7 +1412,7 @@ class SqlWalker implements TreeWalker
                 break;
 
             case ($expr instanceof AST\NewObjectExpression):
-                $sql .= $this->walkNewObject($expr,$selectExpression->fieldIdentificationVariable);
+                $sql .= $this->walkNewObject($expr, $selectExpression->fieldIdentificationVariable);
                 break;
 
             default:

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -198,7 +198,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
             ->with($this->equalTo($collection), $this->equalTo(1), $this->equalTo(2))
             ->will($this->returnValue($slice));
 
-        self::assertEquals($slice, $persister->slice($collection, 1 , 2));
+        self::assertEquals($slice, $persister->slice($collection, 1, 2));
     }
 
     public function testInvokeContains()
@@ -215,7 +215,7 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
             ->with($this->equalTo($collection), $this->equalTo($element))
             ->will($this->returnValue(false));
 
-        self::assertFalse($persister->contains($collection,$element));
+        self::assertFalse($persister->contains($collection, $element));
     }
 
     public function testInvokeContainsKey()

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php
@@ -371,7 +371,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
             ->with($this->equalTo($assoc), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
             ->will($this->returnValue([$entity]));
 
-        self::assertEquals([$entity], $persister->getManyToManyCollection($assoc, 'Foo', 1 ,2));
+        self::assertEquals([$entity], $persister->getManyToManyCollection($assoc, 'Foo', 1, 2));
     }
 
     public function testInvokeGetOneToManyCollection()
@@ -385,7 +385,7 @@ abstract class AbstractEntityPersisterTest extends OrmTestCase
             ->with($this->equalTo($assoc), $this->equalTo('Foo'), $this->equalTo(1), $this->equalTo(2))
             ->will($this->returnValue([$entity]));
 
-        self::assertEquals([$entity], $persister->getOneToManyCollection($assoc, 'Foo', 1 ,2));
+        self::assertEquals([$entity], $persister->getOneToManyCollection($assoc, 'Foo', 1, 2));
     }
 
     public function testInvokeLoadManyToManyCollection()

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -274,7 +274,7 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $result = $q->getResult();
 
         self::assertCount(1, $result);
-        self::assertInstanceOf(CompanyAuction::class, $result[0], sprintf("Is of class %s",get_class($result[0])));
+        self::assertInstanceOf(CompanyAuction::class, $result[0], sprintf("Is of class %s", get_class($result[0])));
 
         $this->em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php
@@ -42,7 +42,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->persist($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->preFlushCalls);
+        self::assertCount(1, $this->listener->preFlushCalls);
         self::assertSame($fix, $this->listener->preFlushCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->preFlushCalls[0][0]);
         self::assertInstanceOf(PreFlushEventArgs::class, $this->listener->preFlushCalls[0][1]);
@@ -62,7 +62,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $dql = "SELECT f FROM Doctrine\Tests\Models\Company\CompanyFixContract f WHERE f.id = ?1";
         $fix = $this->em->createQuery($dql)->setParameter(1, $fix->getId())->getSingleResult();
 
-        self::assertCount(1,$this->listener->postLoadCalls);
+        self::assertCount(1, $this->listener->postLoadCalls);
         self::assertSame($fix, $this->listener->postLoadCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->postLoadCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->postLoadCalls[0][1]);
@@ -78,7 +78,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->persist($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->prePersistCalls);
+        self::assertCount(1, $this->listener->prePersistCalls);
         self::assertSame($fix, $this->listener->prePersistCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->prePersistCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->prePersistCalls[0][1]);
@@ -94,7 +94,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->persist($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->postPersistCalls);
+        self::assertCount(1, $this->listener->postPersistCalls);
         self::assertSame($fix, $this->listener->postPersistCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->postPersistCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->postPersistCalls[0][1]);
@@ -115,7 +115,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->persist($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->preUpdateCalls);
+        self::assertCount(1, $this->listener->preUpdateCalls);
         self::assertSame($fix, $this->listener->preUpdateCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->preUpdateCalls[0][0]);
         self::assertInstanceOf(PreUpdateEventArgs::class, $this->listener->preUpdateCalls[0][1]);
@@ -136,7 +136,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->persist($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->postUpdateCalls);
+        self::assertCount(1, $this->listener->postUpdateCalls);
         self::assertSame($fix, $this->listener->postUpdateCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->postUpdateCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->postUpdateCalls[0][1]);
@@ -155,7 +155,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->remove($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->preRemoveCalls);
+        self::assertCount(1, $this->listener->preRemoveCalls);
         self::assertSame($fix, $this->listener->preRemoveCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->preRemoveCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->preRemoveCalls[0][1]);
@@ -174,7 +174,7 @@ class EntityListenersTest extends OrmFunctionalTestCase
         $this->em->remove($fix);
         $this->em->flush();
 
-        self::assertCount(1,$this->listener->postRemoveCalls);
+        self::assertCount(1, $this->listener->postRemoveCalls);
         self::assertSame($fix, $this->listener->postRemoveCalls[0][0]);
         self::assertInstanceOf(CompanyFixContract::class, $this->listener->postRemoveCalls[0][0]);
         self::assertInstanceOf(LifecycleEventArgs::class, $this->listener->postRemoveCalls[0][1]);

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -182,7 +182,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $repos = $this->em->getRepository(CmsUser::class);
 
         $user = $repos->find($user1Id);
-        self::assertInstanceOf(CmsUser::class,$user);
+        self::assertInstanceOf(CmsUser::class, $user);
         self::assertEquals('Roman', $user->name);
         self::assertEquals('freak', $user->status);
     }
@@ -194,7 +194,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $users = $repos->findBy(['status' => 'dev']);
         self::assertCount(2, $users);
-        self::assertInstanceOf(CmsUser::class,$users[0]);
+        self::assertInstanceOf(CmsUser::class, $users[0]);
         self::assertEquals('Guilherme', $users[0]->name);
         self::assertEquals('dev', $users[0]->status);
     }
@@ -220,7 +220,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $addresses  = $repository->findBy(['user' => [$user1->getId(), $user2->getId()]]);
 
         self::assertCount(2, $addresses);
-        self::assertInstanceOf(CmsAddress::class,$addresses[0]);
+        self::assertInstanceOf(CmsAddress::class, $addresses[0]);
     }
 
     public function testFindByAssociationWithObjectAsParameter()
@@ -244,7 +244,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $addresses  = $repository->findBy(['user' => [$user1, $user2]]);
 
         self::assertCount(2, $addresses);
-        self::assertInstanceOf(CmsAddress::class,$addresses[0]);
+        self::assertInstanceOf(CmsAddress::class, $addresses[0]);
     }
 
     public function testFindFieldByMagicCall()
@@ -254,7 +254,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
         $users = $repos->findByStatus('dev');
         self::assertCount(2, $users);
-        self::assertInstanceOf(CmsUser::class,$users[0]);
+        self::assertInstanceOf(CmsUser::class, $users[0]);
         self::assertEquals('Guilherme', $users[0]->name);
         self::assertEquals('dev', $users[0]->status);
     }
@@ -596,7 +596,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         self::assertCount(2, $usersAsc);
         self::assertCount(2, $usersDesc);
 
-        self::assertInstanceOf(CmsUser::class,$usersAsc[0]);
+        self::assertInstanceOf(CmsUser::class, $usersAsc[0]);
         self::assertEquals('Alexander', $usersAsc[0]->name);
         self::assertEquals('dev', $usersAsc[0]->status);
 

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -744,9 +744,9 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1][1]->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2][1]->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['status']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['status']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['status']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['status']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['status']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['status']);
     }
 
     public function testShouldSupportMultipleNewOperatorsAndSingleScalarWithAliases()
@@ -801,9 +801,9 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1]['cmsAddress']->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2]['cmsAddress']->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['cmsUserStatus']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['cmsUserStatus']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['cmsUserStatus']);
     }
 
     public function testShouldSupportMultipleNewOperatorsAndSingleScalarWithAndWithoutAliases()
@@ -858,9 +858,9 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1][0]->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2][0]->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['status']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['status']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['status']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['status']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['status']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['status']);
     }
 
     public function testShouldSupportMultipleNewOperatorsAndMultipleScalars()
@@ -916,13 +916,13 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1][1]->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2][1]->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['status']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['status']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['status']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['status']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['status']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['status']);
 
-        self::assertEquals($this->fixtures[0]->username,$result[0]['username']);
-        self::assertEquals($this->fixtures[1]->username,$result[1]['username']);
-        self::assertEquals($this->fixtures[2]->username,$result[2]['username']);
+        self::assertEquals($this->fixtures[0]->username, $result[0]['username']);
+        self::assertEquals($this->fixtures[1]->username, $result[1]['username']);
+        self::assertEquals($this->fixtures[2]->username, $result[2]['username']);
     }
 
     public function testShouldSupportMultipleNewOperatorsAndMultipleScalarsWithAliases()
@@ -978,13 +978,13 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1]['cmsAddress']->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2]['cmsAddress']->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['cmsUserStatus']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['cmsUserStatus']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['cmsUserStatus']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['cmsUserStatus']);
 
-        self::assertEquals($this->fixtures[0]->username,$result[0]['cmsUserUsername']);
-        self::assertEquals($this->fixtures[1]->username,$result[1]['cmsUserUsername']);
-        self::assertEquals($this->fixtures[2]->username,$result[2]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[0]->username, $result[0]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[1]->username, $result[1]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[2]->username, $result[2]['cmsUserUsername']);
     }
 
     public function testShouldSupportMultipleNewOperatorsAndMultipleScalarsWithAndWithoutAliases()
@@ -1040,13 +1040,13 @@ class NewOperatorTest extends OrmFunctionalTestCase
         self::assertEquals($this->fixtures[1]->address->country, $result[1][0]->country);
         self::assertEquals($this->fixtures[2]->address->country, $result[2][0]->country);
 
-        self::assertEquals($this->fixtures[0]->status,$result[0]['status']);
-        self::assertEquals($this->fixtures[1]->status,$result[1]['status']);
-        self::assertEquals($this->fixtures[2]->status,$result[2]['status']);
+        self::assertEquals($this->fixtures[0]->status, $result[0]['status']);
+        self::assertEquals($this->fixtures[1]->status, $result[1]['status']);
+        self::assertEquals($this->fixtures[2]->status, $result[2]['status']);
 
-        self::assertEquals($this->fixtures[0]->username,$result[0]['cmsUserUsername']);
-        self::assertEquals($this->fixtures[1]->username,$result[1]['cmsUserUsername']);
-        self::assertEquals($this->fixtures[2]->username,$result[2]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[0]->username, $result[0]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[1]->username, $result[1]['cmsUserUsername']);
+        self::assertEquals($this->fixtures[2]->username, $result[2]['cmsUserUsername']);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -83,7 +83,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
         $class = $this->em->getClassMetadata(get_class($entity));
 
         self::assertEquals(ECommerceProduct::class, $class->getClassName());
@@ -96,8 +96,8 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
     {
         $id = $this->createProduct();
 
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
-        $entity2 = $this->em->find(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
+        $entity2 = $this->em->find(ECommerceProduct::class, $id);
 
         self::assertSame($entity, $entity2);
         self::assertEquals('Doctrine Cookbook', $entity2->getName());
@@ -111,7 +111,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         /* @var $clone ECommerceProduct */
         $clone = clone $entity;
@@ -138,7 +138,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         self::assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
 
@@ -155,7 +155,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         $entity->setName('Doctrine 2 Cookbook');
 
@@ -163,7 +163,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $this->em->clear();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         self::assertEquals('Doctrine 2 Cookbook', $entity->getName());
     }
@@ -173,7 +173,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         self::assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         self::assertEquals($id, $entity->getId());
@@ -188,7 +188,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createAuction();
 
         /* @var $entity CompanyAuction|GhostObjectInterface */
-        $entity = $this->em->getReference(CompanyAuction::class , $id);
+        $entity = $this->em->getReference(CompanyAuction::class, $id);
 
         self::assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         self::assertEquals($id, $entity->getId());
@@ -226,7 +226,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         self::assertFalse($entity->isProxyInitialized(), "Pre-Condition: Object is unitialized proxy.");
         self::assertEquals('Doctrine Cookbook', $entity->getName());
@@ -241,7 +241,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $id = $this->createProduct();
 
         /* @var $entity ECommerceProduct|GhostObjectInterface */
-        $entity = $this->em->getReference(ECommerceProduct::class , $id);
+        $entity = $this->em->getReference(ECommerceProduct::class, $id);
 
         $className = StaticClassNameConverter::getClass($entity);
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -574,11 +574,11 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId);
 
         self::assertFalse($user->articles->isInitialized());
-        self::assertCount(2, $user->articles->slice(0,10));
+        self::assertCount(2, $user->articles->slice(0, 10));
 
         $this->useCMSArticleTopicFilter();
 
-        self::assertCount(1, $user->articles->slice(0,10));
+        self::assertCount(1, $user->articles->slice(0, 10));
     }
 
     private function useCMSGroupPrefixFilter()
@@ -622,11 +622,11 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $user = $this->em->find(CmsUser::class, $this->userId2);
 
         self::assertFalse($user->groups->isInitialized());
-        self::assertCount(2, $user->groups->slice(0,10));
+        self::assertCount(2, $user->groups->slice(0, 10));
 
         $this->useCMSGroupPrefixFilter();
 
-        self::assertCount(1, $user->groups->slice(0,10));
+        self::assertCount(1, $user->groups->slice(0, 10));
     }
 
     private function loadFixtureData()

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -422,7 +422,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $result1    = $this->em->createQuery($dql)->setCacheable(true)->getResult();
 
         self::assertCount(2, $result1);
-        self::assertEquals($queryCount + 1 , $this->getCurrentQueryCount());
+        self::assertEquals($queryCount + 1, $this->getCurrentQueryCount());
         self::assertEquals($this->countries[0]->getId(), $result1[0]->getId());
         self::assertEquals($this->countries[1]->getId(), $result1[1]->getId());
         self::assertEquals($this->countries[0]->getName(), $result1[0]->getName());
@@ -442,7 +442,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->setCacheable(true)
             ->getResult();
 
-        self::assertEquals($queryCount + 2 , $this->getCurrentQueryCount());
+        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
         self::assertCount(2, $result2);
 
         self::assertEquals(5, $this->secondLevelCacheLogger->getPutCount());
@@ -459,7 +459,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         self::assertEquals($result1[0]->getName(), $result2[0]->getName());
         self::assertEquals($result1[1]->getName(), $result2[1]->getName());
 
-        self::assertEquals($queryCount + 2 , $this->getCurrentQueryCount());
+        self::assertEquals($queryCount + 2, $this->getCurrentQueryCount());
     }
 
     public function testBasicQueryFetchJoinsOneToMany()

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php
@@ -101,7 +101,7 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIndexWithJoin()
     {
         $builder = $this->em->createQueryBuilder();
-        $builder->select('u','p')
+        $builder->select('u', 'p')
                 ->from(DDC1335User::class, 'u', 'u.email')
                 ->join('u.phones', 'p', null, null, 'p.id');
 
@@ -138,9 +138,9 @@ class DDC1335Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $p2 = ['22 xxxx-xxxx','22 yyyy-yyyy','22 zzzz-zzzz'];
         $p3 = ['33 xxxx-xxxx','33 yyyy-yyyy','33 zzzz-zzzz'];
 
-        $u1 = new DDC1335User("foo@foo.com", "Foo",$p1);
-        $u2 = new DDC1335User("bar@bar.com", "Bar",$p2);
-        $u3 = new DDC1335User("foobar@foobar.com", "Foo Bar",$p3);
+        $u1 = new DDC1335User("foo@foo.com", "Foo", $p1);
+        $u2 = new DDC1335User("bar@bar.com", "Bar", $p2);
+        $u3 = new DDC1335User("foobar@foobar.com", "Foo Bar", $p3);
 
         $this->em->persist($u1);
         $this->em->persist($u2);
@@ -183,7 +183,7 @@ class DDC1335User
         $this->phones = new \Doctrine\Common\Collections\ArrayCollection();
 
         foreach ($numbers as $number) {
-            $this->phones->add(new DDC1335Phone($this,$number));
+            $this->phones->add(new DDC1335Phone($this, $number));
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php
@@ -32,7 +32,7 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIssue()
     {
         $user1    = new DDC2862User('Foo');
-        $driver1  = new DDC2862Driver('Bar' , $user1);
+        $driver1  = new DDC2862Driver('Bar', $user1);
 
         $this->em->persist($user1);
         $this->em->persist($driver1);
@@ -70,7 +70,7 @@ class DDC2862Test extends \Doctrine\Tests\OrmFunctionalTestCase
     public function testIssueReopened()
     {
         $user1    = new DDC2862User('Foo');
-        $driver1  = new DDC2862Driver('Bar' , $user1);
+        $driver1  = new DDC2862Driver('Bar', $user1);
 
         $this->em->persist($user1);
         $this->em->persist($driver1);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php
@@ -36,7 +36,7 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $query      = $this->em->createQuery('SELECT d.id, d.time, d.date, d.datetime FROM ' . DateTimeModel::class . ' d ORDER BY d.date ASC');
         $result     = $query->getScalarResult();
 
-        self::assertCount(2,$result);
+        self::assertCount(2, $result);
 
         self::assertContains('11:11:11', $result[0]['time']);
         self::assertContains('2010-01-01', $result[0]['date']);
@@ -52,7 +52,7 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $query      = $this->em->createQuery('SELECT d FROM ' . DateTimeModel::class . ' d ORDER BY d.date ASC');
         $result     = $query->getArrayResult();
 
-        self::assertCount(2,$result);
+        self::assertCount(2, $result);
 
         self::assertInstanceOf('DateTime', $result[0]['datetime']);
         self::assertInstanceOf('DateTime', $result[0]['time']);
@@ -80,7 +80,7 @@ class DDC657Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $query      = $this->em->createQuery('SELECT d.id, d.time, d.date, d.datetime FROM ' . DateTimeModel::class . ' d ORDER BY d.date ASC');
         $result     = $query->getResult();
 
-        self::assertCount(2,$result);
+        self::assertCount(2, $result);
 
         self::assertInstanceOf('DateTime', $result[0]['time']);
         self::assertInstanceOf('DateTime', $result[0]['date']);

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -97,8 +97,8 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
     {
         $rms = $this->rsm;
 
-        $this->rsm->addEntityResult(CmsUser::class,'u');
-        $this->rsm->addJoinedEntityResult(CmsPhonenumber::class,'p','u','phonenumbers');
+        $this->rsm->addEntityResult(CmsUser::class, 'u');
+        $this->rsm->addJoinedEntityResult(CmsPhonenumber::class, 'p', 'u', 'phonenumbers');
         $this->rsm->addFieldResult('u', 'id', 'id');
         $this->rsm->addFieldResult('u', 'name', 'name');
         $this->rsm->setDiscriminatorColumn('name', 'name');

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -678,7 +678,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         $findByIdQuery = $class->getNamedNativeQuery('find-by-id');
 
-        self::assertEquals(CmsAddress::class,$findByIdQuery['resultClass']);
+        self::assertEquals(CmsAddress::class, $findByIdQuery['resultClass']);
         self::assertEquals('SELECT * FROM cms_addresses WHERE id = ?',  $findByIdQuery['query']);
 
         $countQuery = $class->getNamedNativeQuery('count');
@@ -722,7 +722,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingJoinedAddress');
 
-        self::assertEquals([],$mapping['columns']);
+        self::assertEquals([], $mapping['columns']);
         self::assertEquals('mappingJoinedAddress', $mapping['name']);
 
         self::assertNull($mapping['entities'][0]['discriminatorColumn']);
@@ -738,7 +738,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingJoinedPhonenumber');
 
-        self::assertEquals([],$mapping['columns']);
+        self::assertEquals([], $mapping['columns']);
         self::assertEquals('mappingJoinedPhonenumber', $mapping['name']);
 
         self::assertNull($mapping['entities'][0]['discriminatorColumn']);
@@ -751,7 +751,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingUserPhonenumberCount');
 
-        self::assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
+        self::assertEquals(['name'=>'numphones'], $mapping['columns'][0]);
         self::assertEquals('mappingUserPhonenumberCount', $mapping['name']);
 
         self::assertNull($mapping['entities'][0]['discriminatorColumn']);
@@ -763,7 +763,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingMultipleJoinsEntityResults');
 
-        self::assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
+        self::assertEquals(['name'=>'numphones'], $mapping['columns'][0]);
         self::assertEquals('mappingMultipleJoinsEntityResults', $mapping['name']);
 
         self::assertNull($mapping['entities'][0]['discriminatorColumn']);

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -549,7 +549,7 @@ class QueryBuilderTest extends OrmTestCase
         $qb = $this->em->createQueryBuilder();
         $qb->select('u')
             ->from(CmsUser::class, 'u')
-            ->join('u.article','a');
+            ->join('u.article', 'a');
 
         $criteria = new Criteria();
         $criteria->orderBy(['a.field' => Criteria::DESC]);
@@ -889,7 +889,7 @@ class QueryBuilderTest extends OrmTestCase
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
-        $qb->join('alias1.articles','alias2');
+        $qb->join('alias1.articles', 'alias2');
 
         $criteria = new Criteria();
         $criteria->where($criteria->expr()->eq('field', 'value1'));
@@ -909,7 +909,7 @@ class QueryBuilderTest extends OrmTestCase
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
-        $qb->join('alias1.articles','alias2');
+        $qb->join('alias1.articles', 'alias2');
 
         $criteria = new Criteria();
         $criteria->where($criteria->expr()->eq('alias1.field', 'value1'));
@@ -929,7 +929,7 @@ class QueryBuilderTest extends OrmTestCase
     {
         $qb = $this->em->createQueryBuilder();
         $qb->select('alias1')->from(CmsUser::class, 'alias1');
-        $qb->join('alias1.articles','alias2');
+        $qb->join('alias1.articles', 'alias2');
 
         $criteria = new Criteria();
         $criteria->where($criteria->expr()->eq('alias1.field', 'value1'));


### PR DESCRIPTION
The fix was applied with [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) rule `method_argument_space`.