### PR TITLE
Removed FAQ paragraph stating public variables are disallowed

### DIFF
--- a/docs/en/reference/faq.rst
+++ b/docs/en/reference/faq.rst
@@ -21,12 +21,6 @@ created database tables and columns.
 Entity Classes
 --------------
 
-I access a variable and its null, what is wrong?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If this variable is a public variable then you are violating one of the criteria for entities.
-All properties have to be protected or private for the proxy object pattern to work.
-
 How can I add default values to a column?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
In #7427 @flaushi mentioned the outdated paragraph. This commit removes
that one.

I have sent the PR towards branch 2.6, because it is the current one. I hope this is correct.