### PR TITLE
Fixed typehint

### DIFF
--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -15,8 +15,8 @@ class EntityNotFoundException extends \RuntimeException implements ORMException
     /**
      * Static constructor.
      *
-     * @param string   $className
-     * @param string[] $id
+     * @param string $className
+     * @param array  $id
      *
      * @return self
      */

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -15,8 +15,8 @@ class EntityNotFoundException extends \RuntimeException implements ORMException
     /**
      * Static constructor.
      *
-     * @param string $className
-     * @param array  $id
+     * @param string  $className
+     * @param mixed[] $id
      *
      * @return self
      */


### PR DESCRIPTION
When calling `EntityNotFoundException::fromClassNameAndIdentifier(Entity::class, ['name' => 3]);` then `phpstan -l max` issues an error
```
Doctrine\ORM\EntityNotFoundException::fromClassNameAndIdentifier()  
         expects array<string>, array<string, int> given.
```

The implementation is obviously done right as an associative array is expected instead of an index one.