### PR TITLE
commit order must consider non-nullability of join columns as prioritised over nullable join columns: Take 2

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1256,7 +1256,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $joinColumns = reset($assoc['joinColumns']);
 
-                $calc->addDependency($targetClass->name, $class->name, (int)empty($joinColumns['nullable']));
+                $calc->addDependency($targetClass->name, $class->name, (int) ! ( ! isset($joinColumns['nullable']) || $joinColumns['nullable'] === true));
 
                 // If the target class has mapped subclasses, these share the same dependency.
                 if ( ! $targetClass->subClasses) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1255,11 +1255,13 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 $joinColumns = reset($assoc['joinColumns']);
+                $joinColumnsNullable = $joinColumns['nullable'] ?? true;
+                $joinColumnsNotNullable = $joinColumnsNullable === false;
 
                 $calc->addDependency(
                     $targetClass->name,
                     $class->name,
-                    (int) (($joinColumns['nullable'] ?? true) === false)
+                    (int) $joinColumnsNotNullable
                 );
 
                 // If the target class has mapped subclasses, these share the same dependency.

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1256,7 +1256,11 @@ class UnitOfWork implements PropertyChangedListener
 
                 $joinColumns = reset($assoc['joinColumns']);
 
-                $calc->addDependency($targetClass->name, $class->name, (int) ! ( ! isset($joinColumns['nullable']) || $joinColumns['nullable'] === true));
+                $calc->addDependency(
+                    $targetClass->name,
+                    $class->name,
+                    (int) (($joinColumns['nullable'] ?? true) === false)
+                );
 
                 // If the target class has mapped subclasses, these share the same dependency.
                 if ( ! $targetClass->subClasses) {

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1256,12 +1256,11 @@ class UnitOfWork implements PropertyChangedListener
 
                 $joinColumns = reset($assoc['joinColumns']);
                 $joinColumnsNullable = $joinColumns['nullable'] ?? true;
-                $joinColumnsNotNullable = $joinColumnsNullable === false;
 
                 $calc->addDependency(
                     $targetClass->name,
                     $class->name,
-                    (int) $joinColumnsNotNullable
+                    $joinColumnsNullable === false ? 1 : 0
                 );
 
                 // If the target class has mapped subclasses, these share the same dependency.

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -15,6 +15,7 @@ use Doctrine\Tests\OrmTestCase;
  */
 class CommitOrderCalculatorTest extends OrmTestCase
 {
+    /** @var CommitOrderCalculator */
     private $_calc;
 
     protected function setUp()
@@ -99,6 +100,27 @@ class CommitOrderCalculatorTest extends OrmTestCase
 
         // We want to perform a strict comparison of the array
         $this->assertContains($sorted, $correctOrders, '', false, true, true);
+    }
+
+    public function testCommitOrdering4()
+    {
+        $class1 = new ClassMetadata(NodeClass1::class);
+        $class2 = new ClassMetadata(NodeClass2::class);
+        $class3 = new ClassMetadata(NodeClass3::class);
+
+        $this->_calc->addNode($class1->name, $class1);
+        $this->_calc->addNode($class2->name, $class2);
+        $this->_calc->addNode($class3->name, $class3);
+
+        $this->_calc->addDependency($class2->name, $class1->name, 1);
+        $this->_calc->addDependency($class1->name, $class2->name, 0);
+        $this->_calc->addDependency($class1->name, $class3->name, 1);
+
+        $sorted = $this->_calc->sort();
+
+        $correctOrder = [$class2, $class1, $class3];
+
+        $this->assertSame($correctOrder, $sorted);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -122,6 +122,31 @@ class CommitOrderCalculatorTest extends OrmTestCase
 
         $this->assertSame($correctOrder, $sorted);
     }
+
+    public function testCommitOrdering5()
+    {
+        $class1 = new ClassMetadata(NodeClass1::class);
+        $class2 = new ClassMetadata(NodeClass2::class);
+        $class3 = new ClassMetadata(NodeClass3::class);
+        $class4 = new ClassMetadata(NodeClass4::class);
+
+        $this->_calc->addNode($class1->name, $class1);
+        $this->_calc->addNode($class2->name, $class2);
+        $this->_calc->addNode($class3->name, $class3);
+        $this->_calc->addNode($class4->name, $class4);
+
+        $this->_calc->addDependency($class1->name, $class4->name, 1);
+        $this->_calc->addDependency($class1->name, $class3->name, 0);
+        $this->_calc->addDependency($class2->name, $class1->name, 1);
+        $this->_calc->addDependency($class3->name, $class2->name, 1);
+
+        $sorted = $this->_calc->sort();
+
+        $correctOrder = [$class3, $class2, $class1, $class4];
+
+        $this->assertSame($correctOrder, $sorted);
+    }
+
 }
 
 class NodeClass1 {}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
- * @group #6499
+ * @group 6499
  *
  *
  * Specifically, DDC6499B has a dependency on DDC6499A, and DDC6499A
@@ -91,6 +91,6 @@ class DDC6499B
     /** @Id @Column(type="integer") @GeneratedValue */
     public $id;
 
-    /** @ManyToOne(targetEntity="DDC6499A") */
+    /** @ManyToOne(targetEntity=DDC6499A::class) */
     private $a;
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -30,12 +30,10 @@ class DDC6499Test extends OrmFunctionalTestCase
     {
         parent::tearDown();
 
-        $this->_schemaTool->dropSchema(
-            [
-                $this->_em->getClassMetadata(DDC6499A::class),
-                $this->_em->getClassMetadata(DDC6499B::class),
-            ]
-        );
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(DDC6499A::class),
+            $this->_em->getClassMetadata(DDC6499B::class),
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -17,12 +17,10 @@ class DDC6499Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->_schemaTool->createSchema(
-            [
+        $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(DDC6499A::class),
             $this->_em->getClassMetadata(DDC6499B::class),
-            ]
-        );
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -44,9 +44,12 @@ class DDC6499Test extends OrmFunctionalTestCase
     public function testIssue() : void
     {
         $b = new DDC6499B();
-        $a = new DDC6499A($b);
+        $a = new DDC6499A();
 
         $this->_em->persist($a);
+
+        $a->b = $b;
+
         $this->_em->persist($b);
 
         $this->_em->flush();
@@ -58,7 +61,9 @@ class DDC6499Test extends OrmFunctionalTestCase
     public function testIssueReversed() : void
     {
         $b = new DDC6499B();
-        $a = new DDC6499A($b);
+        $a = new DDC6499A();
+
+        $a->b = $b;
 
         $this->_em->persist($b);
         $this->_em->persist($a);
@@ -78,11 +83,6 @@ class DDC6499A
 
     /** @JoinColumn(nullable=false) @OneToOne(targetEntity=DDC6499B::class) */
     public $b;
-
-    public function __construct(DDC6499B $b)
-    {
-        $this->b = $b;
-    }
 }
 
 /** @Entity */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6499
+ */
+class DDC6499Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+            $this->_em->getClassMetadata(DDC6499A::class),
+            $this->_em->getClassMetadata(DDC6499B::class),
+            ]
+        );
+    }
+
+    /**
+     * Test for the bug described in issue #6499.
+     */
+    public function testIssue()
+    {
+        $a = new DDC6499A();
+        $this->_em->persist($a);
+
+        $b = new DDC6499B();
+        $a->setB($b);
+        $this->_em->persist($b);
+
+        $this->_em->flush();
+
+        // Issue #6499 will result in a Integrity constraint violation before reaching this point
+        $this->assertEquals(true, true);
+    }
+}
+
+/** @Entity */
+class DDC6499A
+{
+    /**
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity="DDC6499B", mappedBy="a", cascade={"persist", "remove"}, orphanRemoval=true)
+     */
+    private $bs;
+
+    /**
+     * @OneToOne(targetEntity="DDC6499B", cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     */
+    private $b;
+
+    /**
+     * DDC6499A constructor.
+     */
+    public function __construct()
+    {
+        $this->bs = new ArrayCollection();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return DDC6499B[]|ArrayCollection
+     */
+    public function getBs()
+    {
+        return $this->bs;
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function addB(DDC6499B $b)
+    {
+        if ($this->bs->contains($b)) return;
+
+        $this->bs->add($b);
+
+        // Update owning side
+        $b->setA($this);
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function removeB(DDC6499B $b)
+    {
+        if (!$this->bs->contains($b)) return;
+
+        $this->bs->removeElement($b);
+
+        // Not updating owning side due to orphan removal
+    }
+
+    /**
+     * @return DDC6499B
+     */
+    public function getB()
+    {
+        return $this->b;
+    }
+
+    /**
+     * @param DDC6499B $b
+     */
+    public function setB(DDC6499B $b)
+    {
+        $this->b = $b;
+    }
+}
+
+/** @Entity */
+class DDC6499B
+{
+    /**
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(name="id", type="integer")
+     */
+    private $id;
+
+    /**
+     * @ManyToOne(targetEntity="DDC6499A", inversedBy="bs", cascade={"persist"})
+     */
+    private $a;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return DDC6499A
+     */
+    public function getA()
+    {
+        return $this->a;
+    }
+
+    /**
+     * @param DDC6499A $a
+     */
+    public function setA(DDC6499A $a)
+    {
+        $this->a = $a;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7180Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7180Test.php
@@ -2,55 +2,21 @@
 
 namespace Doctrine\Tests\Functional\Ticket;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
  * @group 7180
  */
-class DDC7180Test extends OrmFunctionalTestCase
+final class DDC7180Test extends OrmFunctionalTestCase
 {
-    private static $createdSchema = false;
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
-        if (self::$createdSchema) {
-            return;
-        }
-
-        $this->_schemaTool->createSchema([
-            $this->_em->getClassMetadata(DDC7180A::class),
-            $this->_em->getClassMetadata(DDC7180B::class),
-            $this->_em->getClassMetadata(DDC7180C::class),
-            $this->_em->getClassMetadata(DDC7180D::class),
-            $this->_em->getClassMetadata(DDC7180E::class),
-            $this->_em->getClassMetadata(DDC7180F::class),
-            $this->_em->getClassMetadata(DDC7180G::class),
-        ]);
-
-        self::$createdSchema = true;
+        $this->setUpEntitySchema([DDC7180A::class, DDC7180B::class, DDC7180C::class, DDC7180D::class, DDC7180E::class, DDC7180F::class, DDC7180G::class]);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function tearDown() : void
-    {
-        parent::tearDown();
-
-        $this->_schemaTool->dropSchema([
-            $this->_em->getClassMetadata(DDC7180A::class),
-            $this->_em->getClassMetadata(DDC7180B::class),
-            $this->_em->getClassMetadata(DDC7180C::class),
-        ]);
-    }
-
-    public function testIssue() : void
+    public function testIssue(): void
     {
         $a = new DDC7180A();
         $b = new DDC7180B();
@@ -71,7 +37,7 @@ class DDC7180Test extends OrmFunctionalTestCase
         self::assertInternalType('integer', $c->id);
     }
 
-    public function testIssue3NodeCycle() : void
+    public function testIssue3NodeCycle(): void
     {
         $d = new DDC7180D();
         $e = new DDC7180E();
@@ -113,6 +79,7 @@ class DDC7180A
      */
     public $b;
 }
+
 /**
  * @Entity
  */
@@ -129,6 +96,7 @@ class DDC7180B
      */
     public $a;
 }
+
 /**
  * @Entity
  */

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7180Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7180Test.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Doctrine\Tests\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group 7180
+ */
+class DDC7180Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC7180A::class),
+            $this->_em->getClassMetadata(DDC7180B::class),
+            $this->_em->getClassMetadata(DDC7180C::class),
+        ]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function tearDown() : void
+    {
+        parent::tearDown();
+
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(DDC7180A::class),
+            $this->_em->getClassMetadata(DDC7180B::class),
+            $this->_em->getClassMetadata(DDC7180C::class),
+        ]);
+    }
+
+    public function testIssue() : void
+    {
+        $a = new DDC7180A();
+        $b = new DDC7180B();
+        $c = new DDC7180C();
+
+        $a->b = $b;
+        $b->a = $a;
+        $c->a = $a;
+
+        $this->_em->persist($a);
+        $this->_em->persist($b);
+        $this->_em->persist($c);
+
+        $this->_em->flush();
+
+        self::assertInternalType('integer', $a->id);
+        self::assertInternalType('integer', $b->id);
+        self::assertInternalType('integer', $c->id);
+    }
+}
+
+/**
+ * @Entity
+ */
+class DDC7180A
+{
+    /**
+     * @GeneratedValue()
+     * @Id @Column(type="integer")
+     */
+    public $id;
+    /**
+     * @OneToOne(targetEntity=DDC7180B::class, inversedBy="a")
+     * @JoinColumn(nullable=false)
+     */
+    public $b;
+}
+/**
+ * @Entity
+ */
+class DDC7180B
+{
+    /**
+     * @GeneratedValue()
+     * @Id @Column(type="integer")
+     */
+    public $id;
+    /**
+     * @OneToOne(targetEntity=DDC7180A::class, mappedBy="b")
+     * @JoinColumn(nullable=true)
+     */
+    public $a;
+}
+/**
+ * @Entity
+ */
+class DDC7180C
+{
+    /**
+     * @GeneratedValue()
+     * @Id @Column(type="integer")
+     */
+    public $id;
+    /**
+     * @ManyToOne(targetEntity=DDC7180A::class)
+     * @JoinColumn(nullable=false)
+     */
+    public $a;
+}


### PR DESCRIPTION
This is a resubmission of https://github.com/doctrine/doctrine2/pull/6533, which attempted to fix https://github.com/doctrine/doctrine2/issues/6499 (also https://github.com/doctrine/doctrine2/issues/7006)

Note that that I consulted Marco on slack before doing this.

I don't want to step on anyones toes, but the original PR has seemed to have gone stale and come to a halt. Maybe the original submitter has lost interest/moved on (his fork appears to be gone) or whatever (not judging), but regardless, I'd like to pick this back again and try and get it over the line.

I've maintained the original commits from the PR as well as some of Marco's styling fixes.

#6533 was merged and then reverted (https://github.com/doctrine/doctrine2/pull/6533#issuecomment-321911821). 
The Tests reveal the problem, `CascadeRemoveOrderTest`. If anyone has any idea how this can be fixed before I start poking around, please give me a heads up.