### PR TITLE
Allow all datetime types to be used as version

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3042,9 +3042,9 @@ class ClassMetadataInfo implements ClassMetadata
         $this->versionField = $mapping['fieldName'];
 
         if ( ! isset($mapping['default'])) {
-            if (in_array($mapping['type'], ['integer', 'bigint', 'smallint'])) {
+            if (in_array($mapping['type'], ['integer', 'bigint', 'smallint'], true)) {
                 $mapping['default'] = 1;
-            } else if ($mapping['type'] == 'datetime') {
+            } else if (in_array($mapping['type'], ['datetime', 'datetime_immutable', 'datetimetz', 'datetimetz_immutable'], true)) {
                 $mapping['default'] = 'CURRENT_TIMESTAMP';
             } else {
                 throw MappingException::unsupportedOptimisticLockingType($this->name, $mapping['fieldName'], $mapping['type']);


### PR DESCRIPTION
I am working on an existing database with fields of type `timestamp`. In order to map that to a DateTime object in Doctrine, I've found the solution of adding the `@Version` annotation. But I'd really prefer to get a DateTimeImmutable, which is impossible.

At the moment a field of type `datetime_immutable` with annotation `@Version` will trigger this following error:
```
Locking type "datetime_immutable" (specified in "App\Entity\Bakery", field "createdAt") is not supported by Doctrine.
```

I cannot see any reason not to allow any type of datetime to be mapped to a timestamp in database, so this PR allows all of them. Please tell me if i'm missing something.