### PR TITLE
Fixed parser rejecting valid DQL

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -315,7 +315,7 @@ class Parser
             }
 
             // If parameter is T_IDENTIFIER, then matches T_IDENTIFIER (100) and keywords (200+)
-            if ($token === Lexer::T_IDENTIFIER && $lookaheadType < Lexer::T_IDENTIFIER) {
+            if ($token === Lexer::T_IDENTIFIER && $lookaheadType >= Lexer::T_IDENTIFIER) {
                 $this->syntaxError($this->lexer->getLiteral($token));
             }
         }

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -36,6 +36,14 @@ class DeleteSqlGenerationTest extends OrmTestCase
         }
     }
 
+    public function testSupportsDeleteWithoutWhereAndAlias()
+    {
+        $this->assertSqlGeneration(
+            'DELETE FROM Doctrine\Tests\Models\CMS\CmsUser',
+            'DELETE FROM cms_users'
+        );
+    }
+
     public function testSupportsDeleteWithoutWhereAndFrom()
     {
         $this->assertSqlGeneration(


### PR DESCRIPTION
Doctrine 2.5 allows the following as valid DQL:

"DELETE FROM Namespace\Entity"

Doctrine 2.6 rejects this as a syntax error.

The bug appears to be on the changed line, as the code didn't match the logic specified in the comment. I've not got a massive amount of knowledge on how the parser/lexer is built but changing this to a >= means that the above DQL is accepted as valid and appears to fix the problem.