### PR TITLE
Fixed break/continue error with PHP7.3

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2633,7 +2633,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
-                        continue;
+                        continue 2;
                     }
 
                     $associatedId = array();
@@ -2662,7 +2662,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        continue 2;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
Error was produced using Laravel 5.4 with laravel-doctrine package. Updated server to php 7.3 and composer 1.8.4, and when i tried to use the doctrine extension the break/continue warning throwed the error. 
