### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -622,7 +622,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 throw MappingException::sqlConversionNotAllowedForPrimaryKeyProperties($property);
             }
 
-            if (! in_array($fieldName, $this->identifier)) {
+            if (! in_array($fieldName, $this->identifier, true)) {
                 $this->identifier[] = $fieldName;
             }
         }
@@ -645,7 +645,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             return;
         }
 
-        if (in_array($property->getTypeName(), ['integer', 'bigint', 'smallint'])) {
+        if (in_array($property->getTypeName(), ['integer', 'bigint', 'smallint'], true)) {
             $property->setOptions(array_merge($options, ['default' => 1]));
 
             return;
@@ -686,7 +686,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 throw MappingException::illegalOrphanRemovalOnIdentifierAssociation($this->className, $fieldName);
             }
 
-            if (! in_array($property->getName(), $this->identifier)) {
+            if (! in_array($property->getName(), $this->identifier, true)) {
                 if ($property instanceof ToOneAssociationMetadata && count($property->getJoinColumns()) >= 2) {
                     throw MappingException::cannotMapCompositePrimaryKeyEntitiesAsForeignId(
                         $property->getTargetEntity(),
@@ -711,7 +711,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
         $cascadeTypes = ['remove', 'persist', 'refresh'];
         $cascades     = array_map('strtolower', $property->getCascade());
 
-        if (in_array('all', $cascades)) {
+        if (in_array('all', $cascades, true)) {
             $cascades = $cascadeTypes;
         }
 
@@ -794,7 +794,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
         if ($property->isOrphanRemoval()) {
             $cascades = $property->getCascade();
 
-            if (! in_array('remove', $cascades)) {
+            if (! in_array('remove', $cascades, true)) {
                 $cascades[] = 'remove';
 
                 $property->setCascade($cascades);
@@ -867,7 +867,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
         if ($property->isOrphanRemoval()) {
             $cascades = $property->getCascade();
 
-            if (! in_array('remove', $cascades)) {
+            if (! in_array('remove', $cascades, true)) {
                 $cascades[] = 'remove';
 
                 $property->setCascade($cascades);
@@ -1512,7 +1512,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
      */
     public function addLifecycleCallback($callback, $event)
     {
-        if (isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event])) {
+        if (isset($this->lifecycleCallbacks[$event]) && in_array($callback, $this->lifecycleCallbacks[$event], true)) {
             return;
         }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
@@ -225,7 +225,7 @@ class AnnotationDriver implements Mapping\Driver\MappingDriver
         foreach ($declared as $className) {
             $rc         = new \ReflectionClass($className);
             $sourceFile = $rc->getFileName();
-            if (in_array($sourceFile, $includedFiles) && ! $this->isTransient($className)) {
+            if (in_array($sourceFile, $includedFiles, true) && ! $this->isTransient($className)) {
                 $classes[] = $className;
             }
         }
@@ -1312,7 +1312,7 @@ class AnnotationDriver implements Mapping\Driver\MappingDriver
         $cascadeTypes = ['remove', 'persist', 'refresh'];
         $cascades     = array_map('strtolower', $originalCascades);
 
-        if (in_array('all', $cascades)) {
+        if (in_array('all', $cascades, true)) {
             $cascades = $cascadeTypes;
         }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -226,7 +226,7 @@ class AnnotationDriver implements MappingDriver
         foreach ($declared as $className) {
             $rc         = new \ReflectionClass($className);
             $sourceFile = $rc->getFileName();
-            if (in_array($sourceFile, $includedFiles) && ! $this->isTransient($className)) {
+            if (in_array($sourceFile, $includedFiles, true) && ! $this->isTransient($className)) {
                 $classes[] = $className;
             }
         }
@@ -1306,7 +1306,7 @@ class AnnotationDriver implements MappingDriver
         $cascadeTypes = ['remove', 'persist', 'refresh'];
         $cascades     = array_map('strtolower', $originalCascades);
 
-        if (in_array('all', $cascades)) {
+        if (in_array('all', $cascades, true)) {
             $cascades = $cascadeTypes;
         }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -329,14 +329,14 @@ class DatabaseDriver implements MappingDriver
         $ids = [];
 
         foreach ($columns as $column) {
-            if (in_array($column->getName(), $allForeignKeys)) {
+            if (in_array($column->getName(), $allForeignKeys, true)) {
                 continue;
             }
 
             $fieldName     = $this->getFieldNameForColumn($tableName, $column->getName(), false);
             $fieldMetadata = $this->convertColumnAnnotationToFieldMetadata($tableName, $column, $fieldName);
 
-            if ($primaryKeys && in_array($column->getName(), $primaryKeys)) {
+            if ($primaryKeys && in_array($column->getName(), $primaryKeys, true)) {
                 $fieldMetadata->setPrimaryKey(true);
 
                 $ids[] = $fieldMetadata;
@@ -435,7 +435,7 @@ class DatabaseDriver implements MappingDriver
                 $associationMapping['fieldName'] .= '2'; // "foo" => "foo2"
             }
 
-            if ($primaryKeys && in_array($localColumn, $primaryKeys)) {
+            if ($primaryKeys && in_array($localColumn, $primaryKeys, true)) {
                 $associationMapping['id'] = true;
             }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
@@ -1075,7 +1075,7 @@ class NewAnnotationDriver implements MappingDriver
         $cascadeTypes = ['remove', 'persist', 'refresh'];
         $cascades     = array_map('strtolower', $originalCascades);
 
-        if (in_array('all', $cascades)) {
+        if (in_array('all', $cascades, true)) {
             $cascades = $cascadeTypes;
         }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -750,7 +750,7 @@ class XmlDriver extends FileDriver
 
             if (isset($attributes->name)) {
                 $nameAttribute         = (string) $attributes->name;
-                $array[$nameAttribute] = in_array($nameAttribute, ['unsigned', 'fixed'])
+                $array[$nameAttribute] = in_array($nameAttribute, ['unsigned', 'fixed'], true)
                     ? $this->evaluateBoolean($value)
                     : $value;
             } else {

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -645,7 +645,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $whereClauses    = [];
         $params          = [];
         $types           = [];
-        $joinNeeded      = ! in_array($indexBy, $targetClass->identifier);
+        $joinNeeded      = ! in_array($indexBy, $targetClass->identifier, true);
 
         if ($joinNeeded) { // extra join needed if indexBy is not a @id
             $joinConditions = [];

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1207,7 +1207,7 @@ class BasicEntityPersister implements EntityPersister
         foreach ($orderBy as $fieldName => $orientation) {
             $orientation = strtoupper(trim($orientation));
 
-            if (! in_array($orientation, ['ASC', 'DESC'])) {
+            if (! in_array($orientation, ['ASC', 'DESC'], true)) {
                 throw ORMException::invalidOrientation($this->class->getClassName(), $fieldName);
             }
 
@@ -1689,7 +1689,7 @@ class BasicEntityPersister implements EntityPersister
         $selectedColumns = [];
         $columns         = $this->getSelectConditionStatementColumnSQL($field, $association);
 
-        if (in_array($comparison, [Comparison::IN, Comparison::NIN]) && isset($columns[1])) {
+        if (in_array($comparison, [Comparison::IN, Comparison::NIN], true) && isset($columns[1])) {
             // @todo try to support multi-column IN expressions. Example: (col1, col2) IN (('val1A', 'val2A'), ...)
             throw ORMException::cantUseInOperatorOnCompositeKeys();
         }

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -47,7 +47,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
         if ($property instanceof AssociationMetadata &&
             $value !== null &&
             ! is_object($value) &&
-            ! in_array($comparison->getOperator(), [Comparison::IN, Comparison::NIN])) {
+            ! in_array($comparison->getOperator(), [Comparison::IN, Comparison::NIN], true)) {
             throw PersisterException::matchingAssocationFieldRequiresObject($this->classMetadata->getClassName(), $field);
         }
 

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -70,7 +70,7 @@ abstract class Base
             if (! is_string($arg)) {
                 $class = get_class($arg);
 
-                if (! in_array($class, $this->allowedClasses)) {
+                if (! in_array($class, $this->allowedClasses, true)) {
                     throw new \InvalidArgumentException(
                         sprintf("Expression of type '%s' not allowed in this context.", $class)
                     );

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -394,7 +394,7 @@ class Parser
             }
 
             $expr = $this->identVariableExpressions[$dqlAlias];
-            $key  = array_search($expr, $AST->selectClause->selectExpressions);
+            $key  = array_search($expr, $AST->selectClause->selectExpressions, true);
 
             unset($AST->selectClause->selectExpressions[$key]);
 
@@ -506,7 +506,7 @@ class Parser
      */
     private function isMathOperator($token)
     {
-        return in_array($token['type'], [Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY]);
+        return in_array($token['type'], [Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY], true);
     }
 
     /**
@@ -533,7 +533,7 @@ class Parser
      */
     private function isAggregateFunction($tokenType)
     {
-        return in_array($tokenType, [Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT]);
+        return in_array($tokenType, [Lexer::T_AVG, Lexer::T_MIN, Lexer::T_MAX, Lexer::T_SUM, Lexer::T_COUNT], true);
     }
 
     /**
@@ -543,7 +543,7 @@ class Parser
      */
     private function isNextAllAnySome()
     {
-        return in_array($this->lexer->lookahead['type'], [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME]);
+        return in_array($this->lexer->lookahead['type'], [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME], true);
     }
 
     /**
@@ -2456,8 +2456,8 @@ class Parser
         // Peek beyond the matching closing parenthesis ')'
         $peek = $this->peekBeyondClosingParenthesis();
 
-        if (in_array($peek['value'], ['=', '<', '<=', '<>', '>', '>=', '!=']) ||
-            in_array($peek['type'], [Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS]) ||
+        if (in_array($peek['value'], ['=', '<', '<=', '<>', '>', '>=', '!='], true) ||
+            in_array($peek['type'], [Lexer::T_NOT, Lexer::T_BETWEEN, Lexer::T_LIKE, Lexer::T_IN, Lexer::T_IS, Lexer::T_EXISTS], true) ||
             $this->isMathOperator($peek)) {
             $condPrimary->simpleConditionalExpression = $this->SimpleConditionalExpression();
 
@@ -2952,7 +2952,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $isDistinct    = false;
 
-        if (! in_array($lookaheadType, [Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM])) {
+        if (! in_array($lookaheadType, [Lexer::T_COUNT, Lexer::T_AVG, Lexer::T_MAX, Lexer::T_MIN, Lexer::T_SUM], true)) {
             $this->syntaxError('One of: MAX, MIN, AVG, SUM, COUNT');
         }
 
@@ -2982,7 +2982,7 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
         $value         = $this->lexer->lookahead['value'];
 
-        if (! in_array($lookaheadType, [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME])) {
+        if (! in_array($lookaheadType, [Lexer::T_ALL, Lexer::T_ANY, Lexer::T_SOME], true)) {
             $this->syntaxError('ALL, ANY or SOME');
         }
 

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -191,7 +191,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             return true;
         }
 
-        return ! in_array($metadata->inheritanceType, [InheritanceType::SINGLE_TABLE, InheritanceType::JOINED]);
+        return ! in_array($metadata->inheritanceType, [InheritanceType::SINGLE_TABLE, InheritanceType::JOINED], true);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1440,7 +1440,7 @@ class SqlWalker implements TreeWalker
                         continue;
                     }
 
-                    if ($partialFieldSet && ! in_array($fieldName, $partialFieldSet)) {
+                    if ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true)) {
                         continue;
                     }
 
@@ -1475,7 +1475,7 @@ class SqlWalker implements TreeWalker
                                 continue;
                             }
 
-                            if ($subClass->isInheritedProperty($fieldName) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet))) {
+                            if ($subClass->isInheritedProperty($fieldName) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
                                 continue;
                             }
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -364,7 +364,7 @@ class QueryBuilder
     {
         $rootAlias = null;
 
-        if (in_array($parentAlias, $this->getRootAliases())) {
+        if (in_array($parentAlias, $this->getRootAliases(), true)) {
             $rootAlias = $parentAlias;
         } elseif (isset($this->joinRootAliases[$parentAlias])) {
             $rootAlias = $this->joinRootAliases[$parentAlias];
@@ -882,7 +882,7 @@ class QueryBuilder
     {
         $rootAliases = $this->getRootAliases();
 
-        if (! in_array($alias, $rootAliases)) {
+        if (! in_array($alias, $rootAliases, true)) {
             throw new Query\QueryException(
                 sprintf('Specified root alias %s must be set before invoking indexBy().', $alias)
             );

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -104,7 +104,7 @@ class CountOutputWalker extends SqlWalker
             $property = $rootClass->getProperty($identifier);
 
             if ($property instanceof FieldMetadata) {
-                foreach (array_keys($this->rsm->fieldMappings, $identifier) as $alias) {
+                foreach (array_keys($this->rsm->fieldMappings, $identifier, true) as $alias) {
                     if ($this->rsm->columnOwnerMap[$alias] === $rootAlias) {
                         $sqlIdentifier[$identifier] = $alias;
                     }
@@ -113,7 +113,7 @@ class CountOutputWalker extends SqlWalker
                 $joinColumns = $property->getJoinColumns();
                 $joinColumn  = reset($joinColumns);
 
-                foreach (array_keys($this->rsm->metaMappings, $joinColumn->getColumnName()) as $alias) {
+                foreach (array_keys($this->rsm->metaMappings, $joinColumn->getColumnName(), true) as $alias) {
                     if ($this->rsm->columnOwnerMap[$alias] === $rootAlias) {
                         $sqlIdentifier[$identifier] = $alias;
                     }

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -505,7 +505,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
             $property = $rootClass->getProperty($identifier);
 
             if ($property instanceof FieldMetadata) {
-                foreach (array_keys($this->rsm->fieldMappings, $identifier) as $alias) {
+                foreach (array_keys($this->rsm->fieldMappings, $identifier, true) as $alias) {
                     if ($this->rsm->columnOwnerMap[$alias] === $rootAlias) {
                         $sqlIdentifier[$identifier] = [
                             'type'  => $property->getType(),
@@ -517,7 +517,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
                 $joinColumns = $property->getJoinColumns();
                 $joinColumn  = reset($joinColumns);
 
-                foreach (array_keys($this->rsm->metaMappings, $joinColumn->getColumnName()) as $alias) {
+                foreach (array_keys($this->rsm->metaMappings, $joinColumn->getColumnName(), true) as $alias) {
                     if ($this->rsm->columnOwnerMap[$alias] === $rootAlias) {
                         $sqlIdentifier[$identifier] = [
                             'type'  => $this->rsm->typeMappings[$alias],
@@ -547,7 +547,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     public function walkPathExpression($pathExpr)
     {
-        if (! $this->inSubSelect && ! $this->platformSupportsRowNumber() && ! in_array($pathExpr, $this->orderByPathExpressions)) {
+        if (! $this->inSubSelect && ! $this->platformSupportsRowNumber() && ! in_array($pathExpr, $this->orderByPathExpressions, true)) {
             $this->orderByPathExpressions[] = $pathExpr;
         }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -604,7 +604,7 @@ class SchemaTool
         $idColumns        = $class->getIdentifierColumns($this->em);
         $idColumnNameList = array_keys($idColumns);
 
-        if (! in_array($referencedColumnName, $idColumnNameList)) {
+        if (! in_array($referencedColumnName, $idColumnNameList, true)) {
             return null;
         }
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -78,7 +78,7 @@ class SchemaValidator
         }
 
         foreach ($class->getSubClasses() as $subClass) {
-            if (! in_array($class->getClassName(), class_parents($subClass))) {
+            if (! in_array($class->getClassName(), class_parents($subClass), true)) {
                 $message = "According to the discriminator map class, '%s' has to be a child of '%s', but these entities are not related through inheritance.";
 
                 $ce[] = sprintf($message, $subClass, $class->getClassName());
@@ -200,7 +200,7 @@ class SchemaValidator
                 $joinTable               = $association->getJoinTable();
 
                 foreach ($joinTable->getJoinColumns() as $joinColumn) {
-                    if (! in_array($joinColumn->getReferencedColumnName(), $classIdentifierColumns)) {
+                    if (! in_array($joinColumn->getReferencedColumnName(), $classIdentifierColumns, true)) {
                         $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
 
                         $ce[] = sprintf($message, $joinColumn->getReferencedColumnName(), $class->getClassName());
@@ -209,7 +209,7 @@ class SchemaValidator
                 }
 
                 foreach ($joinTable->getInverseJoinColumns() as $inverseJoinColumn) {
-                    if (! in_array($inverseJoinColumn->getReferencedColumnName(), $targetIdentifierColumns)) {
+                    if (! in_array($inverseJoinColumn->getReferencedColumnName(), $targetIdentifierColumns, true)) {
                         $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
 
                         $ce[] = sprintf($message, $joinColumn->getReferencedColumnName(), $targetMetadata->getClassName());
@@ -251,7 +251,7 @@ class SchemaValidator
                 $joinColumns       = $association->getJoinColumns();
 
                 foreach ($joinColumns as $joinColumn) {
-                    if (! in_array($joinColumn->getReferencedColumnName(), $identifierColumns)) {
+                    if (! in_array($joinColumn->getReferencedColumnName(), $identifierColumns, true)) {
                         $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
 
                         $ce[] = sprintf($message, $joinColumn->getReferencedColumnName(), $targetMetadata->getClassName());

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -780,7 +780,7 @@ class UnitOfWork implements PropertyChangedListener
 
             switch ($state) {
                 case self::STATE_NEW:
-                    if (! in_array('persist', $association->getCascade())) {
+                    if (! in_array('persist', $association->getCascade(), true)) {
                         $this->nonCascadedNewDetectedEntities[\spl_object_id($entry)] = [$association, $entry];
 
                         break;
@@ -1733,7 +1733,7 @@ class UnitOfWork implements PropertyChangedListener
         $class = $this->em->getClassMetadata(get_class($entity));
 
         foreach ($class->getDeclaredPropertiesIterator() as $association) {
-            if (! ($association instanceof AssociationMetadata && in_array('refresh', $association->getCascade()))) {
+            if (! ($association instanceof AssociationMetadata && in_array('refresh', $association->getCascade(), true))) {
                 continue;
             }
 
@@ -1780,7 +1780,7 @@ class UnitOfWork implements PropertyChangedListener
         }
 
         foreach ($class->getDeclaredPropertiesIterator() as $association) {
-            if (! ($association instanceof AssociationMetadata && in_array('persist', $association->getCascade()))) {
+            if (! ($association instanceof AssociationMetadata && in_array('persist', $association->getCascade(), true))) {
                 continue;
             }
 
@@ -1840,7 +1840,7 @@ class UnitOfWork implements PropertyChangedListener
         $class             = $this->em->getClassMetadata(get_class($entity));
 
         foreach ($class->getDeclaredPropertiesIterator() as $association) {
-            if (! ($association instanceof AssociationMetadata && in_array('remove', $association->getCascade()))) {
+            if (! ($association instanceof AssociationMetadata && in_array('remove', $association->getCascade(), true))) {
                 continue;
             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -56,7 +56,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
         $driver = new DatabaseDriver($sm);
 
         foreach ($driver->getAllClassNames() as $className) {
-            if (!in_array(strtolower($className), $classNames)) {
+            if (!in_array(strtolower($className), $classNames, true)) {
                 continue;
             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -1115,7 +1115,7 @@ class MyLocaleFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        if (!in_array("LocaleAware", $targetEntity->getReflectionClass()->getInterfaceNames())) {
+        if (!in_array("LocaleAware", $targetEntity->getReflectionClass()->getInterfaceNames(), true)) {
             return "";
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php
@@ -157,7 +157,7 @@ class DDC2602PostLoadListener
 
             $fieldSelection->field      = $field;
             $fieldSelection->choiceList = $field->choiceList->filter(function ($choice) use ($choiceList) {
-                return in_array($choice->id, $choiceList);
+                return in_array($choice->id, $choiceList, true);
             });
 
             $fieldList->add($fieldSelection);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php
@@ -155,7 +155,7 @@ class DDC3192CurrencyCode extends Type
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return array_search($value, self::$map);
+        return array_search($value, self::$map, true);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php
@@ -135,7 +135,7 @@ class GH6141People
      */
     private static function isValid($valid)
     {
-        return in_array($valid, [self::BOSS, self::EMPLOYEE]);
+        return in_array($valid, [self::BOSS, self::EMPLOYEE], true);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -190,9 +190,9 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $childClass = ChildClass::class;
         $anotherChildClass = AnotherChildClass::class;
 
-        $rootClassKey = array_search($rootClass, $rootDiscriminatorMap);
-        $childClassKey = array_search($childClass, $rootDiscriminatorMap);
-        $anotherChildClassKey = array_search($anotherChildClass, $rootDiscriminatorMap);
+        $rootClassKey = array_search($rootClass, $rootDiscriminatorMap, true);
+        $childClassKey = array_search($childClass, $rootDiscriminatorMap, true);
+        $anotherChildClassKey = array_search($anotherChildClass, $rootDiscriminatorMap, true);
 
         self::assertEquals('rootclass', $rootClassKey);
         self::assertEquals('childclass', $childClassKey);

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -178,7 +178,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         ];
 
         $list = array_filter($list, function($item) use ($invalid) {
-            return ! in_array(pathinfo($item, PATHINFO_FILENAME), $invalid);
+            return ! in_array(pathinfo($item, PATHINFO_FILENAME), $invalid, true);
         });
 
         return array_map(function($item) {

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -649,7 +649,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($GLOBALS['DOCTRINE_MARK_SQL_LOGS'])) {
-            if (in_array(static::$sharedConn->getDatabasePlatform()->getName(), ["mysql", "postgresql"])) {
+            if (in_array(static::$sharedConn->getDatabasePlatform()->getName(), ["mysql", "postgresql"], true)) {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/');
             } elseif (static::$sharedConn->getDatabasePlatform()->getName() === "oracle") {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . get_class($this) . '*/ FROM dual');


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison :shield: