### PR TITLE
Bugfix with namespaces

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -149,7 +149,7 @@ class SchemaTool
         $metadataSchemaConfig   = $schemaManager->createSchemaConfig();
 
         $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
-        $schema = new Schema([], [], $metadataSchemaConfig, $this->getNamespaces());
+        $schema = new Schema([], [], $metadataSchemaConfig, $this->getPlatformNamespaces());
 
         $addedFks = [];
         $blacklistedFks = [];
@@ -901,17 +901,17 @@ class SchemaTool
     }
 
     /**
-     * Gets namespaces for the current platform
-     *
      * @return string[]
      */
-    private function getNamespaces() {
+    private function getPlatformNamespaces() : array
+    {
         if (! $this->platform->supportsSchemas()) {
             return [];
         }
 
-        $namespaces = $this->em->getConnection()->getSchemaManager()->listNamespaceNames();
-
-        return $namespaces;
+        return $this->em
+                    ->getConnection()
+                    ->getSchemaManager()
+                    ->listNamespaceNames();
     }
 }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -149,7 +149,7 @@ class SchemaTool
         $metadataSchemaConfig   = $schemaManager->createSchemaConfig();
 
         $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
-        $schema = new Schema([], [], $metadataSchemaConfig);
+        $schema = new Schema([], [], $metadataSchemaConfig, $this->getNamespaces());
 
         $addedFks = [];
         $blacklistedFks = [];
@@ -898,5 +898,20 @@ class SchemaTool
         }
 
         return $schemaDiff->toSql($this->platform);
+    }
+
+    /**
+     * Gets namespaces for the current platform
+     *
+     * @return string[]
+     */
+    private function getNamespaces() {
+        if (! $this->platform->supportsSchemas()) {
+            return [];
+        }
+
+        $namespaces = $this->em->getConnection()->getSchemaManager()->listNamespaceNames();
+
+        return $namespaces;
     }
 }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -140,7 +140,7 @@ class SchemaTool
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    public function getSchemaFromMetadata(array $classes)
+    public function getSchemaFromMetadata(array $classes, bool $withNamespaces = false)
     {
         // Reminder for processed classes, used for hierarchies
         $processedClasses       = [];
@@ -149,7 +149,8 @@ class SchemaTool
         $metadataSchemaConfig   = $schemaManager->createSchemaConfig();
 
         $metadataSchemaConfig->setExplicitForeignKeyIndexes(false);
-        $schema = new Schema([], [], $metadataSchemaConfig, $this->getPlatformNamespaces());
+        $namespaces = ! $withNamespaces ? [] : $this->getPlatformNamespaces();
+        $schema = new Schema([], [], $metadataSchemaConfig, $namespaces);
 
         $addedFks = [];
         $blacklistedFks = [];

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -133,6 +133,21 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
 
         $this->assertCount(0, $sql, implode("\n", $sql));
     }
+
+    public function testSchemaFromMetadataNamespaces() : void
+    {
+        $schemaTool = new SchemaTool($this->_em);
+        $platform   = $this->_em->getConnection()->getDatabasePlatform();
+        $classes    = [
+            $this->_em->getClassMetadata(Models\CMS\CmsUser::class),
+        ];
+
+        $schemaWithoutNamespaces = $schemaTool->getSchemaFromMetadata($classes);
+        self::assertNotContains('CREATE SCHEMA public', $schemaWithoutNamespaces->toSql($platform));
+
+        $schemaWithNamespaces = $schemaTool->getSchemaFromMetadata($classes, true);
+        self::assertContains('CREATE SCHEMA public', $schemaWithNamespaces->toSql($platform));
+    }
 }
 
 /**


### PR DESCRIPTION
For a schema of metadata, namespaces were not created. Because of this, there was a difference between the current schema and the schema from the metadata when you run `doctrine:migrations:diff` command.