### PR TITLE
Prettified arrays in tool command orm:mapping:describe

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -26,6 +26,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use function json_encode;
 
 /**
  * Show information about mapped entities.
@@ -213,7 +217,7 @@ EOT
         }
 
         if (is_array($value)) {
-            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
         }
 
         if (is_object($value)) {


### PR DESCRIPTION
Adds JSON_PRETTY_PRINT to the orm:mapping:describe tool so that SymfonyStyle::table does not wrap excessively.

See before/after for examples.

![before](https://user-images.githubusercontent.com/4230455/57815339-08775d80-7745-11e9-87ee-70ed000c0985.png)
![after](https://user-images.githubusercontent.com/4230455/57815340-08775d80-7745-11e9-93e2-7666920f4523.png)



