### PR TITLE
Fix BC-break on delete without alias DQL

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -304,21 +304,24 @@ class Parser
         $lookaheadType = $this->lexer->lookahead['type'];
 
         // Short-circuit on first condition, usually types match
-        if ($lookaheadType !== $token) {
-            // If parameter is not identifier (1-99) must be exact match
-            if ($token < Lexer::T_IDENTIFIER) {
-                $this->syntaxError($this->lexer->getLiteral($token));
-            }
+        if ($lookaheadType === $token) {
+            $this->lexer->moveNext();
+            return;
+        }
 
-            // If parameter is keyword (200+) must be exact match
-            if ($token > Lexer::T_IDENTIFIER) {
-                $this->syntaxError($this->lexer->getLiteral($token));
-            }
+        // If parameter is not identifier (1-99) must be exact match
+        if ($token < Lexer::T_IDENTIFIER) {
+            $this->syntaxError($this->lexer->getLiteral($token));
+        }
 
-            // If parameter is T_IDENTIFIER, then matches T_IDENTIFIER (100) and keywords (200+)
-            if ($token === Lexer::T_IDENTIFIER && $lookaheadType < Lexer::T_IDENTIFIER) {
-                $this->syntaxError($this->lexer->getLiteral($token));
-            }
+        // If parameter is keyword (200+) must be exact match
+        if ($token > Lexer::T_IDENTIFIER) {
+            $this->syntaxError($this->lexer->getLiteral($token));
+        }
+
+        // If parameter is T_IDENTIFIER, then matches T_IDENTIFIER (100) and keywords (200+)
+        if ($token === Lexer::T_IDENTIFIER && $lookaheadType < Lexer::T_IDENTIFIER) {
+            $this->syntaxError($this->lexer->getLiteral($token));
         }
 
         $this->lexer->moveNext();
@@ -959,20 +962,20 @@ class Parser
         if ($this->lexer->isNextToken(Lexer::T_FULLY_QUALIFIED_NAME)) {
             $this->match(Lexer::T_FULLY_QUALIFIED_NAME);
 
-            $schemaName = $this->lexer->token['value'];
-        } else if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
-            $this->match(Lexer::T_IDENTIFIER);
-
-            $schemaName = $this->lexer->token['value'];
-        } else {
-            $this->match(Lexer::T_ALIASED_NAME);
-
-            list($namespaceAlias, $simpleClassName) = explode(':', $this->lexer->token['value']);
-
-            $schemaName = $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
+            return $this->lexer->token['value'];
         }
 
-        return $schemaName;
+        if ($this->lexer->isNextToken(Lexer::T_IDENTIFIER)) {
+            $this->match(Lexer::T_IDENTIFIER);
+
+            return $this->lexer->token['value'];
+        }
+
+        $this->match(Lexer::T_ALIASED_NAME);
+
+        [$namespaceAlias, $simpleClassName] = explode(':', $this->lexer->token['value']);
+
+        return $this->em->getConfiguration()->getEntityNamespace($namespaceAlias) . '\\' . $simpleClassName;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Query;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions;
+use function strpos;
 
 /**
  * An LL(*) recursive-descent parser for the context-free grammar of the Doctrine Query Language.
@@ -1280,7 +1281,9 @@ class Parser
             $this->match(Lexer::T_AS);
         }
 
-        $aliasIdentificationVariable = $this->AliasIdentificationVariable();
+        $aliasIdentificationVariable = $this->lexer->isNextToken(Lexer::T_IDENTIFIER)
+            ? $this->AliasIdentificationVariable()
+            : 'alias_should_have_been_set';
 
         $deleteClause->aliasIdentificationVariable = $aliasIdentificationVariable;
         $class = $this->em->getClassMetadata($deleteClause->abstractSchemaName);

--- a/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php
@@ -36,6 +36,14 @@ class DeleteSqlGenerationTest extends OrmTestCase
         }
     }
 
+    public function testSupportsDeleteWithoutWhereAndAlias() : void
+    {
+        $this->assertSqlGeneration(
+            'DELETE FROM Doctrine\Tests\Models\CMS\CmsUser',
+            'DELETE FROM cms_users'
+        );
+    }
+
     public function testSupportsDeleteWithoutWhereAndFrom()
     {
         $this->assertSqlGeneration(


### PR DESCRIPTION
As mentioned in #7053, this fixes the issue without breaking other tests.