### PR TITLE
Require PHP ^8.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             environment:
                 php:
-                    version: 7.2
+                    version: 8.0
             cache:
                 disabled: false
                 directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 language: php
 
 php:
-  - 7.2
-  - nightly
+  - 8.0
 
 env:
   - DB=sqlite
@@ -34,14 +33,12 @@ jobs:
 
     - stage: Test
       env: DB=mysql MYSQL_VERSION=5.7
-      php: 7.2
       before_script:
         - ./tests/travis/install-mysql-$MYSQL_VERSION.sh
       sudo: required
 
     - stage: Test
       env: DB=mysql MYSQL_VERSION=5.7
-      php: nightly
       before_script:
         - ./tests/travis/install-mysql-$MYSQL_VERSION.sh
       sudo: required
@@ -85,12 +82,10 @@ jobs:
     - stage: Code Quality
       env: DB=none CODING_STANDARDS
       install: travis_retry composer install --prefer-dist
-      php: 7.2
       script:
         - ./vendor/bin/phpcs
 
   allow_failures:
-    - php: nightly
     # temporarily disabled
     - env: DB=mysql
     - env: DB=mariadb

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2",
+        "php": "^8.0|^9.0",
         "doctrine/annotations": "~1.5",
         "doctrine/cache": "~1.6",
         "doctrine/collections": "^1.4",


### PR DESCRIPTION
We already require PHP 7.2. 
While having PHP 8.0 as minimum version, we can further:
 * Leverage native generics!
 * Leverage typed properties!
 * Use union and intersection types!
 * Use proper variance for complex types!
 * Use native enums!
 * Use typed callbacks!
 * Use native annotations!
 * ... and much more!

Of course, some of these features are not yet implemented, but why not use them ahead of time, right? :shipit: 

This would essentially make the project _the first to use shiny, new, not-yet-released PHP 8.0!_.

_Not yet supported by Travis/Scrutinizer._

_`^9.0` is a safety measure, we all know what happened to PHP 6. :stuck_out_tongue:_