### PR TITLE
Add readOnly attribute to annotation example

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -391,7 +391,7 @@ Example:
 
     <?php
     /**
-     * @Entity(repositoryClass="MyProject\UserRepository")
+     * @Entity(repositoryClass="MyProject\UserRepository", readOnly=true)
      */
     class User
     {


### PR DESCRIPTION
Small change of the `Entity` annotation, that didn't show how the `readOnly` attribute is used before.