### PR TITLE
fix PHP 7.3 Warning: "continue" targeting switch is equivalent to "br…

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2633,7 +2633,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
-                        continue;
+                        break;
                     }
 
                     $associatedId = array();
@@ -2662,7 +2662,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        break;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
…eak". Did you mean to use "continue 2"?


Found in Fedora QA, for various library using doctrine (not covered by doctrine test suite)
https://apps.fedoraproject.org/koschei/package/php-doctrine-doctrine-bundle?collection=f30
https://apps.fedoraproject.org/koschei/package/php-jms-serializer?collection=f30
etc