### PR TITLE
Add BETWEEN() expr and fix the PHPDoc. 2.5

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -622,15 +622,29 @@ class Expr
     /**
      * Creates an instance of BETWEEN() function, with the given argument.
      *
-     * @param mixed   $val Valued to be inspected by range values.
-     * @param integer $x   Starting range value to be used in BETWEEN() function.
-     * @param integer $y   End point value to be used in BETWEEN() function.
+     * @param mixed      $val Valued to be inspected by range values.
+     * @param int|string $x   Starting range value to be used in BETWEEN() function.
+     * @param int|string $y   End point value to be used in BETWEEN() function.
      *
-     * @return Expr\Func A BETWEEN expression.
+     * @return Expr\Between A BETWEEN expression.
      */
     public function between($val, $x, $y)
     {
-        return $val . ' BETWEEN ' . $x . ' AND ' . $y;
+        return new Expr\Between(Expr\Between::BETWEEN, $val, $x, $y);
+    }
+
+    /**
+     * Creates an instance of BETWEEN() function, with the given argument.
+     *
+     * @param mixed      $val Valued to be inspected by range values.
+     * @param int|string $x   Starting range value to be used in BETWEEN() function.
+     * @param int|string $y   End point value to be used in BETWEEN() function.
+     *
+     * @return Expr\Between A BETWEEN expression.
+     */
+    public function notBetween($val, $x, $y)
+    {
+        return new Expr\Between(Expr\Between::NOT_BETWEEN, $val, $x, $y);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Between.php
+++ b/lib/Doctrine/ORM/Query/Expr/Between.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Doctrine\ORM\Query\Expr;
+
+class Between
+{
+    const NOT_BETWEEN = 'NOT BETWEEN';
+
+    const BETWEEN = 'BETWEEN';
+
+    /**
+     * @var string
+     */
+    protected $operator;
+
+    /**
+     * @var mixed
+     */
+    protected $key;
+
+    /**
+     * @var int|string
+     */
+    protected $min;
+
+    /**
+     * @var int|string
+     */
+    protected $max;
+
+    /**
+     * Constructor.
+     *
+     * @param string     $operator
+     * @param int|string $key
+     * @param int|string $min
+     * @param int|string $max
+     */
+    public function __construct($operator, $key, $min, $max)
+    {
+        $this->operator = $operator;
+        $this->key = $key;
+        $this->min = $min;
+        $this->max = $max;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getMin()
+    {
+        return $this->min;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getMax()
+    {
+        return $this->max;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('%s %s %s AND %s', $this->key, $this->operator, $this->min, $this->max);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -259,6 +259,11 @@ class ExprTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('u.id BETWEEN 3 AND 6', (string) $this->_expr->between('u.id', 3, 6));
     }
 
+    public function testNotBetweenExpr()
+    {
+        $this->assertEquals('u.id NOT BETWEEN 3 AND 6', (string) $this->_expr->notBetween('u.id', 3, 6));
+    }
+
     public function testTrimExpr()
     {
         $this->assertEquals('TRIM(u.id)', (string) $this->_expr->trim('u.id'));


### PR DESCRIPTION
The parameters $x and $y can also be a string, for example a date.