### PR TITLE
Removed redundant `Doctrine\ORM\EntityRepository#__construct()` phpdoc

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -38,9 +38,6 @@ class EntityRepository implements ObjectRepository, Selectable
 
     /**
      * Initializes a new <tt>EntityRepository</tt>.
-     *
-     * @param EntityManagerInterface $em    The EntityManager to use.
-     * @param Mapping\ClassMetadata  $class The class descriptor.
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {


### PR DESCRIPTION
Fix EntityRepository constructor phpdoc to match type declaration