### PR TITLE
Fix XSD regex for table name

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -202,7 +202,7 @@
 
   <xs:simpleType name="tablename" id="tablename">
     <xs:restriction base="xs:token">
-      <xs:pattern value="[a-zA-Z_u01-uff.]+" id="tablename.pattern">
+      <xs:pattern value="([&#x20;-&#x7F;-[`.]]+\.)?([a-zA-Z][a-zA-Z0-9_]*|`[&#x20;-&#x7F;]+`)" id="tablename.pattern">
       </xs:pattern>
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Extracted from #7324 (see also #7329 about the optional schema part).

---

Note: for `master` (3.x, with auto-quoting) the patch would rather be:

```diff
-      <xs:pattern value="[a-zA-Z\-_u01-uff.]+" id="tablename.pattern">
+      <xs:pattern value="[&#x20;-&#x7F;]+" id="tablename.pattern">
```