### PR TITLE
Fixed typo in documentation anchor

### DIFF
--- a/docs/en/reference/limitations-and-known-issues.rst
+++ b/docs/en/reference/limitations-and-known-issues.rst
@@ -107,7 +107,7 @@ blog posts we have written on this topics:
 -  `A re-usable Versionable behavior for Doctrine2 <http://www.doctrine-project.org/2010/02/24/doctrine2-versionable.html>`_
 -  `Write your own ORM on top of Doctrine2 <http://www.doctrine-project.org/2010/07/19/your-own-orm-doctrine2.html>`_
 -  `Doctrine 2 Behavioral Extensions <http://www.doctrine-project.org/2010/11/18/doctrine2-behavioral-extensions.html>`_
--  `Doctrator <https://github.com/pablodip/doctrator`>_
+-  `Doctrator <https://github.com/pablodip/doctrator>`_
 
 Doctrine 2 has enough hooks and extension points so that **you** can
 add whatever you want on top of it. None of this will ever become


### PR DESCRIPTION
Just a syntactical issue on the docs. 😉 