### PR TITLE
Failing test: loading cached collection breaks if EM is cleared/closed

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheLoadAfterClearTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheLoadAfterClearTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\Models\Cache\Attraction;
+use Doctrine\Tests\Models\Cache\Bar;
+use Doctrine\Tests\Models\Cache\Beach;
+use Doctrine\Tests\Models\Cache\City;
+use Doctrine\Tests\Models\Cache\Restaurant;
+
+class SecondLevelCacheLoadAfterClearTest extends SecondLevelCacheAbstractTest
+{
+
+    public function testAssociationLoadAfterClear()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+
+        $cityId = $this->cities[0]->getId();
+
+        $this->_em->clear();
+
+        /** @var City $city */
+        $city = $this->_em->find(City::class, $cityId);
+
+        $this->_em->clear();
+
+        $this->assertNotEmpty($city->getAttractions()->toArray());
+    }
+
+}


### PR DESCRIPTION
Steps to reproduce:

- have SLC and cached one-to-many collection
- load the entity with 1:N association
- close/clear EM (intentionally or due to error)
- try to load items in the association
=> 💥

**Without SLC, it works**

The underlining cause is, that `AbstractEntityPersister::loadOneToManyCollection` tries to access entity identifiers in `UoW:$entityIdentifiers` - which is empty after `em::clear`.

Attached is failing test case. 