### PR TITLE
Fix #6991: correctly resolve identifer values in ManyToManyPersister

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -397,7 +397,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
             $params[] = isset($sourceClass->fieldNames[$refColumnName])
                 ? $identifier[$sourceClass->fieldNames[$refColumnName]]
-                : $identifier[$sourceClass->getFieldForColumn($columnName)];
+                : $identifier[$sourceClass->getFieldForColumn($refColumnName)];
         }
 
         return $params;


### PR DESCRIPTION
This is due to a typo in `\Doctrine\ORM\Persisters\Collection\ManyToManyPersister::getDeleteSQLParameters`:

```
        foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
            $params[] = isset($sourceClass->fieldNames[$refColumnName])
                ? $identifier[$sourceClass->fieldNames[$refColumnName]]
                : $identifier[$sourceClass->getFieldForColumn($columnName)];
        }

```

It should be `$sourceClass->getFieldForColumn($refColumnName)`, as `$columnName` is the join table column, not the entity table column.