### PR TITLE
Fix the handling of circular references in the commit order calculator

### DIFF
--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -164,6 +164,17 @@ class CommitOrderCalculator
                 case self::IN_PROGRESS:
                     if (isset($adjacentVertex->dependencyList[$vertex->hash]) &&
                         $adjacentVertex->dependencyList[$vertex->hash]->weight < $edge->weight) {
+
+                        // If we have some non-visited dependencies in the in-progress dependency, we
+                        // need to visit them before adding the node.
+                        foreach ($adjacentVertex->dependencyList as $adjacentEdge) {
+                            $adjacentEdgeVertex = $this->nodeList[$adjacentEdge->to];
+
+                            if ($adjacentEdgeVertex->state === self::NOT_VISITED) {
+                                $this->visit($adjacentEdgeVertex);
+                            }
+                        }
+
                         $adjacentVertex->state = self::VISITED;
 
                         $this->sortedNodeList[] = $adjacentVertex->value;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7259Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7259Test.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH7259Test extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH7259Space::class, GH7259File::class, GH7259FileVersion::class, GH7259Feed::class]);
+    }
+
+    /**
+     * @group 7259
+     */
+    public function testPersistFileBeforeVersion() : void
+    {
+        $space = new GH7259Space();
+
+        $this->_em->persist($space);
+        $this->_em->flush();
+
+        $feed = new GH7259Feed();
+        $feed->space = $space;
+
+        $file = new GH7259File();
+        $file->space = $space;
+        $fileVersion = new GH7259FileVersion();
+        $fileVersion->file = $file;
+
+        $this->_em->persist($file);
+        $this->_em->persist($fileVersion);
+        $this->_em->persist($feed);
+
+        $this->_em->flush();
+
+        self::assertNotNull($fileVersion->id);
+    }
+
+    /**
+     * @group 7259
+     */
+    public function testPersistFileAfterVersion() : void
+    {
+        $space = new GH7259Space();
+
+        $this->_em->persist($space);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $space = $this->_em->find(GH7259Space::class, $space->id);
+
+        $feed = new GH7259Feed();
+        $feed->space = $space;
+
+        $file = new GH7259File();
+        $file->space = $space;
+        $fileVersion = new GH7259FileVersion();
+        $fileVersion->file = $file;
+
+        $this->_em->persist($fileVersion);
+        $this->_em->persist($file);
+        $this->_em->persist($feed);
+
+        $this->_em->flush();
+
+        self::assertNotNull($fileVersion->id);
+    }
+}
+
+/**
+ * @Entity()
+ */
+class GH7259File
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=GH7259Space::class)
+     * @JoinColumn(nullable=false)
+     *
+     * @var GH7259Space|null
+     */
+    public $space;
+}
+
+/**
+ * @Entity()
+ */
+class GH7259FileVersion
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=GH7259File::class)
+     * @JoinColumn(nullable=false)
+     *
+     * @var GH7259File|null
+     */
+    public $file;
+}
+
+/**
+ * @Entity()
+ */
+class GH7259Space
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=GH7259File::class)
+     * @JoinColumn(nullable=true)
+     *
+     * @var GH7259File|null
+     */
+    public $ruleFile;
+}
+
+/**
+ * @Entity()
+ */
+class GH7259Feed
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=GH7259Space::class)
+     * @JoinColumn(nullable=false)
+     *
+     * @var GH7259Space|null
+     */
+    public $space;
+}


### PR DESCRIPTION
This fixes #7259

On 2.5, both tests are passing. On 2.6.2, the first one is failing while the second one is passing. The only difference between them is the order of `persist($fileVersion)` and `persist($file)`