### PR TITLE
only replace '_id' at end of columnName

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -29,6 +29,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
+use function preg_replace;
 
 /**
  * The DatabaseDriver reverse engineers the mapping metadata from a database.
@@ -548,7 +549,7 @@ class DatabaseDriver implements MappingDriver
 
         // Replace _id if it is a foreignkey column
         if ($fk) {
-            $columnName = str_replace('_id', '', $columnName);
+            $columnName = preg_replace('/_id$/', '', $columnName);
         }
 
         return Inflector::camelize($columnName);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7684Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7684Test.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Tests\ORM\Functional\DatabaseDriverTestCase;
+
+/**
+ * Verifies that associations/columns with an inline '_id' get named properly
+ *
+ * Github issue: 7684
+ */
+class GH7684 extends DatabaseDriverTestCase
+{
+    public function testIssue() : void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            $this->markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $table1 = new Table('GH7684_identity_test_table');
+        $table1->addColumn('id', 'integer');
+        $table1->setPrimaryKey(['id']);
+
+        $table2 = new Table('GH7684_identity_test_assoc_table');
+        $table2->addColumn('id', 'integer');
+        $table2->addColumn('gh7684_identity_test_id', 'integer');
+        $table2->setPrimaryKey(['id']);
+        $table2->addForeignKeyConstraint('GH7684_identity_test', ['gh7684_identity_test_id'], ['id']);
+
+        $metadatas = $this->convertToClassMetadata([$table1, $table2]);
+        $metadata  = $metadatas['Gh7684IdentityTestAssocTable'];
+
+        $this->assertArrayHasKey('gh7684IdentityTest', $metadata->associationMappings);
+    }
+}


### PR DESCRIPTION
I've encountered a problem with foreign-key column-names that have a '_id' (e.g. _identity) in their name.
These columns don't get renamed properly (`partner_identity_card` -> `partnerentityCard`).

The fix could be a `preg_replace` instead of a `string_replace` that only replaces the _id at the end of a column name.