### PR TITLE
[XML] Fix default value of one-to-many order-by to ASC

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM\Mapping\Driver;
 
+use Doctrine\Common\Collections\Criteria;
 use SimpleXMLElement;
 use Doctrine\Common\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
@@ -429,7 +430,10 @@ class XmlDriver extends FileDriver
                 if (isset($oneToManyElement->{'order-by'})) {
                     $orderBy = [];
                     foreach ($oneToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
-                        $orderBy[(string) $orderByField['name']] = (string) $orderByField['direction'];
+                        $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
+                            ? (string) $orderByField['direction']
+                            : Criteria::ASC
+                        ;
                     }
                     $mapping['orderBy'] = $orderBy;
                 }

--- a/tests/Doctrine/Tests/Models/GH7141/GH7141Article.php
+++ b/tests/Doctrine/Tests/Models/GH7141/GH7141Article.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Tests\Models\GH7141;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class GH7141Article
+{
+    private $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -11,6 +12,7 @@ use Doctrine\Tests\Models\DDC3293\DDC3293User;
 use Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed;
 use Doctrine\Tests\Models\DDC889\DDC889Class;
 use Doctrine\Tests\Models\Generic\SerializationModel;
+use Doctrine\Tests\Models\GH7141\GH7141Article;
 use Doctrine\Tests\Models\ValueObjects\Name;
 use Doctrine\Tests\Models\ValueObjects\Person;
 
@@ -172,6 +174,24 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         return array_map(function($item){
             return [$item];
         }, $list);
+    }
+
+    /**
+     * @group GH-7141
+     */
+    public function testOneToManyDefaultOrderByAsc()
+    {
+        $driver = $this->_loadDriver();
+        $class  = new ClassMetadata(GH7141Article::class);
+
+        $class->initializeReflection(new RuntimeReflectionService());
+        $driver->loadMetadataForClass(GH7141Article::class, $class);
+
+
+        $this->assertEquals(
+            Criteria::ASC,
+            $class->getMetadataValue('associationMappings')['tags']['orderBy']['position']
+        );
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.GH7141.GH7141Article.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.GH7141.GH7141Article.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\GH7141\GH7141Article">
+        <one-to-many field="tags" target-entity="NoTargetEntity" mapped-by="noMappedByField">
+            <order-by>
+                <order-by-field name="position"/>
+            </order-by>
+        </one-to-many>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
Problem
--------

As mentioned in issue #7141 , when we use XML mapping for a `<one-to-many>` relation with an `<order-by>` node, the default value `direction=ASC` isn't set by default.

Solution
--------
In this PR, I define the default direction to `ASC` if not set