### PR TITLE
Prevents unexpected errors from bubbling up when attempting to 

### DIFF
--- a/lib/Doctrine/ORM/Tools/CacheSetupException.php
+++ b/lib/Doctrine/ORM/Tools/CacheSetupException.php
@@ -19,27 +19,36 @@
 
 namespace Doctrine\ORM\Tools;
 
+use Doctrine\ORM\ORMException;
+use Throwable;
+
 /**
  * A custom exception for handling failures during cache configuration from Doctrine\ORM\Tools\Setup
  *
+ * @link    www.doctrine-project.org
+ * @since   2.0
  * @author Paul Court <g@rgoyle.com>
  */
-class CacheSetupException extends \Doctrine\ORM\ORMException
+class CacheSetupException extends ORMException
 {
-    
-    public static function autoSetupFailed(\Throwable $previous = null)
+    /**
+     * @param Throwable|null $previous
+     * @return CacheSetupException
+     */
+    public static function autoSetupFailed(Throwable $previous = null)
     {
         $code = 0;
         if ($previous !== null) {
             $code = $previous->getCode();
         }
-        return new self(""
-                . "An attempt to automatically create a cache instance failed! - The most "
-                . "likely cause is the presence of a supported extension (apcu, memcached or "
-                . "redis) but no matching service running locally on 127.0.0.1. The best way"
-                . "to fix this is to manually create a cache instance and pass it to the "
-                . "Doctrine\ORM\Tools\Setup method that you are trying to use.", 
-                $code, 
-                $previous);
+        return new self(''
+            . 'An attempt to automatically create a cache instance failed! - The most '
+            . 'likely cause is the presence of a supported extension (apcu, memcached or '
+            . 'redis) but no matching service running locally on 127.0.0.1. The best way'
+            . 'to fix this is to manually create a cache instance and pass it to the '
+            . 'Doctrine\ORM\Tools\Setup method that you are trying to use.',
+            $code,
+            $previous
+            );
     }
 }

--- a/lib/Doctrine/ORM/Tools/CacheSetupException.php
+++ b/lib/Doctrine/ORM/Tools/CacheSetupException.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\ORM\Tools;
+
+/**
+ * A custom exception for handling failures during cache configuration from Doctrine\ORM\Tools\Setup
+ *
+ * @author Paul Court <g@rgoyle.com>
+ */
+class CacheSetupException extends \Doctrine\ORM\ORMException
+{
+    
+    public static function autoSetupFailed(\Throwable $previous = null)
+    {
+        $code = 0;
+        if ($previous !== null) {
+            $code = $previous->getCode();
+        }
+        return new self(""
+                . "An attempt to automatically create a cache instance failed! - The most "
+                . "likely cause is the presence of a supported extension (apcu, memcached or "
+                . "redis) but no matching service running locally on 127.0.0.1. The best way"
+                . "to fix this is to manually create a cache instance and pass it to the "
+                . "Doctrine\ORM\Tools\Setup method that you are trying to use.", 
+                $code, 
+                $previous);
+    }
+}

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -196,18 +196,10 @@ class Setup
                 return $cache;
             }
             
+            return new ArrayCache();
+            
         } catch (\Throwable $ex) {
-
-            /*
-            Deliberate catch of top level \Exception in the event that an extension IS installed, but
-            an attempt to use it fails (Eg. Redis is installed, but there is no server running on
-            localhost).
-
-            This block is empty because the fallback to use ArrayCache() seems as good for an exception
-            as if there were no matching extensions installed.
-            */
+            throw CacheSetupException::autoSetupFailed($ex);
         }
-
-        return new ArrayCache();
     }
 }

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -173,14 +173,14 @@ class Setup
             */
 
             if (extension_loaded('apcu')) {
-                return new ApcuCache();
+                return new \Doctrine\Common\Cache\ApcuCache();
             }
 
             if (extension_loaded('memcached')) {
                 $memcached = new Memcached();
                 $memcached->addServer('127.0.0.1', 11211);
 
-                $cache = new MemcachedCache();
+                $cache = new \Doctrine\Common\Cache\MemcachedCache();
                 $cache->setMemcached($memcached);
 
                 return $cache;
@@ -190,7 +190,7 @@ class Setup
                 $redis = new Redis();
                 $redis->connect('127.0.0.1');
 
-                $cache = new RedisCache();
+                $cache = new \Doctrine\Common\Cache\RedisCache();
                 $cache->setRedis($redis);
 
                 return $cache;

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -196,7 +196,7 @@ class Setup
                 return $cache;
             }
             
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
 
             /*
             Deliberate catch of top level \Exception in the event that an extension IS installed, but

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -177,7 +177,7 @@ class Setup
             }
 
             if (extension_loaded('memcached')) {
-                $memcached = new Memcached();
+                $memcached = new \Memcached();
                 $memcached->addServer('127.0.0.1', 11211);
 
                 $cache = new \Doctrine\Common\Cache\MemcachedCache();
@@ -187,7 +187,7 @@ class Setup
             }
 
             if (extension_loaded('redis')) {
-                $redis = new Redis();
+                $redis = new \Redis();
                 $redis->connect('127.0.0.1');
 
                 $cache = new \Doctrine\Common\Cache\RedisCache();

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -168,7 +168,7 @@ class Setup
         try {
 
             /*
-            For backwards-compatability, attempt to create to a caching provider with
+            For backwards-compatability, attempt to create a caching provider with
             default settings if that providers extension is installed.
             */
 


### PR DESCRIPTION
autodiscover a cache provider.

The worst case scenario for this situation is when the cache extension *is* installed, but the service is not running on the localhost. For example, our app was attempting to setup doctrine as follows:-

```php
            $config = Setup::createAnnotationMetadataConfiguration([
                __DIR__ . DIRECTORY_SEPARATOR,
            ], $isDevMode);

            if ($isDevMode) {
                // In development we don't want anything being cached for longer than a single request.
                $cache = new ArrayCache();
            } else {
                // Allow Doctrine to cache queries and metadata using Redis
                $redisCredentials = $this->getRedisCredentials();

                $redis = new \Redis();
                $redis->connect((string)$redisCredentials->getHost(), $redisCredentials->getPort()->value());
                $redis->setOption(\Redis::OPT_PREFIX, 'AUTHAPI:' . $this->getAppVersion() . ':');

                $cache = new \Doctrine\Common\Cache\RedisCache();
                $cache->setRedis($redis);
            }

            $config->setQueryCacheImpl($cache);
            $config->setResultCacheImpl($cache);
            $config->setMetadataCacheImpl($cache);
```

Given that the error message in our stack trace was:-

```
PHP Warning:  Redis::connect(): connect() failed: Connection refused in /var/www/vhosts/auth-api/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php on line 185
PHP Fatal error:  Uncaught RedisException: Redis server went away in /var/www/vhosts/auth-api/vendor/doctrine/cache/lib/Doctrine/Common/Cache/RedisCache.php:28
```

It took us a long time to discover that it was the call to `Setup::createAnnotationMetadataConfiguration` which was attempting to create a connection to a local redis instance which doesn't exist (We're using ElastiCache on AWS).

An alternate approach might be to throw a more helpful error message.