### PR TITLE
Update getting-started.rst

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -87,7 +87,7 @@ the following contents:
 
     {
         "require": {
-            "doctrine/orm": "2.4.*",
+            "doctrine/orm": "*",
             "symfony/yaml": "2.*"
         },
         "autoload": {

--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -87,7 +87,7 @@ the following contents:
 
     {
         "require": {
-            "doctrine/orm": "*",
+            "doctrine/orm": "^2.6",
             "symfony/yaml": "2.*"
         },
         "autoload": {


### PR DESCRIPTION
I propose `"doctrine/orm": "2.4.*",` is changed to `"doctrine/orm": "*",` in the example JSON file at the start of the Getting Started with Doctrine tutorial.

Without the change, I got a missing AnnotationFactory.php class error when running the `orm:schema-tool:create` command, and changing it to `"*"` fixed that for me.