### PR TITLE
[XML] Fix default value of many-to-many order-by to ASC

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -549,7 +549,9 @@ class XmlDriver extends FileDriver
                 if (isset($manyToManyElement->{'order-by'})) {
                     $orderBy = [];
                     foreach ($manyToManyElement->{'order-by'}->{'order-by-field'} as $orderByField) {
-                        $orderBy[(string) $orderByField['name']] = (string) $orderByField['direction'];
+                        $orderBy[(string) $orderByField['name']] = isset($orderByField['direction'])
+                            ? (string) $orderByField['direction']
+                            : Criteria::ASC;
                     }
                     $mapping['orderBy'] = $orderBy;
                 }

--- a/tests/Doctrine/Tests/Models/GH7316/GH7316Article.php
+++ b/tests/Doctrine/Tests/Models/GH7316/GH7316Article.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Doctrine\Tests\Models\GH7316;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class GH7316Article
+{
+    private $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -13,6 +13,7 @@ use Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed;
 use Doctrine\Tests\Models\DDC889\DDC889Class;
 use Doctrine\Tests\Models\Generic\SerializationModel;
 use Doctrine\Tests\Models\GH7141\GH7141Article;
+use Doctrine\Tests\Models\GH7316\GH7316Article;
 use Doctrine\Tests\Models\ValueObjects\Name;
 use Doctrine\Tests\Models\ValueObjects\Person;
 
@@ -189,6 +190,20 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
 
         $this->assertEquals(
+            Criteria::ASC,
+            $class->getMetadataValue('associationMappings')['tags']['orderBy']['position']
+        );
+    }
+
+    public function testManyToManyDefaultOrderByAsc() : void
+    {
+        $class  = new ClassMetadata(GH7316Article::class);
+        $class->initializeReflection(new RuntimeReflectionService());
+
+        $driver = $this->_loadDriver();
+        $driver->loadMetadataForClass(GH7316Article::class, $class);
+
+        self::assertEquals(
             Criteria::ASC,
             $class->getMetadataValue('associationMappings')['tags']['orderBy']['position']
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.GH7316.GH7316Article.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.GH7316.GH7316Article.dcm.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                         http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Doctrine\Tests\Models\GH7316\GH7316Article">
+        <many-to-many field="tags" target-entity="NoTargetEntity" mapped-by="noMappedByField">
+            <order-by>
+                <order-by-field name="position"/>
+            </order-by>
+        </many-to-many>
+    </entity>
+</doctrine-mapping>


### PR DESCRIPTION
Fixes #7316 

Props to @Awkan for the original fix applied to one-to-many relationships - this just applied the same fix to many-to-many