### PR TITLE
Add Expr\Andx as allowed parameter in Expr::andX() 

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -41,8 +41,8 @@ class Expr
      *     // (u.type = ?1) AND (u.role = ?2)
      *     $expr->andX($expr->eq('u.type', ':1'), $expr->eq('u.role', ':2'));
      *
-     * @param Expr\Comparison|Expr\Func|Expr\Orx|string $x Optional clause. Defaults to null, but requires at least one
-     *                                                     defined when converting to string.
+     * @param Expr\Comparison|Expr\Func|Expr\Orx|Expr\Andx|string $x Optional clause. Defaults to null, but requires at least one
+     *                                                               defined when converting to string.
      *
      * @return Expr\Andx
      */


### PR DESCRIPTION
As defined in [Andx::$allowedClasses](https://github.com/doctrine/orm/blob/bb1fe1d6c9e3b2ab837445a73b0e76e57683fb78/lib/Doctrine/ORM/Query/Expr/Andx.php). 

An alternative would be to allow `Doctrine\ORM\Query\Expr\Composite`.

Noticed by PHPStan
```
Parameter #1 $x of method Doctrine\ORM\Query\Expr::andX() expects                
         Doctrine\ORM\Query\Expr\Comparison|Doctrine\ORM\Query\Expr\Func|Doctrin          
         e\ORM\Query\Expr\Orx|string|null, Doctrine\ORM\Query\Expr\Andx given. 
```