### PR TITLE
onFlush and postFlush Entity Listeners

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade to 2.7
+
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.6
 
 ## Minor BC BREAK: `Doctrine\ORM\Tools\Console\ConsoleRunner` is now final
@@ -29,11 +36,6 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - APCu extension (ext-apcu) will now be used instead of abandoned APC (ext-apc).
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
-
-## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
-
-Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
-It will be removed in 3.0.
 
 # Upgrade to 2.5
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,11 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
 
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "bin": ["bin/doctrine"],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-master": "2.7.x-dev"
         }
     },
     "archive": {

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -687,9 +687,6 @@ use Throwable;
 
     /**
      * {@inheritDoc}
-     *
-     * @todo Implementation need. This is necessary since $e2 = clone $e1; throws an E_FATAL when access anything on $e:
-     * Fatal error: Maximum function nesting level of '100' reached, aborting!
      */
     public function copy($entity, $deep = false)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -190,6 +190,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Creates a copy of the given entity. Can create a shallow or a deep copy.
      *
+     * @deprecated method will be removed in 3.0
+     *
      * @param object  $entity The entity to copy.
      * @param boolean $deep   FALSE for a shallow copy, TRUE for a deep copy.
      *

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -42,7 +42,9 @@ class EntityListenerBuilder
         Events::preUpdate   => true,
         Events::postUpdate  => true,
         Events::postLoad    => true,
-        Events::preFlush    => true
+        Events::preFlush    => true,
+        Events::onFlush     => true,
+        Events::postFlush   => true
     ];
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3382,11 +3382,31 @@ class UnitOfWork implements PropertyChangedListener
         }
     }
 
+    private function dispatchFlushEntityListener($event)
+    {
+        foreach ($this->identityMap as $className => $entities) {
+            $class = $this->em->getClassMetadata($className);
+            $invoke = $this->listenersInvoker->getSubscribedSystems($class, $event) & ~ListenersInvoker::INVOKE_MANAGER;
+            if (ListenersInvoker::INVOKE_NONE === $invoke) {
+                continue;
+            }
+            foreach ($entities as $entity) {
+                $oid = spl_object_hash($entity);
+                if (! isset($this->entityChangeSets[$oid])) {
+                    continue;
+                }
+                $argClass = 'Doctrine\\ORM\\Event\\'.ucfirst($event).'EventArgs';
+                $this->listenersInvoker->invoke($class, $event, $entity, new $argClass($this->em), $invoke);
+            }
+        }
+    }
+
     private function dispatchOnFlushEvent()
     {
         if ($this->evm->hasListeners(Events::onFlush)) {
             $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
         }
+        $this->dispatchFlushEntityListener(Events::onFlush);
     }
 
     private function dispatchPostFlushEvent()
@@ -3394,6 +3414,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
         }
+        $this->dispatchFlushEntityListener(Events::postFlush);
     }
 
     /**

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -35,7 +35,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.6.1-DEV';
+    const VERSION = '2.7.0-DEV';
 
     /**
      * Compares a Doctrine version with the current one.


### PR DESCRIPTION
Simply check if an onFlush or postFlush entity listener is subscribed
for the current class in the entity manager during dispatch.

This is a followup to merge and unit testing issues in #6414.  This branch only contains the feature that was submitted previously and does not contain any unit testing.  I can attempt to rebuild some unit tests when I have extra time.