### PR TITLE
Add a polyfill for ctype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "doctrine/instantiator": "~1.1",
         "ocramius/package-versions": "^1.1.2",
         "ocramius/proxy-manager": "^2.1.1",
-        "symfony/console": "~3.2|~4.0"
+        "symfony/console": "~3.2|~4.0",
+        "symfony/polyfill-ctype": "~1.8"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ocramius/package-versions": "^1.1.2",
         "ocramius/proxy-manager": "^2.1.1",
         "symfony/console": "~3.2|~4.0",
-        "symfony/polyfill-ctype": "~1.8"
+        "ext-ctype": "*"
     },
     "require-dev": {
         "ext-pdo": "*",


### PR DESCRIPTION
A cytpe function is used here: https://github.com/doctrine/doctrine2/blob/2726636e55fdbdf6fb1ed466f22d34de116fb8f9/lib/Doctrine/ORM/Query/Lexer.php#L163

But ctype is not always enabled, especially for minimalist distributions like alpine.
