### PR TITLE
Add BETWEEN() expr.

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -621,20 +621,6 @@ class Expr
     }
 
     /**
-     * Creates an instance of BETWEEN() function, with the given arguments.
-     *
-     * @param mixed      $val Valued to be inspected by range values.
-     * @param int|string $x   Starting range value to be used in BETWEEN() function.
-     * @param int|string $y   End point value to be used in BETWEEN() function.
-     *
-     * @return Expr\Between A BETWEEN expression.
-     */
-    public function notBetween($val, $x, $y) : Expr\Between
-    {
-        return new Expr\Between(Expr\Between::NOT_BETWEEN, $val, $x, $y);
-    }
-
-    /**
      * Creates an instance of TRIM() function, with the given argument.
      *
      * @param mixed $x Argument to be used as argument of TRIM() function.

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -607,17 +607,31 @@ class Expr
     }
 
     /**
-     * Creates an instance of BETWEEN() function, with the given argument.
+     * Creates an instance of BETWEEN() function, with the given arguments.
      *
      * @param mixed      $val Valued to be inspected by range values.
      * @param int|string $x   Starting range value to be used in BETWEEN() function.
      * @param int|string $y   End point value to be used in BETWEEN() function.
      *
-     * @return Expr\Func A BETWEEN expression.
+     * @return Expr\Between A BETWEEN expression.
      */
-    public function between($val, $x, $y)
+    public function between($val, $x, $y) : Expr\Between
     {
-        return $val . ' BETWEEN ' . $x . ' AND ' . $y;
+        return new Expr\Between(Expr\Between::BETWEEN, $val, $x, $y);
+    }
+
+    /**
+     * Creates an instance of BETWEEN() function, with the given arguments.
+     *
+     * @param mixed      $val Valued to be inspected by range values.
+     * @param int|string $x   Starting range value to be used in BETWEEN() function.
+     * @param int|string $y   End point value to be used in BETWEEN() function.
+     *
+     * @return Expr\Between A BETWEEN expression.
+     */
+    public function notBetween($val, $x, $y) : Expr\Between
+    {
+        return new Expr\Between(Expr\Between::NOT_BETWEEN, $val, $x, $y);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -17,6 +17,7 @@ class Andx extends Composite
         Comparison::class,
         Func::class,
         Orx::class,
+        Between::class,
         self::class,
     ];
 

--- a/lib/Doctrine/ORM/Query/Expr/Between.php
+++ b/lib/Doctrine/ORM/Query/Expr/Between.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\Expr;
+
+final class Between
+{
+    public const NOT_BETWEEN = 'NOT BETWEEN';
+
+    public const BETWEEN = 'BETWEEN';
+
+    /**
+     * @var string
+     */
+    private $operator;
+
+    /**
+     * @var int|string
+     */
+    private $key;
+
+    /**
+     * @var int|string
+     */
+    private $min;
+
+    /**
+     * @var int|string
+     */
+    private $max;
+
+    /**
+     * @param string     $operator
+     * @param int|string $key
+     * @param int|string $min
+     * @param int|string $max
+     */
+    public function __construct(string $operator, $key, $min, $max)
+    {
+        $this->operator = $operator;
+        $this->key = $key;
+        $this->min = $min;
+        $this->max = $max;
+    }
+
+    public function __toString() : string
+    {
+        return sprintf('%s %s %s AND %s', $this->key, $this->operator, $this->min, $this->max);
+    }
+}

--- a/lib/Doctrine/ORM/Query/Expr/Between.php
+++ b/lib/Doctrine/ORM/Query/Expr/Between.php
@@ -10,24 +10,16 @@ final class Between
 
     public const BETWEEN = 'BETWEEN';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $operator;
 
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     private $key;
 
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     private $min;
 
-    /**
-     * @var int|string
-     */
+    /** @var int|string */
     private $max;
 
     /**
@@ -36,16 +28,16 @@ final class Between
      * @param int|string $min
      * @param int|string $max
      */
-    public function __construct(string $operator, $key, $min, $max)
+    public function __construct($operator, $key, $min, $max)
     {
         $this->operator = $operator;
-        $this->key = $key;
-        $this->min = $min;
-        $this->max = $max;
+        $this->key      = $key;
+        $this->min      = $min;
+        $this->max      = $max;
     }
 
     public function __toString() : string
     {
-        return sprintf('%s %s %s AND %s', $this->key, $this->operator, $this->min, $this->max);
+        return $this->key . ' ' . $this->operator . ' ' . $this->min . ' AND ' . $this->max;
     }
 }

--- a/lib/Doctrine/ORM/Query/Expr/Between.php
+++ b/lib/Doctrine/ORM/Query/Expr/Between.php
@@ -28,7 +28,7 @@ final class Between
      * @param int|string $min
      * @param int|string $max
      */
-    public function __construct($operator, $key, $min, $max)
+    public function __construct(string $operator, $key, $min, $max)
     {
         $this->operator = $operator;
         $this->key      = $key;

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -17,6 +17,7 @@ class Orx extends Composite
         Comparison::class,
         Func::class,
         Andx::class,
+        Between::class,
         self::class,
     ];
 

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -242,7 +242,12 @@ class ExprTest extends OrmTestCase
 
     public function testBetweenExpr() : void
     {
-        self::assertEquals('u.id BETWEEN 3 AND 6', (string) $this->expr->between('u.id', 3, 6));
+        self::assertSame('u.id BETWEEN 3 AND 6', (string) $this->expr->between('u.id', 3, 6));
+    }
+
+    public function testNotBetweenExpr() : void
+    {
+        self::assertSame('u.id NOT BETWEEN 3 AND 6', (string) $this->expr->notBetween('u.id', 3, 6));
     }
 
     public function testTrimExpr() : void


### PR DESCRIPTION
The PullRuest added one BETWEEN class and a new method for NOT BETWEEN.


 #6450 here example for this issues

_between and function_
```php
$queryBuilder
            ->where(
                $queryBuilder->expr()->between('CURRENT_TIMESTAMP()', ':min', ':max')
            )
            ->setParameter('min', '2018-04-10 10:19:37')
            ->setParameter('max', '2018-04-12 10:19:37')
        ;
```

_not between and mysql function_
(The mysql function can not use as parameter)
```php
$queryBuilder
            ->where(
                $queryBuilder->expr()->between('CURRENT_TIMESTAMP()', ':min', ':max')
            )
            ->setParameter('min', '2018-04-10 10:19:37')
            ->setParameter('max', '2018-04-12 10:19:37')
        ;
```
_with orX and between_
```php
$queryBuilder
            ->where(
                $queryBuilder->expr()->orX(
                    $queryBuilder->expr()->isNull('user.firstName'),
                    $queryBuilder->expr()->between(':val', 1, 10)
                )
            )
            ->setParameter('val', 5)
        ;
```