### PR TITLE
Fix: Attributes vs. annotations

### DIFF
--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -159,7 +159,7 @@ Here is a one-to-one relationship between a ``Customer`` and a
 ``Cart``. The ``Cart`` has a reference back to the ``Customer`` so
 it is bidirectional.
 
-Here we see the ``mappedBy`` and ``inversedBy`` annotations for the first time.
+Here we see the ``mappedBy`` and ``inversedBy`` attributes for the first time.
 They are used to tell Doctrine which property on the other side refers to the
 object.
 


### PR DESCRIPTION
This PR

* [x] fixes an issue where `inversedBy` and `mappedBy` attributes are referred to as *annotations*

Follows #7301.

💁‍♂️ Unless I'm mistaken, they aren't annotations, but attributes (of annotations).