### PR TITLE
fix: enable usage of findBy with Criteria[]

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1599,6 +1599,19 @@ class BasicEntityPersister implements EntityPersister
     public function getSelectConditionStatementSQL($field, $value, $assoc = null, $comparison = null)
     {
         $selectedColumns = [];
+
+        if ($value instanceof Criteria && $value->getWhereExpression() instanceof Comparison) {
+            /** @var Comparison $expression */
+            $expression = $value->getWhereExpression();
+
+            // replace $field, if it was not specified earlier
+            if (is_numeric($field)) {
+                $field = $expression->getField();
+            }
+            $value = $expression->getValue();
+            $comparison = $expression->getOperator();
+        }
+
         $columns         = $this->getSelectConditionStatementColumnSQL($field, $assoc);
 
         if (count($columns) > 1 && $comparison === Comparison::IN) {

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Persisters;
 
+use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Tests\Models\GeoNames\Admin1AlternateName;
@@ -54,5 +55,18 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
     public function testSelectConditionStatementIn()
     {
         $this->_persister->getSelectConditionStatementSQL('admin1', [], [], Comparison::IN);
+    }
+
+    /**
+     * this represents the case that occurs when getSelectConditionSQL() is called with Criteria[] as $criteria
+     * as used by findBy([$criteris]) with Critia[] given as argument
+     */
+    public function testSelectConditionStatementWithCriteria()
+    {
+        $criteria = Criteria::create();
+        $criteria->where(Criteria::expr()->gt('id', 1));
+
+        $statement= $this->_persister->getSelectConditionStatementSQL(0, $criteria);
+        $this->assertEquals('t0.id > ?', $statement);
     }
 }


### PR DESCRIPTION
This pull request shall enable something like

```
$criteria = new Criteria();
$criteria->where(Criteria::expr()->lt('id', $param));

return $this->entityManager
    ->getRepository(MyEntity::class)
    ->findBy([$criteria]);
```

Criteria is currently ignored in `\Doctrine\ORM\Persisters\Entity\BasicEntityPersister::getSelectConditionSQL()` and `\Doctrine\ORM\Persisters\Entity\BasicEntityPersister::getSelectConditionStatementSQL()`