### PR TITLE
EntityManager: Remove DBAL Connection factory

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,26 @@
 # Upgrade to 3.0
 
+## BC Break: Removed DBAL Connection factory from EntityManager
+
+EntityManager no longer provides a factory for DBAL Connection from an array.
+You must now pass an existing Connection instance directly.
+You can use `Doctrine\DBAL\DriverManager::getConnection()` factory to create new Connection.
+
+Before:
+
+```
+$dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
+$entityManager = EntityManager::create($dbParams, $configuration);
+```
+
+After:
+
+```
+$dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
+$connection = DriverManager::getConnection($dbParams);
+$entityManager = EntityManager::create($connection, $configuration);
+```
+
 ## BC Break: Removed possibility to extend the doctrine mapping xml schema with anything
 
 If you want to extend it now you have to provide your own validation schema.

--- a/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
+++ b/docs/en/cookbook/advanced-field-value-conversion-using-custom-mapping-types.rst
@@ -229,7 +229,7 @@ Example usage
     <?php
 
     // Bootstrapping stuff...
-    // $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config);
+    // $em = \Doctrine\ORM\EntityManager::create($connection, $config);
 
     // Setup custom mapping type
     use Doctrine\DBAL\Types\Type;

--- a/docs/en/cookbook/dql-user-defined-functions.rst
+++ b/docs/en/cookbook/dql-user-defined-functions.rst
@@ -45,7 +45,7 @@ configuration:
     $config->addCustomNumericFunction($name, $class);
     $config->addCustomDatetimeFunction($name, $class);
 
-    $em = EntityManager::create($dbParams, $config);
+    $em = EntityManager::create($connection, $config);
 
 The ``$name`` is the name the function will be referred to in the
 DQL query. ``$class`` is a string of a class-name which has to

--- a/docs/en/cookbook/integrating-with-codeigniter.rst
+++ b/docs/en/cookbook/integrating-with-codeigniter.rst
@@ -43,6 +43,7 @@ Customize it to your needs.
 
     <?php
     use Doctrine\Common\ClassLoader,
+        Doctrine\DBAL\DriverManager,
         Doctrine\ORM\Configuration,
         Doctrine\ORM\EntityManager,
         Doctrine\Common\Cache\ArrayCache,
@@ -91,8 +92,11 @@ Customize it to your needs.
             'dbname' =>   $db['default']['database']
         );
 
+        // Create Connection
+        $connection = DriverManager::getConnection($connectionOptions);
+
         // Create EntityManager
-        $this->em = EntityManager::create($connectionOptions, $config);
+        $this->em = EntityManager::create($connection, $config);
       }
     }
 

--- a/docs/en/cookbook/resolve-target-entity-listener.rst
+++ b/docs/en/cookbook/resolve-target-entity-listener.rst
@@ -129,7 +129,7 @@ the targetEntity resolution will occur reliably:
     // Add the ResolveTargetEntityListener
     $evm->addEventListener(Doctrine\ORM\Events::loadClassMetadata, $rtel);
 
-    $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config, $evm);
+    $em = \Doctrine\ORM\EntityManager::create($connection, $config, $evm);
 
 Final Thoughts
 --------------

--- a/docs/en/cookbook/sql-table-prefixes.rst
+++ b/docs/en/cookbook/sql-table-prefixes.rst
@@ -81,5 +81,5 @@ before the prefix has been set.
     $tablePrefix = new \DoctrineExtensions\TablePrefix('prefix_');
     $evm->addEventListener(\Doctrine\ORM\Events::loadClassMetadata, $tablePrefix);
 
-    $em = \Doctrine\ORM\EntityManager::create($connectionOptions, $config, $evm);
+    $em = \Doctrine\ORM\EntityManager::create($connection, $config, $evm);
 

--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -9,6 +9,8 @@ steps of configuration.
 .. code-block:: php
 
     <?php
+
+    use Doctrine\DBAL\DriverManager;
     use Doctrine\ORM\EntityManager;
     use Doctrine\ORM\Configuration;
     use Doctrine\Common\Proxy\ProxyFactory;
@@ -39,7 +41,8 @@ steps of configuration.
         'path' => 'database.sqlite'
     ];
 
-    $em = EntityManager::create($connectionOptions, $config);
+    $connection = DriverManager::getConnection($connectionOptions);
+    $em = EntityManager::create($connection, $config);
 
 .. note::
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -42,33 +42,36 @@ access point to ORM functionality provided by Doctrine.
 
     <?php
     // bootstrap.php
-    require_once "vendor/autoload.php";
+    require_once 'vendor/autoload.php';
 
-    use Doctrine\ORM\Tools\Setup;
+    use Doctrine\DBAL\DriverManager;
     use Doctrine\ORM\EntityManager;
+    use Doctrine\ORM\Tools\Setup;
 
-    $paths = array("/path/to/entity-files");
+    $paths = ['/path/to/entity-files'];
     $isDevMode = false;
 
     // the connection configuration
-    $dbParams = array(
+    $dbParams = [
         'driver'   => 'pdo_mysql',
         'user'     => 'root',
         'password' => '',
         'dbname'   => 'foo',
-    );
+    ];
 
     $config = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create($dbParams, $config);
+    $connection = DriverManager::getConnection($dbParams);
+    $entityManager = EntityManager::create($connection, $config);
 
 Or if you prefer XML:
 
 .. code-block:: php
 
     <?php
-    $paths = array("/path/to/xml-mappings");
+    $paths = ['/path/to/xml-mappings'];
     $config = Setup::createXMLMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create($dbParams, $config);
+    $connection = DriverManager::getConnection($dbParams);
+    $entityManager = EntityManager::create($connection, $config);
 
 Inside the ``Setup`` methods several assumptions are made:
 

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -738,7 +738,7 @@ You can register custom DQL functions in your ORM Configuration:
     $config->addCustomNumericFunction($name, $class);
     $config->addCustomDatetimeFunction($name, $class);
 
-    $em = EntityManager::create($dbParams, $config);
+    $em = EntityManager::create($connection, $config);
 
 The functions have to return either a string, numeric or datetime
 value depending on the registered function type. As an example we

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -457,7 +457,7 @@ EventManager that is passed to the EntityManager factory:
     $eventManager->addEventListener(array(Events::preUpdate), new MyEventListener());
     $eventManager->addEventSubscriber(new MyEventSubscriber());
 
-    $entityManager = EntityManager::create($dbOpts, $config, $eventManager);
+    $entityManager = EntityManager::create($connection, $config, $eventManager);
 
 You can also retrieve the event manager instance after the
 EntityManager was created:

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -125,6 +125,7 @@ step:
 
     <?php
     // bootstrap.php
+    use Doctrine\DBAL\DriverManager;
     use Doctrine\ORM\Tools\Setup;
     use Doctrine\ORM\EntityManager;
 
@@ -136,13 +137,14 @@ step:
     // or if you prefer XML
     //$config = Setup::createXMLMetadataConfiguration(array(__DIR__."/config"), $isDevMode);
     // database configuration parameters
-    $conn = array(
+    $dbParams = array(
         'driver' => 'pdo_sqlite',
         'path' => __DIR__ . '/db.sqlite',
     );
 
+    $connection = DriverManager::getConnection($dbParams);
     // obtaining the entity manager
-    $entityManager = EntityManager::create($conn, $config);
+    $entityManager = EntityManager::create($connection, $config);
 
 The require_once statement sets up the class autoloading for Doctrine and
 its dependencies using Composer's autoloader.

--- a/tests/Doctrine/Performance/EntityManagerFactory.php
+++ b/tests/Doctrine/Performance/EntityManagerFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Performance;
 
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -29,13 +30,13 @@ final class EntityManagerFactory
             ])
         );
 
-        $entityManager = EntityManager::create(
+        $connection    = DriverManager::getConnection(
             [
                 'driverClass' => Driver::class,
                 'memory'      => true,
-            ],
-            $config
+            ]
         );
+        $entityManager = EntityManager::create($connection, $config);
 
         (new SchemaTool($entityManager))
             ->createSchema(array_map([$entityManager, 'getClassMetadata'], $schemaClassNames));

--- a/tests/Doctrine/Tests/ORM/EntityManagerTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityManagerTest.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
-use Doctrine\ORM\Mapping\Driver\MappingDriver;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\Proxy\Factory\ProxyFactory;
@@ -197,16 +196,6 @@ class EntityManagerTest extends OrmTestCase
     {
         self::assertSame($this->em, $em);
         return 'callback';
-    }
-
-    public function testCreateInvalidConnection() : void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid $connection argument of type integer given: "1".');
-
-        $config = new Configuration();
-        $config->setMetadataDriverImpl($this->createMock(MappingDriver::class));
-        EntityManager::create(1, $config);
     }
 
     /**


### PR DESCRIPTION
Removes the hardcoded magic behind creating Connection instance from an array.