### PR TITLE
Exception Call to undefined method Doctrine\Common\Cache\MemcachedCache::setMemcache()

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -171,11 +171,11 @@ class Setup
 
 
         if (extension_loaded('memcached')) {
-            $memcache = new \Memcached();
-            $memcache->addServer('127.0.0.1', 11211);
+            $memcached = new \Memcached();
+            $memcached->addServer('127.0.0.1', 11211);
 
             $cache = new \Doctrine\Common\Cache\MemcachedCache();
-            $cache->setMemcache($memcache);
+            $cache->setMemcached($memcached);
 
             return $cache;
         }


### PR DESCRIPTION
Executing Doctrine CLI: `doctrine orm:schema-tool:create` and with memcached extension loaded, Doctrine\ORM\Tools\Setup.php  calls to setMemcache method. The MemcachedCache class has the setMemcached method instead. Changed this call in Setup to setMemcached and $memcache to $memcached to keep the name like the extension