### PR TITLE
Remove tools from PHPCs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
       php: 7.2
       script:
         - ./vendor/bin/phpcs lib
-        - ./vendor/bin/phpcs tests tools || true # disabled on CI until ported to new CS
+        - ./vendor/bin/phpcs tests || true # disabled on CI until ported to new CS
 
   allow_failures:
     - php: nightly

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,7 +11,6 @@
 
     <file>lib</file>
     <file>tests</file>
-    <file>tools</file>
 
     <exclude-pattern>*/tests/Doctrine/Tests/Proxies/__CG__/*</exclude-pattern>
 


### PR DESCRIPTION
> ERROR: The file "tools" does not exist.

Probably a leftover from #7110