### PR TITLE
Document getPartialReference() properly

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -174,7 +174,7 @@ interface EntityManagerInterface extends ObjectManager
      * @param string $entityName The name of the entity type.
      * @param mixed  $identifier The entity identifier.
      *
-     * @return object The (partial) entity reference.
+     * @return object|null The (partial) entity reference.
      */
     public function getPartialReference($entityName, $identifier);
 


### PR DESCRIPTION
According to the current implementation that method also returns `null`, the interface's documentation was incorrect.

https://github.com/doctrine/doctrine2/blob/d2b4dd71d2a276edd65d0c170375b445f8a4a4a8/lib/Doctrine/ORM/EntityManager.php#L514-L516