### PR TITLE
Do not schedule detached entities for orphan removal

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1991,9 +1991,9 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleOrphanRemoval($entity)
     {
-        // Detached entities should not be scheduled for orphan removal,
-        // because they have not yet been persisted.
-        if ($this->getEntityState($entity) === self::STATE_DETACHED) {
+        // Entities should not be scheduled for orphan removal,
+        // if they do not exist in the identity map or if they are not about to be inserted.
+        if (!$this->isInIdentityMap($entity) && !$this->isScheduledForInsert($entity)) {
             return;
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1991,7 +1991,13 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleOrphanRemoval($entity)
     {
-        $this->orphanRemovals[spl_object_id($entity)] = $entity;
+        // Detached entities should not be scheduled for orphan removal,
+        // because they have not yet been persisted.
+        if ($this->getEntityState($entity) === self::STATE_DETACHED) {
+            return;
+        }
+
+        $this->orphanRemovals[spl_object_hash($entity)] = $entity;
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1991,12 +1991,6 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleOrphanRemoval($entity)
     {
-        // Entities should not be scheduled for orphan removal,
-        // if they do not exist in the identity map or if they are not about to be inserted.
-        if (!$this->isInIdentityMap($entity) && !$this->isScheduledForInsert($entity)) {
-            return;
-        }
-
         $this->orphanRemovals[spl_object_hash($entity)] = $entity;
     }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1991,7 +1991,7 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function scheduleOrphanRemoval($entity)
     {
-        $this->orphanRemovals[spl_object_hash($entity)] = $entity;
+        $this->orphanRemovals[spl_object_id($entity)] = $entity;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
@@ -132,7 +132,7 @@ class GH7162Child
 
     /**
      * @ORM\ManyToOne(targetEntity=GH7162Parent::class, inversedBy="children")
-     * @ORM\JoinColumn(referencedColumnName="parent_id")
+     * @ORM\JoinColumn(referencedColumnName="id")
      *
      * @var GH7162Parent
      */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\ORM\ORMInvalidArgumentException;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH7162Test extends OrmFunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpEntitySchema([
+            GH7162Parent::class,
+            GH7162Child::class,
+        ]);
+    }
+
+    /**
+     * @group 7067
+     */
+    public function testIssueWithDetachedEntity(): void
+    {
+        // Create a parent without children
+        $parent = new GH7162Parent();
+        $this->em->persist($parent);
+        $this->em->flush();
+        $this->em->clear();
+
+        $parentId = $parent->id;
+
+        // Fetch the parent as a non-cached entity
+        /** @var GH7162Parent $parent */
+        $parent = $this->em->find(GH7162Parent::class, $parentId);
+
+        // Create a new child and add it to the persistent collection
+        // of children: $parent->children
+        $child1 = new GH7162Child();
+        $parent->addChild($child1);
+
+        // Then, remove the same child, causing an orphan removal
+        $parent->removeChild($child1);
+
+        $caughtException = null;
+        $message = '';
+        try {
+            $this->em->flush();
+        } catch (ORMInvalidArgumentException $exception) {
+            $message = $exception->getMessage();
+            $caughtException = $exception;
+        }
+        $this->em->clear();
+
+        self::assertNull(
+            $caughtException,
+            'Child entity is detached and should not be scheduled for orphan removal, but it is.'
+            . ' '
+            . 'Message: '
+            . $message
+        );
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7162Parent
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity=GH7162Child::class, mappedBy="parent", cascade={"remove","persist"}, orphanRemoval=true)
+     *
+     * @var GH7162Child[]|Collection
+     */
+    public $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+
+    /**
+     * @param GH7162Child $child
+     */
+    public function addChild(GH7162Child $child): void
+    {
+        if ($this->children->contains($child)) {
+            return;
+        }
+
+        $this->children->add($child);
+    }
+
+    /**
+     * @param GH7162Child $child
+     */
+    public function removeChild(GH7162Child $child): void
+    {
+        if (!$this->children->contains($child)) {
+            return;
+        }
+
+        $this->children->removeElement($child);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7162Child
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=GH7162Parent::class, inversedBy="children")
+     * @ORM\JoinColumn(referencedColumnName="parentId")
+     *
+     * @var GH7162Parent
+     */
+    public $parent;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7162Test.php
@@ -132,7 +132,7 @@ class GH7162Child
 
     /**
      * @ORM\ManyToOne(targetEntity=GH7162Parent::class, inversedBy="children")
-     * @ORM\JoinColumn(referencedColumnName="parentId")
+     * @ORM\JoinColumn(referencedColumnName="parent_id")
      *
      * @var GH7162Parent
      */


### PR DESCRIPTION
Detached entities should not be scheduled for orphan removal,
because they have not yet been persisted and will result in an exception
when the entity manager is flushed.