### PR TITLE
Removed outdated `$entity` passed phpdoc for `EntityManager::flush()`

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -342,9 +342,6 @@ final class EntityManager implements EntityManagerInterface
      * This effectively synchronizes the in-memory state of managed objects with the
      * database.
      *
-     * If an entity is explicitly passed to this method only this entity and
-     * the cascade-persist semantics + scheduled inserts/removals are synchronized.
-     *
      * @throws OptimisticLockException If a version check on an entity that
      *         makes use of optimistic locking fails.
      * @throws ORMException


### PR DESCRIPTION
Removes outdated info about the possibility to pass an entity that should be flushed instead of all queued changes