### PR TITLE
Update DATE_ADD and DATE_SUB docs

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -635,8 +635,8 @@ clauses:
 -  TRIM([LEADING \| TRAILING \| BOTH] ['trchar' FROM] str) - Trim
    the string by the given trim char, defaults to whitespaces.
 -  UPPER(str) - Return the upper-case of the given string.
--  DATE_ADD(date, days, unit) - Add the number of days to a given date. (Supported units are DAY, MONTH)
--  DATE_SUB(date, days, unit) - Substract the number of days from a given date. (Supported units are DAY, MONTH)
+-  DATE_ADD(date, value, unit) - Add the given time to a given date. (Supported units are SECOND, HOUR, DAY, MONTH)
+-  DATE_SUB(date, value, unit) - Substract the given time from a given date. (Supported units are HOUR, DAY, MONTH)
 -  DATE_DIFF(date1, date2) - Calculate the difference in days between date1-date2.
 
 Arithmetic operators


### PR DESCRIPTION
I've recently opened a [PR](https://github.com/doctrine/orm/pull/7729) for this change on 2.6. It appears that some of the units were added in 2.5, and others in 2.6.
In this PR i add the units that are available in 2.5 to the respective docs.