### PR TITLE
Drop automatic discriminator map discovery

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,20 @@
 # Upgrade to 3.0
 
+## BC Break: Dropped automatic discriminator map discovery
+
+Automatic discriminator map discovery exhibited multiple flaws
+that can't be reliably addressed and supported:
+
+ * discovered entries are not namespaced which leads to collisions,
+ * the class name is part of the discriminator map, therefore the class
+   must never be renamed.
+
+As a consequence this feature has been dropped.
+
+If your code relied on this feature, please build the discriminator map for
+your inheritance tree manually where each entry is an unqualified lowercase
+name of the member entities.
+
 ## BC Break: Missing type declaration added for identifier generators
 
 The interfaces `Doctrine\ORM\Sequencing\Generator` and

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -131,9 +131,7 @@ Things to note:
    be fully qualified if the classes are contained in the same
    namespace as the entity class on which the discriminator map is
    applied.
--  If no discriminator map is provided, then the map is generated
-   automatically. The automatically generated discriminator map
-   contains the lowercase short name of each class as key.
+-  If no discriminator map is provided, an exception will be thrown.
 
 Design-time considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -220,9 +218,7 @@ Things to note:
    be fully qualified if the classes are contained in the same
    namespace as the entity class on which the discriminator map is
    applied.
--  If no discriminator map is provided, then the map is generated
-   automatically. The automatically generated discriminator map
-   contains the lowercase short name of each class as key.
+-  If no discriminator map is provided, an exception will be thrown.
 
 .. note::
 

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\ORM\Exception\ORMException;
-use function array_keys;
 use function array_map;
-use function array_values;
 use function get_parent_class;
 use function implode;
 use function sprintf;
@@ -471,28 +469,6 @@ class MappingException extends \LogicException implements ORMException
             $className,
             $owningClass
         ));
-    }
-
-    /**
-     * @param string   $className
-     * @param string[] $entries
-     * @param string[] $map
-     *
-     * @return MappingException
-     */
-    public static function duplicateDiscriminatorEntry($className, array $entries, array $map)
-    {
-        return new self(
-            'The entries ' . implode(', ', $entries) . " in discriminator map of class '" . $className . "' is duplicated. " .
-            'If the discriminator map is automatically generated you have to convert it to an explicit discriminator map now. ' .
-            'The entries of the current map are: @DiscriminatorMap({' . implode(', ', array_map(
-                function ($a, $b) {
-                    return sprintf("'%s': '%s'", $a, $b);
-                },
-                array_keys($map),
-                array_values($map)
-            )) . '})'
-        );
     }
 
     /**


### PR DESCRIPTION
Metadata factory is currently performing an auto-discovery of discriminator members. This is often problematic and leads to multiple serious issues in long-run:

* since discovered entries are not namespaced, there is high probability of collision i.e. #7271),
* since class name is part of the discriminator map, the class must never be renamed.

#6612 will be a better and more reliable way of building _dynamic_ discriminator maps.

closes #7294
closes #7271