### PR TITLE
Update Paginator.php

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -116,7 +116,7 @@ class Paginator implements \Countable, \IteratorAggregate
         $offset = $this->query->getFirstResult();
         $length = $this->query->getMaxResults();
 
-        if ($this->fetchJoinCollection) {
+        if ($this->fetchJoinCollection && strpos($this->query->getDQL(), 'HAVING') === false) {
             $subQuery = $this->cloneQuery($this->query);
 
             if ($this->useOutputWalker($subQuery)) {


### PR DESCRIPTION
Problem :
When a query with HAVING is used the paginator generates a subquery that adds a where with ids which generates an empty result


Original SQL (generated by doctrine) :

```
SELECT r0_.Id AS Id_0, r0_.LojaId AS LojaId_1, r0_.TipoRemessa AS TipoRemessa_2, r0_.ContemReaproveitamento AS ContemReaproveitamento_3, r0_.DataCadastro AS DataCadastro_4, r0_.CodigoDoCliente AS CodigoDoCliente_5, r0_.NomeDoCliente AS NomeDoCliente_6, r0_.CodigoDoTraco AS CodigoDoTraco_7, r0_.NumeroDocumento AS NumeroDocumento_8, r0_.DescricaoDoTraco AS DescricaoDoTraco_9, r0_.Volume AS Volume_10, r0_.TempoCarga AS TempoCarga_11, r0_.UsuarioCentral AS UsuarioCentral_12, r0_.DataHoraArquivo AS DataHoraArquivo_13, r0_.NomeArquivo AS NomeArquivo_14, r0_.ArquivoTexto AS ArquivoTexto_15, r0_.VolumeReaproveitado AS VolumeReaproveitado_16, r0_.IsRemessaSync AS IsRemessaSync_17 FROM remessa r0_ GROUP BY r0_.LojaId, r0_.NumeroDocumento, r0_.TipoRemessa HAVING count(1) > 1
```

Becomes this :

```
SELECT COUNT(*) AS dctrn_count FROM (SELECT r0_.Id AS Id_0, r0_.LojaId AS LojaId_1, r0_.TipoRemessa AS TipoRemessa_2, r0_.ContemReaproveitamento AS ContemReaproveitamento_3, r0_.DataCadastro AS DataCadastro_4, r0_.CodigoDoCliente AS CodigoDoCliente_5, r0_.NomeDoCliente AS NomeDoCliente_6, r0_.CodigoDoTraco AS CodigoDoTraco_7, r0_.NumeroDocumento AS NumeroDocumento_8, r0_.DescricaoDoTraco AS DescricaoDoTraco_9, r0_.Volume AS Volume_10, r0_.TempoCarga AS TempoCarga_11, r0_.UsuarioCentral AS UsuarioCentral_12, r0_.DataHoraArquivo AS DataHoraArquivo_13, r0_.NomeArquivo AS NomeArquivo_14, r0_.ArquivoTexto AS ArquivoTexto_15, r0_.VolumeReaproveitado AS VolumeReaproveitado_16, r0_.IsRemessaSync AS IsRemessaSync_17 FROM remessa r0_ GROUP BY r0_.LojaId, r0_.NumeroDocumento, r0_.TipoRemessa HAVING count(1) > 1) dctrn_table
```

and

```
SELECT DISTINCT Id_0 FROM (SELECT r0_.Id AS Id_0, r0_.LojaId AS LojaId_1, r0_.TipoRemessa AS TipoRemessa_2, r0_.ContemReaproveitamento AS ContemReaproveitamento_3, r0_.DataCadastro AS DataCadastro_4, r0_.CodigoDoCliente AS CodigoDoCliente_5, r0_.NomeDoCliente AS NomeDoCliente_6, r0_.CodigoDoTraco AS CodigoDoTraco_7, r0_.NumeroDocumento AS NumeroDocumento_8, r0_.DescricaoDoTraco AS DescricaoDoTraco_9, r0_.Volume AS Volume_10, r0_.TempoCarga AS TempoCarga_11, r0_.UsuarioCentral AS UsuarioCentral_12, r0_.DataHoraArquivo AS DataHoraArquivo_13, r0_.NomeArquivo AS NomeArquivo_14, r0_.ArquivoTexto AS ArquivoTexto_15, r0_.VolumeReaproveitado AS VolumeReaproveitado_16, r0_.IsRemessaSync AS IsRemessaSync_17 FROM remessa r0_ GROUP BY r0_.LojaId, r0_.NumeroDocumento, r0_.TipoRemessa HAVING count(1) > 1) dctrn_result LIMIT 20 OFFSET 0 
```

and here is where the problem happens :

```
SELECT r0_.Id AS Id_0, r0_.LojaId AS LojaId_1, r0_.TipoRemessa AS TipoRemessa_2, r0_.ContemReaproveitamento AS ContemReaproveitamento_3, r0_.DataCadastro AS DataCadastro_4, r0_.CodigoDoCliente AS CodigoDoCliente_5, r0_.NomeDoCliente AS NomeDoCliente_6, r0_.CodigoDoTraco AS CodigoDoTraco_7, r0_.NumeroDocumento AS NumeroDocumento_8, r0_.DescricaoDoTraco AS DescricaoDoTraco_9, r0_.Volume AS Volume_10, r0_.TempoCarga AS TempoCarga_11, r0_.UsuarioCentral AS UsuarioCentral_12, r0_.DataHoraArquivo AS DataHoraArquivo_13, r0_.NomeArquivo AS NomeArquivo_14, r0_.ArquivoTexto AS ArquivoTexto_15, r0_.VolumeReaproveitado AS VolumeReaproveitado_16, r0_.IsRemessaSync AS IsRemessaSync_17 FROM remessa r0_ WHERE r0_.Id IN ('11159', '11212', '11224', '11252', '11253', '11260', '11261', '11293', '11309', '11310', '11389', '11408', '11409', '11412', '11416', '11418', '11482', '11485', '11488', '11489') GROUP BY r0_.LojaId, r0_.NumeroDocumento, r0_.TipoRemessa HAVING count(1) > 1 
```

I think that this PR will not break any tests since this is very specific situation

Any comments will be welcome