### PR TITLE
Fix SchemaTool to use executeUpdate

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -91,7 +91,7 @@ class SchemaTool
 
         foreach ($createSchemaSql as $sql) {
             try {
-                $conn->executeQuery($sql);
+                $conn->executeUpdate($sql);
             } catch (\Exception $e) {
                 throw ToolsException::schemaToolFailure($sql, $e);
             }
@@ -733,7 +733,7 @@ class SchemaTool
 
         foreach ($dropSchemaSql as $sql) {
             try {
-                $conn->executeQuery($sql);
+                $conn->executeUpdate($sql);
             } catch (\Exception $e) {
 
             }
@@ -751,7 +751,7 @@ class SchemaTool
         $conn = $this->em->getConnection();
 
         foreach ($dropSchemaSql as $sql) {
-            $conn->executeQuery($sql);
+            $conn->executeUpdate($sql);
         }
     }
 
@@ -840,7 +840,7 @@ class SchemaTool
         $conn = $this->em->getConnection();
 
         foreach ($updateSchemaSql as $sql) {
-            $conn->executeQuery($sql);
+            $conn->executeUpdate($sql);
         }
     }
 


### PR DESCRIPTION
executeUpdate should be used for write queries. Specifically if a master slave connection is used it wont switch to the master unless executeUpdate is used.