### PR TITLE
Fix preUpdate events after collection clear()

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -568,6 +568,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             $uow->scheduleCollectionDeletion($this);
 
             $this->takeSnapshot();
+
+            // keep the collection as dirty after taking a snapshot
+            // to make preUpdate events work for related objects
+            $this->isDirty = true;
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php
@@ -95,6 +95,28 @@ class PersistentCollectionTest extends OrmFunctionalTestCase
         $this->assertEmpty($criteria->getMaxResults());
         $this->assertEmpty($criteria->getOrderings());
     }
+
+    public function testPersistClearCollection()
+    {
+        $collectionHolder = new PersistentCollectionHolder();
+        $content = new PersistentCollectionContent('first element');
+        $collectionHolder->addElement($content);
+
+        $this->_em->persist($collectionHolder);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $collectionHolder = $this->_em->find(PersistentCollectionHolder::class, $collectionHolder->getId());
+        $this->assertCount(1, $collectionHolder->getCollection());
+        $collectionHolder->getRawCollection()->clear();
+
+        $this->_em->persist($collectionHolder);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $collectionHolder = $this->_em->find(PersistentCollectionHolder::class, $collectionHolder->getId());
+        $this->assertCount(0, $collectionHolder->getCollection());
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -144,6 +144,16 @@ class PersistentCollectionTest extends OrmTestCase
         $this->assertEquals([0], array_keys($this->collection->toArray()));
     }
 
+    public function testClearWillMakeCollectionDirty()
+    {
+        $dummy = new \stdClass();
+
+        $this->collection->add($dummy);
+        $this->collection->clear();
+
+        self::assertTrue($this->collection->isDirty());
+    }
+
     /**
      * @group 6613
      * @group 6614


### PR DESCRIPTION
Fix pre update lifecycle callbacks for MANY_TO_MANY collections. Related issue  https://github.com/symfony/symfony/issues/17154.

See https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/UnitOfWork.php#L692.

