### PR TITLE
onFlush and postFlush Entity Listeners

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -42,7 +42,9 @@ class EntityListenerBuilder
         Events::preUpdate   => true,
         Events::postUpdate  => true,
         Events::postLoad    => true,
-        Events::preFlush    => true
+        Events::preFlush    => true,
+        Events::onFlush     => true,
+        Events::postFlush   => true
     ];
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3382,11 +3382,31 @@ class UnitOfWork implements PropertyChangedListener
         }
     }
 
+    private function dispatchFlushEntityListener($event)
+    {
+        foreach ($this->identityMap as $className => $entities) {
+            $class = $this->em->getClassMetadata($className);
+            $invoke = $this->listenersInvoker->getSubscribedSystems($class, $event) & ~ListenersInvoker::INVOKE_MANAGER;
+            if (ListenersInvoker::INVOKE_NONE === $invoke) {
+                continue;
+            }
+            foreach ($entities as $entity) {
+                $oid = spl_object_hash($entity);
+                if (! isset($this->entityChangeSets[$oid])) {
+                    continue;
+                }
+                $argClass = 'Doctrine\\ORM\\Event\\'.ucfirst($event).'EventArgs';
+                $this->listenersInvoker->invoke($class, $event, $entity, new $argClass($this->em), $invoke);
+            }
+        }
+    }
+
     private function dispatchOnFlushEvent()
     {
         if ($this->evm->hasListeners(Events::onFlush)) {
             $this->evm->dispatchEvent(Events::onFlush, new OnFlushEventArgs($this->em));
         }
+        $this->dispatchFlushEntityListener(Events::onFlush);
     }
 
     private function dispatchPostFlushEvent()
@@ -3394,6 +3414,7 @@ class UnitOfWork implements PropertyChangedListener
         if ($this->evm->hasListeners(Events::postFlush)) {
             $this->evm->dispatchEvent(Events::postFlush, new PostFlushEventArgs($this->em));
         }
+        $this->dispatchFlushEntityListener(Events::postFlush);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -69,13 +69,29 @@ class AttachEntityListenersListenerTest extends OrmTestCase
             'postPersistHandler'
         );
 
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestBarEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::onFlush
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestBarEntity::class,
+            AttachEntityListenersListenerTestListener2::class,
+            Events::postFlush
+        );
+
         $metadata = $this->factory->getMetadataFor(AttachEntityListenersListenerTestBarEntity::class);
 
         $this->assertArrayHasKey('postPersist', $metadata->entityListeners);
         $this->assertArrayHasKey('prePersist', $metadata->entityListeners);
+        $this->assertArrayHasKey('onFlush', $metadata->entityListeners);
+        $this->assertArrayHasKey('postFlush', $metadata->entityListeners);
 
         $this->assertCount(2, $metadata->entityListeners['prePersist']);
         $this->assertCount(2, $metadata->entityListeners['postPersist']);
+        $this->assertCount(2, $metadata->entityListeners['onFlush']);
+        $this->assertCount(2, $metadata->entityListeners['postFlush']);
 
         $this->assertEquals('prePersist', $metadata->entityListeners['prePersist'][0]['method']);
         $this->assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['prePersist'][0]['class']);
@@ -88,6 +104,18 @@ class AttachEntityListenersListenerTest extends OrmTestCase
 
         $this->assertEquals('postPersistHandler', $metadata->entityListeners['postPersist'][1]['method']);
         $this->assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
+
+        $this->assertEquals('onFlush', $metadata->entityListeners['onFlush'][0]['method']);
+        $this->assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['onFlush'][0]['class']);
+
+        $this->assertEquals('onFlush', $metadata->entityListeners['onFlush'][1]['method']);
+        $this->assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['onFlush'][1]['class']);
+
+        $this->assertEquals('postFlush', $metadata->entityListeners['postFlush'][0]['method']);
+        $this->assertEquals(AttachEntityListenersListenerTestListener::class, $metadata->entityListeners['postFlush'][0]['class']);
+
+        $this->assertEquals('postFlush', $metadata->entityListeners['postFlush'][1]['method']);
+        $this->assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postFlush'][1]['class']);
     }
 
     /**
@@ -106,6 +134,18 @@ class AttachEntityListenersListenerTest extends OrmTestCase
             AttachEntityListenersListenerTestFooEntity::class,
             AttachEntityListenersListenerTestListener::class,
             Events::postPersist
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestFooEntity::class,
+            AttachEntityListenersListenerTestListener::class,
+            Events::onFlush
+        );
+
+        $this->listener->addEntityListener(
+            AttachEntityListenersListenerTestFooEntity::class,
+            AttachEntityListenersListenerTestListener::class,
+            Events::postFlush
         );
 
         $this->factory->getMetadataFor(AttachEntityListenersListenerTestFooEntity::class);
@@ -157,6 +197,16 @@ class AttachEntityListenersListenerTestListener
     {
         $this->calls[__FUNCTION__][] = func_get_args();
     }
+
+    public function onFlush()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
+
+    public function postFlush()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
 }
 
 class AttachEntityListenersListenerTestListener2
@@ -169,6 +219,16 @@ class AttachEntityListenersListenerTestListener2
     }
 
     public function postPersistHandler()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
+
+    public function onFlush()
+    {
+        $this->calls[__FUNCTION__][] = func_get_args();
+    }
+
+    public function postFlush()
     {
         $this->calls[__FUNCTION__][] = func_get_args();
     }


### PR DESCRIPTION
Simply check if an onFlush or postFlush entity listener is subscribed
for the current class in the entity manager during dispatch.

----------------

This contains Unit Tests per request by @Ocramius.
This references the same code as PR #7203 in the [2.7](https://github.com/doctrine/doctrine2/tree/2.7) branch.