### PR TITLE
fixed type hint

### DIFF
--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1022,7 +1022,7 @@ class QueryBuilder
      * </code>
      *
      * @param string $key   The key/field to set.
-     * @param string $value The value, expression, placeholder, etc.
+     * @param mixed  $value The value, expression, placeholder, etc.
      *
      * @return self
      */


### PR DESCRIPTION
Values in `QueryBuilder::set()` can be `mixed` as they they are only passed to Expr\Comparison which accepts `mixed`.