### PR TITLE
Split and deprecate AbstractQuery#useResultCache()

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,9 +1,19 @@
 # Upgrade to 2.7
 
+## Added `Doctrine\ORM\AbstractQuery#enableResultCache()` and `Doctrine\ORM\AbstractQuery#disableResultCache()` methods	
+
+Method `Doctrine\ORM\AbstractQuery#useResultCache()` which could be used for both enabling and disabling the cache
+(depending on passed flag) was split into two.	
+
 ## Minor BC BREAK: paginator output walkers aren't be called anymore on sub-queries for queries without max results  
 
 To optimize DB interaction, `Doctrine\ORM\Tools\Pagination\Paginator` no longer fetches identifiers to be able to
 perform the pagination with join collections when max results isn't set in the query.
+
+## Deprecated: `Doctrine\ORM\AbstractQuery#useResultCache()`	
+
+Method `Doctrine\ORM\AbstractQuery#useResultCache()` is deprecated because it is split into `enableResultCache()`
+and `disableResultCache()`. It will be removed in 3.0.
 
 ## Deprecated code generators and related console commands
  

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -583,21 +583,45 @@ abstract class AbstractQuery
      * Set whether or not to cache the results of this query and if so, for
      * how long and which ID to use for the cache entry.
      *
-     * @param boolean $bool
-     * @param integer $lifetime
-     * @param string  $resultCacheId
+     * @deprecated 2.7 Use {@see enableResultCache} and {@see disableResultCache} instead.
+     *
+     * @param bool   $useCache
+     * @param int    $lifetime
+     * @param string $resultCacheId
      *
      * @return static This query instance.
      */
-    public function useResultCache($bool, $lifetime = null, $resultCacheId = null)
+    public function useResultCache($useCache, $lifetime = null, $resultCacheId = null)
     {
-        if ($bool) {
-            $this->setResultCacheLifetime($lifetime);
-            $this->setResultCacheId($resultCacheId);
+        return $useCache
+            ? $this->enableResultCache($lifetime, $resultCacheId)
+            : $this->disableResultCache();
+    }
 
-            return $this;
-        }
+    /**
+     * Enables caching of the results of this query, for given or default amount of seconds
+     * and optionally specifies which ID to use for the cache entry.
+     *
+     * @param int|null    $lifetime      How long the cache entry is valid, in seconds.
+     * @param string|null $resultCacheId ID to use for the cache entry.
+     *
+     * @return static This query instance.
+     */
+    public function enableResultCache(?int $lifetime = null, ?string $resultCacheId = null) : self
+    {
+        $this->setResultCacheLifetime($lifetime);
+        $this->setResultCacheId($resultCacheId);
 
+        return $this;
+    }
+
+    /**
+     * Disables caching of the results of this query.
+     *
+     * @return static This query instance.
+     */
+    public function disableResultCache() : self
+    {
         $this->_queryCacheProfile = null;
 
         return $this;

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -128,7 +128,7 @@ class QueryTest extends OrmTestCase
     {
         $this->_em->getConfiguration()->setResultCacheImpl(new ArrayCache());
         $q = $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a");
-        $q->useResultCache(true);
+        $q->enableResultCache();
         $this->assertSame($this->_em->getConfiguration()->getResultCacheImpl(), $q->getQueryCacheProfile()->getResultCacheDriver());
     }
 
@@ -245,7 +245,7 @@ class QueryTest extends OrmTestCase
         $driverConnectionMock->setStatementMock($stmt);
         $res = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u")
             ->useQueryCache(true)
-            ->useResultCache(true, 60)
+            ->enableResultCache(60)
             //let it cache
             ->getResult();
 
@@ -255,7 +255,7 @@ class QueryTest extends OrmTestCase
 
         $res = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u")
             ->useQueryCache(true)
-            ->useResultCache(false)
+            ->disableResultCache()
             ->getResult();
         $this->assertCount(0, $res);
     }
@@ -278,7 +278,7 @@ class QueryTest extends OrmTestCase
         $this->_em->getConfiguration()->setResultCacheImpl(new ArrayCache());
 
         $query = $this->_em->createQuery("SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u")
-                           ->useResultCache(true);
+                           ->enableResultCache();
 
         /** @var DriverConnectionMock $driverConnectionMock */
         $driverConnectionMock = $this->_em->getConnection()
@@ -397,7 +397,7 @@ class QueryTest extends OrmTestCase
         $this->_em->getConfiguration()->setResultCacheImpl(new ArrayCache());
 
         $query = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u');
-        $query->useResultCache(true);
+        $query->enableResultCache();
         $query->setResultCacheProfile();
 
         self::assertAttributeSame(null, '_queryCacheProfile', $query);


### PR DESCRIPTION
Split `useResultCache($boolFlag, ...)` into `enableResultCache()` and `disableResutCache()`.

To create tests for `enableResultCache()` and `disableResultCache()`, `useResultCache()`'s tests were copy-pasted, but I think that's fine.

This is proper PR, original one is https://github.com/doctrine/orm/pull/7213