### PR TITLE
Add Pass Target Entity / Join Table Name to a referenceColumnName and joinKeyColumnName respectively

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -637,7 +637,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 }
 
                 if (! $joinColumn->getReferencedColumnName()) {
-                    $joinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName());
+                    $joinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName($property->getTargetEntity()));
                 }
 
                 $this->fieldNames[$joinColumn->getColumnName()] = $fieldName;
@@ -770,9 +770,9 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             $selfReferencingEntityWithoutJoinColumns = $property->getSourceEntity() === $property->getTargetEntity() && ! $joinTable->hasColumns();
 
             if (! $joinTable->getJoinColumns()) {
-                $referencedColumnName = $this->namingStrategy->referenceColumnName();
+                $referencedColumnName = $this->namingStrategy->referenceColumnName($property->getTargetEntity());
                 $sourceReferenceName  = $selfReferencingEntityWithoutJoinColumns ? 'source' : $referencedColumnName;
-                $columnName           = $this->namingStrategy->joinKeyColumnName($property->getSourceEntity(), $sourceReferenceName);
+                $columnName           = $this->namingStrategy->joinKeyColumnName($property->getSourceEntity(), $sourceReferenceName, $joinTable->getName());
                 $joinColumn           = new JoinColumnMetadata();
 
                 $joinColumn->setColumnName($columnName);
@@ -783,9 +783,9 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             }
 
             if (! $joinTable->getInverseJoinColumns()) {
-                $referencedColumnName = $this->namingStrategy->referenceColumnName();
+                $referencedColumnName = $this->namingStrategy->referenceColumnName($property->getTargetEntity());
                 $targetReferenceName  = $selfReferencingEntityWithoutJoinColumns ? 'target' : $referencedColumnName;
-                $columnName           = $this->namingStrategy->joinKeyColumnName($property->getTargetEntity(), $targetReferenceName);
+                $columnName           = $this->namingStrategy->joinKeyColumnName($property->getTargetEntity(), $targetReferenceName, $joinTable->getName());
                 $joinColumn           = new JoinColumnMetadata();
 
                 $joinColumn->setColumnName($columnName);
@@ -798,7 +798,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             foreach ($joinTable->getJoinColumns() as $joinColumn) {
                 /** @var JoinColumnMetadata $joinColumn */
                 if (! $joinColumn->getReferencedColumnName()) {
-                    $joinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName());
+                    $joinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName($property->getTargetEntity()));
                 }
 
                 $referencedColumnName = $joinColumn->getReferencedColumnName();
@@ -806,7 +806,8 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 if (! $joinColumn->getColumnName()) {
                     $columnName = $this->namingStrategy->joinKeyColumnName(
                         $property->getSourceEntity(),
-                        $referencedColumnName
+                        $referencedColumnName,
+                        $joinTable->getName()
                     );
 
                     $joinColumn->setColumnName($columnName);
@@ -816,7 +817,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
             foreach ($joinTable->getInverseJoinColumns() as $inverseJoinColumn) {
                 /** @var JoinColumnMetadata $inverseJoinColumn */
                 if (! $inverseJoinColumn->getReferencedColumnName()) {
-                    $inverseJoinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName());
+                    $inverseJoinColumn->setReferencedColumnName($this->namingStrategy->referenceColumnName($property->getTargetEntity()));
                 }
 
                 $referencedColumnName = $inverseJoinColumn->getReferencedColumnName();
@@ -824,7 +825,8 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 if (! $inverseJoinColumn->getColumnName()) {
                     $columnName = $this->namingStrategy->joinKeyColumnName(
                         $property->getTargetEntity(),
-                        $referencedColumnName
+                        $referencedColumnName,
+                        $joinTable->getName()
                     );
 
                     $inverseJoinColumn->setColumnName($columnName);

--- a/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php
@@ -914,7 +914,7 @@ class NewAnnotationDriver implements MappingDriver
             ? $this->namingStrategy->propertyToColumnName($fieldName, $classMetadata->getClassName())
             : $joinColumnAnnot->name;
         $referencedColumnName = empty($joinColumnAnnot->referencedColumnName)
-            ? $this->namingStrategy->referenceColumnName()
+            ? $this->namingStrategy->referenceColumnName($classMetadata->getClassName())
             : $joinColumnAnnot->referencedColumnName;
 
         $joinColumn->setColumnName($columnName);

--- a/lib/Doctrine/ORM/Mapping/Factory/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/NamingStrategy.php
@@ -43,9 +43,11 @@ interface NamingStrategy
     /**
      * Returns the default reference column name.
      *
+     * @param string|null $targetEntity
+     *
      * @return string A column name.
      */
-    public function referenceColumnName();
+    public function referenceColumnName($targetEntity = null);
 
     /**
      * Returns a join column name for a property.
@@ -73,8 +75,9 @@ interface NamingStrategy
      *
      * @param string      $entityName           An entity.
      * @param string|null $referencedColumnName A property.
+     * @param string|null $joinTableName
      *
      * @return string A join column name.
      */
-    public function joinKeyColumnName($entityName, $referencedColumnName = null);
+    public function joinKeyColumnName($entityName, $referencedColumnName = null, $joinTableName = null);
 }

--- a/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php
@@ -82,7 +82,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function referenceColumnName()
+    public function referenceColumnName($targetEntity = null)
     {
         return $this->case === CASE_UPPER ? 'ID' : 'id';
     }
@@ -106,7 +106,7 @@ class UnderscoreNamingStrategy implements NamingStrategy
     /**
      * {@inheritdoc}
      */
-    public function joinKeyColumnName($entityName, $referencedColumnName = null)
+    public function joinKeyColumnName($entityName, $referencedColumnName = null, $joinTableName = null)
     {
         return $this->classToTableName($entityName) . '_' .
                 ($referencedColumnName ?: $this->referenceColumnName());

--- a/tests/Doctrine/Tests/ORM/Mapping/NamingStrategy/TablePrefixNamingStrategy.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/NamingStrategy/TablePrefixNamingStrategy.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\ORM\Mapping\Factory;
+namespace Doctrine\Tests\ORM\Mapping\NamingStrategy;
 
+use Doctrine\ORM\Mapping\Factory\NamingStrategy;
 use function strpos;
 use function strrpos;
 use function strtolower;
 use function substr;
 
 /**
- * The default NamingStrategy
+ * Naming strategy prefixes fields with a table name.
  */
-class DefaultNamingStrategy implements NamingStrategy
+class TablePrefixNamingStrategy implements NamingStrategy
 {
     /**
      * {@inheritdoc}
@@ -31,7 +32,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function propertyToColumnName($propertyName, $className = null)
     {
-        return $propertyName;
+        return $this->classToTableName($className) . '_' . $propertyName;
     }
 
     /**
@@ -39,7 +40,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function embeddedFieldToColumnName($propertyName, $embeddedColumnName, $className = null, $embeddedClassName = null)
     {
-        return $propertyName . '_' . $embeddedColumnName;
+        return $this->classToTableName($className) . '_' . $propertyName . '_' . $embeddedColumnName;
     }
 
     /**
@@ -47,7 +48,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function referenceColumnName($targetEntity = null)
     {
-        return 'id';
+        return $this->classToTableName($targetEntity) . '_id';
     }
 
     /**
@@ -55,7 +56,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function joinColumnName($propertyName, $className = null)
     {
-        return $propertyName . '_' . $this->referenceColumnName();
+        return $this->classToTableName($className) . '_' . $propertyName . '_id';
     }
 
     /**
@@ -72,7 +73,7 @@ class DefaultNamingStrategy implements NamingStrategy
      */
     public function joinKeyColumnName($entityName, $referencedColumnName = null, $joinTableName = null)
     {
-        return strtolower($this->classToTableName($entityName) . '_' .
-            ($referencedColumnName ?: $this->referenceColumnName()));
+        return $joinTableName . '_' . strtolower($this->classToTableName($entityName) . '_' .
+            ($referencedColumnName ?: 'id'));
     }
 }


### PR DESCRIPTION
#7595 

Here I've tried to implement passing target entity class name to `NamingStrategy::referenceColumnName` and join table name to `NamingStrategy::joinKeyColumnName`

I tried to be as gentle with API as possible so everything I've added is `nullable` also I added a test naming strategy to test changed api on.