### PR TITLE
Test that cache is created when using single scalar hydrator

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,10 @@
+# Upgrade to 2.7
+
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.6
 
 ## Added `Doctrine\ORM\EntityRepository::count()` method
@@ -36,11 +43,6 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - APCu extension (ext-apcu) will now be used instead of abandoned APC (ext-apc).
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
-
-## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
-
-Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
-It will be removed in 3.0.
 
 # Upgrade to 2.5
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -37,6 +37,11 @@ As a consequence, automatic cache setup in Doctrine\ORM\Tools\Setup::create*Conf
 - Memcached extension (ext-memcached) will be used instead of obsolete Memcache (ext-memcache).
 - XCache support was dropped as it doesn't work with PHP 7.
 
+## Deprecated: `Doctrine\ORM\EntityManagerInterface#copy()`
+
+Method `Doctrine\ORM\EntityManagerInterface#copy()` never got its implementation and is deprecated.
+It will be removed in 3.0.
+
 # Upgrade to 2.5
 
 ## Minor BC BREAK: removed `Doctrine\ORM\Query\SqlWalker#walkCaseExpression()`

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Object-Relational-Mapper for PHP",
     "keywords": ["orm", "database"],
-    "homepage": "http://www.doctrine-project.org",
+    "homepage": "https://www.doctrine-project.org/projects/orm.html",
     "license": "MIT",
     "authors": [
         {"name": "Guilherme Blanco", "email": "guilhermeblanco@gmail.com"},

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "bin": ["bin/doctrine"],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.6.x-dev"
+            "dev-master": "2.7.x-dev"
         }
     },
     "archive": {

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -13,9 +13,9 @@ If this documentation is not helping to answer questions you have about
 Doctrine ORM don't panic. You can get help from different sources:
 
 -  There is a :doc:`FAQ <reference/faq>` with answers to frequent questions.
--  The `Doctrine Mailing List <http://groups.google.com/group/doctrine-user>`_
--  Internet Relay Chat (IRC) in #doctrine on Freenode
--  Report a bug on `JIRA <http://www.doctrine-project.org/jira>`_.
+-  The `Doctrine Mailing List <https://groups.google.com/group/doctrine-user>`_
+-  Slack chat room `#orm <https://www.doctrine-project.org/slack>`_
+-  Report a bug on `GitHub <https://github.com/doctrine/doctrine2/issues>`_.
 -  On `Twitter <https://twitter.com/search/%23doctrine2>`_ with ``#doctrine2``
 -  On `StackOverflow <http://stackoverflow.com/questions/tagged/doctrine2>`_
 
@@ -72,9 +72,9 @@ Advanced Topics
 * :doc:`Transactions and Concurrency <reference/transactions-and-concurrency>`
 * :doc:`Filters <reference/filters>`
 * :doc:`NamingStrategy <reference/namingstrategy>`
-* :doc:`Improving Performance <reference/improving-performance>` 
-* :doc:`Caching <reference/caching>` 
-* :doc:`Partial Objects <reference/partial-objects>` 
+* :doc:`Improving Performance <reference/improving-performance>`
+* :doc:`Caching <reference/caching>`
+* :doc:`Partial Objects <reference/partial-objects>`
 * :doc:`Change Tracking Policies <reference/change-tracking-policies>`
 * :doc:`Best Practices <reference/best-practices>`
 * :doc:`Metadata Drivers <reference/metadata-drivers>`
@@ -103,7 +103,7 @@ Cookbook
 * **Patterns**:
   :doc:`Aggregate Fields <cookbook/aggregate-fields>` |
   :doc:`Decorator Pattern <cookbook/decorator-pattern>` |
-  :doc:`Strategy Pattern <cookbook/strategy-cookbook-introduction>` 
+  :doc:`Strategy Pattern <cookbook/strategy-cookbook-introduction>`
 
 * **DQL Extension Points**:
   :doc:`DQL Custom Walkers <cookbook/dql-custom-walkers>` |

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -684,9 +684,6 @@ use Throwable;
 
     /**
      * {@inheritDoc}
-     *
-     * @todo Implementation need. This is necessary since $e2 = clone $e1; throws an E_FATAL when access anything on $e:
-     * Fatal error: Maximum function nesting level of '100' reached, aborting!
      */
     public function copy($entity, $deep = false)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -190,6 +190,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * Creates a copy of the given entity. Can create a shallow or a deep copy.
      *
+     * @deprecated method will be removed in 3.0
+     *
      * @param object  $entity The entity to copy.
      * @param boolean $deep   FALSE for a shallow copy, TRUE for a deep copy.
      *

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -35,7 +35,7 @@ class Version
     /**
      * Current Doctrine Version
      */
-    const VERSION = '2.6.4-DEV';
+    const VERSION = '2.7.0-DEV';
 
     /**
      * Compares a Doctrine version with the current one.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,10 +19,6 @@
          bootstrap="./tests/Doctrine/Tests/TestInit.php"
 >
 
-    <php>
-        <env name="COLUMNS" value="120"/>
-    </php>
-
     <testsuites>
         <testsuite name="Doctrine ORM Test Suite">
             <directory>./tests/Doctrine/Tests/ORM</directory>
@@ -37,6 +33,8 @@
     </groups>
 
   <php>
+    <env name="COLUMNS" value="120"/>
+
     <!-- "Real" test database -->
     <!-- uncomment, otherwise sqlite memory runs
     <var name="db_type" value="pdo_mysql"/>


### PR DESCRIPTION
Checks that https://github.com/doctrine/dbal/pull/3381 works with the ORM.

This will require most likley to put `doctrine/dbal:^2.9.4` (`2.9.4` is not yet released)

So not sure if it makes sense (but since orm 2.7 requires at least php 7.2, do not see anything wrong with it)

