### PR TITLE
Fix memory leak in AbstractHydrator

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -149,9 +149,11 @@ abstract class AbstractHydrator
 
         $this->prepare();
 
-        $result = $this->hydrateAllData();
-
-        $this->cleanup();
+        try {
+            $result = $this->hydrateAllData();
+        } finally {
+            $this->cleanup();
+        }
 
         return $result;
     }


### PR DESCRIPTION
Method `hydrateAll()` does not take into account possible
exception from `hydrateAllData()` which in turn does not call
`cleanup()`

This is the issue when single scalar is used since it throws exceptions. To demo this, one can just select from an empty table and see how the memory rises.

In this example, few test cases were provided. One that hydrates single scalar result and an other that hydrates an array. In the second case, the memory is constant.

```
$ for i in 1000 10000 100000; do ./run $i; done 
int(1000)
string(4) "3 MB"
string(5) "6 KB"
int(10000)
string(5) "13 MB"
string(5) "6 KB"
int(100000)
string(6) "112 MB"
string(5) "6 KB"
```

After the fix, situation is as following

```
$ for i in 1000 10000 100000; do ./run $i; done
int(1000)
string(4) "2 MB"
string(5) "6 KB"
int(10000)
string(4) "2 MB"
string(5) "6 KB"
int(100000)
string(4) "2 MB"
string(5) "6 KB"
```

What do you suggest, how to add tests? Repeat the same query a few hundred times and set a reasonable threshold like 10MB?

Code used to test this can be found at https://github.com/zlikavac32/doctrine-memory-leak-demo