### PR TITLE
Use precise workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: precise
 sudo: false
 language: php
 


### PR DESCRIPTION
This should make a warning banner disappear. Maybe builds will be more
stable too, who knows?