### PR TITLE
Correct method names and broken link in docs

### DIFF
--- a/docs/en/reference/caching.rst
+++ b/docs/en/reference/caching.rst
@@ -27,10 +27,10 @@ Each driver extends the ``CacheProvider`` class which defines a few
 abstract protected methods that each of the drivers must
 implement:
 
--  \_doFetch($id)
--  \_doContains($id)
--  \_doSave($id, $data, $lifeTime = false)
--  \_doDelete($id)
+-  doFetch($id)
+-  doContains($id)
+-  doSave($id, $data, $lifeTime = false)
+-  doDelete($id)
 
 The public methods ``fetch()``, ``contains()`` etc. use the
 above protected methods which are implemented by the drivers. The
@@ -41,7 +41,7 @@ these methods.
 
 This documentation does not cover every single cache driver included
 with Doctrine. For an up-to-date-list, see the
-`cache directory on GitHub <https://github.com/doctrine/cache/tree/master/lib/Doctrine/Common/Cache>`.
+`cache directory on GitHub <https://github.com/doctrine/cache/tree/master/lib/Doctrine/Common/Cache>`_.
 
 APC
 ~~~


### PR DESCRIPTION
The methods name were incorrectly prefixed with a `\_` and the link
syntax was broken and its URL appeared in plain text in rendered HTML.