### PR TITLE
[CS] Apply Doctrine CS 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/console": "~3.2|~4.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "~2.0.0",
+        "doctrine/coding-standard": "~3.0.0",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/lib/Doctrine/ORM/Cache.php
+++ b/lib/Doctrine/ORM/Cache.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use Doctrine\ORM\Cache\QueryCache;
+use Doctrine\ORM\Cache\Region;
+
 /**
  * Provides an API for querying/managing the second level cache regions.
  */
@@ -38,7 +41,7 @@ interface Cache
     /**
      * @param string $className The entity class.
      *
-     * @return \Doctrine\ORM\Cache\Region|null
+     * @return Region|null
      */
     public function getEntityCacheRegion($className);
 
@@ -46,7 +49,7 @@ interface Cache
      * @param string $className   The entity class.
      * @param string $association The field name that represents the association.
      *
-     * @return \Doctrine\ORM\Cache\Region|null
+     * @return Region|null
      */
     public function getCollectionCacheRegion($className, $association);
 
@@ -153,7 +156,7 @@ interface Cache
      *
      * @param string|null $regionName Query cache region name, or default query cache if the region name is NULL.
      *
-     * @return \Doctrine\ORM\Cache\QueryCache The Query Cache associated with the region name.
+     * @return QueryCache The Query Cache associated with the region name.
      */
     public function getQueryCache($regionName = null);
 }

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -12,27 +12,27 @@ use Doctrine\ORM\Cache\Logging\CacheLogger;
 class CacheConfiguration
 {
     /**
-     * @var \Doctrine\ORM\Cache\CacheFactory|null
+     * @var CacheFactory|null
      */
     private $cacheFactory;
 
     /**
-     * @var \Doctrine\ORM\Cache\RegionsConfiguration|null
+     * @var RegionsConfiguration|null
      */
     private $regionsConfig;
 
     /**
-     * @var \Doctrine\ORM\Cache\Logging\CacheLogger|null
+     * @var CacheLogger|null
      */
     private $cacheLogger;
 
     /**
-     * @var \Doctrine\ORM\Cache\QueryCacheValidator|null
+     * @var QueryCacheValidator|null
      */
     private $queryValidator;
 
     /**
-     * @return \Doctrine\ORM\Cache\CacheFactory|null
+     * @return CacheFactory|null
      */
     public function getCacheFactory()
     {
@@ -45,7 +45,7 @@ class CacheConfiguration
     }
 
     /**
-     * @return \Doctrine\ORM\Cache\Logging\CacheLogger|null
+     * @return CacheLogger|null
      */
     public function getCacheLogger()
     {
@@ -58,7 +58,7 @@ class CacheConfiguration
     }
 
     /**
-     * @return \Doctrine\ORM\Cache\RegionsConfiguration
+     * @return RegionsConfiguration
      */
     public function getRegionsConfiguration()
     {
@@ -75,7 +75,7 @@ class CacheConfiguration
     }
 
     /**
-     * @return \Doctrine\ORM\Cache\QueryCacheValidator
+     * @return QueryCacheValidator
      */
     public function getQueryValidator()
     {

--- a/lib/Doctrine/ORM/Cache/CacheException.php
+++ b/lib/Doctrine/ORM/Cache/CacheException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\ORMException;
+use function sprintf;
 
 /**
  * Exception for cache.

--- a/lib/Doctrine/ORM/Cache/CacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/CacheFactory.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use Doctrine\ORM\Cache;
+use Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister;
+use Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\CacheMetadata;
@@ -19,11 +22,11 @@ interface CacheFactory
     /**
      * Build an entity persister for the given entity metadata.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface            $em        The entity manager.
-     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister The entity persister that will be cached.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata             $metadata  The entity metadata.
+     * @param EntityManagerInterface $em        The entity manager.
+     * @param EntityPersister        $persister The entity persister that will be cached.
+     * @param ClassMetadata          $metadata  The entity metadata.
      *
-     * @return \Doctrine\ORM\Cache\Persister\Entity\CachedEntityPersister
+     * @return CachedEntityPersister
      */
     public function buildCachedEntityPersister(
         EntityManagerInterface $em,
@@ -34,11 +37,11 @@ interface CacheFactory
     /**
      * Build a collection persister for the given relation mapping.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface                    $em          The entity manager.
-     * @param \Doctrine\ORM\Persisters\Collection\CollectionPersister $persister   The collection persister that will be cached.
-     * @param \Doctrine\ORM\Mapping\AssociationMetadata               $association The association mapping.
+     * @param EntityManagerInterface $em          The entity manager.
+     * @param CollectionPersister    $persister   The collection persister that will be cached.
+     * @param AssociationMetadata    $association The association mapping.
      *
-     * @return \Doctrine\ORM\Cache\Persister\Collection\CachedCollectionPersister
+     * @return CachedCollectionPersister
      */
     public function buildCachedCollectionPersister(
         EntityManagerInterface $em,
@@ -49,53 +52,53 @@ interface CacheFactory
     /**
      * Build a query cache based on the given region name
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $em         The Entity manager.
-     * @param string                               $regionName The region name.
+     * @param EntityManagerInterface $em         The Entity manager.
+     * @param string                 $regionName The region name.
      *
-     * @return \Doctrine\ORM\Cache\QueryCache The built query cache.
+     * @return QueryCache The built query cache.
      */
     public function buildQueryCache(EntityManagerInterface $em, $regionName = null);
 
     /**
      * Build an entity hydrator
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $em       The Entity manager.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata  $metadata The entity metadata.
+     * @param EntityManagerInterface $em       The Entity manager.
+     * @param ClassMetadata          $metadata The entity metadata.
      *
-     * @return \Doctrine\ORM\Cache\EntityHydrator The built entity hydrator.
+     * @return EntityHydrator The built entity hydrator.
      */
     public function buildEntityHydrator(EntityManagerInterface $em, ClassMetadata $metadata);
 
     /**
      * Build a collection hydrator
      *
-     * @param \Doctrine\ORM\EntityManagerInterface      $em          The Entity manager.
-     * @param \Doctrine\ORM\Mapping\AssociationMetadata $association The association mapping.
+     * @param EntityManagerInterface $em          The Entity manager.
+     * @param AssociationMetadata    $association The association mapping.
      *
-     * @return \Doctrine\ORM\Cache\CollectionHydrator The built collection hydrator.
+     * @return CollectionHydrator The built collection hydrator.
      */
     public function buildCollectionHydrator(EntityManagerInterface $em, AssociationMetadata $association);
 
     /**
      * Build a cache region
      *
-     * @param \Doctrine\ORM\Mapping\CacheMetadata $cache The cache configuration.
+     * @param CacheMetadata $cache The cache configuration.
      *
-     * @return \Doctrine\ORM\Cache\Region The cache region.
+     * @return Region The cache region.
      */
     public function getRegion(CacheMetadata $cache);
 
     /**
      * Build timestamp cache region
      *
-     * @return \Doctrine\ORM\Cache\TimestampRegion The timestamp region.
+     * @return TimestampRegion The timestamp region.
      */
     public function getTimestampRegion();
 
     /**
      * Build \Doctrine\ORM\Cache
      *
-     * @return \Doctrine\ORM\Cache
+     * @return Cache
      */
     public function createCache(EntityManagerInterface $entityManager);
 }

--- a/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function implode;
+use function ksort;
+use function str_replace;
+use function strtolower;
+
 /**
  * Defines entity collection roles to be stored in the cache region.
  */

--- a/lib/Doctrine/ORM/Cache/CollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/CollectionHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 
@@ -14,19 +15,19 @@ use Doctrine\ORM\PersistentCollection;
 interface CollectionHydrator
 {
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata                    $metadata   The entity metadata.
-     * @param \Doctrine\ORM\Cache\CollectionCacheKey                 $key        The cached collection key.
-     * @param array|\Doctrine\Common\Collections\Collection|object[] $collection The collection.
+     * @param ClassMetadata             $metadata   The entity metadata.
+     * @param CollectionCacheKey        $key        The cached collection key.
+     * @param array|Collection|object[] $collection The collection.
      *
-     * @return \Doctrine\ORM\Cache\CollectionCacheEntry
+     * @return CollectionCacheEntry
      */
     public function buildCacheEntry(ClassMetadata $metadata, CollectionCacheKey $key, $collection);
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata      $metadata   The owning entity metadata.
-     * @param \Doctrine\ORM\Cache\CollectionCacheKey   $key        The cached collection key.
-     * @param \Doctrine\ORM\Cache\CollectionCacheEntry $entry      The cached collection entry.
-     * @param \Doctrine\ORM\PersistentCollection       $collection The collection to load the cache into.
+     * @param ClassMetadata        $metadata   The owning entity metadata.
+     * @param CollectionCacheKey   $key        The cached collection key.
+     * @param CollectionCacheEntry $entry      The cached collection entry.
+     * @param PersistentCollection $collection The collection to load the cache into.
      *
      * @return object[]
      */

--- a/lib/Doctrine/ORM/Cache/ConcurrentRegion.php
+++ b/lib/Doctrine/ORM/Cache/ConcurrentRegion.php
@@ -16,23 +16,23 @@ interface ConcurrentRegion extends Region
     /**
      * Attempts to read lock the mapping for the given key.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key The key of the item to lock.
+     * @param CacheKey $key The key of the item to lock.
      *
-     * @return \Doctrine\ORM\Cache\Lock A lock instance or NULL if the lock already exists.
+     * @return Lock A lock instance or NULL if the lock already exists.
      *
-     * @throws \Doctrine\ORM\Cache\LockException Indicates a problem accessing the region.
+     * @throws LockException Indicates a problem accessing the region.
      */
     public function lock(CacheKey $key);
 
     /**
      * Attempts to read unlock the mapping for the given key.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key  The key of the item to unlock.
-     * @param \Doctrine\ORM\Cache\Lock     $lock The lock previously obtained from {@link readLock}
+     * @param CacheKey $key  The key of the item to unlock.
+     * @param Lock     $lock The lock previously obtained from {@link readLock}
      *
      * @return void
      *
-     * @throws \Doctrine\ORM\Cache\LockException Indicates a problem accessing the region.
+     * @throws LockException Indicates a problem accessing the region.
      */
     public function unlock(CacheKey $key, Lock $lock);
 }

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -10,7 +10,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\StaticClassNameConverter;
+use function is_array;
+use function is_object;
 
 /**
  * Provides an API for querying/managing the second level cache regions.
@@ -18,27 +21,27 @@ use Doctrine\ORM\Utility\StaticClassNameConverter;
 class DefaultCache implements Cache
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\ORM\UnitOfWork
+     * @var UnitOfWork
      */
     private $uow;
 
     /**
-     * @var \Doctrine\ORM\Cache\CacheFactory
+     * @var CacheFactory
      */
     private $cacheFactory;
 
     /**
-     * @var \Doctrine\ORM\Cache\QueryCache[]
+     * @var QueryCache[]
      */
     private $queryCaches = [];
 
     /**
-     * @var \Doctrine\ORM\Cache\QueryCache
+     * @var QueryCache
      */
     private $defaultQueryCache;
 
@@ -270,10 +273,10 @@ class DefaultCache implements Cache
     }
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata   The entity metadata.
-     * @param mixed                               $identifier The entity identifier.
+     * @param ClassMetadata $metadata   The entity metadata.
+     * @param mixed         $identifier The entity identifier.
      *
-     * @return \Doctrine\ORM\Cache\EntityCacheKey
+     * @return EntityCacheKey
      */
     private function buildEntityCacheKey(ClassMetadata $metadata, $identifier)
     {
@@ -285,11 +288,11 @@ class DefaultCache implements Cache
     }
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata        The entity metadata.
-     * @param string                              $association     The field name that represents the association.
-     * @param mixed                               $ownerIdentifier The identifier of the owning entity.
+     * @param ClassMetadata $metadata        The entity metadata.
+     * @param string        $association     The field name that represents the association.
+     * @param mixed         $ownerIdentifier The identifier of the owning entity.
      *
-     * @return \Doctrine\ORM\Cache\CollectionCacheKey
+     * @return CollectionCacheKey
      */
     private function buildCollectionCacheKey(ClassMetadata $metadata, $association, $ownerIdentifier)
     {
@@ -301,8 +304,8 @@ class DefaultCache implements Cache
     }
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata   The entity metadata.
-     * @param mixed                               $identifier The entity identifier.
+     * @param ClassMetadata $metadata   The entity metadata.
+     * @param mixed         $identifier The entity identifier.
      *
      * @return mixed[]
      */

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -25,6 +25,8 @@ use Doctrine\ORM\Mapping\CacheUsage;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use const DIRECTORY_SEPARATOR;
+use function sprintf;
 
 class DefaultCacheFactory implements CacheFactory
 {
@@ -34,17 +36,17 @@ class DefaultCacheFactory implements CacheFactory
     private $cache;
 
     /**
-     * @var \Doctrine\ORM\Cache\RegionsConfiguration
+     * @var RegionsConfiguration
      */
     private $regionsConfig;
 
     /**
-     * @var \Doctrine\ORM\Cache\TimestampRegion|null
+     * @var TimestampRegion|null
      */
     private $timestampRegion;
 
     /**
-     * @var \Doctrine\ORM\Cache\Region[]
+     * @var Region[]
      */
     private $regions = [];
 

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\UnitOfWork;
 
 /**
  * Default hydrator cache for collections
@@ -15,12 +16,12 @@ use Doctrine\ORM\Query;
 class DefaultCollectionHydrator implements CollectionHydrator
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\ORM\UnitOfWork
+     * @var UnitOfWork
      */
     private $uow;
 
@@ -30,7 +31,7 @@ class DefaultCollectionHydrator implements CollectionHydrator
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
-     * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
+     * @param EntityManagerInterface $em The entity manager.
      */
     public function __construct(EntityManagerInterface $em)
     {

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -11,7 +11,9 @@ use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\StaticClassNameConverter;
+use function array_merge;
 
 /**
  * Default hydrator cache for entities
@@ -19,12 +21,12 @@ use Doctrine\ORM\Utility\StaticClassNameConverter;
 class DefaultEntityHydrator implements EntityHydrator
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\ORM\UnitOfWork
+     * @var UnitOfWork
      */
     private $uow;
 
@@ -34,7 +36,7 @@ class DefaultEntityHydrator implements EntityHydrator
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
-     * @param \Doctrine\ORM\EntityManagerInterface $em The entity manager.
+     * @param EntityManagerInterface $em The entity manager.
      */
     public function __construct(EntityManagerInterface $em)
     {

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache;
+use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
@@ -12,6 +13,13 @@ use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
 use ProxyManager\Proxy\GhostObjectInterface;
+use function array_map;
+use function array_shift;
+use function array_unshift;
+use function count;
+use function is_array;
+use function key;
+use function reset;
 
 /**
  * Default query cache implementation.
@@ -19,22 +27,22 @@ use ProxyManager\Proxy\GhostObjectInterface;
 class DefaultQueryCache implements QueryCache
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\ORM\Cache\Region
+     * @var Region
      */
     private $region;
 
     /**
-     * @var \Doctrine\ORM\Cache\QueryCacheValidator
+     * @var QueryCacheValidator
      */
     private $validator;
 
     /**
-     * @var \Doctrine\ORM\Cache\Logging\CacheLogger
+     * @var CacheLogger
      */
     protected $cacheLogger;
 
@@ -44,8 +52,8 @@ class DefaultQueryCache implements QueryCache
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**
-     * @param \Doctrine\ORM\EntityManagerInterface $em     The entity manager.
-     * @param \Doctrine\ORM\Cache\Region           $region The query region.
+     * @param EntityManagerInterface $em     The entity manager.
+     * @param Region                 $region The query region.
      */
     public function __construct(EntityManagerInterface $em, Region $region)
     {

--- a/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\EntityManagerInterface;
+use function array_map;
 
 /**
  * Entity cache entry

--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function implode;
+use function ksort;
+use function str_replace;
+use function strtolower;
+
 /**
  * Defines entity classes roles to be stored in the cache region.
  */

--- a/lib/Doctrine/ORM/Cache/EntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/EntityHydrator.php
@@ -12,19 +12,19 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 interface EntityHydrator
 {
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata The entity metadata.
-     * @param \Doctrine\ORM\Cache\EntityCacheKey  $key      The entity cache key.
-     * @param object                              $entity   The entity.
+     * @param ClassMetadata  $metadata The entity metadata.
+     * @param EntityCacheKey $key      The entity cache key.
+     * @param object         $entity   The entity.
      *
-     * @return \Doctrine\ORM\Cache\EntityCacheEntry
+     * @return EntityCacheEntry
      */
     public function buildCacheEntry(ClassMetadata $metadata, EntityCacheKey $key, $entity);
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata  $metadata The entity metadata.
-     * @param \Doctrine\ORM\Cache\EntityCacheKey   $key      The entity cache key.
-     * @param \Doctrine\ORM\Cache\EntityCacheEntry $entry    The entity cache entry.
-     * @param object                               $entity   The entity to load the cache into. If not specified, a new entity is created.
+     * @param ClassMetadata    $metadata The entity metadata.
+     * @param EntityCacheKey   $key      The entity cache key.
+     * @param EntityCacheEntry $entry    The entity cache entry.
+     * @param object           $entity   The entity to load the cache into. If not specified, a new entity is created.
      */
     public function loadCacheEntry(ClassMetadata $metadata, EntityCacheKey $key, EntityCacheEntry $entry, $entity = null);
 }

--- a/lib/Doctrine/ORM/Cache/Lock.php
+++ b/lib/Doctrine/ORM/Cache/Lock.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function time;
+use function uniqid;
+
 /**
  * Cache Lock
  */

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
@@ -16,72 +16,72 @@ interface CacheLogger
     /**
      * Log an entity put into second level cache.
      *
-     * @param string                             $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\EntityCacheKey $key        The cache key of the entity.
+     * @param string         $regionName The name of the cache region.
+     * @param EntityCacheKey $key        The cache key of the entity.
      */
     public function entityCachePut($regionName, EntityCacheKey $key);
 
     /**
      * Log an entity get from second level cache resulted in a hit.
      *
-     * @param string                             $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\EntityCacheKey $key        The cache key of the entity.
+     * @param string         $regionName The name of the cache region.
+     * @param EntityCacheKey $key        The cache key of the entity.
      */
     public function entityCacheHit($regionName, EntityCacheKey $key);
 
     /**
      * Log an entity get from second level cache resulted in a miss.
      *
-     * @param string                             $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\EntityCacheKey $key        The cache key of the entity.
+     * @param string         $regionName The name of the cache region.
+     * @param EntityCacheKey $key        The cache key of the entity.
      */
     public function entityCacheMiss($regionName, EntityCacheKey $key);
 
     /**
      * Log an entity put into second level cache.
      *
-     * @param string                                 $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\CollectionCacheKey $key        The cache key of the collection.
+     * @param string             $regionName The name of the cache region.
+     * @param CollectionCacheKey $key        The cache key of the collection.
      */
     public function collectionCachePut($regionName, CollectionCacheKey $key);
 
     /**
      * Log an entity get from second level cache resulted in a hit.
      *
-     * @param string                                 $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\CollectionCacheKey $key        The cache key of the collection.
+     * @param string             $regionName The name of the cache region.
+     * @param CollectionCacheKey $key        The cache key of the collection.
      */
     public function collectionCacheHit($regionName, CollectionCacheKey $key);
 
     /**
      * Log an entity get from second level cache resulted in a miss.
      *
-     * @param string                                 $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\CollectionCacheKey $key        The cache key of the collection.
+     * @param string             $regionName The name of the cache region.
+     * @param CollectionCacheKey $key        The cache key of the collection.
      */
     public function collectionCacheMiss($regionName, CollectionCacheKey $key);
 
     /**
      * Log a query put into the query cache.
      *
-     * @param string                            $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\QueryCacheKey $key        The cache key of the query.
+     * @param string        $regionName The name of the cache region.
+     * @param QueryCacheKey $key        The cache key of the query.
      */
     public function queryCachePut($regionName, QueryCacheKey $key);
 
     /**
      * Log a query get from the query cache resulted in a hit.
      *
-     * @param string                            $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\QueryCacheKey $key        The cache key of the query.
+     * @param string        $regionName The name of the cache region.
+     * @param QueryCacheKey $key        The cache key of the query.
      */
     public function queryCacheHit($regionName, QueryCacheKey $key);
 
     /**
      * Log a query get from the query cache resulted in a miss.
      *
-     * @param string                            $regionName The name of the cache region.
-     * @param \Doctrine\ORM\Cache\QueryCacheKey $key        The cache key of the query.
+     * @param string        $regionName The name of the cache region.
+     * @param QueryCacheKey $key        The cache key of the query.
      */
     public function queryCacheMiss($regionName, QueryCacheKey $key);
 }

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -29,7 +29,7 @@ class CacheLoggerChain implements CacheLogger
     /**
      * @param string $name
      *
-     * @return \Doctrine\ORM\Cache\Logging\CacheLogger|null
+     * @return CacheLogger|null
      */
     public function getLogger($name)
     {

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Cache\Logging;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\EntityCacheKey;
 use Doctrine\ORM\Cache\QueryCacheKey;
+use function array_sum;
 
 /**
  * Provide basic second level cache statistics.

--- a/lib/Doctrine/ORM/Cache/Persister/CachedPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/CachedPersister.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Persister;
 
+use Doctrine\ORM\Cache\Region;
+
 /**
  * Interface for persister that support second level cache.
  */
@@ -22,7 +24,7 @@ interface CachedPersister
     /**
      * Gets the The region access.
      *
-     * @return \Doctrine\ORM\Cache\Region
+     * @return Region
      */
     public function getCacheRegion();
 }

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -7,44 +7,51 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Cache\CollectionCacheKey;
+use Doctrine\ORM\Cache\CollectionHydrator;
 use Doctrine\ORM\Cache\EntityCacheKey;
+use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\StaticClassNameConverter;
+use function array_values;
+use function count;
 
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
     /**
-     * @var \Doctrine\ORM\UnitOfWork
+     * @var UnitOfWork
      */
     protected $uow;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadataFactory
+     * @var ClassMetadataFactory
      */
     protected $metadataFactory;
 
     /**
-     * @var \Doctrine\ORM\Persisters\Collection\CollectionPersister
+     * @var CollectionPersister
      */
     protected $persister;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     protected $sourceEntity;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     protected $targetEntity;
 
     /**
-     * @var \Doctrine\ORM\Mapping\AssociationMetadata
+     * @var AssociationMetadata
      */
     protected $association;
 
@@ -54,7 +61,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     protected $queuedCache = [];
 
     /**
-     * @var \Doctrine\ORM\Cache\Region
+     * @var Region
      */
     protected $region;
 
@@ -64,12 +71,12 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     protected $regionName;
 
     /**
-     * @var \Doctrine\ORM\Cache\CollectionHydrator
+     * @var CollectionHydrator
      */
     protected $hydrator;
 
     /**
-     * @var \Doctrine\ORM\Cache\Logging\CacheLogger
+     * @var CacheLogger
      */
     protected $cacheLogger;
 
@@ -126,8 +133,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
     }
 
     /**
-     *
-     * @return \Doctrine\ORM\PersistentCollection|null
+     * @return PersistentCollection|null
      */
     public function loadCollectionCache(PersistentCollection $collection, CollectionCacheKey $key)
     {
@@ -160,7 +166,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
         // Only preserve ordering if association configured it
         if (! ($association instanceof ToManyAssociationMetadata && $association->getIndexedBy())) {
             // Elements may be an array or a Collection
-            $elements = \array_values($elements instanceof Collection ? $elements->getValues() : $elements);
+            $elements = array_values($elements instanceof Collection ? $elements->getValues() : $elements);
         }
 
         $entry = $this->hydrator->buildCacheEntry($this->targetEntity, $key, $elements);

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
@@ -15,26 +17,26 @@ use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 interface CachedCollectionPersister extends CachedPersister, CollectionPersister
 {
     /**
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     public function getSourceEntityMetadata();
 
     /**
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     public function getTargetEntityMetadata();
 
     /**
      * Loads a collection from cache
      *
-     * @return \Doctrine\ORM\PersistentCollection|mixed[]|null
+     * @return PersistentCollection|mixed[]|null
      */
     public function loadCollectionCache(PersistentCollection $collection, CollectionCacheKey $key);
 
     /**
      * Stores a collection into cache
      *
-     * @param array|\Doctrine\Common\Collections\Collection|mixed[] $elements
+     * @param array|Collection|mixed[] $elements
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
+use function spl_object_id;
 
 class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
+use function spl_object_id;
 
 class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\EntityCacheKey;
+use Doctrine\ORM\Cache\EntityHydrator;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 
@@ -14,7 +15,7 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 interface CachedEntityPersister extends CachedPersister, EntityPersister
 {
     /**
-     * @return \Doctrine\ORM\Cache\EntityHydrator
+     * @return EntityHydrator
      */
     public function getEntityHydrator();
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\EntityCacheKey;
+use function get_class;
 
 /**
  * Specific non-strict read/write cached entity persister

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -16,10 +16,10 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 class ReadWriteCachedEntityPersister extends AbstractEntityPersister
 {
     /**
-     * @param \Doctrine\ORM\Persisters\Entity\EntityPersister $persister The entity persister to cache.
-     * @param \Doctrine\ORM\Cache\ConcurrentRegion            $region    The entity cache region.
-     * @param \Doctrine\ORM\EntityManagerInterface            $em        The entity manager.
-     * @param \Doctrine\ORM\Mapping\ClassMetadata             $class     The entity metadata.
+     * @param EntityPersister        $persister The entity persister to cache.
+     * @param ConcurrentRegion       $region    The entity cache region.
+     * @param EntityManagerInterface $em        The entity manager.
+     * @param ClassMetadata          $class     The entity metadata.
      */
     public function __construct(EntityPersister $persister, ConcurrentRegion $region, EntityManagerInterface $em, ClassMetadata $class)
     {

--- a/lib/Doctrine/ORM/Cache/QueryCache.php
+++ b/lib/Doctrine/ORM/Cache/QueryCache.php
@@ -33,7 +33,7 @@ interface QueryCache
     public function get(QueryCacheKey $key, ResultSetMapping $rsm, array $hints = []);
 
     /**
-     * @return \Doctrine\ORM\Cache\Region
+     * @return Region
      */
     public function getRegion();
 }

--- a/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function microtime;
+
 /**
  * Query cache entry
  */

--- a/lib/Doctrine/ORM/Cache/Region.php
+++ b/lib/Doctrine/ORM/Cache/Region.php
@@ -19,7 +19,7 @@ interface Region extends MultiGetRegion
     /**
      * Determine whether this region contains data for the given key.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key The cache key
+     * @param CacheKey $key The cache key
      *
      * @return bool TRUE if the underlying cache contains corresponding data; FALSE otherwise.
      */
@@ -28,38 +28,38 @@ interface Region extends MultiGetRegion
     /**
      * Get an item from the cache.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key The key of the item to be retrieved.
+     * @param CacheKey $key The key of the item to be retrieved.
      *
-     * @return \Doctrine\ORM\Cache\CacheEntry|null The cached entry or NULL
+     * @return CacheEntry|null The cached entry or NULL
      *
-     * @throws \Doctrine\ORM\Cache\CacheException Indicates a problem accessing the item or region.
+     * @throws CacheException Indicates a problem accessing the item or region.
      */
     public function get(CacheKey $key);
 
     /**
      * Put an item into the cache.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey   $key   The key under which to cache the item.
-     * @param \Doctrine\ORM\Cache\CacheEntry $entry The entry to cache.
-     * @param \Doctrine\ORM\Cache\Lock       $lock  The lock previously obtained.
+     * @param CacheKey   $key   The key under which to cache the item.
+     * @param CacheEntry $entry The entry to cache.
+     * @param Lock       $lock  The lock previously obtained.
      *
-     * @throws \Doctrine\ORM\Cache\CacheException Indicates a problem accessing the region.
+     * @throws CacheException Indicates a problem accessing the region.
      */
     public function put(CacheKey $key, CacheEntry $entry, ?Lock $lock = null);
 
     /**
      * Remove an item from the cache.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key The key under which to cache the item.
+     * @param CacheKey $key The key under which to cache the item.
      *
-     * @throws \Doctrine\ORM\Cache\CacheException Indicates a problem accessing the region.
+     * @throws CacheException Indicates a problem accessing the region.
      */
     public function evict(CacheKey $key);
 
     /**
      * Remove all contents of this particular cache region.
      *
-     * @throws \Doctrine\ORM\Cache\CacheException Indicates problem accessing the region.
+     * @throws CacheException Indicates problem accessing the region.
      */
     public function evictAll();
 }

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Region;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\MultiGetCache;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
+use function count;
 
 /**
  * A cache region that enables the retrieval of multiple elements with one call
@@ -17,7 +19,7 @@ class DefaultMultiGetRegion extends DefaultRegion
      * Note that the multiple type is due to doctrine/cache not integrating the MultiGetCache interface
      * in its signature due to BC in 1.x
      *
-     * @var MultiGetCache|\Doctrine\Common\Cache\Cache
+     * @var MultiGetCache|Cache
      */
     protected $cache;
 

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache\Region;
 
 use Doctrine\Common\Cache\Cache as CacheAdapter;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\ClearableCache;
 use Doctrine\ORM\Cache\CacheEntry;
 use Doctrine\ORM\Cache\CacheKey;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
+use function get_class;
+use function sprintf;
 
 /**
  * The simplest cache region compatible with all doctrine-cache drivers.
@@ -54,7 +57,7 @@ class DefaultRegion implements Region
     }
 
     /**
-     * @return \Doctrine\Common\Cache\CacheProvider
+     * @return CacheProvider
      */
     public function getCache()
     {

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -10,6 +10,22 @@ use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\ConcurrentRegion;
 use Doctrine\ORM\Cache\Lock;
 use Doctrine\ORM\Cache\Region;
+use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
+use function array_filter;
+use function array_map;
+use function chmod;
+use function file_get_contents;
+use function file_put_contents;
+use function fileatime;
+use function glob;
+use function is_dir;
+use function is_file;
+use function is_writable;
+use function mkdir;
+use function sprintf;
+use function time;
+use function unlink;
 
 /**
  * Very naive concurrent region, based on file locks.
@@ -19,7 +35,7 @@ class FileLockRegion implements ConcurrentRegion
     public const LOCK_EXTENSION = 'lock';
 
     /**
-     * @var \Doctrine\ORM\Cache\Region
+     * @var Region
      */
     private $region;
 

--- a/lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php
+++ b/lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php
@@ -18,6 +18,6 @@ class UpdateTimestampCache extends DefaultRegion implements TimestampRegion
      */
     public function update(CacheKey $key)
     {
-        $this->put($key, new TimestampCacheEntry);
+        $this->put($key, new TimestampCacheEntry());
     }
 }

--- a/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function microtime;
+
 /**
  * Timestamp cache entry
  */

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache;
 
+use function microtime;
+
 class TimestampQueryCacheValidator implements QueryCacheValidator
 {
     /**
@@ -33,7 +35,6 @@ class TimestampQueryCacheValidator implements QueryCacheValidator
     }
 
     /**
-     *
      * @return bool
      */
     private function regionUpdated(QueryCacheKey $key, QueryCacheEntry $entry)

--- a/lib/Doctrine/ORM/Cache/TimestampRegion.php
+++ b/lib/Doctrine/ORM/Cache/TimestampRegion.php
@@ -12,9 +12,9 @@ interface TimestampRegion extends Region
     /**
      * Update an specific key into the cache region.
      *
-     * @param \Doctrine\ORM\Cache\CacheKey $key The key of the item to update the timestamp.
+     * @param CacheKey $key The key of the item to update the timestamp.
      *
-     * @throws \Doctrine\ORM\Cache\LockException Indicates a problem accessing the region.
+     * @throws LockException Indicates a problem accessing the region.
      */
     public function update(CacheKey $key);
 }

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -28,6 +28,7 @@ use ProxyManager\Factory\LazyLoadingGhostFactory;
 use ProxyManager\FileLocator\FileLocator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
+use function strtolower;
 
 /**
  * Configuration container for all configuration options of Doctrine.
@@ -326,7 +327,7 @@ class Configuration extends DBALConfiguration
      */
     public function addCustomStringFunction(string $functionName, $classNameOrFactory) : void
     {
-        $this->customStringFunctions[\strtolower($functionName)] = $classNameOrFactory;
+        $this->customStringFunctions[strtolower($functionName)] = $classNameOrFactory;
     }
 
     /**
@@ -336,7 +337,7 @@ class Configuration extends DBALConfiguration
      */
     public function getCustomStringFunction(string $functionName)
     {
-        return $this->customStringFunctions[\strtolower($functionName)] ?? null;
+        return $this->customStringFunctions[strtolower($functionName)] ?? null;
     }
 
     /**
@@ -367,7 +368,7 @@ class Configuration extends DBALConfiguration
      */
     public function addCustomNumericFunction(string $functionName, $classNameOrFactory) : void
     {
-        $this->customNumericFunctions[\strtolower($functionName)] = $classNameOrFactory;
+        $this->customNumericFunctions[strtolower($functionName)] = $classNameOrFactory;
     }
 
     /**
@@ -377,7 +378,7 @@ class Configuration extends DBALConfiguration
      */
     public function getCustomNumericFunction(string $functionName)
     {
-        return $this->customNumericFunctions[\strtolower($functionName)] ?? null;
+        return $this->customNumericFunctions[strtolower($functionName)] ?? null;
     }
 
     /**
@@ -408,7 +409,7 @@ class Configuration extends DBALConfiguration
      */
     public function addCustomDatetimeFunction(string $functionName, $classNameOrFactory)
     {
-        $this->customDatetimeFunctions[\strtolower($functionName)] = $classNameOrFactory;
+        $this->customDatetimeFunctions[strtolower($functionName)] = $classNameOrFactory;
     }
 
     /**
@@ -418,7 +419,7 @@ class Configuration extends DBALConfiguration
      */
     public function getCustomDatetimeFunction(string $functionName)
     {
-        return $this->customDatetimeFunctions[\strtolower($functionName)] ?? null;
+        return $this->customDatetimeFunctions[strtolower($functionName)] ?? null;
     }
 
     /**

--- a/lib/Doctrine/ORM/Configuration/MetadataConfiguration.php
+++ b/lib/Doctrine/ORM/Configuration/MetadataConfiguration.php
@@ -9,6 +9,9 @@ use Doctrine\ORM\Mapping\Factory\AbstractClassMetadataFactory;
 use Doctrine\ORM\Mapping\Factory\ClassMetadataResolver;
 use Doctrine\ORM\Mapping\Factory\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\Factory\NamingStrategy;
+use const DIRECTORY_SEPARATOR;
+use function ltrim;
+use function rtrim;
 
 /**
  * Configuration container for class metadata options of Doctrine.

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\Proxy\Factory\ProxyFactory;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\FilterCollection;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use ProxyManager\Proxy\GhostObjectInterface;
@@ -19,14 +25,14 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Returns the cache API for managing the second level cache regions or NULL if the cache is not enabled.
      *
-     * @return \Doctrine\ORM\Cache|null
+     * @return Cache|null
      */
     public function getCache();
 
     /**
      * Gets the database connection object used by the EntityManager.
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
     public function getConnection();
 
@@ -42,7 +48,7 @@ interface EntityManagerInterface extends ObjectManager
      *         ->where($expr->orX($expr->eq('u.id', 1), $expr->eq('u.id', 2)));
      * </code>
      *
-     * @return \Doctrine\ORM\Query\Expr
+     * @return Expr
      */
     public function getExpressionBuilder();
 
@@ -188,7 +194,7 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Gets the EventManager used by the EntityManager.
      *
-     * @return \Doctrine\Common\EventManager
+     * @return EventManager
      */
     public function getEventManager();
 
@@ -223,7 +229,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @param int $hydrationMode
      *
-     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return AbstractHydrator
      */
     public function getHydrator($hydrationMode);
 
@@ -232,7 +238,7 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @param int $hydrationMode
      *
-     * @return \Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @return AbstractHydrator
      *
      * @throws ORMException
      */
@@ -241,14 +247,14 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Gets the proxy factory used by the EntityManager to create entity proxies.
      *
-     * @return \Doctrine\ORM\Proxy\Factory\ProxyFactory
+     * @return ProxyFactory
      */
     public function getProxyFactory();
 
     /**
      * Gets the enabled filters.
      *
-     * @return \Doctrine\ORM\Query\FilterCollection The active filter collection.
+     * @return FilterCollection The active filter collection.
      */
     public function getFilters();
 

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use function implode;
+
 /**
  * Exception thrown when a Proxy fails to retrieve an Entity result.
  */

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Util\Inflector;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use function array_slice;
+use function lcfirst;
+use function sprintf;
+use function strpos;
+use function substr;
 
 /**
  * An EntityRepository serves as a repository for entities with generic as well as
@@ -30,7 +37,7 @@ class EntityRepository implements ObjectRepository, Selectable
     protected $em;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     protected $class;
 
@@ -247,7 +254,7 @@ class EntityRepository implements ObjectRepository, Selectable
      * Select all elements from a selectable that match the expression and
      * return a new collection containing these elements.
      *
-     * @return \Doctrine\Common\Collections\Collection|object[]
+     * @return Collection|object[]
      */
     public function matching(Criteria $criteria)
     {

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs as BaseLifecycleEventArgs;
+use Doctrine\ORM\EntityManagerInterface;
 
 /**
  * Lifecycle Events are triggered by the UnitOfWork during lifecycle transitions
@@ -27,7 +28,7 @@ class LifecycleEventArgs extends BaseLifecycleEventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ORM/Event/ListenersInvoker.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\EntityListenerResolver;
 
 /**
  * A method invoker based on entity lifecycle.
@@ -19,14 +21,14 @@ class ListenersInvoker
     public const INVOKE_MANAGER   = 4;
 
     /**
-     * @var \Doctrine\ORM\Mapping\EntityListenerResolver The Entity listener resolver.
+     * @var EntityListenerResolver The Entity listener resolver.
      */
     private $resolver;
 
     /**
      * The EventManager used for dispatching events.
      *
-     * @var \Doctrine\Common\EventManager
+     * @var EventManager
      */
     private $eventManager;
 
@@ -42,8 +44,8 @@ class ListenersInvoker
     /**
      * Get the subscribed event systems
      *
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata  The entity metadata.
-     * @param string                              $eventName The entity lifecycle event.
+     * @param ClassMetadata $metadata  The entity metadata.
+     * @param string        $eventName The entity lifecycle event.
      *
      * @return int Bitmask of subscribed event systems.
      */
@@ -69,11 +71,11 @@ class ListenersInvoker
     /**
      * Dispatches the lifecycle event of the given entity.
      *
-     * @param \Doctrine\ORM\Mapping\ClassMetadata $metadata  The entity metadata.
-     * @param string                              $eventName The entity lifecycle event.
-     * @param object                              $entity    The Entity on which the event occurred.
-     * @param \Doctrine\Common\EventArgs          $event     The Event args.
-     * @param int                                 $invoke    Bitmask to invoke listeners.
+     * @param ClassMetadata $metadata  The entity metadata.
+     * @param string        $eventName The entity lifecycle event.
+     * @param object        $entity    The Entity on which the event occurred.
+     * @param EventArgs     $event     The Event args.
+     * @param int           $invoke    Bitmask to invoke listeners.
      */
     public function invoke(ClassMetadata $metadata, $eventName, $entity, EventArgs $event, $invoke)
     {

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -24,9 +24,6 @@ class LoadClassMetadataEventArgs extends EventArgs
      */
     private $entityManager;
 
-    /**
-     * Constructor.
-     */
     public function __construct(ClassMetadata $classMetadata, EntityManagerInterface $entityManager)
     {
         $this->classMetadata = $classMetadata;

--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -32,9 +32,6 @@ class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
      */
     private $foundMetadata;
 
-    /**
-     * Constructor.
-     */
     public function __construct(
         string $className,
         ClassMetadataBuildingContext $metadataBuildingContext,

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -17,9 +17,6 @@ class OnClearEventArgs extends EventArgs
      */
     private $em;
 
-    /**
-     * Constructor.
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
@@ -28,7 +25,7 @@ class OnClearEventArgs extends EventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -17,9 +17,6 @@ class OnFlushEventArgs extends EventArgs
      */
     private $em;
 
-    /**
-     * Constructor.
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
@@ -28,7 +25,7 @@ class OnFlushEventArgs extends EventArgs
     /**
      * Retrieve associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -13,13 +13,10 @@ use Doctrine\ORM\EntityManagerInterface;
 class PostFlushEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
-    /**
-     * Constructor.
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
@@ -28,7 +25,7 @@ class PostFlushEventArgs extends EventArgs
     /**
      * Retrieves associated EntityManager.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -13,20 +13,17 @@ use Doctrine\ORM\EntityManagerInterface;
 class PreFlushEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
-    /**
-     * Constructor.
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;
     }
 
     /**
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManagerInterface;
+use function get_class;
+use function sprintf;
 
 /**
  * Class that holds event arguments for a preInsert/preUpdate event.
@@ -17,8 +19,6 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     private $entityChangeSet;
 
     /**
-     * Constructor.
-     *
      * @param object  $entity
      * @param mixed[] $changeSet
      */

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal;
 
+use function array_reverse;
+
 /**
  * CommitOrderCalculator implements topological sorting, which is an ordering
  * algorithm for directed graphs (DG) and/or directed acyclic graphs (DAG) by

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\ORM\UnitOfWork;
 use PDO;
+use function array_merge;
 
 /**
  * Base class for all hydrators. A hydrator is a class that provides some form
@@ -18,7 +23,7 @@ abstract class AbstractHydrator
     /**
      * The ResultSetMapping.
      *
-     * @var \Doctrine\ORM\Query\ResultSetMapping
+     * @var ResultSetMapping
      */
     protected $rsm;
 
@@ -32,14 +37,14 @@ abstract class AbstractHydrator
     /**
      * The dbms Platform instance.
      *
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     protected $platform;
 
     /**
      * The UnitOfWork of the associated EntityManager.
      *
-     * @var \Doctrine\ORM\UnitOfWork
+     * @var UnitOfWork
      */
     protected $uow;
 
@@ -60,7 +65,7 @@ abstract class AbstractHydrator
     /**
      * The statement that provides the data to hydrate.
      *
-     * @var \Doctrine\DBAL\Driver\Statement
+     * @var Statement
      */
     protected $stmt;
 
@@ -368,7 +373,7 @@ abstract class AbstractHydrator
                 // the current discriminator value must be saved in order to disambiguate fields hydration,
                 // should there be field name collisions
                 if ($classMetadata->getParent() && isset($this->rsm->discriminatorColumns[$ownerMap])) {
-                    return $this->cache[$key] = \array_merge(
+                    return $this->cache[$key] = array_merge(
                         $columnInfo,
                         [
                             'discriminatorColumn' => $this->rsm->discriminatorColumns[$ownerMap],
@@ -427,7 +432,7 @@ abstract class AbstractHydrator
      *
      * @param string $className
      *
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     protected function getClassMetadata($className)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -6,6 +6,11 @@ namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use PDO;
+use function count;
+use function end;
+use function is_array;
+use function key;
+use function reset;
 
 /**
  * The ArrayHydrator produces a nested array "graph" that is often (not always)
@@ -237,7 +242,7 @@ class ArrayHydrator extends AbstractHydrator
                 $args  = $newObject['args'];
                 $obj   = $class->newInstanceArgs($args);
 
-                if ($onlyOneRootAlias || \count($args) === $scalarCount) {
+                if ($onlyOneRootAlias || count($args) === $scalarCount) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\ORMException;
+use function implode;
+use function sprintf;
 
 class HydrationException extends ORMException
 {

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -11,7 +11,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 class IterableResult implements \Iterator
 {
     /**
-     * @var \Doctrine\ORM\Internal\Hydration\AbstractHydrator
+     * @var AbstractHydrator
      */
     private $hydrator;
 
@@ -31,7 +31,7 @@ class IterableResult implements \Iterator
     private $current;
 
     /**
-     * @param \Doctrine\ORM\Internal\Hydration\AbstractHydrator $hydrator
+     * @param AbstractHydrator $hydrator
      */
     public function __construct($hydrator)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -14,6 +14,11 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use PDO;
 use ProxyManager\Proxy\GhostObjectInterface;
+use function array_fill_keys;
+use function array_keys;
+use function count;
+use function key;
+use function spl_object_id;
 
 /**
  * The ObjectHydrator constructs an object graph out of an SQL result set.
@@ -161,7 +166,7 @@ class ObjectHydrator extends AbstractHydrator
      * @param string        $fieldName      The name of the field on the entity that holds the collection.
      * @param string        $parentDqlAlias Alias of the parent fetch joining this collection.
      *
-     * @return \Doctrine\ORM\PersistentCollection
+     * @return PersistentCollection
      */
     private function initRelatedCollection($entity, $class, $fieldName, $parentDqlAlias)
     {
@@ -539,7 +544,7 @@ class ObjectHydrator extends AbstractHydrator
                 $args  = $newObject['args'];
                 $obj   = $class->newInstanceArgs($args);
 
-                if ($hasNoScalars && \count($rowData['newObjects']) === 1) {
+                if ($hasNoScalars && count($rowData['newObjects']) === 1) {
                     $result[$resultKey] = $obj;
 
                     continue;

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -8,6 +8,12 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Query;
 use PDO;
+use function array_keys;
+use function array_search;
+use function count;
+use function key;
+use function reset;
+use function sprintf;
 
 class SimpleObjectHydrator extends AbstractHydrator
 {

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -6,6 +6,9 @@ namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use function array_shift;
+use function count;
+use function key;
 
 /**
  * Hydrator that hydrates a single scalar value from the result set.

--- a/lib/Doctrine/ORM/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/AbstractClassMetadataFactory.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Reflection\ReflectionService;
 use Doctrine\ORM\Reflection\RuntimeReflectionService;
 use Doctrine\ORM\Utility\StaticClassNameConverter;
 use ReflectionException;
+use function array_reverse;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
@@ -29,7 +30,7 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
     protected $cacheSalt = '$CLASSMETADATA';
 
     /**
-     * @var \Doctrine\Common\Cache\Cache|null
+     * @var Cache|null
      */
     private $cacheDriver;
 

--- a/lib/Doctrine/ORM/Mapping/AssociationMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationMetadata.php
@@ -51,9 +51,6 @@ class AssociationMetadata implements Property
     /** @var CacheMetadata|null */
     private $cache;
 
-    /**
-     * AssociationMetadata constructor.
-     */
     public function __construct(string $name)
     {
         $this->name = $name;

--- a/lib/Doctrine/ORM/Mapping/CacheMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/CacheMetadata.php
@@ -16,10 +16,6 @@ class CacheMetadata
     /** @var string */
     private $region;
 
-    /**
-     * Constructor.
-     *
-     */
     public function __construct(string $usage, string $region)
     {
         $this->usage  = $usage;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -10,6 +10,22 @@ use Doctrine\ORM\Mapping\Factory\NamingStrategy;
 use Doctrine\ORM\Reflection\ReflectionService;
 use Doctrine\ORM\Sequencing\Planning\ValueGenerationPlan;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_diff;
+use function array_filter;
+use function array_intersect;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function count;
+use function explode;
+use function get_class;
+use function in_array;
+use function interface_exists;
+use function is_subclass_of;
+use function method_exists;
+use function spl_object_id;
+use function sprintf;
+use function strpos;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata
@@ -1483,7 +1499,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
      * @param string $class     The listener class.
      * @param string $method    The listener callback method.
      *
-     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws MappingException
      */
     public function addEntityListener(string $eventName, string $class, string $method) : void
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataBuildingContext.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataBuildingContext.php
@@ -50,9 +50,6 @@ class ClassMetadataBuildingContext
      */
     private $inSecondPass = false;
 
-    /**
-     * ClassMetadataBuildingContext constructor.
-     */
     public function __construct(
         AbstractClassMetadataFactory $classMetadataFactory,
         ReflectionService $reflectionService,

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Platforms;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
@@ -16,6 +18,17 @@ use Doctrine\ORM\Sequencing\Planning\CompositeValueGenerationPlan;
 use Doctrine\ORM\Sequencing\Planning\NoopValueGenerationPlan;
 use Doctrine\ORM\Sequencing\Planning\SingleValueGenerationPlan;
 use ReflectionException;
+use function array_map;
+use function class_exists;
+use function count;
+use function end;
+use function explode;
+use function is_subclass_of;
+use function reset;
+use function sprintf;
+use function strpos;
+use function strtolower;
+use function var_export;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the
@@ -30,7 +43,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private $em;
 
     /**
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     private $targetPlatform;
 
@@ -40,7 +53,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private $driver;
 
     /**
-     * @var \Doctrine\Common\EventManager
+     * @var EventManager
      */
     private $evm;
 

--- a/lib/Doctrine/ORM/Mapping/ColumnMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ColumnMetadata.php
@@ -52,8 +52,6 @@ abstract class ColumnMetadata
     protected $unique = false;
 
     /**
-     * ColumnMetadata constructor.
-     *
      * @todo Leverage this implementation instead of default, blank constructor
      */
     /*public function __construct(string $columnName, Type $type)

--- a/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
@@ -36,9 +36,6 @@ abstract class ComponentMetadata
      */
     protected $declaredProperties = [];
 
-    /**
-     * ComponentMetadata constructor.
-     */
     public function __construct(string $className, ClassMetadataBuildingContext $metadataBuildingContext)
     {
         $reflectionService = $metadataBuildingContext->getReflectionService();

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
+use function trim;
+
 /**
  * The default DefaultEntityListener
  */

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
@@ -9,6 +9,28 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
+use function array_diff;
+use function array_intersect;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function class_exists;
+use function constant;
+use function count;
+use function defined;
+use function get_class;
+use function get_declared_classes;
+use function in_array;
+use function is_dir;
+use function is_numeric;
+use function preg_match;
+use function preg_quote;
+use function realpath;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function strtoupper;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EmbeddableClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EmbeddableClassMetadataBinder.php
@@ -37,8 +37,6 @@ class EmbeddableClassMetadataBinder
     private $classMetadata;
 
     /**
-     * ComponentMetadataBinder constructor.
-     *
      * @param Annotation\Annotation[] $classAnnotations
      */
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php
@@ -37,8 +37,6 @@ class EntityClassMetadataBinder
     private $classMetadata;
 
     /**
-     * ComponentMetadataBinder constructor.
-     *
      * @param Annotation\Annotation[] $classAnnotations
      */
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php
@@ -37,8 +37,6 @@ class MappedSuperClassMetadataBinder
     private $classMetadata;
 
     /**
-     * ComponentMetadataBinder constructor.
-     *
      * @param Annotation\Annotation[] $classAnnotations
      */
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -10,6 +10,28 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Annotation;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
+use function array_diff;
+use function array_intersect;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function class_exists;
+use function constant;
+use function count;
+use function defined;
+use function get_class;
+use function get_declared_classes;
+use function in_array;
+use function is_dir;
+use function is_numeric;
+use function preg_match;
+use function preg_quote;
+use function realpath;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function strtoupper;
 
 /**
  * The AnnotationDriver reads the mapping metadata from docblock annotations.

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -14,6 +14,15 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping;
+use function array_diff;
+use function array_keys;
+use function array_merge;
+use function count;
+use function current;
+use function in_array;
+use function sort;
+use function str_replace;
+use function strtolower;
 
 /**
  * The DatabaseDriver reverse engineers the mapping metadata from a database.

--- a/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\ORM\Mapping;
+use function array_keys;
+use function spl_object_id;
+use function strpos;
 
 /**
  * The DriverChain allows you to add multiple other mapping drivers for

--- a/lib/Doctrine/ORM/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/FileDriver.php
@@ -7,6 +7,10 @@ namespace Doctrine\ORM\Mapping\Driver;
 use Doctrine\Common\Persistence\Mapping\Driver\DefaultFileLocator;
 use Doctrine\Common\Persistence\Mapping\Driver\FileLocator;
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use function array_keys;
+use function array_merge;
+use function is_file;
+use function str_replace;
 
 /**
  * Base driver for file-based metadata drivers.

--- a/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
@@ -11,6 +11,22 @@ use Doctrine\ORM\Annotation;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
 use Doctrine\ORM\Mapping\Factory;
+use function array_diff;
+use function array_filter;
+use function array_intersect;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function constant;
+use function count;
+use function defined;
+use function get_class;
+use function in_array;
+use function is_numeric;
+use function sprintf;
+use function str_replace;
+use function strtolower;
+use function strtoupper;
 
 class NewAnnotationDriver implements MappingDriver
 {
@@ -1089,7 +1105,6 @@ class NewAnnotationDriver implements MappingDriver
     }
 
     /**
-     *
      * @return Annotation\Annotation[]
      */
     private function getPropertyAnnotations(\ReflectionProperty $reflectionProperty)
@@ -1108,7 +1123,6 @@ class NewAnnotationDriver implements MappingDriver
     }
 
     /**
-     *
      * @return Annotation\Annotation[]
      */
     private function getMethodAnnotations(\ReflectionMethod $reflectionMethod)

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -8,6 +8,18 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping;
 use SimpleXMLElement;
+use function array_filter;
+use function class_exists;
+use function constant;
+use function explode;
+use function file_get_contents;
+use function get_class;
+use function in_array;
+use function simplexml_load_string;
+use function sprintf;
+use function str_replace;
+use function strtolower;
+use function strtoupper;
 
 /**
  * XmlDriver is a metadata driver that enables mapping through XML files.

--- a/lib/Doctrine/ORM/Mapping/EmbeddedClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/EmbeddedClassMetadata.php
@@ -25,9 +25,6 @@ class EmbeddedClassMetadata extends ComponentMetadata implements Property
     /** @var bool */
     protected $primaryKey = false;
 
-    /**
-     * EmbeddedClassMetadata constructor.
-     */
     public function __construct(string $name, string $className, ?MappedSuperClassMetadata $parent = null)
     {
         parent::__construct($className, $parent);

--- a/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use function sprintf;
+
 /**
  * Class EntityClassMetadata
  *
@@ -103,9 +105,6 @@ abstract class EntityClassMetadata extends ComponentMetadata
      */
     protected $table;
 
-    /**
-     * MappedSuperClassMetadata constructor.
-     */
     public function __construct(string $className, ClassMetadataBuildingContext $metadataBuildingContext)
     {
         parent::__construct($className, $metadataBuildingContext);
@@ -172,7 +171,6 @@ abstract class EntityClassMetadata extends ComponentMetadata
     }
 
     /**
-     *
      * @throws MappingException
      */
     public function addSubClass(SubClassMetadata $subClassMetadata) : void

--- a/lib/Doctrine/ORM/Mapping/Exporter/AssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/AssociationMetadataExporter.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
+use const PHP_EOL;
+use function array_diff;
+use function implode;
+use function str_repeat;
+use function strtoupper;
 
 abstract class AssociationMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/CacheMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/CacheMetadataExporter.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\CacheMetadata;
+use const PHP_EOL;
+use function implode;
+use function sprintf;
+use function str_repeat;
+use function strtoupper;
 
 class CacheMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping;
+use const PHP_EOL;
+use function implode;
+use function sprintf;
+use function str_repeat;
+use function strtoupper;
 
 class ClassMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ColumnMetadataExporter.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ColumnMetadata;
+use const PHP_EOL;
+use function implode;
+use function ltrim;
+use function str_repeat;
 
 abstract class ColumnMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\DiscriminatorColumnMetadata;
+use function assert;
+use function sprintf;
 
 class DiscriminatorColumnMetadataExporter extends LocalColumnMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php
@@ -6,6 +6,10 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
+use const PHP_EOL;
+use function assert;
+use function implode;
+use function sprintf;
 
 class FieldMetadataExporter extends LocalColumnMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php
@@ -6,6 +6,11 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
+use const PHP_EOL;
+use function assert;
+use function implode;
+use function sprintf;
+use function str_repeat;
 
 class JoinColumnMetadataExporter extends ColumnMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php
@@ -6,6 +6,11 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\JoinTableMetadata;
 use Doctrine\ORM\Mapping\TableMetadata;
+use const PHP_EOL;
+use function assert;
+use function implode;
+use function sprintf;
+use function str_repeat;
 
 class JoinTableMetadataExporter extends TableMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/LocalColumnMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/LocalColumnMetadataExporter.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\LocalColumnMetadata;
+use const PHP_EOL;
+use function implode;
+use function sprintf;
+use function str_repeat;
+use function var_export;
 
 abstract class LocalColumnMetadataExporter extends ColumnMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToManyAssociationMetadataExporter.php
@@ -6,6 +6,11 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
+use const PHP_EOL;
+use function assert;
+use function implode;
+use function sprintf;
+use function str_repeat;
 
 class ManyToManyAssociationMetadataExporter extends ToManyAssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ManyToOneAssociationMetadataExporter.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ManyToOneAssociationMetadata;
+use function assert;
+use function sprintf;
 
 class ManyToOneAssociationMetadataExporter extends ToOneAssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToManyAssociationMetadataExporter.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
+use function assert;
+use function sprintf;
 
 class OneToManyAssociationMetadataExporter extends ToManyAssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/OneToOneAssociationMetadataExporter.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
+use function assert;
+use function sprintf;
 
 class OneToOneAssociationMetadataExporter extends ToOneAssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/TableMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/TableMetadataExporter.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\TableMetadata;
+use const PHP_EOL;
+use function implode;
+use function ltrim;
+use function sprintf;
+use function str_repeat;
 
 class TableMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ToManyAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ToManyAssociationMetadataExporter.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
+use const PHP_EOL;
+use function implode;
+use function str_repeat;
 
 abstract class ToManyAssociationMetadataExporter extends AssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/ToOneAssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/ToOneAssociationMetadataExporter.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use const PHP_EOL;
+use function implode;
+use function str_repeat;
 
 abstract class ToOneAssociationMetadataExporter extends AssociationMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/TransientMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/TransientMetadataExporter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\TransientMetadata;
+use function sprintf;
+use function str_repeat;
 
 class TransientMetadataExporter implements Exporter
 {

--- a/lib/Doctrine/ORM/Mapping/Exporter/VariableExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/VariableExporter.php
@@ -4,6 +4,19 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Exporter;
 
+use const PHP_EOL;
+use function array_keys;
+use function array_reduce;
+use function implode;
+use function is_array;
+use function is_numeric;
+use function ltrim;
+use function sprintf;
+use function str_pad;
+use function str_repeat;
+use function strlen;
+use function var_export;
+
 class VariableExporter implements Exporter
 {
     /**

--- a/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Mapping\Exporter;
 
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\VersionFieldMetadata;
+use function assert;
+use function sprintf;
 
 class VersionFieldMetadataExporter extends FieldMetadataExporter
 {

--- a/lib/Doctrine/ORM/Mapping/Factory/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/AbstractClassMetadataFactory.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\Mapping\Factory\Strategy\ConditionalFileWriterClassMetadataGeneratorStrategy;
 use Doctrine\ORM\Reflection\ReflectionService;
 use Doctrine\ORM\Utility\StaticClassNameConverter;
+use function array_reverse;
 
 /**
  * AbstractClassMetadataFactory is the base of ClassMetadata object creation that contain all the metadata mapping
@@ -58,9 +59,6 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     private $loaded = [];
 
-    /**
-     * ClassMetadataFactory constructor.
-     */
     public function __construct(MetadataConfiguration $configuration)
     {
         $mappingDriver = $configuration->getMappingDriver();

--- a/lib/Doctrine/ORM/Mapping/Factory/Autoloader.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Autoloader.php
@@ -5,6 +5,20 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Factory;
 
 use InvalidArgumentException;
+use const DIRECTORY_SEPARATOR;
+use function call_user_func;
+use function file_exists;
+use function get_class;
+use function gettype;
+use function is_callable;
+use function is_object;
+use function ltrim;
+use function spl_autoload_register;
+use function sprintf;
+use function str_replace;
+use function strlen;
+use function strpos;
+use function substr;
 
 class Autoloader
 {

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataBuildingContext.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataBuildingContext.php
@@ -24,9 +24,6 @@ class ClassMetadataBuildingContext
      */
     private $inSecondPass = false;
 
-    /**
-     * ClassMetadataBuildingContext constructor.
-     */
     public function __construct(AbstractClassMetadataFactory $classMetadataFactory)
     {
         $this->classMetadataFactory = $classMetadataFactory;

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinition.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinition.php
@@ -23,9 +23,6 @@ class ClassMetadataDefinition
      */
     public $parentClassMetadata;
 
-    /**
-     * ClassMetadataDefinition constructor.
-     */
     public function __construct(
         string $entityClassName,
         string $metadataClassName,

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinitionFactory.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinitionFactory.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Mapping\Factory;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\Factory\Strategy\ClassMetadataGeneratorStrategy;
+use function class_exists;
 
 class ClassMetadataDefinitionFactory
 {
@@ -19,9 +20,6 @@ class ClassMetadataDefinitionFactory
      */
     private $generatorStrategy;
 
-    /**
-     * ClassMetadataDefinitionFactory constructor.
-     */
     public function __construct(ClassMetadataResolver $resolver, ClassMetadataGeneratorStrategy $generatorStrategy)
     {
         $this->resolver          = $resolver;

--- a/lib/Doctrine/ORM/Mapping/Factory/DefaultClassMetadataResolver.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/DefaultClassMetadataResolver.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Factory;
 
+use const DIRECTORY_SEPARATOR;
+use function ltrim;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+
 class DefaultClassMetadataResolver implements ClassMetadataResolver
 {
     /**
@@ -23,9 +29,6 @@ class DefaultClassMetadataResolver implements ClassMetadataResolver
      */
     private $directory;
 
-    /**
-     * DefaultClassMetadataResolver constructor.
-     */
     public function __construct(string $namespace, string $directory)
     {
         $this->namespace = ltrim($namespace, '\\');

--- a/lib/Doctrine/ORM/Mapping/Factory/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/DefaultNamingStrategy.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Factory;
 
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function substr;
+
 /**
  * The default NamingStrategy
  */

--- a/lib/Doctrine/ORM/Mapping/Factory/Strategy/ConditionalFileWriterClassMetadataGeneratorStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Strategy/ConditionalFileWriterClassMetadataGeneratorStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping\Factory\Strategy;
 
 use Doctrine\ORM\Mapping\Factory\ClassMetadataDefinition;
+use function file_exists;
 
 class ConditionalFileWriterClassMetadataGeneratorStrategy extends FileWriterClassMetadataGeneratorStrategy
 {

--- a/lib/Doctrine/ORM/Mapping/Factory/Strategy/EvaluatingClassMetadataGeneratorStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Strategy/EvaluatingClassMetadataGeneratorStrategy.php
@@ -14,9 +14,6 @@ class EvaluatingClassMetadataGeneratorStrategy implements ClassMetadataGenerator
      */
     private $generator;
 
-    /**
-     * EvaluatingClassMetadataGeneratorStrategy constructor.
-     */
     public function __construct(ClassMetadataGenerator $generator)
     {
         $this->generator = $generator;

--- a/lib/Doctrine/ORM/Mapping/Factory/Strategy/FileWriterClassMetadataGeneratorStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Strategy/FileWriterClassMetadataGeneratorStrategy.php
@@ -6,6 +6,15 @@ namespace Doctrine\ORM\Mapping\Factory\Strategy;
 
 use Doctrine\ORM\Mapping\Factory\ClassMetadataDefinition;
 use Doctrine\ORM\Mapping\Factory\ClassMetadataGenerator;
+use function chmod;
+use function dirname;
+use function file_put_contents;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function rename;
+use function sprintf;
+use function uniqid;
 
 class FileWriterClassMetadataGeneratorStrategy implements ClassMetadataGeneratorStrategy
 {
@@ -14,9 +23,6 @@ class FileWriterClassMetadataGeneratorStrategy implements ClassMetadataGenerator
      */
     private $generator;
 
-    /**
-     * FileWriterDefinitionGeneratorStrategy constructor.
-     */
     public function __construct(ClassMetadataGenerator $generator)
     {
         $this->generator = $generator;

--- a/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping\Factory;
 
+use const CASE_LOWER;
+use const CASE_UPPER;
+use function preg_replace;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function strtoupper;
+use function substr;
+
 /**
  * Naming strategy implementing the underscore naming convention.
  * Converts 'MyEntity' to 'my_entity' or 'MY_ENTITY'.

--- a/lib/Doctrine/ORM/Mapping/FieldMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMetadata.php
@@ -22,8 +22,6 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     protected $name;
 
     /**
-     * FieldMetadata constructor.
-     *
      * @param string $columnName
      * @param Type   $type
      *

--- a/lib/Doctrine/ORM/Mapping/JoinColumnMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumnMetadata.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
+use function strtoupper;
+
 /**
  * Class JoinColumnMetadata
  */

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\ORM\ORMException;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function get_parent_class;
+use function implode;
+use function sprintf;
 
 /**
  * A MappingException indicates that something is wrong with the mapping setup.

--- a/lib/Doctrine/ORM/Mapping/TableMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/TableMetadata.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use function sprintf;
 
 /**
  * Class TableMetadata
@@ -28,9 +29,6 @@ class TableMetadata
     /** @var mixed[][] */
     protected $uniqueConstraints = [];
 
-    /**
-     * TableMetadata constructor.
-     */
     public function __construct(?string $name = null, ?string $schema = null)
     {
         $this->name   = $name;

--- a/lib/Doctrine/ORM/Mapping/TransientMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/TransientMetadata.php
@@ -20,9 +20,6 @@ class TransientMetadata implements Property
     /** @var string */
     protected $name;
 
-    /**
-     * TransientMetadata constructor.
-     */
     public function __construct(string $name)
     {
         $this->name = $name;

--- a/lib/Doctrine/ORM/Mapping/ValueGeneratorMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ValueGeneratorMetadata.php
@@ -16,8 +16,6 @@ class ValueGeneratorMetadata
     protected $definition;
 
     /**
-     * ValueGeneratorMetadata constructor.
-     *
      * @param mixed[] $definition
      */
     public function __construct(string $type, array $definition = [])

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM;
 
+use function array_values;
+use function is_int;
+use function key;
+use function ksort;
+
 /**
  * Represents a native SQL query.
  */

--- a/lib/Doctrine/ORM/NoResultException.php
+++ b/lib/Doctrine/ORM/NoResultException.php
@@ -9,9 +9,6 @@ namespace Doctrine\ORM;
  */
 class NoResultException extends UnexpectedResultException
 {
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
         parent::__construct('No result was found for query although at least one row was expected.');

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -6,6 +6,9 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache as CacheDriver;
 use Exception;
+use function get_class;
+use function implode;
+use function sprintf;
 
 /**
  * Base exception class for all ORM exceptions.
@@ -57,7 +60,7 @@ class ORMException extends Exception
      * @param string $given
      * @param string $expected
      *
-     * @return \Doctrine\ORM\ORMInvalidArgumentException
+     * @return ORMInvalidArgumentException
      */
     public static function unexpectedAssociationValue($class, $association, $given, $expected)
     {

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -6,6 +6,16 @@ namespace Doctrine\ORM;
 
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use function array_map;
+use function count;
+use function get_class;
+use function gettype;
+use function implode;
+use function is_object;
+use function method_exists;
+use function reset;
+use function spl_object_id;
+use function sprintf;
 
 /**
  * Contains exception messages for all invalid lifecycle state exceptions inside UnitOfWork

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -16,6 +16,14 @@ use Doctrine\ORM\Mapping\FetchMode;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
+use function array_combine;
+use function array_diff_key;
+use function array_map;
+use function array_values;
+use function array_walk;
+use function get_class;
+use function is_object;
+use function spl_object_id;
 
 /**
  * A PersistentCollection represents a collection of elements that have persistent state.
@@ -54,7 +62,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * The EntityManager that manages the persistence of the collection.
      *
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
@@ -229,9 +237,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     {
         $collectionItems = $this->collection->toArray();
 
-        return \array_values(\array_diff_key(
-            \array_combine(\array_map('spl_object_id', $this->snapshot), $this->snapshot),
-            \array_combine(\array_map('spl_object_id', $collectionItems), $collectionItems)
+        return array_values(array_diff_key(
+            array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot),
+            array_combine(array_map('spl_object_id', $collectionItems), $collectionItems)
         ));
     }
 
@@ -245,9 +253,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     {
         $collectionItems = $this->collection->toArray();
 
-        return \array_values(\array_diff_key(
-            \array_combine(\array_map('spl_object_id', $collectionItems), $collectionItems),
-            \array_combine(\array_map('spl_object_id', $this->snapshot), $this->snapshot)
+        return array_values(array_diff_key(
+            array_combine(array_map('spl_object_id', $collectionItems), $collectionItems),
+            array_combine(array_map('spl_object_id', $this->snapshot), $this->snapshot)
         ));
     }
 
@@ -667,7 +675,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * Retrieves the wrapped Collection instance.
      *
-     * @return \Doctrine\Common\Collections\Collection|object[]
+     * @return Collection|object[]
      */
     public function unwrap()
     {
@@ -706,13 +714,13 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     private function restoreNewObjectsInDirtyCollection(array $newObjects) : void
     {
         $loadedObjects               = $this->collection->toArray();
-        $newObjectsByOid             = \array_combine(\array_map('spl_object_id', $newObjects), $newObjects);
-        $loadedObjectsByOid          = \array_combine(\array_map('spl_object_id', $loadedObjects), $loadedObjects);
-        $newObjectsThatWereNotLoaded = \array_diff_key($newObjectsByOid, $loadedObjectsByOid);
+        $newObjectsByOid             = array_combine(array_map('spl_object_id', $newObjects), $newObjects);
+        $loadedObjectsByOid          = array_combine(array_map('spl_object_id', $loadedObjects), $loadedObjects);
+        $newObjectsThatWereNotLoaded = array_diff_key($newObjectsByOid, $loadedObjectsByOid);
 
         if ($newObjectsThatWereNotLoaded) {
             // Reattach NEW objects added through add(), if any.
-            \array_walk($newObjectsThatWereNotLoaded, [$this->collection, 'add']);
+            array_walk($newObjectsThatWereNotLoaded, [$this->collection, 'add']);
 
             $this->isDirty = true;
         }

--- a/lib/Doctrine/ORM/PersistentObject.php
+++ b/lib/Doctrine/ORM/PersistentObject.php
@@ -11,6 +11,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use function get_class;
+use function lcfirst;
+use function substr;
 
 /**
  * PersistentObject base class that implements getter/setter methods for all mapped fields and associations

--- a/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Persisters\Collection;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\UnitOfWork;
 
@@ -19,7 +21,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
     protected $em;
 
     /**
-     * @var \Doctrine\DBAL\Connection
+     * @var Connection
      */
     protected $conn;
 
@@ -31,7 +33,7 @@ abstract class AbstractCollectionPersister implements CollectionPersister
     /**
      * The database platform.
      *
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     protected $platform;
 

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
@@ -15,6 +16,13 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_fill;
+use function count;
+use function get_class;
+use function implode;
+use function in_array;
+use function reset;
+use function sprintf;
 
 /**
  * Persister for many-to-many collections.
@@ -845,7 +853,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
     /**
      * @return string
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     private function getLimitSql(Criteria $criteria)
     {

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_reverse;
+use function array_values;
+use function implode;
+use function sprintf;
 
 /**
  * Persister for one-to-many collections.
@@ -176,7 +184,7 @@ class OneToManyPersister extends AbstractCollectionPersister
     /**
      * @return int
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     private function deleteEntityCollection(PersistentCollection $collection)
     {
@@ -207,7 +215,7 @@ class OneToManyPersister extends AbstractCollectionPersister
      *
      * @return int
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     private function deleteJoinedEntityCollection(PersistentCollection $collection)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
+use function sprintf;
 
 /**
  * Base class for entity persisters that implement a certain inheritance mapping strategy.

--- a/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
@@ -22,14 +22,14 @@ class CachedPersisterContext
     /**
      * Metadata object that describes the mapping of the mapped entity class.
      *
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     public $class;
 
     /**
      * ResultSetMapping that is used for all queries. Is generated lazily once per request.
      *
-     * @var \Doctrine\ORM\Query\ResultSetMapping
+     * @var ResultSetMapping
      */
     public $rsm;
 

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -6,10 +6,13 @@ namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\AssociationMetadata;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
+use Doctrine\ORM\Query\ResultSetMapping;
 
 /**
  * Entity persister interface
@@ -18,14 +21,14 @@ use Doctrine\ORM\PersistentCollection;
 interface EntityPersister
 {
     /**
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     public function getClassMetadata();
 
     /**
      * Gets the ResultSetMapping used for hydration.
      *
-     * @return \Doctrine\ORM\Query\ResultSetMapping
+     * @return ResultSetMapping
      */
     public function getResultSetMapping();
 
@@ -263,7 +266,7 @@ interface EntityPersister
      *
      * @return object The loaded and managed entity instance or NULL if the entity can not be found.
      *
-     * @throws \Doctrine\ORM\Mapping\MappingException
+     * @throws MappingException
      */
     public function loadToOneEntity(
         ToOneAssociationMetadata $association,

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
@@ -16,6 +17,10 @@ use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Mapping\VersionFieldMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_combine;
+use function array_keys;
+use function implode;
+use function is_array;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -89,7 +94,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Execute inserts on subtables.
         // The order doesn't matter because all child tables link to the root table via FK.
         foreach ($subTableStmts as $tableName => $stmt) {
-            /** @var \Doctrine\DBAL\Statement $stmt */
+            /** @var Statement $stmt */
             $paramIndex = 1;
             $data       = $insertData[$tableName] ?? [];
 

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -11,6 +11,9 @@ use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_flip;
+use function implode;
+use function sprintf;
 
 /**
  * Persister for entities that participate in a hierarchy mapped with the

--- a/lib/Doctrine/ORM/Persisters/PersisterException.php
+++ b/lib/Doctrine/ORM/Persisters/PersisterException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters;
 
 use Doctrine\ORM\ORMException;
+use function sprintf;
 
 class PersisterException extends ORMException
 {

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -11,6 +11,9 @@ use Doctrine\Common\Collections\Expr\Value;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
+use function implode;
+use function in_array;
+use function is_object;
 
 /**
  * Visit Expressions and generate SQL WHERE conditions from them.
@@ -18,12 +21,12 @@ use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 class SqlExpressionVisitor extends ExpressionVisitor
 {
     /**
-     * @var \Doctrine\ORM\Persisters\Entity\BasicEntityPersister
+     * @var BasicEntityPersister
      */
     private $persister;
 
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     private $classMetadata;
 

--- a/lib/Doctrine/ORM/Proxy/Factory/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/Factory/ProxyFactory.php
@@ -39,7 +39,7 @@ interface ProxyFactory
     public const AUTOGENERATE_EVAL = 3;
 
     /**
-     * @param \Doctrine\ORM\Mapping\ClassMetadata[] $classes
+     * @param ClassMetadata[] $classes
      */
     public function generateProxyClasses(array $classes) : int;
 

--- a/lib/Doctrine/ORM/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/Factory/StaticProxyFactory.php
@@ -11,6 +11,9 @@ use Doctrine\ORM\Mapping\TransientMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use ProxyManager\Factory\LazyLoadingGhostFactory;
 use ProxyManager\Proxy\GhostObjectInterface;
+use function array_filter;
+use function array_merge;
+use function count;
 
 /**
  * Static factory for proxy objects.
@@ -61,7 +64,7 @@ final class StaticProxyFactory implements ProxyFactory
      */
     public function generateProxyClasses(array $classes) : int
     {
-        $concreteClasses = \array_filter($classes, function (ClassMetadata $metadata) : bool {
+        $concreteClasses = array_filter($classes, function (ClassMetadata $metadata) : bool {
             return ! ($metadata->isMappedSuperclass || $metadata->getReflectionClass()->isAbstract());
         });
 
@@ -77,13 +80,13 @@ final class StaticProxyFactory implements ProxyFactory
                 );
         }
 
-        return \count($concreteClasses);
+        return count($concreteClasses);
     }
 
     /**
      * {@inheritdoc}
      *
-     * @throws \Doctrine\ORM\EntityNotFoundException
+     * @throws EntityNotFoundException
      */
     public function getProxy(ClassMetadata $metadata, array $identifier) : GhostObjectInterface
     {
@@ -149,7 +152,7 @@ final class StaticProxyFactory implements ProxyFactory
      */
     private function skippedFieldsFqns(ClassMetadata $metadata) : array
     {
-        return \array_merge(
+        return array_merge(
             $this->identifierFieldFqns($metadata),
             $this->transientFieldsFqns($metadata)
         );

--- a/lib/Doctrine/ORM/Query/AST/ASTException.php
+++ b/lib/Doctrine/ORM/Query/AST/ASTException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;
+use function get_class;
 
 /**
  * Base exception class for AST exceptions.

--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
@@ -14,7 +15,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class AbsFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression
+     * @var SimpleArithmeticExpression
      */
     public $simpleArithmeticExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use function call_user_func_array;
 
 /**
  * "CONCAT" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use function strtolower;
 
 /**
  * "DATE_ADD" "(" ArithmeticPrimary "," ArithmeticPrimary "," StringPrimary ")"

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use function strtolower;
 
 /**
  * "DATE_SUB(date1, interval, unit)"

--- a/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
@@ -27,13 +27,12 @@ abstract class FunctionNode extends Node
     }
 
     /**
-     *
      * @return string
      */
     abstract public function getSql(SqlWalker $sqlWalker);
 
     /**
-     * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker
+     * @param SqlWalker $sqlWalker
      *
      * @return string
      */
@@ -43,7 +42,6 @@ abstract class FunctionNode extends Node
     }
 
     /**
-     *
      * @return void
      */
     abstract public function parse(Parser $parser);

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\SqlWalker;
+use function reset;
+use function sprintf;
 
 /**
  * "IDENTITY" "(" SingleValuedAssociationPathExpression {"," string} ")"
@@ -15,7 +18,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class IdentityFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\PathExpression
+     * @var PathExpression
      */
     public $pathExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
@@ -21,7 +22,7 @@ class LocateFunction extends FunctionNode
     public $secondStringPrimary;
 
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression|bool
+     * @var SimpleArithmeticExpression|bool
      */
     public $simpleArithmeticExpression = false;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
@@ -14,12 +15,12 @@ use Doctrine\ORM\Query\SqlWalker;
 class ModFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression
+     * @var SimpleArithmeticExpression
      */
     public $firstSimpleArithmeticExpression;
 
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression
+     * @var SimpleArithmeticExpression
      */
     public $secondSimpleArithmeticExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
+use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use function sprintf;
 
 /**
  * "SIZE" "(" CollectionValuedPathExpression ")"
@@ -15,7 +17,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class SizeFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\PathExpression
+     * @var PathExpression
      */
     public $collectionPathExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
@@ -14,7 +15,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class SqrtFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression
+     * @var SimpleArithmeticExpression
      */
     public $simpleArithmeticExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
@@ -18,12 +19,12 @@ class SubstringFunction extends FunctionNode
     public $stringPrimary;
 
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression
+     * @var SimpleArithmeticExpression
      */
     public $firstSimpleArithmeticExpression;
 
     /**
-     * @var \Doctrine\ORM\Query\AST\SimpleArithmeticExpression|null
+     * @var SimpleArithmeticExpression|null
      */
     public $secondSimpleArithmeticExpression;
 

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use function strcasecmp;
 
 /**
  * "TRIM" "(" [["LEADING" | "TRAILING" | "BOTH"] [char] "FROM"] StringPrimary ")"
@@ -35,7 +37,7 @@ class TrimFunction extends FunctionNode
     public $trimChar = false;
 
     /**
-     * @var \Doctrine\ORM\Query\AST\Node
+     * @var Node
      */
     public $stringPrimary;
 

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;
+use function is_numeric;
+use function strlen;
+use function substr;
 
 /**
  * Description of InputParameter.
@@ -24,7 +27,7 @@ class InputParameter extends Node
     /**
      * @param string $value
      *
-     * @throws \Doctrine\ORM\Query\QueryException
+     * @throws QueryException
      */
     public function __construct($value)
     {

--- a/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
@@ -20,8 +20,6 @@ class JoinVariableDeclaration extends Node
     public $indexBy;
 
     /**
-     * Constructor.
-     *
      * @param Join         $join
      * @param IndexBy|null $indexBy
      */

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use Doctrine\ORM\Query\SqlWalker;
+use const PHP_EOL;
+use function get_class;
+use function get_object_vars;
+use function is_array;
+use function is_object;
+use function str_repeat;
+use function var_export;
+
 /**
  * Abstract class of an AST node.
  */
@@ -14,7 +23,7 @@ abstract class Node
      *
      * Implementation is not mandatory for all nodes.
      *
-     * @param \Doctrine\ORM\Query\SqlWalker $walker
+     * @param SqlWalker $walker
      *
      * @throws ASTException
      */

--- a/lib/Doctrine/ORM/Query/AST/OrderByItem.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByItem.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use function strtoupper;
+
 /**
  * OrderByItem ::= (ResultVariable | StateFieldPathExpression) ["ASC" | "DESC"]
  */

--- a/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
@@ -10,7 +10,7 @@ namespace Doctrine\ORM\Query\AST;
 class ParenthesisExpression extends Node
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\Node
+     * @var Node
      */
     public $expression;
 

--- a/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\AST;
 
+use function strtoupper;
+
 /**
  * QuantifiedExpression ::= ("ALL" | "ANY" | "SOME") "(" Subselect ")"
  */

--- a/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
@@ -20,8 +20,6 @@ class SubselectIdentificationVariableDeclaration
     public $aliasIdentificationVariable;
 
     /**
-     * Constructor.
-     *
      * @param PathExpression $associationPathExpression
      * @param string         $aliasIdentificationVariable
      */

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
 
 /**
  * Base class for SQL statement executors.
@@ -53,7 +54,7 @@ abstract class AbstractSqlExecutor
      * @param mixed[]    $params The parameters.
      * @param mixed[]    $types  The parameter types.
      *
-     * @return \Doctrine\DBAL\Driver\Statement
+     * @return Statement
      */
     abstract public function execute(Connection $conn, array $params, array $types);
 }

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -6,7 +6,15 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query\AST;
+use Doctrine\ORM\Query\AST\Node;
+use Doctrine\ORM\Query\SqlWalker;
 use Throwable;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_reverse;
+use function implode;
+use function sprintf;
 
 /**
  * Executes the SQL statements for bulk DQL DELETE statements on classes in
@@ -35,8 +43,8 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
      * {@internal Any SQL construction and preparation takes place in the constructor for
      *            best performance. With a query cache the executor will be cached. }}
      *
-     * @param \Doctrine\ORM\Query\AST\Node  $AST       The root AST node of the DQL query.
-     * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker The walker used for SQL generation from the AST.
+     * @param Node      $AST       The root AST node of the DQL query.
+     * @param SqlWalker $sqlWalker The walker used for SQL generation from the AST.
      */
     public function __construct(AST\Node $AST, $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -6,8 +6,17 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query\AST;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\ParameterTypeInferer;
+use Doctrine\ORM\Query\SqlWalker;
 use Throwable;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_reverse;
+use function array_slice;
+use function implode;
+use function sprintf;
 
 /**
  * Executes the SQL statements for bulk DQL UPDATE statements on classes in
@@ -46,8 +55,8 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
      * {@internal Any SQL construction and preparation takes place in the constructor for
      *            best performance. With a query cache the executor will be cached. }}
      *
-     * @param \Doctrine\ORM\Query\AST\Node  $AST       The root AST node of the DQL query.
-     * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker The walker used for SQL generation from the AST.
+     * @param Node      $AST       The root AST node of the DQL query.
+     * @param SqlWalker $sqlWalker The walker used for SQL generation from the AST.
      */
     public function __construct(AST\Node $AST, $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Query\AST;
+use Doctrine\ORM\Query\SqlWalker;
 
 /**
  * Executor that executes the SQL statements for DQL DELETE/UPDATE statements on classes
@@ -14,7 +15,7 @@ use Doctrine\ORM\Query\AST;
 class SingleTableDeleteUpdateExecutor extends AbstractSqlExecutor
 {
     /**
-     * @param \Doctrine\ORM\Query\SqlWalker $sqlWalker
+     * @param SqlWalker $sqlWalker
      */
     public function __construct(AST\Node $AST, $sqlWalker)
     {

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use function func_get_args;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_numeric;
+use function is_string;
+use function str_replace;
+
 /**
  * This class is used to generate DQL expressions via a set of PHP static functions.
  * @todo Rename: ExpressionBuilder

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use function count;
+use function get_class;
+use function implode;
+use function in_array;
+use function is_string;
+use function sprintf;
+
 /**
  * Abstract base Expr class for building DQL parts.
  */
@@ -88,7 +95,7 @@ abstract class Base
      */
     public function count()
     {
-        return \count($this->parts);
+        return count($this->parts);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use function implode;
+use function is_object;
+use function stripos;
+
 /**
  * Expression class for building DQL and parts.
  */

--- a/lib/Doctrine/ORM/Query/Expr/Func.php
+++ b/lib/Doctrine/ORM/Query/Expr/Func.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use function implode;
+
 /**
  * Expression class for generating DQL functions.
  */

--- a/lib/Doctrine/ORM/Query/Expr/Join.php
+++ b/lib/Doctrine/ORM/Query/Expr/Join.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use function strtoupper;
+
 /**
  * Expression class for DQL join.
  */

--- a/lib/Doctrine/ORM/Query/Expr/OrderBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/OrderBy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Expr;
 
+use function count;
+use function implode;
+
 /**
  * Expression class for building DQL Order By parts.
  */
@@ -60,7 +63,7 @@ class OrderBy
      */
     public function count()
     {
-        return \count($this->parts);
+        return count($this->parts);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query\Filter;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ParameterTypeInferer;
+use function ksort;
+use function serialize;
 
 /**
  * The base class that user defined filters should extend.
@@ -113,7 +116,7 @@ abstract class SQLFilter
     /**
      * Returns the database connection used by the entity manager
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
     final protected function getConnection()
     {

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+use function ksort;
 
 /**
  * Collection class for all the query filters.
@@ -26,21 +29,21 @@ class FilterCollection
     /**
      * The used Configuration.
      *
-     * @var \Doctrine\ORM\Configuration
+     * @var Configuration
      */
     private $config;
 
     /**
      * The EntityManager that "owns" this FilterCollection instance.
      *
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
      * Instances of enabled filters.
      *
-     * @var \Doctrine\ORM\Query\Filter\SQLFilter[]
+     * @var SQLFilter[]
      */
     private $enabledFilters = [];
 
@@ -63,7 +66,7 @@ class FilterCollection
     /**
      * Gets all the enabled filters.
      *
-     * @return \Doctrine\ORM\Query\Filter\SQLFilter[] The enabled filters.
+     * @return SQLFilter[] The enabled filters.
      */
     public function getEnabledFilters()
     {
@@ -75,7 +78,7 @@ class FilterCollection
      *
      * @param string $name Name of the filter.
      *
-     * @return \Doctrine\ORM\Query\Filter\SQLFilter The enabled filter.
+     * @return SQLFilter The enabled filter.
      *
      * @throws \InvalidArgumentException If the filter does not exist.
      */
@@ -105,7 +108,7 @@ class FilterCollection
      *
      * @param string $name Name of the filter.
      *
-     * @return \Doctrine\ORM\Query\Filter\SQLFilter The disabled filter.
+     * @return SQLFilter The disabled filter.
      *
      * @throws \InvalidArgumentException If the filter does not exist.
      */
@@ -127,7 +130,7 @@ class FilterCollection
      *
      * @param string $name Name of the filter.
      *
-     * @return \Doctrine\ORM\Query\Filter\SQLFilter The filter.
+     * @return SQLFilter The filter.
      *
      * @throws \InvalidArgumentException If the filter is not enabled.
      */

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use function constant;
+use function ctype_alpha;
+use function defined;
+use function is_numeric;
+use function str_replace;
+use function stripos;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
+
 /**
  * Scans a DQL query for tokens.
  */

--- a/lib/Doctrine/ORM/Query/Parameter.php
+++ b/lib/Doctrine/ORM/Query/Parameter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use function trim;
+
 /**
  * Defines a Query Parameter.
  */
@@ -31,8 +33,6 @@ class Parameter
     private $type;
 
     /**
-     * Constructor.
-     *
      * @param string $name  Parameter name
      * @param mixed  $value Parameter value
      * @param mixed  $type  Parameter type

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -6,6 +6,10 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use function current;
+use function is_array;
+use function is_bool;
+use function is_int;
 
 /**
  * Provides an enclosed support for parameter inferring.

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
+
 /**
  * Encapsulates the resulting components from a DQL query parsing process that
  * can be serialized.
@@ -13,14 +15,14 @@ class ParserResult
     /**
      * The SQL executor used for executing the SQL.
      *
-     * @var \Doctrine\ORM\Query\Exec\AbstractSqlExecutor
+     * @var AbstractSqlExecutor
      */
     private $sqlExecutor;
 
     /**
      * The ResultSetMapping that describes how to map the SQL result set.
      *
-     * @var \Doctrine\ORM\Query\ResultSetMapping
+     * @var ResultSetMapping
      */
     private $resultSetMapping;
 
@@ -37,7 +39,7 @@ class ParserResult
      */
     public function __construct()
     {
-        $this->resultSetMapping = new ResultSetMapping;
+        $this->resultSetMapping = new ResultSetMapping();
     }
 
     /**
@@ -62,7 +64,7 @@ class ParserResult
     /**
      * Sets the SQL executor that should be used for this ParserResult.
      *
-     * @param \Doctrine\ORM\Query\Exec\AbstractSqlExecutor $executor
+     * @param AbstractSqlExecutor $executor
      */
     public function setSqlExecutor($executor)
     {
@@ -72,7 +74,7 @@ class ParserResult
     /**
      * Gets the SQL executor used by this ParserResult.
      *
-     * @return \Doctrine\ORM\Query\Exec\AbstractSqlExecutor
+     * @return AbstractSqlExecutor
      */
     public function getSqlExecutor()
     {

--- a/lib/Doctrine/ORM/Query/Printer.php
+++ b/lib/Doctrine/ORM/Query/Printer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use function str_repeat;
+
 /**
  * A parse tree printer for Doctrine Query Language parser.
  */

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Query;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\AST\PathExpression;
+use function sprintf;
 
 /**
  * Description of QueryException.
@@ -186,7 +187,6 @@ class QueryException extends ORMException
     }
 
     /**
-     *
      * @return QueryException
      */
     public static function associationPathInverseSideNotSupported(PathExpression $pathExpr)
@@ -198,7 +198,6 @@ class QueryException extends ORMException
     }
 
     /**
-     *
      * @return QueryException
      */
     public static function iterateWithFetchJoinNotAllowed(AssociationMetadata $association)

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Collections\Expr\CompositeExpression;
 use Doctrine\Common\Collections\Expr\ExpressionVisitor;
 use Doctrine\Common\Collections\Expr\Value;
+use function count;
+use function str_replace;
+use function strpos;
 
 /**
  * Converts Collection expressions to Query expressions.
@@ -55,7 +59,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
      * Gets bound parameters.
      * Filled after {@link dispach()}.
      *
-     * @return \Doctrine\Common\Collections\Collection|mixed[]
+     * @return Collection|mixed[]
      */
     public function getParameters()
     {
@@ -124,7 +128,7 @@ class QueryExpressionVisitor extends ExpressionVisitor
         }
 
         $parameterName  = str_replace('.', '_', $comparison->getField());
-        $parameterCount = \count($this->parameters);
+        $parameterCount = count($this->parameters);
 
         foreach ($this->parameters as $parameter) {
             if ($parameter->getName() === $parameterName) {

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Query;
 
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
+use function array_merge;
+use function count;
 
 /**
  * A ResultSetMapping describes how a result set of an SQL query maps to a Doctrine result.

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -14,6 +14,10 @@ use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function explode;
+use function in_array;
+use function sprintf;
+use function strpos;
 
 /**
  * A ResultSetMappingBuilder uses the EntityManager to automatically populate entity fields.

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\InheritanceType;
@@ -18,6 +22,23 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_diff;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_float;
+use function is_numeric;
+use function is_string;
+use function reset;
+use function sprintf;
+use function strtolower;
+use function strtoupper;
+use function trim;
 
 /**
  * The SqlWalker is a TreeWalker that walks over a DQL AST and constructs
@@ -76,17 +97,17 @@ class SqlWalker implements TreeWalker
     private $parserResult;
 
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\DBAL\Connection
+     * @var Connection
      */
     private $conn;
 
     /**
-     * @var \Doctrine\ORM\AbstractQuery
+     * @var AbstractQuery
      */
     private $query;
 
@@ -148,7 +169,7 @@ class SqlWalker implements TreeWalker
     /**
      * The database platform abstraction.
      *
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     private $platform;
 
@@ -179,7 +200,7 @@ class SqlWalker implements TreeWalker
     /**
      * Gets the Connection used by the walker.
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
     public function getConnection()
     {
@@ -189,7 +210,7 @@ class SqlWalker implements TreeWalker
     /**
      * Gets the EntityManager used by the walker.
      *
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
@@ -2122,7 +2143,7 @@ class SqlWalker implements TreeWalker
 
     /**
      * {@inheritdoc}
-     * @throws \Doctrine\ORM\Query\QueryException
+     * @throws QueryException
      */
     public function walkInstanceOfExpression($instanceOfExpr)
     {
@@ -2379,7 +2400,6 @@ class SqlWalker implements TreeWalker
     }
 
     /**
-     *
      * @return string The list in parentheses of valid child discriminators from the given class
      *
      * @throws QueryException

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\AbstractQuery;
+
 /**
  * Interface for walkers of DQL ASTs (abstract syntax trees).
  */
@@ -12,9 +14,9 @@ interface TreeWalker
     /**
      * Initializes TreeWalker with important information about the ASTs to be walked.
      *
-     * @param \Doctrine\ORM\AbstractQuery      $query           The parsed Query.
-     * @param \Doctrine\ORM\Query\ParserResult $parserResult    The result of the parsing process.
-     * @param mixed[][]                        $queryComponents The query components (symbol table).
+     * @param AbstractQuery $query           The parsed Query.
+     * @param ParserResult  $parserResult    The result of the parsing process.
+     * @param mixed[][]     $queryComponents The query components (symbol table).
      */
     public function __construct($query, $parserResult, array $queryComponents);
 
@@ -195,7 +197,6 @@ interface TreeWalker
 
     /**
      * Walks down a DeleteStatement AST node, thereby generating the appropriate SQL.
-     *
      *
      * @return string The SQL.
      */

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\AbstractQuery;
+use function array_diff;
+use function array_keys;
+
 /**
  * An adapter implementation of the TreeWalker interface. The methods in this class
  * are empty. ﻿This class exists as convenience for creating tree walkers.
@@ -13,14 +17,14 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * The original Query.
      *
-     * @var \Doctrine\ORM\AbstractQuery
+     * @var AbstractQuery
      */
     private $query;
 
     /**
      * The ParserResult of the original query that was produced by the Parser.
      *
-     * @var \Doctrine\ORM\Query\ParserResult
+     * @var ParserResult
      */
     private $parserResult;
 
@@ -66,7 +70,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieves the Query Instance responsible for the current walkers execution.
      *
-     * @return \Doctrine\ORM\AbstractQuery
+     * @return AbstractQuery
      */
     protected function getQuery()
     {
@@ -76,7 +80,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * Retrieves the ParserResult.
      *
-     * @return \Doctrine\ORM\Query\ParserResult
+     * @return ParserResult
      */
     protected function getParserResult()
     {

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
+use function array_diff;
+use function array_keys;
+
 /**
  * Represents a chain of tree walkers that modify an AST and finally emit output.
  * Only the last walker in the chain can emit output. Any previous walkers can modify

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Query;
+use function key;
+use function next;
+use function reset;
 
 class TreeWalkerChainIterator implements \Iterator, \ArrayAccess
 {

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -6,9 +6,25 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
-
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\QueryExpressionVisitor;
+use function array_keys;
+use function array_merge;
+use function array_unshift;
+use function func_get_args;
+use function func_num_args;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_numeric;
+use function is_object;
+use function is_string;
+use function key;
+use function reset;
+use function sprintf;
+use function strpos;
+use function strrpos;
+use function substr;
 
 /**
  * This class is responsible for building DQL query strings via an object oriented
@@ -539,7 +555,7 @@ class QueryBuilder
      *        )));
      * </code>
      *
-     * @param \Doctrine\Common\Collections\ArrayCollection|array|mixed[] $parameters The query parameters to set.
+     * @param ArrayCollection|array|mixed[] $parameters The query parameters to set.
      *
      * @return self
      */
@@ -566,7 +582,7 @@ class QueryBuilder
     /**
      * Gets all defined query parameters for the query being constructed.
      *
-     * @return \Doctrine\Common\Collections\ArrayCollection The currently defined query parameters.
+     * @return ArrayCollection The currently defined query parameters.
      */
     public function getParameters()
     {
@@ -1252,7 +1268,6 @@ class QueryBuilder
      * Adds where expressions with AND operator.
      * Adds orderings.
      * Overrides firstResult and maxResults if they're set.
-     *
      *
      * @return self
      *

--- a/lib/Doctrine/ORM/Reflection/RuntimeReflectionService.php
+++ b/lib/Doctrine/ORM/Reflection/RuntimeReflectionService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Reflection;
 
 use Doctrine\Common\Persistence\Mapping\MappingException;
+use function class_exists;
+use function class_parents;
 
 /**
  * PHP Runtime Reflection Service.

--- a/lib/Doctrine/ORM/Reflection/StaticReflectionService.php
+++ b/lib/Doctrine/ORM/Reflection/StaticReflectionService.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Reflection;
 
+use function strpos;
+use function strrev;
+use function strrpos;
+use function substr;
+
 /**
  * PHP Runtime Reflection Service.
  */

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Repository;
 
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use function spl_object_id;
 
 /**
  * This factory is used to create default repository objects for entities at runtime.
@@ -14,7 +16,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * The list of EntityRepository instances.
      *
-     * @var \Doctrine\Common\Persistence\ObjectRepository[]
+     * @var ObjectRepository[]
      */
     private $repositoryList = [];
 
@@ -32,10 +34,10 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * Create a new repository instance for an entity class.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string                               $entityName    The name of the entity.
+     * @param EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                 $entityName    The name of the entity.
      *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @return ObjectRepository
      */
     private function createRepository(EntityManagerInterface $entityManager, $entityName)
     {

--- a/lib/Doctrine/ORM/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/RepositoryFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Repository;
 
+use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -14,10 +15,10 @@ interface RepositoryFactory
     /**
      * Gets the repository for an entity class.
      *
-     * @param \Doctrine\ORM\EntityManagerInterface $entityManager The EntityManager instance.
-     * @param string                               $entityName    The name of the entity.
+     * @param EntityManagerInterface $entityManager The EntityManager instance.
+     * @param string                 $entityName    The name of the entity.
      *
-     * @return \Doctrine\Common\Persistence\ObjectRepository
+     * @return ObjectRepository
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName);
 }

--- a/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php
@@ -21,8 +21,6 @@ class BigIntegerIdentityGenerator implements Generator
     private $sequenceName;
 
     /**
-     * Constructor.
-     *
      * @param string|null $sequenceName The name of the sequence to pass to lastInsertId()
      *                                  to obtain the last generated identifier within the current
      *                                  database session/connection, if any.

--- a/lib/Doctrine/ORM/Sequencing/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/IdentityGenerator.php
@@ -21,8 +21,6 @@ class IdentityGenerator implements Generator
     private $sequenceName;
 
     /**
-     * Constructor.
-     *
      * @param string|null $sequenceName The name of the sequence to pass to lastInsertId()
      *                                  to obtain the last generated identifier within the current
      *                                  database session/connection, if any.

--- a/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
@@ -6,6 +6,8 @@ namespace Doctrine\ORM\Sequencing;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Serializable;
+use function serialize;
+use function unserialize;
 
 /**
  * Represents an ID generator that uses a database sequence.

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use function ltrim;
 
 /**
  * Mechanism to programmatically attach entity listeners.
@@ -39,7 +41,7 @@ class AttachEntityListenersListener
      */
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
-        /** @var \Doctrine\ORM\Mapping\ClassMetadata $metadata */
+        /** @var ClassMetadata $metadata */
         $metadata = $event->getClassMetadata();
 
         if (! isset($this->entityListeners[$metadata->getClassName()])) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -12,6 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Command to clear a collection cache region.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -12,6 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Command to clear a entity cache region.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -12,6 +12,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Command to clear a query cache region.

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -12,6 +12,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function file_exists;
+use function is_dir;
+use function is_writable;
+use function mkdir;
+use function realpath;
+use function sprintf;
 
 /**
  * Command to (re)generate the proxy classes used by doctrine.

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function count;
+use function sprintf;
 
 /**
  * Show information about mapped entities.

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -18,6 +18,26 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function count;
+use function current;
+use function get_class;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_object;
+use function is_scalar;
+use function json_encode;
+use function preg_match;
+use function preg_quote;
+use function print_r;
+use function sprintf;
+use function strtolower;
+use function ucfirst;
 
 /**
  * Show information about mapped entities.
@@ -139,7 +159,7 @@ EOT
      *
      * @param string $entityName Full or partial entity name
      *
-     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     * @return ClassMetadata
      */
     private function getClassMetadata($entityName, EntityManagerInterface $entityManager)
     {
@@ -341,7 +361,6 @@ EOT
     }
 
     /**
-     *
      * @return string[]
      */
     private function formatTable(?TableMetadata $tableMetadata = null)

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -11,6 +11,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function constant;
+use function defined;
+use function is_numeric;
+use function sprintf;
+use function str_replace;
+use function strtoupper;
 
 /**
  * Command to execute DQL queries in a given EntityManager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to create the database schema for a set of classes based on their mappings.

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function count;
+use function sprintf;
 
 /**
  * Command to drop the database schema for a set of classes based on their mappings.

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -9,6 +9,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function count;
+use function sprintf;
 
 /**
  * Command to generate the SQL needed to update the database schema to match

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to validate that the current mapping is valid.

--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 
 /**
@@ -32,7 +33,7 @@ final class ConsoleRunner
     /**
      * Runs console with the given helper set.
      *
-     * @param \Symfony\Component\Console\Command\Command[] $commands
+     * @param SymfonyCommand[] $commands
      */
     public static function run(HelperSet $helperSet, array $commands = []) : void
     {
@@ -44,7 +45,7 @@ final class ConsoleRunner
      * Creates a console application with the given helperset and
      * optional commands.
      *
-     * @param \Symfony\Component\Console\Command\Command[] $commands
+     * @param SymfonyCommand[] $commands
      *
      * @throws \OutOfBoundsException
      */

--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -19,9 +19,6 @@ class EntityManagerHelper extends Helper
      */
     protected $em;
 
-    /**
-     * Constructor.
-     */
     public function __construct(EntityManagerInterface $em)
     {
         $this->em = $em;

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Console;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use function count;
+use function iterator_to_array;
+use function preg_match;
+use function sprintf;
 
 /**
  * Used by CLI Tools to restrict entity-based commands to given patterns.

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -11,6 +11,13 @@ use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use ProxyManager\Proxy\GhostObjectInterface;
+use function count;
+use function fclose;
+use function fopen;
+use function fwrite;
+use function gettype;
+use function is_object;
+use function spl_object_id;
 
 /**
  * Use this logger to dump the identity map during the onFlush event. This is useful for debugging

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
@@ -14,12 +14,12 @@ use Doctrine\ORM\EntityManagerInterface;
 class GenerateSchemaEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\DBAL\Schema\Schema
+     * @var Schema
      */
     private $schema;
 

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
@@ -15,17 +15,17 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 class GenerateSchemaTableEventArgs extends EventArgs
 {
     /**
-     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     * @var ClassMetadata
      */
     private $classMetadata;
 
     /**
-     * @var \Doctrine\DBAL\Schema\Schema
+     * @var Schema
      */
     private $schema;
 
     /**
-     * @var \Doctrine\DBAL\Schema\Table
+     * @var Table
      */
     private $classTable;
 

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -4,10 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Pagination;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\ParserResult;
+use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Query\SqlWalker;
+use function array_diff;
+use function array_keys;
+use function count;
+use function implode;
+use function reset;
+use function sprintf;
 
 /**
  * Wraps the query in order to accurately count the root objects.
@@ -21,12 +31,12 @@ use Doctrine\ORM\Query\SqlWalker;
 class CountOutputWalker extends SqlWalker
 {
     /**
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     private $platform;
 
     /**
-     * @var \Doctrine\ORM\Query\ResultSetMapping
+     * @var ResultSetMapping
      */
     private $rsm;
 
@@ -36,15 +46,13 @@ class CountOutputWalker extends SqlWalker
     private $queryComponents;
 
     /**
-     * Constructor.
-     *
      * Stores various parameters that are otherwise unavailable
      * because Doctrine\ORM\Query\SqlWalker keeps everything private without
      * accessors.
      *
-     * @param \Doctrine\ORM\Query              $query
-     * @param \Doctrine\ORM\Query\ParserResult $parserResult
-     * @param mixed[][]                        $queryComponents
+     * @param Query        $query
+     * @param ParserResult $parserResult
+     * @param mixed[][]    $queryComponents
      */
     public function __construct($query, $parserResult, array $queryComponents)
     {

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -11,6 +11,8 @@ use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
+use function count;
+use function reset;
 
 /**
  * Replaces the selectClause of the AST with a COUNT statement.

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Pagination;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Query;
@@ -13,6 +12,9 @@ use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
+use function count;
+use function is_string;
+use function reset;
 
 /**
  * Replaces the selectClause of the AST with a SELECT DISTINCT root.id equivalent.
@@ -132,7 +134,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
     /**
      * Retrieve either an IdentityFunction (IDENTITY(u.assoc)) or a state field (u.name).
      *
-     * @return \Doctrine\ORM\Query\AST\Functions\IdentityFunction
+     * @return IdentityFunction
      */
     private function createSelectExpressionItem(PathExpression $pathExpression)
     {

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -10,6 +10,10 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;
+use function array_key_exists;
+use function array_map;
+use function array_sum;
+use function count;
 
 /**
  * The paginator can handle various complex scenarios with DQL.
@@ -37,8 +41,6 @@ class Paginator implements \Countable, \IteratorAggregate
     private $count;
 
     /**
-     * Constructor.
-     *
      * @param Query|QueryBuilder $query               A Doctrine ORM query or query builder.
      * @param bool               $fetchJoinCollection Whether the query joins a collection (true by default).
      */

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -6,8 +6,10 @@ namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\OrderByClause;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use function trim;
 
 /**
  * RowNumberOverFunction
@@ -17,7 +19,7 @@ use Doctrine\ORM\Query\SqlWalker;
 class RowNumberOverFunction extends FunctionNode
 {
     /**
-     * @var \Doctrine\ORM\Query\AST\OrderByClause
+     * @var OrderByClause
      */
     public $orderByClause;
 

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -19,6 +19,8 @@ use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\AST\WhereClause;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
+use function count;
+use function reset;
 
 /**
  * Replaces the whereClause of the AST with a WHERE id IN (:foo_1, :foo_2) equivalent.
@@ -93,7 +95,7 @@ class WhereInWalker extends TreeWalkerAdapter
             $expression->not = false;
         }
 
-        $conditionalPrimary                              = new ConditionalPrimary;
+        $conditionalPrimary                              = new ConditionalPrimary();
         $conditionalPrimary->simpleConditionalExpression = $expression;
 
         if ($AST->whereClause) {
@@ -112,7 +114,7 @@ class WhereInWalker extends TreeWalkerAdapter
             } elseif ($AST->whereClause->conditionalExpression instanceof ConditionalExpression
                 || $AST->whereClause->conditionalExpression instanceof ConditionalFactor
             ) {
-                $tmpPrimary                              = new ConditionalPrimary;
+                $tmpPrimary                              = new ConditionalPrimary();
                 $tmpPrimary->conditionalExpression       = $AST->whereClause->conditionalExpression;
                 $AST->whereClause->conditionalExpression = new ConditionalTerm(
                     [

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -9,6 +9,8 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\AssociationMetadata;
+use function array_key_exists;
+use function ltrim;
 
 /**
  * ResolveTargetEntityListener

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Index;
@@ -25,6 +26,17 @@ use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
+use function array_diff;
+use function array_key_exists;
+use function array_keys;
+use function count;
+use function implode;
+use function in_array;
+use function is_int;
+use function is_numeric;
+use function reset;
+use function sprintf;
+use function strtolower;
 
 /**
  * The SchemaTool is a tool to create/drop/update database schemas based on
@@ -33,12 +45,12 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 class SchemaTool
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var EntityManagerInterface
      */
     private $em;
 
     /**
-     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     * @var AbstractPlatform
      */
     private $platform;
 
@@ -112,7 +124,7 @@ class SchemaTool
      *
      * @return Schema
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     public function getSchemaFromMetadata(array $classes)
     {
@@ -129,7 +141,7 @@ class SchemaTool
         $blacklistedFks = [];
 
         foreach ($classes as $class) {
-            /** @var \Doctrine\ORM\Mapping\ClassMetadata $class */
+            /** @var ClassMetadata $class */
             if ($this->processingNotRequired($class, $processedClasses)) {
                 continue;
             }
@@ -501,7 +513,7 @@ class SchemaTool
      * @param mixed[][]     $addedFks
      * @param bool[]        $blacklistedFks
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     private function gatherRelationsSql($class, $table, $schema, &$addedFks, &$blacklistedFks)
     {
@@ -645,7 +657,7 @@ class SchemaTool
      * @param mixed[][]            $addedFks
      * @param bool[]               $blacklistedFks
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     private function gatherRelationJoinColumns(
         $joinColumns,
@@ -669,7 +681,7 @@ class SchemaTool
             );
 
             if (! $definingClass) {
-                throw new \Doctrine\ORM\ORMException(sprintf(
+                throw new ORMException(sprintf(
                     'Column name "%s" referenced for relation from %s towards %s does not exist.',
                     $joinColumn->getReferencedColumnName(),
                     $mapping->getSourceEntity(),

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -15,6 +15,17 @@ use Doctrine\ORM\Mapping\OneToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\OneToOneAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use function array_diff;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function class_parents;
+use function count;
+use function implode;
+use function in_array;
+use function sprintf;
 
 /**
  * Performs strict validation of the mapping schema

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -13,6 +13,10 @@ use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\ClassLoader;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
+use function class_exists;
+use function extension_loaded;
+use function md5;
+use function sys_get_temp_dir;
 
 /**
  * Convenience class for setting up Doctrine from different installations and configurations.

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -8,6 +8,8 @@ use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\UnitOfWork;
+use function implode;
+use function is_object;
 
 /**
  * The IdentifierFlattener utility now houses some of the identifier manipulation logic from unit of work, so that it

--- a/lib/Doctrine/ORM/Utility/NormalizeIdentifier.php
+++ b/lib/Doctrine/ORM/Utility/NormalizeIdentifier.php
@@ -8,6 +8,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use Doctrine\ORM\ORMException;
+use function array_key_exists;
+use function reset;
 
 /**
  * @internal do not use in your own codebase: no BC compliance on this class
@@ -22,7 +25,7 @@ final class NormalizeIdentifier
      *
      * @return mixed[]
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     public function __invoke(
         EntityManagerInterface $entityManager,
@@ -32,7 +35,7 @@ final class NormalizeIdentifier
         $normalizedAssociatedId = [];
 
         foreach ($targetClass->getDeclaredPropertiesIterator() as $name => $declaredProperty) {
-            if (! \array_key_exists($name, $flatIdentifier)) {
+            if (! array_key_exists($name, $flatIdentifier)) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use function sprintf;
 
 /**
  * The PersisterHelper contains logic to infer binding types which is used in

--- a/lib/Doctrine/ORM/Utility/StaticClassNameConverter.php
+++ b/lib/Doctrine/ORM/Utility/StaticClassNameConverter.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Utility;
 
 use ProxyManager\Configuration;
 use ProxyManager\Inflector\ClassNameInflectorInterface;
+use function get_class;
 
 /**
  * This class provides utility method to retrieve class names, and to convert
@@ -51,6 +52,6 @@ abstract class StaticClassNameConverter
         $inflector                       = self::$classNameInflector
             ?? self::$classNameInflector = (new Configuration())->getClassNameInflector();
 
-        return $inflector->getUserClassName(\get_class($object));
+        return $inflector->getUserClassName(get_class($object));
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,10 +4,10 @@
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
-    <arg name="colors" />
+    <arg name="colors"/>
 
-    <!-- Ignore warnings and show progress of the run -->
-    <arg value="np"/>
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
 
     <file>lib</file>
     <file>tests</file>
@@ -19,6 +19,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
@@ -56,5 +57,9 @@
 
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
         <exclude-pattern>lib/Doctrine/ORM/Mapping/*</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
+        <exclude-pattern>lib/Doctrine/ORM/Annotation/*</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
Changes from 2.0 -> 3.0:
* Import all functions and constants in `use`
* Remove useless comments
* Use new with parenthesis
* Unqualified class references in annotations

Excluded:
* EarlyExit sniff: To be handled separately as is not just cosmetics.
* ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName: Excluded for Annotation namespace - annotations do not work with `use`.

~I'll drop WIP label and dev-master dependency once Slevomat CS 4.4.5 with bugfixes is out, but feel free to review already.~