### PR TITLE
Fix: Consistently format inversedBy and mappedBy attributes

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -397,7 +397,7 @@ Things to note:
 -  This feature is available for all kind of associations. (OneToOne, OneToMany, ManyToOne, ManyToMany)
 -  The association type *CANNOT* be changed.
 -  The override could redefine the joinTables or joinColumns depending on the association type.
--  The override could redefine inversedBy to reference more than one extended entity.
+-  The override could redefine ``inversedBy`` to reference more than one extended entity.
 -  The override could redefine fetch to modify the fetch strategy of the extended entity.
 
 Attribute Override

--- a/docs/en/reference/unitofwork-associations.rst
+++ b/docs/en/reference/unitofwork-associations.rst
@@ -16,11 +16,11 @@ Bidirectional Associations
 The following rules apply to **bidirectional** associations:
 
 - The inverse side has to have the ``mappedBy`` attribute of the OneToOne,
-  OneToMany, or ManyToMany mapping declaration. The mappedBy
+  OneToMany, or ManyToMany mapping declaration. The ``mappedBy``
   attribute contains the name of the association-field on the owning side.
 - The owning side has to have the ``inversedBy`` attribute of the
   OneToOne, ManyToOne, or ManyToMany mapping declaration.
-  The inversedBy attribute contains the name of the association-field
+  The ``inversedBy`` attribute contains the name of the association-field
   on the inverse-side.
 - ManyToOne is always the owning side of a bidirectional association.
 - OneToMany is always the inverse side of a bidirectional association.


### PR DESCRIPTION
This PR

* [x] consistently formats references to the `inversedBy` and `mappedBy` attributes