### PR TITLE
Add __debugInfo to entity manager

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -174,6 +174,11 @@ final class EntityManager implements EntityManagerInterface
         }
     }
 
+    public function __debugInfo()
+    {
+        return [];
+    }
+    
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Not expecting this to go in as is; opened this to start a discussion on what is valuable to dump and what isn't.

I've var_dump'd the entity manager waaaay too many times, this stops it from becoming a huge mess.