### PR TITLE
Unable to run from vendor/bin/doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
             "Doctrine\\Performance\\": "tests/Doctrine/Performance"
         }
     },
-    "bin": ["bin/doctrine"],
+    "bin": ["bin/doctrine", "bin/doctrine.php"],
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"


### PR DESCRIPTION
This commit broke ability to run `vendor/bin/doctrine`.
https://github.com/doctrine/doctrine2/commit/1d6adcaf4af69cd903e19c12f0685b1c26e1675e
