### PR TITLE
Fix wrong type in phpdoc of `Doctrine\ORM\Id\AbstractIdGenerator#generate()`

### DIFF
--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -27,7 +27,7 @@ abstract class AbstractIdGenerator
      * Generates an identifier for an entity.
      *
      * @param EntityManager $em
-     * @param \Doctrine\ORM\Mapping\Entity $entity
+     * @param object $entity
      * @return mixed
      */
     abstract public function generate(EntityManager $em, $entity);

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -27,7 +27,7 @@ abstract class AbstractIdGenerator
      * Generates an identifier for an entity.
      *
      * @param EntityManager $em
-     * @param object $entity
+     * @param object|null $entity
      * @return mixed
      */
     abstract public function generate(EntityManager $em, $entity);


### PR DESCRIPTION
\Doctrine\ORM\Mapping\Entity is the annotation class which is not correct. The entity object itself is meant here as tests also assume see https://github.com/doctrine/doctrine2/blob/2.6/tests/Doctrine/Tests/ORM/Id/AssignedGeneratorTest.php#L28

Found this when running phpstan on our code that used a custom generator.