### PR TITLE
Fix getting started syntax issue causing rendering glitches

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -397,7 +397,7 @@ makes it an **invalid object**.
 Rich entities should represent **behavior**, not **data**, therefore
 they should be valid even after a ``__construct()`` call.
 
-To help creating such objects, we can rely on ``DTO``s, and/or make
+To help creating such objects, we can rely on ``DTOs``, and/or make
 our entities always up-to-date. This can be performed with static constructors,
 or rich mutators that accept ``DTOs`` as parameters.
 


### PR DESCRIPTION
consistent with `DTOs` in next sentence and fixing this glitch:

<img width="919" alt="screenshot 2018-03-23 a 22 22 50" src="https://user-images.githubusercontent.com/2211145/37853907-fae0b86a-2ee8-11e8-86bf-62d3047854f4.PNG">
