### PR TITLE
DDC-3063 #comment add a helpful error so a developer can decide what to do next

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -434,6 +434,16 @@ class Expr
             }
         }
 
+        if (!count((array) $y)) {
+            throw QueryException::syntaxError(
+                'The provided array for the IN (values) must contain at least one element. 
+        Zero were provided. 
+        When the count of IN(values) is zero, add an *unreachable value for your data-set* to prevent this error.
+        e.g.: if you have values ranging from /[a-f]+/ in the column(s) being matched, add a fake IN([\'G\']) value.  
+        '
+            );
+        }
+
         return new Expr\Func($x . ' IN', (array) $y);
     }
 


### PR DESCRIPTION
Current error: '[Syntax Error] line X, col Y: Error: Expected Literal, got ')''

The outcome is still the same with a Syntax Error being thrown.

New syntax error contains helpful directions to resolve this problem.