### PR TITLE
Use alternate keyserver

### DIFF
--- a/tests/travis/install-mysql-5.7.sh
+++ b/tests/travis/install-mysql-5.7.sh
@@ -8,6 +8,7 @@ sudo service mysql stop
 sudo apt-get remove "^mysql.*"
 sudo apt-get autoremove
 sudo apt-get autoclean
+sudo apt-key adv --keyserver pgp.mit.edu --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5
 echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
 wget http://dev.mysql.com/get/mysql-apt-config_0.8.6-1_all.deb
 sudo DEBIAN_FRONTEND=noninteractive dpkg -i mysql-apt-config_0.8.6-1_all.deb


### PR DESCRIPTION
All the keys at repo.mysql.com expired. Also, it is recommended to check
packages with keys published on a different server in case the first one
is compromised.