### PR TITLE
Fix config template for PHPUnit >= 7.2

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,10 +19,6 @@
          bootstrap="./tests/Doctrine/Tests/TestInit.php"
 >
 
-    <php>
-        <env name="COLUMNS" value="120"/>
-    </php>
-
     <testsuites>
         <testsuite name="Doctrine ORM Test Suite">
             <directory>./tests/Doctrine/Tests/ORM</directory>
@@ -37,6 +33,8 @@
     </groups>
 
   <php>
+    <env name="COLUMNS" value="120"/>
+
     <!-- "Real" test database -->
     <!-- uncomment, otherwise sqlite memory runs
     <var name="db_type" value="pdo_mysql"/>


### PR DESCRIPTION
Merge duplicate `<php>` elements to fix

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 44:
  - Element 'php': This element is not expected.

  Test results may not be as expected.
```

See sebastianbergmann/phpunit#3066