### PR TITLE
QueryDqlFunctionTest: Increase delta for testDateAdd() to work in February

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -348,7 +348,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
 
         return [
             'year'   => ['year', 1, 365 * $secondsInDay, 3 * $secondsInDay],
-            'month'  => ['month', 1, 30 * $secondsInDay, 2 * $secondsInDay],
+            'month'  => ['month', 1, 30 * $secondsInDay, 2.5 * $secondsInDay],
             'week'   => ['week', 1, 7 * $secondsInDay, $secondsInDay],
             'hour'   => ['hour', 1, 3600],
             'minute' => ['minute', 1, 60],


### PR DESCRIPTION
Fixes #7031.

Needs backport to 2.6.