### PR TITLE
Fixed updating of entity with quoted identifier join column

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -452,7 +452,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             $params[]       = $identifier[$idField];
-            $where[]        = $this->class->associationMappings[$idField]['joinColumns'][0]['name'];
+            $where[]        = $this->quoteStrategy->getJoinColumnName($this->class->associationMappings[$idField]['joinColumns'][0], $this->class, $this->platform);
             $targetMapping  = $this->em->getClassMetadata($this->class->associationMappings[$idField]['targetEntity']);
 
             switch (true) {

--- a/tests/Doctrine/Tests/Models/Quote/UserData.php
+++ b/tests/Doctrine/Tests/Models/Quote/UserData.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Doctrine\Tests\Models\Quote;
+
+/**
+ * @Entity
+ * @Table(name="`quote-user-data`")
+ */
+class UserData
+{
+
+	/**
+	 * @Id
+	 * @OneToOne(targetEntity="User")
+	 * @JoinColumn(name="`user-id`", referencedColumnName="`user-id`", onDelete="CASCADE")
+	 */
+	public $user;
+
+	/**
+	 * @Column(type="string", name="`name`")
+	 */
+	public $name;
+
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/QuotedIdentifierAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QuotedIdentifierAssociationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Quote\User;
+use Doctrine\Tests\Models\Quote\UserData;
+
+/**
+ * Tests that association with quoted JoinColumn is updated
+ */
+class QuotedIdentifierAssociationTest extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+	protected function setUp()
+	{
+		$this->useModelSet('quote');
+		parent::setUp();
+	}
+
+	public function testUpdateEntityWithIdentifierAssociationWithQuotedJoinColumn()
+	{
+		$user = new User();
+		$user->name = 'John Doe';
+		$this->_em->persist($user);
+		$this->_em->flush();
+
+		$userData = new UserData();
+		$userData->name = '123456789';
+		$userData->user = $user;
+		$this->_em->persist($userData);
+		$this->_em->flush();
+
+		$userData->name = '4321';
+		$this->_em->flush();
+
+		$queries = $this->_sqlLoggerStack->queries;
+		$platform = $this->_em->getConnection()->getDatabasePlatform();
+		$quotedTableName = $platform->quoteIdentifier('quote-user-data');
+		$quotedColumn = $platform->quoteIdentifier('name');
+		$quotedIdentifier = $platform->quoteIdentifier('user-id');
+
+		$this->assertNotEquals('quote-user-data', $quotedTableName);
+		$this->assertNotEquals('name', $quotedColumn);
+		$this->assertNotEquals('user-id', $quotedIdentifier);
+
+		$this->assertSQLEquals(sprintf('UPDATE %s SET %s = ? WHERE %s = ?', $quotedTableName, $quotedColumn, $quotedIdentifier), $queries[$this->_sqlLoggerStack->currentQuery - 1]['sql']);
+	}
+
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -238,7 +238,8 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Quote\Group::class,
             Models\Quote\NumericEntity::class,
             Models\Quote\Phone::class,
-            Models\Quote\User::class
+            Models\Quote\User::class,
+            Models\Quote\UserData::class,
         ],
         'vct_onetoone' => [
             Models\ValueConversionType\InversedOneToOneEntity::class,


### PR DESCRIPTION
When entity has `JoinColumn` as its identifier, and this `JoinColumn` is quoted, the identifier is not quoted when building `UPDATE` query.

Quoting works fine when entity is inserted or selected...