### PR TITLE
Change Stackoverflow tag to doctrine-orm

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -17,7 +17,7 @@ Doctrine ORM don't panic. You can get help from different sources:
 -  Slack chat room `#orm <https://www.doctrine-project.org/slack>`_
 -  Report a bug on `GitHub <https://github.com/doctrine/orm/issues>`_.
 -  On `Twitter <https://twitter.com/search/%23doctrine2>`_ with ``#doctrine2``
--  On `StackOverflow <http://stackoverflow.com/questions/tagged/doctrine2>`_
+-  On `StackOverflow <http://stackoverflow.com/questions/tagged/doctrine-orm>`_
 
 If you need more structure over the different topics you can browse the :doc:`table
 of contents <toc>`.


### PR DESCRIPTION
I'm targeting this PR to 2.6 to be merged up and, if needed, cherry picked down.

Please don't merge before https://meta.stackoverflow.com/questions/378567/retag-doctrine2-to-doctrine-orm is resolved.