### PR TITLE
FlintCI integration

### DIFF
--- a/.flintci.yml
+++ b/.flintci.yml
@@ -1,0 +1,5 @@
+services:
+  phpcs:
+    config_path: phpcs.xml.dist
+  phpcbf:
+    config_path: phpcs.xml.dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,13 +79,6 @@ jobs:
       before_script: wget https://phpbench.github.io/phpbench/phpbench.phar https://phpbench.github.io/phpbench/phpbench.phar.pubkey
       script: php phpbench.phar run -l dots --report=default
 
-    - stage: Code Quality
-      env: DB=none CODING_STANDARDS
-      php: 7.2
-      script:
-        - ./vendor/bin/phpcs lib
-        - ./vendor/bin/phpcs tests tools || true # disabled on CI until ported to new CS
-
   allow_failures:
     - php: nightly
 


### PR DESCRIPTION
As suggested to @Majkl578, here is a proposition to integrate FlintCI for coding style review.

This tool will use your current CS configuration files and will publish PR status, diff comment and fix your code.

Another tools are available: https://flintci.io/docs

To finish this integration, just enable the repositories and re-open the PR to check if it works! :+1: 

I recommend to deactivate the "Comment on failure" this one is more useful for platform that does not support PR status, like GitLab.

As a side note, phpstan is also planned: https://gitlab.com/flintci/flintci/issues/133

Thanks!