### PR TITLE
Fix #7629 - `scheduledForSynchronization` leaks memory when using `@ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -349,6 +349,8 @@ class UnitOfWork implements PropertyChangedListener
             $this->dispatchOnFlushEvent();
             $this->dispatchPostFlushEvent();
 
+            $this->postCommitCleanup();
+
             return; // Nothing to do.
         }
 
@@ -426,7 +428,11 @@ class UnitOfWork implements PropertyChangedListener
 
         $this->dispatchPostFlushEvent();
 
-        // Clean up
+        $this->postCommitCleanup();
+    }
+
+    private function postCommitCleanup() : void
+    {
         $this->entityInsertions            =
         $this->entityUpdates               =
         $this->entityDeletions             =

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH7629Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH7629Entity::class,
+        ]);
+
+        $this->em->persist(new GH7629Entity());
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    public function testClearScheduledForSynchronizationWhenCommitEmpty() : void
+    {
+        $entity = $this->em->find(GH7629Entity::class, 1);
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        self::assertFalse($this->em->getUnitOfWork()->isScheduledForDirtyCheck($entity));
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
+ */
+class GH7629Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+}


### PR DESCRIPTION
Test to demonstrate unexpected behavior, related to issue #7629