### PR TITLE
Make the iterate() function to respect its parent prototype

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -658,7 +658,7 @@ final class Query extends AbstractQuery
      *
      * @return IterableResult
      */
-    public function iterate($parameters = null, $hydrationMode = self::HYDRATE_OBJECT)
+    public function iterate($parameters = null, $hydrationMode = null)
     {
         $this->setHint(self::HINT_INTERNAL_ITERATION, true);
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -867,7 +867,7 @@ class QueryTest extends OrmFunctionalTestCase
         self::assertInstanceOf(CmsUser::class, $users[2]);
         self::assertNull($users[3]);
     }
-    
+
     public function testIterateWithCustomHydrationMode() : void
     {
         $user           = new CmsUser();
@@ -881,14 +881,15 @@ class QueryTest extends OrmFunctionalTestCase
 
         $iterable = $this
             ->em
-            ->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u")
+            ->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u')
             ->setHydrationMode(Query::HYDRATE_ARRAY)
             ->iterate()
         ;
 
         $element = null;
-        foreach ($iterable as $element)
+        foreach ($iterable as $element) {
             break;
+        }
 
         // Assert that we have at least one element found through the foreach
         $this->assertNotNull($element);

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -875,12 +875,12 @@ class QueryTest extends OrmFunctionalTestCase
         $user->username = 'sandvige';
         $user->status   = 'happy <3';
 
-        $this->_em->persist($user);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->em->persist($user);
+        $this->em->flush();
+        $this->em->clear();
 
         $iterable = $this
-            ->_em
+            ->em
             ->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u")
             ->setHydrationMode(Query::HYDRATE_ARRAY)
             ->iterate()

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -867,4 +867,33 @@ class QueryTest extends OrmFunctionalTestCase
         self::assertInstanceOf(CmsUser::class, $users[2]);
         self::assertNull($users[3]);
     }
+    
+    public function testIterateWithCustomHydrationMode() : void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Edouard COLE';
+        $user->username = 'sandvige';
+        $user->status   = 'happy <3';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $iterable = $this
+            ->_em
+            ->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u")
+            ->setHydrationMode(Query::HYDRATE_ARRAY)
+            ->iterate()
+        ;
+
+        $element = null;
+        foreach ($iterable as $element)
+            break;
+
+        // Assert that we have at least one element found through the foreach
+        $this->assertNotNull($element);
+
+        // Assert the fetched element is NOT an entity as an Query::HYDRATE_ARRAY have been requested
+        $this->assertNotInstanceOf('Doctrine\Tests\Models\CMS\CmsUser', $element[0]);
+    }
 }


### PR DESCRIPTION
The iterate() method defined in Query.php is not respecting the defined prototype in AbstractQuery.php with the second default parameter. This makes not possible to define a specific hydration mode when using the iterate() method default behavior with setHydrationMode() because the setter is called only if the given value is !== null.