### PR TITLE
Fix build: Disable test assertion upon a non-mockable ClassMetadataFactory method

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -183,12 +183,14 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         // ClassMetadataFactory::addDefaultDiscriminatorMap shouldn't be called again, because the
         // discriminator map is already cached
-        $cmf = $this->getMockBuilder(ClassMetadataFactory::class)->setMethods(['addDefaultDiscriminatorMap'])->getMock();
-        $cmf->setEntityManager($em);
-        $cmf->expects($this->never())
-            ->method('addDefaultDiscriminatorMap');
 
-        $rootMetadata = $cmf->getMetadataFor(RootClass::class);
+        // TODO This tests calls to a private method on ClassMetadataFactory - this is not supported by PHPUnit
+        // $cmf = $this->getMockBuilder(ClassMetadataFactory::class)->setMethods(['addDefaultDiscriminatorMap'])->getMock();
+        // $cmf->setEntityManager($em);
+        // $cmf->expects($this->never())
+        //     ->method('addDefaultDiscriminatorMap');
+
+        // $rootMetadata = $cmf->getMetadataFor(RootClass::class);
     }
 
     public function testGetAllMetadataWorksWithBadConnection() : void


### PR DESCRIPTION
`ClassMetadataFactory::addDefaultDiscriminatorMap()` is a private method and as such  is not mockable. Older PHPUnit versions ignored this.

This is a BC break in PHPUnit 7.4: https://github.com/sebastianbergmann/phpunit/blob/7.4.0/ChangeLog-7.4.md#740---2018-10-05