### PR TITLE
Update SingleScalarHydrator to match documentation

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -25,7 +25,7 @@ class SingleScalarHydrator extends AbstractHydrator
         $numRows = count($data);
 
         if ($numRows === 0) {
-            throw new NoResultException();
+            return null;
         }
 
         if ($numRows > 1) {


### PR DESCRIPTION
Hello!

The documentation in `AbstractQuery` indicates that the only exception that should be thrown by `$query->getSingleScalarResult()` is a `NonUniqueResultException`, and that if no results exist, NULL should be returned instead.

Because of this line, however, it is indeed possible for a `NoResultException` to be thrown instead. This is unexpected behavior that's inconsistent with the annotated `@throws` clauses in `AbstractQuery`.

There are probably multiple ways to approach this issue (i.e. "catching" this exception upstream and returning null), but this seems to be the simplest approach to bring the result back into line with upstream documentation.