### PR TITLE
Correct DOMDocument constructor in test

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -152,8 +152,8 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
      */
     public function testValidateXmlSchema($xmlMappingFile)
     {
-        $xsdSchemaFile  = __DIR__ . '/../../../../../doctrine-mapping.xsd';
-        $dom            = new \DOMDocument('UTF-8');
+        $xsdSchemaFile = __DIR__ . '/../../../../../doctrine-mapping.xsd';
+        $dom           = new \DOMDocument();
 
         $dom->load($xmlMappingFile);
 


### PR DESCRIPTION
http://php.net/manual/en/domdocument.construct.php reads:

```
public DOMDocument::__construct ([ string $version [, string $encoding ]] )
```

so `new \DOMDocument('UTF-8')` is incorrect, should be `new \DOMDocument('1.0', 'UTF-8')`,

but the top user note explains:

> The constuctor arguments are useful if you want to build a new document using createElement, appendChild etc.
> 
> By contrast, these arguments are overriden as soon as you load a document from source by calling load() or loadXML().
> 
> * If the source contains an XML declaration specifying an encoding, that encoding is used.
> * If the XML declaration does not specify an encoding, or if the source does not contain a declaration at all, UTF-8 is assumed.
> 
> This behaviour applies no matter what you declared when you called new DOMDocument().

so here the argument(s) should rather simply be left out.

---

The additional CS fixes make it also applicable to `master` as is.