### PR TITLE
SchemaValidator: Fixed bug in inverse JoinTable column name

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -212,7 +212,7 @@ class SchemaValidator
                     if (! in_array($inverseJoinColumn->getReferencedColumnName(), $targetIdentifierColumns, true)) {
                         $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
 
-                        $ce[] = sprintf($message, $joinColumn->getReferencedColumnName(), $targetMetadata->getClassName());
+                        $ce[] = sprintf($message, $inverseJoinColumn->getReferencedColumnName(), $targetMetadata->getClassName());
                         break;
                     }
                 }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -59,7 +59,7 @@ class SchemaValidatorTest extends OrmTestCase
         $class1 = $this->em->getClassMetadata(InvalidEntity1::class);
         $class2 = $this->em->getClassMetadata(InvalidEntity2::class);
 
-        $ce = $this->validator->validateClass($class1);
+        $errors = $this->validator->validateClass($class1);
 
         $message1 = "The inverse join columns of the many-to-many table '%s' have to contain to ALL identifier columns of the target entity '%s', however '%s' are missing.";
         $message2 = "The join columns of the many-to-many table '%s' have to contain to ALL identifier columns of the source entity '%s', however '%s' are missing.";
@@ -69,7 +69,7 @@ class SchemaValidatorTest extends OrmTestCase
                 sprintf($message1, 'Entity1Entity2', InvalidEntity2::class, 'key4'),
                 sprintf($message2, 'Entity1Entity2', InvalidEntity1::class, 'key2'),
             ],
-            $ce
+            $errors
         );
     }
 
@@ -81,7 +81,7 @@ class SchemaValidatorTest extends OrmTestCase
         $class1 = $this->em->getClassMetadata(InvalidEntity1::class);
         $class2 = $this->em->getClassMetadata(InvalidEntity2::class);
 
-        $ce = $this->validator->validateClass($class2);
+        $errors = $this->validator->validateClass($class2);
 
         $message1 = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
         $message2 = "The join columns of the association '%s' have to match to ALL identifier columns of the target entity '%s', however '%s' are missing.";
@@ -91,7 +91,7 @@ class SchemaValidatorTest extends OrmTestCase
                 sprintf($message1, 'id', InvalidEntity1::class),
                 sprintf($message2, 'assoc', InvalidEntity1::class, "key1', 'key2"),
             ],
-            $ce
+            $errors
         );
     }
 
@@ -103,9 +103,9 @@ class SchemaValidatorTest extends OrmTestCase
         $class1 = $this->em->getClassMetadata(DDC1587ValidEntity2::class);
         $class2 = $this->em->getClassMetadata(DDC1587ValidEntity1::class);
 
-        $ce = $this->validator->validateClass($class1);
+        $errors = $this->validator->validateClass($class1);
 
-        self::assertEquals([], $ce);
+        self::assertEquals([], $errors);
     }
 
     /**
@@ -114,7 +114,7 @@ class SchemaValidatorTest extends OrmTestCase
     public function testInvalidTripleAssociationAsKeyMapping()
     {
         $classThree = $this->em->getClassMetadata(DDC1649Three::class);
-        $ce = $this->validator->validateClass($classThree);
+        $errors = $this->validator->validateClass($classThree);
 
         $message1 = "Cannot map association %s#%s as identifier, because the target entity '%s' also maps an association as identifier.";
         $message2 = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
@@ -124,7 +124,7 @@ class SchemaValidatorTest extends OrmTestCase
                 sprintf($message1, DDC1649Three::class, 'two', DDC1649Two::class),
                 sprintf($message2, 'id', DDC1649Two::class),
             ],
-            $ce
+            $errors
         );
     }
 
@@ -134,7 +134,7 @@ class SchemaValidatorTest extends OrmTestCase
     public function testInvalidBiDirectionalRelationMappingMissingInversedByAttribute()
     {
         $class = $this->em->getClassMetadata(DDC3274One::class);
-        $ce = $this->validator->validateClass($class);
+        $errors = $this->validator->validateClass($class);
 
         $message = "The property %s#%s is on the inverse side of a bi-directional relationship, but the "
             . "specified mappedBy association on the target-entity %s#%s does not contain the required 'inversedBy=\"%s\"' attribute.";
@@ -143,7 +143,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 sprintf($message, DDC3274One::class, 'two', DDC3274Two::class, 'one', 'two')
             ],
-            $ce
+            $errors
         );
     }
 
@@ -153,7 +153,7 @@ class SchemaValidatorTest extends OrmTestCase
     public function testInvalidOrderByInvalidField()
     {
         $class = $this->em->getClassMetadata(DDC3322One::class);
-        $ce = $this->validator->validateClass($class);
+        $errors = $this->validator->validateClass($class);
 
         $message = "The association %s#%s is ordered by a property '%s' that is non-existing field on the target entity '%s'.";
 
@@ -161,7 +161,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 sprintf($message, DDC3322One::class, 'invalidAssoc', 'invalidField', DDC3322ValidEntity1::class)
             ],
-            $ce
+            $errors
         );
     }
 
@@ -171,7 +171,7 @@ class SchemaValidatorTest extends OrmTestCase
     public function testInvalidOrderByCollectionValuedAssociation()
     {
         $class = $this->em->getClassMetadata(DDC3322Two::class);
-        $ce = $this->validator->validateClass($class);
+        $errors = $this->validator->validateClass($class);
 
         $message = "The association %s#%s is ordered by a property '%s' on '%s' that is a collection-valued association.";
 
@@ -179,7 +179,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 sprintf($message, DDC3322Two::class, 'invalidAssoc', 'oneToMany', DDC3322ValidEntity1::class)
             ],
-            $ce
+            $errors
         );
     }
 
@@ -189,7 +189,7 @@ class SchemaValidatorTest extends OrmTestCase
     public function testInvalidOrderByAssociationInverseSide()
     {
         $class = $this->em->getClassMetadata(DDC3322Three::class);
-        $ce = $this->validator->validateClass($class);
+        $errors = $this->validator->validateClass($class);
 
         $message = "The association %s#%s is ordered by a property '%s' on '%s' that is the inverse side of an association.";
 
@@ -197,14 +197,14 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 sprintf($message, DDC3322Three::class, 'invalidAssoc', 'oneToOneInverse', DDC3322ValidEntity1::class)
             ],
-            $ce
+            $errors
         );
     }
 
     public function testInvalidReferencedJoinTableColumnIsNotPrimary() : void
     {
         $class = $this->em->getClassMetadata(InvalidEntity3::class);
-        $ce = $this->validator->validateClass($class);
+        $errors = $this->validator->validateClass($class);
 
         $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
 
@@ -212,7 +212,7 @@ class SchemaValidatorTest extends OrmTestCase
             [
                 sprintf($message, 'nonId4', InvalidEntity4::class)
             ],
-            $ce
+            $errors
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -200,6 +200,21 @@ class SchemaValidatorTest extends OrmTestCase
             $ce
         );
     }
+
+    public function testInvalidReferencedJoinTableColumnIsNotPrimary() : void
+    {
+        $class = $this->em->getClassMetadata(InvalidEntity3::class);
+        $ce = $this->validator->validateClass($class);
+
+        $message = "The referenced column name '%s' has to be a primary key column on the target entity class '%s'.";
+
+        self::assertEquals(
+            [
+                sprintf($message, 'nonId4', InvalidEntity4::class)
+            ],
+            $ce
+        );
+    }
 }
 
 /**
@@ -244,6 +259,42 @@ class InvalidEntity2
      * @ORM\ManyToOne(targetEntity=InvalidEntity1::class)
      */
     protected $assoc;
+}
+
+/**
+ * @ORM\Entity
+ */
+class InvalidEntity3
+{
+    /**
+     * @ORM\Id @ORM\Column
+     */
+    protected $id3;
+
+    /**
+     * @ORM\ManyToMany(targetEntity=InvalidEntity4::class)
+     * @ORM\JoinTable(name="invalid_entity_3_4")
+     * @ORM\JoinTable (name="Entity1Entity2",
+     *      joinColumns={@ORM\JoinColumn(name="id3_fk", referencedColumnName="id3")},
+     *      inverseJoinColumns={@ORM\JoinColumn(name="id4_fk", referencedColumnName="nonId4")}
+     * )
+     */
+    protected $invalid4;
+}
+
+/**
+ * @ORM\Entity
+ */
+class InvalidEntity4
+{
+    /**
+     * @ORM\Id @ORM\Column
+     */
+    protected $id4;
+    /**
+     * @ORM\Column
+     */
+    protected $nonId4;
 }
 
 /**


### PR DESCRIPTION
Fixes regular bug found by PHPStan 0.9.2 (slipped through #7013 which was built on top of 0.9.1 at that time).

@Ocramius Worth backporting to 2.6 as well (if relevant)?

This should make Travis green for master. 🎉 