### PR TITLE
Fix failing tests. Remove useless mock

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -180,15 +180,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         self::assertEquals($childDiscriminatorMap, $rootDiscriminatorMap);
         self::assertEquals($anotherChildDiscriminatorMap, $rootDiscriminatorMap);
-
-        // ClassMetadataFactory::addDefaultDiscriminatorMap shouldn't be called again, because the
-        // discriminator map is already cached
-        $cmf = $this->getMockBuilder(ClassMetadataFactory::class)->setMethods(['addDefaultDiscriminatorMap'])->getMock();
-        $cmf->setEntityManager($em);
-        $cmf->expects($this->never())
-            ->method('addDefaultDiscriminatorMap');
-
-        $rootMetadata = $cmf->getMetadataFor(RootClass::class);
     }
 
     public function testGetAllMetadataWorksWithBadConnection() : void


### PR DESCRIPTION
 - this mock didn't work well before because phpunit didn't mock method addDefaultDiscriminatorMap.
 - since phpunit 7.4.0 it throws warning in case of mocking method which is not really mocked (sebastianbergmann/phpunit#3127)