### PR TITLE
added possibility to create custom boolean function to use on where clause

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -55,6 +55,11 @@ use Doctrine\ORM\Repository\RepositoryFactory;
 class Configuration extends \Doctrine\DBAL\Configuration
 {
     /**
+     * @var array
+     */
+    private $customBooleanFunctions;
+
+    /**
      * Sets the directory where Doctrine generates any necessary proxy class files.
      *
      * @param string $dir

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -564,6 +564,46 @@ class Configuration extends \Doctrine\DBAL\Configuration
             $this->addCustomDatetimeFunction($name, $className);
         }
     }
+    
+    /**
+     * Registers a custom DQL function that produces a boolean value.
+     * Such a function can then be used in any DQL statement on where clauses
+     *
+     * DQL function names are case-insensitive.
+     *
+     * @param string|callable $classNameOrFactory Class name or a callable that returns the function.
+     */
+    public function addCustomBooleanFunction(string $functionName, $classNameOrFactory)
+    {
+        $this->customBooleanFunctions[strtolower($functionName)] = $classNameOrFactory;
+    }
+
+    /**
+     * Gets the implementation class name of a registered custom boolean DQL function.
+     *
+     * @return string|callable|null
+     */
+    public function getCustomBooleanFunction(string $functionName)
+    {
+        return $this->customBooleanFunctions[strtolower($functionName)] ?? null;
+    }
+
+    /**
+     * Sets a map of custom DQL boolean functions.
+     *
+     * Keys must be function names and values the FQCN of the implementing class.
+     * The function names will be case-insensitive in DQL.
+     *
+     * Any previously added date/time functions are discarded.
+     *
+     * @param iterable|string[] $functions The map of custom DQL date/time functions.
+     */
+    public function setCustomBooleanFunctions(array $functions) : void
+    {
+        foreach ($functions as $name => $className) {
+            $this->addCustomBooleanFunction($name, $className);
+        }
+    }
 
     /**
      * Sets the custom hydrator modes in one pass.

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2523,6 +2523,11 @@ class Parser
                 case '(':
                     // Peeks beyond the matched closing parenthesis.
                     $token = $this->peekBeyondClosingParenthesis(false);
+                    
+                    if (null === $token 
+                        || in_array($token['type'], [Lexer::T_AND, Lexer::T_OR, Lexer::T_CLOSE_PARENTHESIS], true)) {
+                        return $this->CustomBooleanFunctionDeclaration();
+                    }
 
                     if ($token['type'] === Lexer::T_NOT) {
                         $token = $this->lexer->peek();
@@ -2589,6 +2594,20 @@ class Parser
         }
 
         return $this->ComparisonExpression();
+    }
+    
+    public function CustomBooleanFunctionDeclaration()
+    {
+        $token = $this->lexer->lookahead;
+        $funcName = strtolower($token['value']);
+        // Check for custom functions afterwards
+        $config = $this->em->getConfiguration();
+
+        if ($config->getCustomBooleanFunction($funcName) !== null) {
+            return $this->CustomFunctionsReturningBoolean();
+        }
+        
+        $this->syntaxError('known custom boolean function', $token);
     }
 
     /**
@@ -3520,6 +3539,24 @@ class Parser
         // getCustomStringFunction is case-insensitive
         $functionName  = $this->lexer->lookahead['value'];
         $functionClass = $this->em->getConfiguration()->getCustomStringFunction($functionName);
+
+        $function = is_string($functionClass)
+            ? new $functionClass($functionName)
+            : call_user_func($functionClass, $functionName);
+
+        $function->parse($this);
+
+        return $function;
+    }
+
+    /**
+     * @return Functions\FunctionNode
+     */
+    public function CustomFunctionsReturningBoolean(): Functions\FunctionNode
+    {
+        // getCustomStringFunction is case-insensitive
+        $functionName  = $this->lexer->lookahead['value'];
+        $functionClass = $this->em->getConfiguration()->getCustomBooleanFunction($functionName);
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)


### PR DESCRIPTION
There is special cases on some platforms where you have functions on where clause wich are not part of comparisons. Instead they do some sort of boolean filtering internaly and use special indexes inside the engine itself.
That's the case for example spatial indexes in mysql:
```sql
SELECT fid,ST_AsText(g) FROM geom
 WHERE  MBRContains(ST_GeomFromText(@poly),g);
```
and postgres:
```sql
SELECT namelow
  FROM jacksonco_streets, medford_parks
  WHERE ST_DWithin(medford_parks.the_geom,
    jacksonco_streets.the_geom, 5000 / 0.3048)
  AND medford_parks.name = 'Hawthorne Park / Pool';
```
And its also the case for full-text serach on mysql:
```sql
SELECT * FROM articles WHERE MATCH (title,body)
    AGAINST ('+MySQL -YourSQL' IN BOOLEAN MODE);
```
Doctrine itself has a custom function registry wich allows a parser for such functions to be registered, but if you use it on a WHERE clause, an exception is thrown saying a comparison operator is expected after the function, which is not desirable for boolean functions, that means doctrine orm does not support full text search os spatial indexes (at least i couldn't find a way to do it, maybe using doctrine filters?).

On my project i had to drop DQL and use natural query with the result set mapper, however that made impossible to create a custom filter for the api-platform bundle (and problably would have to for other cool abstractions out there). So i made this PR to fix that problem.

However, i think there's some uglyness on the ParserTest, but i couldn't think of a better way to test this fix, if necessary, i can take all feedback and do something better. Also, i dont know of the code on the parser is on the correct design for this context, if not, i will be glad to fix that too. 

PS: One last thing, i've created a new registry key for custom functions called customBooleanFunctions, wich would possible lead to documentations change and the addition of that registry on doctrine bundle configuration, let me know if thats undesirable.