### PR TITLE
Allow all datetime types to be used as version

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -526,7 +526,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             return;
         }
 
-        if ($property->getTypeName() === 'datetime') {
+        if (in_array($property->getTypeName(), ['datetime', 'datetime_immutable', 'datetimetz', 'datetimetz_immutable'], true)) {
             $property->setOptions(array_merge($options, ['default' => 'CURRENT_TIMESTAMP']));
 
             return;

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Annotation as ORM;
 use Doctrine\ORM\OptimisticLockException;
@@ -26,6 +27,7 @@ class OptimisticTest extends OrmFunctionalTestCase
                     $this->em->getClassMetadata(OptimisticJoinedChild::class),
                     $this->em->getClassMetadata(OptimisticStandard::class),
                     $this->em->getClassMetadata(OptimisticTimestamp::class),
+                    $this->em->getClassMetadata(OptimisticImmutableTimestamp::class),
                 ]
             );
         } catch (Exception $e) {
@@ -204,6 +206,22 @@ class OptimisticTest extends OrmFunctionalTestCase
         return $test;
     }
 
+    public function testOptimisticImmutableTimestampSetsDefaultValue() : OptimisticImmutableTimestamp
+    {
+        $test = new OptimisticImmutableTimestamp();
+
+        $test->name = 'Testing';
+
+        self::assertNull($test->version, 'Pre-Condition');
+
+        $this->em->persist($test);
+        $this->em->flush();
+
+        self::assertInstanceOf(DateTimeImmutable::class, $test->version);
+
+        return $test;
+    }
+
     /**
      * @depends testOptimisticTimestampSetsDefaultValue
      */
@@ -337,5 +355,24 @@ class OptimisticTimestamp
     public $name;
 
     /** @ORM\Version @ORM\Column(type="datetime") */
+    public $version;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="optimistic_immutable_timestamp")
+ */
+class OptimisticImmutableTimestamp
+{
+    /**
+     * @ORM\Id @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    public $id;
+
+    /** @ORM\Column(type="string", length=255) */
+    public $name;
+
+    /** @ORM\Version @ORM\Column(type="datetime_immutable") */
     public $version;
 }


### PR DESCRIPTION
Replaces https://github.com/doctrine/orm/pull/7554

---

I am working on an existing database with fields of type timestamp. In order to map that to a DateTime object in Doctrine, I've found the solution of adding the @Version annotation. But I'd really prefer to get a DateTimeImmutable, which is impossible.

At the moment a field of type datetime_immutable with annotation @Version will trigger this following error:

Locking type "datetime_immutable" (specified in "App\Entity\Bakery", field "createdAt") is not supported by Doctrine.
I cannot see any reason not to allow any type of datetime to be mapped to a timestamp in database, so this PR allows all of them. Please tell me if i'm missing something.