### PR TITLE
Inheritance middle-layer doesn't get hydrated

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -299,8 +299,7 @@ abstract class AbstractHydrator
                     // If there are field name collisions in the child class, then we need
                     // to only hydrate if we are looking at the correct discriminator value
                     if (isset($cacheKeyInfo['discriminatorColumn'], $data[$cacheKeyInfo['discriminatorColumn']])
-                        // Note: loose comparison required. See https://github.com/doctrine/doctrine2/pull/6304#issuecomment-323294442
-                        && ! in_array($data[$cacheKeyInfo['discriminatorColumn']], $cacheKeyInfo['discriminatorValues'])
+                        && ! in_array((string) $data[$cacheKeyInfo['discriminatorColumn']], $cacheKeyInfo['discriminatorValues'], true)
                     ) {
                         break;
                     }
@@ -398,13 +397,13 @@ abstract class AbstractHydrator
                 // should there be field name collisions
                 if ($classMetadata->parentClasses && isset($this->_rsm->discriminatorColumns[$ownerMap])) {
                     $discriminatorValues = array_map(
-                        function (string $subClass) {
-                            return $this->getClassMetadata($subClass)->discriminatorValue;
+                        function (string $subClass) : string {
+                            return (string) $this->getClassMetadata($subClass)->discriminatorValue;
                         },
                         $classMetadata->subClasses
                     );
 
-                    $discriminatorValues[] = $classMetadata->discriminatorValue;
+                    $discriminatorValues[] = (string) $classMetadata->discriminatorValue;
 
                     return $this->_cache[$key] = \array_merge(
                         $columnInfo,

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -396,21 +396,12 @@ abstract class AbstractHydrator
                 // the current discriminator value must be saved in order to disambiguate fields hydration,
                 // should there be field name collisions
                 if ($classMetadata->parentClasses && isset($this->_rsm->discriminatorColumns[$ownerMap])) {
-                    $discriminatorValues = array_map(
-                        function (string $subClass) : string {
-                            return (string) $this->getClassMetadata($subClass)->discriminatorValue;
-                        },
-                        $classMetadata->subClasses
-                    );
-
-                    $discriminatorValues[] = (string) $classMetadata->discriminatorValue;
-
                     return $this->_cache[$key] = \array_merge(
                         $columnInfo,
                         [
                             'discriminatorColumn' => $this->_rsm->discriminatorColumns[$ownerMap],
                             'discriminatorValue'  => $classMetadata->discriminatorValue,
-                            'discriminatorValues' => $discriminatorValues,
+                            'discriminatorValues' => $this->getDiscriminatorValues($classMetadata),
                         ]
                     );
                 }
@@ -461,6 +452,23 @@ abstract class AbstractHydrator
         // this column is a left over, maybe from a LIMIT query hack for example in Oracle or DB2
         // maybe from an additional column that has not been defined in a NativeQuery ResultSetMapping.
         return null;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getDiscriminatorValues(ClassMetadata $classMetadata) : array
+    {
+        $values = array_map(
+            function (string $subClass) : string {
+                return (string) $this->getClassMetadata($subClass)->discriminatorValue;
+            },
+            $classMetadata->subClasses
+        );
+
+        $values[] = (string) $classMetadata->discriminatorValue;
+
+        return $values;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6937Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6937Test.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group 6937
+ */
+final class GH6937Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH6937Person::class, GH6937Employee::class, GH6937Manager::class]);
+    }
+
+    public function testPhoneNumberIsPopulatedWithFind() : void
+    {
+        $manager              = new GH6937Manager();
+        $manager->name        = 'Kevin';
+        $manager->phoneNumber = '555-5555';
+        $manager->department  = 'Accounting';
+
+        $this->_em->persist($manager);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $persistedManager = $this->_em->find(GH6937Person::class, $manager->id);
+
+        self::assertSame('Kevin', $persistedManager->name);
+        self::assertSame('555-5555', $persistedManager->phoneNumber);
+        self::assertSame('Accounting', $persistedManager->department);
+    }
+
+    public function testPhoneNumberIsPopulatedWithQueryBuilderUsingSimpleObjectHydrator() : void
+    {
+        $manager              = new GH6937Manager();
+        $manager->name        = 'Kevin';
+        $manager->phoneNumber = '555-5555';
+        $manager->department  = 'Accounting';
+
+        $this->_em->persist($manager);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $persistedManager = $this->_em->getRepository(GH6937Person::class)
+                                      ->createQueryBuilder('e')
+                                      ->where('e.id = :id')
+                                      ->setParameter('id', $manager->id)
+                                      ->getQuery()
+                                      ->getOneOrNullResult(AbstractQuery::HYDRATE_SIMPLEOBJECT);
+
+        self::assertSame('Kevin', $persistedManager->name);
+        self::assertSame('555-5555', $persistedManager->phoneNumber);
+        self::assertSame('Accounting', $persistedManager->department);
+    }
+
+    public function testPhoneNumberIsPopulatedWithQueryBuilder() : void
+    {
+        $manager              = new GH6937Manager();
+        $manager->name        = 'Kevin';
+        $manager->phoneNumber = '555-5555';
+        $manager->department  = 'Accounting';
+
+        $this->_em->persist($manager);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $persistedManager = $this->_em->getRepository(GH6937Person::class)
+                                      ->createQueryBuilder('e')
+                                      ->where('e.id = :id')
+                                      ->setParameter('id', $manager->id)
+                                      ->getQuery()
+                                      ->getOneOrNullResult();
+
+        self::assertSame('Kevin', $persistedManager->name);
+        self::assertSame('555-5555', $persistedManager->phoneNumber);
+        self::assertSame('Accounting', $persistedManager->department);
+    }
+}
+
+/**
+ * @Entity
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"employee"=GH6937Employee::class, "manager"=GH6937Manager::class})
+ */
+abstract class GH6937Person
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @Column(type="string") */
+    public $name;
+}
+
+/**
+ * @Entity
+ */
+abstract class GH6937Employee extends GH6937Person
+{
+    /** @Column(type="string") */
+    public $phoneNumber;
+}
+
+/**
+ * @Entity
+ */
+class GH6937Manager extends GH6937Employee
+{
+    /** @Column(type="string") */
+    public $department;
+}


### PR DESCRIPTION
This is a failing test to show the issue.

Given the following inheritance structure: 

`Person <- Employee <- Manager` 

When hydrating a manager using a query builder created from the person repository, the employee's properties do not get hydrated.

I think this was caused by #6304.