### PR TITLE
Remove hack to access class scope inside closures

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3123Test.php
@@ -22,7 +22,6 @@ class DDC3123Test extends OrmFunctionalTestCase
 
     public function testIssue() : void
     {
-        $test = $this;
         $user = new CmsUser();
         $uow  = $this->em->getUnitOfWork();
 
@@ -39,8 +38,8 @@ class DDC3123Test extends OrmFunctionalTestCase
         $listener
             ->expects($this->once())
             ->method(Events::postFlush)
-            ->will($this->returnCallback(static function () use ($uow, $test) {
-                $test->assertAttributeEmpty('extraUpdates', $uow, 'ExtraUpdates are reset before postFlush');
+            ->will($this->returnCallback(static function () use ($uow) {
+                self::assertAttributeEmpty('extraUpdates', $uow, 'ExtraUpdates are reset before postFlush');
             }));
 
         $this->em->getEventManager()->addEventListener(Events::postFlush, $listener);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3644Test.php
@@ -154,23 +154,19 @@ class DDC3644User
 
     public function setAddresses(Collection $addresses)
     {
-        $self = $this;
-
         $this->addresses = $addresses;
 
-        $addresses->map(static function ($address) use ($self) {
-            $address->user = $self;
+        $addresses->map(function ($address) {
+            $address->user = $this;
         });
     }
 
     public function setPets(Collection $pets)
     {
-        $self = $this;
-
         $this->pets = $pets;
 
-        $pets->map(static function ($pet) use ($self) {
-            $pet->owner = $self;
+        $pets->map(function ($pet) {
+            $pet->owner = $this;
         });
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -335,8 +335,6 @@ class ClassMetadataFactoryTest extends OrmTestCase
      */
     public function testFallbackLoadingCausesEventTriggeringThatCanModifyFetchedMetadata() : void
     {
-        $test = $this;
-
         /** @var ClassMetadata $metadata */
         $metadata     = $this->createMock(ClassMetadata::class);
         $cmf          = new ClassMetadataFactory();
@@ -350,10 +348,10 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $listener
             ->expects($this->any())
             ->method('onClassMetadataNotFound')
-            ->will($this->returnCallback(static function (OnClassMetadataNotFoundEventArgs $args) use ($metadata, $em, $test) {
-                $test->assertNull($args->getFoundMetadata());
-                $test->assertSame('Foo', $args->getClassName());
-                $test->assertSame($em, $args->getObjectManager());
+            ->will($this->returnCallback(static function (OnClassMetadataNotFoundEventArgs $args) use ($metadata, $em) {
+                self::assertNull($args->getFoundMetadata());
+                self::assertSame('Foo', $args->getClassName());
+                self::assertSame($em, $args->getObjectManager());
 
                 $args->setFoundMetadata($metadata);
             }));


### PR DESCRIPTION
Found some os these while working at #7688.