### PR TITLE
Add another static analysis tool, grandfathering in existing issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ phpunit.xml.dist export-ignore
 run-all.sh export-ignore
 phpcs.xml.dist export-ignore
 composer.lock export-ignore
+psalm-baseline.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,9 @@ jobs:
       before_script:
         - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
         - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-      script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
+      script:
+        - vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
+        - vendor/bin/psalm --show-info=false
 
     - stage: Code Quality
       env: DB=none BENCHMARK

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "ext-pdo": "*",
         "doctrine/coding-standard": "^6.0",
         "phpstan/phpstan-shim": "^0.9.2",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "vimeo/psalm": "^3.2"
     },
     "autoload": {
         "psr-4": { "Doctrine\\ORM\\": "lib/Doctrine/ORM" }
@@ -72,6 +73,6 @@
         }
     },
     "archive": {
-        "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar", "vendor/satooshi", "lib/vendor", "*.swp"]
+        "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar", "vendor/satooshi", "lib/vendor", "*.swp", "psalm-baseline.xml"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3467,16 +3467,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.2.9",
+            "version": "3.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc"
+                "reference": "b9bece4cbcb3f342c8412618f73ca02db98064e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/473c8cb83209de1b66a1487400c0ea47a2ee65cc",
-                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b9bece4cbcb3f342c8412618f73ca02db98064e8",
+                "reference": "b9bece4cbcb3f342c8412618f73ca02db98064e8",
                 "shasum": ""
             },
             "require": {
@@ -3502,7 +3502,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
                 "phpunit/phpunit": "^6.0 || ^7.0",
-                "psalm/plugin-phpunit": "^0.5.1",
+                "psalm/plugin-phpunit": "^0.5.5",
                 "squizlabs/php_codesniffer": "3.4.0"
             },
             "suggest": {
@@ -3543,7 +3543,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-04-22T17:18:19+00:00"
+            "time": "2019-04-29T16:19:51+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4572bf84ed9a890cbabc1c9ec4e14ec4",
+    "content-hash": "db272b09b3589edc01af08ebe974dbd7",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1190,6 +1190,185 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "7075ef7d74dbd32626bfd31c976b23055c3ade6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/7075ef7d74dbd32626bfd31c976b23055c3ade6a",
+                "reference": "7075ef7d74dbd32626bfd31c976b23055c3ade6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/phpunit-util": "^1",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpstan/phpstan": "^0.8.5",
+                "phpunit/phpunit": "^6.0.9",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "time": "2018-12-11T10:31:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "6bbfcb6f47e92577e739586ba0c87e867be70a23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/6bbfcb6f47e92577e739586ba0c87e867be70a23",
+                "reference": "6bbfcb6f47e92577e739586ba0c87e867be70a23",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "infection/infection": "^0.9.3",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "time": "2018-12-27T18:08:06+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2019-01-28T20:25:53+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.5.0",
             "source": {
@@ -1317,6 +1496,150 @@
             "time": "2019-03-15T12:45:47+00:00"
         },
         {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/241c470695366e7b83672be04ea0e64d8085a551",
+                "reference": "241c470695366e7b83672be04ea0e64d8085a551",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0",
+                "php": ">=7.0",
+                "phpdocumentor/reflection-docblock": "^4.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "time": "2018-09-10T08:58:41+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "1bdd1bcc95428edf85ec04c7b558d0886c07280f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/1bdd1bcc95428edf85ec04c7b558d0886c07280f",
+                "reference": "1bdd1bcc95428edf85ec04c7b558d0886c07280f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "phpunit/phpunit": "^6.3",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "time": "2018-09-25T11:42:25+00:00"
+        },
+        {
+            "name": "muglug/package-versions-56",
+            "version": "1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/muglug/PackageVersions.git",
+                "reference": "a67bed26deaaf9269a348e53063bc8d4dcc60ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/muglug/PackageVersions/zipball/a67bed26deaaf9269a348e53063bc8d4dcc60ffd",
+                "reference": "a67bed26deaaf9269a348e53063bc8d4dcc60ffd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.3",
+                "ext-zip": "*",
+                "phpunit/phpunit": "^5.7.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Muglug\\PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Muglug\\PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Abdul Malik Ikhsan",
+                    "email": "samsonasik@gmail.com"
+                },
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "A backport of ocramius/package-versions that supports php ^5.6. Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-03-26T03:22:13+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.7.0",
             "source": {
@@ -1360,6 +1683,148 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/3868fe1128ce1169228acdb623359dca74db5ef3",
+                "reference": "3868fe1128ce1169228acdb623359dca74db5ef3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "time": "2017-11-28T21:30:01+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "reference": "5221f49a608808c1e4d436df32884cbc1b821ac0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2019-02-16T20:54:15+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "c8b5998a342d7861f2e921403f44e0a2f3ef2be0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/c8b5998a342d7861f2e921403f44e0a2f3ef2be0",
+                "reference": "c8b5998a342d7861f2e921403f44e0a2f3ef2be0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "contact@nullivex.com",
+                    "homepage": "http://bryantong.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "http://openlss.org"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "http://openlss.org",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "time": "2016-11-10T19:10:18+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1462,6 +1927,57 @@
             ],
             "description": "Library for handling version information and constraints",
             "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "php-cs-fixer/diff",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/diff.git",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "reference": "78bb099e9c16361126c86ce82ec4405ebab8e756",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "symfony/process": "^3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "SpacePossum"
+                }
+            ],
+            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "homepage": "https://github.com/PHP-CS-Fixer",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2018-02-15T16:58:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1614,6 +2130,67 @@
                 }
             ],
             "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpmyadmin/sql-parser",
+            "version": "v4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmyadmin/sql-parser.git",
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/0eb16ef5e3acacbc792be336754e42d98791a33f",
+                "reference": "0eb16ef5e3acacbc792be336754e42d98791a33f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5",
+                "sami/sami": "^4.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMyAdmin\\SqlParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The phpMyAdmin Team",
+                    "email": "developers@phpmyadmin.net",
+                    "homepage": "https://www.phpmyadmin.net/team/"
+                }
+            ],
+            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
+            "homepage": "https://github.com/phpmyadmin/sql-parser",
+            "keywords": [
+                "analysis",
+                "lexer",
+                "parser",
+                "sql"
+            ],
+            "time": "2019-01-05T13:46:38+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -2146,6 +2723,53 @@
             ],
             "abandoned": true,
             "time": "2018-04-11T04:50:36+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2842,6 +3466,86 @@
             "time": "2017-04-07T12:08:54+00:00"
         },
         {
+            "name": "vimeo/psalm",
+            "version": "3.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/473c8cb83209de1b66a1487400c0ea47a2ee65cc",
+                "reference": "473c8cb83209de1b66a1487400c0ea47a2ee65cc",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/xdebug-handler": "^1.1",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.2",
+                "muglug/package-versions-56": "1.2.4",
+                "netresearch/jsonmapper": "^1.0",
+                "nikic/php-parser": "^4.0.2 || ^4.1",
+                "openlss/lib-array2xml": "^0.0.10||^0.5.1",
+                "php": "^7.0",
+                "php-cs-fixer/diff": "^1.2",
+                "phpmyadmin/sql-parser": "^4.0",
+                "symfony/console": "^3.3||^4.0",
+                "webmozart/glob": "^4.1",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "phpunit/phpunit": "^6.0 || ^7.0",
+                "psalm/plugin-phpunit": "^0.5.1",
+                "squizlabs/php_codesniffer": "3.4.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalter",
+                "psalm-language-server",
+                "psalm-plugin"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\Plugin\\": "src/Psalm/Plugin",
+                    "Psalm\\": "src/Psalm"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "time": "2019-04-22T17:18:19+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.3.0",
             "source": {
@@ -2890,6 +3594,99 @@
                 "validate"
             ],
             "time": "2018-01-29T19:49:41+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/glob.git",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/glob/zipball/3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "reference": "3cbf63d4973cf9d780b93d2da8eec7e4a9e63bbe",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0",
+                "webmozart/path-util": "^2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1",
+                "symfony/filesystem": "^2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "time": "2015-12-29T11:14:33+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -211,6 +211,12 @@
     </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCache.php">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;defaultQueryCache = $this-&gt;cacheFactory-&gt;buildQueryCache($this-&gt;em)</code>
     </DocblockTypeContradiction>
@@ -235,18 +241,16 @@
       <code>$regionName === null &amp;&amp; $this-&gt;defaultQueryCache !== null</code>
       <code>$this-&gt;defaultQueryCache</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="4">
-      <code>$metadata-&gt;getProperty($association)</code>
-      <code>$metadata-&gt;getProperty($association)</code>
-      <code>$metadata-&gt;getProperty($association)</code>
-      <code>$metadata-&gt;getProperty($association)</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="2">
       <code>getRootClassName</code>
       <code>getDeclaredPropertiesIterator</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCacheFactory.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$region</code>
+      <code>$region</code>
+    </ArgumentTypeCoercion>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
@@ -265,10 +269,6 @@
       <code>$cache</code>
       <code>$cache</code>
     </PossiblyNullArgument>
-    <TypeCoercion occurrences="2">
-      <code>$region</code>
-      <code>$region</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php">
     <InvalidNullableReturnType occurrences="1">
@@ -309,6 +309,15 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultQueryCache.php">
+    <ArgumentTypeCoercion occurrences="7">
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>$assocValue === null</code>
     </DocblockTypeContradiction>
@@ -337,15 +346,6 @@
       <code>getCacheLogger</code>
       <code>getValue</code>
     </PossiblyNullReference>
-    <TypeCoercion occurrences="7">
-      <code>$cacheKeys-&gt;identifiers[$index]</code>
-      <code>$cacheKeys-&gt;identifiers[$index]</code>
-      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
-      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="6">
       <code>getCacheRegion</code>
       <code>getCacheRegion</code>
@@ -395,6 +395,9 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$cache</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;hydrator-&gt;loadCacheEntry($this-&gt;sourceEntity, $key, $cache, $collection)</code>
     </InvalidReturnStatement>
@@ -415,15 +418,14 @@
       <code>getCacheFactory</code>
       <code>buildCollectionHydrator</code>
     </PossiblyNullReference>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$em-&gt;getMetadataFactory()</code>
+    </PropertyTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="3">
       <code>$this-&gt;cacheLogger &amp;&amp; $cached</code>
       <code>$this-&gt;cacheLogger</code>
       <code>$this-&gt;cacheLogger</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="2">
-      <code>$em-&gt;getMetadataFactory()</code>
-      <code>$cache</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="2">
       <code>getCacheRegion</code>
       <code>getEntityHydrator</code>
@@ -446,6 +448,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$cacheEntry</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="2">
       <code>$criteria instanceof Criteria</code>
       <code>$entity === null</code>
@@ -485,6 +490,9 @@
       <code>getTimestampRegion</code>
       <code>getValue</code>
     </PossiblyNullReference>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$em-&gt;getMetadataFactory()</code>
+    </PropertyTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="14">
       <code>$this-&gt;cacheLogger &amp;&amp; $cached</code>
       <code>$this-&gt;cacheLogger</code>
@@ -501,10 +509,6 @@
       <code>$this-&gt;cacheLogger</code>
       <code>$this-&gt;cacheLogger</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="2">
-      <code>$em-&gt;getMetadataFactory()</code>
-      <code>$cacheEntry</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="12">
       <code>getInsertSQL</code>
       <code>getTargetEntity</code>
@@ -610,6 +614,9 @@
     </NoInterfaceProperties>
   </file>
   <file src="lib/Doctrine/ORM/Configuration.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$repositoryClassName</code>
+    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="3">
       <code>$this-&gt;customStringFunctions</code>
       <code>$this-&gt;customNumericFunctions</code>
@@ -624,9 +631,6 @@
     <MissingReturnType occurrences="1">
       <code>addCustomDatetimeFunction</code>
     </MissingReturnType>
-    <TypeCoercion occurrences="1">
-      <code>$repositoryClassName</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Configuration/MetadataConfiguration.php">
     <DeprecatedConstant occurrences="1">
@@ -657,6 +661,9 @@
     </TooManyArguments>
   </file>
   <file src="lib/Doctrine/ORM/EntityManager.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;metadataFactory</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="7">
       <code>$this-&gt;expressionBuilder === null</code>
       <code>is_object($entity)</code>
@@ -710,6 +717,9 @@
       <code>$filterCollection</code>
       <code>$cache</code>
     </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>new $metadataFactoryClassName()</code>
+    </PropertyTypeCoercion>
     <RedundantCondition occurrences="1">
       <code>is_object($connection)</code>
     </RedundantCondition>
@@ -717,10 +727,6 @@
       <code>$this-&gt;filterCollection === null || $this-&gt;filterCollection-&gt;isClean()</code>
       <code>$this-&gt;filterCollection !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="2">
-      <code>new $metadataFactoryClassName()</code>
-      <code>$this-&gt;metadataFactory</code>
-    </TypeCoercion>
     <TypeDoesNotContainType occurrences="1">
       <code>': "' . $connection . '"'</code>
     </TypeDoesNotContainType>
@@ -790,12 +796,12 @@
       <code>$stmt</code>
       <code>$hints</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="4">
+    <PropertyTypeCoercion occurrences="4">
       <code>$stmt</code>
       <code>$resultSetMapping</code>
       <code>$stmt</code>
       <code>$resultSetMapping</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getType</code>
     </UndefinedInterfaceMethod>
@@ -924,9 +930,9 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>LazyCriteriaCollection</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$entityPersister</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod occurrences="1">
       <code>matching</code>
     </UndefinedInterfaceMethod>
@@ -965,9 +971,9 @@
       <code>$targetEntity</code>
       <code>$sourceEntity</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$declaringClass</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadata.php">
     <DocblockTypeContradiction occurrences="5">
@@ -1163,6 +1169,17 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php">
+    <ArgumentTypeCoercion occurrences="9">
+      <code>$className</code>
+      <code>$metadata-&gt;getClassName()</code>
+      <code>$cacheAnnot</code>
+      <code>$columnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$override</code>
+      <code>$cacheAnnot</code>
+    </ArgumentTypeCoercion>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Mapping\ClassMetadata</code>
     </ImplementedReturnTypeMismatch>
@@ -1225,17 +1242,6 @@
       <code>$entityAnnot-&gt;repositoryClass !== null</code>
       <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="9">
-      <code>$className</code>
-      <code>$metadata-&gt;getClassName()</code>
-      <code>$cacheAnnot</code>
-      <code>$columnAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$joinTableAnnot</code>
-      <code>$override</code>
-      <code>$cacheAnnot</code>
-    </TypeCoercion>
     <UndefinedPropertyFetch occurrences="2">
       <code>$parent-&gt;inheritanceType</code>
       <code>$parent-&gt;table</code>
@@ -1250,22 +1256,34 @@
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;classAnnotations[Annotation\Entity::class]</code>
+    </ArgumentTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$entityAnnotation-&gt;repositoryClass !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;classAnnotations[Annotation\Entity::class]</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;classAnnotations[Annotation\MappedSuperclass::class]</code>
+    </ArgumentTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>$mappedSuperclassAnnotation-&gt;repositoryClass !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;classAnnotations[Annotation\MappedSuperclass::class]</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php">
+    <ArgumentTypeCoercion occurrences="10">
+      <code>$className</code>
+      <code>$metadata-&gt;getClassName()</code>
+      <code>$cacheAnnot</code>
+      <code>$columnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$tableAnnot</code>
+      <code>$override</code>
+      <code>$cacheAnnot</code>
+    </ArgumentTypeCoercion>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Mapping\ClassMetadata</code>
     </ImplementedReturnTypeMismatch>
@@ -1320,23 +1338,13 @@
     <PossiblyNullArgument occurrences="1">
       <code>$metadata-&gt;getTableName()</code>
     </PossiblyNullArgument>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$reader</code>
+    </PropertyTypeCoercion>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>$entityAnnot-&gt;repositoryClass !== null</code>
       <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="11">
-      <code>$reader</code>
-      <code>$className</code>
-      <code>$metadata-&gt;getClassName()</code>
-      <code>$cacheAnnot</code>
-      <code>$columnAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$joinTableAnnot</code>
-      <code>$tableAnnot</code>
-      <code>$override</code>
-      <code>$cacheAnnot</code>
-    </TypeCoercion>
     <UndefinedPropertyFetch occurrences="3">
       <code>$parent-&gt;inheritanceType</code>
       <code>$parent-&gt;isMappedSuperclass</code>
@@ -1421,6 +1429,20 @@
     </PossiblyNullArgument>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php">
+    <ArgumentTypeCoercion occurrences="12">
+      <code>$className</code>
+      <code>$cacheAnnot</code>
+      <code>$classMetadata</code>
+      <code>$classMetadata</code>
+      <code>$className</code>
+      <code>$cacheAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$cacheAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$cacheAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$cacheAnnot</code>
+    </ArgumentTypeCoercion>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Mapping\ClassMetadata</code>
     </ImplementedReturnTypeMismatch>
@@ -1491,20 +1513,6 @@
       <code>$entityAnnot-&gt;repositoryClass !== null</code>
       <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="12">
-      <code>$className</code>
-      <code>$cacheAnnot</code>
-      <code>$classMetadata</code>
-      <code>$classMetadata</code>
-      <code>$className</code>
-      <code>$cacheAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$cacheAnnot</code>
-      <code>$joinColumnAnnot</code>
-      <code>$cacheAnnot</code>
-      <code>$joinTableAnnot</code>
-      <code>$cacheAnnot</code>
-    </TypeCoercion>
     <UndefinedMethod occurrences="1">
       <code>getClassName</code>
     </UndefinedMethod>
@@ -1516,6 +1524,9 @@
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$override</code>
+    </ArgumentTypeCoercion>
     <InvalidStringClass occurrences="1">
       <code>new $existingClass($fieldName)</code>
     </InvalidStringClass>
@@ -1526,9 +1537,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$metadata-&gt;getTableName()</code>
     </PossiblyNullArgument>
-    <TypeCoercion occurrences="1">
-      <code>$override</code>
-    </TypeCoercion>
     <UndefinedPropertyFetch occurrences="2">
       <code>$parent-&gt;inheritanceType</code>
       <code>$parent-&gt;table</code>
@@ -1548,9 +1556,9 @@
       <code>$declaringClass</code>
       <code>$reflection</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$declaringClass</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/EntityClassMetadata.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -1769,9 +1777,9 @@
       <code>$declaringClass</code>
       <code>$reflection</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$declaringClass</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/VersionFieldMetadata.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -1805,6 +1813,9 @@
     </NullArgument>
   </file>
   <file src="lib/Doctrine/ORM/PersistentCollection.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_object($value)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Collection|object[]</code>
     </ImplementedReturnTypeMismatch>
@@ -1821,8 +1832,11 @@
       <code>setDirty</code>
       <code>setInitialized</code>
     </MissingReturnType>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;association-&gt;getIndexedBy()</code>
+      <code>$offset</code>
+      <code>$offset</code>
+      <code>$offset</code>
     </PossiblyNullArgument>
     <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>$association-&gt;getInversedBy() ?: $association-&gt;getMappedBy()</code>
@@ -1849,9 +1863,6 @@
     <TooManyArguments occurrences="1">
       <code>andX</code>
     </TooManyArguments>
-    <TooManyTemplateParams occurrences="1">
-      <code>Collection|object[]</code>
-    </TooManyTemplateParams>
     <UndefinedInterfaceMethod occurrences="1">
       <code>matching</code>
     </UndefinedInterfaceMethod>
@@ -1874,6 +1885,13 @@
     </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="4">
       <code>$types</code>
       <code>$criteria</code>
@@ -1947,13 +1965,6 @@
     <PossiblyUndefinedMethod occurrences="1">
       <code>getJoinTable</code>
     </PossiblyUndefinedMethod>
-    <TypeCoercion occurrences="5">
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="7">
       <code>getJoinTable</code>
       <code>getColumnName</code>
@@ -1977,6 +1988,11 @@
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$criteria</code>
+      <code>$association</code>
+      <code>$criteria</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>$criteria</code>
     </InvalidArgument>
@@ -1993,11 +2009,6 @@
     <PossiblyNullReference occurrences="1">
       <code>getJoinColumns</code>
     </PossiblyNullReference>
-    <TypeCoercion occurrences="3">
-      <code>$criteria</code>
-      <code>$association</code>
-      <code>$criteria</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getJoinColumns</code>
     </UndefinedInterfaceMethod>
@@ -2024,6 +2035,14 @@
     </PossiblyNullArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>$versionProperty</code>
+      <code>$versionedClass</code>
+      <code>$versionedClass</code>
+      <code>$stmt</code>
+      <code>$stmt</code>
+      <code>$eagerProperty</code>
+    </ArgumentTypeCoercion>
     <DuplicateArrayKey occurrences="1">
       <code>Comparison::IS          =&gt; '= %s'</code>
     </DuplicateArrayKey>
@@ -2180,14 +2199,6 @@
       <code>$property instanceof ToManyAssociationMetadata &amp;&amp; $property-&gt;getIndexedBy()</code>
       <code>$this-&gt;insertSql !== null</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="6">
-      <code>$versionProperty</code>
-      <code>$versionedClass</code>
-      <code>$versionedClass</code>
-      <code>$stmt</code>
-      <code>$stmt</code>
-      <code>$eagerProperty</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="19">
       <code>getTargetEntity</code>
       <code>getJoinColumns</code>
@@ -2233,6 +2244,9 @@
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$property-&gt;getDeclaringClass()</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($id)</code>
     </DocblockTypeContradiction>
@@ -2281,9 +2295,6 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>! is_array($id) || ! isset($id[$columnName])</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="1">
-      <code>$property-&gt;getDeclaringClass()</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="7">
       <code>getInsertSQL</code>
       <code>getInsertSQL</code>
@@ -2579,12 +2590,12 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;stringPrimary</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
     <InvalidScalarArgument occurrences="1"/>
@@ -2597,12 +2608,12 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;stringPrimary</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -2677,12 +2688,12 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;stringPrimary</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php">
     <MissingReturnType occurrences="1">
@@ -3054,9 +3065,9 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$filterHash</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;enabledFilters</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedClass occurrences="1">
       <code>new $filterClass($this-&gt;em)</code>
     </UndefinedClass>
@@ -3293,6 +3304,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$parentClass</code>
+      <code>$scalarExpression</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="9">
       <code>''</code>
       <code>$condExpr instanceof AST\ConditionalExpression</code>
@@ -3412,10 +3427,6 @@
       <code>$leftExpr instanceof AST\Node</code>
       <code>$rightExpr instanceof AST\Node</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="2">
-      <code>$parentClass</code>
-      <code>$scalarExpression</code>
-    </TypeCoercion>
     <UndefinedMethod occurrences="3">
       <code>getTableName</code>
       <code>getMaxResults</code>
@@ -3592,11 +3603,11 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Reflection/RuntimeReflectionService.php">
-    <TypeCoercion occurrences="3">
+    <ArgumentTypeCoercion occurrences="3">
       <code>$className</code>
       <code>$className</code>
       <code>$className</code>
-    </TypeCoercion>
+    </ArgumentTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Reflection/StaticReflectionService.php">
     <PossiblyFalseOperand occurrences="2">
@@ -3663,6 +3674,21 @@
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="13">
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+      <code>$ownerId</code>
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+      <code>$ownerClass</code>
+      <code>$assoc</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php">
     <InvalidReturnType occurrences="1">
@@ -3671,6 +3697,15 @@
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityId</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php">
     <MissingReturnType occurrences="1">
@@ -3692,6 +3727,12 @@
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+    </PossiblyInvalidArgument>
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_object($queryRegion)</code>
     </RedundantConditionGivenDocblockType>
@@ -3717,6 +3758,9 @@
     <InvalidReturnType occurrences="1">
       <code>execute</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$input-&gt;getOption('filter')</code>
+    </InvalidScalarArgument>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
@@ -3761,6 +3805,9 @@
       <code>configure</code>
       <code>displayEntity</code>
     </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$input-&gt;getArgument('entityName')</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullReference occurrences="4">
       <code>getName</code>
       <code>getAllClassNames</code>
@@ -3775,9 +3822,16 @@
     <InvalidReturnType occurrences="1">
       <code>execute</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$hydrationModeName</code>
+    </InvalidScalarArgument>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$hydrationModeName</code>
+      <code>$dql</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php">
     <InvalidArgument occurrences="1">
@@ -3919,6 +3973,9 @@
     </PossiblyNullPropertyFetch>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/Paginator.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$parameters</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;count === null</code>
     </DocblockTypeContradiction>
@@ -3935,9 +3992,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$count</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$parameters</code>
-    </TypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -3985,6 +4039,9 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/SchemaTool.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$idProperty</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="6">
       <code>$processedClasses</code>
       <code>$pkColumns</code>
@@ -4038,9 +4095,6 @@
       <code>is_numeric($indexName)</code>
       <code>$indexName</code>
     </RedundantCondition>
-    <TypeCoercion occurrences="1">
-      <code>$idProperty</code>
-    </TypeCoercion>
     <UndefinedMethod occurrences="1">
       <code>getJoinColumns</code>
     </UndefinedMethod>
@@ -4083,6 +4137,14 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/UnitOfWork.php">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>$property</code>
+      <code>$property</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>'count'</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="5">
       <code>$this-&gt;entityDeletions</code>
       <code>$owner === null</code>
@@ -4208,14 +4270,6 @@
       <code>$owner === null</code>
       <code>! is_object($object) || ! $this-&gt;isInIdentityMap($object)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeCoercion occurrences="6">
-      <code>$property</code>
-      <code>$property</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>'count'</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="8">
       <code>getMapping</code>
       <code>getMapping</code>
@@ -4400,6 +4454,9 @@
     </MissingReturnType>
   </file>
   <file src="tests/Doctrine/Tests/EventListener/CacheMetadataListener.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$em</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>$metadata</code>
     </InvalidArgument>
@@ -4408,9 +4465,6 @@
       <code>recordVisit</code>
       <code>enableCaching</code>
     </MissingReturnType>
-    <TypeCoercion occurrences="1">
-      <code>$em</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getClassName</code>
     </UndefinedInterfaceMethod>
@@ -4472,9 +4526,9 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>ConnectionMock</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$platform</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedThisPropertyAssignment occurrences="1">
       <code>$this-&gt;platform</code>
     </UndefinedThisPropertyAssignment>
@@ -5663,16 +5717,6 @@
       <code>getDescription</code>
     </MissingReturnType>
   </file>
-  <file src="tests/Doctrine/Tests/Models/ManyToManyPersister/ChildClass.php">
-    <TooManyTemplateParams occurrences="1">
-      <code>Collection|ParentClass[]</code>
-    </TooManyTemplateParams>
-  </file>
-  <file src="tests/Doctrine/Tests/Models/ManyToManyPersister/ParentClass.php">
-    <TooManyTemplateParams occurrences="1">
-      <code>Collection|ChildClass[]</code>
-    </TooManyTemplateParams>
-  </file>
   <file src="tests/Doctrine/Tests/Models/Navigation/NavCountry.php">
     <MissingParamType occurrences="1">
       <code>$name</code>
@@ -5953,6 +5997,12 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1"/>
     <PossiblyNullArgument occurrences="4">
       <code>$association</code>
@@ -5975,12 +6025,6 @@
       <code>$regionsConfig</code>
       <code>DefaultCacheFactoryTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="4">
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-      <code>$association</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="18">
       <code>expects</code>
       <code>expects</code>
@@ -6003,6 +6047,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata-&gt;getProperty($association)</code>
+    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="2">
       <code>putEntityCacheEntry</code>
       <code>putCollectionCacheEntry</code>
@@ -6015,9 +6062,6 @@
       <code>$em</code>
       <code>DefaultCacheTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$metadata-&gt;getProperty($association)</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="2">
       <code>getCacheRegion</code>
       <code>getCacheRegion</code>
@@ -6037,6 +6081,10 @@
     </TooManyArguments>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$proxy</code>
+      <code>$proxy</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$proxy</code>
     </PossiblyNullArgument>
@@ -6045,10 +6093,6 @@
       <code>$em</code>
       <code>DefaultEntityHydratorTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="2">
-      <code>$proxy</code>
-      <code>$proxy</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php">
     <MissingPropertyType occurrences="10">
@@ -6139,6 +6183,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$assoc</code>
+    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1"/>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
@@ -6156,9 +6203,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$assoc</code>
     </PossiblyNullArgument>
-    <TypeCoercion occurrences="1">
-      <code>$assoc</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="9">
       <code>flushAll</code>
       <code>expects</code>
@@ -6182,6 +6226,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$region</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
       <code>Region</code>
@@ -6189,9 +6236,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>ReadWriteCachedCollectionPersisterTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$region</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="18">
       <code>expects</code>
       <code>expects</code>
@@ -6274,6 +6318,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$region</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">
       <code>Region</code>
@@ -6281,9 +6328,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>ReadWriteCachedEntityPersisterTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$region</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="14">
       <code>expects</code>
       <code>expects</code>
@@ -6428,9 +6472,9 @@
       <code>$em</code>
       <code>EntityManagerTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;getTestEntityManager()</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedClass occurrences="4">
       <code>$nestedIdReference</code>
       <code>$nestedIdReference</code>
@@ -6663,6 +6707,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$poi</code>
+    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="2">
       <code>putGermanysBrandenburderTor</code>
       <code>putTripAroundEurope</code>
@@ -6683,9 +6730,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>CompositePrimaryKeyTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$poi</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyWithAssociationsTest.php">
     <MissingPropertyType occurrences="1">
@@ -6822,7 +6866,7 @@
       <code>$listener</code>
       <code>EntityListenersTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1"/>
+    <PropertyTypeCoercion occurrences="1"/>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php">
     <MissingPropertyType occurrences="1">
@@ -8116,12 +8160,19 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/QueryTest.php">
-    <InvalidScalarArgument occurrences="4">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$identityMap[CmsArticle::class]</code>
+    </ArgumentTypeCoercion>
+    <InvalidScalarArgument occurrences="5">
       <code>1</code>
       <code>2</code>
+      <code>$extractValue</code>
       <code>1</code>
       <code>FetchMode::EAGER</code>
     </InvalidScalarArgument>
+    <InvalidTemplateParam occurrences="1">
+      <code>$parameters-&gt;map($extractValue)</code>
+    </InvalidTemplateParam>
     <MissingPropertyType occurrences="7">
       <code>$article1-&gt;id</code>
       <code>$author-&gt;id</code>
@@ -8140,9 +8191,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>QueryTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$identityMap[CmsArticle::class]</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php">
     <MissingParamType occurrences="2">
@@ -8397,6 +8445,14 @@
     </PossiblyNullReference>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="7">
       <code>$leavingFrom</code>
       <code>$goingTo</code>
@@ -8420,14 +8476,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheCompositePrimaryKeyTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="6">
-      <code>$leavingFrom</code>
-      <code>$goingTo</code>
-      <code>$leavingFrom</code>
-      <code>$goingTo</code>
-      <code>$leavingFrom</code>
-      <code>$goingTo</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php">
     <MissingPropertyType occurrences="1">
@@ -8494,6 +8542,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$ref</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$owner</code>
     </PossiblyNullArgument>
@@ -8513,9 +8564,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheExtraLazyCollectionTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$ref</code>
-    </TypeCoercion>
     <UndefinedInterfaceMethod occurrences="4">
       <code>setFetchMode</code>
       <code>setFetchMode</code>
@@ -8524,6 +8572,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(Attraction::class, $this-&gt;attractions[5]-&gt;getId())</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;em-&gt;find(Attraction::class, $this-&gt;attractions[5]-&gt;getId())</code>
     </PossiblyNullArgument>
@@ -8555,9 +8606,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheJoinTableInheritanceTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;em-&gt;find(Attraction::class, $this-&gt;attractions[5]-&gt;getId())</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php">
     <PossiblyNullArgument occurrences="1">
@@ -8619,6 +8667,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$c3</code>
+    </ArgumentTypeCoercion>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$action2</code>
     </InvalidPropertyAssignmentValue>
@@ -8692,11 +8743,11 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheManyToOneTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$c3</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$entity</code>
+    </ArgumentTypeCoercion>
     <MissingPropertyType occurrences="1">
       <code>$token-&gt;token</code>
     </MissingPropertyType>
@@ -8776,9 +8827,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheOneToManyTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$entity</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php">
     <MissingPropertyType occurrences="2">
@@ -8860,17 +8908,20 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(Country::class, $this-&gt;countries[0]-&gt;getId())</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$country</code>
     </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheRepositoryTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;em-&gt;find(Country::class, $this-&gt;countries[0]-&gt;getId())</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(City::class, $this-&gt;cities[1]-&gt;getId())</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;em-&gt;find(City::class, $this-&gt;cities[1]-&gt;getId())</code>
     </PossiblyNullArgument>
@@ -8907,9 +8958,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>SecondLevelCacheSingleTableInheritanceTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;em-&gt;find(City::class, $this-&gt;cities[1]-&gt;getId())</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php">
     <MissingParamType occurrences="5">
@@ -9043,12 +9091,12 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$class-&gt;getProperty('customer')</code>
+    </ArgumentTypeCoercion>
     <PropertyNotSetInConstructor occurrences="1">
       <code>StandardEntityPersisterTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$class-&gt;getProperty('customer')</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1040Test.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -9454,6 +9502,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$addressRef</code>
+    </ArgumentTypeCoercion>
     <MissingPropertyType occurrences="1">
       <code>$user-&gt;id</code>
     </MissingPropertyType>
@@ -9478,9 +9529,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>DDC142Test</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$addressRef</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php">
     <MissingParamType occurrences="1">
@@ -10084,6 +10132,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$class-&gt;getProperty('categories')</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$class-&gt;getProperty('categories')</code>
     </PossiblyNullArgument>
@@ -10096,9 +10147,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>DDC2074Test</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$class-&gt;getProperty('categories')</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php">
     <MissingParamType occurrences="2">
@@ -10296,8 +10344,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php">
-    <MissingPropertyType occurrences="3">
+    <MissingPropertyType occurrences="4">
       <code>$address-&gt;id</code>
+      <code>$address-&gt;users-&gt;first()-&gt;user</code>
       <code>$user-&gt;id</code>
       <code>$user-&gt;id</code>
     </MissingPropertyType>
@@ -10305,25 +10354,21 @@
       <code>$user-&gt;id</code>
       <code>$user-&gt;id</code>
     </NoInterfaceProperties>
+    <PossiblyInvalidPropertyFetch occurrences="1">
+      <code>$address-&gt;users-&gt;first()-&gt;user</code>
+    </PossiblyInvalidPropertyFetch>
     <PossiblyUndefinedMethod occurrences="1">
       <code>initializeProxy</code>
     </PossiblyUndefinedMethod>
     <PropertyNotSetInConstructor occurrences="1">
       <code>DDC2306Test</code>
     </PropertyNotSetInConstructor>
-    <TooManyTemplateParams occurrences="2">
-      <code>DDC2306UserAddress[]|Collection</code>
-      <code>DDC2306UserAddress[]|Collection</code>
-    </TooManyTemplateParams>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php">
     <PropertyNotSetInConstructor occurrences="2">
       <code>$logger</code>
       <code>DDC2346Test</code>
     </PropertyNotSetInConstructor>
-    <TooManyTemplateParams occurrences="1">
-      <code>DDC2346Bar[]|Collection</code>
-    </TooManyTemplateParams>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php">
     <MissingPropertyType occurrences="1">
@@ -10685,6 +10730,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$sameUser</code>
+      <code>$equalUser</code>
+    </ArgumentTypeCoercion>
     <MissingReturnType occurrences="2">
       <code>applyName</code>
       <code>getName</code>
@@ -10696,10 +10745,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>DDC2984Test</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="2">
-      <code>$sameUser</code>
-      <code>$equalUser</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php">
     <MissingParamType occurrences="1">
@@ -11405,6 +11450,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(get_class($group1), $groupId)</code>
+    </ArgumentTypeCoercion>
     <MissingPropertyType occurrences="4">
       <code>$user-&gt;id</code>
       <code>$group2-&gt;id</code>
@@ -11417,9 +11465,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>DDC767Test</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$this-&gt;em-&gt;find(get_class($group1), $groupId)</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php">
     <MissingConstructor occurrences="1">
@@ -11782,9 +11827,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>GH7062Test</code>
     </PropertyNotSetInConstructor>
-    <TooManyTemplateParams occurrences="1">
-      <code>Collection|GH7062RankingPosition[]</code>
-    </TooManyTemplateParams>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7067Test.php">
     <MissingConstructor occurrences="1">
@@ -11815,10 +11857,10 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>GH7259Test</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="2">
+    <PropertyTypeCoercion occurrences="2">
       <code>$space</code>
       <code>$space</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7286Test.php">
     <PropertyNotSetInConstructor occurrences="4">
@@ -12981,6 +13023,9 @@
     </UndefinedMethod>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Persisters/ManyToManyPersisterTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$childReloaded-&gt;parents</code>
+    </ArgumentTypeCoercion>
     <PossiblyNullArgument occurrences="1">
       <code>$childReloaded-&gt;parents</code>
     </PossiblyNullArgument>
@@ -12990,9 +13035,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>ManyToManyPersisterTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>$childReloaded-&gt;parents</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php">
     <InvalidArgument occurrences="15">
@@ -13395,9 +13437,9 @@
       <code>$connection</code>
       <code>SequenceGeneratorTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;entityManager-&gt;getConnection()</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php">
     <MissingPropertyType occurrences="2">
@@ -13433,6 +13475,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheMetadataCommandTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </ArgumentTypeCoercion>
     <MissingParamType occurrences="2">
       <code>$driver</code>
       <code>$name</code>
@@ -13442,11 +13487,11 @@
       <code>$command</code>
       <code>ClearCacheMetadataCommandTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>new $driver()</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryCommandTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </ArgumentTypeCoercion>
     <MissingParamType occurrences="2">
       <code>$driver</code>
       <code>$name</code>
@@ -13456,9 +13501,6 @@
       <code>$command</code>
       <code>ClearCacheQueryCommandTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>new $driver()</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php">
     <PropertyNotSetInConstructor occurrences="3">
@@ -13468,6 +13510,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheResultCommandTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </ArgumentTypeCoercion>
     <MissingParamType occurrences="2">
       <code>$driver</code>
       <code>$name</code>
@@ -13477,9 +13522,6 @@
       <code>$command</code>
       <code>ClearCacheResultCommandTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
-      <code>new $driver()</code>
-    </TypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php">
     <InvalidArgument occurrences="2">
@@ -13492,9 +13534,9 @@
       <code>$tester</code>
       <code>InfoCommandTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;application-&gt;find('orm:info')</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod occurrences="7">
       <code>method</code>
       <code>method</code>
@@ -13512,9 +13554,9 @@
       <code>$tester</code>
       <code>MappingDescribeCommandTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;application-&gt;find('orm:mapping:describe')</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php">
     <PropertyNotSetInConstructor occurrences="4">
@@ -13666,9 +13708,9 @@
       <code>$factory</code>
       <code>ResolveTargetEntityListenerTest</code>
     </PropertyNotSetInConstructor>
-    <TypeCoercion occurrences="1">
+    <PropertyTypeCoercion occurrences="1">
       <code>$this-&gt;em-&gt;getMetadataFactory()</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getTargetEntity</code>
     </UndefinedInterfaceMethod>
@@ -13830,6 +13872,10 @@
     </UndefinedPropertyAssignment>
   </file>
   <file src="tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$em-&gt;reveal()</code>
+      <code>$em-&gt;reveal()</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>$this-&gt;createMock(Mapping\ClassMetadataFactory::class)</code>
     </InvalidArgument>
@@ -13842,10 +13888,6 @@
       <code>willReturn</code>
       <code>willReturn</code>
     </TooManyArguments>
-    <TypeCoercion occurrences="2">
-      <code>$em-&gt;reveal()</code>
-      <code>$em-&gt;reveal()</code>
-    </TypeCoercion>
     <UndefinedPropertyAssignment occurrences="3">
       <code>$childClassMetadata-&gt;name</code>
       <code>$classMetadata-&gt;name</code>
@@ -13873,6 +13915,10 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="tests/Doctrine/Tests/OrmFunctionalTestCase.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>self::$metadataCacheImpl</code>
+      <code>$conn</code>
+    </ArgumentTypeCoercion>
     <DocblockTypeContradiction occurrences="2">
       <code>$this-&gt;em === null</code>
       <code>$this-&gt;em</code>
@@ -13902,17 +13948,13 @@
       <code>getConfiguration</code>
       <code>getEventManager</code>
     </PossiblyUndefinedMethod>
-    <TypeCoercion occurrences="3">
+    <PropertyTypeCoercion occurrences="1">
       <code>new $GLOBALS['DOCTRINE_CACHE_IMPL']()</code>
-      <code>self::$metadataCacheImpl</code>
-      <code>$conn</code>
-    </TypeCoercion>
+    </PropertyTypeCoercion>
   </file>
   <file src="tests/Doctrine/Tests/OrmPerformanceTestCase.php">
-    <InvalidReturnType occurrences="1">
+    <MissingReturnType occurrences="2">
       <code>runTest</code>
-    </InvalidReturnType>
-    <MissingReturnType occurrences="1">
       <code>setMaxRunningTime</code>
     </MissingReturnType>
     <PropertyNotSetInConstructor occurrences="1">
@@ -14153,6 +14195,9 @@
     </MissingFile>
   </file>
   <file src="tests/Doctrine/Tests/TestUtil.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$subscriberInstance</code>
+    </ArgumentTypeCoercion>
     <InvalidStringClass occurrences="1">
       <code>new $subscriberClass()</code>
     </InvalidStringClass>
@@ -14165,9 +14210,6 @@
       <code>getParamsForTemporaryConnection</code>
       <code>getParamsForMainConnection</code>
     </MissingReturnType>
-    <TypeCoercion occurrences="1">
-      <code>$subscriberInstance</code>
-    </TypeCoercion>
   </file>
   <file src="vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php">
     <ImplementedReturnTypeMismatch occurrences="2">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,14178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files>
+  <file src="lib/Doctrine/ORM/AbstractQuery.php">
+    <DocblockTypeContradiction occurrences="9">
+      <code>$resultCacheDriver !== null &amp;&amp; ! ($resultCacheDriver instanceof \Doctrine\Common\Cache\Cache)</code>
+      <code>new QueryCacheProfile(0, null, $resultCacheDriver)</code>
+      <code>0</code>
+      <code>new QueryCacheProfile($lifetime, null, $this-&gt;em-&gt;getConfiguration()-&gt;getResultCacheImpl())</code>
+      <code>0</code>
+      <code>$fetchMode !== Mapping\FetchMode::EAGER</code>
+      <code>is_numeric($stmt)</code>
+      <code>new QueryCacheProfile(0, $id, $this-&gt;em-&gt;getConfiguration()-&gt;getResultCacheImpl())</code>
+      <code>null</code>
+    </DocblockTypeContradiction>
+    <InvalidNullableReturnType occurrences="3">
+      <code>int</code>
+      <code>\Doctrine\Common\Cache\Cache</code>
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <InvalidReturnStatement occurrences="1">
+      <code>$value</code>
+    </InvalidReturnStatement>
+    <InvalidScalarArgument occurrences="1">
+      <code>$key</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>free</code>
+    </MissingReturnType>
+    <NullableReturnStatement occurrences="4">
+      <code>$this-&gt;cacheMode</code>
+      <code>$this-&gt;queryCacheProfile-&gt;getResultCacheDriver()</code>
+      <code>$this-&gt;em-&gt;getConfiguration()-&gt;getResultCacheImpl()</code>
+      <code>$this-&gt;queryCacheProfile ? $this-&gt;queryCacheProfile-&gt;getCacheKey() : null</code>
+    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="5">
+      <code>$resultCacheDriver</code>
+      <code>$resultCacheDriver</code>
+      <code>$resultCacheDriver</code>
+      <code>$lifetime</code>
+      <code>$resultCacheId</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$profile</code>
+      <code>$profile</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="3">
+      <code>getCacheLogger</code>
+      <code>fetch</code>
+      <code>getQueryCache</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$resultSetMapping</code>
+      <code>$queryCacheProfile</code>
+      <code>$hydrationCacheProfile</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="8">
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;queryCacheProfile &amp;&amp; $this-&gt;queryCacheProfile-&gt;getResultCacheDriver()</code>
+      <code>$lifetime !== null</code>
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;hydrationCacheProfile !== null</code>
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;queryCacheProfile</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="2">
+      <code>$setCacheEntry($stmt)</code>
+      <code>$setCacheEntry($data)</code>
+    </TooManyArguments>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/AssociationOverride.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/AssociationOverrides.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/AttributeOverride.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/AttributeOverrides.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Cache.php">
+    <MissingConstructor occurrences="1">
+      <code>$region</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/ChangeTrackingPolicy.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Column.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/CustomIdGenerator.php">
+    <MissingConstructor occurrences="1">
+      <code>$class</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/DiscriminatorColumn.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/DiscriminatorMap.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Embedded.php">
+    <MissingConstructor occurrences="1">
+      <code>$class</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Entity.php">
+    <MissingConstructor occurrences="1">
+      <code>$repositoryClass</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Index.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/InheritanceType.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/JoinColumn.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/JoinColumns.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/JoinTable.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/ManyToMany.php">
+    <MissingConstructor occurrences="1">
+      <code>$targetEntity</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/ManyToOne.php">
+    <MissingConstructor occurrences="1">
+      <code>$targetEntity</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/MappedSuperclass.php">
+    <MissingConstructor occurrences="1">
+      <code>$repositoryClass</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/OneToMany.php">
+    <MissingConstructor occurrences="1">
+      <code>$mappedBy</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/OneToOne.php">
+    <MissingConstructor occurrences="1">
+      <code>$targetEntity</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/OrderBy.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/SequenceGenerator.php">
+    <MissingConstructor occurrences="1">
+      <code>$sequenceName</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/Table.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Annotation/UniqueConstraint.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/CacheConfiguration.php">
+    <MissingReturnType occurrences="4">
+      <code>setCacheFactory</code>
+      <code>setCacheLogger</code>
+      <code>setRegionsConfiguration</code>
+      <code>setQueryValidator</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getTimestampRegion</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultCache.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;defaultQueryCache = $this-&gt;cacheFactory-&gt;buildQueryCache($this-&gt;em)</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="1">
+      <code>evictQueryRegion</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="4">
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1"/>
+    <PossiblyNullReference occurrences="1">
+      <code>getCacheFactory</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$defaultQueryCache</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$this-&gt;defaultQueryCache !== null</code>
+      <code>$regionName === null &amp;&amp; $this-&gt;defaultQueryCache !== null</code>
+      <code>$this-&gt;defaultQueryCache</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="4">
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+      <code>$metadata-&gt;getProperty($association)</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getRootClassName</code>
+      <code>getDeclaredPropertiesIterator</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultCacheFactory.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$this-&gt;regionsConfig-&gt;getLockLifetime($regionName)</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="3">
+      <code>setFileLockRegionDirectory</code>
+      <code>setRegion</code>
+      <code>setTimestampRegion</code>
+    </MissingReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;fileLockRegionDirectory</code>
+    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="2">
+      <code>$cache</code>
+      <code>$cache</code>
+    </PossiblyNullArgument>
+    <TypeCoercion occurrences="2">
+      <code>$region</code>
+      <code>$region</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>loadCacheEntry</code>
+    </InvalidNullableReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getTargetEntity</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getTargetEntity</code>
+      <code>getCacheRegion</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php">
+    <MissingReturnType occurrences="1">
+      <code>loadCacheEntry</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$association-&gt;getMappedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$data</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="3">
+      <code>getValue</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedInterfaceMethod occurrences="5">
+      <code>getJoinColumns</code>
+      <code>getCache</code>
+      <code>getFetchMode</code>
+      <code>getTargetEntity</code>
+      <code>getCacheRegion</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultQueryCache.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$assocValue === null</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="2">
+      <code>$assocValue</code>
+      <code>$assocValue</code>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="1">
+      <code>mixed[]|object</code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;getAssociationPathValue($entity, $path)</code>
+    </NullableReturnStatement>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$assocValue</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="3">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$cacheConfig-&gt;getCacheLogger()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>getCacheLogger</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <TypeCoercion occurrences="7">
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="6">
+      <code>getCacheRegion</code>
+      <code>getCacheRegion</code>
+      <code>storeEntityCache</code>
+      <code>getCacheRegion</code>
+      <code>storeEntityCache</code>
+      <code>storeEntityCache</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php">
+    <MissingReturnType occurrences="10">
+      <code>setLogger</code>
+      <code>collectionCacheHit</code>
+      <code>collectionCacheMiss</code>
+      <code>collectionCachePut</code>
+      <code>entityCacheHit</code>
+      <code>entityCacheMiss</code>
+      <code>entityCachePut</code>
+      <code>queryCacheHit</code>
+      <code>queryCacheMiss</code>
+      <code>queryCachePut</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php">
+    <InvalidReturnStatement occurrences="3">
+      <code>array_sum($this-&gt;cachePutCountMap)</code>
+      <code>array_sum($this-&gt;cacheHitCountMap)</code>
+      <code>array_sum($this-&gt;cacheMissCountMap)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="3">
+      <code>int</code>
+      <code>int</code>
+      <code>int</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="11">
+      <code>collectionCacheMiss</code>
+      <code>collectionCacheHit</code>
+      <code>collectionCachePut</code>
+      <code>entityCacheMiss</code>
+      <code>entityCacheHit</code>
+      <code>entityCachePut</code>
+      <code>queryCacheHit</code>
+      <code>queryCacheMiss</code>
+      <code>queryCachePut</code>
+      <code>clearRegionStats</code>
+      <code>clearStats</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;hydrator-&gt;loadCacheEntry($this-&gt;sourceEntity, $key, $cache, $collection)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>PersistentCollection|null</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="2">
+      <code>evictCollectionCache</code>
+      <code>evictElementCache</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$entry-&gt;identifiers</code>
+    </NoInterfaceProperties>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$cacheConfig-&gt;getCacheLogger()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>getCacheFactory</code>
+      <code>buildCollectionHydrator</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$this-&gt;cacheLogger &amp;&amp; $cached</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="2">
+      <code>$em-&gt;getMetadataFactory()</code>
+      <code>$cache</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getCacheRegion</code>
+      <code>getEntityHydrator</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>lock</code>
+      <code>lock</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$criteria instanceof Criteria</code>
+      <code>$entity === null</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="4">
+      <code>$criteria</code>
+      <code>$criteria</code>
+      <code>$criteria</code>
+      <code>$criteria</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="2">
+      <code>$fieldName</code>
+      <code>$entity</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getInsertSQL</code>
+      <code>storeJoinedAssociations</code>
+      <code>getOwningTable</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$cacheEntry-&gt;class</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="2">
+      <code>$orderBy</code>
+      <code>$orderBy</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="2">
+      <code>$limit</code>
+      <code>$offset</code>
+    </PossiblyNullOperand>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$em-&gt;getCache()</code>
+      <code>$cacheConfig-&gt;getCacheLogger()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="3">
+      <code>getCacheFactory</code>
+      <code>getTimestampRegion</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="14">
+      <code>$this-&gt;cacheLogger &amp;&amp; $cached</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$result</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+      <code>$this-&gt;cacheLogger</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="2">
+      <code>$em-&gt;getMetadataFactory()</code>
+      <code>$cacheEntry</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="12">
+      <code>getInsertSQL</code>
+      <code>getTargetEntity</code>
+      <code>storeEntityCache</code>
+      <code>getOwningTable</code>
+      <code>loadCollectionCache</code>
+      <code>getCacheRegion</code>
+      <code>storeCollectionCache</code>
+      <code>getCacheRegion</code>
+      <code>loadCollectionCache</code>
+      <code>getCacheRegion</code>
+      <code>storeCollectionCache</code>
+      <code>getCacheRegion</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php">
+    <MissingParamType occurrences="2">
+      <code>$entity</code>
+      <code>$isChanged</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+      <code>updateCache</code>
+    </MissingReturnType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;cacheLogger &amp;&amp; $cached</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+    <RedundantCondition occurrences="1">
+      <code>$isChanged</code>
+    </RedundantCondition>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>lock</code>
+      <code>lock</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php">
+    <InvalidArgument occurrences="1">
+      <code>$cache</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$lifetime</code>
+    </MissingParamType>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>fetchMultiple</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/DefaultRegion.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;cache</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="3">
+      <code>put</code>
+      <code>evict</code>
+      <code>evictAll</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>CacheProvider</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/FileLockRegion.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>lock</code>
+    </InvalidNullableReturnType>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$lockLifetime</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="1">
+      <code>unlock</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="3">
+      <code>put</code>
+      <code>evict</code>
+      <code>evictAll</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php">
+    <MissingReturnType occurrences="1">
+      <code>update</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/RegionsConfiguration.php">
+    <MissingPropertyType occurrences="1">
+      <code>$lifetimes</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>setDefaultLifetime</code>
+      <code>setDefaultLockLifetime</code>
+      <code>setLifetime</code>
+      <code>setLockLifetime</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php">
+    <NoInterfaceProperties occurrences="1">
+      <code>$timestamp-&gt;time</code>
+    </NoInterfaceProperties>
+  </file>
+  <file src="lib/Doctrine/ORM/Configuration.php">
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;customStringFunctions</code>
+      <code>$this-&gt;customNumericFunctions</code>
+      <code>$this-&gt;customDatetimeFunctions</code>
+    </InvalidPropertyAssignmentValue>
+    <MismatchingDocblockParamType occurrences="1">
+      <code>iterable|string[]</code>
+    </MismatchingDocblockParamType>
+    <MissingConstructor occurrences="1">
+      <code>$filters</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>addCustomDatetimeFunction</code>
+    </MissingReturnType>
+    <TypeCoercion occurrences="1">
+      <code>$repositoryClassName</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Configuration/MetadataConfiguration.php">
+    <DeprecatedConstant occurrences="1">
+      <code>AbstractClassMetadataFactory::AUTOGENERATE_ALWAYS</code>
+    </DeprecatedConstant>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;namingStrategy</code>
+    </DocblockTypeContradiction>
+    <MissingConstructor occurrences="1">
+      <code>$namespace</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="6">
+      <code>setNamespace</code>
+      <code>setDirectory</code>
+      <code>setResolver</code>
+      <code>setMappingDriver</code>
+      <code>setNamingStrategy</code>
+      <code>setAutoGenerate</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php">
+    <MissingParamType occurrences="2">
+      <code>$lockMode</code>
+      <code>$lockVersion</code>
+    </MissingParamType>
+    <TooManyArguments occurrences="1">
+      <code>find</code>
+    </TooManyArguments>
+  </file>
+  <file src="lib/Doctrine/ORM/EntityManager.php">
+    <DocblockTypeContradiction occurrences="7">
+      <code>$this-&gt;expressionBuilder === null</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+      <code>$connection instanceof Connection</code>
+      <code>$this-&gt;filterCollection === null</code>
+      <code>$this-&gt;filterCollection === null</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Mapping\ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="2">
+      <code>$hydrationMode</code>
+      <code>$hydrationMode</code>
+    </InvalidArgument>
+    <InvalidReturnStatement occurrences="1">
+      <code>$entity</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="3">
+      <code>object|null</code>
+      <code>getReference</code>
+      <code>getPartialReference</code>
+    </InvalidReturnType>
+    <InvalidStringClass occurrences="2">
+      <code>new $metadataFactoryClassName()</code>
+      <code>new $class($this)</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="1">
+      <code>errorIfClosed</code>
+    </MissingReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$entityName</code>
+    </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>newHydrator</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$entity</code>
+      <code>$entity</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getCacheFactory</code>
+      <code>createCache</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$expressionBuilder</code>
+      <code>$filterCollection</code>
+      <code>$cache</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="1">
+      <code>is_object($connection)</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$this-&gt;filterCollection === null || $this-&gt;filterCollection-&gt;isClean()</code>
+      <code>$this-&gt;filterCollection !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="2">
+      <code>new $metadataFactoryClassName()</code>
+      <code>$this-&gt;metadataFactory</code>
+    </TypeCoercion>
+    <TypeDoesNotContainType occurrences="1">
+      <code>': "' . $connection . '"'</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="lib/Doctrine/ORM/EntityRepository.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Collection|object[]</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingReturnType occurrences="1">
+      <code>clear</code>
+    </MissingReturnType>
+    <TooManyArguments occurrences="1">
+      <code>find</code>
+    </TooManyArguments>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/LifecycleEventArgs.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;getObjectManager()</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>EntityManagerInterface</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/ListenersInvoker.php">
+    <MissingReturnType occurrences="1">
+      <code>invoke</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/PreUpdateEventArgs.php">
+    <MissingReturnType occurrences="2">
+      <code>setNewValue</code>
+      <code>assertValidField</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Exception/MissingIdentifierField.php">
+    <MissingParamType occurrences="2">
+      <code>$fieldName</code>
+      <code>$className</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/CommitOrderCalculator.php">
+    <MissingReturnType occurrences="3">
+      <code>addNode</code>
+      <code>addDependency</code>
+      <code>visit</code>
+    </MissingReturnType>
+    <RedundantCondition occurrences="1">
+      <code>$vertex-&gt;state !== self::VISITED</code>
+    </RedundantCondition>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php">
+    <MissingReturnType occurrences="4">
+      <code>onClear</code>
+      <code>prepare</code>
+      <code>cleanup</code>
+      <code>hydrateRowData</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="1">
+      <code>isPrimaryKey</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$rsm</code>
+      <code>$stmt</code>
+      <code>$hints</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="4">
+      <code>$stmt</code>
+      <code>$resultSetMapping</code>
+      <code>$stmt</code>
+      <code>$resultSetMapping</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getType</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php">
+    <MissingReturnType occurrences="3">
+      <code>prepare</code>
+      <code>hydrateRowData</code>
+      <code>updateResultPointer</code>
+    </MissingReturnType>
+    <PossiblyInvalidArrayOffset occurrences="1">
+      <code>$coll[$index]</code>
+    </PossiblyInvalidArrayOffset>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ArrayHydrator</code>
+    </PropertyNotSetInConstructor>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>return;</code>
+    </ReferenceConstraintViolation>
+    <TypeDoesNotContainNull occurrences="1">
+      <code>$coll === null</code>
+    </TypeDoesNotContainNull>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/IterableResult.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>mixed[]|false</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;next()</code>
+    </InvalidPropertyAssignmentValue>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;current!==false</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php">
+    <InvalidArrayAccess occurrences="1">
+      <code>$this-&gt;rootAliases[$dqlAlias]</code>
+    </InvalidArrayAccess>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>[]</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="5">
+      <code>$oid</code>
+      <code>$oid</code>
+      <code>spl_object_id($element)</code>
+      <code>spl_object_id($element)</code>
+      <code>$oid</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="4">
+      <code>prepare</code>
+      <code>cleanup</code>
+      <code>hydrateRowData</code>
+      <code>onClear</code>
+    </MissingReturnType>
+    <PossiblyInvalidArrayAccess occurrences="1">
+      <code>$this-&gt;rootAliases[$parentAlias]</code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidArrayAssignment occurrences="1">
+      <code>$this-&gt;rootAliases[$dqlAlias]</code>
+    </PossiblyInvalidArrayAssignment>
+    <PossiblyInvalidMethodCall occurrences="2">
+      <code>takeSnapshot</code>
+      <code>clear</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;rootAliases</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullArgument occurrences="2">
+      <code>$association-&gt;getInversedBy()</code>
+      <code>$mappedBy</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="5">
+      <code>getMappedBy</code>
+      <code>getInversedBy</code>
+      <code>getInversedBy</code>
+      <code>getValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ObjectHydrator</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>getMappedBy</code>
+      <code>getInversedBy</code>
+      <code>getInversedBy</code>
+      <code>takeSnapshot</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php">
+    <MissingReturnType occurrences="1">
+      <code>hydrateRowData</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ScalarHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php">
+    <MissingReturnType occurrences="3">
+      <code>prepare</code>
+      <code>cleanup</code>
+      <code>hydrateRowData</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;class-&gt;discriminatorColumn-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$class</code>
+      <code>SimpleObjectHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleScalarHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php">
+    <MissingReturnType occurrences="2">
+      <code>deferPostLoadInvoking</code>
+      <code>hydrationComplete</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/LazyCriteriaCollection.php">
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$element</code>
+    </MoreSpecificImplementedParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LazyCriteriaCollection</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$entityPersister</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AbstractClassMetadataFactory.php">
+    <ImplementedReturnTypeMismatch occurrences="2">
+      <code>array</code>
+      <code>ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidNullableReturnType occurrences="1">
+      <code>ClassMetadata</code>
+    </InvalidNullableReturnType>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;loadedMetadata</code>
+    </InvalidPropertyAssignmentValue>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$class</code>
+    </MoreSpecificImplementedParamType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;loadedMetadata[$className]</code>
+    </NullableReturnStatement>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AssociationMetadata.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$reflectionService-&gt;getAccessibleProperty($this-&gt;declaringClass-&gt;getClassName(), $this-&gt;name)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$declaringClass</code>
+      <code>$reflection</code>
+      <code>$targetEntity</code>
+      <code>$sourceEntity</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$declaringClass</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ClassMetadata.php">
+    <DocblockTypeContradiction occurrences="5">
+      <code>$this-&gt;table</code>
+      <code>$type === InheritanceType::NONE</code>
+      <code>$type === InheritanceType::SINGLE_TABLE</code>
+      <code>$type === InheritanceType::JOINED</code>
+      <code>$type === InheritanceType::TABLE_PER_CLASS</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>$parent</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;fieldNames</code>
+      <code>$type</code>
+      <code>$this-&gt;fieldNames</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$columns</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$type</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="1">
+      <code>$fieldName</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="18">
+      <code>setClassName</code>
+      <code>validateAndCompleteFieldMapping</code>
+      <code>validateAndCompleteVersionFieldMapping</code>
+      <code>validateAndCompleteAssociationMapping</code>
+      <code>validateAndCompleteToOneAssociationMetadata</code>
+      <code>validateAndCompleteToManyAssociationMetadata</code>
+      <code>validateAndCompleteOneToOneMapping</code>
+      <code>validateAndCompleteManyToOneMapping</code>
+      <code>validateAndCompleteOneToManyMapping</code>
+      <code>validateAndCompleteManyToManyMapping</code>
+      <code>getIdentifierFieldNames</code>
+      <code>setIdentifier</code>
+      <code>getIdentifier</code>
+      <code>hasField</code>
+      <code>addProperty</code>
+      <code>addInheritedProperty</code>
+      <code>setCustomRepositoryClassName</code>
+      <code>addLifecycleCallback</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="9">
+      <code>$this-&gt;discriminatorColumn-&gt;getColumnName()</code>
+      <code>$this-&gt;getTableName()</code>
+      <code>$property-&gt;getType()</code>
+      <code>! $this-&gt;isMappedSuperclass ? $this-&gt;getTableName() : null</code>
+      <code>$referencedColumnName</code>
+      <code>$originalProperty</code>
+      <code>$this-&gt;getProperty($property-&gt;getName())</code>
+      <code>$discriminatorColumn-&gt;getColumnName()</code>
+      <code>$discriminatorColumn-&gt;getTableName() ?? $this-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="5">
+      <code>$this-&gt;fieldNames</code>
+      <code>$columns</code>
+      <code>$columns</code>
+      <code>$this-&gt;fieldNames</code>
+      <code>$this-&gt;fieldNames</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullOperand occurrences="2">
+      <code>$this-&gt;getSchemaName()</code>
+      <code>$this-&gt;getTableName()</code>
+    </PossiblyNullOperand>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$repositoryClassName</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="7">
+      <code>canRequireSQLConversion</code>
+      <code>getTargetEntity</code>
+      <code>isOwningSide</code>
+      <code>getMappedBy</code>
+      <code>getTargetEntity</code>
+      <code>getInverseJoinColumns</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$customRepositoryClassName</code>
+      <code>$discriminatorColumn</code>
+      <code>$table</code>
+      <code>$valueGenerationPlan</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$this-&gt;discriminatorColumn</code>
+      <code>$this-&gt;discriminatorColumn !== null &amp;&amp; $this-&gt;discriminatorColumn-&gt;getColumnName() === $columnName</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="11">
+      <code>getTargetEntity</code>
+      <code>isOwningSide</code>
+      <code>getMappedBy</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getColumnName</code>
+      <code>setInversedBy</code>
+      <code>getFetchMode</code>
+      <code>setFetchMode</code>
+      <code>getTableName</code>
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="4">
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;targetPlatform</code>
+    </DocblockTypeContradiction>
+    <InvalidClone occurrences="1">
+      <code>clone $parent-&gt;getCache()</code>
+    </InvalidClone>
+    <InvalidReturnType occurrences="1">
+      <code>Sequencing\Generator</code>
+    </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$parent-&gt;inheritanceType</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>new $class()</code>
+    </LessSpecificReturnStatement>
+    <MissingConstructor occurrences="1">
+      <code>$targetPlatform</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="2">
+      <code>setEntityManager</code>
+      <code>completeFieldIdentifierGeneratorMapping</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="8">
+      <code>$this-&gt;em</code>
+      <code>$this-&gt;em</code>
+      <code>$property-&gt;getTableName() ?? $tableName</code>
+      <code>$joinColumn-&gt;getTableName() ?? $tableName</code>
+      <code>$field-&gt;getTableName()</code>
+      <code>$field-&gt;getColumnName()</code>
+      <code>$class-&gt;getTableName()</code>
+      <code>$property-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;em-&gt;getConfiguration()-&gt;getMetadataDriverImpl()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="9">
+      <code>getConfiguration</code>
+      <code>getConfiguration</code>
+      <code>isAbstract</code>
+      <code>getType</code>
+      <code>getDefinition</code>
+      <code>getConnection</code>
+      <code>getType</code>
+      <code>getDefinition</code>
+      <code>getDefinition</code>
+    </PossiblyNullReference>
+    <UndefinedMethod occurrences="1">
+      <code>getSchemaName</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ColumnMetadata.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ComponentMetadata.php">
+    <InvalidArgument occurrences="1">
+      <code>$property</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="1">
+      <code>$property-&gt;getColumnName()</code>
+    </InvalidScalarArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;getProperty($propertyName)</code>
+    </PossiblyNullArgument>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_object($object)</code>
+    </DocblockTypeContradiction>
+    <InvalidStringClass occurrences="1">
+      <code>new $className()</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="1">
+      <code>register</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/AnnotationDriver.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Mapping\ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="2">
+      <code>$table</code>
+      <code>$tableAnnot</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $existingClass($fieldName)</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="3">
+      <code>addPaths</code>
+      <code>addExcludePaths</code>
+      <code>setFileExtension</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="38">
+      <code>$changeTrackingAnnot-&gt;value</code>
+      <code>$inheritanceTypeAnnot-&gt;value</code>
+      <code>$columnAnnot-&gt;type</code>
+      <code>$generatedValueAnnot-&gt;strategy</code>
+      <code>$seqGeneratorAnnot-&gt;sequenceName</code>
+      <code>$seqGeneratorAnnot-&gt;allocationSize</code>
+      <code>$customGeneratorAnnot-&gt;class</code>
+      <code>$customGeneratorAnnot-&gt;arguments</code>
+      <code>$oneToOneAnnot-&gt;targetEntity</code>
+      <code>$oneToOneAnnot-&gt;cascade</code>
+      <code>$oneToOneAnnot-&gt;orphanRemoval</code>
+      <code>$oneToOneAnnot-&gt;fetch</code>
+      <code>$oneToOneAnnot-&gt;mappedBy</code>
+      <code>$oneToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$manyToOneAnnot-&gt;targetEntity</code>
+      <code>$manyToOneAnnot-&gt;cascade</code>
+      <code>$manyToOneAnnot-&gt;fetch</code>
+      <code>$manyToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$oneToManyAnnot-&gt;targetEntity</code>
+      <code>$oneToManyAnnot-&gt;cascade</code>
+      <code>$oneToManyAnnot-&gt;orphanRemoval</code>
+      <code>$oneToManyAnnot-&gt;fetch</code>
+      <code>$oneToManyAnnot-&gt;mappedBy</code>
+      <code>$oneToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+      <code>$manyToManyAnnot-&gt;targetEntity</code>
+      <code>$manyToManyAnnot-&gt;cascade</code>
+      <code>$manyToManyAnnot-&gt;orphanRemoval</code>
+      <code>$manyToManyAnnot-&gt;fetch</code>
+      <code>$manyToManyAnnot-&gt;mappedBy</code>
+      <code>$manyToManyAnnot-&gt;inversedBy</code>
+      <code>$manyToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+      <code>$discriminatorMapAnnotation-&gt;value</code>
+      <code>$associationOverridesAnnot-&gt;value</code>
+      <code>$attributeOverridesAnnot-&gt;value</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$entityAnnot-&gt;repositoryClass !== null</code>
+      <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="9">
+      <code>$className</code>
+      <code>$metadata-&gt;getClassName()</code>
+      <code>$cacheAnnot</code>
+      <code>$columnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$override</code>
+      <code>$cacheAnnot</code>
+    </TypeCoercion>
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$parent-&gt;inheritanceType</code>
+      <code>$parent-&gt;table</code>
+    </UndefinedPropertyFetch>
+    <UnresolvableInclude occurrences="1">
+      <code>require_once $sourceFile</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EmbeddableClassMetadataBinder.php">
+    <UndefinedMethod occurrences="1">
+      <code>$this-&gt;classMetadata</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/EntityClassMetadataBinder.php">
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$entityAnnotation-&gt;repositoryClass !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;classAnnotations[Annotation\Entity::class]</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/Annotation/Binder/MappedSuperClassMetadataBinder.php">
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$mappedSuperclassAnnotation-&gt;repositoryClass !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;classAnnotations[Annotation\MappedSuperclass::class]</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Mapping\ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidStringClass occurrences="1">
+      <code>new $existingClass($fieldName)</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="3">
+      <code>addPaths</code>
+      <code>addExcludePaths</code>
+      <code>setFileExtension</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="38">
+      <code>$changeTrackingAnnot-&gt;value</code>
+      <code>$inheritanceTypeAnnot-&gt;value</code>
+      <code>$columnAnnot-&gt;type</code>
+      <code>$generatedValueAnnot-&gt;strategy</code>
+      <code>$seqGeneratorAnnot-&gt;sequenceName</code>
+      <code>$seqGeneratorAnnot-&gt;allocationSize</code>
+      <code>$customGeneratorAnnot-&gt;class</code>
+      <code>$customGeneratorAnnot-&gt;arguments</code>
+      <code>$oneToOneAnnot-&gt;targetEntity</code>
+      <code>$oneToOneAnnot-&gt;cascade</code>
+      <code>$oneToOneAnnot-&gt;orphanRemoval</code>
+      <code>$oneToOneAnnot-&gt;fetch</code>
+      <code>$oneToOneAnnot-&gt;mappedBy</code>
+      <code>$oneToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$manyToOneAnnot-&gt;targetEntity</code>
+      <code>$manyToOneAnnot-&gt;cascade</code>
+      <code>$manyToOneAnnot-&gt;fetch</code>
+      <code>$manyToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$oneToManyAnnot-&gt;targetEntity</code>
+      <code>$oneToManyAnnot-&gt;cascade</code>
+      <code>$oneToManyAnnot-&gt;orphanRemoval</code>
+      <code>$oneToManyAnnot-&gt;fetch</code>
+      <code>$oneToManyAnnot-&gt;mappedBy</code>
+      <code>$oneToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+      <code>$manyToManyAnnot-&gt;targetEntity</code>
+      <code>$manyToManyAnnot-&gt;cascade</code>
+      <code>$manyToManyAnnot-&gt;orphanRemoval</code>
+      <code>$manyToManyAnnot-&gt;fetch</code>
+      <code>$manyToManyAnnot-&gt;mappedBy</code>
+      <code>$manyToManyAnnot-&gt;inversedBy</code>
+      <code>$manyToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+      <code>$discriminatorMapAnnotation-&gt;value</code>
+      <code>$associationOverridesAnnot-&gt;value</code>
+      <code>$attributeOverridesAnnot-&gt;value</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$entityAnnot-&gt;repositoryClass !== null</code>
+      <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="11">
+      <code>$reader</code>
+      <code>$className</code>
+      <code>$metadata-&gt;getClassName()</code>
+      <code>$cacheAnnot</code>
+      <code>$columnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$tableAnnot</code>
+      <code>$override</code>
+      <code>$cacheAnnot</code>
+    </TypeCoercion>
+    <UndefinedPropertyFetch occurrences="3">
+      <code>$parent-&gt;inheritanceType</code>
+      <code>$parent-&gt;isMappedSuperclass</code>
+      <code>$parent-&gt;table</code>
+    </UndefinedPropertyFetch>
+    <UnresolvableInclude occurrences="1">
+      <code>require_once $sourceFile</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">
+    <InvalidArgument occurrences="3">
+      <code>$associationMapping</code>
+      <code>$associationMapping</code>
+      <code>$associationMapping</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;classNamesForTables</code>
+      <code>$this-&gt;fieldNamesForColumns</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="2">
+      <code>$table-&gt;getPrimaryKey()-&gt;getColumns()</code>
+      <code>$this-&gt;fieldNamesForColumns[$tableName][$columnName]</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2">
+      <code>Identifier[]</code>
+      <code>string</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="8">
+      <code>setNamespace</code>
+      <code>setClassNameForTable</code>
+      <code>setFieldNameForColumn</code>
+      <code>setTables</code>
+      <code>reverseEngineerMappingFromDatabase</code>
+      <code>buildTable</code>
+      <code>buildFieldMappings</code>
+      <code>buildToOneAssociationMappings</code>
+    </MissingReturnType>
+    <PossiblyInvalidOperand occurrences="1"/>
+    <PossiblyNullArgument occurrences="7">
+      <code>$metadata-&gt;getTableName()</code>
+      <code>$tableName</code>
+      <code>$tableName</code>
+      <code>$column-&gt;getLength()</code>
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$tableName</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="3">
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$this-&gt;tables</code>
+      <code>$this-&gt;tables</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullOperand occurrences="1">
+      <code>$this-&gt;namespace</code>
+    </PossiblyNullOperand>
+    <PossiblyNullReference occurrences="4">
+      <code>getColumns</code>
+      <code>getIndexes</code>
+      <code>getColumns</code>
+      <code>getColumns</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/DriverChain.php">
+    <MissingReturnType occurrences="2">
+      <code>setDefaultDriver</code>
+      <code>addDriver</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/FileDriver.php">
+    <MissingReturnType occurrences="3">
+      <code>setLocator</code>
+      <code>setGlobalBasename</code>
+      <code>initialize</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;globalBasename</code>
+      <code>$this-&gt;globalBasename</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/NewAnnotationDriver.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Mapping\ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="6">
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$this-&gt;getFetchMode($className, $oneToOneAnnot-&gt;fetch)</code>
+      <code>$this-&gt;getFetchMode($className, $manyToOneAnnot-&gt;fetch)</code>
+      <code>$this-&gt;getFetchMode($className, $oneToManyAnnot-&gt;fetch)</code>
+      <code>$this-&gt;getFetchMode($className, $manyToManyAnnot-&gt;fetch)</code>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="1">
+      <code>Mapping\Property</code>
+    </InvalidNullableReturnType>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$classMetadata</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>Mapping\ClassMetadata</code>
+    </MoreSpecificReturnType>
+    <NoInterfaceProperties occurrences="35">
+      <code>$columnAnnot-&gt;type</code>
+      <code>$columnAnnot-&gt;name</code>
+      <code>$columnAnnot-&gt;scale</code>
+      <code>$columnAnnot-&gt;precision</code>
+      <code>$columnAnnot-&gt;nullable</code>
+      <code>$columnAnnot-&gt;unique</code>
+      <code>$columnAnnot-&gt;columnDefinition</code>
+      <code>$columnAnnot-&gt;length</code>
+      <code>$oneToOneAnnot-&gt;targetEntity</code>
+      <code>$oneToOneAnnot-&gt;cascade</code>
+      <code>$oneToOneAnnot-&gt;orphanRemoval</code>
+      <code>$oneToOneAnnot-&gt;fetch</code>
+      <code>$oneToOneAnnot-&gt;mappedBy</code>
+      <code>$oneToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$manyToOneAnnot-&gt;targetEntity</code>
+      <code>$manyToOneAnnot-&gt;cascade</code>
+      <code>$manyToOneAnnot-&gt;fetch</code>
+      <code>$manyToOneAnnot-&gt;inversedBy</code>
+      <code>$joinColumnsAnnot-&gt;value</code>
+      <code>$oneToManyAnnot-&gt;targetEntity</code>
+      <code>$oneToManyAnnot-&gt;cascade</code>
+      <code>$oneToManyAnnot-&gt;orphanRemoval</code>
+      <code>$oneToManyAnnot-&gt;fetch</code>
+      <code>$oneToManyAnnot-&gt;mappedBy</code>
+      <code>$oneToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+      <code>$manyToManyAnnot-&gt;targetEntity</code>
+      <code>$manyToManyAnnot-&gt;cascade</code>
+      <code>$manyToManyAnnot-&gt;orphanRemoval</code>
+      <code>$manyToManyAnnot-&gt;fetch</code>
+      <code>$manyToManyAnnot-&gt;mappedBy</code>
+      <code>$manyToManyAnnot-&gt;inversedBy</code>
+      <code>$manyToManyAnnot-&gt;indexBy</code>
+      <code>$orderByAnnot-&gt;value</code>
+    </NoInterfaceProperties>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$fieldMetadata-&gt;getType()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>canRequireSQLConversion</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$entityAnnot-&gt;repositoryClass !== null</code>
+      <code>$mappedSuperclassAnnot-&gt;repositoryClass !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="12">
+      <code>$className</code>
+      <code>$cacheAnnot</code>
+      <code>$classMetadata</code>
+      <code>$classMetadata</code>
+      <code>$className</code>
+      <code>$cacheAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$cacheAnnot</code>
+      <code>$joinColumnAnnot</code>
+      <code>$cacheAnnot</code>
+      <code>$joinTableAnnot</code>
+      <code>$cacheAnnot</code>
+    </TypeCoercion>
+    <UndefinedMethod occurrences="1">
+      <code>getClassName</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php">
+    <MissingParamType occurrences="2">
+      <code>$prefixes</code>
+      <code>$fileExtension</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $existingClass($fieldName)</code>
+    </InvalidStringClass>
+    <MissingParamType occurrences="2">
+      <code>$locator</code>
+      <code>$fileExtension</code>
+    </MissingParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <TypeCoercion occurrences="1">
+      <code>$override</code>
+    </TypeCoercion>
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$parent-&gt;inheritanceType</code>
+      <code>$parent-&gt;table</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/EmbeddedClassMetadata.php">
+    <InvalidArgument occurrences="1">
+      <code>$parent</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$reflectionService-&gt;getAccessibleProperty($this-&gt;declaringClass-&gt;getClassName(), $this-&gt;name)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$declaringClass</code>
+      <code>$reflection</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$declaringClass</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/EntityClassMetadata.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$table</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>getVersion</code>
+    </UndefinedMethod>
+    <UndefinedPropertyAssignment occurrences="1">
+      <code>$superClassMetadata-&gt;subClasses</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/AssociationMetadataExporter.php">
+    <PossiblyNullOperand occurrences="2">
+      <code>$value-&gt;getMappedBy()</code>
+      <code>$value-&gt;getInversedBy()</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/ClassMetadataExporter.php">
+    <PossiblyNullOperand occurrences="1">
+      <code>$metadata-&gt;getCustomRepositoryClassName()</code>
+    </PossiblyNullOperand>
+    <PossiblyNullReference occurrences="2">
+      <code>getNamespaceName</code>
+      <code>getShortName</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$lines</code>
+    </PossiblyUndefinedVariable>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$metadata instanceof Mapping\MappedSuperClassMetadata</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/ColumnMetadataExporter.php">
+    <PossiblyNullOperand occurrences="2">
+      <code>$value-&gt;getColumnDefinition()</code>
+      <code>$value-&gt;getTableName()</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/DiscriminatorColumnMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/FieldMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/JoinColumnMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="2">
+      <code>$value-&gt;getReferencedColumnName()</code>
+      <code>$value-&gt;getAliasedName()</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/JoinTableMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/LocalColumnMetadataExporter.php">
+    <PossiblyNullOperand occurrences="3">
+      <code>$value-&gt;getLength()</code>
+      <code>$value-&gt;getScale()</code>
+      <code>$value-&gt;getPrecision()</code>
+    </PossiblyNullOperand>
+    <PossiblyNullReference occurrences="2">
+      <code>getType</code>
+      <code>getDefinition</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/TableMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="1">
+      <code>$value-&gt;getSchema()</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/ToManyAssociationMetadataExporter.php">
+    <PossiblyNullOperand occurrences="1">
+      <code>$value-&gt;getIndexedBy()</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Exporter/VersionFieldMetadataExporter.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/AbstractClassMetadataFactory.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;loaded</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="1">
+      <code>getMetadataFor</code>
+    </InvalidReturnType>
+    <InvalidStringClass occurrences="1">
+      <code>new $metadataFqcn($definition-&gt;parentClassMetadata)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$classMetadata</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="1">
+      <code>setMetadataFor</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>ClassMetadata</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/Autoloader.php">
+    <TypeDoesNotContainType occurrences="1">
+      <code>is_object($notFoundCallback)</code>
+    </TypeDoesNotContainType>
+    <UnresolvableInclude occurrences="1">
+      <code>require $file</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/ClassMetadataGenerator.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$definition-&gt;parentClassMetadata</code>
+    </PossiblyNullArgument>
+    <TooFewArguments occurrences="1">
+      <code>loadMetadataForClass</code>
+    </TooFewArguments>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/DefaultNamingStrategy.php">
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($className, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/RuntimeClassMetadataFactory.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;reflectionService</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$reflectionService</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/StaticClassMetadataFactory.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;reflectionService</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$reflectionService</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/Strategy/FileReaderClassMetadataGeneratorStrategy.php">
+    <UnresolvableInclude occurrences="1">
+      <code>require $filePath</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/Strategy/FileWriterClassMetadataGeneratorStrategy.php">
+    <MissingReturnType occurrences="1">
+      <code>ensureDirectoryIsReady</code>
+    </MissingReturnType>
+    <UnresolvableInclude occurrences="1">
+      <code>require $filePath</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Factory/UnderscoreNamingStrategy.php">
+    <MissingReturnType occurrences="1">
+      <code>setCase</code>
+    </MissingReturnType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($className, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/FieldMetadata.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$reflectionService-&gt;getAccessibleProperty($this-&gt;declaringClass-&gt;getClassName(), $this-&gt;name)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$declaringClass</code>
+      <code>$reflection</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/MappingException.php">
+    <PossiblyNullOperand occurrences="1">
+      <code>$path</code>
+    </PossiblyNullOperand>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getTypeName</code>
+      <code>getTypeName</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php">
+    <MethodSignatureMismatch occurrences="2">
+      <code>$object</code>
+      <code>$object</code>
+    </MethodSignatureMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/RootClassMetadata.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>RootClassMetadata</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/SubClassMetadata.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SubClassMetadata</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/TableMetadata.php">
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;name</code>
+      <code>$this-&gt;name</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/TransientMetadata.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$reflectionService-&gt;getAccessibleProperty($this-&gt;declaringClass-&gt;getClassName(), $this-&gt;name)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$declaringClass</code>
+      <code>$reflection</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$declaringClass</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/VersionFieldMetadata.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>VersionFieldMetadata</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/NativeQuery.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>mixed</code>
+    </LessSpecificImplementedReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>doExecute</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$sql</code>
+      <code>NativeQuery</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/ORMInvalidArgumentException.php">
+    <InvalidCast occurrences="1">
+      <code>$obj</code>
+    </InvalidCast>
+  </file>
+  <file src="lib/Doctrine/ORM/OptimisticLockException.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$expectedLockVersion instanceof DateTime</code>
+      <code>$actualLockVersion instanceof DateTime</code>
+    </DocblockTypeContradiction>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/PersistentCollection.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Collection|object[]</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidScalarArgument occurrences="2">
+      <code>spl_object_id($element)</code>
+      <code>spl_object_id($element)</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="7">
+      <code>setOwner</code>
+      <code>hydrateAdd</code>
+      <code>hydrateSet</code>
+      <code>takeSnapshot</code>
+      <code>changed</code>
+      <code>setDirty</code>
+      <code>setInitialized</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;association-&gt;getIndexedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$association-&gt;getInversedBy() ?: $association-&gt;getMappedBy()</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>setValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$owner</code>
+      <code>$association</code>
+      <code>$backRefFieldName</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="14">
+      <code>$this-&gt;association !== null</code>
+      <code>$this-&gt;association !== null</code>
+      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
+      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
+      <code>$this-&gt;owner !== null</code>
+      <code>$this-&gt;association-&gt;isOwningSide() &amp;&amp; $this-&gt;owner</code>
+      <code>is_object($this-&gt;collection)</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="1">
+      <code>andX</code>
+    </TooManyArguments>
+    <TooManyTemplateParams occurrences="1">
+      <code>Collection|object[]</code>
+    </TooManyTemplateParams>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/PersistentObject.php">
+    <MissingReturnType occurrences="3">
+      <code>setEntityManager</code>
+      <code>completeOwningSide</code>
+      <code>initializeDoctrine</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$mappedByField</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="5">
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getClassMetadata</code>
+      <code>getProperty</code>
+      <code>getClassName</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
+    <InvalidArgument occurrences="4">
+      <code>$types</code>
+      <code>$criteria</code>
+      <code>$types</code>
+      <code>$types</code>
+    </InvalidArgument>
+    <InvalidReturnStatement occurrences="2"/>
+    <InvalidReturnType occurrences="2">
+      <code>string[]|string[][]</code>
+      <code>string[]|string[][]</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="2">
+      <code>getDeleteSQL</code>
+      <code>getDeleteSQLParameters</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$deleteSql</code>
+      <code>$deleteTypes</code>
+      <code>$insertSql</code>
+      <code>$insertTypes</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="29">
+      <code>$referencedColumnName</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$owningAssociation-&gt;getMappedBy()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$indexByProperty-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="5">
+      <code>$sourceClass-&gt;fieldNames</code>
+      <code>$ownerMetadata-&gt;fieldNames</code>
+      <code>$sourceClass-&gt;fieldNames</code>
+      <code>$sourceClass-&gt;fieldNames</code>
+      <code>$targetClass-&gt;fieldNames</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="9">
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+      <code>getType</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getJoinTable</code>
+    </PossiblyUndefinedMethod>
+    <TypeCoercion occurrences="5">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="7">
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+      <code>getType</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="10">
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getIndexedBy</code>
+      <code>getJoinTable</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
+    <InvalidArgument occurrences="1">
+      <code>$criteria</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>delete</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$association-&gt;getMappedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="1">
+      <code>$association-&gt;getMappedBy()</code>
+    </PossiblyNullOperand>
+    <PossiblyNullReference occurrences="1">
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <TypeCoercion occurrences="3">
+      <code>$criteria</code>
+      <code>$association</code>
+      <code>$criteria</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;columns</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$data</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="4">
+      <code>$joinColumnMetadata-&gt;getTableName()</code>
+      <code>$joinColumnMetadata-&gt;getColumnName()</code>
+      <code>$joinColumnMetadata-&gt;getColumnName()</code>
+      <code>$columnType</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="2">
+      <code>$this-&gt;columns</code>
+      <code>$data</code>
+    </PossiblyNullArrayOffset>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
+    <DuplicateArrayKey occurrences="1">
+      <code>Comparison::IS          =&gt; '= %s'</code>
+    </DuplicateArrayKey>
+    <InvalidArgument occurrences="3">
+      <code>$type</code>
+      <code>$types</code>
+      <code>$types</code>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="1">
+      <code>loadById</code>
+    </InvalidNullableReturnType>
+    <InvalidPropertyAssignmentValue occurrences="4">
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="2">
+      <code>$result</code>
+      <code>$columns</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="3">
+      <code>mixed[]</code>
+      <code>loadToOneEntity</code>
+      <code>string[]</code>
+    </InvalidReturnType>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$this-&gt;conn-&gt;executeQuery($sql, $params, $types)</code>
+      <code>$this-&gt;conn-&gt;executeQuery($sql, $params, $types)</code>
+    </LessSpecificReturnStatement>
+    <MissingParamType occurrences="1">
+      <code>$entity</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>assignDefaultVersionValue</code>
+      <code>updateTable</code>
+      <code>deleteJoinTableRecords</code>
+      <code>getInsertSQL</code>
+      <code>switchPersisterContext</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>DriverStatement</code>
+      <code>Statement</code>
+    </MoreSpecificReturnType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullArgument occurrences="48">
+      <code>$versionProperty</code>
+      <code>$versionProperty-&gt;getColumnName()</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$column-&gt;getColumnName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$referencedColumnName</code>
+      <code>$versionProperty-&gt;getColumnName()</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$referencedColumnName</code>
+      <code>$referencedColumnName</code>
+      <code>$referencedColumnName</code>
+      <code>$referencedColumnName</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$association-&gt;getIndexedBy()</code>
+      <code>$association-&gt;getIndexedBy()</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$property-&gt;getTableName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$property-&gt;getIndexedBy()</code>
+      <code>$property-&gt;getMappedBy()</code>
+      <code>$eagerEntity-&gt;getTableName()</code>
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$sourceClass-&gt;getTableName()</code>
+      <code>$class-&gt;getTableName()</code>
+      <code>$columnName</code>
+      <code>$referencedColumnName</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getType()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$column-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$property-&gt;getTableName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$property-&gt;getMappedBy()</code>
+      <code>$referencedColumnName</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="8">
+      <code>$targetClass-&gt;fieldNames</code>
+      <code>$this-&gt;columns</code>
+      <code>$result</code>
+      <code>$this-&gt;columns</code>
+      <code>$result</code>
+      <code>$hints['fetched']['r']</code>
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="36">
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>convertToPHPValue</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>convertToDatabaseValueSQL</code>
+      <code>getType</code>
+      <code>getName</code>
+      <code>getJoinTable</code>
+      <code>getName</code>
+      <code>setValue</code>
+      <code>getJoinColumns</code>
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>getJoinTable</code>
+      <code>getTargetEntity</code>
+      <code>getValue</code>
+      <code>getSourceEntity</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+      <code>convertToDatabaseValueSQL</code>
+      <code>getName</code>
+      <code>getType</code>
+      <code>getTableName</code>
+      <code>getColumnName</code>
+      <code>getType</code>
+      <code>convertToDatabaseValueSQL</code>
+      <code>getJoinTable</code>
+      <code>isOwningSide</code>
+      <code>getDeclaringClass</code>
+      <code>getTargetEntity</code>
+      <code>getInverseJoinColumns</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>getTableName</code>
+      <code>getTableName</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$insertSql</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$property instanceof ToManyAssociationMetadata &amp;&amp; $property-&gt;getIndexedBy()</code>
+      <code>$this-&gt;insertSql !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="6">
+      <code>$versionProperty</code>
+      <code>$versionedClass</code>
+      <code>$versionedClass</code>
+      <code>$stmt</code>
+      <code>$stmt</code>
+      <code>$eagerProperty</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="19">
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getTargetEntity</code>
+      <code>getSourceEntity</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getColumnName</code>
+      <code>getTableName</code>
+      <code>getColumnName</code>
+      <code>getType</code>
+      <code>getJoinColumns</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getClassName</code>
+      <code>isIdentifierComposite</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="7">
+      <code>getIdentifierColumns</code>
+      <code>getTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getTableName</code>
+      <code>getJoinColumns</code>
+    </UndefinedMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$versionedClass-&gt;table</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$selectJoinSql</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php">
+    <MissingParamType occurrences="1">
+      <code>$entity</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_array($id)</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="1">
+      <code>$type</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingParamType occurrences="1">
+      <code>$entity</code>
+    </MissingParamType>
+    <PossiblyNullArgument occurrences="17">
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$rootClass-&gt;getTableName()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$rootClass-&gt;getTableName()</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$idColumn-&gt;getColumnName()</code>
+      <code>$referencedColumnName</code>
+      <code>$discrColumn-&gt;getTableName()</code>
+      <code>$discrColumnName</code>
+      <code>$discrColumn-&gt;getColumnName()</code>
+      <code>$discrColumnName</code>
+      <code>$discrColumnType</code>
+      <code>$referencedColumnName</code>
+      <code>$referencedColumnName</code>
+      <code>$idColumn-&gt;getColumnName()</code>
+      <code>$subClass-&gt;getTableName()</code>
+      <code>$idColumn-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="4">
+      <code>$subTableStmts</code>
+      <code>$insertData</code>
+      <code>$this-&gt;columns</code>
+      <code>$this-&gt;columns</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="4">
+      <code>getTableName</code>
+      <code>getDeclaringClass</code>
+      <code>hasValueGenerator</code>
+      <code>getValueGenerator</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>! is_array($id) || ! isset($id[$columnName])</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="1">
+      <code>$property-&gt;getDeclaringClass()</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="7">
+      <code>getInsertSQL</code>
+      <code>getInsertSQL</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>hasValueGenerator</code>
+      <code>getValueGenerator</code>
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="4">
+      <code>getTableName</code>
+      <code>getTableName</code>
+      <code>getTableName</code>
+      <code>getTableName</code>
+    </UndefinedMethod>
+    <UndefinedPropertyFetch occurrences="4">
+      <code>$versionedClass-&gt;table</code>
+      <code>$parentClass-&gt;table</code>
+      <code>$parentClass-&gt;table</code>
+      <code>$parentClass-&gt;table</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;columns</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="1">
+      <code>getInsertColumnList</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="9">
+      <code>$discrColumn-&gt;getTableName()</code>
+      <code>$discrColumnName</code>
+      <code>$discrColumn-&gt;getColumnName()</code>
+      <code>$discrColumnName</code>
+      <code>$discrColumnType</code>
+      <code>$referencedColumnName</code>
+      <code>$this-&gt;class-&gt;getTableName()</code>
+      <code>$discrColumn-&gt;getTableName()</code>
+      <code>$discrColumn-&gt;getColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$this-&gt;columns</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="1">
+      <code>convertToDatabaseValueSQL</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$columnList</code>
+    </PossiblyUndefinedVariable>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/SqlValueVisitor.php">
+    <InvalidReturnType occurrences="1">
+      <code>walkCompositeExpression</code>
+    </InvalidReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Proxy/Factory/StaticProxyFactory.php">
+    <PossiblyNullReference occurrences="4">
+      <code>isAbstract</code>
+      <code>getProperty</code>
+      <code>getDeclaringClass</code>
+      <code>getProperty</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Query.php">
+    <DocblockTypeContradiction occurrences="4">
+      <code>$this-&gt;resultSetMapping === null</code>
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;resultSetMapping === null</code>
+      <code>$this-&gt;queryCacheProfile === null</code>
+    </DocblockTypeContradiction>
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>mixed</code>
+    </LessSpecificImplementedReturnType>
+    <MissingReturnType occurrences="3">
+      <code>evictResultSetCache</code>
+      <code>evictEntityCacheRegion</code>
+      <code>free</code>
+    </MissingReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$hydrationMode</code>
+    </MoreSpecificImplementedParamType>
+    <PossiblyNullOperand occurrences="2">
+      <code>$this-&gt;maxResults</code>
+      <code>$this-&gt;maxResults</code>
+    </PossiblyNullOperand>
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$this-&gt;parse()-&gt;getResultSetMapping()</code>
+      <code>$this-&gt;parserResult-&gt;getResultSetMapping()</code>
+      <code>$timeToLive</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>delete</code>
+      <code>evictEntityRegion</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$dql</code>
+      <code>$parserResult</code>
+      <code>$firstResult</code>
+      <code>$queryCacheTTL</code>
+      <code>Query</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$this-&gt;queryCacheProfile</code>
+      <code>$this-&gt;queryCacheProfile === null || ! $this-&gt;getExpireResultCache()</code>
+      <code>$timeToLive !== null</code>
+      <code>$dqlQuery !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedMethod occurrences="1">
+      <code>getMetadataValue</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/AggregateExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/BetweenExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/CoalesceExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ComparisonExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalFactor.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalTerm.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/DeleteClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aliasIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/DeleteStatement.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ExistsExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/FromClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$simpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstArithmetic</code>
+      <code>$secondArithmetic</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstArithmetic</code>
+      <code>$secondArithmetic</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstStringPrimary</code>
+      <code>$secondStringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$firstDateExpression</code>
+      <code>$intervalExpression</code>
+      <code>$unit</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$this-&gt;unit-&gt;value</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$date1</code>
+      <code>$date2</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php">
+    <MissingReturnType occurrences="1">
+      <code>getSql</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DateSubFunction</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$this-&gt;unit-&gt;value</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php">
+    <InvalidMethodCall occurrences="1">
+      <code>getProperty</code>
+    </InvalidMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$tableName</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$pathExpression</code>
+      <code>$fieldMapping</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;fieldMapping !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
+    <InvalidScalarArgument occurrences="1"/>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;simpleArithmeticExpression</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstStringPrimary</code>
+      <code>$secondStringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstSimpleArithmeticExpression</code>
+      <code>$secondSimpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php">
+    <InvalidMethodCall occurrences="4">
+      <code>getProperty</code>
+      <code>getTableName</code>
+      <code>getTableName</code>
+      <code>getTableName</code>
+    </InvalidMethodCall>
+    <PossiblyNullArgument occurrences="2">
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$association-&gt;getMappedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getJoinTable</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$collectionPathExpression</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$simpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$sqlWalker-&gt;walkSimpleArithmeticExpression($this-&gt;firstSimpleArithmeticExpression)</code>
+      <code>$optionalSecondSimpleArithmeticExpression</code>
+    </InvalidScalarArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$stringPrimary</code>
+      <code>$firstSimpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php">
+    <MissingReturnType occurrences="1">
+      <code>parseTrimMode</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$leading</code>
+      <code>$trailing</code>
+      <code>$both</code>
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/GroupByClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/HavingClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/InExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/IndexBy.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/InputParameter.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$not</code>
+      <code>$value</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Join.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>walkJoinPathExpression</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>walkJoinVariableDeclaration</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/LikeExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Literal.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NewObjectExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Node.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_array($obj)</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($obj)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NullIfExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/OrderByClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/OrderByItem.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/PathExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectStatement.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$fieldIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>walkWhenClauseExpression</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Subselect.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SubselectFromClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aliasIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateItem.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateStatement.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/WhenClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>walkWhenClauseExpression</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/WhereClause.php">
+    <MissingReturnType occurrences="1">
+      <code>dispatch</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
+    <MissingReturnType occurrences="2">
+      <code>setQueryCacheProfile</code>
+      <code>removeQueryCacheProfile</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php">
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$primaryClass-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MultiTableDeleteExecutor</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$AST-&gt;deleteClause</code>
+      <code>$AST-&gt;whereClause</code>
+    </UndefinedPropertyFetch>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;sqlStatements</code>
+    </UninitializedProperty>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php">
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$primaryClass-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MultiTableUpdateExecutor</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyFetch occurrences="2">
+      <code>$AST-&gt;updateClause</code>
+      <code>$AST-&gt;whereClause</code>
+    </UndefinedPropertyFetch>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;sqlStatements</code>
+    </UninitializedProperty>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;sqlStatements</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$sqlWalker-&gt;walkSelectStatement($AST)</code>
+    </InvalidPropertyAssignmentValue>
+    <MoreSpecificReturnType occurrences="1">
+      <code>execute</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleSelectExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;sqlStatements</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$sqlWalker-&gt;walkUpdateStatement($AST)</code>
+      <code>$sqlWalker-&gt;walkDeleteStatement($AST)</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleTableDeleteUpdateExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$val . ' BETWEEN ' . $x . ' AND ' . $y</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>Expr\Func</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="1">
+      <code>$y</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Composite.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_object($part)</code>
+    </DocblockTypeContradiction>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/From.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$indexBy</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Join.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$alias</code>
+      <code>$conditionType</code>
+      <code>$condition</code>
+      <code>$indexBy</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/OrderBy.php">
+    <MissingReturnType occurrences="1">
+      <code>add</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/FilterCollection.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $filterClass($this-&gt;em)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;enabledFilters[$name]</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="1">
+      <code>setFiltersStateDirty</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>SQLFilter</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$filterHash</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;enabledFilters</code>
+    </TypeCoercion>
+    <UndefinedClass occurrences="1">
+      <code>new $filterClass($this-&gt;em)</code>
+    </UndefinedClass>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Lexer.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Lexer</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Parameter.php">
+    <MissingReturnType occurrences="1">
+      <code>setValue</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Parser.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;lexer-&gt;lookahead === null</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="4">
+      <code>$AST</code>
+      <code>$identificationVariables</code>
+      <code>$groupByItems</code>
+      <code>$expression</code>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="6">
+      <code>mixed[]</code>
+      <code>AST\SelectStatement|AST\UpdateStatement|AST\DeleteStatement</code>
+      <code>AST\Literal</code>
+      <code>string</code>
+      <code>Functions\FunctionNode</code>
+      <code>Functions\FunctionNode</code>
+    </InvalidNullableReturnType>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$className</code>
+      <code>$literals</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="6">
+      <code>new AST\InputParameter($this-&gt;lexer-&gt;token['value'])</code>
+      <code>new AST\JoinAssociationDeclaration($joinAssociationPathExpression, $aliasIdentificationVariable, $indexBy)</code>
+      <code>$conditionalTerms[0]</code>
+      <code>$conditionalFactors[0]</code>
+      <code>$conditionalPrimary</code>
+      <code>$this-&gt;SimpleEntityExpression()</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="6">
+      <code>AST\ArithmeticExpression</code>
+      <code>AST\JoinAssociationPathExpression</code>
+      <code>AST\ConditionalExpression</code>
+      <code>AST\ConditionalTerm</code>
+      <code>AST\ConditionalFactor</code>
+      <code>AST\PathExpression</code>
+    </InvalidReturnType>
+    <InvalidStringClass occurrences="6">
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $functionClass($functionName)</code>
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $functionClass($functionName)</code>
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $functionClass($functionName)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="3">
+      <code>$function</code>
+      <code>$function</code>
+      <code>$function</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="16">
+      <code>setCustomOutputTreeWalker</code>
+      <code>addCustomTreeWalker</code>
+      <code>match</code>
+      <code>free</code>
+      <code>fixIdentificationVariableOrder</code>
+      <code>syntaxError</code>
+      <code>semanticalError</code>
+      <code>processDeferredIdentificationVariables</code>
+      <code>processDeferredNewObjectExpressions</code>
+      <code>processDeferredPartialObjectExpressions</code>
+      <code>processDeferredResultVariables</code>
+      <code>processDeferredPathExpressions</code>
+      <code>processRootEntityAliasSelected</code>
+      <code>SimpleConditionalExpression</code>
+      <code>ArithmeticPrimary</code>
+      <code>StringPrimary</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="3">
+      <code>Functions\FunctionNode</code>
+      <code>Functions\FunctionNode</code>
+      <code>Functions\FunctionNode</code>
+    </MoreSpecificReturnType>
+    <NullableReturnStatement occurrences="4">
+      <code>$token</code>
+      <code>$statement</code>
+      <code>null</code>
+      <code>null</code>
+    </NullableReturnStatement>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($fromClassName, '\\')</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$stringExpr</code>
+      <code>$expr</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="6">
+      <code>$peek</code>
+      <code>$peek</code>
+      <code>$peek</code>
+      <code>$functionClass</code>
+      <code>$functionClass</code>
+      <code>$functionClass</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="30">
+      <code>$peek['type']</code>
+      <code>$qComp['nestingLevel']</code>
+      <code>$qComp['nestingLevel']</code>
+      <code>$qComp['metadata']</code>
+      <code>$glimpse['type']</code>
+      <code>$glimpse['type']</code>
+      <code>$next['type']</code>
+      <code>$this-&gt;lexer-&gt;glimpse()['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$token['type']</code>
+      <code>$peek['value']</code>
+      <code>$token['type']</code>
+      <code>$token['value']</code>
+      <code>$token['type']</code>
+      <code>$lookahead['type']</code>
+      <code>$lookahead['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['value']</code>
+      <code>$peek['value']</code>
+      <code>$peek['type']</code>
+      <code>$peek['value']</code>
+      <code>$glimpse['value']</code>
+      <code>$glimpse['type']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>getNumberOfRequiredParameters</code>
+      <code>getProperty</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$args</code>
+    </PossiblyUndefinedVariable>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$customOutputWalker</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$AST instanceof AST\SelectStatement</code>
+      <code>sprintf("'%s'", $token['value'])</code>
+      <code>$this-&gt;lexer-&gt;lookahead !== null</code>
+      <code>$customFunctionDeclaration !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedClass occurrences="1">
+      <code>new $outputWalkerClass($this-&gt;query, $this-&gt;parserResult, $this-&gt;queryComponents)</code>
+    </UndefinedClass>
+    <UndefinedMethod occurrences="1">
+      <code>getEntityNamespace</code>
+    </UndefinedMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$AST-&gt;selectClause</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ParserResult.php">
+    <MissingReturnType occurrences="3">
+      <code>setResultSetMapping</code>
+      <code>setSqlExecutor</code>
+      <code>addParameterMapping</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$sqlExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Printer.php">
+    <MissingReturnType occurrences="3">
+      <code>startProduction</code>
+      <code>endProduction</code>
+      <code>println</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/QueryException.php">
+    <PossiblyNullOperand occurrences="1">
+      <code>$pathExpr-&gt;field</code>
+    </PossiblyNullOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/QueryExpressionVisitor.php">
+    <MissingReturnType occurrences="1">
+      <code>clearParameters</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ResultSetMapping.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;entityMappings</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;relationMap[$alias]</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>AssociationMetadata</code>
+    </InvalidReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <MissingReturnType occurrences="2">
+      <code>addRootEntityFromClassMetadata</code>
+      <code>addJoinedEntityFromClassMetadata</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="7">
+      <code>$columnName</code>
+      <code>$columnName</code>
+      <code>$columnName</code>
+      <code>$columnName</code>
+      <code>$referencedColumnName</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getType()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getColumnName</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
+    <DocblockTypeContradiction occurrences="9">
+      <code>''</code>
+      <code>$condExpr instanceof AST\ConditionalExpression</code>
+      <code>$condTerm instanceof AST\ConditionalTerm</code>
+      <code>! ($factor instanceof AST\ConditionalFactor)</code>
+      <code>is_string($expression)</code>
+      <code>is_string($stringExpr)</code>
+      <code>is_numeric($leftExpr) ? $leftExpr : $this-&gt;conn-&gt;quote($leftExpr)</code>
+      <code>is_numeric($rightExpr) ? $rightExpr : $this-&gt;conn-&gt;quote($rightExpr)</code>
+      <code>$simpleArithmeticExpr instanceof AST\SimpleArithmeticExpression</code>
+    </DocblockTypeContradiction>
+    <ImplicitToStringCast occurrences="1">
+      <code>$expr</code>
+    </ImplicitToStringCast>
+    <InvalidPropertyAssignmentValue occurrences="4">
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarFields</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="3">
+      <code>$resultAlias</code>
+      <code>$resultAlias</code>
+      <code>$resultAlias</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;query</code>
+    </LessSpecificReturnStatement>
+    <MissingParamType occurrences="1">
+      <code>$inParam</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>walkIndexBy</code>
+      <code>walkInParameter</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>Query</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$aggExpression-&gt;pathExpression</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="48">
+      <code>$class-&gt;getTableName()</code>
+      <code>$column-&gt;getColumnName()</code>
+      <code>$subClass-&gt;getTableName()</code>
+      <code>$column-&gt;getColumnName()</code>
+      <code>$AST-&gt;whereClause</code>
+      <code>$AST-&gt;whereClause</code>
+      <code>$AST-&gt;whereClause</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getTableName()</code>
+      <code>$referencedColumnName</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getType()</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getTableName()</code>
+      <code>$referencedColumnName</code>
+      <code>$columnName</code>
+      <code>$joinColumn-&gt;getType()</code>
+      <code>$identificationVariableDecl-&gt;rangeVariableDeclaration</code>
+      <code>$field</code>
+      <code>$class-&gt;getTableName()</code>
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$sourceClass-&gt;getTableName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$joinTable-&gt;getName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$association-&gt;getIndexedBy()</code>
+      <code>$class-&gt;getTableName()</code>
+      <code>$resultAlias</code>
+      <code>$property-&gt;getTableName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$property-&gt;getTableName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$subselect-&gt;whereClause</code>
+      <code>$tableName</code>
+      <code>$tableName</code>
+      <code>$tableName</code>
+      <code>$tableName</code>
+      <code>$condExpr</code>
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$targetColumn-&gt;getColumnName()</code>
+      <code>$targetClass-&gt;getTableName()</code>
+      <code>$targetColumn-&gt;getColumnName()</code>
+      <code>$arithmeticExpr-&gt;simpleArithmeticExpression</code>
+      <code>$arithmeticExpr-&gt;subselect</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="4">
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarFields[$dqlAlias]</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$parserResult-&gt;getResultSetMapping()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="7">
+      <code>getQuotedQualifiedName</code>
+      <code>convertToPHPValueSQL</code>
+      <code>convertToPHPValueSQL</code>
+      <code>dispatch</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>isSubclassOf</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+    </PossiblyUndefinedMethod>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$whereClause !== null</code>
+      <code>($factor-&gt;not ? 'NOT ' : '') . $this-&gt;walkConditionalPrimary($factor-&gt;conditionalPrimary)</code>
+      <code>$leftExpr instanceof AST\Node</code>
+      <code>$rightExpr instanceof AST\Node</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="2">
+      <code>$parentClass</code>
+      <code>$scalarExpression</code>
+    </TypeCoercion>
+    <UndefinedMethod occurrences="3">
+      <code>getTableName</code>
+      <code>getMaxResults</code>
+      <code>getFirstResult</code>
+    </UndefinedMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$parentClass-&gt;table</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerAdapter.php">
+    <InvalidReturnType occurrences="47">
+      <code>walkSelectStatement</code>
+      <code>walkSelectClause</code>
+      <code>walkFromClause</code>
+      <code>walkFunction</code>
+      <code>walkOrderByClause</code>
+      <code>walkOrderByItem</code>
+      <code>walkHavingClause</code>
+      <code>walkJoin</code>
+      <code>walkSelectExpression</code>
+      <code>walkQuantifiedExpression</code>
+      <code>walkSubselect</code>
+      <code>walkSubselectFromClause</code>
+      <code>walkSimpleSelectClause</code>
+      <code>walkSimpleSelectExpression</code>
+      <code>walkAggregateExpression</code>
+      <code>walkGroupByClause</code>
+      <code>walkGroupByItem</code>
+      <code>walkUpdateStatement</code>
+      <code>walkDeleteStatement</code>
+      <code>walkDeleteClause</code>
+      <code>walkUpdateClause</code>
+      <code>walkUpdateItem</code>
+      <code>walkWhereClause</code>
+      <code>walkConditionalExpression</code>
+      <code>walkConditionalTerm</code>
+      <code>walkConditionalFactor</code>
+      <code>walkConditionalPrimary</code>
+      <code>walkExistsExpression</code>
+      <code>walkCollectionMemberExpression</code>
+      <code>walkEmptyCollectionComparisonExpression</code>
+      <code>walkNullComparisonExpression</code>
+      <code>walkInExpression</code>
+      <code>walkInstanceOfExpression</code>
+      <code>walkLiteral</code>
+      <code>walkBetweenExpression</code>
+      <code>walkLikeExpression</code>
+      <code>walkStateFieldPathExpression</code>
+      <code>walkComparisonExpression</code>
+      <code>walkInputParameter</code>
+      <code>walkArithmeticExpression</code>
+      <code>walkArithmeticTerm</code>
+      <code>walkStringPrimary</code>
+      <code>walkArithmeticFactor</code>
+      <code>walkSimpleArithmeticExpression</code>
+      <code>walkPathExpression</code>
+      <code>walkResultVariable</code>
+      <code>getExecutor</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="2">
+      <code>$query</code>
+      <code>$parserResult</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerChain.php">
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>new TreeWalkerChainIterator($this, $query, $parserResult)</code>
+      <code>$this-&gt;walkers</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="47">
+      <code>walkSelectStatement</code>
+      <code>walkSelectClause</code>
+      <code>walkFromClause</code>
+      <code>walkFunction</code>
+      <code>walkOrderByClause</code>
+      <code>walkOrderByItem</code>
+      <code>walkHavingClause</code>
+      <code>walkJoin</code>
+      <code>walkSelectExpression</code>
+      <code>walkQuantifiedExpression</code>
+      <code>walkSubselect</code>
+      <code>walkSubselectFromClause</code>
+      <code>walkSimpleSelectClause</code>
+      <code>walkSimpleSelectExpression</code>
+      <code>walkAggregateExpression</code>
+      <code>walkGroupByClause</code>
+      <code>walkGroupByItem</code>
+      <code>walkUpdateStatement</code>
+      <code>walkDeleteStatement</code>
+      <code>walkDeleteClause</code>
+      <code>walkUpdateClause</code>
+      <code>walkUpdateItem</code>
+      <code>walkWhereClause</code>
+      <code>walkConditionalExpression</code>
+      <code>walkConditionalTerm</code>
+      <code>walkConditionalFactor</code>
+      <code>walkConditionalPrimary</code>
+      <code>walkExistsExpression</code>
+      <code>walkCollectionMemberExpression</code>
+      <code>walkEmptyCollectionComparisonExpression</code>
+      <code>walkNullComparisonExpression</code>
+      <code>walkInExpression</code>
+      <code>walkInstanceOfExpression</code>
+      <code>walkLiteral</code>
+      <code>walkBetweenExpression</code>
+      <code>walkLikeExpression</code>
+      <code>walkStateFieldPathExpression</code>
+      <code>walkComparisonExpression</code>
+      <code>walkInputParameter</code>
+      <code>walkArithmeticExpression</code>
+      <code>walkArithmeticTerm</code>
+      <code>walkStringPrimary</code>
+      <code>walkArithmeticFactor</code>
+      <code>walkSimpleArithmeticExpression</code>
+      <code>walkPathExpression</code>
+      <code>walkResultVariable</code>
+      <code>getExecutor</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="2">
+      <code>$query</code>
+      <code>$parserResult</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>addTreeWalker</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php">
+    <InvalidReturnType occurrences="1">
+      <code>rewind</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="2">
+      <code>$query</code>
+      <code>$parserResult</code>
+    </MissingParamType>
+    <UndefinedClass occurrences="1"/>
+  </file>
+  <file src="lib/Doctrine/ORM/QueryBuilder.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>int</code>
+    </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$key</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="1">
+      <code>$queryPartName</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>where</code>
+      <code>andWhere</code>
+      <code>orWhere</code>
+      <code>resetDQLParts</code>
+    </MissingReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;cacheMode</code>
+    </NullableReturnStatement>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$spacePos</code>
+      <code>$spacePos</code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand occurrences="2">
+      <code>$spacePos</code>
+      <code>$spacePos</code>
+    </PossiblyFalseOperand>
+    <PossiblyNullArgument occurrences="2">
+      <code>$alias</code>
+      <code>$alias</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$dql</code>
+      <code>$firstResult</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;dql !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Reflection/RuntimeReflectionService.php">
+    <TypeCoercion occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Reflection/StaticReflectionService.php">
+    <PossiblyFalseOperand occurrences="2">
+      <code>strrpos($className, '\\')</code>
+      <code>strpos(strrev($className), '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $repositoryClassName($entityManager, $metadata)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>new $repositoryClassName($entityManager, $metadata)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>ObjectRepository</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Sequencing/BigIntegerIdentityGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$sequenceName</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Sequencing/IdentityGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$sequenceName</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Sequencing/Planning/ColumnValueGeneratorExecutor.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>[$this-&gt;column-&gt;getColumnName() =&gt; $convertedValue]</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>convertToPHPValue</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Sequencing/TableGenerator.php">
+    <PossiblyFalseOperand occurrences="3">
+      <code>$this-&gt;nextValue</code>
+      <code>$currentLevel</code>
+      <code>$this-&gt;nextValue</code>
+    </PossiblyFalseOperand>
+    <PossiblyNullOperand occurrences="1">
+      <code>$this-&gt;nextValue</code>
+    </PossiblyNullOperand>
+    <UndefinedMethod occurrences="2">
+      <code>getTableHiLoCurrentValSql</code>
+      <code>getTableHiLoUpdateNextValSql</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php">
+    <MissingReturnType occurrences="2">
+      <code>addEntityListener</code>
+      <code>loadClassMetadata</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php">
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php">
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($queryRegion)</code>
+    </DocblockTypeContradiction>
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($queryRegion)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php">
+    <InvalidArgument occurrences="2">
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+    </InvalidArgument>
+    <InvalidMethodCall occurrences="1">
+      <code>getClassName</code>
+    </InvalidMethodCall>
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <TooManyArguments occurrences="1">
+      <code>generateProxyClasses</code>
+    </TooManyArguments>
+    <UndefinedMethod occurrences="2">
+      <code>getProxyDir</code>
+      <code>getProxyDir</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getAllClassNames</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php">
+    <InvalidArgument occurrences="2">
+      <code>$metadata-&gt;entityListeners</code>
+      <code>$parentClass-&gt;getParent()</code>
+    </InvalidArgument>
+    <InvalidReturnStatement occurrences="6">
+      <code>$output</code>
+      <code>$value</code>
+      <code>$output</code>
+      <code>$output</code>
+      <code>$this-&gt;formatField('Entity listeners', array_map('get_class', $entityListeners))</code>
+      <code>$output</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="6">
+      <code>string[]</code>
+      <code>string</code>
+      <code>string[]</code>
+      <code>string[]</code>
+      <code>string</code>
+      <code>string[]</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="2">
+      <code>configure</code>
+      <code>displayEntity</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="4">
+      <code>getName</code>
+      <code>getAllClassNames</code>
+      <code>getType</code>
+      <code>getDefinition</code>
+    </PossiblyNullReference>
+    <RawObjectIteration occurrences="1">
+      <code>$property</code>
+    </RawObjectIteration>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php">
+    <InvalidReturnType occurrences="1">
+      <code>execute</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php">
+    <InvalidArgument occurrences="1">
+      <code>$metadatas</code>
+    </InvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php">
+    <InvalidArgument occurrences="1">
+      <code>$errorMessages</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/MetadataFilter.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;getInnerIterator()</code>
+    </InvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">
+    <MissingReturnType occurrences="2">
+      <code>onFlush</code>
+      <code>dumpIdentityMap</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php">
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$query</code>
+    </MoreSpecificImplementedParamType>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$this-&gt;queryComponents</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$parserResult-&gt;getResultSetMapping()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$fromRoot-&gt;rangeVariableDeclaration-&gt;aliasIdentificationVariable</code>
+    </PossiblyNullPropertyFetch>
+    <UndefinedMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/CountWalker.php">
+    <InvalidReturnType occurrences="1">
+      <code>walkSelectStatement</code>
+    </InvalidReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$rootAlias</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$queryComponents</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$fromRoot-&gt;rangeVariableDeclaration-&gt;aliasIdentificationVariable</code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/Exception/RowNumberOverFunctionNotEnabled.php">
+    <MissingReturnType occurrences="1">
+      <code>create</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php">
+    <InvalidArgument occurrences="1">
+      <code>$fields</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="2">
+      <code>rebuildOrderByForRowNumber</code>
+      <code>addMissingItemsFromOrderByToSelect</code>
+    </MissingReturnType>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$query</code>
+    </MoreSpecificImplementedParamType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($orderByItemString, ' ')</code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArrayOffset occurrences="3">
+      <code>$selectAliasToExpressionMap</code>
+      <code>$selects[$idVar]</code>
+      <code>$this-&gt;queryComponents</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullIterator occurrences="1">
+      <code>$orderByClause-&gt;orderByItems</code>
+    </PossiblyNullIterator>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$parserResult-&gt;getResultSetMapping()</code>
+      <code>$query-&gt;getMaxResults()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$orderByClause-&gt;orderByItems</code>
+      <code>$fromRoot-&gt;rangeVariableDeclaration-&gt;aliasIdentificationVariable</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$em</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$selectExpression instanceof SelectExpression</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>clone $pathExpression</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2">
+      <code>walkSelectStatement</code>
+      <code>IdentityFunction</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>validate</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$rootAlias</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$queryComponents</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$fromRoot-&gt;rangeVariableDeclaration-&gt;aliasIdentificationVariable</code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/Paginator.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;count === null</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="1">
+      <code>appendTreeWalker</code>
+    </MissingReturnType>
+    <NullArgument occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </NullArgument>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>array_sum(array_map('current', $this-&gt;getCountQuery()-&gt;getScalarResult()))</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$count</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$parameters</code>
+    </TypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$orderByClause</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression instanceof ConditionalPrimary</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="4">
+      <code>[$pathExpression]</code>
+      <code>[$conditionalPrimary]</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$expression-&gt;literals</code>
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression-&gt;conditionalFactors</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="1">
+      <code>walkSelectStatement</code>
+    </InvalidReturnType>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullArgument occurrences="1">
+      <code>$rootAlias</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$queryComponents</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$fromRoot-&gt;rangeVariableDeclaration-&gt;aliasIdentificationVariable</code>
+    </PossiblyNullPropertyFetch>
+    <RedundantConditionGivenDocblockType occurrences="1"/>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php">
+    <InvalidArgument occurrences="2">
+      <code>$resolvedMetadata</code>
+      <code>$class</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="3">
+      <code>addResolveTargetEntity</code>
+      <code>onClassMetadataNotFound</code>
+      <code>loadClassMetadata</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/SchemaTool.php">
+    <InvalidArgument occurrences="6">
+      <code>$processedClasses</code>
+      <code>$pkColumns</code>
+      <code>$pkColumns</code>
+      <code>[$columnName]</code>
+      <code>$primaryKeyColumns</code>
+      <code>$unique['columns']</code>
+    </InvalidArgument>
+    <InvalidNullableReturnType occurrences="1">
+      <code>mixed[]</code>
+    </InvalidNullableReturnType>
+    <MissingReturnType occurrences="8">
+      <code>createSchema</code>
+      <code>addDiscriminatorColumnDefinition</code>
+      <code>gatherColumns</code>
+      <code>gatherRelationsSql</code>
+      <code>gatherRelationJoinColumns</code>
+      <code>dropSchema</code>
+      <code>dropDatabase</code>
+      <code>updateSchema</code>
+    </MissingReturnType>
+    <NullableReturnStatement occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="13">
+      <code>$property-&gt;getColumnName()</code>
+      <code>$idProperty</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$indexName</code>
+      <code>$indexName</code>
+      <code>$discrColumn-&gt;getColumnName()</code>
+      <code>$property-&gt;getColumnName()</code>
+      <code>$fieldMetadata-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$joinColumn-&gt;getColumnName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="7">
+      <code>getType</code>
+      <code>getDefinition</code>
+      <code>getDefinition</code>
+      <code>getName</code>
+      <code>getType</code>
+      <code>getQuotedQualifiedName</code>
+      <code>getColumns</code>
+    </PossiblyNullReference>
+    <RedundantCondition occurrences="2">
+      <code>is_numeric($indexName)</code>
+      <code>$indexName</code>
+    </RedundantCondition>
+    <TypeCoercion occurrences="1">
+      <code>$idProperty</code>
+    </TypeCoercion>
+    <UndefinedMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$property-&gt;getDeclaringClass()-&gt;isMappedSuperclass</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/SchemaValidator.php">
+    <DocblockTypeContradiction occurrences="4">
+      <code>$targetAssociation</code>
+      <code>$targetAssociation instanceof FieldMetadata</code>
+      <code>$targetAssociation</code>
+      <code>$targetAssociation instanceof FieldMetadata</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="2">
+      <code>$class</code>
+      <code>$allMetadata</code>
+    </InvalidArgument>
+    <PossiblyNullArgument occurrences="6">
+      <code>$mappedBy</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$inverseJoinColumn-&gt;getReferencedColumnName()</code>
+      <code>$joinTable-&gt;getName()</code>
+      <code>$joinTable-&gt;getName()</code>
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <RedundantCondition occurrences="1">
+      <code>$targetProperty instanceof AssociationMetadata &amp;&amp; ! $targetProperty-&gt;isOwningSide()</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$targetAssociation</code>
+      <code>$targetAssociation</code>
+      <code>$targetAssociation</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getClassName</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/UnitOfWork.php">
+    <DocblockTypeContradiction occurrences="5">
+      <code>$this-&gt;entityDeletions</code>
+      <code>$owner === null</code>
+      <code>$entity === null</code>
+      <code>is_object($object)</code>
+      <code>is_object($object)</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="2">
+      <code>$collectionToDelete</code>
+      <code>$collectionToUpdate</code>
+    </InvalidArgument>
+    <InvalidArrayAccess occurrences="9">
+      <code>$this-&gt;identityMap[$className][$idHash]</code>
+      <code>$this-&gt;identityMap[$className][$idHash]</code>
+      <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
+      <code>$this-&gt;identityMap[$classMetadata-&gt;getRootClassName()][$idHash]</code>
+      <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
+      <code>$this-&gt;identityMap[$class-&gt;getRootClassName()][$idHash]</code>
+      <code>$this-&gt;identityMap[$class-&gt;getRootClassName()][$idHash]</code>
+      <code>$this-&gt;identityMap[$targetClass-&gt;getRootClassName()][$relatedIdHash]</code>
+      <code>$this-&gt;identityMap[$targetClass-&gt;getRootClassName()][$relatedIdHash]</code>
+    </InvalidArrayAccess>
+    <InvalidArrayAssignment occurrences="2">
+      <code>$this-&gt;identityMap[$className][$idHash]</code>
+      <code>$this-&gt;identityMap[$class-&gt;getRootClassName()][$idHash]</code>
+    </InvalidArrayAssignment>
+    <InvalidCast occurrences="1">
+      <code>$obj</code>
+    </InvalidCast>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;extraUpdates</code>
+      <code>$this-&gt;readOnlyObjects</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>array_sum(array_map('count', $this-&gt;identityMap))</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>int</code>
+    </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$weight</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$calc-&gt;sort()</code>
+    </LessSpecificReturnStatement>
+    <MissingReturnType occurrences="40">
+      <code>commit</code>
+      <code>computeScheduleInsertsChangeSets</code>
+      <code>executeExtraUpdates</code>
+      <code>computeChangeSet</code>
+      <code>computeChangeSets</code>
+      <code>computeAssociationChanges</code>
+      <code>persistNew</code>
+      <code>executeUpdates</code>
+      <code>executeDeletions</code>
+      <code>scheduleForInsert</code>
+      <code>scheduleForDelete</code>
+      <code>persist</code>
+      <code>doPersist</code>
+      <code>remove</code>
+      <code>doRemove</code>
+      <code>refresh</code>
+      <code>doRefresh</code>
+      <code>cascadeRefresh</code>
+      <code>cascadePersist</code>
+      <code>cascadeRemove</code>
+      <code>lock</code>
+      <code>clear</code>
+      <code>scheduleOrphanRemoval</code>
+      <code>cancelOrphanRemoval</code>
+      <code>scheduleCollectionDeletion</code>
+      <code>triggerEagerLoads</code>
+      <code>loadCollection</code>
+      <code>setOriginalEntityData</code>
+      <code>setOriginalEntityProperty</code>
+      <code>scheduleForSynchronization</code>
+      <code>registerManaged</code>
+      <code>clearEntityChangeSet</code>
+      <code>initializeObject</code>
+      <code>markReadOnly</code>
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+      <code>performCallbackOnCachedPersister</code>
+      <code>dispatchOnFlushEvent</code>
+      <code>dispatchPostFlushEvent</code>
+      <code>hydrationComplete</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>ClassMetadata[]</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>getMapping</code>
+      <code>getMapping</code>
+      <code>takeSnapshot</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullArgument occurrences="5">
+      <code>$property</code>
+      <code>$property</code>
+      <code>$association-&gt;getMappedBy()</code>
+      <code>$newValue</code>
+      <code>$association-&gt;getInversedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$targetClass-&gt;fieldNames</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="14">
+      <code>hasValueGenerator</code>
+      <code>getValueGenerator</code>
+      <code>getName</code>
+      <code>setValue</code>
+      <code>getType</code>
+      <code>hasValueGenerator</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>getCacheFactory</code>
+      <code>buildCachedEntityPersister</code>
+      <code>getCacheFactory</code>
+      <code>buildCachedCollectionPersister</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$owner === null</code>
+      <code>! is_object($object) || ! $this-&gt;isInIdentityMap($object)</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeCoercion occurrences="6">
+      <code>$property</code>
+      <code>$property</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>'count'</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="8">
+      <code>getMapping</code>
+      <code>getMapping</code>
+      <code>takeSnapshot</code>
+      <code>hasValueGenerator</code>
+      <code>getValueGenerator</code>
+      <code>hasValueGenerator</code>
+      <code>unwrap</code>
+      <code>unwrap</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="1">
+      <code>getJoinColumns</code>
+    </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$discriminators</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Utility/IdentifierFlattener.php">
+    <PossiblyNullReference occurrences="3">
+      <code>getTargetEntity</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>getTargetEntity</code>
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Utility/NormalizeIdentifier.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>[reset($targetIdMetadata-&gt;identifier) =&gt; $flatIdentifier[$name]]</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Utility/PersisterHelper.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>Type</code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$property-&gt;getType()</code>
+    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="2">
+      <code>$joinColumn-&gt;getReferencedColumnName()</code>
+      <code>$association-&gt;getMappedBy()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="3">
+      <code>getTargetEntity</code>
+      <code>getInverseJoinColumns</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getTargetEntity</code>
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Performance/ChangeSet/UnitOfWorkComputeChangesBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$users</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="4">
+      <code>$user-&gt;address</code>
+      <code>$user-&gt;email</code>
+      <code>$user-&gt;username</code>
+      <code>$user-&gt;name</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinArrayHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinFullObjectHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/MixedQueryFetchJoinPartialObjectHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleHydrationBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$entityManager</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleInsertPerformanceBench.php">
+    <InvalidOperand occurrences="1">
+      <code>$key</code>
+    </InvalidOperand>
+    <MissingConstructor occurrences="1">
+      <code>$entityManager</code>
+    </MissingConstructor>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;entityManager-&gt;getClassMetadata(CMS\CmsUser::class)-&gt;getTableName()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>execute</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleQueryArrayHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleQueryFullObjectHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleQueryPartialObjectHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SimpleQueryScalarHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$hydrator</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SingleTableInheritanceHydrationPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$contractsRepository</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Hydration/SingleTableInheritanceInsertPerformanceBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$entityManager</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/LazyLoading/ProxyInitializationTimeBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$cmsUsers</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/LazyLoading/ProxyInstantiationTimeBench.php">
+    <MissingConstructor occurrences="1">
+      <code>$proxyFactory</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Mock/NonLoadingPersister.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>loadById</code>
+    </InvalidNullableReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NonLoadingPersister</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Performance/Mock/NonProxyLoadingEntityManager.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>ClassMetadata</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="tests/Doctrine/Tests/DbalFunctionalTestCase.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$conn</code>
+      <code>DbalFunctionalTestCase</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;sharedFixture</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/DbalTestCase.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DbalTestCase</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/DbalTypes/Rot13Type.php">
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/DbalTypes/UpperCaseStringType.php">
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/EventListener/CacheMetadataListener.php">
+    <InvalidArgument occurrences="1">
+      <code>$metadata</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="3">
+      <code>loadClassMetadata</code>
+      <code>recordVisit</code>
+      <code>enableCaching</code>
+    </MissingReturnType>
+    <TypeCoercion occurrences="1">
+      <code>$em</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getClassName</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$metadata-&gt;associationMappings</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/CacheRegionMock.php">
+    <MissingPropertyType occurrences="3">
+      <code>$calls</code>
+      <code>$returns</code>
+      <code>$name</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>addReturn</code>
+      <code>evict</code>
+      <code>evictAll</code>
+      <code>put</code>
+      <code>clear</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/ClassMetadataMock.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClassMetadataMock</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/ConcurrentRegionMock.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>lock</code>
+    </InvalidNullableReturnType>
+    <MissingPropertyType occurrences="3">
+      <code>$calls</code>
+      <code>$exceptions</code>
+      <code>$locks</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="6">
+      <code>throwException</code>
+      <code>addException</code>
+      <code>setLock</code>
+      <code>evict</code>
+      <code>evictAll</code>
+      <code>put</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>LockException::unexpectedLockValue($lock)</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/ConnectionMock.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>ResultStatement</code>
+    </InvalidNullableReturnType>
+    <InvalidReturnType occurrences="2">
+      <code>insert</code>
+      <code>lastInsertId</code>
+    </InvalidReturnType>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;queryResult</code>
+    </NullableReturnStatement>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ConnectionMock</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$platform</code>
+    </TypeCoercion>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;platform</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php">
+    <InvalidReturnType occurrences="7">
+      <code>getBooleanTypeDeclarationSQL</code>
+      <code>getIntegerTypeDeclarationSQL</code>
+      <code>getBigIntTypeDeclarationSQL</code>
+      <code>getSmallIntTypeDeclarationSQL</code>
+      <code>_getCommonIntegerTypeDeclarationSQL</code>
+      <code>getVarcharTypeDeclarationSQL</code>
+      <code>getClobTypeDeclarationSQL</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DatabasePlatformMock</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>DBALException</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/DriverConnectionMock.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>new StatementMock()</code>
+      <code>new StatementMock()</code>
+    </DocblockTypeContradiction>
+    <InvalidReturnType occurrences="7">
+      <code>quote</code>
+      <code>int</code>
+      <code>lastInsertId</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>rollBack</code>
+      <code>errorInfo</code>
+    </InvalidReturnType>
+    <MissingConstructor occurrences="1">
+      <code>$statementMock</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>setStatementMock</code>
+    </MissingReturnType>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$this-&gt;statementMock</code>
+      <code>$this-&gt;statementMock</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/DriverMock.php">
+    <InvalidReturnType occurrences="1">
+      <code>getDatabase</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>convertExceptionCode</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/EntityManagerMock.php">
+    <MissingParamType occurrences="1">
+      <code>$conn</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>create</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/EntityPersisterMock.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$genType</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnType occurrences="2">
+      <code>exists</code>
+      <code>delete</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="1">
+      <code>$entity</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/HydratorMockStatement.php">
+    <InvalidReturnType occurrences="9">
+      <code>bindValue</code>
+      <code>bindParam</code>
+      <code>columnCount</code>
+      <code>errorCode</code>
+      <code>errorInfo</code>
+      <code>execute</code>
+      <code>int</code>
+      <code>getIterator</code>
+      <code>setFetchMode</code>
+    </InvalidReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/MockTreeWalker.php">
+    <InvalidNullableReturnType occurrences="1">
+      <code>getExecutor</code>
+    </InvalidNullableReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/SchemaManagerMock.php">
+    <InvalidReturnType occurrences="1">
+      <code>_getPortableTableColumnDefinition</code>
+    </InvalidReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/SequenceMock.php">
+    <MissingReturnType occurrences="1">
+      <code>reset</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/StatementArrayMock.php">
+    <MissingParamType occurrences="1">
+      <code>$result</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/StatementMock.php">
+    <InvalidReturnType occurrences="13">
+      <code>bindValue</code>
+      <code>bindParam</code>
+      <code>errorCode</code>
+      <code>errorInfo</code>
+      <code>execute</code>
+      <code>int</code>
+      <code>closeCursor</code>
+      <code>columnCount</code>
+      <code>setFetchMode</code>
+      <code>fetch</code>
+      <code>fetchAll</code>
+      <code>fetchColumn</code>
+      <code>getIterator</code>
+    </InvalidReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Mocks/TimestampRegionMock.php">
+    <MissingReturnType occurrences="1">
+      <code>update</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsAddress.php">
+    <MissingReturnType occurrences="6">
+      <code>getId</code>
+      <code>getUser</code>
+      <code>getCountry</code>
+      <code>getZipCode</code>
+      <code>getCity</code>
+      <code>setUser</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsAddressDTO.php">
+    <MissingParamType occurrences="3">
+      <code>$country</code>
+      <code>$city</code>
+      <code>$zip</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$country</code>
+      <code>$city</code>
+      <code>$zip</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsAddressListener.php">
+    <MissingPropertyType occurrences="1">
+      <code>$calls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="10">
+      <code>prePersist</code>
+      <code>postPersist</code>
+      <code>preUpdate</code>
+      <code>postUpdate</code>
+      <code>preRemove</code>
+      <code>postRemove</code>
+      <code>postLoad</code>
+      <code>preFlush</code>
+      <code>postPersistHandler</code>
+      <code>prePersistHandler</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsArticle.php">
+    <MissingReturnType occurrences="2">
+      <code>setAuthor</code>
+      <code>addComment</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsComment.php">
+    <MissingReturnType occurrences="1">
+      <code>setArticle</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsEmail.php">
+    <MissingParamType occurrences="1">
+      <code>$email</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>getId</code>
+      <code>getEmail</code>
+      <code>setEmail</code>
+      <code>getUser</code>
+      <code>setUser</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsEmployee.php">
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getName</code>
+      <code>getSpouse</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsGroup.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>setName</code>
+      <code>getName</code>
+      <code>addUser</code>
+      <code>getUsers</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsPhonenumber.php">
+    <MissingReturnType occurrences="2">
+      <code>setUser</code>
+      <code>getUser</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsTag.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>setName</code>
+      <code>getName</code>
+      <code>addUser</code>
+      <code>getUsers</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsUser.php">
+    <MissingParamType occurrences="1">
+      <code>$index</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$nonPersistedProperty</code>
+      <code>$nonPersistedPropertyObject</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="15">
+      <code>getId</code>
+      <code>getStatus</code>
+      <code>getUsername</code>
+      <code>getName</code>
+      <code>addPhonenumber</code>
+      <code>getPhonenumbers</code>
+      <code>addArticle</code>
+      <code>addGroup</code>
+      <code>getGroups</code>
+      <code>addTag</code>
+      <code>getTags</code>
+      <code>removePhonenumber</code>
+      <code>getAddress</code>
+      <code>setAddress</code>
+      <code>setEmail</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CMS/CmsUserDTO.php">
+    <MissingParamType occurrences="4">
+      <code>$name</code>
+      <code>$email</code>
+      <code>$address</code>
+      <code>$phonenumbers</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="4">
+      <code>$name</code>
+      <code>$email</code>
+      <code>$address</code>
+      <code>$phonenumbers</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Action.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>addToken</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Address.php">
+    <MissingParamType occurrences="1">
+      <code>$location</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Attraction.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="8">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getCity</code>
+      <code>setCity</code>
+      <code>getInfos</code>
+      <code>addInfo</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/AttractionContactInfo.php">
+    <MissingParamType occurrences="2">
+      <code>$fone</code>
+      <code>$fone</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getFone</code>
+      <code>setFone</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/AttractionInfo.php">
+    <MissingParamType occurrences="1">
+      <code>$id</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getAttraction</code>
+      <code>setAttraction</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/AttractionLocationInfo.php">
+    <MissingParamType occurrences="2">
+      <code>$address</code>
+      <code>$address</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getAddress</code>
+      <code>setAddress</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/City.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="10">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getState</code>
+      <code>setState</code>
+      <code>addTravel</code>
+      <code>getTravels</code>
+      <code>addAttraction</code>
+      <code>getAttractions</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Client.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/ComplexAction.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>addToken</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Country.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Flight.php">
+    <MissingParamType occurrences="1">
+      <code>$departure</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getLeavingFrom</code>
+      <code>getGoingTo</code>
+      <code>getDeparture</code>
+      <code>setDeparture</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Login.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Person.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/State.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="9">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getCountry</code>
+      <code>setCountry</code>
+      <code>getCities</code>
+      <code>setCities</code>
+      <code>addCity</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Token.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;action</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>Action</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="1">
+      <code>$token</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>addLogin</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$action</code>
+      <code>$complexAction</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Travel.php">
+    <MissingReturnType occurrences="3">
+      <code>setTraveler</code>
+      <code>addVisitedCity</code>
+      <code>removeVisitedCity</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/Traveler.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="8">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>setProfile</code>
+      <code>getTravels</code>
+      <code>addTravel</code>
+      <code>removeTravel</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/TravelerProfile.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$nae</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getInfo</code>
+      <code>setInfo</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Cache/TravelerProfileInfo.php">
+    <MissingParamType occurrences="3">
+      <code>$description</code>
+      <code>$id</code>
+      <code>$description</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getId</code>
+      <code>setId</code>
+      <code>getDescription</code>
+      <code>setDescription</code>
+      <code>getProfile</code>
+      <code>setProfile</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyAuction.php">
+    <MissingParamType occurrences="1">
+      <code>$data</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setData</code>
+      <code>getData</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyCar.php">
+    <MissingParamType occurrences="1">
+      <code>$brand</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getBrand</code>
+    </MissingReturnType>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;title</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyContract.php">
+    <MissingReturnType occurrences="8">
+      <code>getId</code>
+      <code>markCompleted</code>
+      <code>isCompleted</code>
+      <code>getSalesPerson</code>
+      <code>setSalesPerson</code>
+      <code>getEngineers</code>
+      <code>addEngineer</code>
+      <code>removeEngineer</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyContractListener.php">
+    <MissingPropertyType occurrences="8">
+      <code>$postPersistCalls</code>
+      <code>$prePersistCalls</code>
+      <code>$postUpdateCalls</code>
+      <code>$preUpdateCalls</code>
+      <code>$postRemoveCalls</code>
+      <code>$preRemoveCalls</code>
+      <code>$preFlushCalls</code>
+      <code>$postLoadCalls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="8">
+      <code>postPersistHandler</code>
+      <code>prePersistHandler</code>
+      <code>postUpdateHandler</code>
+      <code>preUpdateHandler</code>
+      <code>postRemoveHandler</code>
+      <code>preRemoveHandler</code>
+      <code>preFlushHandler</code>
+      <code>postLoadHandler</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyEmployee.php">
+    <MissingParamType occurrences="3">
+      <code>$salary</code>
+      <code>$dep</code>
+      <code>$date</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getSalary</code>
+      <code>setSalary</code>
+      <code>getDepartment</code>
+      <code>setDepartment</code>
+      <code>getStartDate</code>
+      <code>setStartDate</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyEvent.php">
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getOrganization</code>
+      <code>setOrganization</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyFixContract.php">
+    <MissingParamType occurrences="1">
+      <code>$fixPrice</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>calculatePrice</code>
+      <code>getFixPrice</code>
+      <code>setFixPrice</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php">
+    <MissingParamType occurrences="2">
+      <code>$hoursWorked</code>
+      <code>$pricePerHour</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="8">
+      <code>calculatePrice</code>
+      <code>getHoursWorked</code>
+      <code>setHoursWorked</code>
+      <code>getPricePerHour</code>
+      <code>setPricePerHour</code>
+      <code>getManagers</code>
+      <code>addManager</code>
+      <code>removeManager</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php">
+    <MissingParamType occurrences="1">
+      <code>$maxPrice</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>calculatePrice</code>
+      <code>getMaxPrice</code>
+      <code>setMaxPrice</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContractListener.php">
+    <MissingPropertyType occurrences="1">
+      <code>$prePersistCalls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>prePersistHandler1</code>
+      <code>prePersistHandler2</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyManager.php">
+    <MissingParamType occurrences="1">
+      <code>$title</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getTitle</code>
+      <code>setTitle</code>
+      <code>getCar</code>
+      <code>setCar</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyOrganization.php">
+    <MissingParamType occurrences="1">
+      <code>$event</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>getId</code>
+      <code>getEvents</code>
+      <code>addEvent</code>
+      <code>getMainEvent</code>
+      <code>setMainEvent</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyPerson.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="7">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getSpouse</code>
+      <code>getFriends</code>
+      <code>addFriend</code>
+      <code>setSpouse</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Company/CompanyRaffle.php">
+    <MissingParamType occurrences="1">
+      <code>$data</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setData</code>
+      <code>getData</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedIdentityClass.php">
+    <MissingConstructor occurrences="1">
+      <code>$children</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CompositeKeyInheritance/JoinedDerivedRootClass.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>'part-1'</code>
+    </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/CustomType/CustomTypeParent.php">
+    <MissingReturnType occurrences="4">
+      <code>addMyFriend</code>
+      <code>getMyFriends</code>
+      <code>addFriendWithMe</code>
+      <code>getFriendsWithMe</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117ApproveChanges.php">
+    <MissingParamType occurrences="3">
+      <code>$details</code>
+      <code>$reference</code>
+      <code>$translation</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>getArticleDetails</code>
+      <code>getReference</code>
+      <code>getTranslation</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117Article.php">
+    <MissingParamType occurrences="5">
+      <code>$title</code>
+      <code>$details</code>
+      <code>$reference</code>
+      <code>$language</code>
+      <code>$title</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="10">
+      <code>setDetails</code>
+      <code>id</code>
+      <code>addReference</code>
+      <code>references</code>
+      <code>addTranslation</code>
+      <code>getText</code>
+      <code>getDetails</code>
+      <code>getLinks</code>
+      <code>resetText</code>
+      <code>getTranslations</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117ArticleDetails.php">
+    <MissingParamType occurrences="3">
+      <code>$article</code>
+      <code>$text</code>
+      <code>$text</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>update</code>
+      <code>getText</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117Editor.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$t-&gt;lastTranslatedBy</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>addLastTranslation</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117Link.php">
+    <MissingParamType occurrences="3">
+      <code>$source</code>
+      <code>$target</code>
+      <code>$description</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117Reference.php">
+    <MissingParamType occurrences="4">
+      <code>$source</code>
+      <code>$target</code>
+      <code>$description</code>
+      <code>$desc</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>source</code>
+      <code>target</code>
+      <code>setDescription</code>
+      <code>getDescription</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC117/DDC117Translation.php">
+    <MissingParamType occurrences="3">
+      <code>$article</code>
+      <code>$language</code>
+      <code>$title</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getArticleId</code>
+      <code>getLanguage</code>
+      <code>getLastTranslatedBy</code>
+      <code>getReviewedByEditors</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC1476/DDC1476EntityWithDefaultFieldType.php">
+    <MissingReturnType occurrences="1">
+      <code>setName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>DDC1590User</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC2372/DDC2372Address.php">
+    <MissingParamType occurrences="1">
+      <code>$street</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>getId</code>
+      <code>getStreet</code>
+      <code>setStreet</code>
+      <code>getUser</code>
+      <code>setUser</code>
+    </MissingReturnType>
+    <UndefinedClass occurrences="1">
+      <code>User</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC2372/DDC2372User.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC2372/Traits/DDC2372Address.php">
+    <MissingReturnType occurrences="2">
+      <code>getAddress</code>
+      <code>setAddress</code>
+    </MissingReturnType>
+    <UndefinedClass occurrences="1">
+      <code>Address</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC2504/DDC2504RootClass.php">
+    <MissingConstructor occurrences="1">
+      <code>$other</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3293/DDC3293Address.php">
+    <MissingPropertyType occurrences="3">
+      <code>$street</code>
+      <code>$city</code>
+      <code>$country</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3293/DDC3293User.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3293/DDC3293UserPrefixed.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3346/DDC3346Article.php">
+    <MissingConstructor occurrences="1">
+      <code>$user</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3579/DDC3579Group.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setName</code>
+      <code>addAdmin</code>
+    </MissingReturnType>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;users</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3579/DDC3579User.php">
+    <MissingReturnType occurrences="2">
+      <code>setName</code>
+      <code>addGroup</code>
+    </MissingReturnType>
+    <UndefinedMethod occurrences="1">
+      <code>addUser</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3597/DDC3597Image.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3597Image</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3597/DDC3597Media.php">
+    <MissingParamType occurrences="1">
+      <code>$distributionHash</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setSize</code>
+      <code>setFormat</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$format</code>
+      <code>DDC3597Media</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3597/DDC3597Root.php">
+    <MissingReturnType occurrences="2">
+      <code>prePersist</code>
+      <code>preUpdate</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3597/Embeddable/DDC3597Dimension.php">
+    <MissingParamType occurrences="2">
+      <code>$width</code>
+      <code>$height</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setWidth</code>
+      <code>setHeight</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityA.php">
+    <MissingConstructor occurrences="1">
+      <code>$id1</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="2">
+      <code>setId1</code>
+      <code>setId2</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC3711/DDC3711EntityB.php">
+    <MissingConstructor occurrences="1">
+      <code>$id1</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="3">
+      <code>setId1</code>
+      <code>setId2</code>
+      <code>addEntityA</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC964/DDC964Address.php">
+    <MissingReturnType occurrences="4">
+      <code>setCountry</code>
+      <code>setZip</code>
+      <code>setCity</code>
+      <code>setStreet</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC964/DDC964Admin.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC964Admin</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC964/DDC964Group.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setName</code>
+      <code>addUser</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC964/DDC964Guest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC964Guest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DDC964/DDC964User.php">
+    <MissingReturnType occurrences="4">
+      <code>setName</code>
+      <code>addGroup</code>
+      <code>setAddress</code>
+      <code>loadMetadata</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$address</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>setIdGeneratorType</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DirectoryTree/AbstractContentItem.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>getId</code>
+      <code>setName</code>
+      <code>getName</code>
+      <code>getParent</code>
+      <code>setNodeIsLoaded</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DirectoryTree/Directory.php">
+    <MissingParamType occurrences="1">
+      <code>$path</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>setPath</code>
+      <code>getPath</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/DirectoryTree/File.php">
+    <MissingParamType occurrences="1">
+      <code>$ext</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getExtension</code>
+      <code>setExtension</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceCart.php">
+    <MissingParamType occurrences="1">
+      <code>$payment</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="9">
+      <code>getId</code>
+      <code>getPayment</code>
+      <code>setPayment</code>
+      <code>setCustomer</code>
+      <code>removeCustomer</code>
+      <code>getCustomer</code>
+      <code>getProducts</code>
+      <code>addProduct</code>
+      <code>removeProduct</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceCategory.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="13">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>addProduct</code>
+      <code>removeProduct</code>
+      <code>getProducts</code>
+      <code>setParent</code>
+      <code>getChildren</code>
+      <code>getParent</code>
+      <code>addChild</code>
+      <code>brokenAddChild</code>
+      <code>removeChild</code>
+      <code>removeParent</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceCustomer.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="10">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>setCart</code>
+      <code>brokenSetCart</code>
+      <code>getCart</code>
+      <code>removeCart</code>
+      <code>setMentor</code>
+      <code>removeMentor</code>
+      <code>getMentor</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceFeature.php">
+    <MissingParamType occurrences="1">
+      <code>$description</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getId</code>
+      <code>getDescription</code>
+      <code>setDescription</code>
+      <code>setProduct</code>
+      <code>removeProduct</code>
+      <code>getProduct</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceProduct.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$categories</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$isCloned</code>
+      <code>$wakeUp</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="17">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getShipping</code>
+      <code>setShipping</code>
+      <code>removeShipping</code>
+      <code>getFeatures</code>
+      <code>addFeature</code>
+      <code>brokenAddFeature</code>
+      <code>removeFeature</code>
+      <code>addCategory</code>
+      <code>removeCategory</code>
+      <code>setCategories</code>
+      <code>getCategories</code>
+      <code>getRelated</code>
+      <code>addRelated</code>
+      <code>removeRelated</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ECommerce/ECommerceShipping.php">
+    <MissingParamType occurrences="1">
+      <code>$days</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getDays</code>
+      <code>setDays</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Forum/ForumCategory.php">
+    <MissingReturnType occurrences="1">
+      <code>getId</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Forum/ForumEntry.php">
+    <MissingReturnType occurrences="1">
+      <code>getTopicByReference</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Forum/ForumUser.php">
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>getUsername</code>
+      <code>getAvatar</code>
+      <code>setAvatar</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/FriendObject/ComparableObject.php">
+    <MissingPropertyType occurrences="1">
+      <code>$other-&gt;comparedField</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/GeoNames/Admin1.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/GeoNames/Admin1AlternateName.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/GeoNames/City.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/GeoNames/Country.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Global/GlobalNamespaceModel.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Issue5989/Issue5989Employee.php">
+    <MissingConstructor occurrences="1">
+      <code>$tags</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Issue5989/Issue5989Manager.php">
+    <MissingConstructor occurrences="1">
+      <code>$tags</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Legacy/LegacyArticle.php">
+    <MissingReturnType occurrences="1">
+      <code>setAuthor</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Legacy/LegacyCar.php">
+    <MissingReturnType occurrences="3">
+      <code>getDescription</code>
+      <code>addUser</code>
+      <code>getUsers</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Legacy/LegacyUser.php">
+    <MissingParamType occurrences="1">
+      <code>$reference</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="7">
+      <code>getId</code>
+      <code>getUsername</code>
+      <code>addArticle</code>
+      <code>addReference</code>
+      <code>references</code>
+      <code>addCar</code>
+      <code>getCars</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Legacy/LegacyUserReference.php">
+    <MissingParamType occurrences="2">
+      <code>$description</code>
+      <code>$desc</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>source</code>
+      <code>target</code>
+      <code>setDescription</code>
+      <code>getDescription</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ManyToManyPersister/ChildClass.php">
+    <TooManyTemplateParams occurrences="1">
+      <code>Collection|ParentClass[]</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ManyToManyPersister/ParentClass.php">
+    <TooManyTemplateParams occurrences="1">
+      <code>Collection|ChildClass[]</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Navigation/NavCountry.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Navigation/NavPhotos.php">
+    <MissingParamType occurrences="2">
+      <code>$poi</code>
+      <code>$file</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getPointOfInterest</code>
+      <code>getFile</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Navigation/NavPointOfInterest.php">
+    <MissingParamType occurrences="4">
+      <code>$lat</code>
+      <code>$long</code>
+      <code>$name</code>
+      <code>$country</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getLong</code>
+      <code>getLat</code>
+      <code>getName</code>
+      <code>getCountry</code>
+      <code>addVisitor</code>
+      <code>getVisitors</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Navigation/NavTour.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>addPointOfInterest</code>
+      <code>getPointOfInterests</code>
+      <code>getName</code>
+      <code>getId</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Navigation/NavUser.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/NonPublicSchemaJoins/User.php">
+    <MissingConstructor occurrences="1">
+      <code>$readers</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/OneToOneSingleTableInheritance/Cat.php">
+    <MissingConstructor occurrences="1">
+      <code>$litterBox</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Quote/Address.php">
+    <MissingReturnType occurrences="4">
+      <code>setUser</code>
+      <code>getId</code>
+      <code>getZip</code>
+      <code>getUser</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Quote/FullAddress.php">
+    <MissingConstructor occurrences="1">
+      <code>$city</code>
+    </MissingConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Quote/Group.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$parent</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Quote/User.php">
+    <MissingReturnType occurrences="4">
+      <code>getPhones</code>
+      <code>getAddress</code>
+      <code>getGroups</code>
+      <code>setAddress</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Reflection/AbstractEmbeddable.php">
+    <MissingPropertyType occurrences="1">
+      <code>$propertyInAbstractClass</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Reflection/ArrayObjectExtendingClass.php">
+    <MissingPropertyType occurrences="3">
+      <code>$privateProperty</code>
+      <code>$protectedProperty</code>
+      <code>$publicProperty</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Reflection/ClassWithMixedProperties.php">
+    <MissingPropertyType occurrences="5">
+      <code>$staticProperty</code>
+      <code>$publicProperty</code>
+      <code>$protectedProperty</code>
+      <code>$privateProperty</code>
+      <code>$privatePropertyOverride</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Reflection/ConcreteEmbeddable.php">
+    <MissingPropertyType occurrences="1">
+      <code>$propertyInConcreteClass</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Reflection/ParentClass.php">
+    <MissingPropertyType occurrences="1">
+      <code>$privatePropertyOverride</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Routing/RoutingLocation.php">
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Routing/RoutingRouteBooking.php">
+    <MissingReturnType occurrences="1">
+      <code>getPassengerName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/StockExchange/Bond.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>addStock</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$id</code>
+      <code>$stocks</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/StockExchange/Market.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$symbol</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>getName</code>
+      <code>addStock</code>
+      <code>getStock</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/StockExchange/Stock.php">
+    <MissingParamType occurrences="2">
+      <code>$symbol</code>
+      <code>$initialOfferingPrice</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>getSymbol</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Taxi/Car.php">
+    <MissingParamType occurrences="2">
+      <code>$brand</code>
+      <code>$model</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getBrand</code>
+      <code>setBrand</code>
+      <code>setModel</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Taxi/Driver.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>setName</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Taxi/PaidRide.php">
+    <MissingParamType occurrences="1">
+      <code>$fare</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>setFare</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Tweet/Tweet.php">
+    <MissingReturnType occurrences="1">
+      <code>setAuthor</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/Tweet/User.php">
+    <MissingReturnType occurrences="2">
+      <code>addTweet</code>
+      <code>addUserList</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ValueObjects/Name.php">
+    <MissingPropertyType occurrences="2">
+      <code>$firstName</code>
+      <code>$lastName</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/Models/ValueObjects/Person.php">
+    <MissingPropertyType occurrences="2">
+      <code>$id</code>
+      <code>$name</code>
+    </MissingPropertyType>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php">
+    <MissingParamType occurrences="2">
+      <code>$key</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>dataProviderCacheValues</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/CacheConfigTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$logger</code>
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$validator</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$config</code>
+      <code>CacheConfigTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>method</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/CacheKeyTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CacheKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php">
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$this-&gt;mock</code>
+      <code>$this-&gt;mock</code>
+      <code>$this-&gt;mock</code>
+      <code>$this-&gt;mock</code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedMethod occurrences="9">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$logger</code>
+      <code>$mock</code>
+      <code>CacheLoggerChainTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultCacheFactoryTest.php">
+    <InvalidPropertyAssignmentValue occurrences="1"/>
+    <PossiblyNullArgument occurrences="4">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="7">
+      <code>setCache</code>
+      <code>getCache</code>
+      <code>setCache</code>
+      <code>getCache</code>
+      <code>setCache</code>
+      <code>getCache</code>
+      <code>setCache</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$factory</code>
+      <code>$em</code>
+      <code>$regionsConfig</code>
+      <code>DefaultCacheFactoryTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="4">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="18">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>setCache</code>
+      <code>expects</code>
+      <code>getCache</code>
+      <code>setCache</code>
+      <code>expects</code>
+      <code>getCache</code>
+      <code>setCache</code>
+      <code>expects</code>
+      <code>getCache</code>
+      <code>setCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>setNamespace</code>
+      <code>getCache</code>
+      <code>getCache</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php">
+    <MissingReturnType occurrences="2">
+      <code>putEntityCacheEntry</code>
+      <code>putCollectionCacheEntry</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$metadata-&gt;getProperty($association)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$cache</code>
+      <code>$em</code>
+      <code>DefaultCacheTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$metadata-&gt;getProperty($association)</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getCacheRegion</code>
+      <code>getCacheRegion</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getEntityCacheRegion</code>
+      <code>put</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$structure</code>
+      <code>DefaultCollectionHydratorTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>new DefaultCollectionHydrator($this-&gt;em, $targetPersister)</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$proxy</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$structure</code>
+      <code>$em</code>
+      <code>DefaultEntityHydratorTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="2">
+      <code>$proxy</code>
+      <code>$proxy</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php">
+    <MissingPropertyType occurrences="10">
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$this-&gt;region-&gt;calls</code>
+      <code>$queryCache</code>
+      <code>$region</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$result</code>
+      <code>$result</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="4">
+      <code>$result[0]</code>
+      <code>$result[1]</code>
+      <code>$result[0]</code>
+      <code>$result[1]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="9">
+      <code>setCacheFactory</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$queryCache</code>
+      <code>$em</code>
+      <code>$region</code>
+      <code>$cacheFactory</code>
+      <code>DefaultQueryCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php">
+    <DeprecatedInterface occurrences="2">
+      <code>SharedArrayCache</code>
+      <code>class ($this) extends CacheProvider {</code>
+    </DeprecatedInterface>
+    <InaccessibleMethod occurrences="6">
+      <code>doFetch</code>
+      <code>doContains</code>
+      <code>doSave</code>
+      <code>doDelete</code>
+      <code>doFlush</code>
+      <code>doGetStats</code>
+    </InaccessibleMethod>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$actual[0]</code>
+      <code>$actual[1]</code>
+    </PossiblyNullArrayAccess>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DefaultRegionTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getCache</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>60</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>cleanTestDirectory</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$region</code>
+      <code>$directory</code>
+      <code>FileLockRegionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/MultiGetRegionTest.php">
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$actual[0]</code>
+      <code>$actual[1]</code>
+    </PossiblyNullArrayAccess>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MultiGetRegionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php">
+    <InvalidPropertyAssignmentValue occurrences="1"/>
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>Region</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="4">
+      <code>$owner</code>
+      <code>$assoc</code>
+      <code>$class</code>
+      <code>$elements</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>createPersisterDefault</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$assoc</code>
+    </PossiblyNullArgument>
+    <TypeCoercion occurrences="1">
+      <code>$assoc</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="9">
+      <code>flushAll</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersisterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NonStrictReadWriteCachedCollectionPersisterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersisterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ReadOnlyCachedCollectionPersisterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersisterTest.php">
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>Region</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ReadWriteCachedCollectionPersisterTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$region</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="18">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Entity/AbstractEntityPersisterTest.php">
+    <InvalidArgument occurrences="7">
+      <code>['name' =&gt; 'Foo']</code>
+      <code>'foo'</code>
+      <code>'Foo'</code>
+      <code>'Foo'</code>
+      <code>'Foo'</code>
+      <code>'Foo'</code>
+      <code>$identifier</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1"/>
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>Region</code>
+    </InvalidReturnType>
+    <UndefinedInterfaceMethod occurrences="24">
+      <code>flushAll</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersisterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NonStrictReadWriteCachedEntityPersisterTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="6">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ReadOnlyCachedEntityPersisterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersisterTest.php">
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>Region</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ReadWriteCachedEntityPersisterTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$region</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="14">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Cache/StatisticsCacheLoggerTest.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$logger</code>
+      <code>StatisticsCacheLoggerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="1">
+      <code>testCommitOrdering3</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="11">
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$calc</code>
+      <code>$metadataBuildingContext</code>
+      <code>CommitOrderCalculatorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/ConfigurationTest.php">
+    <InvalidArgument occurrences="9">
+      <code>$metadataDriver</code>
+      <code>$queryCacheImpl</code>
+      <code>$queryCacheImpl</code>
+      <code>$queryCacheImpl</code>
+      <code>$cache</code>
+      <code>$cache</code>
+      <code>$namingStrategy</code>
+      <code>$resolver</code>
+      <code>$mockClass</code>
+    </InvalidArgument>
+    <InvalidParamDefault occurrences="1">
+      <code>string</code>
+    </InvalidParamDefault>
+    <MissingReturnType occurrences="3">
+      <code>setProductionSettings</code>
+      <code>setDefaultRepositoryClassName</code>
+      <code>annotatedMethod</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$configuration</code>
+      <code>ConfigurationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;wrapped</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="1">
+      <code>$method</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getMethodParameters</code>
+      <code>getParameters</code>
+    </MissingReturnType>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$wrapped</code>
+      <code>$decorator</code>
+      <code>EntityManagerDecoratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Entity/ConstructorTest.php">
+    <MissingParamType occurrences="1">
+      <code>$username</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$entity-&gt;username</code>
+      <code>$id</code>
+      <code>$username</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ConstructorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/EntityManagerTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$this-&gt;createMock(MappingDriver::class)</code>
+      <code>1</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="3">
+      <code>$methodName</code>
+      <code>$value</code>
+      <code>$em</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>dataMethodsAffectedByNoObjectArguments</code>
+      <code>dataAffectedByErrorIfClosedException</code>
+      <code>dataToBeReturnedByTransactional</code>
+      <code>transactionalCallback</code>
+    </MissingReturnType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullArgument occurrences="5">
+      <code>$user</code>
+      <code>$simpleIdReference</code>
+      <code>$nestedIdReference</code>
+      <code>$simpleIdReferenceA</code>
+      <code>$simpleIdReferenceB</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;id</code>
+      <code>$nestedIdReference-&gt;simpleId</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>EntityManagerTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;getTestEntityManager()</code>
+    </TypeCoercion>
+    <UndefinedClass occurrences="4">
+      <code>$nestedIdReference</code>
+      <code>$nestedIdReference</code>
+      <code>$nestedIdReference-&gt;simpleIdA</code>
+      <code>$nestedIdReference-&gt;simpleIdB</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>EntityNotFoundExceptionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Event/OnClassMetadataNotFoundEventArgsTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+      <code>$entityManager</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OnClassMetadataNotFoundEventArgsTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/AbstractManyToManyAssociationTestCase.php">
+    <MissingParamType occurrences="6">
+      <code>$firstId</code>
+      <code>$secondId</code>
+      <code>$firstId</code>
+      <code>$secondId</code>
+      <code>$firstId</code>
+      <code>$secondId</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$firstField</code>
+      <code>$secondField</code>
+      <code>$table</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>assertForeignKeysContain</code>
+      <code>assertForeignKeysNotContain</code>
+      <code>countForeignKeys</code>
+      <code>assertCollectionEquals</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>AbstractManyToManyAssociationTestCase</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <MismatchingDocblockParamType occurrences="2">
+      <code>kateglo\application\models\Lemma</code>
+      <code>kateglo\application\models\Lemma</code>
+    </MismatchingDocblockParamType>
+    <MissingReturnType occurrences="1">
+      <code>removePhrase</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>getType</code>
+      <code>getDefinitions</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="6">
+      <code>AdvancedAssociationTest</code>
+      <code>$id</code>
+      <code>$lemma</code>
+      <code>$id</code>
+      <code>$type</code>
+      <code>$abbreviation</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="7">
+      <code>kateglo\application\helpers\collections\ArrayCollection</code>
+      <code>kateglo\application\helpers\collections\ArrayCollection</code>
+      <code>kateglo\application\models\Lemma</code>
+      <code>kateglo\application\models\Lemma</code>
+      <code>kateglo\application\helpers\collections\ArrayCollection</code>
+      <code>$phrase</code>
+      <code>$phrase</code>
+    </UndefinedClass>
+    <UndefinedThisPropertyFetch occurrences="2">
+      <code>$this-&gt;sources</code>
+      <code>$this-&gt;categories</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php">
+    <MissingReturnType occurrences="1">
+      <code>generateFixture</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>AdvancedDqlQueryTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>FetchMode::EAGER</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="12">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;phonenumbers</code>
+      <code>$address-&gt;id</code>
+      <code>$user-&gt;phonenumbers</code>
+      <code>$user-&gt;phonenumbers</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$article-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$article-&gt;id</code>
+      <code>$article-&gt;user</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="5">
+      <code>$articleNew</code>
+      <code>$articleNew</code>
+      <code>$userRef</code>
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="2">
+      <code>$articleNew</code>
+      <code>$user</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$articleNew-&gt;text</code>
+      <code>$articleNew-&gt;text</code>
+      <code>$user-&gt;id</code>
+      <code>$this-&gt;em-&gt;find(get_class($user), $userId)-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>BasicFunctionalTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php">
+    <MissingParamType occurrences="1">
+      <code>$position</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getId</code>
+      <code>setOneToOneG</code>
+      <code>getOneToOneG</code>
+      <code>addOneToManyG</code>
+      <code>getOneToManyGs</code>
+      <code>getId</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$eOloaded</code>
+      <code>$eOloaded</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CascadeRemoveOrderTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;position</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php">
+    <PossiblyNullReference occurrences="12">
+      <code>getName</code>
+      <code>getName</code>
+      <code>getSalary</code>
+      <code>getTitle</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getSalary</code>
+      <code>getTitle</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getFriends</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClassTableInheritanceTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>matching</code>
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php">
+    <MissingParamType occurrences="3">
+      <code>$related</code>
+      <code>$data</code>
+      <code>$ctiParent</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="11">
+      <code>getId</code>
+      <code>getRelated</code>
+      <code>setRelated</code>
+      <code>getData</code>
+      <code>setData</code>
+      <code>getId</code>
+      <code>getCTIParent</code>
+      <code>setCTIParent</code>
+      <code>getId</code>
+      <code>addCTIChild</code>
+      <code>getCTIChildren</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="8">
+      <code>getCTIParent</code>
+      <code>getCTIParent</code>
+      <code>getCTIParent</code>
+      <code>getCTIParent</code>
+      <code>getCTIChildren</code>
+      <code>getCTIChildren</code>
+      <code>getCTIChildren</code>
+      <code>getCTIChildren</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClassTableInheritanceTest2</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ClearEventTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$listener-&gt;called</code>
+      <code>$called</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>onClear</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClearEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php">
+    <MissingReturnType occurrences="2">
+      <code>putGermanysBrandenburderTor</code>
+      <code>putTripAroundEurope</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$poi</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="8">
+      <code>getLat</code>
+      <code>getLong</code>
+      <code>getName</code>
+      <code>getPointOfInterests</code>
+      <code>addVisitor</code>
+      <code>addVisitor</code>
+      <code>getVisitors</code>
+      <code>getVisitors</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CompositePrimaryKeyTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$poi</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyWithAssociationsTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$admin1-&gt;names</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$name1-&gt;id</code>
+      <code>$name1-&gt;name</code>
+      <code>$name2-&gt;id</code>
+      <code>$name2-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CompositePrimaryKeyWithAssociationsTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/CustomFunctionsTest.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$parser-&gt;AggregateExpression()</code>
+    </InvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>CustomFunctionsTest</code>
+      <code>$field</code>
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="2">
+      <code>AggregateExpression</code>
+      <code>$this-&gt;aggregateExpression</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/CustomIdObjectTypeTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$parent-&gt;children</code>
+      <code>$parent-&gt;children</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CustomIdObjectTypeTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php">
+    <InvalidArgument occurrences="16">
+      <code>['id']</code>
+      <code>['id']</code>
+      <code>['id']</code>
+      <code>$metadatas</code>
+      <code>['id']</code>
+      <code>['id']</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>['id']</code>
+      <code>['id']</code>
+      <code>['id']</code>
+      <code>['column_index1', 'column_index2']</code>
+      <code>['column_unique_index1', 'column_unique_index2']</code>
+      <code>$metadatas</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$sm</code>
+      <code>DatabaseDriverTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="6">
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+      <code>$metadatas</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php">
+    <InvalidArgument occurrences="4">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+    </InvalidArgument>
+    <InvalidDocblockParamName occurrences="1">
+      <code>$className</code>
+    </InvalidDocblockParamName>
+    <InvalidReturnStatement occurrences="1">
+      <code>$metadatas</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>ClassMetadata</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>convertToClassMetadata</code>
+    </MissingReturnType>
+    <TooFewArguments occurrences="1">
+      <code>loadMetadataForClass</code>
+    </TooFewArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php">
+    <MissingPropertyType occurrences="3">
+      <code>$user-&gt;id</code>
+      <code>$a-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getUser</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;type</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="5">
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>getUser</code>
+      <code>getUser</code>
+      <code>getUser</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DefaultValuesTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/EntityListenersTest.php">
+    <EmptyArrayAccess occurrences="8">
+      <code>$this-&gt;listener-&gt;preFlushCalls[0]</code>
+      <code>$this-&gt;listener-&gt;postLoadCalls[0]</code>
+      <code>$this-&gt;listener-&gt;prePersistCalls[0]</code>
+      <code>$this-&gt;listener-&gt;postPersistCalls[0]</code>
+      <code>$this-&gt;listener-&gt;preUpdateCalls[0]</code>
+      <code>$this-&gt;listener-&gt;postUpdateCalls[0]</code>
+      <code>$this-&gt;listener-&gt;preRemoveCalls[0]</code>
+      <code>$this-&gt;listener-&gt;postRemoveCalls[0]</code>
+    </EmptyArrayAccess>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$listener</code>
+      <code>EntityListenersTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1"/>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/EntityRepositoryCriteriaTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>loadFixture</code>
+      <code>loadNullFieldFixtures</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;tweets</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>EntityRepositoryCriteriaTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="6">
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php">
+    <MissingParamType occurrences="8">
+      <code>$name</code>
+      <code>$username</code>
+      <code>$status</code>
+      <code>$address</code>
+      <code>$country</code>
+      <code>$city</code>
+      <code>$street</code>
+      <code>$zip</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$user-&gt;id</code>
+      <code>$address-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>loadFixture</code>
+      <code>loadAssociatedFixture</code>
+      <code>loadFixtureUserEmail</code>
+      <code>buildUser</code>
+      <code>buildAddress</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;status</code>
+      <code>$address-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>setEmail</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>EntityRepositoryTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="6">
+      <code>find</code>
+      <code>find</code>
+      <code>find</code>
+      <code>find</code>
+      <code>findOneBy</code>
+      <code>findOneBy</code>
+    </TooManyArguments>
+    <UndefinedInterfaceMethod occurrences="41">
+      <code>findByStatus</code>
+      <code>count</code>
+      <code>count</code>
+      <code>count</code>
+      <code>countByStatus</code>
+      <code>findByStatus</code>
+      <code>findByThisFieldDoesNotExist</code>
+      <code>findByStatus</code>
+      <code>foo</code>
+      <code>findByUser</code>
+      <code>findOneByUser</code>
+      <code>findByStatus</code>
+      <code>findByStatus</code>
+      <code>findByStatus</code>
+      <code>findByStatus</code>
+      <code>isDefaultRepository</code>
+      <code>isCustomRepository</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>createResultSetMappingBuilder</code>
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php">
+    <MissingPropertyType occurrences="37">
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;phonenumbers</code>
+      <code>$user-&gt;articles</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;articles</code>
+      <code>$article1-&gt;id</code>
+      <code>$group1-&gt;id</code>
+      <code>$otherClass-&gt;id</code>
+      <code>$childClass1-&gt;id</code>
+      <code>$user-&gt;tweets</code>
+      <code>$user-&gt;tweets</code>
+      <code>$user-&gt;tweets</code>
+      <code>$tweet-&gt;author</code>
+      <code>$user-&gt;tweets</code>
+      <code>$tweet-&gt;author</code>
+      <code>$user-&gt;tweets</code>
+      <code>$user-&gt;userLists</code>
+      <code>$user-&gt;userLists</code>
+      <code>$user-&gt;userLists</code>
+      <code>$userList-&gt;owner</code>
+      <code>$user-&gt;userLists</code>
+      <code>$user-&gt;userLists</code>
+      <code>$user-&gt;id</code>
+      <code>$tweet-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$userList-&gt;id</code>
+      <code>$userId</code>
+      <code>$userId2</code>
+      <code>$groupId</code>
+      <code>$articleId</code>
+      <code>$ddc2504OtherClassId</code>
+      <code>$ddc2504ChildClassId</code>
+      <code>$username</code>
+      <code>$groupname</code>
+      <code>$topic</code>
+      <code>$phonenumber</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadFixture</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="38">
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;articles</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;articles</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;articles</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;groups</code>
+      <code>$otherClass-&gt;childClasses</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;groups</code>
+      <code>$tweet-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="24">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setCache</code>
+      <code>setCache</code>
+      <code>setCache</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>addGroup</code>
+      <code>addGroup</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>isInitialized</code>
+      <code>isInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ExtraLazyCollectionTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="22">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setCache</code>
+      <code>setCache</code>
+      <code>setCache</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setFetchMode</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+      <code>setIndexedBy</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/FlushEventTest.php">
+    <MissingParamType occurrences="3">
+      <code>$args</code>
+      <code>$args</code>
+      <code>$args</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$user-&gt;phonenumbers</code>
+      <code>$listener-&gt;preFlush</code>
+      <code>$listener-&gt;onFlush</code>
+      <code>$preFlush</code>
+      <code>$onFlush</code>
+      <code>$postFlush</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>onFlush</code>
+      <code>preFlush</code>
+      <code>onFlush</code>
+      <code>postFlush</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>FlushEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/HydrationCacheTest.php">
+    <InvalidClass occurrences="1">
+      <code>CmsUser</code>
+    </InvalidClass>
+    <NullArgument occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </NullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>HydrationCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php">
+    <MissingPropertyType occurrences="6">
+      <code>$address-&gt;user</code>
+      <code>$user2-&gt;address</code>
+      <code>$user1-&gt;address</code>
+      <code>$address-&gt;user</code>
+      <code>$user2-&gt;address</code>
+      <code>$user1-&gt;address</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="1">
+      <code>getAddress</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>IdentityMapTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/IndexByAssociationTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$bond</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadFixture</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$bond-&gt;stocks</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$market</code>
+      <code>IndexByAssociationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/JoinedTableCompositeKeyTest.php">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>JoinedChildClass</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>JoinedTableCompositeKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/LifecycleCallbackTest.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="19">
+      <code>$entity-&gt;prePersistCallbackInvoked</code>
+      <code>$entity-&gt;postPersistCallbackInvoked</code>
+      <code>$entity-&gt;prePersistCallbackInvoked</code>
+      <code>$entity-&gt;preFlushCallbackInvoked</code>
+      <code>$c-&gt;entities</code>
+      <code>$e1-&gt;prePersistCallbackInvoked</code>
+      <code>$e2-&gt;prePersistCallbackInvoked</code>
+      <code>$c-&gt;entities</code>
+      <code>$c-&gt;entities</code>
+      <code>$entA-&gt;entities</code>
+      <code>$e-&gt;calls</code>
+      <code>$prePersistCallbackInvoked</code>
+      <code>$postPersistCallbackInvoked</code>
+      <code>$postLoadCallbackInvoked</code>
+      <code>$postLoadCascaderNotNull</code>
+      <code>$preFlushCallbackInvoked</code>
+      <code>$postLoadCallbackInvoked</code>
+      <code>$postLoadEntitiesCount</code>
+      <code>$calls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="24">
+      <code>getId</code>
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getId</code>
+      <code>getValue</code>
+      <code>doStuffOnPrePersist</code>
+      <code>doStuffOnPostPersist</code>
+      <code>doStuffOnPostLoad</code>
+      <code>doStuffOnPreUpdate</code>
+      <code>doStuffOnPreFlush</code>
+      <code>doStuffOnPostLoad</code>
+      <code>getId</code>
+      <code>doStuff</code>
+      <code>preUpdate</code>
+      <code>postPersistHandler</code>
+      <code>prePersistHandler</code>
+      <code>postUpdateHandler</code>
+      <code>preUpdateHandler</code>
+      <code>postRemoveHandler</code>
+      <code>preRemoveHandler</code>
+      <code>preFlushHandler</code>
+      <code>postLoadHandler</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$reference</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$reference</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$reference-&gt;postLoadCallbackInvoked</code>
+      <code>$reference-&gt;postLoadCallbackInvoked</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="3">
+      <code>getName</code>
+      <code>getValue</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LifecycleCallbackTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Locking/GearmanLockTest.php">
+    <MissingParamType occurrences="14">
+      <code>$task</code>
+      <code>$forTime</code>
+      <code>$notLongerThan</code>
+      <code>$entityName</code>
+      <code>$entityId</code>
+      <code>$lockMode</code>
+      <code>$dql</code>
+      <code>$params</code>
+      <code>$lockMode</code>
+      <code>$entityName</code>
+      <code>$entityId</code>
+      <code>$lockMode</code>
+      <code>$fn</code>
+      <code>$fixture</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="4">
+      <code>$article-&gt;id</code>
+      <code>$gearman</code>
+      <code>$maxRunTime</code>
+      <code>$articleId</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="7">
+      <code>gearmanTaskCompleted</code>
+      <code>assertLockDoesNotBlock</code>
+      <code>assertLockWorked</code>
+      <code>asyncFindWithLock</code>
+      <code>asyncDqlWithLock</code>
+      <code>asyncLock</code>
+      <code>startJob</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GearmanLockTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedConstant occurrences="1">
+      <code>GEARMAN_SUCCESS</code>
+    </UndefinedConstant>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;tasks</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php">
+    <MissingParamType occurrences="6">
+      <code>$job</code>
+      <code>$job</code>
+      <code>$job</code>
+      <code>$job</code>
+      <code>$job</code>
+      <code>$conn</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="7">
+      <code>run</code>
+      <code>process</code>
+      <code>findWithLock</code>
+      <code>dqlWithLock</code>
+      <code>lock</code>
+      <code>processWorkload</code>
+      <code>createEntityManager</code>
+    </MissingReturnType>
+    <UndefinedClass occurrences="3">
+      <code>GearmanWorker</code>
+      <code>$query</code>
+      <code>$query</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php">
+    <MissingPropertyType occurrences="3">
+      <code>$article-&gt;version</code>
+      <code>$article-&gt;version</code>
+      <code>$article-&gt;version</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LockTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;handles</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$expectedVersionExpired</code>
+    </InvalidArgument>
+    <MissingPropertyType occurrences="10">
+      <code>$test-&gt;version</code>
+      <code>$child-&gt;id</code>
+      <code>$test-&gt;version</code>
+      <code>$parent-&gt;id</code>
+      <code>$entity-&gt;id</code>
+      <code>$test-&gt;id</code>
+      <code>$test-&gt;version</code>
+      <code>$test-&gt;version</code>
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getVersion</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$proxy</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getEntity</code>
+      <code>getEntity</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OptimisticTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;conn</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="4">
+      <code>$this-&gt;conn</code>
+      <code>$this-&gt;conn</code>
+      <code>$this-&gt;conn</code>
+      <code>$this-&gt;conn</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ManyToManyBasicAssociationTest.php">
+    <MissingPropertyType occurrences="14">
+      <code>$user-&gt;groups</code>
+      <code>$group-&gt;users</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$freshUser-&gt;groups</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>assertGblancoGroupCountIs</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$user</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="10">
+      <code>$newUser-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="6">
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getTags</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyBasicAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>findOneById</code>
+      <code>findOneById</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php">
+    <MissingParamType occurrences="2">
+      <code>$products</code>
+      <code>$categories</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="7">
+      <code>$firstField</code>
+      <code>$secondField</code>
+      <code>$table</code>
+      <code>$firstProduct</code>
+      <code>$secondProduct</code>
+      <code>$firstCategory</code>
+      <code>$secondCategory</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>createLoadingFixture</code>
+      <code>findProducts</code>
+      <code>findCategories</code>
+      <code>assertLazyLoadFromInverseSide</code>
+      <code>assertLazyLoadFromOwningSide</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyBidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ManyToManyEventTest.php">
+    <MissingParamType occurrences="1">
+      <code>$args</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>postUpdate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$listener</code>
+      <code>ManyToManyEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$products</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="7">
+      <code>$firstField</code>
+      <code>$secondField</code>
+      <code>$table</code>
+      <code>$firstProduct</code>
+      <code>$secondProduct</code>
+      <code>$firstRelated</code>
+      <code>$secondRelated</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>assertLoadingOfOwningSide</code>
+      <code>createLoadingFixture</code>
+      <code>findProducts</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManySelfReferentialAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ManyToManyUnidirectionalAssociationTest.php">
+    <MissingPropertyType occurrences="7">
+      <code>$firstField</code>
+      <code>$secondField</code>
+      <code>$table</code>
+      <code>$firstProduct</code>
+      <code>$secondProduct</code>
+      <code>$firstCart</code>
+      <code>$secondCart</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>createFixture</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyUnidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/MappedSuperclassTest.php">
+    <PossiblyNullReference occurrences="5">
+      <code>getParent</code>
+      <code>getParent</code>
+      <code>getParent</code>
+      <code>getParent</code>
+      <code>getParent</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MappedSuperclassTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>1</code>
+      <code>2</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="3">
+      <code>$addr-&gt;id</code>
+      <code>$addr-&gt;street</code>
+      <code>$platform</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NativeQueryTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php">
+    <MissingParamType occurrences="5">
+      <code>$hydrationMode</code>
+      <code>$hydrationMode</code>
+      <code>$foo</code>
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="9">
+      <code>$u1-&gt;email</code>
+      <code>$u1-&gt;address</code>
+      <code>$u1-&gt;phonenumbers</code>
+      <code>$u2-&gt;email</code>
+      <code>$u2-&gt;address</code>
+      <code>$u2-&gt;phonenumbers</code>
+      <code>$u3-&gt;email</code>
+      <code>$u3-&gt;address</code>
+      <code>$u3-&gt;phonenumbers</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>provideDataForHydrationMode</code>
+      <code>loadFixtures</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$fixtures</code>
+      <code>NewOperatorTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="3">
+      <code>$this-&gt;foo</code>
+      <code>$this-&gt;bor</code>
+      <code>$this-&gt;foo</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php">
+    <MissingParamType occurrences="5">
+      <code>$propName</code>
+      <code>$oldValue</code>
+      <code>$newValue</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$user-&gt;listeners</code>
+      <code>$group-&gt;listeners</code>
+      <code>$listeners</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="9">
+      <code>onPropertyChanged</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getGroups</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getUsers</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;listeners</code>
+      <code>$group-&gt;listeners</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="8">
+      <code>getGroups</code>
+      <code>getUsers</code>
+      <code>getGroups</code>
+      <code>setName</code>
+      <code>getGroups</code>
+      <code>getUsers</code>
+      <code>getUsers</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NotifyPolicyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$product</code>
+      <code>$firstFeature</code>
+      <code>$secondFeature</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>createFixture</code>
+      <code>assertFeatureForeignKeyIs</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="4">
+      <code>getFeatures</code>
+      <code>getFeatures</code>
+      <code>getFeatures</code>
+      <code>addFeature</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyBidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>getName</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToManyOrphanRemovalTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$userId</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$userProxy</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;phonenumbers</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="6">
+      <code>getPhonenumbers</code>
+      <code>getPhonenumbers</code>
+      <code>getPhonenumbers</code>
+      <code>addPhonenumber</code>
+      <code>getPhonenumbers</code>
+      <code>addPhonenumber</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyOrphanRemovalTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$parent</code>
+      <code>$firstChild</code>
+      <code>$secondChild</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>createFixture</code>
+      <code>assertForeignKeyIs</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManySelfReferentialAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToManyUnidirectionalAssociationTest.php">
+    <MissingPropertyType occurrences="4">
+      <code>$route-&gt;legs</code>
+      <code>$routeA-&gt;legs</code>
+      <code>$routeB-&gt;legs</code>
+      <code>$locations</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyUnidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$customer</code>
+      <code>$cart</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>createFixture</code>
+      <code>assertCartForeignKeyIs</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneBidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$train</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="9">
+      <code>$owner-&gt;id</code>
+      <code>$owner-&gt;train</code>
+      <code>$driver-&gt;train</code>
+      <code>$driver-&gt;id</code>
+      <code>$waggon-&gt;id</code>
+      <code>$driver-&gt;id</code>
+      <code>$waggon-&gt;id</code>
+      <code>$owner-&gt;id</code>
+      <code>$order-&gt;train</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="6">
+      <code>setDriver</code>
+      <code>setOwner</code>
+      <code>addWaggon</code>
+      <code>setTrain</code>
+      <code>setTrain</code>
+      <code>setTrain</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$train-&gt;driver</code>
+      <code>$train-&gt;driver</code>
+      <code>$driver-&gt;train</code>
+      <code>$waggon-&gt;train</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>OneToOneEagerLoadingTest</code>
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneInverseSideLoadAfterDqlQueryTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$fetchedInverse-&gt;owning</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneInverseSideLoadAfterDqlQueryTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneOrphanRemovalTest.php">
+    <PossiblyNullArgument occurrences="2">
+      <code>$userProxy</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>setEmail</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneOrphanRemovalTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php">
+    <MissingParamType occurrences="4">
+      <code>$customer</code>
+      <code>$value</code>
+      <code>$other1</code>
+      <code>$other2</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$customer</code>
+      <code>$mentor</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="8">
+      <code>assertLoadingOfAssociation</code>
+      <code>assertForeignKeyIs</code>
+      <code>createFixture</code>
+      <code>getId</code>
+      <code>setOther1</code>
+      <code>getOther1</code>
+      <code>setOther2</code>
+      <code>getOther2</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="8">
+      <code>getMentor</code>
+      <code>setFetchMode</code>
+      <code>getOther1</code>
+      <code>getOther2</code>
+      <code>getOther1</code>
+      <code>getOther1</code>
+      <code>getOther2</code>
+      <code>getOther2</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneSelfReferentialAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneSingleTableInheritanceTest.php">
+    <MissingPropertyType occurrences="4">
+      <code>$cat-&gt;id</code>
+      <code>$foundCat-&gt;id</code>
+      <code>$cat-&gt;litterBox-&gt;id</code>
+      <code>$foundCat-&gt;litterBox-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneSingleTableInheritanceTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$product</code>
+      <code>$shipping</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>_testEagerLoad</code>
+      <code>createFixture</code>
+      <code>assertForeignKeyIs</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>setFetchMode</code>
+      <code>getShipping</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneUnidirectionalAssociationTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OrderedCollectionTest.php">
+    <MissingPropertyType occurrences="5">
+      <code>$route-&gt;legs</code>
+      <code>$route-&gt;id</code>
+      <code>$route-&gt;id</code>
+      <code>$route-&gt;bookings</code>
+      <code>$locations</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>createPersistedRouteWithLegs</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$route-&gt;legs</code>
+      <code>$route-&gt;bookings</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OrderedCollectionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$dog-&gt;children</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OrderedJoinedTableInheritanceCollectionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PaginationTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$condition</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>walkSelectStatement</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="65">
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$baseDql</code>
+      <code>$checkField</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$fetchJoinCollection</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalkers</code>
+      <code>$useOutputWalker</code>
+      <code>$fetchJoinCollection</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$company-&gt;departments</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="10">
+      <code>iterateWithOrderAsc</code>
+      <code>iterateWithOrderAscWithLimit</code>
+      <code>iterateWithOrderAscWithLimitAndOffset</code>
+      <code>iterateWithOrderDesc</code>
+      <code>iterateWithOrderDescWithLimit</code>
+      <code>iterateWithOrderDescWithLimitAndOffset</code>
+      <code>populate</code>
+      <code>useOutputWalkers</code>
+      <code>fetchJoinCollection</code>
+      <code>useOutputWalkersAndFetchJoinCollection</code>
+    </MissingReturnType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>PaginationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;groups</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>loadTweetFixture</code>
+      <code>loadQuoteFixture</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;tweets</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>PersistentCollectionCriteriaTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PersistentCollectionTest.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>addElement</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="8">
+      <code>getCollection</code>
+      <code>addElement</code>
+      <code>getCollection</code>
+      <code>getRawCollection</code>
+      <code>addElement</code>
+      <code>getId</code>
+      <code>getRawCollection</code>
+      <code>getCollection</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>PersistentCollectionTest</code>
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="2">
+      <code>new PersistentCollectionContent('first element')</code>
+      <code>new PersistentCollectionContent('second element')</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PersistentObjectTest.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <PossiblyNullReference occurrences="4">
+      <code>getName</code>
+      <code>setName</code>
+      <code>getName</code>
+      <code>getParent</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>PersistentObjectTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PostFlushEventTest.php">
+    <MissingConstructor occurrences="1">
+      <code>$receivedArgs</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>postFlush</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$listener</code>
+      <code>PostFlushEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/PostLoadEventTest.php">
+    <MissingParamType occurrences="1">
+      <code>$className</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="5">
+      <code>$checkerListener-&gt;checked</code>
+      <code>$checkerListener-&gt;populated</code>
+      <code>$checked</code>
+      <code>$populated</code>
+      <code>$firedByClasses</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>loadFixture</code>
+      <code>postLoad</code>
+      <code>postLoad</code>
+      <code>postLoad</code>
+      <code>countHandledEvents</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="3">
+      <code>getName</code>
+      <code>getEmail</code>
+      <code>getPhonenumbers</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$userId</code>
+      <code>PostLoadEventTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$object-&gt;getEmail() !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ProxiesLikeEntitiesTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$this-&gt;user-&gt;username</code>
+    </MissingPropertyType>
+    <NoInterfaceProperties occurrences="5">
+      <code>$proxy-&gt;id</code>
+      <code>$proxy-&gt;username</code>
+      <code>$proxy-&gt;name</code>
+      <code>$proxy-&gt;name</code>
+      <code>$proxy-&gt;id</code>
+    </NoInterfaceProperties>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$this-&gt;em-&gt;find(CmsUser::class, $proxy-&gt;getId())-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="3">
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>getId</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$user</code>
+      <code>$proxyClassName</code>
+      <code>ProxiesLikeEntitiesTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getId</code>
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php">
+    <InvalidArgument occurrences="5">
+      <code>$cache</code>
+      <code>self::isType('string')</code>
+      <code>self::isInstanceOf(ParserResult::class)</code>
+      <code>$this-&gt;isType('string')</code>
+      <code>$cache</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="3">
+      <code>$query</code>
+      <code>$query</code>
+      <code>$query</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cacheDataReflection</code>
+      <code>QueryCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php">
+    <MissingReturnType occurrences="1">
+      <code>generateFixture</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>QueryDqlFunctionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/QueryTest.php">
+    <InvalidScalarArgument occurrences="4">
+      <code>1</code>
+      <code>2</code>
+      <code>1</code>
+      <code>FetchMode::EAGER</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="7">
+      <code>$article1-&gt;id</code>
+      <code>$author-&gt;id</code>
+      <code>$result[0]-&gt;topic</code>
+      <code>$result[0]-&gt;user</code>
+      <code>$user1-&gt;id</code>
+      <code>$user2-&gt;id</code>
+      <code>$user3-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="1">
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>QueryTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$identityMap[CmsArticle::class]</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ReadOnlyTest.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$number</code>
+    </MissingParamType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$dbReadOnly-&gt;name</code>
+      <code>$dbReadOnly-&gt;numericValue</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ReadOnlyTest</code>
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$clone-&gt;isCloned</code>
+      <code>$entity-&gt;isCloned</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>createProduct</code>
+      <code>createAuction</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="3">
+      <code>getName</code>
+      <code>getName</code>
+      <code>getShipping</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="16">
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>setName</code>
+      <code>getName</code>
+      <code>isProxyInitialized</code>
+      <code>getId</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>getId</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>getName</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>initializeProxy</code>
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$factory</code>
+      <code>ReferenceProxyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php">
+    <InvalidMethodCall occurrences="3">
+      <code>getResultCacheDriver</code>
+      <code>setHint</code>
+      <code>getResult</code>
+    </InvalidMethodCall>
+    <MissingParamType occurrences="2">
+      <code>$query</code>
+      <code>$query</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cacheDataReflection</code>
+      <code>ResultCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="6">
+      <code>$em</code>
+      <code>$em</code>
+      <code>$name</code>
+      <code>$targetTable</code>
+      <code>$targetTable</code>
+      <code>$targetTable</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="17">
+      <code>$article1-&gt;id</code>
+      <code>$article2-&gt;id</code>
+      <code>$group-&gt;id</code>
+      <code>$group2-&gt;id</code>
+      <code>$userId</code>
+      <code>$userId2</code>
+      <code>$articleId</code>
+      <code>$articleId2</code>
+      <code>$groupId</code>
+      <code>$groupId2</code>
+      <code>$managerId</code>
+      <code>$managerId2</code>
+      <code>$contractId1</code>
+      <code>$contractId2</code>
+      <code>$organizationId</code>
+      <code>$eventId1</code>
+      <code>$eventId2</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="14">
+      <code>configureFilters</code>
+      <code>getMockConnection</code>
+      <code>getMockEntityManager</code>
+      <code>addMockFilterCollection</code>
+      <code>loadLazyFixtureData</code>
+      <code>useCMSArticleTopicFilter</code>
+      <code>useCMSGroupPrefixFilter</code>
+      <code>loadFixtureData</code>
+      <code>loadCompanyJoinedSubclassFixtureData</code>
+      <code>loadCompanySingleTableInheritanceFixtureData</code>
+      <code>useCompletedContractFilter</code>
+      <code>usePersonNameFilter</code>
+      <code>loadCompanyOrganizationEventJoinedSubclassFixtureData</code>
+      <code>useCompanyEventIdFilter</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="18">
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;groups</code>
+      <code>$manager-&gt;managedContracts</code>
+      <code>$manager-&gt;managedContracts</code>
+      <code>$manager-&gt;managedContracts</code>
+      <code>$contract-&gt;managers</code>
+      <code>$contract-&gt;managers</code>
+      <code>$contract-&gt;managers</code>
+      <code>$manager-&gt;soldContracts</code>
+      <code>$manager-&gt;soldContracts</code>
+      <code>$manager-&gt;soldContracts</code>
+      <code>$organization-&gt;events</code>
+      <code>$organization-&gt;events</code>
+      <code>$organization-&gt;events</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="5">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>getInterfaceNames</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SQLFilterTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="8">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>findById</code>
+      <code>findById</code>
+      <code>findOneById</code>
+      <code>findOneById</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CompanySchemaTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaTool/DBAL483Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DBAL483Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php">
+    <MissingParamType occurrences="1">
+      <code>$classes</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$classes</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>assertCreatedSchemaNeedsNoUpdates</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC214Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MySqlSchemaToolTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php">
+    <MissingConstructor occurrences="2">
+      <code>$pk</code>
+      <code>$pk</code>
+    </MissingConstructor>
+    <PossiblyNullReference occurrences="1">
+      <code>getValueGenerator</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>PostgreSqlSchemaToolTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getValueGenerator</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php">
+    <MissingReturnType occurrences="1">
+      <code>registerType</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SchemaValidatorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php">
+    <MissingParamType occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$association</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="10">
+      <code>$people</code>
+      <code>$addresses</code>
+      <code>$countries</code>
+      <code>$states</code>
+      <code>$cities</code>
+      <code>$travels</code>
+      <code>$travelers</code>
+      <code>$attractions</code>
+      <code>$attractionsInfo</code>
+      <code>$travelersWithProfile</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="14">
+      <code>loadFixturesCountries</code>
+      <code>loadFixturesStates</code>
+      <code>loadFixturesCities</code>
+      <code>loadFixturesTraveler</code>
+      <code>loadFixturesTravelersWithProfile</code>
+      <code>loadFixturesTravelersProfileInfo</code>
+      <code>loadFixturesTravels</code>
+      <code>loadFixturesAttractions</code>
+      <code>loadFixturesAttractionsInfo</code>
+      <code>loadFixturesPersonWithAddress</code>
+      <code>getEntityRegion</code>
+      <code>getCollectionRegion</code>
+      <code>getDefaultQueryRegionName</code>
+      <code>evictRegions</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;em-&gt;getCache()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>getName</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php">
+    <PossiblyNullArgument occurrences="7">
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$flight</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="9">
+      <code>getLeavingFrom</code>
+      <code>getGoingTo</code>
+      <code>getLeavingFrom</code>
+      <code>getGoingTo</code>
+      <code>getDeparture</code>
+      <code>setDeparture</code>
+      <code>getLeavingFrom</code>
+      <code>getGoingTo</code>
+      <code>getDeparture</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheCompositePrimaryKeyTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="6">
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+      <code>$leavingFrom</code>
+      <code>$goingTo</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyWithAssociationsTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$admin1-&gt;names</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>evictRegions</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;em-&gt;getCache()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$admin1Rome-&gt;country</code>
+      <code>$admin1Rome-&gt;names</code>
+      <code>$admin1Rome-&gt;country</code>
+      <code>$admin1Rome-&gt;names</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cache</code>
+      <code>SecondLevelCacheCompositePrimaryKeyWithAssociationsTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheConcurrentTest.php">
+    <MissingPropertyType occurrences="3">
+      <code>$countryMetadata</code>
+      <code>$cache</code>
+      <code>$regions</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="9">
+      <code>setCacheFactory</code>
+      <code>getEntityCacheRegion</code>
+      <code>setLock</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCities</code>
+      <code>getCollectionCacheRegion</code>
+      <code>setLock</code>
+      <code>getCities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cacheFactory</code>
+      <code>SecondLevelCacheConcurrentTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>setLock</code>
+      <code>setLock</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCriteriaTest.php">
+    <PossiblyNullReference occurrences="2">
+      <code>getCities</code>
+      <code>getCities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheCriteriaTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="6">
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheExtraLazyCollectionTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$owner</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="11">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheExtraLazyCollectionTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$ref</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheJoinTableInheritanceTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;em-&gt;find(Attraction::class, $this-&gt;attractions[5]-&gt;getId())</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="23">
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getFone</code>
+      <code>getId</code>
+      <code>getFone</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getFone</code>
+      <code>getFone</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getFone</code>
+      <code>getFone</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+      <code>getInfos</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheJoinTableInheritanceTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(Attraction::class, $this-&gt;attractions[5]-&gt;getId())</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$travel</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="49">
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+      <code>getVisitedCities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheManyToManyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToOneTest.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$action2</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingDocblockType occurrences="1">
+      <code>$entity</code>
+    </MissingDocblockType>
+    <MissingPropertyType occurrences="6">
+      <code>$token-&gt;token</code>
+      <code>$action-&gt;name</code>
+      <code>$token-&gt;token</code>
+      <code>$action1-&gt;name</code>
+      <code>$action2-&gt;name</code>
+      <code>$action3-&gt;name</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$c3</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$entity-&gt;token</code>
+      <code>$entity-&gt;token</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="47">
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCities</code>
+      <code>addCity</code>
+      <code>getId</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getCountry</code>
+      <code>getAction</code>
+      <code>getAction</code>
+      <code>getAction</code>
+      <code>getComplexAction</code>
+      <code>getComplexAction</code>
+      <code>getComplexAction</code>
+      <code>getComplexAction</code>
+      <code>getComplexAction</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheManyToOneTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$c3</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToManyTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$token-&gt;token</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$state</code>
+      <code>$state</code>
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$entity-&gt;token</code>
+      <code>$entity-&gt;logins</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="62">
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getCities</code>
+      <code>getTravels</code>
+      <code>getTravels</code>
+      <code>getTravels</code>
+      <code>getTravels</code>
+      <code>getTravels</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheOneToManyTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$entity</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheOneToOneTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$token-&gt;token</code>
+      <code>$client-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="13">
+      <code>$p1-&gt;id</code>
+      <code>$p1-&gt;name</code>
+      <code>$p1-&gt;address</code>
+      <code>$p2-&gt;id</code>
+      <code>$p2-&gt;name</code>
+      <code>$p2-&gt;address</code>
+      <code>$p3-&gt;address</code>
+      <code>$p4-&gt;address</code>
+      <code>$p3-&gt;id</code>
+      <code>$p3-&gt;name</code>
+      <code>$p4-&gt;id</code>
+      <code>$p4-&gt;name</code>
+      <code>$entity-&gt;token</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="36">
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getProfile</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getInfo</code>
+      <code>getInfo</code>
+      <code>getClient</code>
+      <code>getClient</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheOneToOneTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php">
+    <NoInterfaceProperties occurrences="1">
+      <code>$entry-&gt;time</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="1">
+      <code>$entry</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$entry-&gt;time</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>put</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheQueryCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheRepositoryTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$country</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheRepositoryTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(Country::class, $this-&gt;countries[0]-&gt;getId())</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheSingleTableInheritanceTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;em-&gt;find(City::class, $this-&gt;cities[1]-&gt;getId())</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="28">
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+      <code>getAttractions</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheSingleTableInheritanceTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(City::class, $this-&gt;cities[1]-&gt;getId())</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheTest.php">
+    <MissingParamType occurrences="5">
+      <code>$eventName</code>
+      <code>$args</code>
+      <code>$args</code>
+      <code>$args</code>
+      <code>$args</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$callbacks</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>dispatch</code>
+      <code>postFlush</code>
+      <code>postUpdate</code>
+      <code>postRemove</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="6">
+      <code>$c1</code>
+      <code>$c2</code>
+      <code>$s1</code>
+      <code>$s2</code>
+      <code>$state</code>
+      <code>$country</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="31">
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>setName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getValue</code>
+      <code>setValue</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SequenceEmulatedIdentityStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SequenceGeneratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SingleTableCompositeKeyTest.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;em-&gt;find(SingleRootClass::class, ['keyPart1' =&gt; 'part-1', 'keyPart2' =&gt; 'part-2'])</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>JoinedChildClass</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleTableCompositeKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/SingleTableInheritanceTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>FetchMode::EAGER</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="5">
+      <code>$salesPerson</code>
+      <code>$engineers</code>
+      <code>$fix</code>
+      <code>$flex</code>
+      <code>$ultra</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>persistRelatedEmployees</code>
+      <code>loadFullFixture</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$fix</code>
+      <code>$this-&gt;em-&gt;find(get_class($this-&gt;fix), $this-&gt;fix-&gt;getId())</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="10">
+      <code>getFixPrice</code>
+      <code>getSalesPerson</code>
+      <code>getMaxPrice</code>
+      <code>getHoursWorked</code>
+      <code>getPricePerHour</code>
+      <code>setFixPrice</code>
+      <code>getFixPrice</code>
+      <code>getFixPrice</code>
+      <code>getHoursWorked</code>
+      <code>getHoursWorked</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleTableInheritanceTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>matching</code>
+      <code>matching</code>
+      <code>matching</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/StandardEntityPersisterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>StandardEntityPersisterTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$class-&gt;getProperty('customer')</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1040Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1040Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1041Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1041Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1043Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;status</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1043Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1080Test.php">
+    <InvalidArgument occurrences="5">
+      <code>'foo title 1'</code>
+      <code>'foo title 2'</code>
+      <code>'bar title 1'</code>
+      <code>'bar title 2'</code>
+      <code>'bar title 3'</code>
+    </InvalidArgument>
+    <MissingConstructor occurrences="1">
+      <code>$orderNr</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="6">
+      <code>setFooID</code>
+      <code>setFooTitle</code>
+      <code>setFooBars</code>
+      <code>setBarID</code>
+      <code>setBarTitle</code>
+      <code>setFooBars</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$orderNr</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="1">
+      <code>getFooBars</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1080Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="12">
+      <code>the</code>
+      <code>the</code>
+      <code>the</code>
+      <code>field_type</code>
+      <code>field_type</code>
+      <code>field_type</code>
+      <code>the</code>
+      <code>the</code>
+      <code>the</code>
+      <code>field_type</code>
+      <code>field_type</code>
+      <code>field_type</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1113Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1113Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1129Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$article-&gt;version</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1129Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1151Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php">
+    <InvalidArgument occurrences="1">
+      <code>$specialProduct</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$specialProduct</code>
+    </InvalidPropertyAssignmentValue>
+    <MismatchingDocblockParamType occurrences="1">
+      <code>Product</code>
+    </MismatchingDocblockParamType>
+    <MissingConstructor occurrences="2">
+      <code>$id</code>
+      <code>$subclassProperty</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="9">
+      <code>createSpecialProductAndProxyHolderReferencingIt</code>
+      <code>createProxyForSpecialProduct</code>
+      <code>setPropertyAndAssignTagToSpecialProduct</code>
+      <code>getId</code>
+      <code>setSpecialProduct</code>
+      <code>getSpecialProduct</code>
+      <code>getId</code>
+      <code>setSubclassProperty</code>
+      <code>setProduct</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>DDC1163Test</code>
+      <code>$id</code>
+      <code>$product</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="3">
+      <code>SpecialProduct</code>
+      <code>Product</code>
+      <code>Product</code>
+    </UndefinedClass>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;productId</code>
+      <code>$this-&gt;proxyHolderId</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="2">
+      <code>$this-&gt;proxyHolderId</code>
+      <code>$this-&gt;productId</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;em-&gt;find(get_class($editor), $editor-&gt;id)</code>
+    </LessSpecificReturnStatement>
+    <MissingPropertyType occurrences="15">
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;id</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;id</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;id</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;id</code>
+      <code>$article1</code>
+      <code>$article2</code>
+      <code>$reference</code>
+      <code>$translation</code>
+      <code>$articleDetails</code>
+    </MissingPropertyType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>DDC117Editor</code>
+    </MoreSpecificReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$refRep</code>
+      <code>$article</code>
+      <code>$reference</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$editor-&gt;reviewingTranslations</code>
+      <code>$editor-&gt;reviewingTranslations</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="22">
+      <code>target</code>
+      <code>source</code>
+      <code>target</code>
+      <code>source</code>
+      <code>setDescription</code>
+      <code>getDescription</code>
+      <code>references</code>
+      <code>references</code>
+      <code>id</code>
+      <code>references</code>
+      <code>references</code>
+      <code>addTranslation</code>
+      <code>addTranslation</code>
+      <code>getDetails</code>
+      <code>source</code>
+      <code>getArticleDetails</code>
+      <code>getReference</code>
+      <code>getTranslation</code>
+      <code>id</code>
+      <code>id</code>
+      <code>getLinks</code>
+      <code>getLinks</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC117Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php">
+    <InvalidPropertyAssignmentValue occurrences="6">
+      <code>$hotel</code>
+      <code>$room1</code>
+      <code>$hotel</code>
+      <code>$room2</code>
+      <code>$hotel-&gt;bookings</code>
+      <code>$hotel-&gt;bookings</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="2">
+      <code>$bookings</code>
+      <code>$hotel</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1181Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="3">
+      <code>Booking[]</code>
+      <code>Hotel</code>
+      <code>Room</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1193Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$company-&gt;id</code>
+      <code>$company-&gt;member</code>
+    </MissingPropertyType>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1193Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyAssignment occurrences="1">
+      <code>$person-&gt;company</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1209Test.php">
+    <InvalidToString occurrences="1">
+      <code>__toString</code>
+    </InvalidToString>
+    <MissingPropertyType occurrences="4">
+      <code>$entity-&gt;date</code>
+      <code>$future2-&gt;starting_datetime</code>
+      <code>$future2-&gt;during_datetime</code>
+      <code>$future2-&gt;ending_datetime</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getId</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1209Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1225Test.php">
+    <MissingReturnType occurrences="1">
+      <code>setTestEntity2</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1225Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1228Test.php">
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$profile</code>
+      <code>$profile</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="2">
+      <code>$id</code>
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getProfile</code>
+      <code>getName</code>
+      <code>setName</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$user</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyUndefinedMethod occurrences="4">
+      <code>isProxyInitialized</code>
+      <code>setName</code>
+      <code>isProxyInitialized</code>
+      <code>getName</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1228Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>Profile</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1238Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getId</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1238Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="3">
+      <code>$user</code>
+      <code>$user2</code>
+      <code>$user</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1250Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$c2-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1250Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1300Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$locale</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>DDC1300Test</code>
+      <code>$fooID</code>
+      <code>$fooReference</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>array|Zend_Config|null</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1301Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$userId</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadFixture</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$user-&gt;articles</code>
+      <code>$user-&gt;references</code>
+      <code>$user-&gt;cars</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="6">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1301Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="6">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedPropertyAssignment occurrences="3">
+      <code>$user1-&gt;status</code>
+      <code>$user2-&gt;status</code>
+      <code>$user3-&gt;status</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1306Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1306Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1335Test.php">
+    <MissingParamType occurrences="4">
+      <code>$email</code>
+      <code>$name</code>
+      <code>$user</code>
+      <code>$number</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>loadFixture</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1335Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1360Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1400Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user1-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1400Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC142Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$addressRef</code>
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="2">
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="3">
+      <code>getAddress</code>
+      <code>getAddress</code>
+      <code>getAddress</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC142Test</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$addressRef</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1430Test.php">
+    <MissingParamType occurrences="1">
+      <code>$status</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>loadFixtures</code>
+      <code>setStatus</code>
+      <code>addProduct</code>
+      <code>setOrder</code>
+      <code>setValue</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DDC1430Test</code>
+      <code>$order</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>createQueryBuilder</code>
+      <code>createQueryBuilder</code>
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1436Test.php">
+    <MissingParamType occurrences="1">
+      <code>$parent</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>setParent</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="3">
+      <code>getId</code>
+      <code>getParent</code>
+      <code>getParent</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1436Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC144Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>method</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC144Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1452Test.php">
+    <MissingReturnType occurrences="1">
+      <code>getEntitiesB</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1452Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1454Test.php">
+    <MissingReturnType occurrences="1">
+      <code>getFileId</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1454Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1458Test.php">
+    <MissingParamType occurrences="3">
+      <code>$value</code>
+      <code>$additional</code>
+      <code>$bool</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>getAdditional</code>
+      <code>setAdditional</code>
+      <code>getBool</code>
+      <code>setBool</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="5">
+      <code>setValue</code>
+      <code>getValue</code>
+      <code>getAdditional</code>
+      <code>getValue</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1258Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1461Test.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$acc</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="1">
+      <code>$twitterAccount</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;twitterAccount</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1461Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>TwitterAccount</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1514Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$a1-&gt;id</code>
+      <code>$a2-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1514Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1515Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$bar-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$bar-&gt;foo</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1515Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1526Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1526Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1545Test.php">
+    <MissingParamType occurrences="1">
+      <code>$link</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$article-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user2-&gt;id</code>
+      <code>$articleId</code>
+      <code>$userId</code>
+      <code>$user2Id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>initDb</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignment occurrences="3">
+      <code>$article</code>
+      <code>$article</code>
+      <code>$article</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user2-&gt;id</code>
+      <code>$user2-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1545Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1548Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$rel-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$obt-&gt;e2</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1548Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>getEntities</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="6">
+      <code>$sqlLogger-&gt;queries</code>
+      <code>$sqlLogger-&gt;queries</code>
+      <code>$sqlLogger-&gt;queries</code>
+      <code>$sqlLogger-&gt;queries</code>
+      <code>$sqlLogger-&gt;queries</code>
+      <code>$sqlLogger-&gt;queries</code>
+    </NoInterfaceProperties>
+    <PossiblyNullReference occurrences="2">
+      <code>getEntities</code>
+      <code>getEntities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1595Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC163Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC163Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1643Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$user1-&gt;id</code>
+      <code>$user2-&gt;id</code>
+      <code>$user1</code>
+      <code>$user2</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$user1</code>
+      <code>$user1</code>
+      <code>$user1</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$user1-&gt;groups</code>
+      <code>$user2-&gt;groups</code>
+      <code>$user2-&gt;groups</code>
+      <code>$user2-&gt;groups</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1643Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php">
+    <MissingPropertyType occurrences="5">
+      <code>$post-&gt;comments</code>
+      <code>$post-&gt;comments</code>
+      <code>$post-&gt;comments</code>
+      <code>$post-&gt;comments</code>
+      <code>$post-&gt;comments</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="1">
+      <code>executeUpdate</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1654Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1655Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$baz-&gt;id</code>
+      <code>$bar-&gt;id</code>
+      <code>$loaded</code>
+      <code>$subLoaded</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>postLoad</code>
+      <code>postSubLoaded</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$bar</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="6">
+      <code>$baz-&gt;foos</code>
+      <code>$bar-&gt;loaded</code>
+      <code>$bar-&gt;subLoaded</code>
+      <code>$bar-&gt;loaded</code>
+      <code>$bar-&gt;subLoaded</code>
+      <code>$bar-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1655Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1666Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1666Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1685Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$paginator</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1685Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC168Test.php">
+    <InvalidArgument occurrences="1">
+      <code>$metadata</code>
+    </InvalidArgument>
+    <MissingPropertyType occurrences="1">
+      <code>$oldMetadata</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC168Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php">
+    <MissingParamType occurrences="7">
+      <code>$propName</code>
+      <code>$oldValue</code>
+      <code>$newValue</code>
+      <code>$name</code>
+      <code>$child</code>
+      <code>$name</code>
+      <code>$parent</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="5">
+      <code>$parent-&gt;listeners</code>
+      <code>$child-&gt;listeners</code>
+      <code>$fetchedChild-&gt;listeners</code>
+      <code>$fetchedChild-&gt;listeners</code>
+      <code>$listeners</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="11">
+      <code>onPropertyChanged</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>setChild</code>
+      <code>getChild</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>setParent</code>
+      <code>getParent</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="2">
+      <code>$fetchedChild-&gt;listeners</code>
+      <code>$fetchedChild-&gt;listeners</code>
+    </NoInterfaceProperties>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$fetchedParent-&gt;listeners</code>
+      <code>$secondFetchedParent-&gt;listeners</code>
+      <code>$thirdFetchedChild-&gt;listeners</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>initializeProxy</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1690Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$idNews</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1695Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>DateTimeZone</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1707Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$entity-&gt;postLoad</code>
+      <code>$postLoad</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>onPostLoad</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1707Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>DDC1509File</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1719Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$e1-&gt;id</code>
+      <code>$e2-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="4">
+      <code>$e1</code>
+      <code>$e2</code>
+      <code>$e1</code>
+      <code>$e2</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="2">
+      <code>$e1</code>
+      <code>$e2</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$e1-&gt;id</code>
+      <code>$e2-&gt;id</code>
+      <code>$e1-&gt;value</code>
+      <code>$e2-&gt;value</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1719Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1757Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1757Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1778Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$user</code>
+      <code>$phone</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="3">
+      <code>getPhonenumbers</code>
+      <code>getPhonenumbers</code>
+      <code>getPhonenumbers</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1778Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php">
+    <MissingReturnType occurrences="1">
+      <code>getVersion</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1787Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1843Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$e1-&gt;id</code>
+      <code>$e2-&gt;id</code>
+      <code>$e3-&gt;id</code>
+      <code>$e4-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="8">
+      <code>$e1</code>
+      <code>$e2</code>
+      <code>$e3</code>
+      <code>$e4</code>
+      <code>$e4</code>
+      <code>$e3</code>
+      <code>$e2</code>
+      <code>$e1</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="4">
+      <code>$e1</code>
+      <code>$e2</code>
+      <code>$e3</code>
+      <code>$e4</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="8">
+      <code>$e1-&gt;id</code>
+      <code>$e2-&gt;id</code>
+      <code>$e3-&gt;id</code>
+      <code>$e4-&gt;id</code>
+      <code>$e1-&gt;name</code>
+      <code>$e2-&gt;name</code>
+      <code>$e3-&gt;name</code>
+      <code>$e4-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1843Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php">
+    <MissingParamType occurrences="2">
+      <code>$class</code>
+      <code>$class</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>createCars</code>
+      <code>createDrivers</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1884Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1885Test.php">
+    <MissingPropertyType occurrences="5">
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="4">
+      <code>$user</code>
+      <code>$user</code>
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="18">
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;groups</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;name</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;groups</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="12">
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+      <code>getGroups</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$user</code>
+      <code>DDC1885Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyAssignment occurrences="1">
+      <code>$user-&gt;email</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1918Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1918Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="3">
+      <code>setTitle</code>
+      <code>addBuyer</code>
+      <code>setTitle</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>DDC1925Test</code>
+      <code>$id</code>
+      <code>$title</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>setPhone</code>
+      <code>getPhone</code>
+      <code>setUser</code>
+      <code>getUser</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC192Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1995Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1995Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1998Test.php">
+    <MissingParamType occurrences="1">
+      <code>$val</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$entity-&gt;num</code>
+      <code>$val</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC1998Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC199Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC199Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2012Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$item-&gt;id</code>
+      <code>$calls</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$item</code>
+      <code>$item</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$item</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$item-&gt;tsv</code>
+      <code>$item-&gt;tsv</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2012Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2074Test.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$class-&gt;getProperty('categories')</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="4">
+      <code>getCategories</code>
+      <code>getCategories</code>
+      <code>getCategories</code>
+      <code>getCategories</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2074Test</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$class-&gt;getProperty('categories')</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>loadFixture</code>
+      <code>setMyEntity2</code>
+      <code>getMyEntity2</code>
+      <code>getId</code>
+      <code>getValue</code>
+      <code>setValue</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>getMyEntity2</code>
+      <code>getMyEntity2</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2084Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2090Test.php">
+    <PossiblyNullReference occurrences="8">
+      <code>getSalary</code>
+      <code>getSalary</code>
+      <code>getStartDate</code>
+      <code>getStartDate</code>
+      <code>getSalary</code>
+      <code>getSalary</code>
+      <code>getStartDate</code>
+      <code>getStartDate</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2090Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>setName</code>
+      <code>getGroups</code>
+      <code>setName</code>
+      <code>getUsers</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC211Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php">
+    <InvalidArgument occurrences="2">
+      <code>['object_id']</code>
+      <code>['user_id']</code>
+    </InvalidArgument>
+    <InvalidReturnStatement occurrences="2">
+      <code>$this-&gt;followedUsers</code>
+      <code>$this-&gt;followedStructures</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="2">
+      <code>Doctrine\Common\Collections\Collection</code>
+      <code>Doctrine\Common\Collections\Collection</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="2">
+      <code>getUser</code>
+      <code>removeFollower</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>DDC2138Test</code>
+      <code>$user</code>
+      <code>$followedStructure</code>
+      <code>DDC2138UserFollowedStructure</code>
+      <code>DDC2138UserFollowedUser</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="10">
+      <code>Structure</code>
+      <code>Structure</code>
+      <code>Structure</code>
+      <code>UserFollowedUser</code>
+      <code>UserFollowedUser</code>
+      <code>UserFollowedUser</code>
+      <code>Doctrine\Common\Collections\Collection</code>
+      <code>UserFollowedStructure</code>
+      <code>UserFollowedStructure</code>
+      <code>Doctrine\Common\Collections\Collection</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$entity-&gt;version</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2175Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2182Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2214Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$foo-&gt;id</code>
+      <code>$foo-&gt;bar</code>
+    </MissingPropertyType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$logger-&gt;queries</code>
+    </NoInterfaceProperties>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2214Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2224Test.php">
+    <MissingReturnType occurrences="1">
+      <code>setUpBeforeClass</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2224Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2230Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$listener</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="1">
+      <code>$insertedAddress-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$addressProxy-&gt;listener</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>initializeProxy</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2230Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2231Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$this-&gt;persistedEntityManagerAwareEntity-&gt;id</code>
+      <code>$this-&gt;persistedEntityManagerAwareEntity-&gt;id</code>
+    </MissingPropertyType>
+    <NoInterfaceProperties occurrences="2">
+      <code>$emAware-&gt;em</code>
+      <code>$emAware-&gt;em</code>
+    </NoInterfaceProperties>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>initializeProxy</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$persistedEntityManagerAwareEntity</code>
+      <code>DDC2231Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2252Test.php">
+    <MissingParamType occurrences="1">
+      <code>$privilege</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="4">
+      <code>$user</code>
+      <code>$merchant</code>
+      <code>$membership</code>
+      <code>$privileges</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="8">
+      <code>loadFixtures</code>
+      <code>getPrivilegeid</code>
+      <code>getAccountid</code>
+      <code>getUid</code>
+      <code>getMemberships</code>
+      <code>addMembership</code>
+      <code>addPrivilege</code>
+      <code>getPrivileges</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$membership</code>
+      <code>$membership</code>
+      <code>$membership</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="7">
+      <code>getPrivileges</code>
+      <code>getPrivileges</code>
+      <code>getPrivileges</code>
+      <code>getPrivileges</code>
+      <code>getPrivileges</code>
+      <code>addPrivilege</code>
+      <code>getPrivileges</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2252Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2306Test.php">
+    <MissingPropertyType occurrences="3">
+      <code>$address-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <NoInterfaceProperties occurrences="2">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </NoInterfaceProperties>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>initializeProxy</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2306Test</code>
+    </PropertyNotSetInConstructor>
+    <TooManyTemplateParams occurrences="2">
+      <code>DDC2306UserAddress[]|Collection</code>
+      <code>DDC2306UserAddress[]|Collection</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2346Test.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$logger</code>
+      <code>DDC2346Test</code>
+    </PropertyNotSetInConstructor>
+    <TooManyTemplateParams occurrences="1">
+      <code>DDC2346Bar[]|Collection</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2350Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;reportedBugs</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2350Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php">
+    <InvalidArgument occurrences="1">
+      <code>$entityManager</code>
+    </InvalidArgument>
+    <PossiblyUndefinedMethod occurrences="4">
+      <code>expects</code>
+      <code>expects</code>
+      <code>setEntityManager</code>
+      <code>getMetadataFor</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2359Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC237Test.php">
+    <MissingPropertyType occurrences="3">
+      <code>$x-&gt;id</code>
+      <code>$z-&gt;id</code>
+      <code>$y-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$x2-&gt;y</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC237Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2387Test.php">
+    <InvalidArgument occurrences="2">
+      <code>['id']</code>
+      <code>['product_id', 'attribute_name']</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2387Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2494Test.php">
+    <MissingParamType occurrences="2">
+      <code>$id</code>
+      <code>$temp</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$calls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>getId</code>
+      <code>getTemp</code>
+      <code>getCampaigns</code>
+      <code>getId</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="7">
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+      <code>getCurrency</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DDC2494Test</code>
+      <code>$campaigns</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2519Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$userId</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadFixture</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2519Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyAssignment occurrences="3">
+      <code>$user1-&gt;status</code>
+      <code>$user2-&gt;status</code>
+      <code>$user3-&gt;status</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2575Test.php">
+    <MissingParamType occurrences="4">
+      <code>$id</code>
+      <code>$value</code>
+      <code>$id</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$rootsEntities</code>
+      <code>$aEntities</code>
+      <code>$bEntities</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2575Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2579Test.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$val</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="4">
+      <code>$entity-&gt;value</code>
+      <code>$entity-&gt;id</code>
+      <code>$assoc-&gt;assocAssoc</code>
+      <code>$val</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$entity-&gt;value</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2579Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC258Test.php">
+    <MissingPropertyType occurrences="8">
+      <code>$c2-&gt;id</code>
+      <code>$obj-&gt;title</code>
+      <code>$obj-&gt;description</code>
+      <code>$obj-&gt;title</code>
+      <code>$obj-&gt;description</code>
+      <code>$obj-&gt;text</code>
+      <code>$obj-&gt;apples</code>
+      <code>$obj-&gt;bananas</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$e2-&gt;title</code>
+      <code>$e2-&gt;description</code>
+      <code>$e2-&gt;text</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC258Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2602Test.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$fieldList</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="3">
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>DDC2602Test</code>
+      <code>$id</code>
+      <code>$field</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2655Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2655Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2660Test.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2660Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2692Test.php">
+    <InvalidArgument occurrences="1">
+      <code>$listener</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="1">
+      <code>preFlush</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2692Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2759Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2759Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2775Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>addAuthorization</code>
+      <code>addRole</code>
+      <code>addAuthorization</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2775Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2780Test.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="1">
+      <code>$project</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2780Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2790Test.php">
+    <MissingReturnType occurrences="1">
+      <code>onFlush</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2790Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC279Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$x-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC279Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2825Test.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $className()</code>
+    </InvalidStringClass>
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <PossiblyNullArgument occurrences="1">
+      <code>$classMetadata-&gt;getTableName()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2825Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2862Test.php">
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$userProfile</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>setName</code>
+      <code>setUserProfile</code>
+      <code>setName</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="20">
+      <code>containsEntity</code>
+      <code>containsEntity</code>
+      <code>getUserProfile</code>
+      <code>setName</code>
+      <code>containsEntity</code>
+      <code>containsEntity</code>
+      <code>getUserProfile</code>
+      <code>getName</code>
+      <code>getUserProfile</code>
+      <code>evictEntityRegion</code>
+      <code>evictEntityRegion</code>
+      <code>containsEntity</code>
+      <code>containsEntity</code>
+      <code>getUserProfile</code>
+      <code>containsEntity</code>
+      <code>containsEntity</code>
+      <code>getUserProfile</code>
+      <code>getUserProfile</code>
+      <code>getUserProfile</code>
+      <code>getUserProfile</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2862Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="3">
+      <code>User</code>
+      <code>User</code>
+      <code>User</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2895Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$lastModified</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="1">
+      <code>$ddc2895-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>setLastModifiedPreUpdate</code>
+      <code>setLastModified</code>
+      <code>setId</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2895Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2931Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$second-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="1">
+      <code>getRank</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2931Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2943Test.php">
+    <MissingParamType occurrences="6">
+      <code>$regionName</code>
+      <code>$count</code>
+      <code>$pageSize</code>
+      <code>$regionName</code>
+      <code>$count</code>
+      <code>$pageSize</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>loadFixtures</code>
+      <code>assertPaginatorQueryPut</code>
+      <code>assertPaginatorQueryHit</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="4">
+      <code>getEntityCacheRegion</code>
+      <code>getName</code>
+      <code>getEntityCacheRegion</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2943Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2984Test.php">
+    <MissingReturnType occurrences="2">
+      <code>applyName</code>
+      <code>getName</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$sameUser</code>
+      <code>$equalUser</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2984Test</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="2">
+      <code>$sameUser</code>
+      <code>$equalUser</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2996Test.php">
+    <MissingParamType occurrences="1">
+      <code>$event</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$pref-&gt;user-&gt;counter</code>
+      <code>$pref-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>preFlush</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$pref-&gt;user</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC2996Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3033Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="3">
+      <code>$product-&gt;buyers</code>
+      <code>$product-&gt;changeSet</code>
+      <code>$changeSet</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>preUpdate</code>
+      <code>postUpdate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>DDC3033Test</code>
+      <code>$id</code>
+      <code>$title</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3042Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3042Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3068Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$foo</code>
+      <code>$merc</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3068Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC309Test.php">
+    <PossiblyInvalidArrayAccess occurrences="4">
+      <code>$c[0]</code>
+      <code>$u[0]</code>
+      <code>$c[0]</code>
+      <code>$u[0]</code>
+    </PossiblyInvalidArrayAccess>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC309Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3103Test.php">
+    <InvalidArgument occurrences="2">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+    </InvalidArgument>
+    <MissingConstructor occurrences="1">
+      <code>$nameValue</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3103Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3123Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3160Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$listener-&gt;inserts</code>
+      <code>$listener-&gt;updates</code>
+      <code>$inserts</code>
+      <code>$updates</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>onFlush</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3160Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3170Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3170Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3192Test.php">
+    <MissingParamType occurrences="2">
+      <code>$code</code>
+      <code>$amount</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$transaction-&gt;id</code>
+      <code>$map</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$resultByPersister-&gt;currency</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DDC3192Test</code>
+      <code>$transactions</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3223Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$profileStatus</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="1">
+      <code>$participant-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getId</code>
+    </MissingReturnType>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>isProxyInitialized</code>
+      <code>getId</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3223Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$boss-&gt;id</code>
+      <code>$employee-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3300Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php">
+    <MissingParamType occurrences="6">
+      <code>$name</code>
+      <code>$street</code>
+      <code>$number</code>
+      <code>$city</code>
+      <code>$name</code>
+      <code>$company</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3303Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC331Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC331Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3330Test.php">
+    <MissingReturnType occurrences="2">
+      <code>createBuildingAndHalls</code>
+      <code>addHall</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3330Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3346Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$author-&gt;articles</code>
+      <code>$authors[0]-&gt;articles</code>
+      <code>$authors[0]-&gt;articles</code>
+      <code>$user-&gt;articles</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadAuthorFixture</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3346Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC345Test.php">
+    <MissingPropertyType occurrences="7">
+      <code>$user-&gt;Memberships</code>
+      <code>$group-&gt;Memberships</code>
+      <code>$membership-&gt;prePersistCallCount</code>
+      <code>$membership-&gt;preUpdateCallCount</code>
+      <code>$membership-&gt;updated</code>
+      <code>$prePersistCallCount</code>
+      <code>$preUpdateCallCount</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>doStuffOnPrePersist</code>
+      <code>doStuffOnPreUpdate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC345Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC353Test.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getPictureId</code>
+      <code>setProduct</code>
+      <code>getProduct</code>
+      <code>setFile</code>
+      <code>getFile</code>
+      <code>getFileId</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$file</code>
+      <code>$picture</code>
+      <code>$picture</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getFile</code>
+      <code>getFile</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC353Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;product</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;product</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3582Test.php">
+    <MissingParamType occurrences="1">
+      <code>$id</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$entity-&gt;embeddable1</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3582Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3597Test.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$imageEntity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getId</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3597Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php">
+    <InvalidReturnType occurrences="1">
+      <code>lastInsertId</code>
+    </InvalidReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$veryLargeId</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="3">
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>forwardCall</code>
+      <code>setAutoCommit</code>
+      <code>getNestedTransactionSavePointName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DDC3634Test</code>
+      <code>DDC3634LastInsertIdMockingConnection</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php">
+    <MissingParamType occurrences="2">
+      <code>$address</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>setAddresses</code>
+      <code>setPets</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$user</code>
+      <code>$user</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$user-&gt;addresses</code>
+      <code>$user-&gt;pets</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="2">
+      <code>setAddresses</code>
+      <code>setPets</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3644Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3719Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$manager-&gt;managedContracts</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3719Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC371Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC371Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php">
+    <MissingParamType occurrences="4">
+      <code>$attributes</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$id</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$attribute1-&gt;id</code>
+      <code>$attribute2-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getAttributes</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3785Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC381Test.php">
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getOtherMethod</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getOtherMethod</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC381Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3967Test.php">
+    <PossiblyNullReference occurrences="1">
+      <code>evictEntityRegion</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC3967Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC4003Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC4003Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC4024Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC4024Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$customer-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$customer-&gt;contacts</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC422Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC425Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php">
+    <MissingParamType occurrences="5">
+      <code>$value</code>
+      <code>$update_inverse</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="14">
+      <code>setNumber</code>
+      <code>getNumber</code>
+      <code>setClient</code>
+      <code>getClient</code>
+      <code>getId</code>
+      <code>setId</code>
+      <code>setName</code>
+      <code>getName</code>
+      <code>addPhone</code>
+      <code>getPhones</code>
+      <code>setMainPhone</code>
+      <code>getMainPhone</code>
+      <code>getId</code>
+      <code>setId</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getPhones</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC440Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC444Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC444Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC448Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC448Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC493Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC493Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC512Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$customer1-&gt;id</code>
+      <code>$item-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC512Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC513Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC513Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC522Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$fkt-&gt;id</code>
+      <code>$fkCust-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$fkt2-&gt;cart</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC522Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyAssignment occurrences="1">
+      <code>$fkCust-&gt;name</code>
+    </UndefinedPropertyAssignment>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$expected-&gt;name</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC531Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$item2-&gt;id</code>
+      <code>$item1-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>getParent</code>
+      <code>getChildren</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$item3-&gt;parent</code>
+      <code>$item4-&gt;parent</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="2">
+      <code>getChildren</code>
+      <code>getChildren</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC531Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC5684Test.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$object-&gt;id</code>
+      <code>$object-&gt;id</code>
+      <code>$value</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>convertToPHPValue</code>
+      <code>getName</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$object-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC5684Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC588Test.php">
+    <MissingParamType occurrences="1">
+      <code>$name</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC588Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC599Test.php">
+    <InvalidArgument occurrences="1">
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <MissingPropertyType occurrences="1">
+      <code>$item-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getChildren</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$item</code>
+      <code>$item</code>
+      <code>$item</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="3">
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>getCascade</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC599Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getCascade</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC618Test.php">
+    <MissingParamType occurrences="3">
+      <code>$title</code>
+      <code>$title</code>
+      <code>$author</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>addBook</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC618Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6303Test.php">
+    <MissingParamType occurrences="1">
+      <code>$originalData</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$entity-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC6303Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC633Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$app-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$eagerAppointment-&gt;patient</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC633Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6460Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC6460Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>findOneById</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC656Test.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$type</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$entity-&gt;specificationId</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>getName</code>
+      <code>setName</code>
+      <code>getType</code>
+      <code>setType</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>getType</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC656Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC657Test.php">
+    <MissingReturnType occurrences="1">
+      <code>loadFixtures</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC657Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC698Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$description</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="10">
+      <code>getId</code>
+      <code>addGroup</code>
+      <code>addChannel</code>
+      <code>getName</code>
+      <code>setName</code>
+      <code>getDescription</code>
+      <code>setDescription</code>
+      <code>getChildren</code>
+      <code>getParents</code>
+      <code>getChannels</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC719Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="3">
+      <code>ArrayCollection</code>
+      <code>Group</code>
+      <code>Channel</code>
+    </UndefinedClass>
+    <UndefinedMethod occurrences="1">
+      <code>parent::__construct()</code>
+    </UndefinedMethod>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;channels</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC735Test.php">
+    <MissingReturnType occurrences="4">
+      <code>getReviews</code>
+      <code>addReview</code>
+      <code>removeReview</code>
+      <code>getId</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC735Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC736Test.php">
+    <InvalidReturnType occurrences="2">
+      <code>walkSelectStatement</code>
+      <code>walkSelectClause</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC736Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingConstructor occurrences="2">
+      <code>$id</code>
+      <code>$id</code>
+    </MissingConstructor>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$user-&gt;favoriteComments</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC742Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setCacheDriver</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC748Test.php">
+    <MissingPropertyType occurrences="3">
+      <code>$user-&gt;articles</code>
+      <code>$address-&gt;user</code>
+      <code>$user-&gt;address</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC748Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC767Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$user-&gt;id</code>
+      <code>$group2-&gt;id</code>
+      <code>$group3-&gt;id</code>
+      <code>$pUser-&gt;groups</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;em-&gt;find(get_class($group1), $groupId)</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC767Test</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;find(get_class($group1), $groupId)</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC809Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$Variants</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="1">
+      <code>getSpecificationValues</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC809Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC812Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$article-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC812Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php">
+    <MissingParamType occurrences="5">
+      <code>$word</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$lft</code>
+      <code>$rgt</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$like-&gt;id</code>
+      <code>$like-&gt;id</code>
+      <code>$index-&gt;id</code>
+      <code>$index-&gt;id</code>
+      <code>$index-&gt;id</code>
+      <code>$index-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC832Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC837Test.php">
+    <MissingParamType occurrences="1">
+      <code>$sysname</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="9">
+      <code>$c1-&gt;id</code>
+      <code>$c2-&gt;id</code>
+      <code>$obj-&gt;title</code>
+      <code>$obj-&gt;description</code>
+      <code>$obj-&gt;title</code>
+      <code>$obj-&gt;description</code>
+      <code>$obj-&gt;text</code>
+      <code>$obj-&gt;apples</code>
+      <code>$obj-&gt;bananas</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getSysname</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="7">
+      <code>$e1-&gt;title</code>
+      <code>$e1-&gt;description</code>
+      <code>$e1-&gt;aggregate</code>
+      <code>$e2-&gt;title</code>
+      <code>$e2-&gt;description</code>
+      <code>$e2-&gt;text</code>
+      <code>$e2-&gt;aggregate</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC837Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC849Test.php">
+    <MissingPropertyType occurrences="3">
+      <code>$user</code>
+      <code>$group1</code>
+      <code>$group2</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC849Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC881Test.php">
+    <InvalidClass occurrences="2">
+      <code>DDC881Phonenumber</code>
+      <code>DDC881Phonecall</code>
+    </InvalidClass>
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$id</code>
+      <code>$phoneNumber</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="8">
+      <code>getName</code>
+      <code>setName</code>
+      <code>setId</code>
+      <code>setUser</code>
+      <code>setPhoneNumber</code>
+      <code>getCalls</code>
+      <code>setPhoneNumber</code>
+      <code>getPhoneNumber</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC881Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php">
+    <MissingReturnType occurrences="1">
+      <code>assertManagerCanBeUpdatedOnAnotherConnection</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC933Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC949Test.php">
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$true-&gt;booleanField</code>
+      <code>$false-&gt;booleanField</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC949Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>getId</code>
+      <code>getVersion</code>
+      <code>setName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC960Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php">
+    <MissingPropertyType occurrences="6">
+      <code>$role-&gt;extendedBy</code>
+      <code>$child-&gt;extends</code>
+      <code>$child-&gt;roleID</code>
+      <code>$parent-&gt;childs</code>
+      <code>$parent-&gt;id</code>
+      <code>$child-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>childs</code>
+      <code>getRoleID</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="6">
+      <code>$child-&gt;extends</code>
+      <code>$parent-&gt;childs</code>
+      <code>$child-&gt;id</code>
+      <code>$child-&gt;childs</code>
+      <code>$child-&gt;id</code>
+      <code>$child-&gt;childs</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DDC992Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH2947Test.php">
+    <MissingReturnType occurrences="3">
+      <code>createQuery</code>
+      <code>createData</code>
+      <code>updateData</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH2947Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH5562Test.php">
+    <MissingConstructor occurrences="2">
+      <code>$id</code>
+      <code>$username</code>
+    </MissingConstructor>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$merchant</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$merchant-&gt;manager</code>
+      <code>$merchant-&gt;id</code>
+      <code>$merchant-&gt;manager</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH5562Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH5762Test.php">
+    <MissingParamType occurrences="4">
+      <code>$id</code>
+      <code>$name</code>
+      <code>$brand</code>
+      <code>$model</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$this-&gt;driver-&gt;driverRides</code>
+      <code>$this-&gt;car-&gt;carRides</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>fetchData</code>
+      <code>createData</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH5762Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$firstArticle-&gt;version</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH5804Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php">
+    <MissingConstructor occurrences="2">
+      <code>$id</code>
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="5">
+      <code>setId</code>
+      <code>setCustomer</code>
+      <code>setId</code>
+      <code>setCart</code>
+      <code>getName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH5887Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6029Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$user-&gt;groups</code>
+      <code>$product-&gt;features</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6029Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6141Test.php">
+    <MissingReturnType occurrences="1">
+      <code>getName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6141Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6217Test.php">
+    <MissingPropertyType occurrences="4">
+      <code>$eager-&gt;id</code>
+      <code>$lazy-&gt;id</code>
+      <code>$found[0]-&gt;lazy</code>
+      <code>$found[0]-&gt;eager</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6217Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6362Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6362Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6402Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$address-&gt;id</code>
+      <code>$address-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>createAddress</code>
+      <code>createFullAddress</code>
+      <code>persistAddress</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$address-&gt;user</code>
+      <code>$address-&gt;user</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6402Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6464Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6531Test.php">
+    <MissingPropertyType occurrences="3">
+      <code>$user-&gt;id</code>
+      <code>$article-&gt;attributes</code>
+      <code>$order-&gt;items</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>addAttribute</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6531Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6682Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6682Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>ClassMetadataInfo</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6699Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6699Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6740Test.php">
+    <PossiblyNullReference occurrences="5">
+      <code>getCategories</code>
+      <code>getCategories</code>
+      <code>getCategories</code>
+      <code>getCategories</code>
+      <code>getCategories</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$productId</code>
+      <code>$firstCategoryId</code>
+      <code>$secondCategoryId</code>
+      <code>GH6740Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH6937Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$manager-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$persistedManager-&gt;name</code>
+      <code>$persistedManager-&gt;phoneNumber</code>
+      <code>$persistedManager-&gt;department</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH6937Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7012Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7012Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7062Test.php">
+    <PossiblyNullIterator occurrences="1">
+      <code>$ranking-&gt;positions</code>
+    </PossiblyNullIterator>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$ranking-&gt;positions</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7062Test</code>
+    </PropertyNotSetInConstructor>
+    <TooManyTemplateParams occurrences="1">
+      <code>Collection|GH7062RankingPosition[]</code>
+    </TooManyTemplateParams>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7067Test.php">
+    <MissingConstructor occurrences="1">
+      <code>$lastUpdate</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="1">
+      <code>$entity-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7067Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7068Test.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7068Test</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>find</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7259Test.php">
+    <MissingConstructor occurrences="4">
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+    </MissingConstructor>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7259Test</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="2">
+      <code>$space</code>
+      <code>$space</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7286Test.php">
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>GH7286Test</code>
+      <code>$id</code>
+      <code>$first</code>
+      <code>$second</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7366Test.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>GH7366Test</code>
+      <code>$id</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>find</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php">
+    <PossiblyNullArgument occurrences="2">
+      <code>$entity</code>
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>GH7629Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Issue5989Test.php">
+    <MissingPropertyType occurrences="2">
+      <code>$manager-&gt;id</code>
+      <code>$employee-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$manager-&gt;tags</code>
+      <code>$employee-&gt;tags</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Issue5989Test</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php">
+    <MissingPropertyType occurrences="1">
+      <code>$test-&gt;id</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket2481Test</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;conn</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket4646InstanceOfAbstractTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket4646InstanceOfAbstractTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket4646InstanceOfMultiLevelTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket4646InstanceOfMultiLevelTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket4646InstanceOfParametricTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket4646InstanceOfParametricTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket4646InstanceOfTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket4646InstanceOfTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket4646InstanceOfWithMultipleParametersTest.php">
+    <MissingReturnType occurrences="1">
+      <code>getId</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>Ticket4646MultipleInstanceOfWithMultipleParametersTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket69.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ArrayCollection()</code>
+    </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;parent</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>Phrase</code>
+    </InvalidReturnType>
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingReturnType occurrences="12">
+      <code>setLemma</code>
+      <code>addRelation</code>
+      <code>removeRelation</code>
+      <code>setParent</code>
+      <code>removeParent</code>
+      <code>setChild</code>
+      <code>setType</code>
+      <code>removeType</code>
+      <code>setType</code>
+      <code>setAbbreviation</code>
+      <code>addRelation</code>
+      <code>removeRelation</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="7">
+      <code>AdvancedAssociationTest</code>
+      <code>$id</code>
+      <code>$lemma</code>
+      <code>$id</code>
+      <code>$type</code>
+      <code>$abbreviation</code>
+      <code>$relations</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;type !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedClass occurrences="9">
+      <code>kateglo\application\utilities\collections\ArrayCollection</code>
+      <code>$this-&gt;relations</code>
+      <code>$this-&gt;relations</code>
+      <code>kateglo\application\utilities\collections\ArrayCollection</code>
+      <code>Phrase</code>
+      <code>kateglo\application\utilities\collections\ArrayCollection</code>
+      <code>$this-&gt;relations</code>
+      <code>$this-&gt;relations</code>
+      <code>kateglo\application\utilities\collections\ArrayCollection</code>
+    </UndefinedClass>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;types</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;lemma</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/TypeTest.php">
+    <MissingPropertyType occurrences="4">
+      <code>$serialize-&gt;array</code>
+      <code>$dateTime-&gt;id</code>
+      <code>$dateTime-&gt;id</code>
+      <code>$dateTime-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="2">
+      <code>$dateTimeDb-&gt;date</code>
+      <code>$dateTimeDb-&gt;datetime</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>TypeTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php">
+    <MissingPropertyType occurrences="4">
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;id</code>
+      <code>$parent-&gt;id</code>
+      <code>$parent-&gt;id</code>
+    </MissingPropertyType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignment occurrences="1">
+      <code>$entity</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="8">
+      <code>$entity-&gt;lowerCaseString</code>
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;namedLowerCaseString</code>
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;namedLowerCaseString</code>
+      <code>$entity-&gt;id</code>
+      <code>$entity-&gt;customInteger</code>
+      <code>$entity-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>getMyFriends</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>TypeValueSqlTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/UnitOfWorkLifecycleTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>UnitOfWorkLifecycleTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="7">
+      <code>$auxiliary-&gt;id4</code>
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;foreignEntity</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyCompositeIdForeignKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="6">
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;id2</code>
+      <code>$owning-&gt;id3</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyCompositeIdTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php">
+    <MissingPropertyType occurrences="4">
+      <code>$inversed1-&gt;associatedEntities</code>
+      <code>$owning1-&gt;associatedEntities</code>
+      <code>$owning2-&gt;associatedEntities</code>
+      <code>$inversed2-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="8">
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyExtraLazyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$owning-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="5">
+      <code>$inversed-&gt;id1</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$inversed-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="6">
+      <code>$auxiliary-&gt;id4</code>
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;foreignEntity</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyCompositeIdForeignKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$inversed-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="5">
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;id2</code>
+      <code>$owning-&gt;id3</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyCompositeIdTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$inversed-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyExtraLazyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$inversed-&gt;associatedEntities</code>
+    </MissingPropertyType>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$inversed-&gt;id1</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntities</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToManyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php">
+    <PossiblyNullPropertyFetch occurrences="6">
+      <code>$auxiliary-&gt;id4</code>
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;foreignEntity</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntity</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneCompositeIdForeignKeyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php">
+    <PossiblyNullPropertyFetch occurrences="5">
+      <code>$inversed-&gt;id1</code>
+      <code>$inversed-&gt;id2</code>
+      <code>$owning-&gt;id3</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntity</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneCompositeIdTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php">
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$inversed-&gt;id1</code>
+      <code>$owning-&gt;id2</code>
+      <code>$owning-&gt;associatedEntity</code>
+      <code>$inversed-&gt;associatedEntity</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OneToOneTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php">
+    <MissingParamType occurrences="8">
+      <code>$embeddableClassName</code>
+      <code>$declaredEmbeddableClassName</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$street</code>
+      <code>$zip</code>
+      <code>$city</code>
+      <code>$id</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="4">
+      <code>$person-&gt;id</code>
+      <code>$person-&gt;address</code>
+      <code>$person-&gt;id</code>
+      <code>$car-&gt;id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getInfiniteEmbeddableNestingData</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$person</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="4">
+      <code>$person-&gt;address</code>
+      <code>$person-&gt;id</code>
+      <code>$person-&gt;address</code>
+      <code>$person-&gt;id</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ValueObjectsTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="11">
+      <code>getReflectionProperty</code>
+      <code>getReflectionProperty</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Functional/VersionedOneToOneTest.php">
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$firstEntity-&gt;secondEntity</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>VersionedOneToOneTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php">
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;getMockBuilder(ResultSetMapping::class)</code>
+    </InvalidPropertyAssignmentValue>
+    <PossiblyUndefinedMethod occurrences="4">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$mockEventManager</code>
+      <code>$mockStatement</code>
+      <code>$mockResultMapping</code>
+      <code>$hydrator</code>
+      <code>AbstractHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/ArrayHydratorTest.php">
+    <MissingParamType occurrences="7">
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$entityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>provideDataForUserEntityResult</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ArrayHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/CustomHydratorTest.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>'CustomHydrator'</code>
+    </InvalidScalarArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>CustomHydratorTest</code>
+      <code>CustomHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/HydrationTestCase.php">
+    <MissingParamType occurrences="2">
+      <code>$resultSetMapping</code>
+      <code>$isMixedQuery</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>createParserResult</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>HydrationTestCase</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>setMixedQuery</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$this-&gt;em-&gt;getClassMetadata(ECommerceShipping::class)</code>
+      <code>$this-&gt;em-&gt;getClassMetadata(ECommerceShipping::class)</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="11">
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+      <code>$userEntityKey</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$result[0]-&gt;boards</code>
+      <code>$result[1]-&gt;boards</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>provideDataForUserEntityResult</code>
+      <code>provideDataForMultipleRootEntityResult</code>
+      <code>provideDataForProductEntityResult</code>
+      <code>swapPrivateProperty</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="2">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ObjectHydratorTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>setFetchMode</code>
+      <code>setFetchMode</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$em</code>
+      <code>$rsm</code>
+      <code>$metadataBuildingContext</code>
+      <code>ResultSetMappingTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/ScalarHydratorTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ScalarHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SimpleObjectHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php">
+    <MissingParamType occurrences="2">
+      <code>$name</code>
+      <code>$resultSet</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleScalarHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$this-&gt;listenersInvoker</code>
+      <code>$this-&gt;entityManager</code>
+      <code>$metadata1</code>
+      <code>$metadata2</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="1">
+      <code>invocationFlagProvider</code>
+    </MissingReturnType>
+    <PossiblyUndefinedMethod occurrences="8">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$listenersInvoker</code>
+      <code>$entityManager</code>
+      <code>$handler</code>
+      <code>HydrationCompleteHandlerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;persister</code>
+    </InvalidArgument>
+    <PossiblyUndefinedMethod occurrences="9">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$persister</code>
+      <code>$criteria</code>
+      <code>$lazyCriteriaCollection</code>
+      <code>LazyCriteriaCollectionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php">
+    <InvalidArgument occurrences="12">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$guestMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$adminMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$guestMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$adminMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$adminMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$contractMetadata-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="1">
+      <code>Mapping\InheritanceType::NONE</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="1">
+      <code>$entityClassName</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>createClassMetadata</code>
+      <code>doStuffOnPrePersist</code>
+      <code>doOtherStuffOnPrePersistToo</code>
+      <code>doStuffOnPostPersist</code>
+      <code>loadMetadata</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="52">
+      <code>getValueGenerator</code>
+      <code>getValueGenerator</code>
+      <code>getName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getTypeName</code>
+      <code>getLength</code>
+      <code>isNullable</code>
+      <code>isUnique</code>
+      <code>getOptions</code>
+      <code>getOptions</code>
+      <code>getTypeName</code>
+      <code>getValueGenerator</code>
+      <code>isOwningSide</code>
+      <code>getInversedBy</code>
+      <code>getCascade</code>
+      <code>isOwningSide</code>
+      <code>isOrphanRemoval</code>
+      <code>getCascade</code>
+      <code>getOrderBy</code>
+      <code>isOwningSide</code>
+      <code>getCascade</code>
+      <code>getOrderBy</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getColumnDefinition</code>
+      <code>getJoinColumns</code>
+      <code>getTypeName</code>
+      <code>getTypeName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getInversedBy</code>
+      <code>getFetchMode</code>
+      <code>isPrimaryKey</code>
+      <code>getName</code>
+      <code>isPrimaryKey</code>
+      <code>getName</code>
+      <code>getUsage</code>
+      <code>getRegion</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="78">
+      <code>getValueGenerator</code>
+      <code>getValueGenerator</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getTypeName</code>
+      <code>getLength</code>
+      <code>isNullable</code>
+      <code>isUnique</code>
+      <code>getOptions</code>
+      <code>getOptions</code>
+      <code>getTypeName</code>
+      <code>getValueGenerator</code>
+      <code>isOwningSide</code>
+      <code>getInversedBy</code>
+      <code>getCascade</code>
+      <code>isOwningSide</code>
+      <code>isOrphanRemoval</code>
+      <code>getCascade</code>
+      <code>getOrderBy</code>
+      <code>isOwningSide</code>
+      <code>getCascade</code>
+      <code>getOrderBy</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getColumnDefinition</code>
+      <code>getJoinColumns</code>
+      <code>isTrue</code>
+      <code>isTrue</code>
+      <code>getTypeName</code>
+      <code>getTypeName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>hasValueGenerator</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getMappedBy</code>
+      <code>getMappedBy</code>
+      <code>getInversedBy</code>
+      <code>getInversedBy</code>
+      <code>isOwningSide</code>
+      <code>isOwningSide</code>
+      <code>getFetchMode</code>
+      <code>getFetchMode</code>
+      <code>getCascade</code>
+      <code>getCascade</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getMappedBy</code>
+      <code>getMappedBy</code>
+      <code>getInversedBy</code>
+      <code>getInversedBy</code>
+      <code>isOwningSide</code>
+      <code>isOwningSide</code>
+      <code>getFetchMode</code>
+      <code>getFetchMode</code>
+      <code>getCascade</code>
+      <code>getCascade</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+      <code>getInversedBy</code>
+      <code>getFetchMode</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getLength</code>
+      <code>isNullable</code>
+      <code>isUnique</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getLength</code>
+      <code>isNullable</code>
+      <code>isUnique</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="2">
+      <code>setGeneratorDefinition</code>
+      <code>setIdGeneratorType</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$classPage-&gt;getDeclaredPropertiesIterator()</code>
+      <code>$classDirectory-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="1">
+      <code>$entityClassName</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>loadDriverForCMSModels</code>
+      <code>loadDriver</code>
+      <code>ensureIsLoaded</code>
+      <code>postLoad</code>
+      <code>preUpdate</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="7">
+      <code>getTypeName</code>
+      <code>getSourceEntity</code>
+      <code>getSourceEntity</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>AnnotationDriverTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="7">
+      <code>getTypeName</code>
+      <code>getSourceEntity</code>
+      <code>getSourceEntity</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <MissingConstructor occurrences="1">
+      <code>$id</code>
+    </MissingConstructor>
+    <MissingPropertyType occurrences="3">
+      <code>$transient1</code>
+      <code>$transient2</code>
+      <code>$transient</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cmf</code>
+      <code>BasicInheritanceMappingTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="6">
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+    </UndefinedClass>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$this-&gt;equalTo(CmsUser::class)</code>
+      <code>$this-&gt;equalTo(CmsArticle::class)</code>
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="2">
+      <code>iterable</code>
+      <code>generate</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="4">
+      <code>$metadataDriver</code>
+      <code>$conn</code>
+      <code>$className</code>
+      <code>$metadata</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="7">
+      <code>$mockMetadata</code>
+      <code>$requestedClasses</code>
+      <code>$id</code>
+      <code>$name</code>
+      <code>$other</code>
+      <code>$association</code>
+      <code>$embedded</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>createEntityManager</code>
+      <code>setMetadataForClass</code>
+      <code>getRequestedClasses</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="12">
+      <code>getValueGenerator</code>
+      <code>setValueGenerator</code>
+      <code>setValueGenerator</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClassMetadataFactoryTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="12">
+      <code>getValueGenerator</code>
+      <code>setValueGenerator</code>
+      <code>setValueGenerator</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getColumnName</code>
+      <code>getJoinColumns</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="1">
+      <code>isIdGeneratorIdentity</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/ClassMetadataLoadEventTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$test-&gt;about</code>
+      <code>$about</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadClassMetadata</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ClassMetadataLoadEventTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getProperty</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$this-&gt;createMock(Mapping\ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(Mapping\ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(Mapping\ClassMetadataFactory::class)</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="1">
+      <code>Mapping\InheritanceType::SINGLE_TABLE</code>
+    </InvalidScalarArgument>
+    <PossiblyInvalidArgument occurrences="43">
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$className</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="14">
+      <code>isNullable</code>
+      <code>isNullable</code>
+      <code>isNullable</code>
+      <code>getTargetEntity</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getValueGenerator</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$metadataBuildingContext</code>
+      <code>ClassMetadataTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="14">
+      <code>isNullable</code>
+      <code>isNullable</code>
+      <code>isNullable</code>
+      <code>getTargetEntity</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinColumns</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getJoinTable</code>
+      <code>getValueGenerator</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedVariable occurrences="1">
+      <code>$cm</code>
+    </UndefinedVariable>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/EntityListenerResolverTest.php">
+    <InvalidArgument occurrences="1">
+      <code>'CompanyContractListener'</code>
+    </InvalidArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $className()</code>
+    </InvalidStringClass>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$resolver</code>
+      <code>EntityListenerResolverTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/NamingStrategy/JoinColumnClassNamingStrategy.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$className</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/NamingStrategyTest.php">
+    <MissingParamType occurrences="3">
+      <code>$expected</code>
+      <code>$className</code>
+      <code>$className</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>NamingStrategyTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>joinKeyColumnName</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php">
+    <MissingReturnType occurrences="2">
+      <code>testCanSetAndGetEmbeddedProperty</code>
+      <code>testWillSkipReadingPropertiesFromNullEmbeddable</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ReflectionEmbeddedPropertyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php">
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;dir</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="5">
+      <code>$this-&gt;dir</code>
+      <code>$this-&gt;dir</code>
+      <code>$this-&gt;dir</code>
+      <code>$this-&gt;dir</code>
+      <code>$this-&gt;dir</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/Symfony/XmlDriverTest.php">
+    <MissingReturnType occurrences="2">
+      <code>getFileExtension</code>
+      <code>getDriver</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>XmlDriverTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$class-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <MissingPropertyType occurrences="3">
+      <code>$id</code>
+      <code>$foo</code>
+      <code>$id</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>loadDriver</code>
+      <code>dataValidSchema</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>isPrimaryKey</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>XmlMappingDriverTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedPropertyFetch occurrences="2"/>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Performance/SecondLevelCacheTest.php">
+    <MissingParamType occurrences="4">
+      <code>$label</code>
+      <code>$label</code>
+      <code>$label</code>
+      <code>$label</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>queryEntity</code>
+      <code>findEntityOneToMany</code>
+      <code>findEntity</code>
+      <code>findAllEntity</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$em-&gt;getConfiguration()-&gt;getSQLLogger()-&gt;queries</code>
+    </NoInterfaceProperties>
+    <PossiblyNullReference occurrences="1">
+      <code>getCities</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SecondLevelCacheTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/PersistentCollectionTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$classMetaData</code>
+      <code>$class</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="1">
+      <code>setUpPersistentCollection</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$unitOfWork</code>
+      <code>$unitOfWork</code>
+      <code>$unitOfWork</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="5">
+      <code>add</code>
+      <code>add</code>
+      <code>add</code>
+      <code>add</code>
+      <code>add</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$collection</code>
+      <code>$emMock</code>
+      <code>PersistentCollectionTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getProperty</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$persister</code>
+      <code>$em</code>
+      <code>BasicEntityPersisterCompositeTypeParametersTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$persister</code>
+      <code>$em</code>
+      <code>BasicEntityPersisterCompositeTypeSqlTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterTypeValueSqlTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$persister</code>
+      <code>$em</code>
+      <code>BasicEntityPersisterTypeValueSqlTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>getExecuteUpdates</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Persisters/ManyToManyPersisterTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$childReloaded-&gt;parents</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$childReloaded-&gt;parents</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ManyToManyPersisterTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$childReloaded-&gt;parents</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Proxy/ProxyFactoryTest.php">
+    <InvalidArgument occurrences="15">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$persister</code>
+      <code>$classMetaData</code>
+      <code>$persister</code>
+      <code>$classMetaData</code>
+      <code>$persister</code>
+      <code>$classMetaData</code>
+      <code>$persister</code>
+      <code>$classMetaData</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ComparableObject::class)</code>
+      <code>$metadata</code>
+      <code>$metadata</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(FuncGetArgs::class)</code>
+    </InvalidArgument>
+    <PossiblyInvalidArgument occurrences="5">
+      <code>$persister</code>
+      <code>$comparable</code>
+      <code>$persister</code>
+      <code>$comparable2</code>
+      <code>$persister</code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedMethod occurrences="21">
+      <code>getDescription</code>
+      <code>getDescription</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>getId</code>
+      <code>getSalary</code>
+      <code>getName</code>
+      <code>expects</code>
+      <code>isProxyInitialized</code>
+      <code>equalTo</code>
+      <code>isProxyInitialized</code>
+      <code>expects</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>equalTo</code>
+      <code>isProxyInitialized</code>
+      <code>isProxyInitialized</code>
+      <code>expects</code>
+      <code>isProxyInitialized</code>
+      <code>funcGetArgsCallingMethod</code>
+      <code>isProxyInitialized</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="6">
+      <code>$connectionMock</code>
+      <code>$uowMock</code>
+      <code>$emMock</code>
+      <code>$proxyFactory</code>
+      <code>$metadataBuildingContext</code>
+      <code>ProxyFactoryTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersJoinTest.php">
+    <InvalidReturnType occurrences="1">
+      <code>walkSelectStatement</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="3">
+      <code>$dqlToBeTested</code>
+      <code>$sqlToBeConfirmed</code>
+      <code>$identificationVariableDecl</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>assertSqlGeneration</code>
+      <code>modifySelectStatement</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$rangeVariableDecl-&gt;abstractSchemaName</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CustomTreeWalkersJoinTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/CustomTreeWalkersTest.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$condExpr instanceof Query\AST\ConditionalExpression</code>
+    </DocblockTypeContradiction>
+    <InvalidArgument occurrences="2">
+      <code>1</code>
+      <code>[$singleTerm]</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="3">
+      <code>walkSelectStatement</code>
+      <code>walkSelectStatement</code>
+      <code>walkSelectStatement</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="8">
+      <code>$dqlToBeTested</code>
+      <code>$treeWalkers</code>
+      <code>$outputWalker</code>
+      <code>$dqlToBeTested</code>
+      <code>$sqlToBeConfirmed</code>
+      <code>$treeWalkers</code>
+      <code>$outputWalker</code>
+      <code>$identificationVariableDecl</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>generateSql</code>
+      <code>assertSqlGeneration</code>
+      <code>modifySelectStatement</code>
+    </MissingReturnType>
+    <PossiblyNullArrayAccess occurrences="1">
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression-&gt;conditionalTerms[0]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyAssignment occurrences="3">
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression</code>
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression</code>
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression</code>
+    </PossiblyNullPropertyAssignment>
+    <PossiblyNullPropertyFetch occurrences="3">
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression</code>
+      <code>$selectStatement-&gt;whereClause-&gt;conditionalExpression</code>
+      <code>$rangeVariableDecl-&gt;abstractSchemaName</code>
+    </PossiblyNullPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CustomTreeWalkersTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/DeleteSqlGenerationTest.php">
+    <MissingParamType occurrences="2">
+      <code>$dqlToBeTested</code>
+      <code>$sqlToBeConfirmed</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>assertSqlGeneration</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DeleteSqlGenerationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/ExprTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$expr</code>
+      <code>ExprTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php">
+    <MissingReturnType occurrences="1">
+      <code>testShouldAllowToDisableFilter</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>FilterCollectionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/LanguageRecognitionTest.php">
+    <MissingParamType occurrences="11">
+      <code>$dql</code>
+      <code>$debug</code>
+      <code>$dql</code>
+      <code>$debug</code>
+      <code>$dql</code>
+      <code>$hints</code>
+      <code>$dql</code>
+      <code>$id</code>
+      <code>$arg1</code>
+      <code>$arg2</code>
+      <code>$arg3</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="4">
+      <code>assertValidDQL</code>
+      <code>assertInvalidDQL</code>
+      <code>parseDql</code>
+      <code>invalidDQL</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>LanguageRecognitionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/LexerTest.php">
+    <MissingParamType occurrences="2">
+      <code>$type</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>provideTokens</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LexerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php">
+    <MissingParamType occurrences="2">
+      <code>$value</code>
+      <code>$expected</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>providerParameterTypeInferer</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ParameterTypeInfererTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/ParserResultTest.php">
+    <MissingPropertyType occurrences="1">
+      <code>$parserResult</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ParserResultTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/ParserTest.php">
+    <MissingParamType occurrences="5">
+      <code>$expectedToken</code>
+      <code>$inputString</code>
+      <code>$expectedToken</code>
+      <code>$inputString</code>
+      <code>$dql</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="3">
+      <code>validMatches</code>
+      <code>invalidMatches</code>
+      <code>createParser</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ParserTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/QueryExpressionVisitorTest.php">
+    <MissingReturnType occurrences="1">
+      <code>comparisonData</code>
+    </MissingReturnType>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>add</code>
+    </PossiblyInvalidMethodCall>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$visitor</code>
+      <code>QueryExpressionVisitorTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="2">
+      <code>andX</code>
+      <code>orX</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/QueryTest.php">
+    <InvalidScalarArgument occurrences="6">
+      <code>2</code>
+      <code>1</code>
+      <code>2</code>
+      <code>ParameterType::INTEGER</code>
+      <code>ParameterType::INTEGER</code>
+      <code>2</code>
+    </InvalidScalarArgument>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullReference occurrences="9">
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>QueryTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>setFirstResult</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php">
+    <MissingParamType occurrences="1">
+      <code>$operator</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$em</code>
+      <code>$simpleArithmeticExpression</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>assertSqlGeneration</code>
+      <code>assertInvalidSqlGeneration</code>
+      <code>setValue</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SelectSqlGenerationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/SqlWalkerTest.php">
+    <MissingParamType occurrences="3">
+      <code>$tableName</code>
+      <code>$expectedAlias</code>
+      <code>$tableName</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$sqlWalker</code>
+      <code>SqlWalkerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Query/UpdateSqlGenerationTest.php">
+    <MissingParamType occurrences="2">
+      <code>$dqlToBeTested</code>
+      <code>$sqlToBeConfirmed</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$em</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>assertSqlGeneration</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>UpdateSqlGenerationTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/QueryBuilderTest.php">
+    <InvalidArgument occurrences="4">
+      <code>'u'</code>
+      <code>CmsUser::class . ' u'</code>
+      <code>'u.foo = ?1'</code>
+      <code>'u.bar = ?2'</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="1">
+      <code>$expectedDql</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>assertValidQueryBuilder</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="17">
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$em</code>
+      <code>QueryBuilderTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>andX</code>
+    </TooManyArguments>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;createMock(ReflectionService::class)</code>
+    </InvalidArgument>
+    <PossiblyInvalidArgument occurrences="9">
+      <code>$this-&gt;entityManager</code>
+      <code>$this-&gt;entityManager</code>
+      <code>$this-&gt;entityManager</code>
+      <code>$this-&gt;entityManager</code>
+      <code>$em1</code>
+      <code>$em2</code>
+      <code>$em1</code>
+      <code>$em2</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedMethod occurrences="5">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$entityManager</code>
+      <code>$configuration</code>
+      <code>$repositoryFactory</code>
+      <code>$metadataBuildingContext</code>
+      <code>DefaultRepositoryFactoryTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Sequencing/SequenceGeneratorTest.php">
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$entityManager</code>
+      <code>$sequenceGenerator</code>
+      <code>$connection</code>
+      <code>SequenceGeneratorTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;entityManager-&gt;getConnection()</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php">
+    <MissingPropertyType occurrences="2">
+      <code>$calls</code>
+      <code>$calls</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>prePersist</code>
+      <code>postLoadHandler</code>
+      <code>postPersist</code>
+      <code>prePersist</code>
+      <code>postPersistHandler</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$em</code>
+      <code>$listener</code>
+      <code>$factory</code>
+      <code>AttachEntityListenersListenerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheCollectionRegionCommandTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheEntityRegionCommandTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheEntityRegionCommandTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheMetadataCommandTest.php">
+    <MissingParamType occurrences="2">
+      <code>$driver</code>
+      <code>$name</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheMetadataCommandTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryCommandTest.php">
+    <MissingParamType occurrences="2">
+      <code>$driver</code>
+      <code>$name</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheQueryCommandTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheQueryRegionCommandTest.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheQueryRegionCommandTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheResultCommandTest.php">
+    <MissingParamType occurrences="2">
+      <code>$driver</code>
+      <code>$name</code>
+    </MissingParamType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$application</code>
+      <code>$command</code>
+      <code>ClearCacheResultCommandTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>new $driver()</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/InfoCommandTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$em</code>
+      <code>$em</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$application</code>
+      <code>$command</code>
+      <code>$tester</code>
+      <code>InfoCommandTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;application-&gt;find('orm:info')</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="7">
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php">
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$application</code>
+      <code>$command</code>
+      <code>$tester</code>
+      <code>MappingDescribeCommandTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;application-&gt;find('orm:mapping:describe')</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/Command/RunDqlCommandTest.php">
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$application</code>
+      <code>$command</code>
+      <code>$tester</code>
+      <code>RunDqlCommandTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/ConsoleRunnerTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>ConsoleRunnerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Console/MetadataFilterTest.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$cmf</code>
+      <code>MetadataFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php">
+    <MissingParamType occurrences="2">
+      <code>$dql</code>
+      <code>$sql</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>provideDataForCountQuery</code>
+    </MissingReturnType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CountOutputWalkerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/CountWalkerTest.php">
+    <MissingParamType occurrences="2">
+      <code>$dql</code>
+      <code>$sql</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>provideDataForCountQuery</code>
+    </MissingReturnType>
+    <NullArgument occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </NullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>CountWalkerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LimitSubqueryOutputWalkerTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="30">
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+      <code>setDatabasePlatform</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LimitSubqueryWalkerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/PaginationTestCase.php">
+    <MissingReturnType occurrences="1">
+      <code>getId</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;connection</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;createMock(AbstractHydrator::class)</code>
+    </InvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$connection</code>
+      <code>$em</code>
+      <code>$hydrator</code>
+      <code>PaginatorTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>method</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="9">
+      <code>method</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>method</code>
+      <code>method</code>
+    </UndefinedMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>WhereInWalkerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/ResolveTargetEntityListenerTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$cm-&gt;getDeclaredPropertiesIterator()</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="2">
+      <code>getId</code>
+      <code>getId</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getTargetEntity</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$em</code>
+      <code>$listener</code>
+      <code>$factory</code>
+      <code>ResolveTargetEntityListenerTest</code>
+    </PropertyNotSetInConstructor>
+    <TypeCoercion occurrences="1">
+      <code>$this-&gt;em-&gt;getMetadataFactory()</code>
+    </TypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getTargetEntity</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php">
+    <InvalidArgument occurrences="1">
+      <code>['username']</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="1">
+      <code>InheritanceType::SINGLE_TABLE</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="4">
+      <code>$listener-&gt;tableCalls</code>
+      <code>$listener-&gt;schemaCalled</code>
+      <code>$tableCalls</code>
+      <code>$schemaCalled</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>postGenerateSchemaTable</code>
+      <code>postGenerateSchema</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="3">
+      <code>setColumnDefinition</code>
+      <code>getColumns</code>
+      <code>getColumns</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SchemaToolTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setColumnDefinition</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php">
+    <MissingConstructor occurrences="2">
+      <code>$pk</code>
+      <code>$agent</code>
+    </MissingConstructor>
+    <PossiblyNullReference occurrences="1">
+      <code>addPaths</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$em</code>
+      <code>$validator</code>
+      <code>SchemaValidatorTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>Identifier</code>
+    </UndefinedClass>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>addPaths</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Tools/SetupTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$cache</code>
+    </InvalidArgument>
+    <MissingPropertyType occurrences="2">
+      <code>$originalAutoloaderCount</code>
+      <code>$originalIncludePath</code>
+    </MissingPropertyType>
+    <PossiblyNullReference occurrences="3">
+      <code>getNamespace</code>
+      <code>getNamespace</code>
+      <code>getNamespace</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SetupTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>getNamespace</code>
+      <code>getNamespace</code>
+      <code>getNamespace</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/UnitOfWorkTest.php">
+    <InvalidArgument occurrences="24">
+      <code>$this-&gt;createMock(ClassMetadataFactory::class)</code>
+      <code>$this-&gt;eventManager</code>
+      <code>$this-&gt;eventManager</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ForumUser::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ForumUser::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ForumAvatar::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(NotifyChangedEntity::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(NotifyChangedRelatedItem::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata('Doctrine\Tests\ORM\NotifyChangedEntity')</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata('Doctrine\Tests\ORM\NotifyChangedRelatedItem')</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(VersionedAssignedIdentifierEntity::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(CmsPhonenumber::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ForumUser::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(ForumUser::class)</code>
+      <code>$metadata</code>
+      <code>$metadata</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(CascadePersistedEntity::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(EntityWithCascadingAssociation::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(EntityWithNonCascadingAssociation::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(CascadePersistedEntity::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(EntityWithCascadingAssociation::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(EntityWithNonCascadingAssociation::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(CascadePersistedEntity::class)</code>
+      <code>$this-&gt;emMock-&gt;getClassMetadata(EntityWithNonCascadingAssociation::class)</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="4">
+      <code>GeneratorType::IDENTITY</code>
+      <code>GeneratorType::IDENTITY</code>
+      <code>GeneratorType::IDENTITY</code>
+      <code>GeneratorType::IDENTITY</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="6">
+      <code>$value</code>
+      <code>$data</code>
+      <code>$propName</code>
+      <code>$oldValue</code>
+      <code>$newValue</code>
+      <code>$owner</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="5">
+      <code>$user-&gt;id</code>
+      <code>$user-&gt;id</code>
+      <code>$avatar-&gt;id</code>
+      <code>$listeners</code>
+      <code>$transient</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="11">
+      <code>entitiesWithValidIdentifiersProvider</code>
+      <code>entitiesWithInvalidIdentifiersProvider</code>
+      <code>getId</code>
+      <code>getItems</code>
+      <code>setTransient</code>
+      <code>getData</code>
+      <code>setData</code>
+      <code>onPropertyChanged</code>
+      <code>getId</code>
+      <code>getOwner</code>
+      <code>setOwner</code>
+    </MissingReturnType>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$this-&gt;metadataBuildingContext</code>
+      <code>$this-&gt;metadataBuildingContext</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="6">
+      <code>$unitOfWork</code>
+      <code>$connectionMock</code>
+      <code>$emMock</code>
+      <code>$eventManager</code>
+      <code>$metadataBuildingContext</code>
+      <code>UnitOfWorkTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="2">
+      <code>commit</code>
+      <code>commit</code>
+    </TooManyArguments>
+    <UndefinedPropertyAssignment occurrences="2">
+      <code>$user-&gt;name</code>
+      <code>$nonCascading-&gt;cascaded</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;createMock(Mapping\ClassMetadataFactory::class)</code>
+    </InvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$staticMetadataBuildingContext</code>
+      <code>HierarchyDiscriminatorResolverTest</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </TooManyArguments>
+    <TypeCoercion occurrences="2">
+      <code>$em-&gt;reveal()</code>
+      <code>$em-&gt;reveal()</code>
+    </TypeCoercion>
+    <UndefinedPropertyAssignment occurrences="3">
+      <code>$childClassMetadata-&gt;name</code>
+      <code>$classMetadata-&gt;name</code>
+      <code>$classMetadata-&gt;name</code>
+    </UndefinedPropertyAssignment>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Utility/IdentifierFlattenerTest.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$firstEntity</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$identifierFlattener</code>
+      <code>IdentifierFlattenerTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Utility/NormalizeIdentifierTest.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$normalizeIdentifier</code>
+      <code>NormalizeIdentifierTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/ORM/Utility/StaticClassNameConverterTest.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>StaticClassNameConverterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Doctrine/Tests/OrmFunctionalTestCase.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$this-&gt;em === null</code>
+      <code>$this-&gt;em</code>
+    </DocblockTypeContradiction>
+    <InvalidStringClass occurrences="1">
+      <code>new $subscriberClass()</code>
+    </InvalidStringClass>
+    <MissingParamType occurrences="2">
+      <code>$expectedSql</code>
+      <code>$actualSql</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>useModelSet</code>
+      <code>setUpEntitySchema</code>
+      <code>onNotSuccessfulTest</code>
+      <code>assertSQLEquals</code>
+      <code>setUpDBALTypes</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$conn</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getConfiguration</code>
+      <code>getEventManager</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>getConfiguration</code>
+      <code>getEventManager</code>
+    </PossiblyUndefinedMethod>
+    <TypeCoercion occurrences="3">
+      <code>new $GLOBALS['DOCTRINE_CACHE_IMPL']()</code>
+      <code>self::$metadataCacheImpl</code>
+      <code>$conn</code>
+    </TypeCoercion>
+  </file>
+  <file src="tests/Doctrine/Tests/OrmPerformanceTestCase.php">
+    <InvalidReturnType occurrences="1">
+      <code>runTest</code>
+    </InvalidReturnType>
+    <MissingReturnType occurrences="1">
+      <code>setMaxRunningTime</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>OrmPerformanceTestCase</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_int($maxRunningTime)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="tests/Doctrine/Tests/OrmTestCase.php">
+    <MissingParamType occurrences="2">
+      <code>$conf</code>
+      <code>$log</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>enableSecondLevelCache</code>
+    </MissingReturnType>
+  </file>
+  <file src="tests/Doctrine/Tests/Proxies/DoctrineTestsORMFunctionalProxyTest__PM__DoctrineTestsModelsECommerceECommerceProductGenerated521e1281db1406a715cbf825c049cf74.php">
+    <InaccessibleProperty occurrences="5">
+      <code>$instance-&gt;name</code>
+      <code>$instance-&gt;shipping</code>
+      <code>$instance-&gt;features</code>
+      <code>$instance-&gt;categories</code>
+      <code>$instance-&gt;related</code>
+    </InaccessibleProperty>
+    <InvalidArgument occurrences="4">
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>setProxyInitializer</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="5">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$signature521e1281db1406a715cbf825c049cf74</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>staticProxyConstructor</code>
+    </MissingReturnType>
+    <PossiblyInvalidFunctionCall occurrences="13">
+      <code>$cacheDoctrine_Tests_Models_ECommerce_ECommerceProduct($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+    </PossiblyInvalidFunctionCall>
+  </file>
+  <file src="tests/Doctrine/Tests/Proxies/DoctrineTestsProxies__PM__DoctrineTestsModelsCompanyCompanyEmployeeGenerated88b770d16dbcdc60d86a97f58b74029c.php">
+    <InaccessibleProperty occurrences="6">
+      <code>$instance-&gt;salary</code>
+      <code>$instance-&gt;department</code>
+      <code>$instance-&gt;startDate</code>
+      <code>$instance-&gt;name</code>
+      <code>$instance-&gt;spouse</code>
+      <code>$instance-&gt;friends</code>
+    </InaccessibleProperty>
+    <InvalidArgument occurrences="4">
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>setProxyInitializer</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="5">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$signature88b770d16dbcdc60d86a97f58b74029c</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>staticProxyConstructor</code>
+    </MissingReturnType>
+    <PossiblyInvalidFunctionCall occurrences="13">
+      <code>$cacheDoctrine_Tests_Models_Company_CompanyEmployee($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+    </PossiblyInvalidFunctionCall>
+  </file>
+  <file src="tests/Doctrine/Tests/Proxies/DoctrineTestsProxies__PM__DoctrineTestsModelsECommerceECommerceFeatureGenerated6812881f61eca3abcfb0d8332637f9d1.php">
+    <InaccessibleProperty occurrences="2">
+      <code>$instance-&gt;description</code>
+      <code>$instance-&gt;product</code>
+    </InaccessibleProperty>
+    <InvalidArgument occurrences="4">
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>setProxyInitializer</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="5">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$signature6812881f61eca3abcfb0d8332637f9d1</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>staticProxyConstructor</code>
+    </MissingReturnType>
+    <PossiblyInvalidFunctionCall occurrences="13">
+      <code>$cacheDoctrine_Tests_Models_ECommerce_ECommerceFeature($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+    </PossiblyInvalidFunctionCall>
+  </file>
+  <file src="tests/Doctrine/Tests/Proxies/DoctrineTestsProxies__PM__DoctrineTestsModelsFriendObjectComparableObjectGenerated33594d823b0c750acd1a8c76bba47f1f.php">
+    <InaccessibleProperty occurrences="1">
+      <code>$instance-&gt;comparedField</code>
+    </InaccessibleProperty>
+    <InvalidArgument occurrences="4">
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>setProxyInitializer</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="5">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$signature33594d823b0c750acd1a8c76bba47f1f</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>staticProxyConstructor</code>
+    </MissingReturnType>
+    <PossiblyInvalidFunctionCall occurrences="13">
+      <code>$cacheDoctrine_Tests_Models_FriendObject_ComparableObject($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+    </PossiblyInvalidFunctionCall>
+  </file>
+  <file src="tests/Doctrine/Tests/Proxies/DoctrineTestsProxies__PM__DoctrineTestsModelsProxySpecificsFuncGetArgsGenerated748bee19d28c4d24d53e7599e163e58d.php">
+    <InvalidArgument occurrences="4">
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+      <code>$expectedType</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="1">
+      <code>setProxyInitializer</code>
+    </InvalidReturnType>
+    <MissingParamType occurrences="5">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$name</code>
+      <code>$name</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$signature748bee19d28c4d24d53e7599e163e58d</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>staticProxyConstructor</code>
+    </MissingReturnType>
+    <PossiblyInvalidFunctionCall occurrences="12">
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor($this, $value)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+      <code>$accessor($this)</code>
+      <code>$accessor($this)</code>
+      <code>$accessor()</code>
+    </PossiblyInvalidFunctionCall>
+  </file>
+  <file src="tests/Doctrine/Tests/TestInit.php">
+    <MissingFile occurrences="1">
+      <code>require __DIR__ . '/../../../../../autoload.php'</code>
+    </MissingFile>
+  </file>
+  <file src="tests/Doctrine/Tests/TestUtil.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $subscriberClass()</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="7">
+      <code>getConnectionParams</code>
+      <code>hasRequiredConnectionParams</code>
+      <code>getSpecifiedConnectionParams</code>
+      <code>getFallbackConnectionParams</code>
+      <code>addDbEventSubscribers</code>
+      <code>getParamsForTemporaryConnection</code>
+      <code>getParamsForMainConnection</code>
+    </MissingReturnType>
+    <TypeCoercion occurrences="1">
+      <code>$subscriberInstance</code>
+    </TypeCoercion>
+  </file>
+  <file src="vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php">
+    <ImplementedReturnTypeMismatch occurrences="2">
+      <code>void</code>
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<psalm
+    name="Example Psalm config with recommended defaults"
+    totallyTyped="false"
+    allowPhpStormGenerics="true"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="lib" />
+        <directory name="tests" />
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </PossiblyUnusedMethod>
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
There are a bunch of different ways to improve the code quality of a large project.

One way that's worked reasonably well at `$workplace` is to grandfather in a bunch of existing issues, such that any new code must abide by higher standards than existing code.

We do this with a baseline file - it records the current issues with the codebase, with some sort of marker to identify where in the file the issue happened. New code that triggers similar issues presumably has different markers, so a new specific error is emitted.

One benefit is that you don't have to fix a single type of issue all in one go - you can make incremental changes, and see the size of the generated baseline file shrink over time.

This approach isn't for everyone, or every project. I leave it up to you to decide if this is a good fit for Doctrine.