### PR TITLE
ManyToManyPersister fails to remove join table entry if there is multiple join columns

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -419,7 +419,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
             $params[] = isset($sourceClass->fieldNames[$refColumnName])
                 ? $identifier[$sourceClass->fieldNames[$refColumnName]]
-                : $identifier[$sourceClass->getFieldForColumn($columnName)];
+                : $identifier[$sourceClass->getFieldForColumn($refColumnName)];
         }
 
         return $params;

--- a/tests/Doctrine/Tests/Models/ManyToManyPersister/ChildClass.php
+++ b/tests/Doctrine/Tests/Models/ManyToManyPersister/ChildClass.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\Tests\Models\ManyToManyPersister;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @Entity
+ * @Table(name="manytomanypersister_child")
+ */
+class ChildClass
+{
+    /**
+     * @Id
+     * @Column(name="id1", type="integer")
+     *
+     * @var integer
+     */
+    public $id1;
+
+    /**
+     * @Id
+     * @ManyToOne(targetEntity=OtherParentClass::class, cascade={"persist"})
+     * @JoinColumn(name="other_parent_id", referencedColumnName="id")
+     *
+     * @var OtherParentClass
+     */
+    public $otherParent;
+
+    /**
+     * @ManyToMany(targetEntity=ParentClass::class, inversedBy="children")
+     * @JoinTable(
+     *     name="parent_child",
+     *     joinColumns={
+     *         @JoinColumn(name="child_id1", referencedColumnName="id1"),
+     *         @JoinColumn(name="child_id2", referencedColumnName="other_parent_id")
+     *     },
+     *     inverseJoinColumns={@JoinColumn(name="parent_id", referencedColumnName="id")}
+     * )
+     *
+     * @var Collection|ParentClass[]
+     */
+    public $parents;
+
+    public function __construct(int $id1, OtherParentClass $otherParent)
+    {
+        $this->id1         = $id1;
+        $this->otherParent = $otherParent;
+        $this->parents     = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/ManyToManyPersister/OtherParentClass.php
+++ b/tests/Doctrine/Tests/Models/ManyToManyPersister/OtherParentClass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Doctrine\Tests\Models\ManyToManyPersister;
+
+/**
+ * @Entity
+ * @Table(name="manytomanypersister_other_parent")
+ */
+class OtherParentClass
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     *
+     * @var integer
+     */
+    public $id;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/Doctrine/Tests/Models/ManyToManyPersister/ParentClass.php
+++ b/tests/Doctrine/Tests/Models/ManyToManyPersister/ParentClass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Doctrine\Tests\Models\ManyToManyPersister;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\ManyToMany;
+
+/**
+ * @Entity
+ * @Table(name="manytomanypersister_parent")
+ */
+class ParentClass
+{
+    /**
+     * @Id
+     * @Column(name="id", type="integer")
+     *
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * @ManyToMany(targetEntity=ChildClass::class, mappedBy="parents", orphanRemoval=true, cascade={"persist"})
+     *
+     * @var Collection|ChildClass[]
+     */
+    public $children;
+
+    public function __construct(int $id)
+    {
+        $this->id       = $id;
+        $this->children = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Persisters/ManyToManyPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/ManyToManyPersisterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Persisters;
+
+use Doctrine\ORM\Persisters\Collection\ManyToManyPersister;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Models\ManyToManyPersister\ChildClass;
+use Doctrine\Tests\Models\ManyToManyPersister\OtherParentClass;
+use Doctrine\Tests\Models\ManyToManyPersister\ParentClass;
+use Doctrine\Tests\OrmTestCase;
+
+/**
+ * @covers \Doctrine\ORM\Persisters\Collection\ManyToManyPersister
+ */
+final class ManyToManyPersisterTest extends OrmTestCase
+{
+    /**
+     * @group 6991
+     * @group ManyToManyPersister
+     *
+     * @throws \Doctrine\ORM\ORMException
+     */
+    public function testDeleteManyToManyCollection(): void
+    {
+        $parent      = new ParentClass(1);
+        $otherParent = new OtherParentClass(42);
+        $child       = new ChildClass(1, $otherParent);
+
+        $parent->children->add($child);
+        $child->parents->add($parent);
+
+        $em = $this->_getTestEntityManager();
+        $em->persist($parent);
+        $em->flush();
+
+        /** @var ChildClass|null $childReloaded */
+        $childReloaded = $em->find(ChildClass::class, ['id1' => 1, 'otherParent' => $otherParent]);
+
+        self::assertNotNull($childReloaded);
+
+        $persister = new ManyToManyPersister($em);
+        $persister->delete($childReloaded->parents);
+
+        /** @var ConnectionMock $conn */
+        $conn = $em->getConnection();
+
+        $updates    = $conn->getExecuteUpdates();
+        $lastUpdate = array_pop($updates);
+
+        self::assertEquals('DELETE FROM parent_child WHERE child_id1 = ? AND child_id2 = ?', $lastUpdate['query']);
+        self::assertEquals([1, 42], $lastUpdate['params']);
+    }
+}


### PR DESCRIPTION
This is due to a typo in `\Doctrine\ORM\Persisters\Collection\ManyToManyPersister::getDeleteSQLParameters`:

```php
        foreach ($mapping['relationToSourceKeyColumns'] as $columnName => $refColumnName) {
            $params[] = isset($sourceClass->fieldNames[$refColumnName])
                ? $identifier[$sourceClass->fieldNames[$refColumnName]]
                : $identifier[$sourceClass->getFieldForColumn($columnName)];
        }

```

It should be `$sourceClass->getFieldForColumn($refColumnName)`, as `$columnName` is the join table column, not the entity table column.