### PR TITLE
Updated docblocks

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -736,7 +736,7 @@ abstract class AbstractQuery
      * @return mixed
      *
      * @throws NonUniqueResultException If the query result is not unique.
-     * @throws NoResultException        If the query returned no result and hydration mode is not HYDRATE_SINGLE_SCALAR.
+     * @throws NoResultException        If the query returned no result
      */
     public function getSingleResult($hydrationMode = null)
     {
@@ -765,6 +765,7 @@ abstract class AbstractQuery
      * @return mixed The scalar result, or NULL if the query returned no result.
      *
      * @throws NonUniqueResultException If the query result is not unique.
+     * @throws NoResultException        If the query returned no result
      */
     public function getSingleScalarResult()
     {


### PR DESCRIPTION
As it can be seen from https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php#L24 **NoResultException** is thrown even when HYDRATE_SINGLE_SCALAR mode is used.