### PR TITLE
Avoid unnecessary flush after processing first row

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -89,11 +89,11 @@ with the batching strategy that was already used for bulk inserts:
     foreach ($q->toIterable() as $user) {
         $user->increaseCredit();
         $user->calculateNewBonuses();
+        ++$i;
         if (($i % $batchSize) === 0) {
             $em->flush(); // Executes all updates.
             $em->clear(); // Detaches all objects from Doctrine!
         }
-        ++$i;
     }
     $em->flush();
 
@@ -147,11 +147,11 @@ The following example shows how to do this:
     $q = $em->createQuery('select u from MyProject\Model\User u');
     foreach($q->toIterable() as $row) {
         $em->remove($row);
+        ++$i;
         if (($i % $batchSize) === 0) {
             $em->flush(); // Executes all deletions.
             $em->clear(); // Detaches all objects from Doctrine!
         }
-        ++$i;
     }
     $em->flush();
 


### PR DESCRIPTION
The code as is needlessly flushes after just one row is updated or removed. It makes more sense to update after ``$batchSize`` elements are updated or removed, just as it is in the insert case.