### PR TITLE
Change bug reporting link from dead Jira to GitHub

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -15,7 +15,7 @@ Doctrine ORM don't panic. You can get help from different sources:
 -  There is a :doc:`FAQ <reference/faq>` with answers to frequent questions.
 -  The `Doctrine Mailing List <http://groups.google.com/group/doctrine-user>`_
 -  Internet Relay Chat (IRC) in #doctrine on Freenode
--  Report a bug on `JIRA <http://www.doctrine-project.org/jira>`_.
+-  Report a bug on `GitHub <https://github.com/doctrine/doctrine2/issues>`_.
 -  On `Twitter <https://twitter.com/search/%23doctrine2>`_ with ``#doctrine2``
 -  On `StackOverflow <http://stackoverflow.com/questions/tagged/doctrine2>`_
 


### PR DESCRIPTION
As per the desc, I am not sure I have chosen the best location though (not sure if it is general enough).