### PR TITLE
Drop explicit PDO dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     },
     "require": {
         "php": "^7.2",
-        "ext-pdo": "*",
         "doctrine/annotations": "~1.5",
         "doctrine/cache": "~1.6",
         "doctrine/collections": "^1.4",
@@ -29,6 +28,7 @@
         "symfony/console": "~3.2|~4.0"
     },
     "require-dev": {
+        "ext-pdo": "*",
         "doctrine/coding-standard": "^3.0",
         "phpunit/phpunit": "^7.0"
     },


### PR DESCRIPTION
After doctrine/dbal#2958, #7076 and #7065, there is no longer reason for an explicit dependency on PDO in ORM.
DBAL dropped it already, ORM should too.