### PR TITLE
Fix PHP 7.4 notice in Parser::ArithmeticPrimary()

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2853,7 +2853,7 @@ class Parser
             default:
                 $peek = $this->lexer->glimpse();
 
-                if ($peek['value'] == '(') {
+                if ($peek && $peek['value'] == '(') {
                     return $this->FunctionDeclaration();
                 }
 


### PR DESCRIPTION
This fixes a "Trying to access array offset on value of type null" notice thrown in PHP 7.4