### PR TITLE
Make code php 7.3 lint-compatible

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2715,7 +2715,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
-                        continue;
+                        break;
                     }
 
                     $associatedId = [];
@@ -2744,7 +2744,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        break;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
Current v2.6.2 raised a warning when ran on php 7.3 : 
```
$ php7.3 -v ; find . -name '*.php' -exec php7.3 -l {} \;| grep -v '^No syntax errors'
PHP 7.3.0alpha4 (cli) (built: Jul 23 2018 11:02:37) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.0-dev, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.3.0alpha4, Copyright (c) 1999-2018, by Zend Technologies
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./lib/Doctrine/ORM/UnitOfWork.php on line 2718
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./lib/Doctrine/ORM/UnitOfWork.php on line 2747
```
I changed the `continue` into `break` ([meaning of `continue;` inside a switch](https://secure.php.net/continue)), although `continue 2` seems to be equivalent as there is no code after the `switch` statement.