### PR TITLE
Adds possibility to overwrite EntityManager

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -831,7 +831,7 @@ final class EntityManager implements EntityManagerInterface
 
         $connection = static::createConnection($connection, $config, $eventManager);
 
-        return new EntityManager($connection, $config, $connection->getEventManager());
+        return new static($connection, $config, $connection->getEventManager());
     }
 
     /**


### PR DESCRIPTION
In order to customize the EntityManager class it is necessary to use "static" in its create() method.