### PR TITLE
fix Catchable Fatal Error: Argument 3 passed to Doctrine\ORM\Event\Pr…

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1057,7 +1057,15 @@ class UnitOfWork implements PropertyChangedListener
             }
 
             if ($preUpdateInvoke != ListenersInvoker::INVOKE_NONE) {
-                $this->listenersInvoker->invoke($class, Events::preUpdate, $entity, new PreUpdateEventArgs($entity, $this->em, $this->entityChangeSets[$oid]), $preUpdateInvoke);
+                if (isset($this->entityChangeSets[$oid]) && $this->entityChangeSets[$oid] !== null) {
+                    $this->listenersInvoker->invoke(
+                        $class,
+                        Events::preUpdate,
+                        $entity,
+                        new PreUpdateEventArgs($entity, $this->em, $this->entityChangeSets[$oid]),
+                        $preUpdateInvoke
+                    );
+                }
                 $this->recomputeSingleEntityChangeSet($class, $entity);
             }
 


### PR DESCRIPTION
Hi, guys
When I want to remove entity, that has few relations, I get this error:

Catchable Fatal Error: Argument 3 passed to Doctrine\ORM\Event\PreUpdateEventArgs::__construct() must be of the type array, null given, called in /var/www/akela/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php on line 1065 and defined

After debugging and understanding what's going on, I found a solution

Hope, you can help me to fix this issue