### PR TITLE
Fix XSD regex for fqcn and tablename patterns

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -424,7 +424,7 @@
 
   <xs:simpleType name="fqcn" id="fqcn">
     <xs:restriction base="xs:token">
-      <xs:pattern value="[a-zA-Z_u01-uff][a-zA-Z0-9_u01-uff]+" id="fqcn.pattern">
+      <xs:pattern value="([a-zA-Z_&#x7F;][a-zA-Z0-9_&#x7F;]*\\)*[a-zA-Z_&#x7F;][a-zA-Z0-9_&#x7F;]*" id="fqcn.pattern">
       </xs:pattern>
     </xs:restriction>
   </xs:simpleType>

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -202,7 +202,7 @@
 
   <xs:simpleType name="tablename" id="tablename">
     <xs:restriction base="xs:token">
-      <xs:pattern value="[a-zA-Z_u01-uff.]+" id="tablename.pattern">
+      <xs:pattern value="([&#x20;-&#x7F;-[`.]]+\.)?([a-zA-Z][a-zA-Z0-9_]*|`[&#x20;-&#x7F;]+`)" id="tablename.pattern">
       </xs:pattern>
     </xs:restriction>
   </xs:simpleType>

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -275,6 +275,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
         foreach ([
             'fqcn' => ['custom-id-generator', 'class'],
+            'tablename' => ['entity', 'table'],
         ] as $type => [$element, $attribute]) {
             $errorMessagePrefix = sprintf("Element '%s', attribute '%s': ", $namespaced($element), $attribute);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -206,7 +206,15 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $invalid = self::getInvalidXmlMappingMap();
 
         $list = array_filter($list, function($item) use ($invalid){
-            return ! array_key_exists(pathinfo($item, PATHINFO_FILENAME), $invalid);
+            $matchesInvalid = false;
+            foreach ($invalid as $filenamePattern => $unused) {
+                if (fnmatch($filenamePattern, pathinfo($item, PATHINFO_FILENAME))) {
+                    $matchesInvalid = true;
+                    break;
+                }
+            }
+
+            return ! $matchesInvalid;
         });
 
         return array_map(function($item){
@@ -220,19 +228,17 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $invalid = self::getInvalidXmlMappingMap();
 
         $map = [];
-        foreach ($invalid as $filename => $errorMessageRegexes) {
-            $foundItem = null;
-            foreach ($list as $item) {
-                if (pathinfo($item, PATHINFO_FILENAME) === $filename) {
-                    $foundItem = $item;
-                    break;
-                }
-            }
+        foreach ($invalid as $filenamePattern => $errorMessageRegexes) {
+            $foundItems = array_filter($list, function($item) use ($filenamePattern){
+                return fnmatch($filenamePattern, pathinfo($item, PATHINFO_FILENAME));
+            });
 
-            if ($foundItem !== null) {
-                $map[$foundItem] = $errorMessageRegexes;
+            if (count($foundItems) > 0) {
+                foreach ($foundItems as $foundItem) {
+                    $map[$foundItem] = $errorMessageRegexes;
+                }
             } else {
-                throw new \RuntimeException(sprintf('Found no XML mapping with filename "%s".', $filename));
+                throw new \RuntimeException(sprintf('Found no XML mapping with filename pattern "%s".', $filenamePattern));
             }
         }
 
@@ -250,15 +256,30 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     }
 
     /**
-     * @return array<string, string[]> ($filename => $errorMessageRegexes)
+     * @return array<string, string[]> ($filenamePattern => $errorMessageRegexes)
      */
     static private function getInvalidXmlMappingMap()
     {
+        $namespaced = function ($name) {
+            return sprintf('{%s}%s', 'http://doctrine-project.org/schemas/orm/doctrine-mapping', $name);
+        };
+
         $invalid = [
             'Doctrine.Tests.Models.DDC889.DDC889Class.dcm' => [
-                "Element '{http://doctrine-project.org/schemas/orm/doctrine-mapping}class': This element is not expected. Expected is %s.",
+                sprintf("Element '%s': This element is not expected. Expected is %%s.", $namespaced('class')),
             ],
         ];
+
+        foreach ([
+            'fqcn' => ['custom-id-generator', 'class'],
+        ] as $type => [$element, $attribute]) {
+            $errorMessagePrefix = sprintf("Element '%s', attribute '%s': ", $namespaced($element), $attribute);
+
+            $invalid[sprintf('pattern-%s-invalid-*', $type)] = [
+                $errorMessagePrefix . "[facet 'pattern'] The value '%s' is not accepted by the pattern '%s'.",
+                $errorMessagePrefix . sprintf("'%%s' is not a valid value of the atomic type '%s'.", $namespaced($type)),
+            ];
+        }
 
         // Convert basic sprintf-style formats to PCRE patterns
         return array_map(function ($errorMessageFormats) {

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -162,7 +162,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
      * @dataProvider dataValidSchemaInvalidMappings
      * @group 6389
      */
-    public function testValidateXmlSchemaWithInvalidMapping($xmlMappingFile, $errorMessageRegexes)
+    public function testValidateXmlSchemaWithInvalidMapping(string $xmlMappingFile, array $errorMessageRegexes) : void
     {
         $savedUseErrors = libxml_use_internal_errors(true);
         libxml_clear_errors();
@@ -186,11 +186,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         }
     }
 
-    /**
-     * @param string $xmlMappingFile
-     * @return bool
-     */
-    private function doValidateXmlSchema($xmlMappingFile)
+    private function doValidateXmlSchema(string $xmlMappingFile) : bool
     {
         $xsdSchemaFile = __DIR__ . '/../../../../../doctrine-mapping.xsd';
         $dom           = new \DOMDocument('1.0', 'UTF-8');
@@ -205,7 +201,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $list    = self::getAllXmlMappingPaths();
         $invalid = self::getInvalidXmlMappingMap();
 
-        $list = array_filter($list, function ($filename) use ($invalid) {
+        $list = array_filter($list, function (string $filename) use ($invalid) : bool {
             $matchesInvalid = false;
             foreach ($invalid as $filenamePattern => $unused) {
                 if (fnmatch($filenamePattern, $filename)) {
@@ -217,19 +213,19 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
             return ! $matchesInvalid;
         }, ARRAY_FILTER_USE_KEY);
 
-        return array_map(function ($item) {
+        return array_map(function (string $item) : array {
             return [$item];
         }, $list);
     }
 
-    public static function dataValidSchemaInvalidMappings()
+    public static function dataValidSchemaInvalidMappings() : array
     {
         $list    = self::getAllXmlMappingPaths();
         $invalid = self::getInvalidXmlMappingMap();
 
         $map = [];
         foreach ($invalid as $filenamePattern => $errorMessageRegexes) {
-            $foundItems = array_filter($list, function ($filename) use ($filenamePattern) {
+            $foundItems = array_filter($list, function (string $filename) use ($filenamePattern) : bool {
                 return fnmatch($filenamePattern, $filename);
             }, ARRAY_FILTER_USE_KEY);
 
@@ -248,7 +244,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @return array<string, string> ($filename => $path)
      */
-    private static function getAllXmlMappingPaths()
+    private static function getAllXmlMappingPaths() : array
     {
         $list = [];
         foreach (glob(__DIR__ . '/xml/*.xml') as $path) {
@@ -261,9 +257,9 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @return array<string, string[]> ($filenamePattern => $errorMessageRegexes)
      */
-    private static function getInvalidXmlMappingMap()
+    private static function getInvalidXmlMappingMap() : array
     {
-        $namespaced = function ($name) {
+        $namespaced = function (string $name) : string {
             return sprintf('{%s}%s', 'http://doctrine-project.org/schemas/orm/doctrine-mapping', $name);
         };
 
@@ -286,8 +282,8 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         }
 
         // Convert basic sprintf-style formats to PCRE patterns
-        return array_map(function ($errorMessageFormats) {
-            return array_map(function ($errorMessageFormat) {
+        return array_map(function (array $errorMessageFormats) : array {
+            return array_map(function (string $errorMessageFormat) : string {
                 return '/^' . strtr(preg_quote($errorMessageFormat, '/'), [
                         '%%' => '%',
                         '%s' => '.*',

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -192,20 +192,20 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
      */
     private function doValidateXmlSchema($xmlMappingFile)
     {
-        $xsdSchemaFile  = __DIR__ . '/../../../../../doctrine-mapping.xsd';
-        $dom            = new \DOMDocument('1.0', 'UTF-8');
+        $xsdSchemaFile = __DIR__ . '/../../../../../doctrine-mapping.xsd';
+        $dom           = new \DOMDocument('1.0', 'UTF-8');
 
         $dom->load($xmlMappingFile);
 
         return $dom->schemaValidate($xsdSchemaFile);
     }
 
-    static public function dataValidSchema()
+    public static function dataValidSchema()
     {
         $list    = self::getAllXmlMappingPaths();
         $invalid = self::getInvalidXmlMappingMap();
 
-        $list = array_filter($list, function($filename) use ($invalid){
+        $list = array_filter($list, function ($filename) use ($invalid) {
             $matchesInvalid = false;
             foreach ($invalid as $filenamePattern => $unused) {
                 if (fnmatch($filenamePattern, $filename)) {
@@ -217,19 +217,19 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
             return ! $matchesInvalid;
         }, ARRAY_FILTER_USE_KEY);
 
-        return array_map(function($item){
+        return array_map(function ($item) {
             return [$item];
         }, $list);
     }
 
-    static public function dataValidSchemaInvalidMappings()
+    public static function dataValidSchemaInvalidMappings()
     {
         $list    = self::getAllXmlMappingPaths();
         $invalid = self::getInvalidXmlMappingMap();
 
         $map = [];
         foreach ($invalid as $filenamePattern => $errorMessageRegexes) {
-            $foundItems = array_filter($list, function($filename) use ($filenamePattern){
+            $foundItems = array_filter($list, function ($filename) use ($filenamePattern) {
                 return fnmatch($filenamePattern, $filename);
             }, ARRAY_FILTER_USE_KEY);
 
@@ -248,7 +248,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @return array<string, string> ($filename => $path)
      */
-    static private function getAllXmlMappingPaths()
+    private static function getAllXmlMappingPaths()
     {
         $list = [];
         foreach (glob(__DIR__ . '/xml/*.xml') as $path) {
@@ -261,7 +261,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     /**
      * @return array<string, string[]> ($filenamePattern => $errorMessageRegexes)
      */
-    static private function getInvalidXmlMappingMap()
+    private static function getInvalidXmlMappingMap()
     {
         $namespaced = function ($name) {
             return sprintf('{%s}%s', 'http://doctrine-project.org/schemas/orm/doctrine-mapping', $name);

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -153,7 +153,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
     public function testValidateXmlSchema($xmlMappingFile)
     {
         $xsdSchemaFile  = __DIR__ . '/../../../../../doctrine-mapping.xsd';
-        $dom            = new \DOMDocument('UTF-8');
+        $dom            = new \DOMDocument('1.0', 'UTF-8');
 
         $dom->load($xmlMappingFile);
 

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_20.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_20.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsSpace">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_2D.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_2D.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsHyphen">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo-Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_2F.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_2F.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsSlash">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo/Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_3B.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_3B.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsSemicolon">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo;Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_5E.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_5E.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsCircumflex">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo^Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_7E.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-char_7E.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidContainsTilde">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo~Bar" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-multibyte.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-multibyte.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidMultibyte">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Eléphant" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-starts_with_digit.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-invalid-starts_with_digit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternFqcnInvalidStartsWithDigit">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="3lephant" />
+        </id>
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-valid-basic.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-valid-basic.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="PatternFqcnValidBasicSingleLetter">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="C" />
+        </id>
+    </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-valid-basic.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-fqcn-valid-basic.xml
@@ -4,6 +4,20 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                           http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
+    <entity name="PatternFqcnValidBasicNamespaced">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="Foo\Bar\Qux" />
+        </id>
+    </entity>
+
+    <entity name="PatternFqcnValidBasicWord">
+        <id name="id">
+            <generator strategy="CUSTOM" />
+            <custom-id-generator class="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789" />
+        </id>
+    </entity>
+
     <entity name="PatternFqcnValidBasicSingleLetter">
         <id name="id">
             <generator strategy="CUSTOM" />

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_20.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_20.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsSpace"
+            table="foo bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_2D.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_2D.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsHyphen"
+            table="foo-bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_2F.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_2F.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsSlash"
+            table="foo/bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_3B.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_3B.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsSemicolon"
+            table="foo;bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_5E.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_5E.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsCircumflex"
+            table="foo^bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_7E.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_char_7E.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainContainsTilde"
+            table="foo~bar">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_multibyte.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-plain_multibyte.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidPlainMultibyte"
+            table="Eléphant">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-quoted_multibyte.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-invalid-quoted_multibyte.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="PatternTablenameInvalidQuotedMultibyte"
+            table="`Eléphant`">
+    </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-plain_basic.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-plain_basic.xml
@@ -4,20 +4,16 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                           http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="PatternTablenameValidQuotedContainsHyphen"
-            table="`foo-bar`">
+    <entity name="PatternTablenameValidPlainBasicWord"
+            table="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789">
     </entity>
 
-    <entity name="PatternTablenameValidQuotedContainsSemicolon"
-            table="`foo;bar`">
+    <entity name="PatternTablenameValidPlainBasicCapitalized"
+            table="Foo">
     </entity>
 
-    <entity name="PatternTablenameValidQuotedContainsSpace"
-            table="`foo bar`">
-    </entity>
-
-    <entity name="PatternTablenameValidQuotedContainsPuncts"
-            table="`a/b^c~d`">
+    <entity name="PatternTablenameValidPlainBasicSingleLetter"
+            table="t">
     </entity>
 
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-quoted_basic.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-quoted_basic.xml
@@ -4,20 +4,16 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                           http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="PatternTablenameValidQuotedContainsHyphen"
-            table="`foo-bar`">
+    <entity name="PatternTablenameValidQuotedBasicWord"
+            table="`abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789`">
     </entity>
 
-    <entity name="PatternTablenameValidQuotedContainsSemicolon"
-            table="`foo;bar`">
+    <entity name="PatternTablenameValidQuotedBasicCapitalized"
+            table="`Foo`">
     </entity>
 
-    <entity name="PatternTablenameValidQuotedContainsSpace"
-            table="`foo bar`">
-    </entity>
-
-    <entity name="PatternTablenameValidQuotedContainsPuncts"
-            table="`a/b^c~d`">
+    <entity name="PatternTablenameValidQuotedBasicSingleLetter"
+            table="`t`">
     </entity>
 
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-quoted_chars.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/pattern-tablename-valid-quoted_chars.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="PatternTablenameValidQuotedContainsHyphen"
+            table="`foo-bar`">
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
Follow-up to #6389's discussion. Mainly: "`[u01-uff]`" is just *wrong* (in any regex flavor, BTW).

Recap of the currently incorrect cases _(and inconsistencies)_:

- `tablename`:
    - rejects `` `foo-bar` `` [does not allow the hyphen even if quoted] _(while accepting `` `foo;bar` ``)_
    - accepts `foo;bar` [allows the semicolon although unquoted] _(while rejecting `foo-bar`)_
- `fqcn`:
    - rejects `C` [requires at least 2 chars]
    - accepts `Foo;Bar` [allows the semicolon] _(while rejecting `Foo-Bar`)_
    - accepts `3lephant` [allows digits for the first char]

---

Note: the pattern for `fqcn` is rather straightforward, but not so for `tablename`:
- different SQL database vendors allow different extra characters for [un]quoted identifiers...
- it seems that Doctrine supports the form "`myschema.mytable`", where `mytable` *may* be quoted whereas `myschema` may *not* but *will become* if `mytable` is ([here](https://github.com/doctrine/doctrine2/blob/96f166a7e90149adb1357c5db73c615407ea394e/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php#L80-L91) -> [here](https://github.com/doctrine/doctrine2/blob/96f166a7e90149adb1357c5db73c615407ea394e/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2297-L2309), then [here](https://github.com/doctrine/doctrine2/blob/96f166a7e90149adb1357c5db73c615407ea394e/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php#L49-L61) -> [there](https://github.com/doctrine/dbal/blob/a7dc38d87bc5b89704b7c3388b1438701a4dfb0a/lib/Doctrine/DBAL/Platforms/AbstractPlatform.php#L1922-L1925))...
- cannot be merged into master *as-is*, because Doctrine 3.x will auto-quote everything...

Also, this adds many small XML test files (mostly because invalid cases have to be tested separately [and I split the valid cases a bit], but not all are strictly necessary)...

(But still, I think that at least those "`u01-uff`" should be fixed.)

Found related:
- #6728
- #6883
- #7001
- [#7085's second commit](https://github.com/doctrine/doctrine2/pull/7085/commits/0b04aa900063f3afe5a11e9697de01dd7c5a3987)