### PR TITLE
Fix parameter value processing for objects with unloaded metadata

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -189,6 +189,25 @@ class QueryTest extends OrmTestCase
         );
     }
 
+    public function testProcessParameterValueObject() : void
+    {
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.user = :user');
+        $user = new CmsUser();
+        $user->id = 12345;
+
+        self::assertSame(
+            12345,
+            $query->processParameterValue($user)
+        );
+    }
+
+    public function testProcessParameterValueNull() : void
+    {
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.user = :user');
+
+        self::assertNull($query->processParameterValue(null));
+    }
+
     public function testDefaultQueryHints()
     {
         $config = $this->_em->getConfiguration();


### PR DESCRIPTION
When binding an object as query parameter, the query object normally tries to convert this object into its identifier. This however only happened if class metadata for the object was already loaded. If it wasn't loaded, conversion was skipped leading to wrong results. While `getMetadataFor` is more performance sensitive than `hasMetadataFor`, we may not assumed that metadata for the bound object has been loaded yet.

The code has been changed to no longer check the metadata factory and call `UnitOfWork::getSingleIdentifierValue` directly, ignoring any mapping exception in the process. This preserves behaviour where binding any unmapped object to a query will send the entire object to the database.