### PR TITLE
Remove impossible-to-hit condition

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -266,12 +266,6 @@ class ArrayHydrator extends AbstractHydrator
      */
     private function updateResultPointer(array &$coll, $index, $dqlAlias, $oneToOne)
     {
-        if ($coll === null) {
-            unset($this->resultPointers[$dqlAlias]); // Ticket #1228
-
-            return;
-        }
-
         if ($oneToOne) {
             $this->resultPointers[$dqlAlias] =& $coll;
 


### PR DESCRIPTION
Because we have a hard type check for `$coll`