### PR TITLE
Change variable name in docs

### DIFF
--- a/docs/en/reference/native-sql.rst
+++ b/docs/en/reference/native-sql.rst
@@ -92,7 +92,7 @@ a mapping from DQL alias (key) to SQL alias (value)
 
     <?php
 
-    $selectClause = $builder->generateSelectClause(array(
+    $selectClause = $rsm->generateSelectClause(array(
         'u' => 't1',
         'g' => 't2'
     ));


### PR DESCRIPTION
To make it consistent throughout document. Everywhere else in the doc it's `$rsm`, but in this one spot it was `$builder`, so I've changed it to `$rsm`.