### PR TITLE
Test to reproduce bug related to composite keys and EAGER fetch

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2802,6 +2802,9 @@ class UnitOfWork implements PropertyChangedListener
                                 default:
                                     // TODO: This is very imperformant, ignore it?
                                     $newValue = $this->em->find($assoc['targetEntity'], $associatedId);
+                                    if ($newValue === null) {
+                                        throw EntityNotFoundException::fromClassNameAndIdentifier($assoc['targetEntity'], $associatedId);
+                                    }
                                     break;
                             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7692Test.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH7692Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH7692Project::class,
+            GH7692Contact::class,
+        ]);
+    }
+
+    public function testWrongForeignKeysInDatabaseAreHandledByDoctrine(): void
+    {
+        // Create a row that references missing rows
+        $this->_em->getConnection()->insert('project', [
+            // This composite foreign key doesn't exist
+            'contact_category' => 999,
+            'contact_number' => 999,
+        ]);
+
+        $projects = $this->_em->createQuery('SELECT p FROM Doctrine\Tests\ORM\Functional\Ticket\GH7692Project p')->getResult();
+        $this->assertCount(1, $projects);
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="project")
+ */
+class GH7692Project
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH7692Contact", fetch="EAGER")
+     * @JoinColumns({
+     *     @JoinColumn(name="contact_category", referencedColumnName="category"),
+     *     @JoinColumn(name="contact_number", referencedColumnName="number")
+     * })
+     */
+    public $contact;
+}
+
+/**
+ * @Entity
+ */
+class GH7692Contact
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    public $category;
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    public $number;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7692Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7692Test.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class GH7692Test extends OrmFunctionalTestCase
@@ -14,13 +15,34 @@ class GH7692Test extends OrmFunctionalTestCase
         parent::setUp();
 
         $this->setUpEntitySchema([
+            GH7692AddressBook::class,
             GH7692Project::class,
             GH7692Contact::class,
         ]);
     }
 
-    public function testWrongForeignKeysInDatabaseAreHandledByDoctrine(): void
+    public function testWithoutEagerLoading(): void
     {
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage("Entity of type 'Doctrine\Tests\ORM\Functional\Ticket\GH7692Contact' for IDs category(999), number(999) was not found");
+
+        // Create a row that references missing rows
+        $this->_em->getConnection()->insert('address_book', [
+            // This composite foreign key doesn't exist
+            'contact_category' => 999,
+            'contact_number' => 999,
+        ]);
+
+        $books = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\ORM\Functional\Ticket\GH7692AddressBook a')->getResult();
+        $this->assertCount(1, $books);
+        $books[0]->contact->name; // access the property on the proxy to trigger the exception
+    }
+
+    public function testWithEagerLoading(): void
+    {
+        $this->expectException(EntityNotFoundException::class);
+        $this->expectExceptionMessage("Entity of type 'Doctrine\Tests\ORM\Functional\Ticket\GH7692Contact' for IDs category(999), number(999) was not found");
+
         // Create a row that references missing rows
         $this->_em->getConnection()->insert('project', [
             // This composite foreign key doesn't exist
@@ -28,9 +50,33 @@ class GH7692Test extends OrmFunctionalTestCase
             'contact_number' => 999,
         ]);
 
-        $projects = $this->_em->createQuery('SELECT p FROM Doctrine\Tests\ORM\Functional\Ticket\GH7692Project p')->getResult();
-        $this->assertCount(1, $projects);
+        $this->_em->createQuery('SELECT p FROM Doctrine\Tests\ORM\Functional\Ticket\GH7692Project p')->getResult();
     }
+}
+
+/**
+ * @Entity
+ * @Table(name="address_book")
+ */
+class GH7692AddressBook
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * WITHOUT EAGER
+     *
+     * @ManyToOne(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH7692Contact")
+     * @JoinColumns({
+     *     @JoinColumn(name="contact_category", referencedColumnName="category"),
+     *     @JoinColumn(name="contact_number", referencedColumnName="number")
+     * })
+     */
+    public $contact;
 }
 
 /**
@@ -47,6 +93,8 @@ class GH7692Project
     public $id;
 
     /**
+     * WITH EAGER
+     *
      * @ManyToOne(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH7692Contact", fetch="EAGER")
      * @JoinColumns({
      *     @JoinColumn(name="contact_category", referencedColumnName="category"),
@@ -72,4 +120,9 @@ class GH7692Contact
      * @Column(type="integer")
      */
     public $number;
+
+    /**
+     * @Column(type="string")
+     */
+    public $name;
 }


### PR DESCRIPTION
This PR adds a test that reproduces a bug. I have no idea yet on how to fix it, suggestions are welcome.

### Scenario

`A` (manyToOne)-> `B`.

- a row (table `A`) exists in database with foreign keys pointing to a row `B` that doesn't exist
- `B` has a composite primary key
- the relation has `fetch="EAGER"`

### Expected result

Since the target entity doesn't exist `null` should be loaded instead. That is the case for all the other scenarios.

### Actual result

The following error:

```
Warning: spl_object_hash() expects parameter 1 to be object, null given
```

in lib/Doctrine/ORM/UnitOfWork.php:2809
