### PR TITLE
add option to bypass LimitSubqueryWalker Validation

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -96,6 +96,11 @@ abstract class AbstractQuery
     protected $hydrationCacheProfile;
 
     /**
+     * @var bool
+     */
+    protected $validateLimitSubqueryWalker = true;
+
+    /**
      * Whether to use second level cache, if available.
      *
      * @var bool
@@ -459,6 +464,26 @@ abstract class AbstractQuery
     public function getHydrationCacheProfile()
     {
         return $this->hydrationCacheProfile;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getValidateLimitSubqueryWalker()
+    {
+        return $this->validateLimitSubqueryWalker;
+    }
+
+    /**
+     * @param bool $validateLimitSubqueryWalker
+     *
+     * @return static This query instance.
+     */
+    public function setValidateLimitSubqueryWalker($validateLimitSubqueryWalker)
+    {
+        $this->validateLimitSubqueryWalker = $validateLimitSubqueryWalker;
+
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -109,7 +109,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         $from            = $AST->fromClause->identificationVariableDeclarations;
         $fromRoot        = reset($from);
 
-        if ($query instanceof Query && $query->getMaxResults() && $AST->orderByClause && count($fromRoot->joins)) {
+        if ($query instanceof Query && $query->getMaxResults() && $AST->orderByClause && count($fromRoot->joins) && $query->getValidateLimitSubqueryWalker()) {
             // Check each orderby item.
             // TODO: check complex orderby items too...
             foreach ($AST->orderByClause->orderByItems as $orderByItem) {


### PR DESCRIPTION
Add option to bypass LimitSubqueryWalker Validation.
Useful when a filter is present on the relationship TO_MANY, turning it into ONE_TO_ONE