### PR TITLE
Cannot persist new entity if primary key contains a foreign key and the referenced object is in state new and its id is not assigned

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -939,8 +939,11 @@ class UnitOfWork implements PropertyChangedListener
 
                 $class->setIdentifierValues($entity, $idValue);
             }
-
-            $this->entityIdentifiers[$oid] = $idValue;
+            // Some identifiers may be foreign keys to new entities.
+            // In this case, we don't have the value yet and should treat it as if we have a post-insert generator
+            if(!in_array(null, $idValue, true)) {
+                $this->entityIdentifiers[$oid] = $idValue;
+            }
         }
 
         $this->entityStates[$oid] = self::STATE_MANAGED;
@@ -1033,11 +1036,15 @@ class UnitOfWork implements PropertyChangedListener
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
 
+        $theseInsertions = [];
+
         foreach ($this->entityInsertions as $oid => $entity) {
 
             if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
                 continue;
             }
+
+            $theseInsertions[$oid] = $entity;
 
             $persister->addInsert($entity);
 
@@ -1066,6 +1073,33 @@ class UnitOfWork implements PropertyChangedListener
                 $this->originalEntityData[$oid][$idField] = $idValue;
 
                 $this->addToIdentityMap($entity);
+            }
+        } else {
+            foreach ($theseInsertions as $oid => $entity) {
+                if(!isset($this->entityIdentifiers[$oid])) {
+                    //entity was not added to identity map because some identifiers ar foreign keys to new entities.
+                    //add it now
+                    $idFields   = $class->getIdentifierFieldNames();
+                    foreach ($idFields as $idField) {
+                        $value = $class->getFieldValue($entity, $idField);
+
+                        if (isset($class->associationMappings[$idField])) {
+                            // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
+                            $value = $this->getSingleIdentifierValue($value);
+                        }
+
+                        $identifier[$idField] = $value;
+                    }
+
+                    $this->entityIdentifiers[$oid] = $identifier;
+
+                    foreach($identifier as $idField => $idValue) {
+                        $this->originalEntityData[$oid][$idField] = $idValue;
+                    }
+
+                    $this->entityStates[$oid] = self::STATE_MANAGED;
+                    $this->addToIdentityMap($entity);
+                }
             }
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1087,6 +1087,7 @@ class UnitOfWork implements PropertyChangedListener
                 if(!isset($this->entityIdentifiers[$oid])) {
                     //entity was not added to identity map because some identifiers are foreign keys to new entities.
                     //add it now
+                    $identifier = [];
                     $idFields   = $class->getIdentifierFieldNames();
                     foreach ($idFields as $idField) {
                         $value = $class->getFieldValue($entity, $idField);

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -942,14 +942,7 @@ class UnitOfWork implements PropertyChangedListener
 
             // Some identifiers may be foreign keys to new entities.
             // In this case, we don't have the value yet and should treat it as if we have a post-insert generator
-            $hasMissingIdsWhichAreForeignKeys = false;
-            foreach($idValue as $idField => $idFieldValue) {
-                if($idFieldValue === null && isset($class->associationMappings[$idField])) {
-                    $hasMissingIdsWhichAreForeignKeys = true;
-                    break;
-                }
-            }
-            if(!$hasMissingIdsWhichAreForeignKeys) {
+            if(!$this->hasMissingIdsWhichAreForeignKeys($class, $idValue)) {
                 $this->entityIdentifiers[$oid] = $idValue;
             }
         }
@@ -957,6 +950,18 @@ class UnitOfWork implements PropertyChangedListener
         $this->entityStates[$oid] = self::STATE_MANAGED;
 
         $this->scheduleForInsert($entity);
+    }
+
+    private function hasMissingIdsWhichAreForeignKeys(ClassMetadata $class, array $idValue) {
+        $hasMissingIdsWhichAreForeignKeys = false;
+        foreach($idValue as $idField => $idFieldValue) {
+            if($idFieldValue === null && isset($class->associationMappings[$idField])) {
+                $hasMissingIdsWhichAreForeignKeys = true;
+                break;
+            }
+        }
+
+        return$hasMissingIdsWhichAreForeignKeys;
     }
 
     /**
@@ -1044,7 +1049,7 @@ class UnitOfWork implements PropertyChangedListener
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
 
-        $theseInsertions = [];
+        $insertionsForClass = [];
 
         foreach ($this->entityInsertions as $oid => $entity) {
 
@@ -1052,7 +1057,7 @@ class UnitOfWork implements PropertyChangedListener
                 continue;
             }
 
-            $theseInsertions[$oid] = $entity;
+            $insertionsForClass[$oid] = $entity;
 
             $persister->addInsert($entity);
 
@@ -1083,31 +1088,11 @@ class UnitOfWork implements PropertyChangedListener
                 $this->addToIdentityMap($entity);
             }
         } else {
-            foreach ($theseInsertions as $oid => $entity) {
+            foreach ($insertionsForClass as $oid => $entity) {
                 if(!isset($this->entityIdentifiers[$oid])) {
                     //entity was not added to identity map because some identifiers are foreign keys to new entities.
                     //add it now
-                    $identifier = [];
-                    $idFields   = $class->getIdentifierFieldNames();
-                    foreach ($idFields as $idField) {
-                        $value = $class->getFieldValue($entity, $idField);
-
-                        if (isset($class->associationMappings[$idField])) {
-                            // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
-                            $value = $this->getSingleIdentifierValue($value);
-                        }
-
-                        $identifier[$idField] = $value;
-                    }
-
-                    $this->entityIdentifiers[$oid] = $identifier;
-
-                    foreach($identifier as $idField => $idValue) {
-                        $this->originalEntityData[$oid][$idField] = $idValue;
-                    }
-
-                    $this->entityStates[$oid] = self::STATE_MANAGED;
-                    $this->addToIdentityMap($entity);
+                    $this->addToEntityIdentifiersAndEntityMap($class, $oid, $entity);
                 }
             }
         }
@@ -1115,6 +1100,30 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($entities as $entity) {
             $this->listenersInvoker->invoke($class, Events::postPersist, $entity, new LifecycleEventArgs($entity, $this->em), $invoke);
         }
+    }
+
+    private function addToEntityIdentifiersAndEntityMap(ClassMetadata $class, $oid, $entity) {
+        $identifier = [];
+        $idFields   = $class->getIdentifierFieldNames();
+        foreach ($idFields as $idField) {
+            $value = $class->getFieldValue($entity, $idField);
+
+            if (isset($class->associationMappings[$idField])) {
+                // NOTE: Single Columns as associated identifiers only allowed - this constraint it is enforced.
+                $value = $this->getSingleIdentifierValue($value);
+            }
+
+            $identifier[$idField] = $value;
+        }
+
+        $this->entityIdentifiers[$oid] = $identifier;
+
+        foreach($identifier as $idField => $idValue) {
+            $this->originalEntityData[$oid][$idField] = $idValue;
+        }
+
+        $this->entityStates[$oid] = self::STATE_MANAGED;
+        $this->addToIdentityMap($entity);
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -939,9 +939,17 @@ class UnitOfWork implements PropertyChangedListener
 
                 $class->setIdentifierValues($entity, $idValue);
             }
+
             // Some identifiers may be foreign keys to new entities.
             // In this case, we don't have the value yet and should treat it as if we have a post-insert generator
-            if(!in_array(null, $idValue, true)) {
+            $hasMissingIdsWhichAreForeignKeys = false;
+            foreach($idValue as $idField => $idFieldValue) {
+                if($idFieldValue === null && isset($class->associationMappings[$idField])) {
+                    $hasMissingIdsWhichAreForeignKeys = true;
+                    break;
+                }
+            }
+            if(!$hasMissingIdsWhichAreForeignKeys) {
                 $this->entityIdentifiers[$oid] = $idValue;
             }
         }
@@ -1077,7 +1085,7 @@ class UnitOfWork implements PropertyChangedListener
         } else {
             foreach ($theseInsertions as $oid => $entity) {
                 if(!isset($this->entityIdentifiers[$oid])) {
-                    //entity was not added to identity map because some identifiers ar foreign keys to new entities.
+                    //entity was not added to identity map because some identifiers are foreign keys to new entities.
                     //add it now
                     $idFields   = $class->getIdentifierFieldNames();
                     foreach ($idFields as $idField) {

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/Product.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/Product.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
+
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class Product
+ * @package Doctrine\Tests\Models\IdentityThroughForeignKeyTest
+ * @Entity()
+ * @Table(name="identitythroughforeignkey_product")
+ */
+class Product {
+
+    /**
+     * @var integer
+     * @Id()
+     * @GeneratedValue(strategy="IDENTITY")
+     * @Column(name="id")
+     */
+    public $id;
+
+    /**
+     * @var Collection|ProductColor[]
+     * @OneToMany(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductColor", mappedBy="product", cascade={"persist"})
+     */
+    public $colors;
+
+    /**
+     * @var Collection|ProductColor[]
+     * @OneToMany(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductSize", mappedBy="product", cascade={"persist"})
+     */
+    public $sizes;
+
+    /**
+     * @var Collection|ProductVariant[]
+     * @OneToMany(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductVariant", mappedBy="product", cascade={"persist"})
+     */
+    public $variants;
+
+    public function __construct() {
+        $this->colors = new ArrayCollection();
+        $this->sizes = new ArrayCollection();
+        $this->variants = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/Product.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/Product.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
 
-
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -13,7 +12,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @Entity()
  * @Table(name="identitythroughforeignkey_product")
  */
-class Product {
+class Product
+{
 
     /**
      * @var integer
@@ -41,9 +41,10 @@ class Product {
      */
     public $variants;
 
-    public function __construct() {
-        $this->colors = new ArrayCollection();
-        $this->sizes = new ArrayCollection();
+    public function __construct()
+    {
+        $this->colors   = new ArrayCollection();
+        $this->sizes    = new ArrayCollection();
         $this->variants = new ArrayCollection();
     }
 }

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductColor.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductColor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
+
+/**
+ * Class ProductColor
+ * @package Doctrine\Tests\Models\IdentityThroughForeignKeyTest
+ * @Entity()
+ * @Table(name="identitythroughforeignkey_product_color")
+ */
+class ProductColor {
+
+    /**
+     * @var integer
+     * @Id()
+     * @GeneratedValue(strategy="IDENTITY")
+     * @Column(name="id", type="integer")
+     */
+    public $id;
+
+    /**
+     * @var Product
+     * @ManyToOne(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\Product", inversedBy="colors")
+     * @JoinColumn(name="product_id", referencedColumnName="id")
+     */
+    public $product;
+}

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductColor.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductColor.php
@@ -8,7 +8,8 @@ namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
  * @Entity()
  * @Table(name="identitythroughforeignkey_product_color")
  */
-class ProductColor {
+class ProductColor
+{
 
     /**
      * @var integer

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductSize.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductSize.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class ProductSize
+ * @package Doctrine\Tests\Models\IdentityThroughForeignKeyTest
+ * @Entity()
+ * @Table(name="identitythroughforeignkey_product_size")
+ */
+class ProductSize {
+
+    /**
+     * @var integer
+     * @Id()
+     * @GeneratedValue(strategy="IDENTITY")
+     * @Column(name="id", type="integer")
+     */
+    public $id;
+
+    /**
+     * @var Product
+     * @ManyToOne(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\Product", inversedBy="sizes")
+     * @JoinColumn(name="product_id", referencedColumnName="id")
+     */
+    public $product;
+}

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductSize.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductSize.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
+
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -9,7 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @Entity()
  * @Table(name="identitythroughforeignkey_product_size")
  */
-class ProductSize {
+class ProductSize
+{
 
     /**
      * @var integer

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductVariant.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductVariant.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
+
+/**
+ * Class ProductVariant
+ * @package Doctrine\Tests\Models\IdentityThroughForeignKeyTest
+ * @Entity()
+ * @Table(name="identitythroughforeignkey_product_variant")
+ */
+class ProductVariant {
+
+    /**
+     * @var Product
+     * @Id()
+     * @ManyToOne(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\Product", inversedBy="variants")
+     * @JoinColumn(name="product_id", referencedColumnName="id")
+     */
+    public $product;
+
+    /**
+     * @var ProductColor
+     * @Id()
+     * @ManyToOne(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductColor")
+     * @JoinColumn(name="color_id", referencedColumnName="id")
+     */
+    public $color;
+
+    /**
+     * @var ProductSize
+     * @Id()
+     * @ManyToOne(targetEntity="Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductSize")
+     * @JoinColumn(name="size_id", referencedColumnName="id")
+     */
+    public $size;
+}

--- a/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductVariant.php
+++ b/tests/Doctrine/Tests/Models/IdentityThroughForeignKeyTest/ProductVariant.php
@@ -8,7 +8,8 @@ namespace Doctrine\Tests\Models\IdentityThroughForeignKeyTest;
  * @Entity()
  * @Table(name="identitythroughforeignkey_product_variant")
  */
-class ProductVariant {
+class ProductVariant
+{
 
     /**
      * @var Product

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
@@ -40,11 +40,18 @@ class IdentityThroughForeignKeyTest extends OrmTestCase {
         $product->variants->add($variant);
 
         $this->em->persist($product);
+
+        //check that flush does not throw
         $this->em->flush();
 
-        /** @var ConnectionMock $conn */
-        $conn = $this->em->getConnection();
-        print_r($conn->getInserts());
-        $this->assertTrue(true);
+        $identifier = $this->em->getClassMetadata(ProductVariant::class)->getIdentifierValues($variant);
+
+        foreach($identifier as $k => $v) {
+            $identifier[$k] = $this->em->getClassMetadata(get_class($v))->getIdentifierValues($v)['id'];
+        }
+
+        //check that identityMap content is correct
+        //find by primary key should return the same instance
+        $this->assertTrue($variant === $this->em->find(ProductVariant::class, $identifier));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\Tests\ORM\Functional;
 
-
 use Doctrine\ORM\EntityManager;
 use Doctrine\Tests\Mocks\ConnectionMock;
 use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\Product;
@@ -11,32 +10,35 @@ use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductSize;
 use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductVariant;
 use Doctrine\Tests\OrmTestCase;
 
-class IdentityThroughForeignKeyTest extends OrmTestCase {
+class IdentityThroughForeignKeyTest extends OrmTestCase
+{
 
     /** @var EntityManager */
     protected $em;
 
-    protected function setUp() {
+    protected function setUp()
+    {
         parent::setUp();
         $this->em = $this->_getTestEntityManager();
     }
 
 
-    public function testIdentityThroughForeignKeyCollectionPersistence() {
+    public function testIdentityThroughForeignKeyCollectionPersistence()
+    {
         $product = new Product();
 
-        $color = new ProductColor();
+        $color          = new ProductColor();
         $color->product = $product;
         $product->colors->add($color);
 
-        $size = new ProductSize();
+        $size          = new ProductSize();
         $size->product = $product;
         $product->sizes->add($size);
 
-        $variant = new ProductVariant();
+        $variant          = new ProductVariant();
         $variant->product = $product;
-        $variant->color = $color;
-        $variant->size = $size;
+        $variant->color   = $color;
+        $variant->size    = $size;
         $product->variants->add($variant);
 
         $this->em->persist($product);
@@ -46,7 +48,7 @@ class IdentityThroughForeignKeyTest extends OrmTestCase {
 
         $identifier = $this->em->getClassMetadata(ProductVariant::class)->getIdentifierValues($variant);
 
-        foreach($identifier as $k => $v) {
+        foreach ($identifier as $k => $v) {
             $identifier[$k] = $this->em->getClassMetadata(get_class($v))->getIdentifierValues($v)['id'];
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityThroughForeignKeyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\Product;
+use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductColor;
+use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductSize;
+use Doctrine\Tests\Models\IdentityThroughForeignKeyTest\ProductVariant;
+use Doctrine\Tests\OrmTestCase;
+
+class IdentityThroughForeignKeyTest extends OrmTestCase {
+
+    /** @var EntityManager */
+    protected $em;
+
+    protected function setUp() {
+        parent::setUp();
+        $this->em = $this->_getTestEntityManager();
+    }
+
+
+    public function testIdentityThroughForeignKeyCollectionPersistence() {
+        $product = new Product();
+
+        $color = new ProductColor();
+        $color->product = $product;
+        $product->colors->add($color);
+
+        $size = new ProductSize();
+        $size->product = $product;
+        $product->sizes->add($size);
+
+        $variant = new ProductVariant();
+        $variant->product = $product;
+        $variant->color = $color;
+        $variant->size = $size;
+        $product->variants->add($variant);
+
+        $this->em->persist($product);
+        $this->em->flush();
+
+        /** @var ConnectionMock $conn */
+        $conn = $this->em->getConnection();
+        print_r($conn->getInserts());
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
As the id of the referenced entity is generated, when `UnitOfWork#persistNew` computes the primary key, it may contain some `null` values.

Because of https://github.com/doctrine/doctrine2/commit/1cb8d790b64f542406a576b878d67abe284e7275 , `UnitOfWork#addToIdentityMap` does not allow this anymore, which is a good thing.

We need to delay the insertion into `identityMap` and `entityIdentifiers` after the actual insert to ensure that we have a complete primary key, as we do with post-insert ID generators.

This kinda worked in 2.5, but in the end `identityMap` and `entityIdentifiers` contained wrong values anyway.