### PR TITLE
Fix #7629 - `scheduledForSynchronization` leaks memory when using `@ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")`

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -356,6 +356,8 @@ class UnitOfWork implements PropertyChangedListener
             $this->dispatchOnFlushEvent();
             $this->dispatchPostFlushEvent();
 
+            $this->postCommitCleanup($entity);
+
             return; // Nothing to do.
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH7629Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH7629Entity::class,
+        ]);
+
+        $this->_em->persist(new GH7629Entity());
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testClearScheduledForSynchronizationWhenCommitEmpty(): void
+    {
+        $entity = $this->_em->find(GH7629Entity::class, 1);
+
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        self::assertFalse($this->_em->getUnitOfWork()->isScheduledForDirtyCheck($entity));
+    }
+}
+
+/**
+ * @Entity
+ * @ChangeTrackingPolicy("DEFERRED_EXPLICIT")
+ */
+class GH7629Entity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+}


### PR DESCRIPTION
Fixes #7629