### PR TITLE
Add quoted column keys while hydrating column information.

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -115,13 +115,6 @@ class SimpleObjectHydrator extends AbstractHydrator
                 throw new \Exception(sprintf('Unable to retrieve association information for column "%s"', $column));
             }
 
-            // Generate quoted column alias for column info hydrating.
-            if (preg_match(',(.+)_(\d+)$,', $column, $matches)) {
-              $column = $this->_em->getConfiguration()
-                ->getQuoteStrategy()
-                ->getColumnAlias($matches[1], $matches[2], $this->_platform, $this->getClassMetadata($entityName));
-            }
-
             $cacheKeyInfo = $this->hydrateColumnInfo($column);
 
             if ( ! $cacheKeyInfo) {

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -115,6 +115,13 @@ class SimpleObjectHydrator extends AbstractHydrator
                 throw new \Exception(sprintf('Unable to retrieve association information for column "%s"', $column));
             }
 
+            // Generate quoted column alias for column info hydrating.
+            if (preg_match(',(.+)_(\d+)$,', $column, $matches)) {
+              $column = $this->_em->getConfiguration()
+                ->getQuoteStrategy()
+                ->getColumnAlias($matches[1], $matches[2], $this->_platform, $this->getClassMetadata($entityName));
+            }
+
             $cacheKeyInfo = $this->hydrateColumnInfo($column);
 
             if ( ! $cacheKeyInfo) {

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -115,6 +115,18 @@ class SimpleObjectHydrator extends AbstractHydrator
                 throw new \Exception(sprintf('Unable to retrieve association information for column "%s"', $column));
             }
 
+            // Generate quoted column alias or column name for column info hydrating.
+            if (preg_match(',(.+)_(\d+)$,', $column, $matches)) {
+              $column = $this->_em->getConfiguration()
+                ->getQuoteStrategy()
+                ->getColumnAlias($matches[1], $matches[2], $this->_platform, $this->getClassMetadata($entityName));
+            }
+            else {
+              $column = $this->_em->getConfiguration()
+                ->getQuoteStrategy()
+                ->getColumnName($column, $this->getClassMetadata($entityName), $this->_platform);
+            }
+
             $cacheKeyInfo = $this->hydrateColumnInfo($column);
 
             if ( ! $cacheKeyInfo) {

--- a/tests/Doctrine/Tests/Mocks/QuoteStrategyMock.php
+++ b/tests/Doctrine/Tests/Mocks/QuoteStrategyMock.php
@@ -61,6 +61,8 @@ final class QuoteStrategyMock extends AnsiQuoteStrategy
       case 'sqlite':
       case 'mysql':
         return "`{$string}`";
+      case 'pgsql':
+          return "'{$string}'";
       case 'mssql':
         return "[{$string}]";
     }

--- a/tests/Doctrine/Tests/Mocks/QuoteStrategyMock.php
+++ b/tests/Doctrine/Tests/Mocks/QuoteStrategyMock.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Tests\Mocks;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Mapping\AnsiQuoteStrategy;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * Class QuoteStrategyMock
+ *
+ * This mock was created for the GH7262Test case.
+ *
+ * @author Michael Petri <mpetri@lyska.io>
+ * @see \Doctrine\Tests\ORM\Functional\Ticket\GH7262Test
+ *
+ * @package Doctrine\Tests\Mocks
+ */
+final class QuoteStrategyMock extends AnsiQuoteStrategy
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTableName(ClassMetadata $class, AbstractPlatform $platform)
+  {
+    return $this->quote(parent::getTableName($class, $platform), $platform);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getColumnName($fieldName, ClassMetadata $class, AbstractPlatform $platform)
+  {
+    return $this->quote(parent::getColumnName($fieldName, $class, $platform), $platform);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getColumnAlias($columnName, $counter, AbstractPlatform $platform, ClassMetadata $class = NULL)
+  {
+    return $this->quote($columnName, $platform);
+  }
+
+  /**
+   * Quotes a string depending on the current platform.
+   *
+   * @param string $string
+   *   The string to quote.
+   * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+   *   The current platform.
+   *
+   * @return string
+   *   The quoted string if the platform could be detected.
+   */
+  private function quote(string $string, AbstractPlatform $platform)
+  {
+
+    switch ($platform->getName()) {
+      case 'sqlite':
+      case 'mysql':
+        return "`{$string}`";
+      case 'mssql':
+        return "[{$string}]";
+    }
+
+    return $string;
+  }
+
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7262Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7262Test.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Persistence\PersistentObject;
+use Doctrine\Tests\Mocks\QuoteStrategyMock;
+use Doctrine\Tests\Models\Hydration\SimpleEntity;
+
+/**
+ * Class GH7262Test
+ *
+ * @author Michael Petri <mpetri@lyska.io>
+ * @see https://github.com/doctrine/doctrine2/issues/7262
+ *
+ * @package Doctrine\Tests\ORM\Functional\Ticket
+ */
+final class GH7262Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+  /**
+   * Setup test case with custom quote strategy.
+   */
+  public function setUp()
+  {
+    parent::setUp();
+
+    $this->_em
+      ->getConfiguration()
+      ->setQuoteStrategy(new QuoteStrategyMock());
+
+    try {
+      $this->_schemaTool->createSchema(
+        [
+          $this->_em->getClassMetadata(SimpleEntity::class),
+        ]
+      );
+    } catch (\Exception $e) {
+    }
+
+    PersistentObject::setObjectManager($this->_em);
+  }
+
+  /**
+   * Tests that the custom quote strategy is set.
+   */
+  public function testQuoteStrategyIsSet()
+  {
+    $this->assertEquals(
+      QuoteStrategyMock::class,
+      get_class($this->_em->getConfiguration()->getQuoteStrategy()),
+      'Quote strategy of type ' . QuoteStrategyMock::class . ' is required.'
+    );
+  }
+
+  /**
+   * Tests finding persisted entities while quote strategy is enabled.
+   *
+   * @throws \Doctrine\ORM\ORMException
+   * @throws \Doctrine\ORM\OptimisticLockException
+   */
+  public function testFindPersistedEntitiesWithActiveQuoteStrategy()
+  {
+    $entity = new SimpleEntity();
+
+    $this->_em->persist($entity);
+    $this->_em->flush();
+
+    $this->assertNotEmpty($entity->id, 'Primary key after persisting an entity expected.');
+
+    $entities = $this->_em->getRepository(SimpleEntity::class)
+      ->findAll();
+
+    $this->assertNotEmpty($entities, 'One persisted entity expected.');
+  }
+
+}


### PR DESCRIPTION
We can't hydrate column information while using a quote strategy because all or the most internal doctrine mappings use the quoted column alias name.

While hydrating a result row data we know we've only got the unquoted column alias and there is no way to quote an existing column alias.
So we need to split the column alias back to the real column name and the alias counter.
This is easy because we know it's get generated in the format '<column_name>_<counter>' by the basic entity persister.

With this information we can use the current quote strategy to generate a quoted column alias.

This PR should solve at least the following issues:

* https://github.com/doctrine/doctrine2/issues/7262
* https://github.com/doctrine/doctrine2/issues/5654