### PR TITLE
[docs] Fix RST directive syntax / code blocks

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -429,14 +429,14 @@ according to the used database platform.
 
 .. _reference-basic-mapping-custom-mapping-types:
 
-.. versionadded: 2.3
+.. versionadded:: 2.3
 
 For more control over column quoting the ``Doctrine\ORM\Mapping\QuoteStrategy`` interface
 was introduced in 2.3. It is invoked for every column, table, alias and other
 SQL names. You can implement the QuoteStrategy and set it by calling
 ``Doctrine\ORM\Configuration#setQuoteStrategy()``.
 
-.. versionadded: 2.4
+.. versionadded:: 2.4
 
 The ANSI Quote Strategy was added, which assumes quoting is not necessary for any SQL name.
 You can use it with the following code:

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -615,7 +615,7 @@ then phonenumber-id:
             object(stdClass)[299]
               public '__CLASS__' => string 'Doctrine\Tests\Models\CMS\CmsUser' (length=33)
               public 'id' => int 1
-              ..
+              ...
           'nameUpper' => string 'ROMANB' (length=6)
       1 =>
         array

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -370,7 +370,7 @@ Example of a rich entity with proper accessors and mutators:
                 return $checkHash($password, $this->passwordHash) && ! $this->hasActiveBans();
             }
 
-            public function changePassword(string $password, callable $hash): void
+            public function changePassword(string $password, callable $hash): void
             {
                 $this->passwordHash = $hash($password);
             }


### PR DESCRIPTION
Note:
the syntax fix applies to `master`, `2.7` and `2.6`;
the space fix applies to `master` only.