### PR TITLE
[RFC] Tighten owning side resolution

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -169,7 +169,7 @@
 
   <xs:simpleType name="tablename" id="tablename">
     <xs:restriction base="xs:token">
-      <xs:pattern value="[a-zA-Z_u01-uff.]+" id="tablename.pattern">
+      <xs:pattern value="[a-zA-Z\-_u01-uff.]+" id="tablename.pattern">
       </xs:pattern>
     </xs:restriction>
   </xs:simpleType>

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -654,7 +654,6 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
         }
 
         $property->setSourceEntity($this->className);
-        $property->setOwningSide($property->getMappedBy() === null);
         $property->setTargetEntity($targetEntity);
 
         // Complete id mapping
@@ -712,10 +711,6 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
     protected function validateAndCompleteToOneAssociationMetadata(ToOneAssociationMetadata $property)
     {
         $fieldName = $property->getName();
-
-        if ($property->getJoinColumns()) {
-            $property->setOwningSide(true);
-        }
 
         if ($property->isOwningSide()) {
             if (empty($property->getJoinColumns())) {
@@ -833,9 +828,6 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
      */
     protected function validateAndCompleteOneToManyMapping(OneToManyAssociationMetadata $property)
     {
-        // OneToMany MUST be inverse side
-        $property->setOwningSide(false);
-
         // OneToMany MUST have mappedBy
         if (! $property->getMappedBy()) {
             throw MappingException::oneToManyRequiresMappedBy($property->getName());

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -357,13 +357,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     private function addInheritedProperties(ClassMetadata $subClass, ClassMetadata $parentClass) : void
     {
-        $isAbstract = $parentClass->isMappedSuperclass;
-
         foreach ($parentClass->getDeclaredPropertiesIterator() as $fieldName => $property) {
-            if ($isAbstract && $property instanceof ToManyAssociationMetadata && ! $property->isOwningSide()) {
-                throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->getClassName(), $fieldName);
-            }
-
             $subClass->addInheritedProperty($property);
         }
     }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -120,7 +120,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ($parent) {
             $classMetadata->setParent($parent);
 
-            $this->addInheritedProperties($classMetadata, $parent);
+            foreach ($parent->getDeclaredPropertiesIterator() as $fieldName => $property) {
+                $classMetadata->addInheritedProperty($property);
+            }
 
             $classMetadata->setInheritanceType($parent->inheritanceType);
             $classMetadata->setIdentifier($parent->identifier);
@@ -348,18 +350,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         $parts = explode('\\', $className);
 
         return strtolower(end($parts));
-    }
-
-    /**
-     * Adds inherited fields to the subclass mapping.
-     *
-     * @throws MappingException
-     */
-    private function addInheritedProperties(ClassMetadata $subClass, ClassMetadata $parentClass) : void
-    {
-        foreach ($parentClass->getDeclaredPropertiesIterator() as $fieldName => $property) {
-            $subClass->addInheritedProperty($property);
-        }
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -355,6 +355,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($oneToOneElement['mapped-by'])) {
                     $association->setMappedBy((string) $oneToOneElement['mapped-by']);
+                    $association->setOwningSide(false);
                 } else {
                     if (isset($oneToOneElement['inversed-by'])) {
                         $association->setInversedBy((string) $oneToOneElement['inversed-by']);
@@ -403,6 +404,7 @@ class XmlDriver extends FileDriver
                 $targetEntity = (string) $oneToManyElement['target-entity'];
 
                 $association->setTargetEntity($targetEntity);
+                $association->setOwningSide(false);
                 $association->setMappedBy((string) $oneToManyElement['mapped-by']);
 
                 if (isset($associationIds[$association->getName()])) {
@@ -531,6 +533,7 @@ class XmlDriver extends FileDriver
 
                 if (isset($manyToManyElement['mapped-by'])) {
                     $association->setMappedBy((string) $manyToManyElement['mapped-by']);
+                    $association->setOwningSide(false);
                 } elseif (isset($manyToManyElement->{'join-table'})) {
                     if (isset($manyToManyElement['inversed-by'])) {
                         $association->setInversedBy((string) $manyToManyElement['inversed-by']);

--- a/lib/Doctrine/ORM/Mapping/Exporter/AssociationMetadataExporter.php
+++ b/lib/Doctrine/ORM/Mapping/Exporter/AssociationMetadataExporter.php
@@ -38,6 +38,7 @@ abstract class AssociationMetadataExporter implements Exporter
 
         if (! empty($value->getMappedBy())) {
             $lines[] = $objectReference . '->setMappedBy("' . $value->getMappedBy() . '");';
+            $lines[] = $objectReference . '->setOwningSide(false);';
         }
 
         if (! empty($value->getInversedBy())) {
@@ -48,7 +49,6 @@ abstract class AssociationMetadataExporter implements Exporter
         $lines[] = $objectReference . '->setTargetEntity("' . $value->getTargetEntity() . '");';
         $lines[] = $objectReference . '->setFetchMode(Mapping\FetchMode::' . strtoupper($value->getFetchMode()) . '");';
         $lines[] = $objectReference . '->setCascade(' . $variableExporter->export($cascade, $indentationLevel + 1) . ');';
-        $lines[] = $objectReference . '->setOwningSide(' . $variableExporter->export($value->isOwningSide(), $indentationLevel + 1) . ');';
         $lines[] = $objectReference . '->setOrphanRemoval(' . $variableExporter->export($value->isOrphanRemoval(), $indentationLevel + 1) . ');';
         $lines[] = $objectReference . '->setPrimaryKey(' . $variableExporter->export($value->isPrimaryKey(), $indentationLevel + 1) . ');';
 

--- a/tests/Doctrine/Tests/Models/Quote/User.php
+++ b/tests/Doctrine/Tests/Models/Quote/User.php
@@ -31,7 +31,6 @@ class User
     public $phones;
 
     /**
-     * @ORM\JoinColumn(name="address-id", referencedColumnName="address-id")
      * @ORM\OneToOne(
      *     targetEntity=Address::class,
      *     mappedBy="user",

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -26,6 +26,7 @@ use Doctrine\Tests\Models\Company\CompanyFlexContract;
 use Doctrine\Tests\Models\Company\CompanyFlexUltraContract;
 use Doctrine\Tests\Models\Company\CompanyFlexUltraContractListener;
 use Doctrine\Tests\Models\Company\CompanyPerson;
+use Doctrine\Tests\Models\Quote;
 use Doctrine\Tests\Models\DDC1476\DDC1476EntityWithDefaultFieldType;
 use Doctrine\Tests\Models\DDC2825\ExplicitSchemaAndTable;
 use Doctrine\Tests\Models\DDC2825\SchemaAndTableInTableName;
@@ -357,6 +358,62 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         self::assertFalse($nameOptions['fixed']);
 
         return $class;
+    }
+
+    public function testOwningSideResolution() : void
+    {
+        // One to One owning
+        $fullAddressClass = $this->createClassMetadata(Quote\FullAddress::class);
+        $cityAssociation  = $fullAddressClass->getProperty('city');
+
+        self::assertInstanceOf(Mapping\OneToOneAssociationMetadata::class, $cityAssociation);
+        self::assertTrue($cityAssociation->isOwningSide());
+
+        // One to One owning / One To One inverse
+        $addressClass    = $this->createClassMetadata(Quote\Address::class);
+        $userAssociation = $addressClass->getProperty('user');
+
+        self::assertInstanceOf(Mapping\OneToOneAssociationMetadata::class, $userAssociation);
+        self::assertTrue($userAssociation->isOwningSide());
+
+        $userClass          = $this->createClassMetadata(Quote\User::class);
+        $addressAssociation = $userClass->getProperty('address');
+
+        self::assertInstanceOf(Mapping\OneToOneAssociationMetadata::class, $addressAssociation);
+        self::assertFalse($addressAssociation->isOwningSide());
+
+        // Many to One owning
+        $groupClass       = $this->createClassMetadata(Quote\Group::class);
+        $groupAssociation = $groupClass->getProperty('parent');
+
+        self::assertInstanceOf(Mapping\ManyToOneAssociationMetadata::class, $groupAssociation);
+        self::assertTrue($groupAssociation->isOwningSide());
+
+        // Many To One owning / One To Many inverse
+        $phoneClass      = $this->createClassMetadata(Quote\Phone::class);
+        $userAssociation = $phoneClass->getProperty('user');
+
+        self::assertInstanceOf(Mapping\ManyToOneAssociationMetadata::class, $userAssociation);
+        self::assertTrue($userAssociation->isOwningSide());
+
+        $userClass        = $this->createClassMetadata(Quote\User::class);
+        $phoneAssociation = $userClass->getProperty('phones');
+
+        self::assertInstanceOf(Mapping\OneToManyAssociationMetadata::class, $phoneAssociation);
+        self::assertFalse($phoneAssociation->isOwningSide());
+
+        // Many to Many owning / Many to Many inverse
+        $userClass        = $this->createClassMetadata(Quote\User::class);
+        $groupAssociation = $userClass->getProperty('groups');
+
+        self::assertInstanceOf(Mapping\ManyToManyAssociationMetadata::class, $groupAssociation);
+        self::assertTrue($groupAssociation->isOwningSide());
+
+        $groupClass      = $this->createClassMetadata(Quote\Group::class);
+        $userAssociation = $groupClass->getProperty('users');
+
+        self::assertInstanceOf(Mapping\ManyToManyAssociationMetadata::class, $userAssociation);
+        self::assertFalse($userAssociation->isOwningSide());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -360,7 +360,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         return $class;
     }
 
-    public function testOwningSideResolution() : void
+    public function testOneToOneUnidirectional() : void
     {
         // One to One owning
         $fullAddressClass = $this->createClassMetadata(Quote\FullAddress::class);
@@ -368,7 +368,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertInstanceOf(Mapping\OneToOneAssociationMetadata::class, $cityAssociation);
         self::assertTrue($cityAssociation->isOwningSide());
+    }
 
+    public function testOneToOneBidirectional() : void
+    {
         // One to One owning / One To One inverse
         $addressClass    = $this->createClassMetadata(Quote\Address::class);
         $userAssociation = $addressClass->getProperty('user');
@@ -381,14 +384,20 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertInstanceOf(Mapping\OneToOneAssociationMetadata::class, $addressAssociation);
         self::assertFalse($addressAssociation->isOwningSide());
+    }
 
+    public function testManyToOneUnidirectional() : void
+    {
         // Many to One owning
         $groupClass       = $this->createClassMetadata(Quote\Group::class);
         $groupAssociation = $groupClass->getProperty('parent');
 
         self::assertInstanceOf(Mapping\ManyToOneAssociationMetadata::class, $groupAssociation);
         self::assertTrue($groupAssociation->isOwningSide());
+    }
 
+    public function testManyToOneBidirectional() : void
+    {
         // Many To One owning / One To Many inverse
         $phoneClass      = $this->createClassMetadata(Quote\Phone::class);
         $userAssociation = $phoneClass->getProperty('user');
@@ -401,7 +410,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         self::assertInstanceOf(Mapping\OneToManyAssociationMetadata::class, $phoneAssociation);
         self::assertFalse($phoneAssociation->isOwningSide());
+    }
 
+    public function testManyToManyBidirectional() : void
+    {
         // Many to Many owning / Many to Many inverse
         $userClass        = $this->createClassMetadata(Quote\User::class);
         $groupAssociation = $userClass->getProperty('groups');

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -356,13 +356,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
         self::assertEquals('user-id', $addressUserJoinColumn->getColumnName());
         self::assertEquals('user-id', $addressUserJoinColumn->getReferencedColumnName());
 
-        $address               = $userMetadata->getProperty('address');
-        $addressJoinColumns    = $address->getJoinColumns();
-        $userAddressJoinColumn = reset($addressJoinColumns);
-
-        self::assertEquals('address-id', $userAddressJoinColumn->getColumnName());
-        self::assertEquals('address-id', $userAddressJoinColumn->getReferencedColumnName());
-
         $groups                       = $userMetadata->getProperty('groups');
         $groupsJoinTable              = $groups->getJoinTable();
         $userGroupsJoinColumns        = $groupsJoinTable->getJoinColumns();

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -772,6 +772,7 @@ class ClassMetadataTest extends OrmTestCase
         $association->setTargetEntity(DDC117Article::class);
         $association->setPrimaryKey(true);
         $association->setMappedBy('details');
+        $association->setOwningSide(false);
 
         $cm->addProperty($association);
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Address.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Address.dcm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\Address" table="quote-address" inheritance-type="SINGLE_TABLE">
+        <discriminator-column name="type" type="string" />
+
+        <discriminator-map>
+            <discriminator-mapping value="simple" class="Doctrine\Tests\Models\Quote\Address" />
+            <discriminator-mapping value="full" class="Doctrine\Tests\Models\Quote\FullAddress" />
+        </discriminator-map>
+
+        <id name="id" type="integer" column="address-id">
+            <generator />
+        </id>
+
+        <field name="zip" column="address-zip" />
+
+        <one-to-one field="user" target-entity="Doctrine\Tests\Models\Quote\User" inversed-by="address">
+            <join-column name="user-id" referenced-column-name="user-id" />
+        </one-to-one>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.City.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.City.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\City" table="quote-city">
+        <id name="id" type="integer" column="city-id">
+            <generator />
+        </id>
+
+        <field name="name" column="city-name" />
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.FullAddress.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.FullAddress.dcm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\FullAddress">
+        <one-to-one field="city" target-entity="Doctrine\Tests\Models\Quote\City">
+            <cascade><cascade-persist /></cascade>
+            <join-column name="city-id" referenced-column-name="city-id" />
+        </one-to-one>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Group.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Group.dcm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\Group" table="quote-group">
+        <id name="id" type="integer" column="group-id">
+            <generator />
+        </id>
+
+        <field name="name" column="group-name" />
+
+        <many-to-one field="parent" target-entity="Doctrine\Tests\Models\Quote\Group">
+            <cascade><cascade-persist /></cascade>
+            <join-column name="parent-id" referenced-column-name="group-id" />
+        </many-to-one>
+
+        <many-to-many field="users" target-entity="Doctrine\Tests\Models\Quote\User" mapped-by="groups" />
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Phone.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.Phone.dcm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\Phone" table="quote-phone">
+        <id name="number" type="string" column="phone-number" />
+
+        <many-to-one field="user" target-entity="Doctrine\Tests\Models\Quote\User" inversed-by="phones">
+            <join-column name="user-id" referenced-column-name="user-id" />
+        </many-to-one>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.Quote.User.dcm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\Quote\User" table="quote-user">
+        <id name="id" type="integer" column="user-id">
+            <generator />
+        </id>
+
+        <field name="name" column="user-name" />
+
+        <one-to-many field="phones" target-entity="Doctrine\Tests\ORM\Mapping\Phone" mapped-by="user">
+            <cascade><cascade-persist /></cascade>
+        </one-to-many>
+
+        <one-to-one field="address" target-entity="Doctrine\Tests\Models\Quote\Address" mapped-by="user" fetch="EAGER">
+            <cascade><cascade-persist /></cascade>
+        </one-to-one>
+
+        <many-to-many field="groups" target-entity="Doctrine\Tests\Models\Quote\Group" inversed-by="users" fetch="EXTRA_LAZY">
+            <cascade>
+                <cascade-all/>
+            </cascade>
+            <join-table name="quote-users-groups">
+                <join-columns>
+                    <join-column name="user-id" referenced-column-name="user-id" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="group-id" referenced-column-name="group-id" />
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2011,7 +2011,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     {
         $this->assertSqlGeneration(
             'SELECT u, a FROM Doctrine\Tests\Models\Quote\User u JOIN u.address a',
-            'SELECT t0."user-id" AS c0, t0."user-name" AS c1, t1."address-id" AS c2, t1."address-zip" AS c3, t1."type" AS c4 FROM "quote-user" t0 INNER JOIN "quote-address" t1 ON t0."address-id" = t1."address-id" AND t1."type" IN (\'simple\', \'full\')'
+            'SELECT t0."user-id" AS c0, t0."user-name" AS c1, t1."address-id" AS c2, t1."address-zip" AS c3, t1."type" AS c4 FROM "quote-user" t0 INNER JOIN "quote-address" t1 ON t0."user-id" = t1."user-id" AND t1."type" IN (\'simple\', \'full\')'
         );
 
         $this->assertSqlGeneration(


### PR DESCRIPTION
Fixed bug with potential double owning side in OneToOne when JoinColumns were mapped on both association sides. In that case, the ownership was determined based on association flow (in A -> B, A:b was owning, while in B -> A, B:a was owning).