### PR TITLE
Remove unecessary need for if statment

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -122,13 +122,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
             return null;
         }
 
-        $cache = $this->hydrator->loadCacheEntry($this->sourceEntity, $key, $cache, $collection);
-
-        if ($cache === null) {
-            return null;
-        }
-
-        return $cache;
+        return $this->hydrator->loadCacheEntry($this->sourceEntity, $key, $cache, $collection);
     }
 
     /**


### PR DESCRIPTION
If `$cache` were `null`, we're returning `null` or `$cache` itself. So, no need for this `if` :)