### PR TITLE
Remove remnants of yaml from documentation

### DIFF
--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -42,7 +42,6 @@
       reference/change-tracking-policies
       reference/partial-objects
       reference/xml-mapping
-      reference/yaml-mapping
       reference/annotations-reference
       reference/php-mapping
       reference/caching


### PR DESCRIPTION
Just a rest of yaml I found.