### PR TITLE
update phpstan to 0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ composer.phar
 /.phpcs-cache
 phpbench.phar
 phpbench.phar.pubkey
+/phpstan.neon

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
       before_script:
         - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-      script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
+      script: vendor/bin/phpstan analyse
 
     - stage: Code Quality
       env: DB=none BENCHMARK

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "doctrine/coding-standard": "^6.0",
-        "phpstan/phpstan-shim": "^0.9.2",
+        "phpstan/phpstan-shim": "^0.11",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4572bf84ed9a890cbabc1c9ec4e14ec4",
+    "content-hash": "36598469b3c632f3bc971af779ca4c2a",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1679,69 +1679,25 @@
             "time": "2018-02-19T10:16:54+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "0.3.1",
+            "name": "phpstan/phpstan-shim",
+            "version": "0.11.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74"
+                "url": "https://github.com/phpstan/phpstan-shim.git",
+                "reference": "70e1a346907142449ac085745f158aa715b4e0b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/2cc49f47c69b023eaf05b48e6529389893b13d74",
-                "reference": "2cc49f47c69b023eaf05b48e6529389893b13d74",
+                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/70e1a346907142449ac085745f158aa715b4e0b8",
+                "reference": "70e1a346907142449ac085745f158aa715b4e0b8",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.1"
             },
-            "require-dev": {
-                "consistence/coding-standard": "^2.0.0",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan": "^0.10",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^3.3.0",
-                "symfony/process": "^3.4 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-01-14T12:26:23+00:00"
-        },
-        {
-            "name": "phpstan/phpstan-shim",
-            "version": "0.9.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan-shim.git",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
-                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.0"
-            },
             "replace": {
+                "nikic/php-parser": "^4.0.2",
+                "phpstan/phpdoc-parser": "^0.3",
                 "phpstan/phpstan": "self.version"
             },
             "bin": [
@@ -1751,15 +1707,20 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "0.11-dev"
                 }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan Phar distribution",
-            "time": "2018-01-28T14:29:27+00:00"
+            "time": "2019-03-14T15:24:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -38,7 +38,7 @@ abstract class TreeWalkerAdapter implements TreeWalker
     /**
      * {@inheritdoc}
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {
         $this->query           = $query;
         $this->parserResult    = $parserResult;

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Query;
 
 use function array_diff;
 use function array_keys;
+use Doctrine\ORM\AbstractQuery;
 
 /**
  * Represents a chain of tree walkers that modify an AST and finally emit output.
@@ -55,7 +56,7 @@ class TreeWalkerChain implements TreeWalker
     /**
      * {@inheritdoc}
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {
         $this->queryComponents = $queryComponents;
         $this->walkers         = new TreeWalkerChainIterator($this, $query, $parserResult);

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
 use Doctrine\ORM\Query;
@@ -49,7 +50,7 @@ class CountOutputWalker extends SqlWalker
      * @param ParserResult $parserResult
      * @param mixed[][]    $queryComponents
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {
         $this->platform        = $query->getEntityManager()->getConnection()->getDatabasePlatform();
         $this->rsm             = $parserResult->getResultSetMapping();

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
@@ -89,7 +90,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
      * @param ParserResult $parserResult
      * @param mixed[][]    $queryComponents
      */
-    public function __construct($query, $parserResult, array $queryComponents)
+    public function __construct(AbstractQuery $query, ParserResult $parserResult, array $queryComponents)
     {
         $this->platform        = $query->getEntityManager()->getConnection()->getDatabasePlatform();
         $this->rsm             = $parserResult->getResultSetMapping();

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,8 @@
 parameters:
+    level: 1
+    paths:
+        - lib
+
     earlyTerminatingMethodCalls:
         Doctrine\ORM\Query\Parser:
             - syntaxError


### PR DESCRIPTION
There is issue which I dont know how you want to resolve:
`Doctrine\ORM\Persisters\Entity\BasicEntityPersister.php:`
```
Array has 2 duplicate keys with value '=' (\Doctrine\Common\Collections\Expr\Comparison::EQ, \Doctrine\Common\Collections\Expr\Comparison::IS).
```

Just tell me which one I should delete and I fix it in this PR.