### PR TITLE
Remove redundant isset

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -248,7 +248,7 @@ class Paginator implements \Countable, \IteratorAggregate
         foreach ($parameters as $key => $parameter) {
             $parameterName = $parameter->getName();
 
-            if (! (isset($parameterMappings[$parameterName]) || array_key_exists($parameterName, $parameterMappings))) {
+            if (! array_key_exists($parameterName, $parameterMappings)) {
                 unset($parameters[$key]);
             }
         }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -590,7 +590,7 @@ class UnitOfWork implements PropertyChangedListener
 
             foreach ($actualData as $propName => $actualValue) {
                 // skip field, its a partially omitted one!
-                if (! (isset($originalData[$propName]) || array_key_exists($propName, $originalData))) {
+                if (! array_key_exists($propName, $originalData)) {
                     continue;
                 }
 


### PR DESCRIPTION
Looks like the previous logic was checking if the `key` exists in an `array`, allowing `null`.