### PR TITLE
Null proxy data after clearing the UnitOfWork and loading same object via another proxy

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue7052Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue7052Test.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Tests\Models\CMS\CmsEmployee;
+
+/**
+ * @group issue-7052
+ */
+class Issue7052Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(array(
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\Issue7052Child'),
+            $this->_em->getClassMetadata(__NAMESPACE__ . '\\Issue7052Parent'),
+        ));
+    }
+
+    public function testIssue()
+    {
+        $parent = new Issue7052Parent();
+        $parent->name = "parent test";
+
+        $childA = new Issue7052Child();
+        $childA->name = "child A";
+        $childA->parent = $parent;
+
+        $childB = new Issue7052Child();
+        $childB->name = "child B";
+        $childB->parent = $parent;
+
+        $this->_em->persist($parent);
+        $this->_em->persist($childA);
+        $this->_em->persist($childB);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $childA = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childA->id);
+
+        $this->_em->clear();
+
+        $childB = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childB->id);
+
+        $parentFromChildB = $childB->parent;
+
+        $this->assertNotNull($childA->parent->name, "Unable to get parent name after EM cleared.");
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="issuebitonexxx_child")
+ */
+class Issue7052Child
+{
+    /** @Id @GeneratedValue @Column(type="integer") */
+    public $id;
+
+    /**
+     * @Column
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @ManyToOne(targetEntity="Issue7052Parent", fetch="LAZY")
+     * @JoinTable(
+     *   name="issuebtonexxx_parent",
+     *   inverseJoinColumns={@JoinColumn(name="parent_id", referencedColumnName="id")}
+     * )
+     */
+    public $parent;
+}
+
+/**
+ * @Entity
+ * @Table(name="issuebitonexxx_parent")
+ */
+class Issue7052Parent
+{
+    /** @Id @GeneratedValue @Column(type="integer") */
+    public $id;
+
+    /**
+     * @Column
+     * @var string
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue7052Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Issue7052Test.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\Models\CMS\CmsEmployee;
 
 /**
- * @group issue-7052
+ * @group 7052
  */
 class Issue7052Test extends \Doctrine\Tests\OrmFunctionalTestCase
 {
@@ -22,15 +22,13 @@ class Issue7052Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
     public function testIssue()
     {
-        $parent = new Issue7052Parent();
+        $parent       = new Issue7052Parent();
         $parent->name = "parent test";
 
-        $childA = new Issue7052Child();
-        $childA->name = "child A";
+        $childA         = new Issue7052Child();
         $childA->parent = $parent;
 
-        $childB = new Issue7052Child();
-        $childB->name = "child B";
+        $childB         = new Issue7052Child();
         $childB->parent = $parent;
 
         $this->_em->persist($parent);
@@ -39,55 +37,51 @@ class Issue7052Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        $childA = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childA->id);
+        $childAFromDb = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childA->id);
 
         $this->_em->clear();
 
-        $childB = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childB->id);
+        $childBFromDb = $this->_em->find('Doctrine\Tests\ORM\Functional\Ticket\Issue7052Child', $childB->id);
 
-        $parentFromChildB = $childB->parent;
+        $parentFromChildB = $childBFromDb->parent;
 
-        $this->assertNotNull($childA->parent->name, "Unable to get parent name after EM cleared.");
+        self::assertNotSame($childA, $childAFromDb);
+        self::assertNotNull($childAFromDb->parent->name, "Unable to get parent name on second loaded child after EM cleared.");
     }
 }
 
 /**
  * @Entity
- * @Table(name="issuebitonexxx_child")
  */
 class Issue7052Child
 {
-    /** @Id @GeneratedValue @Column(type="integer") */
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+    */
     public $id;
 
     /**
-     * @Column
-     * @var string
-     */
-    public $name;
-
-    /**
-     * @ManyToOne(targetEntity="Issue7052Parent", fetch="LAZY")
-     * @JoinTable(
-     *   name="issuebtonexxx_parent",
-     *   inverseJoinColumns={@JoinColumn(name="parent_id", referencedColumnName="id")}
-     * )
+     * @ManyToOne(targetEntity=Issue7052Parent::class, fetch="LAZY")
      */
     public $parent;
 }
 
 /**
  * @Entity
- * @Table(name="issuebitonexxx_parent")
  */
 class Issue7052Parent
 {
-    /** @Id @GeneratedValue @Column(type="integer") */
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
     public $id;
 
     /**
      * @Column
-     * @var string
      */
     public $name;
 }


### PR DESCRIPTION
Given 3 objects, childA, childB and parent. Parent is accessible from both child objects by the parent attribute.
When I load childA, and I clear the UnitOfwork, and I load childB, and I access its parent.
When I access childA parent,
Then childA parent have its data null.

I've created the following test that reproduces this issue.
As per your contributing guidelines, I know you prefer PR on master. But this test passes properly on master.
And it fails in 2.5, 2.6 and 2.7.

So if you prefer, I can do the PR on master, and then backport it to the 2.5, 2.6 and 2.7 version. But I'm not sure it would make sense.

Is there another process when the bug is only in a branch, but master has changed so much I can really do a cherry pick of a potential solution from master to that branch?

Thanks a lot!