### PR TITLE
Fix exporter signatures

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
@@ -837,7 +837,7 @@ class AnnotationDriver implements Mapping\Driver\MappingDriver
     private function convertTableAnnotationToTableMetadata(
         Annotation\Table $tableAnnot,
         Mapping\TableMetadata $table
-    ) : void {
+    ) : Mapping\TableMetadata {
         if (! empty($tableAnnot->name)) {
             $table->setName($tableAnnot->name);
         }

--- a/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMetadata;
 
 class DiscriminatorColumnMetadataExporter extends LocalColumnMetadataExporter
 {
     public const VARIABLE = '$discriminatorColumn';
 
-    protected function exportInstantiation(DiscriminatorColumnMetadata $metadata) : string
+    protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\DiscriminatorColumnMetadata("%s", Type::getType("%s"));',

--- a/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
@@ -13,6 +13,8 @@ class DiscriminatorColumnMetadataExporter extends LocalColumnMetadataExporter
 
     protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
+        assert($metadata instanceof DiscriminatorColumnMetadata);
+
         return sprintf(
             'new Mapping\DiscriminatorColumnMetadata("%s", Type::getType("%s"));',
             $metadata->getColumnName(),

--- a/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 
 class FieldMetadataExporter extends LocalColumnMetadataExporter
 {
     public const VARIABLE = '$property';
 
-    protected function exportInstantiation(FieldMetadata $metadata) : string
+    protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
         $lines   = [];
         $lines[] = sprintf(

--- a/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
@@ -13,6 +13,8 @@ class FieldMetadataExporter extends LocalColumnMetadataExporter
 
     protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
+        assert($metadata instanceof FieldMetadata);
+
         $lines   = [];
         $lines[] = sprintf(
             'new Mapping\FieldMetadata("%s", "%s", Type::getType("%s"));',

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
@@ -31,6 +31,8 @@ class JoinColumnMetadataExporter extends ColumnMetadataExporter
 
     protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
+        assert($metadata instanceof JoinColumnMetadata);
+
         return sprintf(
             'new Mapping\JoinColumnMetadata("%s", Type::getType("%s"));',
             $metadata->getColumnName(),

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
 
 class JoinColumnMetadataExporter extends ColumnMetadataExporter
@@ -28,7 +29,7 @@ class JoinColumnMetadataExporter extends ColumnMetadataExporter
         return implode(PHP_EOL, $lines);
     }
 
-    protected function exportInstantiation(JoinColumnMetadata $metadata) : string
+    protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\JoinColumnMetadata("%s", Type::getType("%s"));',

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\TableMetadata;
 use Doctrine\ORM\Mapping\JoinTableMetadata;
 
 class JoinTableMetadataExporter extends TableMetadataExporter
@@ -36,7 +37,7 @@ class JoinTableMetadataExporter extends TableMetadataExporter
         return implode(PHP_EOL, $lines);
     }
 
-    protected function exportInstantiation(JoinTableMetadata $metadata) : string
+    protected function exportInstantiation(TableMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\JoinTableMetadata("%s");',

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
@@ -39,6 +39,8 @@ class JoinTableMetadataExporter extends TableMetadataExporter
 
     protected function exportInstantiation(TableMetadata $metadata) : string
     {
+        assert($metadata instanceof JoinTableMetadata);
+
         return sprintf(
             'new Mapping\JoinTableMetadata("%s");',
             $metadata->getName()

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
@@ -38,6 +38,8 @@ class ManyToManyAssociationMetadataExporter extends ToManyAssociationMetadataExp
      */
     protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
+        assert($metadata instanceof ManyToManyAssociationMetadata);
+
         return sprintf(
             'new Mapping\ManyToManyAssociationMetadata("%s");',
             $metadata->getName()

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 
 class ManyToManyAssociationMetadataExporter extends ToManyAssociationMetadataExporter
@@ -35,7 +36,7 @@ class ManyToManyAssociationMetadataExporter extends ToManyAssociationMetadataExp
     /**
      * {@inheritdoc}
      */
-    protected function exportInstantiation(ManyToManyAssociationMetadata $metadata) : string
+    protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\ManyToManyAssociationMetadata("%s");',

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
@@ -14,6 +14,8 @@ class ManyToOneAssociationMetadataExporter extends ToOneAssociationMetadataExpor
      */
     protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
+        assert($metadata instanceof ManyToOneAssociationMetadata);
+
         return sprintf(
             'new Mapping\ManyToOneAssociationMetadata("%s");',
             $metadata->getName()

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMetadata;
 
 class ManyToOneAssociationMetadataExporter extends ToOneAssociationMetadataExporter
@@ -11,7 +12,7 @@ class ManyToOneAssociationMetadataExporter extends ToOneAssociationMetadataExpor
     /**
      * {@inheritdoc}
      */
-    protected function exportInstantiation(ManyToOneAssociationMetadata $metadata) : string
+    protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\ManyToOneAssociationMetadata("%s");',

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
@@ -14,6 +14,8 @@ class OneToManyAssociationMetadataExporter extends ToManyAssociationMetadataExpo
      */
     protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
+        assert($metadata instanceof OneToManyAssociationMetadata);
+
         return sprintf(
             'new Mapping\OneToManyAssociationMetadata("%s");',
             $metadata->getName()

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
 
 class OneToManyAssociationMetadataExporter extends ToManyAssociationMetadataExporter
@@ -11,7 +12,7 @@ class OneToManyAssociationMetadataExporter extends ToManyAssociationMetadataExpo
     /**
      * {@inheritdoc}
      */
-    protected function exportInstantiation(OneToManyAssociationMetadata $metadata) : string
+    protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\OneToManyAssociationMetadata("%s");',

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 
 class OneToOneAssociationMetadataExporter extends ToOneAssociationMetadataExporter
@@ -11,7 +12,7 @@ class OneToOneAssociationMetadataExporter extends ToOneAssociationMetadataExport
     /**
      * {@inheritdoc}
      */
-    protected function exportInstantiation(OneToOneAssociationMetadata $metadata) : string
+    protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\OneToOneAssociationMetadata("%s");',

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
@@ -14,6 +14,8 @@ class OneToOneAssociationMetadataExporter extends ToOneAssociationMetadataExport
      */
     protected function exportInstantiation(AssociationMetadata $metadata) : string
     {
+        assert($metadata instanceof OneToOneAssociationMetadata);
+
         return sprintf(
             'new Mapping\OneToOneAssociationMetadata("%s");',
             $metadata->getName()

--- a/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
@@ -13,6 +13,8 @@ class VersionFieldMetadataExporter extends FieldMetadataExporter
 
     protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
+        assert($metadata instanceof VersionFieldMetadata);
+
         return sprintf(
             'new Mapping\VersionFieldMetadata("%s", "%s", Type::getType("%s"));',
             $metadata->getName(),

--- a/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\VersionFieldMetadata;
 
 class VersionFieldMetadataExporter extends FieldMetadataExporter
 {
     public const VARIABLE = '$versionProperty';
 
-    protected function exportInstantiation(VersionFieldMetadata $metadata) : string
+    protected function exportInstantiation(ColumnMetadata $metadata) : string
     {
         return sprintf(
             'new Mapping\VersionFieldMetadata("%s", "%s", Type::getType("%s"));',


### PR DESCRIPTION
All these classes extend another that has a wider type for the first argument of `exportInstantiation()`, and using these classes causes a fatal error in PHP.