### PR TITLE
Use non-deprecated version of Lexer and Inflector

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Util\Inflector;
+use Doctrine\Common\Inflector\Inflector;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -19,9 +19,9 @@
 
 namespace Doctrine\ORM\Mapping\Driver;
 
+use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Util\Inflector;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\Common\Lexer\AbstractLexer;
+
 /**
  * Scans a DQL query for tokens.
  *
@@ -27,7 +29,7 @@ namespace Doctrine\ORM\Query;
  * @author Roman Borschel <roman@code-factory.org>
  * @since 2.0
  */
-class Lexer extends \Doctrine\Common\Lexer
+class Lexer extends AbstractLexer
 {
     // All tokens that are not valid identifiers must be < 100
     const T_NONE                 = 1;


### PR DESCRIPTION
As of https://github.com/doctrine/common/pull/845, `Doctrine\Common\Lexer` and `Doctrine\Common\Util\Inflector` trigger silent deprecations.