### PR TITLE
[doc] Finish incomplete definition of class UTCDateTimeType

### DIFF
--- a/docs/en/cookbook/working-with-datetime.rst
+++ b/docs/en/cookbook/working-with-datetime.rst
@@ -90,7 +90,10 @@ the UTC time at the time of the booking and the timezone the event happened in.
 
     class UTCDateTimeType extends DateTimeType
     {
-        static private $utc;
+        /**
+         * @var \DateTimeZone
+         */
+        private static $utc;
 
         public function convertToDatabaseValue($value, AbstractPlatform $platform)
         {
@@ -110,7 +113,7 @@ the UTC time at the time of the booking and the timezone the event happened in.
             $converted = \DateTime::createFromFormat(
                 $platform->getDateTimeFormatString(),
                 $value,
-                self::$utc ? self::$utc : self::$utc = new \DateTimeZone('UTC')
+                self::getUtc()
             );
 
             if (! $converted) {
@@ -122,6 +125,11 @@ the UTC time at the time of the booking and the timezone the event happened in.
             }
 
             return $converted;
+        }
+        
+        private static function getUtc(): \DateTimeZone
+        {
+            return self::$utc ?: self::$utc = new \DateTimeZone('UTC');
         }
     }
 


### PR DESCRIPTION
Method `convertToDatabaseValue()` invokes method `self::getUtc()`, but no actual definition of that method were present. On the other hand, method `convertToPHPValue()` contained the code that should have been inside of the missing `self::getUtc()`. This commit fixes the issue.
