### PR TITLE
Fix of single link to dbal docs in advanced-configuration.rst

### DIFF
--- a/docs/en/reference/advanced-configuration.rst
+++ b/docs/en/reference/advanced-configuration.rst
@@ -292,7 +292,7 @@ instance of ``Doctrine\DBAL\Connection``. If an array is passed it
 is directly passed along to the DBAL Factory
 ``Doctrine\DBAL\DriverManager::getConnection()``. The DBAL
 configuration is explained in the
-`DBAL section <./../../../../../projects/doctrine-dbal/en/latest/reference/configuration.html>`_.
+`DBAL section <https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html>`_.
 
 Proxy Objects
 -------------


### PR DESCRIPTION
I missed a link in #7385, that needs to be fixed in the 2.6 branch. The fix for the master branch is already handled in #7576.