### PR TITLE
Fix renamed depended test method

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -60,7 +60,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     /**
      * @param <type> $query
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnFirstResult($query) : void
     {
@@ -76,7 +76,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     /**
      * @param <type> $query
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnMaxResults($query) : void
     {
@@ -91,7 +91,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     /**
      * @param <type> $query
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnHydrationMode($query) : void
     {


### PR DESCRIPTION
https://github.com/doctrine/doctrine2/pull/7046/commits/1b845c7c84046324cbe63fdfd95c8da96ef1a336#diff-a0b1e1b662ca3385ea46b3f7e6a93745L46 renamed the test method `testQueryCache_DependsOnHints` to `testQueryCacheDependsOnHints` but forgot to update the corresponding `@depends` annotations, resulting in dependent tests not being run anymore.

Currently:

```
$ ./vendor/bin/phpunit tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
PHPUnit 7.3.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.8-1+0~20180725124257.2+stretch~1.gbp571e56
Configuration: /z/phpunit.xml.dist

.SSS..                                                              6 / 6 (100%)

Time: 270 ms, Memory: 10.00MB

There were 3 skipped tests:

1) Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCacheDependsOnFirstResult
This test depends on "Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCache_DependsOnHints" to pass.

2) Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCacheDependsOnMaxResults
This test depends on "Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCache_DependsOnHints" to pass.

3) Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCacheDependsOnHydrationMode
This test depends on "Doctrine\Tests\ORM\Functional\QueryCacheTest::testQueryCache_DependsOnHints" to pass.

OK, but incomplete, skipped, or risky tests!
Tests: 6, Assertions: 6, Skipped: 3.
```

With this patch:

```
$ ./vendor/bin/phpunit tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
PHPUnit 7.3.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.2.8-1+0~20180725124257.2+stretch~1.gbp571e56
Configuration: /z/phpunit.xml.dist

......                                                              6 / 6 (100%)

Time: 262 ms, Memory: 10.00MB

OK (6 tests, 9 assertions)
```