### PR TITLE
Apply Doctrine CS 4.0, version composer.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ CONTRIBUTING.md export-ignore
 phpunit.xml.dist export-ignore
 run-all.sh export-ignore
 phpcs.xml.dist export-ignore
+composer.lock export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ lib/Doctrine/DBAL
 .project
 .idea
 vendor/
-composer.lock
 composer.phar
 /tests/Doctrine/Performance/history.db
 /.phpcs-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
   - composer self-update
 
-install: travis_retry composer update --prefer-dist
+install:
+  - rm composer.lock
+  - travis_retry composer update --prefer-dist
 
 script:
   - if [[ "$DB" == "mysql" || "$DB" == "mariadb" ]]; then mysql -e "CREATE SCHEMA doctrine_tests; GRANT ALL PRIVILEGES ON doctrine_tests.* to travis@'%'"; fi
@@ -52,6 +54,7 @@ jobs:
       if: type = cron
       env: DB=sqlite DEV_DEPENDENCIES
       install:
+        - rm composer.lock
         - composer config minimum-stability dev
         - travis_retry composer update --prefer-dist
 
@@ -68,11 +71,10 @@ jobs:
 
     - stage: Code Quality
       env: DB=none STATIC_ANALYSIS
-      install: travis_retry composer update --prefer-dist --prefer-stable
+      install: travis_retry composer install --prefer-dist
       before_script:
         - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
       script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
 
     - stage: Code Quality
@@ -82,6 +84,7 @@ jobs:
 
     - stage: Code Quality
       env: DB=none CODING_STANDARDS
+      install: travis_retry composer install --prefer-dist
       php: 7.2
       script:
         - ./vendor/bin/phpcs lib

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "doctrine/coding-standard": "^4.0",
+        "phpstan/phpstan-shim": "^0.9.2",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "ext-pdo": "*",
-        "doctrine/coding-standard": "^3.0",
+        "doctrine/coding-standard": "^4.0",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2571 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a0d3dcf76d32cf2eed692a8072ebc8fd",
+    "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-12-06T07:11:42+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^5.7",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-08-25T07:02:50+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-08-31T08:43:38+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "83995663c993207ff1b3dd0a02bb565defb982a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/83995663c993207ff1b3dd0a02bb565defb982a6",
+                "reference": "83995663c993207ff1b3dd0a02bb565defb982a6",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.7.1",
+                "ocramius/package-versions": "^1.2",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^3.0",
+                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "^2.0.5||^3.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2018-03-02T02:39:07+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-02-05T13:05:30+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "81d53b2878f1d1c40ad27270e64b51798485dfc5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/81d53b2878f1d1c40ad27270e64b51798485dfc5",
+                "reference": "81d53b2878f1d1c40ad27270e64b51798485dfc5",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.1.3",
+                "php": "^7.2.0",
+                "zendframework/zend-code": "^3.3.0"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.6.1",
+                "ext-phar": "*",
+                "humbug/humbug": "1.0.0-RC.0@RC",
+                "nikic/php-parser": "^3.1.1",
+                "padraic/phpunit-accelerator": "dev-master@DEV",
+                "phpbench/phpbench": "^0.12.2",
+                "phpstan/phpstan": "dev-master#856eb10a81c1d27c701a83f167dc870fd8f4236a as 0.9.999",
+                "phpstan/phpstan-phpunit": "dev-master#5629c0a1f4a9c417cb1077cf6693ad9753895761",
+                "phpunit/phpunit": "^6.4.3",
+                "squizlabs/php_codesniffer": "^2.9.1"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2017-11-16T23:22:31+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-26T15:55:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2017-10-20T15:21:32+00:00"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2017-07-11T19:17:22+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
+        {
+            "name": "doctrine/coding-standard",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/coding-standard.git",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+                "php": "^7.1",
+                "slevomat/coding-standard": "^4.5.0",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Steve Müller",
+                    "email": "st.mueller@dzh-online.de"
+                }
+            ],
+            "description": "Doctrine Coding Standard",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "code",
+                "coding",
+                "cs",
+                "doctrine",
+                "sniffer",
+                "standard",
+                "style"
+            ],
+            "time": "2018-03-03T23:49:15+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2018-02-19T10:16:54+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-shim",
+            "version": "0.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-shim.git",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.0"
+            },
+            "replace": {
+                "phpstan/phpstan": "self.version"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Phar distribution",
+            "time": "2018-01-28T14:29:27+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-02T07:01:41+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2018-02-01T13:07:23+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2018-02-01T13:16:43+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-26T07:03:12+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2018-02-15T05:27:38+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-02-01T13:46:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2018-02-01T13:45:15+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2017-07-01T08:51:00+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2017-04-03T13:19:02+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "3957603813d466aa820231a6ac9d4d73d0dcf935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/3957603813d466aa820231a6ac9d4d73d0dcf935",
+                "reference": "3957603813d466aa820231a6ac9d4d73d0dcf935",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16",
+                "phpstan/phpstan": "0.9.2",
+                "phpstan/phpstan-phpunit": "0.9.4",
+                "phpstan/phpstan-strict-rules": "0.9",
+                "phpunit/php-code-coverage": "6.0.1",
+                "phpunit/phpunit": "7.0.2"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2018-03-02T15:11:15+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
+        }
+    ],
+    "aliases": [
+        {
+            "alias": "3.x-dev",
+            "alias_normalized": "3.9999999.9999999.9999999-dev",
+            "version": "dev-develop",
+            "package": "doctrine/dbal"
+        }
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "doctrine/dbal": 20
+    },
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.2"
+    },
+    "platform-dev": {
+        "ext-pdo": "*"
+    }
+}

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -94,9 +94,7 @@ abstract class AbstractQuery
      */
     protected $hydrationMode = self::HYDRATE_OBJECT;
 
-    /**
-     * @var QueryCacheProfile
-     */
+    /** @var QueryCacheProfile */
     protected $queryCacheProfile;
 
     /**
@@ -106,9 +104,7 @@ abstract class AbstractQuery
      */
     protected $expireResultCache = false;
 
-    /**
-     * @var QueryCacheProfile
-     */
+    /** @var QueryCacheProfile */
     protected $hydrationCacheProfile;
 
     /**
@@ -118,9 +114,7 @@ abstract class AbstractQuery
      */
     protected $cacheable = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $hasCache = false;
 
     /**
@@ -137,14 +131,10 @@ abstract class AbstractQuery
      */
     protected $cacheMode;
 
-    /**
-     * @var CacheLogger|null
-     */
+    /** @var CacheLogger|null */
     protected $cacheLogger;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $lifetime = 0;
 
     /**
@@ -233,7 +223,7 @@ abstract class AbstractQuery
      */
     public function setLifetime($lifetime)
     {
-        $this->lifetime = (integer) $lifetime;
+        $this->lifetime = (int) $lifetime;
 
         return $this;
     }
@@ -253,7 +243,7 @@ abstract class AbstractQuery
      */
     public function setCacheMode($cacheMode)
     {
-        $this->cacheMode = (integer) $cacheMode;
+        $this->cacheMode = (int) $cacheMode;
 
         return $this;
     }

--- a/lib/Doctrine/ORM/Annotation/Cache.php
+++ b/lib/Doctrine/ORM/Annotation/Cache.php
@@ -19,8 +19,6 @@ final class Cache implements Annotation
      */
     public $usage = 'READ_ONLY';
 
-    /**
-     * @var string Cache region name.
-     */
+    /** @var string Cache region name. */
     public $region;
 }

--- a/lib/Doctrine/ORM/Annotation/Column.php
+++ b/lib/Doctrine/ORM/Annotation/Column.php
@@ -10,14 +10,10 @@ namespace Doctrine\ORM\Annotation;
  */
 final class Column implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $type = 'string';
 
     /**
@@ -41,23 +37,15 @@ final class Column implements Annotation
      */
     public $scale = 0;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $unique = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $nullable = false;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $options = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $columnDefinition;
 }

--- a/lib/Doctrine/ORM/Annotation/CustomIdGenerator.php
+++ b/lib/Doctrine/ORM/Annotation/CustomIdGenerator.php
@@ -10,13 +10,9 @@ namespace Doctrine\ORM\Annotation;
  */
 final class CustomIdGenerator implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $class;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $arguments = [];
 }

--- a/lib/Doctrine/ORM/Annotation/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Annotation/DiscriminatorColumn.php
@@ -10,19 +10,13 @@ namespace Doctrine\ORM\Annotation;
  */
 final class DiscriminatorColumn implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $type;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $length;
 
     /**
@@ -32,8 +26,6 @@ final class DiscriminatorColumn implements Annotation
      */
     public $fieldName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $columnDefinition;
 }

--- a/lib/Doctrine/ORM/Annotation/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Annotation/DiscriminatorMap.php
@@ -10,8 +10,6 @@ namespace Doctrine\ORM\Annotation;
  */
 final class DiscriminatorMap implements Annotation
 {
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $value;
 }

--- a/lib/Doctrine/ORM/Annotation/Embedded.php
+++ b/lib/Doctrine/ORM/Annotation/Embedded.php
@@ -16,8 +16,6 @@ final class Embedded implements Annotation
      */
     public $class;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $columnPrefix;
 }

--- a/lib/Doctrine/ORM/Annotation/Entity.php
+++ b/lib/Doctrine/ORM/Annotation/Entity.php
@@ -10,13 +10,9 @@ namespace Doctrine\ORM\Annotation;
  */
 final class Entity implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $repositoryClass;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $readOnly = false;
 }

--- a/lib/Doctrine/ORM/Annotation/Index.php
+++ b/lib/Doctrine/ORM/Annotation/Index.php
@@ -10,28 +10,18 @@ namespace Doctrine\ORM\Annotation;
  */
 final class Index implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $columns;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $unique = false;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $flags = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $options = [];
 }

--- a/lib/Doctrine/ORM/Annotation/JoinColumn.php
+++ b/lib/Doctrine/ORM/Annotation/JoinColumn.php
@@ -10,34 +10,22 @@ namespace Doctrine\ORM\Annotation;
  */
 final class JoinColumn implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $referencedColumnName = 'id';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $unique = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $nullable = true;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $onDelete;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $columnDefinition;
 
     /**

--- a/lib/Doctrine/ORM/Annotation/JoinColumns.php
+++ b/lib/Doctrine/ORM/Annotation/JoinColumns.php
@@ -10,8 +10,6 @@ namespace Doctrine\ORM\Annotation;
  */
 final class JoinColumns implements Annotation
 {
-    /**
-     * @var array<\Doctrine\ORM\Annotation\JoinColumn>
-     */
+    /** @var array<\Doctrine\ORM\Annotation\JoinColumn> */
     public $value;
 }

--- a/lib/Doctrine/ORM/Annotation/JoinTable.php
+++ b/lib/Doctrine/ORM/Annotation/JoinTable.php
@@ -10,23 +10,15 @@ namespace Doctrine\ORM\Annotation;
  */
 final class JoinTable implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $schema;
 
-    /**
-     * @var array<\Doctrine\ORM\Annotation\JoinColumn>
-     */
+    /** @var array<\Doctrine\ORM\Annotation\JoinColumn> */
     public $joinColumns = [];
 
-    /**
-     * @var array<\Doctrine\ORM\Annotation\JoinColumn>
-     */
+    /** @var array<\Doctrine\ORM\Annotation\JoinColumn> */
     public $inverseJoinColumns = [];
 }

--- a/lib/Doctrine/ORM/Annotation/ManyToMany.php
+++ b/lib/Doctrine/ORM/Annotation/ManyToMany.php
@@ -10,24 +10,16 @@ namespace Doctrine\ORM\Annotation;
  */
 final class ManyToMany implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $targetEntity;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $mappedBy;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $inversedBy;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $cascade = [];
 
     /**
@@ -39,13 +31,9 @@ final class ManyToMany implements Annotation
      */
     public $fetch = 'LAZY';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $orphanRemoval = false;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $indexBy;
 }

--- a/lib/Doctrine/ORM/Annotation/ManyToOne.php
+++ b/lib/Doctrine/ORM/Annotation/ManyToOne.php
@@ -10,14 +10,10 @@ namespace Doctrine\ORM\Annotation;
  */
 final class ManyToOne implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $targetEntity;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $cascade = [];
 
     /**
@@ -29,8 +25,6 @@ final class ManyToOne implements Annotation
      */
     public $fetch = 'LAZY';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $inversedBy;
 }

--- a/lib/Doctrine/ORM/Annotation/MappedSuperclass.php
+++ b/lib/Doctrine/ORM/Annotation/MappedSuperclass.php
@@ -10,8 +10,6 @@ namespace Doctrine\ORM\Annotation;
  */
 final class MappedSuperclass implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $repositoryClass;
 }

--- a/lib/Doctrine/ORM/Annotation/OneToMany.php
+++ b/lib/Doctrine/ORM/Annotation/OneToMany.php
@@ -10,19 +10,13 @@ namespace Doctrine\ORM\Annotation;
  */
 final class OneToMany implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $mappedBy;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $targetEntity;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $cascade = [];
 
     /**
@@ -34,13 +28,9 @@ final class OneToMany implements Annotation
      */
     public $fetch = 'LAZY';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $orphanRemoval = false;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $indexBy;
 }

--- a/lib/Doctrine/ORM/Annotation/OneToOne.php
+++ b/lib/Doctrine/ORM/Annotation/OneToOne.php
@@ -10,24 +10,16 @@ namespace Doctrine\ORM\Annotation;
  */
 final class OneToOne implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $targetEntity;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $mappedBy;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $inversedBy;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $cascade = [];
 
     /**
@@ -39,8 +31,6 @@ final class OneToOne implements Annotation
      */
     public $fetch = 'LAZY';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $orphanRemoval = false;
 }

--- a/lib/Doctrine/ORM/Annotation/OrderBy.php
+++ b/lib/Doctrine/ORM/Annotation/OrderBy.php
@@ -10,8 +10,6 @@ namespace Doctrine\ORM\Annotation;
  */
 final class OrderBy implements Annotation
 {
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $value;
 }

--- a/lib/Doctrine/ORM/Annotation/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Annotation/SequenceGenerator.php
@@ -10,13 +10,9 @@ namespace Doctrine\ORM\Annotation;
  */
 final class SequenceGenerator implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $sequenceName;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $allocationSize = 1;
 }

--- a/lib/Doctrine/ORM/Annotation/Table.php
+++ b/lib/Doctrine/ORM/Annotation/Table.php
@@ -10,28 +10,18 @@ namespace Doctrine\ORM\Annotation;
  */
 final class Table implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $schema;
 
-    /**
-     * @var array<\Doctrine\ORM\Annotation\Index>
-     */
+    /** @var array<\Doctrine\ORM\Annotation\Index> */
     public $indexes = [];
 
-    /**
-     * @var array<\Doctrine\ORM\Annotation\UniqueConstraint>
-     */
+    /** @var array<\Doctrine\ORM\Annotation\UniqueConstraint> */
     public $uniqueConstraints = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $options = [];
 }

--- a/lib/Doctrine/ORM/Annotation/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Annotation/UniqueConstraint.php
@@ -10,23 +10,15 @@ namespace Doctrine\ORM\Annotation;
  */
 final class UniqueConstraint implements Annotation
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $columns;
 
-    /**
-     * @var array<string>
-     */
+    /** @var array<string> */
     public $flags = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $options = [];
 }

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -11,24 +11,16 @@ use Doctrine\ORM\Cache\Logging\CacheLogger;
  */
 class CacheConfiguration
 {
-    /**
-     * @var CacheFactory|null
-     */
+    /** @var CacheFactory|null */
     private $cacheFactory;
 
-    /**
-     * @var RegionsConfiguration|null
-     */
+    /** @var RegionsConfiguration|null */
     private $regionsConfig;
 
-    /**
-     * @var CacheLogger|null
-     */
+    /** @var CacheLogger|null */
     private $cacheLogger;
 
-    /**
-     * @var QueryCacheValidator|null
-     */
+    /** @var QueryCacheValidator|null */
     private $queryValidator;
 
     /**

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -20,29 +20,19 @@ use function is_object;
  */
 class DefaultCache implements Cache
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var UnitOfWork
-     */
+    /** @var UnitOfWork */
     private $uow;
 
-    /**
-     * @var CacheFactory
-     */
+    /** @var CacheFactory */
     private $cacheFactory;
 
-    /**
-     * @var QueryCache[]
-     */
+    /** @var QueryCache[] */
     private $queryCaches = [];
 
-    /**
-     * @var QueryCache
-     */
+    /** @var QueryCache */
     private $defaultQueryCache;
 
     /**

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -30,29 +30,19 @@ use function sprintf;
 
 class DefaultCacheFactory implements CacheFactory
 {
-    /**
-     * @var CacheAdapter
-     */
+    /** @var CacheAdapter */
     private $cache;
 
-    /**
-     * @var RegionsConfiguration
-     */
+    /** @var RegionsConfiguration */
     private $regionsConfig;
 
-    /**
-     * @var TimestampRegion|null
-     */
+    /** @var TimestampRegion|null */
     private $timestampRegion;
 
-    /**
-     * @var Region[]
-     */
+    /** @var Region[] */
     private $regions = [];
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     private $fileLockRegionDirectory;
 
     public function __construct(RegionsConfiguration $cacheConfig, CacheAdapter $cache)

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -15,19 +15,13 @@ use Doctrine\ORM\UnitOfWork;
  */
 class DefaultCollectionHydrator implements CollectionHydrator
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var UnitOfWork
-     */
+    /** @var UnitOfWork */
     private $uow;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -20,19 +20,13 @@ use function array_merge;
  */
 class DefaultEntityHydrator implements EntityHydrator
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var UnitOfWork
-     */
+    /** @var UnitOfWork */
     private $uow;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -26,29 +26,19 @@ use function reset;
  */
 class DefaultQueryCache implements QueryCache
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var Region
-     */
+    /** @var Region */
     private $region;
 
-    /**
-     * @var QueryCacheValidator
-     */
+    /** @var QueryCacheValidator */
     private $validator;
 
-    /**
-     * @var CacheLogger
-     */
+    /** @var CacheLogger */
     protected $cacheLogger;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private static $hints = [Query::HINT_CACHE_ENABLED => true];
 
     /**

--- a/lib/Doctrine/ORM/Cache/Lock.php
+++ b/lib/Doctrine/ORM/Cache/Lock.php
@@ -9,17 +9,13 @@ use function uniqid;
 
 class Lock
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $value;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $time;
 
-    public function __construct(string $value, int $time = null)
+    public function __construct(string $value, ?int $time = null)
     {
         $this->value = $value;
         $this->time  = $time ?: time();

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -10,9 +10,7 @@ use Doctrine\ORM\Cache\QueryCacheKey;
 
 class CacheLoggerChain implements CacheLogger
 {
-    /**
-     * @var array<\Doctrine\ORM\Cache\Logging\CacheLogger>
-     */
+    /** @var array<\Doctrine\ORM\Cache\Logging\CacheLogger> */
     private $loggers = [];
 
     /**

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -14,19 +14,13 @@ use function array_sum;
  */
 class StatisticsCacheLogger implements CacheLogger
 {
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     private $cacheMissCountMap = [];
 
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     private $cacheHitCountMap = [];
 
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     private $cachePutCountMap = [];
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -25,59 +25,37 @@ use function count;
 
 abstract class AbstractCollectionPersister implements CachedCollectionPersister
 {
-    /**
-     * @var UnitOfWork
-     */
+    /** @var UnitOfWork */
     protected $uow;
 
-    /**
-     * @var ClassMetadataFactory
-     */
+    /** @var ClassMetadataFactory */
     protected $metadataFactory;
 
-    /**
-     * @var CollectionPersister
-     */
+    /** @var CollectionPersister */
     protected $persister;
 
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     protected $sourceEntity;
 
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     protected $targetEntity;
 
-    /**
-     * @var AssociationMetadata
-     */
+    /** @var AssociationMetadata */
     protected $association;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     protected $queuedCache = [];
 
-    /**
-     * @var Region
-     */
+    /** @var Region */
     protected $region;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $regionName;
 
-    /**
-     * @var CollectionHydrator
-     */
+    /** @var CollectionHydrator */
     protected $hydrator;
 
-    /**
-     * @var CacheLogger
-     */
+    /** @var CacheLogger */
     protected $cacheLogger;
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -31,64 +31,40 @@ use function sha1;
 
 abstract class AbstractEntityPersister implements CachedEntityPersister
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     protected $em;
 
-    /**
-     * @var ClassMetadataFactory
-     */
+    /** @var ClassMetadataFactory */
     protected $metadataFactory;
 
-    /**
-     * @var EntityPersister
-     */
+    /** @var EntityPersister */
     protected $persister;
 
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     protected $class;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     protected $queuedCache = [];
 
-    /**
-     * @var Region
-     */
+    /** @var Region */
     protected $region;
 
-    /**
-     * @var TimestampRegion
-     */
+    /** @var TimestampRegion */
     protected $timestampRegion;
 
-    /**
-     * @var TimestampCacheKey
-     */
+    /** @var TimestampCacheKey */
     protected $timestampKey;
 
-    /**
-     * @var EntityHydrator
-     */
+    /** @var EntityHydrator */
     protected $hydrator;
 
-    /**
-     * @var Cache
-     */
+    /** @var Cache */
     protected $cache;
 
-    /**
-     * @var CacheLogger
-     */
+    /** @var CacheLogger */
     protected $cacheLogger;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $regionName;
 
     /**

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -22,19 +22,13 @@ class DefaultRegion implements Region
 {
     public const REGION_KEY_SEPARATOR = '_';
 
-    /**
-     * @var CacheAdapter
-     */
+    /** @var CacheAdapter */
     protected $cache;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $lifetime = 0;
 
     /**
@@ -45,7 +39,7 @@ class DefaultRegion implements Region
     {
         $this->cache    = $cache;
         $this->name     = (string) $name;
-        $this->lifetime = (integer) $lifetime;
+        $this->lifetime = (int) $lifetime;
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -34,19 +34,13 @@ class FileLockRegion implements ConcurrentRegion
 {
     public const LOCK_EXTENSION = 'lock';
 
-    /**
-     * @var Region
-     */
+    /** @var Region */
     private $region;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $directory;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $lockLifetime;
 
     /**

--- a/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
@@ -14,19 +14,13 @@ class RegionsConfiguration
      */
     private $lifetimes = [];
 
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     private $lockLifetimes = [];
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $defaultLifetime;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $defaultLockLifetime;
 
     /**
@@ -35,8 +29,8 @@ class RegionsConfiguration
      */
     public function __construct($defaultLifetime = 3600, $defaultLockLifetime = 60)
     {
-        $this->defaultLifetime     = (integer) $defaultLifetime;
-        $this->defaultLockLifetime = (integer) $defaultLockLifetime;
+        $this->defaultLifetime     = (int) $defaultLifetime;
+        $this->defaultLockLifetime = (int) $defaultLockLifetime;
     }
 
     /**
@@ -52,7 +46,7 @@ class RegionsConfiguration
      */
     public function setDefaultLifetime($defaultLifetime)
     {
-        $this->defaultLifetime = (integer) $defaultLifetime;
+        $this->defaultLifetime = (int) $defaultLifetime;
     }
 
     /**
@@ -68,7 +62,7 @@ class RegionsConfiguration
      */
     public function setDefaultLockLifetime($defaultLockLifetime)
     {
-        $this->defaultLockLifetime = (integer) $defaultLockLifetime;
+        $this->defaultLockLifetime = (int) $defaultLockLifetime;
     }
 
     /**
@@ -87,7 +81,7 @@ class RegionsConfiguration
      */
     public function setLifetime($name, $lifetime)
     {
-        $this->lifetimes[$name] = (integer) $lifetime;
+        $this->lifetimes[$name] = (int) $lifetime;
     }
 
     /**
@@ -106,6 +100,6 @@ class RegionsConfiguration
      */
     public function setLockLifetime($name, $lifetime)
     {
-        $this->lockLifetimes[$name] = (integer) $lifetime;
+        $this->lockLifetimes[$name] = (int) $lifetime;
     }
 }

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -8,9 +8,7 @@ use function microtime;
 
 class TimestampQueryCacheValidator implements QueryCacheValidator
 {
-    /**
-     * @var TimestampRegion
-     */
+    /** @var TimestampRegion */
     private $timestampRegion;
 
     public function __construct(TimestampRegion $timestampRegion)

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -38,94 +38,58 @@ use function strtolower;
  */
 class Configuration extends DBALConfiguration
 {
-    /**
-     * @var ProxyManagerConfiguration|null
-     */
+    /** @var ProxyManagerConfiguration|null */
     private $proxyManagerConfiguration;
 
-    /**
-     * @var MappingDriver|null
-     */
+    /** @var MappingDriver|null */
     private $metadataDriver;
 
-    /**
-     * @var CacheDriver|null
-     */
+    /** @var CacheDriver|null */
     private $queryCache;
 
-    /**
-     * @var CacheDriver|null
-     */
+    /** @var CacheDriver|null */
     private $hydrationCache;
 
-    /**
-     * @var CacheDriver|null
-     */
+    /** @var CacheDriver|null */
     private $metadataCache;
 
-    /**
-     * @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name
-     */
+    /** @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name */
     private $customStringFunctions = [];
 
-    /**
-     * @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name
-     */
+    /** @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name */
     private $customNumericFunctions = [];
 
-    /**
-     * @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name
-     */
+    /** @var string[][]|ResultSetMapping[][] tuples of [$sqlString, $resultSetMapping] indexed by query name */
     private $customDatetimeFunctions = [];
 
-    /**
-     * @var string[] of hydrator class names, indexed by mode name
-     */
+    /** @var string[] of hydrator class names, indexed by mode name */
     private $customHydrationModes = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $classMetadataFactoryClassName = ClassMetadataFactory::class;
 
-    /**
-     * @var string[] of filter class names, indexed by filter name
-     */
+    /** @var string[] of filter class names, indexed by filter name */
     private $filters;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $defaultRepositoryClassName = EntityRepository::class;
 
-    /**
-     * @var NamingStrategy|null
-     */
+    /** @var NamingStrategy|null */
     private $namingStrategy;
 
-    /**
-     * @var EntityListenerResolver|null
-     */
+    /** @var EntityListenerResolver|null */
     private $entityListenerResolver;
 
-    /**
-     * @var RepositoryFactory|null
-     */
+    /** @var RepositoryFactory|null */
     private $repositoryFactory;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $isSecondLevelCacheEnabled = false;
 
-    /**
-     * @var CacheConfiguration|null
-     */
+    /** @var CacheConfiguration|null */
     private $secondLevelCacheConfiguration;
 
-    /**
-     * @var mixed[] indexed by hint name
-     */
+    /** @var mixed[] indexed by hint name */
     private $defaultQueryHints = [];
 
     /**

--- a/lib/Doctrine/ORM/Configuration/MetadataConfiguration.php
+++ b/lib/Doctrine/ORM/Configuration/MetadataConfiguration.php
@@ -18,34 +18,22 @@ use function rtrim;
  */
 class MetadataConfiguration
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $namespace;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $directory;
 
-    /**
-     * @var ClassMetadataResolver
-     */
+    /** @var ClassMetadataResolver */
     private $resolver;
 
-    /**
-     * @var MappingDriver
-     */
+    /** @var MappingDriver */
     private $mappingDriver;
 
-    /**
-     * @var NamingStrategy
-     */
+    /** @var NamingStrategy */
     private $namingStrategy;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $autoGenerate = AbstractClassMetadataFactory::AUTOGENERATE_ALWAYS;
 
     public function getNamespace() : string

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
  */
 abstract class EntityManagerDecorator extends ObjectManagerDecorator implements EntityManagerInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     protected $wrapped;
 
     public function __construct(EntityManagerInterface $wrapped)

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -131,9 +131,7 @@ final class EntityManager implements EntityManagerInterface
      */
     private $filterCollection;
 
-    /**
-     * @var Cache The second level cache regions API.
-     */
+    /** @var Cache The second level cache regions API. */
     private $cache;
 
     /**

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -26,19 +26,13 @@ use function substr;
  */
 class EntityRepository implements ObjectRepository, Selectable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $entityName;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     protected $em;
 
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     protected $class;
 
     /**

--- a/lib/Doctrine/ORM/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ORM/Event/ListenersInvoker.php
@@ -20,9 +20,7 @@ class ListenersInvoker
     public const INVOKE_CALLBACKS = 2;
     public const INVOKE_MANAGER   = 4;
 
-    /**
-     * @var EntityListenerResolver The Entity listener resolver.
-     */
+    /** @var EntityListenerResolver The Entity listener resolver. */
     private $resolver;
 
     /**

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -14,14 +14,10 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class LoadClassMetadataEventArgs extends EventArgs
 {
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     private $classMetadata;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
     public function __construct(ClassMetadata $classMetadata, EntityManagerInterface $entityManager)

--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -17,19 +17,13 @@ use Doctrine\ORM\Mapping\ClassMetadataBuildingContext;
  */
 class OnClassMetadataNotFoundEventArgs extends ManagerEventArgs
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $className;
 
-    /**
-     * @var ClassMetadataBuildingContext
-     */
+    /** @var ClassMetadataBuildingContext */
     private $metadataBuildingContext;
 
-    /**
-     * @var ClassMetadata|null
-     */
+    /** @var ClassMetadata|null */
     private $foundMetadata;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class OnClearEventArgs extends EventArgs
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class OnFlushEventArgs extends EventArgs
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class PostFlushEventArgs extends EventArgs
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -12,9 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class PreFlushEventArgs extends EventArgs
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -13,9 +13,7 @@ use function sprintf;
  */
 class PreUpdateEventArgs extends LifecycleEventArgs
 {
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $entityChangeSet;
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -18,34 +18,22 @@ use function reset;
  */
 class ArrayHydrator extends AbstractHydrator
 {
-    /**
-     * @var bool[]
-     */
+    /** @var bool[] */
     private $rootAliases = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $isSimpleQuery = false;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $identifierMap = [];
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $resultPointers = [];
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $idTemplate = [];
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $resultCounter = 0;
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -10,24 +10,16 @@ namespace Doctrine\ORM\Internal\Hydration;
  */
 class IterableResult implements \Iterator
 {
-    /**
-     * @var AbstractHydrator
-     */
+    /** @var AbstractHydrator */
     private $hydrator;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $rewinded = false;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $key = -1;
 
-    /**
-     * @var object|null
-     */
+    /** @var object|null */
     private $current;
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -27,39 +27,25 @@ use function spl_object_id;
  */
 class ObjectHydrator extends AbstractHydrator
 {
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $identifierMap = [];
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $resultPointers = [];
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $idTemplate = [];
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $resultCounter = 0;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $rootAliases = [];
 
-    /**
-     * @var Collection[]|object[][]
-     */
+    /** @var Collection[]|object[][] */
     private $initializedCollections = [];
 
-    /**
-     * @var Collection[]|object[][]
-     */
+    /** @var Collection[]|object[][] */
     private $existingCollections = [];
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -17,9 +17,7 @@ use function sprintf;
 
 class SimpleObjectHydrator extends AbstractHydrator
 {
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     private $class;
 
     /**

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -16,19 +16,13 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 final class HydrationCompleteHandler
 {
-    /**
-     * @var ListenersInvoker
-     */
+    /** @var ListenersInvoker */
     private $listenersInvoker;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredPostLoadInvocations = [];
 
     /**

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -19,19 +19,13 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
  */
 class LazyCriteriaCollection extends AbstractLazyCollection implements Selectable
 {
-    /**
-     * @var BasicEntityPersister
-     */
+    /** @var BasicEntityPersister */
     protected $entityPersister;
 
-    /**
-     * @var Criteria
-     */
+    /** @var Criteria */
     protected $criteria;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     private $count;
 
     public function __construct(EntityPersister $entityPersister, Criteria $criteria)

--- a/lib/Doctrine/ORM/Mapping/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/AbstractClassMetadataFactory.php
@@ -29,24 +29,16 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     protected $cacheSalt = '$CLASSMETADATA';
 
-    /**
-     * @var Cache|null
-     */
+    /** @var Cache|null */
     private $cacheDriver;
 
-    /**
-     * @var ClassMetadata[]
-     */
+    /** @var ClassMetadata[] */
     private $loadedMetadata = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $initialized = false;
 
-    /**
-     * @var ReflectionService|null
-     */
+    /** @var ReflectionService|null */
     protected $reflectionService;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataBuildingContext.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataBuildingContext.php
@@ -37,14 +37,10 @@ class ClassMetadataBuildingContext
     /** @var NamingStrategy */
     private $namingStrategy;
 
-    /**
-     * @var SecondPass[]
-     */
+    /** @var SecondPass[] */
     protected $secondPassList = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $inSecondPass = false;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -38,24 +38,16 @@ use function var_export;
  */
 class ClassMetadataFactory extends AbstractClassMetadataFactory
 {
-    /**
-     * @var EntityManagerInterface|null
-     */
+    /** @var EntityManagerInterface|null */
     private $em;
 
-    /**
-     * @var AbstractPlatform
-     */
+    /** @var AbstractPlatform */
     private $targetPlatform;
 
-    /**
-     * @var Driver\MappingDriver
-     */
+    /** @var Driver\MappingDriver */
     private $driver;
 
-    /**
-     * @var EventManager
-     */
+    /** @var EventManager */
     private $evm;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ColumnMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ColumnMetadata.php
@@ -8,44 +8,28 @@ use Doctrine\DBAL\Types\Type;
 
 abstract class ColumnMetadata
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $tableName;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $columnName;
 
-    /**
-     * @var Type|null
-     */
+    /** @var Type|null */
     protected $type;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $columnDefinition;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     protected $options = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $primaryKey = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $nullable = false;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $unique = false;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ComponentMetadata.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Mapping;
  */
 abstract class ComponentMetadata
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $className;
 
-    /**
-     * @var ComponentMetadata|null
-     */
+    /** @var ComponentMetadata|null */
     protected $parent;
 
     /**
@@ -26,14 +22,10 @@ abstract class ComponentMetadata
      */
     protected $reflectionClass;
 
-    /**
-     * @var CacheMetadata|null
-     */
+    /** @var CacheMetadata|null */
     protected $cache;
 
-    /**
-     * @var Property[]
-     */
+    /** @var Property[] */
     protected $declaredProperties = [];
 
     public function __construct(string $className, ClassMetadataBuildingContext $metadataBuildingContext)

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -15,9 +15,7 @@ use function trim;
  */
 class DefaultEntityListenerResolver implements EntityListenerResolver
 {
-    /**
-     * @var object[] Map to store entity listener instances.
-     */
+    /** @var object[] Map to store entity listener instances. */
     private $instances = [];
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php
@@ -37,9 +37,7 @@ use function strtoupper;
  */
 class AnnotationDriver implements Mapping\Driver\MappingDriver
 {
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     protected $entityAnnotationClasses = [
         Annotation\Entity::class           => 1,
         Annotation\MappedSuperclass::class => 2,

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EmbeddableClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EmbeddableClassMetadataBinder.php
@@ -12,14 +12,10 @@ use Doctrine\ORM\Mapping;
  */
 class EmbeddableClassMetadataBinder
 {
-    /**
-     * @var Mapping\ClassMetadataBuildingContext
-     */
+    /** @var Mapping\ClassMetadataBuildingContext */
     private $metadataBuildingContext;
 
-    /**
-     * @var \ReflectionClass
-     */
+    /** @var \ReflectionClass */
     private $reflectionClass;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php
@@ -12,14 +12,10 @@ use Doctrine\ORM\Mapping;
  */
 class EntityClassMetadataBinder
 {
-    /**
-     * @var Mapping\ClassMetadataBuildingContext
-     */
+    /** @var Mapping\ClassMetadataBuildingContext */
     private $metadataBuildingContext;
 
-    /**
-     * @var \ReflectionClass
-     */
+    /** @var \ReflectionClass */
     private $reflectionClass;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php
@@ -9,14 +9,10 @@ use Doctrine\ORM\Mapping;
 
 class MappedSuperClassMetadataBinder
 {
-    /**
-     * @var Mapping\ClassMetadataBuildingContext
-     */
+    /** @var Mapping\ClassMetadataBuildingContext */
     private $metadataBuildingContext;
 
-    /**
-     * @var \ReflectionClass
-     */
+    /** @var \ReflectionClass */
     private $reflectionClass;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -40,9 +40,7 @@ use function strtoupper;
  */
 class AnnotationDriver implements MappingDriver
 {
-    /**
-     * @var int[]
-     */
+    /** @var int[] */
     protected $entityAnnotationClasses = [
         Annotation\Entity::class           => 1,
         Annotation\MappedSuperclass::class => 2,

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -29,34 +29,22 @@ use function strtolower;
  */
 class DatabaseDriver implements MappingDriver
 {
-    /**
-     * @var AbstractSchemaManager
-     */
+    /** @var AbstractSchemaManager */
     private $sm;
 
-    /**
-     * @var Table[]|null
-     */
+    /** @var Table[]|null */
     private $tables;
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $classToTableNames = [];
 
-    /**
-     * @var Table[]
-     */
+    /** @var Table[] */
     private $manyToManyTables = [];
 
-    /**
-     * @var Table[]
-     */
+    /** @var Table[] */
     private $classNamesForTables = [];
 
-    /**
-     * @var Table[][]
-     */
+    /** @var Table[][] */
     private $fieldNamesForColumns = [];
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
@@ -22,9 +22,7 @@ class DriverChain implements MappingDriver
      */
     private $defaultDriver;
 
-    /**
-     * @var MappingDriver[]
-     */
+    /** @var MappingDriver[] */
     private $drivers = [];
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/FileDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/FileDriver.php
@@ -22,19 +22,13 @@ use function str_replace;
  */
 abstract class FileDriver implements MappingDriver
 {
-    /**
-     * @var FileLocator
-     */
+    /** @var FileLocator */
     protected $locator;
 
-    /**
-     * @var mixed[]|null
-     */
+    /** @var mixed[]|null */
     protected $classCache;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $globalBasename;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
@@ -50,9 +50,7 @@ class NewAnnotationDriver implements MappingDriver
      */
     protected $locator;
 
-    /**
-     * @var Factory\NamingStrategy
-     */
+    /** @var Factory\NamingStrategy */
     protected $namingStrategy;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/EntityClassMetadata.php
@@ -11,14 +11,10 @@ abstract class EntityClassMetadata extends ComponentMetadata
     /** @var string The name of the Entity */
     protected $entityName;
 
-    /**
-     * @var string|null The name of the custom repository class used for the entity class.
-     */
+    /** @var string|null The name of the custom repository class used for the entity class. */
     protected $customRepositoryClassName;
 
-    /**
-     * @var Property|null The field which is used for versioning in optimistic locking (if any).
-     */
+    /** @var Property|null The field which is used for versioning in optimistic locking (if any). */
     protected $declaredVersion;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Factory/AbstractClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/AbstractClassMetadataFactory.php
@@ -39,24 +39,16 @@ abstract class AbstractClassMetadataFactory implements ClassMetadataFactory
      */
     public const AUTOGENERATE_FILE_NOT_EXISTS = 2;
 
-    /**
-     * @var ClassMetadataDefinitionFactory
-     */
+    /** @var ClassMetadataDefinitionFactory */
     protected $definitionFactory;
 
-    /**
-     * @var MappingDriver
-     */
+    /** @var MappingDriver */
     protected $mappingDriver;
 
-    /**
-     * @var ClassMetadataDefinition[]
-     */
+    /** @var ClassMetadataDefinition[] */
     private $definitions = [];
 
-    /**
-     * @var ClassMetadata[]
-     */
+    /** @var ClassMetadata[] */
     private $loaded = [];
 
     public function __construct(MetadataConfiguration $configuration)

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataBuildingContext.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataBuildingContext.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Mapping\Factory;
  */
 class ClassMetadataBuildingContext
 {
-    /**
-     * @var AbstractClassMetadataFactory
-     */
+    /** @var AbstractClassMetadataFactory */
     private $classMetadataFactory;
 
-    /**
-     * @var SecondPass[]
-     */
+    /** @var SecondPass[] */
     protected $secondPassList = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $inSecondPass = false;
 
     public function __construct(AbstractClassMetadataFactory $classMetadataFactory)

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinition.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinition.php
@@ -8,19 +8,13 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 
 class ClassMetadataDefinition
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $entityClassName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $metadataClassName;
 
-    /**
-     * @var ClassMetadata|null
-     */
+    /** @var ClassMetadata|null */
     public $parentClassMetadata;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinitionFactory.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataDefinitionFactory.php
@@ -10,14 +10,10 @@ use function class_exists;
 
 class ClassMetadataDefinitionFactory
 {
-    /**
-     * @var ClassMetadataResolver
-     */
+    /** @var ClassMetadataResolver */
     private $resolver;
 
-    /**
-     * @var ClassMetadataGeneratorStrategy
-     */
+    /** @var ClassMetadataGeneratorStrategy */
     private $generatorStrategy;
 
     public function __construct(ClassMetadataResolver $resolver, ClassMetadataGeneratorStrategy $generatorStrategy)

--- a/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/ClassMetadataGenerator.php
@@ -12,14 +12,10 @@ use Doctrine\ORM\Mapping\Exporter\ClassMetadataExporter;
  */
 class ClassMetadataGenerator
 {
-    /**
-     * @var MappingDriver
-     */
+    /** @var MappingDriver */
     protected $mappingDriver;
 
-    /**
-     * @var ClassMetadataExporter
-     */
+    /** @var ClassMetadataExporter */
     private $metadataExporter;
 
     public function __construct(

--- a/lib/Doctrine/ORM/Mapping/Factory/DefaultClassMetadataResolver.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/DefaultClassMetadataResolver.php
@@ -19,14 +19,10 @@ class DefaultClassMetadataResolver implements ClassMetadataResolver
      */
     public const MARKER = '__CG__';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $namespace;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $directory;
 
     public function __construct(string $namespace, string $directory)

--- a/lib/Doctrine/ORM/Mapping/Factory/Strategy/EvaluatingClassMetadataGeneratorStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Strategy/EvaluatingClassMetadataGeneratorStrategy.php
@@ -9,9 +9,7 @@ use Doctrine\ORM\Mapping\Factory\ClassMetadataGenerator;
 
 class EvaluatingClassMetadataGeneratorStrategy implements ClassMetadataGeneratorStrategy
 {
-    /**
-     * @var ClassMetadataGenerator
-     */
+    /** @var ClassMetadataGenerator */
     private $generator;
 
     public function __construct(ClassMetadataGenerator $generator)

--- a/lib/Doctrine/ORM/Mapping/Factory/Strategy/FileWriterClassMetadataGeneratorStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/Strategy/FileWriterClassMetadataGeneratorStrategy.php
@@ -18,9 +18,7 @@ use function uniqid;
 
 class FileWriterClassMetadataGeneratorStrategy implements ClassMetadataGeneratorStrategy
 {
-    /**
-     * @var ClassMetadataGenerator
-     */
+    /** @var ClassMetadataGenerator */
     private $generator;
 
     public function __construct(ClassMetadataGenerator $generator)

--- a/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
@@ -19,9 +19,7 @@ use function substr;
  */
 class UnderscoreNamingStrategy implements NamingStrategy
 {
-    /**
-     * @var int
-     */
+    /** @var int */
     private $case;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/FieldMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMetadata.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Mapping;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Reflection\ReflectionService;
 
 class FieldMetadata extends LocalColumnMetadata implements Property
@@ -18,21 +17,10 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     /** @var string */
     protected $name;
 
-    /**
-     * @param string $columnName
-     * @param Type   $type
-     *
-     * @todo Leverage this implementation instead of default, simple constructor
-     */
-    /*public function __construct(string $name, string $columnName, Type $type)
+    public function __construct(string $name/*, string $columnName, Type $type*/)
     {
-        parent::__construct($columnName, $type);
-
-        $this->name = $name;
-    }*/
-
-    public function __construct(string $name)
-    {
+//        @todo Leverage this implementation instead of default, simple constructor
+//        parent::__construct($columnName, $type);
         $this->name = $name;
     }
 

--- a/lib/Doctrine/ORM/Mapping/LocalColumnMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/LocalColumnMetadata.php
@@ -6,24 +6,16 @@ namespace Doctrine\ORM\Mapping;
 
 abstract class LocalColumnMetadata extends ColumnMetadata
 {
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     protected $length;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     protected $scale;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     protected $precision;
 
-    /**
-     * @var ValueGeneratorMetadata|null
-     */
+    /** @var ValueGeneratorMetadata|null */
     protected $valueGenerator;
 
     public function getLength() : ?int

--- a/lib/Doctrine/ORM/Mapping/MappedSuperClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/MappedSuperClassMetadata.php
@@ -6,14 +6,10 @@ namespace Doctrine\ORM\Mapping;
 
 class MappedSuperClassMetadata extends ComponentMetadata
 {
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     protected $customRepositoryClassName;
 
-    /**
-     * @var Property|null
-     */
+    /** @var Property|null */
     protected $declaredVersion;
 
     public function getCustomRepositoryClassName() : ?string

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -18,24 +18,16 @@ use ReflectionProperty;
  */
 class ReflectionEmbeddedProperty extends ReflectionProperty
 {
-    /**
-     * @var ReflectionProperty reflection property of the class where the embedded object has to be put
-     */
+    /** @var ReflectionProperty reflection property of the class where the embedded object has to be put */
     private $parentProperty;
 
-    /**
-     * @var ReflectionProperty reflection property of the embedded object
-     */
+    /** @var ReflectionProperty reflection property of the embedded object */
     private $childProperty;
 
-    /**
-     * @var string name of the embedded class to be eventually instantiated
-     */
+    /** @var string name of the embedded class to be eventually instantiated */
     private $embeddedClass;
 
-    /**
-     * @var Instantiator|null
-     */
+    /** @var Instantiator|null */
     private $instantiator;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ToOneAssociationMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ToOneAssociationMetadata.php
@@ -6,9 +6,7 @@ namespace Doctrine\ORM\Mapping;
 
 class ToOneAssociationMetadata extends AssociationMetadata
 {
-    /**
-     * @var JoinColumnMetadata[]
-     */
+    /** @var JoinColumnMetadata[] */
     private $joinColumns = [];
 
     /**

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -14,9 +14,7 @@ use function ksort;
  */
 final class NativeQuery extends AbstractQuery
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $sql;
 
     /**

--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -10,9 +10,7 @@ namespace Doctrine\ORM;
  */
 class OptimisticLockException extends ORMException
 {
-    /**
-     * @var object|null
-     */
+    /** @var object|null */
     private $entity;
 
     /**

--- a/lib/Doctrine/ORM/PersistentObject.php
+++ b/lib/Doctrine/ORM/PersistentObject.php
@@ -46,14 +46,10 @@ use function substr;
  */
 abstract class PersistentObject implements EntityManagerAware
 {
-    /**
-     * @var EntityManagerInterface|null
-     */
+    /** @var EntityManagerInterface|null */
     private static $entityManager = null;
 
-    /**
-     * @var ClassMetadata|null
-     */
+    /** @var ClassMetadata|null */
     private $cm;
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
@@ -14,19 +14,13 @@ use Doctrine\ORM\UnitOfWork;
  */
 abstract class AbstractCollectionPersister implements CollectionPersister
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     protected $em;
 
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     protected $conn;
 
-    /**
-     * @var UnitOfWork
-     */
+    /** @var UnitOfWork */
     protected $uow;
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -163,7 +163,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         // If there is a provided criteria, make part of conditions
         // @todo Fix this. Current SQL returns something like:
-        //
         /*if ($criteria && ($expression = $criteria->getWhereExpression()) !== null) {
             // A join is needed on the target entity
             $targetTableName = $targetClass->table->getQuotedQualifiedName($this->platform);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -90,9 +90,7 @@ use function trim;
  */
 class BasicEntityPersister implements EntityPersister
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private static $comparisonMap = [
         Comparison::EQ          => '= %s',
         Comparison::IS          => '= %s',
@@ -154,19 +152,13 @@ class BasicEntityPersister implements EntityPersister
      */
     private $insertSql;
 
-    /**
-     * @var CachedPersisterContext
-     */
+    /** @var CachedPersisterContext */
     protected $currentPersisterContext;
 
-    /**
-     * @var CachedPersisterContext
-     */
+    /** @var CachedPersisterContext */
     private $limitsHandlingContext;
 
-    /**
-     * @var CachedPersisterContext
-     */
+    /** @var CachedPersisterContext */
     private $noLimitsContext;
 
     /**

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -20,14 +20,10 @@ use function is_object;
  */
 class SqlExpressionVisitor extends ExpressionVisitor
 {
-    /**
-     * @var BasicEntityPersister
-     */
+    /** @var BasicEntityPersister */
     private $persister;
 
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     private $classMetadata;
 
     public function __construct(BasicEntityPersister $persister, ClassMetadata $classMetadata)

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -14,14 +14,10 @@ use Doctrine\Common\Collections\Expr\Value;
  */
 class SqlValueVisitor extends ExpressionVisitor
 {
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $values = [];
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $types = [];
 
     /**

--- a/lib/Doctrine/ORM/Proxy/Factory/StaticProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/Factory/StaticProxyFactory.php
@@ -24,29 +24,19 @@ final class StaticProxyFactory implements ProxyFactory
 {
     private const SKIPPED_PROPERTIES = 'skippedProperties';
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
-    /**
-     * @var LazyLoadingGhostFactory
-     */
+    /** @var LazyLoadingGhostFactory */
     private $proxyFactory;
 
-    /**
-     * @var \Closure[] indexed by metadata class name
-     */
+    /** @var \Closure[] indexed by metadata class name */
     private $cachedInitializers = [];
 
-    /**
-     * @var EntityPersister[] indexed by metadata class name
-     */
+    /** @var EntityPersister[] indexed by metadata class name */
     private $cachedPersisters = [];
 
-    /**
-     * @var string[][][] indexed by metadata class name
-     */
+    /** @var string[][][] indexed by metadata class name */
     private $cachedSkippedProperties = [];
 
     public function __construct(

--- a/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class AggregateExpression extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $functionName;
 
-    /**
-     * @var PathExpression|SimpleArithmeticExpression
-     */
+    /** @var PathExpression|SimpleArithmeticExpression */
     public $pathExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ArithmeticExpression extends Node
 {
-    /**
-     * @var SimpleArithmeticExpression|null
-     */
+    /** @var SimpleArithmeticExpression|null */
     public $simpleArithmeticExpression;
 
-    /**
-     * @var Subselect|null
-     */
+    /** @var Subselect|null */
     public $subselect;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ArithmeticFactor extends Node
 {
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $arithmeticPrimary;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ArithmeticTerm extends Node
 {
-    /**
-     * @var ArithmeticFactor[]
-     */
+    /** @var ArithmeticFactor[] */
     public $arithmeticFactors;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
@@ -6,24 +6,16 @@ namespace Doctrine\ORM\Query\AST;
 
 class BetweenExpression extends Node
 {
-    /**
-     * @var ArithmeticExpression
-     */
+    /** @var ArithmeticExpression */
     public $expression;
 
-    /**
-     * @var ArithmeticExpression
-     */
+    /** @var ArithmeticExpression */
     public $leftBetweenExpression;
 
-    /**
-     * @var ArithmeticExpression
-     */
+    /** @var ArithmeticExpression */
     public $rightBetweenExpression;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class CoalesceExpression extends Node
 {
-    /**
-     * @var Node[]
-     */
+    /** @var Node[] */
     public $scalarExpressions = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
@@ -12,14 +12,10 @@ class CollectionMemberExpression extends Node
     /** @var mixed */
     public $entityExpression;
 
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $collectionValuedPathExpression;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
@@ -14,19 +14,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ComparisonExpression extends Node
 {
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $leftExpression;
 
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $rightExpression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $operator;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ConditionalExpression extends Node
 {
-    /**
-     * @var ConditionalTerm[]
-     */
+    /** @var ConditionalTerm[] */
     public $conditionalTerms = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ConditionalFactor extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not = false;
 
-    /**
-     * @var ConditionalPrimary
-     */
+    /** @var ConditionalPrimary */
     public $conditionalPrimary;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ConditionalPrimary extends Node
 {
-    /**
-     * @var Node|null
-     */
+    /** @var Node|null */
     public $simpleConditionalExpression;
 
-    /**
-     * @var ConditionalExpression|null
-     */
+    /** @var ConditionalExpression|null */
     public $conditionalExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ConditionalTerm extends Node
 {
-    /**
-     * @var ConditionalFactor[]
-     */
+    /** @var ConditionalFactor[] */
     public $conditionalFactors = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/DeleteClause.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteClause.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class DeleteClause extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $abstractSchemaName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $aliasIdentificationVariable;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class DeleteStatement extends Node
 {
-    /**
-     * @var DeleteClause
-     */
+    /** @var DeleteClause */
     public $deleteClause;
 
-    /**
-     * @var WhereClause|null
-     */
+    /** @var WhereClause|null */
     public $whereClause;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class EmptyCollectionComparisonExpression extends Node
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $expression;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ExistsExpression extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
-    /**
-     * @var Subselect
-     */
+    /** @var Subselect */
     public $subselect;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/FromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/FromClause.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class FromClause extends Node
 {
-    /**
-     * @var IdentificationVariableDeclaration[]
-     */
+    /** @var IdentificationVariableDeclaration[] */
     public $identificationVariableDeclarations = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -14,9 +14,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class AbsFunction extends FunctionNode
 {
-    /**
-     * @var SimpleArithmeticExpression
-     */
+    /** @var SimpleArithmeticExpression */
     public $simpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 final class AvgFunction extends FunctionNode
 {
-    /**
-     * @var AggregateExpression
-     */
+    /** @var AggregateExpression */
     private $aggregateExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
-use function call_user_func_array;
 
 /**
  * "CONCAT" "(" StringPrimary "," StringPrimary {"," StringPrimary }* ")"

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 final class CountFunction extends FunctionNode
 {
-    /**
-     * @var AggregateExpression
-     */
+    /** @var AggregateExpression */
     private $aggregateExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 abstract class FunctionNode extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -17,14 +17,10 @@ use function sprintf;
  */
 class IdentityFunction extends FunctionNode
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $pathExpression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $fieldMapping;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -21,9 +21,7 @@ class LocateFunction extends FunctionNode
     /** @var Node */
     public $secondStringPrimary;
 
-    /**
-     * @var SimpleArithmeticExpression|bool
-     */
+    /** @var SimpleArithmeticExpression|bool */
     public $simpleArithmeticExpression = false;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 final class MaxFunction extends FunctionNode
 {
-    /**
-     * @var AggregateExpression
-     */
+    /** @var AggregateExpression */
     private $aggregateExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 final class MinFunction extends FunctionNode
 {
-    /**
-     * @var AggregateExpression
-     */
+    /** @var AggregateExpression */
     private $aggregateExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -14,14 +14,10 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class ModFunction extends FunctionNode
 {
-    /**
-     * @var SimpleArithmeticExpression
-     */
+    /** @var SimpleArithmeticExpression */
     public $firstSimpleArithmeticExpression;
 
-    /**
-     * @var SimpleArithmeticExpression
-     */
+    /** @var SimpleArithmeticExpression */
     public $secondSimpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -16,9 +16,7 @@ use function sprintf;
  */
 class SizeFunction extends FunctionNode
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $collectionPathExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -14,9 +14,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class SqrtFunction extends FunctionNode
 {
-    /**
-     * @var SimpleArithmeticExpression
-     */
+    /** @var SimpleArithmeticExpression */
     public $simpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -18,14 +18,10 @@ class SubstringFunction extends FunctionNode
     /** @var Node */
     public $stringPrimary;
 
-    /**
-     * @var SimpleArithmeticExpression
-     */
+    /** @var SimpleArithmeticExpression */
     public $firstSimpleArithmeticExpression;
 
-    /**
-     * @var SimpleArithmeticExpression|null
-     */
+    /** @var SimpleArithmeticExpression|null */
     public $secondSimpleArithmeticExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
@@ -13,9 +13,7 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 final class SumFunction extends FunctionNode
 {
-    /**
-     * @var AggregateExpression
-     */
+    /** @var AggregateExpression */
     private $aggregateExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -16,29 +16,19 @@ use function strcasecmp;
  */
 class TrimFunction extends FunctionNode
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $leading;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $trailing;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $both;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $trimChar = false;
 
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $stringPrimary;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class GeneralCaseExpression extends Node
 {
-    /**
-     * @var WhenClause[]
-     */
+    /** @var WhenClause[] */
     public $whenClauses = [];
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $elseScalarExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/GroupByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/GroupByClause.php
@@ -8,9 +8,7 @@ use Doctrine\ORM\Query\Expr\GroupBy;
 
 class GroupByClause extends Node
 {
-    /**
-     * @var GroupBy[]
-     */
+    /** @var GroupBy[] */
     public $groupByItems = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/HavingClause.php
+++ b/lib/Doctrine/ORM/Query/AST/HavingClause.php
@@ -6,9 +6,7 @@ namespace Doctrine\ORM\Query\AST;
 
 class HavingClause extends Node
 {
-    /**
-     * @var ConditionalExpression
-     */
+    /** @var ConditionalExpression */
     public $conditionalExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class IdentificationVariableDeclaration extends Node
 {
-    /**
-     * @var RangeVariableDeclaration|null
-     */
+    /** @var RangeVariableDeclaration|null */
     public $rangeVariableDeclaration;
 
-    /**
-     * @var IndexBy|null
-     */
+    /** @var IndexBy|null */
     public $indexBy;
 
-    /**
-     * @var Join[]
-     */
+    /** @var Join[] */
     public $joins = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -9,24 +9,16 @@ namespace Doctrine\ORM\Query\AST;
  */
 class InExpression extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
-    /**
-     * @var ArithmeticExpression
-     */
+    /** @var ArithmeticExpression */
     public $expression;
 
-    /**
-     * @var Literal[]
-     */
+    /** @var Literal[] */
     public $literals = [];
 
-    /**
-     * @var Subselect|null
-     */
+    /** @var Subselect|null */
     public $subselect;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class IndexBy extends Node
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $simpleStateFieldPathExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -14,14 +14,10 @@ use function substr;
  */
 class InputParameter extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $isNamed;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $name;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
@@ -10,19 +10,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class InstanceOfExpression extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $identificationVariable;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     public $value;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Join.php
+++ b/lib/Doctrine/ORM/Query/AST/Join.php
@@ -14,19 +14,13 @@ class Join extends Node
     public const JOIN_TYPE_LEFTOUTER = 2;
     public const JOIN_TYPE_INNER     = 3;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $joinType = self::JOIN_TYPE_INNER;
 
-    /**
-     * @var Node|null
-     */
+    /** @var Node|null */
     public $joinAssociationDeclaration;
 
-    /**
-     * @var ConditionalExpression|null
-     */
+    /** @var ConditionalExpression|null */
     public $conditionalExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class JoinAssociationDeclaration extends Node
 {
-    /**
-     * @var JoinAssociationPathExpression
-     */
+    /** @var JoinAssociationPathExpression */
     public $joinAssociationPathExpression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $aliasIdentificationVariable;
 
-    /**
-     * @var IndexBy|null
-     */
+    /** @var IndexBy|null */
     public $indexBy;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class JoinAssociationPathExpression extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $identificationVariable;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $associationField;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class JoinClassPathExpression extends Node
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $abstractSchemaName;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $aliasIdentificationVariable;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class JoinVariableDeclaration extends Node
 {
-    /**
-     * @var Join
-     */
+    /** @var Join */
     public $join;
 
-    /**
-     * @var IndexBy|null
-     */
+    /** @var IndexBy|null */
     public $indexBy;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/LikeExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/LikeExpression.php
@@ -9,24 +9,16 @@ namespace Doctrine\ORM\Query\AST;
  */
 class LikeExpression extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $stringExpression;
 
-    /**
-     * @var InputParameter
-     */
+    /** @var InputParameter */
     public $stringPattern;
 
-    /**
-     * @var Literal|null
-     */
+    /** @var Literal|null */
     public $escapeChar;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Literal.php
+++ b/lib/Doctrine/ORM/Query/AST/Literal.php
@@ -10,14 +10,10 @@ class Literal extends Node
     public const BOOLEAN = 2;
     public const NUMERIC = 3;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $type;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $value;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class NewObjectExpression extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $className;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     public $args;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class NullComparisonExpression extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $not;
 
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $expression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class NullIfExpression extends Node
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $firstExpression;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $secondExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/OrderByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByClause.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class OrderByClause extends Node
 {
-    /**
-     * @var OrderByItem[]
-     */
+    /** @var OrderByItem[] */
     public $orderByItems = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/OrderByItem.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByItem.php
@@ -11,14 +11,10 @@ use function strtoupper;
  */
 class OrderByItem extends Node
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $expression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $type;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class ParenthesisExpression extends Node
 {
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $expression;
 
     public function __construct(Node $expression)

--- a/lib/Doctrine/ORM/Query/AST/PartialObjectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PartialObjectExpression.php
@@ -6,14 +6,10 @@ namespace Doctrine\ORM\Query\AST;
 
 class PartialObjectExpression extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $identificationVariable;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     public $partialFieldSet;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/PathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PathExpression.php
@@ -19,24 +19,16 @@ class PathExpression extends Node
     public const TYPE_SINGLE_VALUED_ASSOCIATION     = 4;
     public const TYPE_STATE_FIELD                   = 8;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $type;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $expectedType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $identificationVariable;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $field;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
@@ -11,14 +11,10 @@ use function strtoupper;
  */
 class QuantifiedExpression extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $type;
 
-    /**
-     * @var Subselect
-     */
+    /** @var Subselect */
     public $subselect;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class RangeVariableDeclaration extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $abstractSchemaName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $aliasIdentificationVariable;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $isRoot;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectClause.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SelectClause extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $isDistinct;
 
-    /**
-     * @var SelectExpression[]
-     */
+    /** @var SelectExpression[] */
     public $selectExpressions = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectExpression.php
@@ -10,19 +10,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SelectExpression extends Node
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $expression;
 
-    /**
-     * @var string|null
-     */
+    /** @var string|null */
     public $fieldIdentificationVariable;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $hiddenAliasResultVariable;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SelectStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectStatement.php
@@ -9,34 +9,22 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SelectStatement extends Node
 {
-    /**
-     * @var SelectClause
-     */
+    /** @var SelectClause */
     public $selectClause;
 
-    /**
-     * @var FromClause
-     */
+    /** @var FromClause */
     public $fromClause;
 
-    /**
-     * @var WhereClause|null
-     */
+    /** @var WhereClause|null */
     public $whereClause;
 
-    /**
-     * @var GroupByClause|null
-     */
+    /** @var GroupByClause|null */
     public $groupByClause;
 
-    /**
-     * @var HavingClause|null
-     */
+    /** @var HavingClause|null */
     public $havingClause;
 
-    /**
-     * @var OrderByClause|null
-     */
+    /** @var OrderByClause|null */
     public $orderByClause;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SimpleArithmeticExpression extends Node
 {
-    /**
-     * @var ArithmeticTerm[]
-     */
+    /** @var ArithmeticTerm[] */
     public $arithmeticTerms = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SimpleCaseExpression extends Node
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $caseOperand;
 
-    /**
-     * @var SimpleWhenClause[]
-     */
+    /** @var SimpleWhenClause[] */
     public $simpleWhenClauses = [];
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $elseScalarExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SimpleSelectClause extends Node
 {
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $isDistinct = false;
 
-    /**
-     * @var SimpleSelectExpression
-     */
+    /** @var SimpleSelectExpression */
     public $simpleSelectExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
@@ -10,14 +10,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SimpleSelectExpression extends Node
 {
-    /**
-     * @var Node
-     */
+    /** @var Node */
     public $expression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $fieldIdentificationVariable;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SimpleWhenClause extends Node
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $caseScalarExpression;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $thenScalarExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/Subselect.php
+++ b/lib/Doctrine/ORM/Query/AST/Subselect.php
@@ -9,34 +9,22 @@ namespace Doctrine\ORM\Query\AST;
  */
 class Subselect extends Node
 {
-    /**
-     * @var SimpleSelectClause
-     */
+    /** @var SimpleSelectClause */
     public $simpleSelectClause;
 
-    /**
-     * @var SubselectFromClause
-     */
+    /** @var SubselectFromClause */
     public $subselectFromClause;
 
-    /**
-     * @var WhereClause|null
-     */
+    /** @var WhereClause|null */
     public $whereClause;
 
-    /**
-     * @var GroupByClause|null
-     */
+    /** @var GroupByClause|null */
     public $groupByClause;
 
-    /**
-     * @var HavingClause|null
-     */
+    /** @var HavingClause|null */
     public $havingClause;
 
-    /**
-     * @var OrderByClause|null
-     */
+    /** @var OrderByClause|null */
     public $orderByClause;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SubselectFromClause extends Node
 {
-    /**
-     * @var IdentificationVariableDeclaration[]
-     */
+    /** @var IdentificationVariableDeclaration[] */
     public $identificationVariableDeclarations = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class SubselectIdentificationVariableDeclaration
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $associationPathExpression;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $aliasIdentificationVariable;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/UpdateClause.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateClause.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\AST;
  */
 class UpdateClause extends Node
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $abstractSchemaName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     public $aliasIdentificationVariable;
 
-    /**
-     * @var UpdateItem[]
-     */
+    /** @var UpdateItem[] */
     public $updateItems = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/UpdateItem.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateItem.php
@@ -11,14 +11,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class UpdateItem extends Node
 {
-    /**
-     * @var PathExpression
-     */
+    /** @var PathExpression */
     public $pathExpression;
 
-    /**
-     * @var InputParameter|ArithmeticExpression|null
-     */
+    /** @var InputParameter|ArithmeticExpression|null */
     public $newValue;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class UpdateStatement extends Node
 {
-    /**
-     * @var UpdateClause
-     */
+    /** @var UpdateClause */
     public $updateClause;
 
-    /**
-     * @var WhereClause|null
-     */
+    /** @var WhereClause|null */
     public $whereClause;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/WhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhenClause.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\AST;
  */
 class WhenClause extends Node
 {
-    /**
-     * @var ConditionalExpression
-     */
+    /** @var ConditionalExpression */
     public $caseConditionExpression;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $thenScalarExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/AST/WhereClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhereClause.php
@@ -9,9 +9,7 @@ namespace Doctrine\ORM\Query\AST;
  */
 class WhereClause extends Node
 {
-    /**
-     * @var ConditionalExpression
-     */
+    /** @var ConditionalExpression */
     public $conditionalExpression;
 
     /**

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -14,14 +14,10 @@ use Doctrine\DBAL\Driver\Statement;
  */
 abstract class AbstractSqlExecutor
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $sqlStatements;
 
-    /**
-     * @var QueryCacheProfile
-     */
+    /** @var QueryCacheProfile */
     protected $queryCacheProfile;
 
     /**

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -22,19 +22,13 @@ use function sprintf;
  */
 class MultiTableDeleteExecutor extends AbstractSqlExecutor
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $createTempTableSql;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $dropTempTableSql;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $insertSql;
 
     /**

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -24,29 +24,19 @@ use function sprintf;
  */
 class MultiTableUpdateExecutor extends AbstractSqlExecutor
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $createTempTableSql;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $dropTempTableSql;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $insertSql;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $sqlParameters = [];
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $numParametersInUpdateClause = 0;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class Andx extends Composite
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $separator = ' AND ';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $allowedClasses = [
         Comparison::class,
         Func::class,

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -16,29 +16,19 @@ use function sprintf;
  */
 abstract class Base
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $preSeparator = '(';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $separator = ', ';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $postSeparator = ')';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $allowedClasses = [];
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     protected $parts = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Comparison.php
+++ b/lib/Doctrine/ORM/Query/Expr/Comparison.php
@@ -16,19 +16,13 @@ class Comparison
     public const GT  = '>';
     public const GTE = '>=';
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $leftExpr;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $operator;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $rightExpr;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/From.php
+++ b/lib/Doctrine/ORM/Query/Expr/From.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class From
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $from;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $alias;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $indexBy;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Func.php
+++ b/lib/Doctrine/ORM/Query/Expr/Func.php
@@ -11,14 +11,10 @@ use function implode;
  */
 class Func
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     protected $arguments;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/GroupBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/GroupBy.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class GroupBy extends Base
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $preSeparator = '';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $postSeparator = '';
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Join.php
+++ b/lib/Doctrine/ORM/Query/Expr/Join.php
@@ -17,34 +17,22 @@ class Join
     public const ON   = 'ON';
     public const WITH = 'WITH';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $joinType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $join;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $alias;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $conditionType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $condition;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $indexBy;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Literal.php
+++ b/lib/Doctrine/ORM/Query/Expr/Literal.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class Literal extends Base
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $preSeparator = '';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $postSeparator = '';
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Math.php
+++ b/lib/Doctrine/ORM/Query/Expr/Math.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class Math
 {
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $leftExpr;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $operator;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $rightExpr;
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/OrderBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/OrderBy.php
@@ -12,29 +12,19 @@ use function implode;
  */
 class OrderBy
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $preSeparator = '';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $separator = ', ';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $postSeparator = '';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $allowedClasses = [];
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     protected $parts = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -9,14 +9,10 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class Orx extends Composite
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $separator = ' OR ';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $allowedClasses = [
         Comparison::class,
         Func::class,

--- a/lib/Doctrine/ORM/Query/Expr/Select.php
+++ b/lib/Doctrine/ORM/Query/Expr/Select.php
@@ -9,19 +9,13 @@ namespace Doctrine\ORM\Query\Expr;
  */
 class Select extends Base
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $preSeparator = '';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $postSeparator = '';
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     protected $allowedClasses = [Func::class];
 
     /**

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -47,14 +47,10 @@ class FilterCollection
      */
     private $enabledFilters = [];
 
-    /**
-     * @var string The filter hash from the last time the query was parsed.
-     */
+    /** @var string The filter hash from the last time the query was parsed. */
     private $filterHash;
 
-    /**
-     * @var int The current state of this filter.
-     */
+    /** @var int The current state of this filter. */
     private $filtersState = self::FILTERS_STATE_CLEAN;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -91,29 +91,19 @@ class Parser
      * and still need to be validated.
      */
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredIdentificationVariables = [];
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredPartialObjectExpressions = [];
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredPathExpressions = [];
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredResultVariables = [];
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $deferredNewObjectExpressions = [];
 
     /**
@@ -172,9 +162,7 @@ class Parser
      */
     private $customOutputWalker;
 
-    /**
-     * @var Node[]
-     */
+    /** @var Node[] */
     private $identVariableExpressions = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -19,9 +19,7 @@ use function strpos;
  */
 class QueryExpressionVisitor extends ExpressionVisitor
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private static $operatorMap = [
         Comparison::GT => Expr\Comparison::GT,
         Comparison::GTE => Expr\Comparison::GTE,
@@ -29,19 +27,13 @@ class QueryExpressionVisitor extends ExpressionVisitor
         Comparison::LTE => Expr\Comparison::LTE,
     ];
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $queryAliases;
 
-    /**
-     * @var Expr
-     */
+    /** @var Expr */
     private $expr;
 
-    /**
-     * @var mixed[]
-     */
+    /** @var mixed[] */
     private $parameters = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -4,20 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Query;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\JoinColumnMetadata;
-use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
-use function explode;
 use function in_array;
 use function sprintf;
-use function strpos;
 
 /**
  * A ResultSetMappingBuilder uses the EntityManager to automatically populate entity fields.
@@ -46,14 +41,10 @@ class ResultSetMappingBuilder extends ResultSetMapping
      */
     public const COLUMN_RENAMING_INCREMENT = 3;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $sqlCounter = 0;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -51,9 +51,7 @@ class SqlWalker implements TreeWalker
      */
     public const HINT_DISTINCT = 'doctrine.distinct';
 
-    /**
-     * @var ResultSetMapping
-     */
+    /** @var ResultSetMapping */
     private $rsm;
 
     /**
@@ -91,29 +89,19 @@ class SqlWalker implements TreeWalker
      */
     private $newObjectCounter = 0;
 
-    /**
-     * @var ParserResult
-     */
+    /** @var ParserResult */
     private $parserResult;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     private $conn;
 
-    /**
-     * @var AbstractQuery
-     */
+    /** @var AbstractQuery */
     private $query;
 
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $tableAliasMap = [];
 
     /**

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -11,21 +11,13 @@ use function reset;
 
 class TreeWalkerChainIterator implements \Iterator, \ArrayAccess
 {
-    /**
-     * @var TreeWalker[]
-     */
+    /** @var TreeWalker[] */
     private $walkers = [];
-    /**
-     * @var TreeWalkerChain
-     */
+    /** @var TreeWalkerChain */
     private $treeWalkerChain;
-    /**
-     * @var Query
-     */
+    /** @var Query */
     private $query;
-    /**
-     * @var ParserResult
-     */
+    /** @var ParserResult */
     private $parserResult;
 
     public function __construct(TreeWalkerChain $treeWalkerChain, $query, $parserResult)

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -135,9 +135,7 @@ class QueryBuilder
      */
     protected $cacheMode;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     protected $lifetime = 0;
 
     /**

--- a/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/SequenceGenerator.php
@@ -28,14 +28,10 @@ class SequenceGenerator implements Generator, Serializable
      */
     private $sequenceName;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $nextValue = 0;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     private $maxValue;
 
     public function __construct(string $sequenceName, int $allocationSize)

--- a/lib/Doctrine/ORM/Sequencing/TableGenerator.php
+++ b/lib/Doctrine/ORM/Sequencing/TableGenerator.php
@@ -11,29 +11,19 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class TableGenerator implements Generator
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $tableName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $sequenceName;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $allocationSize;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     private $nextValue;
 
-    /**
-     * @var int|null
-     */
+    /** @var int|null */
     private $maxValue;
 
     public function __construct(string $tableName, string $sequenceName = 'default', int $allocationSize = 10)

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -13,9 +13,7 @@ use function ltrim;
  */
 class AttachEntityListenersListener
 {
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $entityListeners = [];
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -18,9 +18,7 @@ use function sprintf;
  */
 class UpdateCommand extends AbstractCommand
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name = 'orm:schema-tool:update';
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -15,9 +15,7 @@ use function sprintf;
  */
 class MetadataFilter extends \FilterIterator implements \Countable
 {
-    /**
-     * @var string[]
-     */
+    /** @var string[] */
     private $filter = [];
 
     /**

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -25,14 +25,10 @@ use function spl_object_id;
  */
 class DebugUnitOfWorkListener
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $file;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $context;
 
     /**

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
@@ -13,14 +13,10 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class GenerateSchemaEventArgs extends EventArgs
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var Schema
-     */
+    /** @var Schema */
     private $schema;
 
     public function __construct(EntityManagerInterface $em, Schema $schema)

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
@@ -14,19 +14,13 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  */
 class GenerateSchemaTableEventArgs extends EventArgs
 {
-    /**
-     * @var ClassMetadata
-     */
+    /** @var ClassMetadata */
     private $classMetadata;
 
-    /**
-     * @var Schema
-     */
+    /** @var Schema */
     private $schema;
 
-    /**
-     * @var Table
-     */
+    /** @var Table */
     private $classTable;
 
     public function __construct(ClassMetadata $classMetadata, Schema $schema, Table $classTable)

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -30,19 +30,13 @@ use function sprintf;
  */
 class CountOutputWalker extends SqlWalker
 {
-    /**
-     * @var AbstractPlatform
-     */
+    /** @var AbstractPlatform */
     private $platform;
 
-    /**
-     * @var ResultSetMapping
-     */
+    /** @var ResultSetMapping */
     private $rsm;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $queryComponents;
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -52,39 +52,25 @@ class LimitSubqueryOutputWalker extends SqlWalker
 {
     private const ORDER_BY_PATH_EXPRESSION = '/(?<![a-z0-9_])%s\.%s(?![a-z0-9_])/i';
 
-    /**
-     * @var AbstractPlatform
-     */
+    /** @var AbstractPlatform */
     private $platform;
 
-    /**
-     * @var ResultSetMapping
-     */
+    /** @var ResultSetMapping */
     private $rsm;
 
-    /**
-     * @var mixed[][]
-     */
+    /** @var mixed[][] */
     private $queryComponents;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $firstResult;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $maxResults;
 
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var PathExpression[]
-     */
+    /** @var PathExpression[] */
     private $orderByPathExpressions = [];
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -20,24 +20,16 @@ use function count;
  */
 class Paginator implements \Countable, \IteratorAggregate
 {
-    /**
-     * @var Query
-     */
+    /** @var Query */
     private $query;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $fetchJoinCollection;
 
-    /**
-     * @var bool|null
-     */
+    /** @var bool|null */
     private $useOutputWalkers;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $count;
 
     /**

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -18,9 +18,7 @@ use function trim;
  */
 class RowNumberOverFunction extends FunctionNode
 {
-    /**
-     * @var OrderByClause
-     */
+    /** @var OrderByClause */
     public $orderByClause;
 
     /**

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -20,9 +20,7 @@ use function ltrim;
  */
 class ResolveTargetEntityListener implements EventSubscriber
 {
-    /**
-     * @var string[] indexed by original entity name
-     */
+    /** @var string[] indexed by original entity name */
     private $resolveTargetEntities = [];
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -44,14 +44,10 @@ use function strtolower;
  */
 class SchemaTool
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
-    /**
-     * @var AbstractPlatform
-     */
+    /** @var AbstractPlatform */
     private $platform;
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -32,9 +32,7 @@ use function sprintf;
  */
 class SchemaValidator
 {
-    /**
-     * @var EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $em;
 
     public function __construct(EntityManagerInterface $em)

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -260,9 +260,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private $listenersInvoker;
 
-    /**
-     * @var Instantiator
-     */
+    /** @var Instantiator */
     private $instantiator;
 
     /**
@@ -286,9 +284,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private $eagerLoadingEntities = [];
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $hasCache = false;
 
     /**
@@ -298,9 +294,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     private $hydrationCompleteHandler;
 
-    /**
-     * @var NormalizeIdentifier
-     */
+    /** @var NormalizeIdentifier */
     private $normalizeIdentifier;
 
     /**

--- a/lib/Doctrine/ORM/Utility/StaticClassNameConverter.php
+++ b/lib/Doctrine/ORM/Utility/StaticClassNameConverter.php
@@ -16,9 +16,7 @@ use function get_class;
  */
 abstract class StaticClassNameConverter
 {
-    /**
-     * @var ClassNameInflectorInterface|null
-     */
+    /** @var ClassNameInflectorInterface|null */
     private static $classNameInflector;
 
     final private function __construct()

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,6 +20,8 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
@@ -61,5 +63,13 @@
 
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
         <exclude-pattern>lib/Doctrine/ORM/Annotation/*</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment">
+        <exclude-pattern>lib/Doctrine/ORM/Cache/DefaultQueryCache.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
+        <exclude-pattern>lib/Doctrine/ORM/EntityManagerInterface.php</exclude-pattern>
     </rule>
 </ruleset>


### PR DESCRIPTION
* Exclude abstract/exception naming sniff
  * Abstracts either need to be reworked separately or ignored.
  * Exceptions are being handled in #6743.
* Exclude EntityManagerInterface from interface naming sniff
  * Do we want to rename this in 3.0?
* Use inline comments for single `@var` annotations
* Use short type casts
* Remove empty comments
* Apply other fixes (and fix previous breakages in master)

-----

Controversially, after the discussions in/around #30, we should start versioning the composer.lock file and use it to run CS/SA checks on CI. I am still not convinced it's a good idea to have it in the root though, but Composer doesn't have a switch to specify alternative lock file path...

-----

CS stage green, PHPStan stage fixed in #7113.