### PR TITLE
Fix test on Postgres when running on 30/31 march

### DIFF
--- a/tests/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -369,7 +369,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
 
         return [
             'year'   => ['year', 1, $secondsInDay],
-            'month'  => ['month', 1, $secondsInDay],
+            'month'  => ['month', 1, 4 * $secondsInDay],
             'week'   => ['week', 1, $secondsInDay],
             'day'    => ['day', 2, $secondsInDay],
             'hour'   => ['hour', 1, 3600],


### PR DESCRIPTION
Adjusted the delta to account for March 30-31 -> Feb 28th + 1 extra day for DST changes. I guess it doesn't hurt to be extra careful.

Today is march 30th and postgres returns "feb 28th" when doing now() - '1 month', for reference:
```
Doctrine\Tests\ORM\Functional\QueryDqlFunctionTest::testDateSub with data set "month" ('month', 1, 86400)
Failed asserting that two DateTime objects are equal.
--- Expected
+++ Actual
@@ @@
-2019-03-02T16:50:58.973200+0100
+2019-02-28T16:50:58.973200+0100
```

