### PR TITLE
Add constructor types to SqlWalker and TreeWalker

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -162,9 +162,11 @@ class SqlWalker implements TreeWalker
     private $platform;
 
     /**
-     * {@inheritDoc}
+     * @param AbstractQuery $query
+     * @param ParserResult $parserResult
+     * @param array $queryComponents
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {
         $this->query           = $query;
         $this->parserResult    = $parserResult;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -162,9 +162,7 @@ class SqlWalker implements TreeWalker
     private $platform;
 
     /**
-     * @param AbstractQuery $query
-     * @param ParserResult $parserResult
-     * @param array $queryComponents
+     * {@inheritDoc}
      */
     public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -18,7 +18,7 @@ interface TreeWalker
      * @param ParserResult  $parserResult    The result of the parsing process.
      * @param mixed[][]     $queryComponents The query components (symbol table).
      */
-    public function __construct($query, $parserResult, array $queryComponents);
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents);
 
     /**
      * Returns internal queryComponents array.


### PR DESCRIPTION
I was trying to use the SqlWalker but had no idea what objects were required for passing in. It had an inherit doc annotation, so I found that in the interface. 

Then I noticed that although the docblock said what each param was in the interface, it allows you to pass in any old rubbish, so I thought I'd fix that for you :-)