### PR TITLE
Fix for $isDevMode in Setup helpers

### DIFF
--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -157,18 +157,17 @@ class Setup
 
     private static function createCacheInstance(bool $isDevMode, ?Cache $cache) : Cache
     {
-        if ($cache !== null) {
-            return $cache;
-        }
-
         if ($isDevMode === true) {
             return new ArrayCache();
+        }
+
+        if ($cache !== null) {
+            return $cache;
         }
 
         if (extension_loaded('apcu')) {
             return new \Doctrine\Common\Cache\ApcuCache();
         }
-
 
         if (extension_loaded('memcached')) {
             $memcached = new \Memcached();

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -128,11 +128,21 @@ class SetupTest extends OrmTestCase
     public function testConfigureCache()
     {
         $cache = new ArrayCache();
-        $config = Setup::createAnnotationMetadataConfiguration([], true, null, $cache);
+        $config = Setup::createAnnotationMetadataConfiguration([], false, null, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());
         $this->assertSame($cache, $config->getMetadataCacheImpl());
         $this->assertSame($cache, $config->getQueryCacheImpl());
+    }
+
+    public function testDevModeOverridesCacheCustomInstance()
+    {
+        $cache = new ArrayCache();
+        $config = Setup::createAnnotationMetadataConfiguration([], true, null, $cache);
+
+        $this->assertNotSame($cache, $config->getResultCacheImpl());
+        $this->assertNotSame($cache, $config->getMetadataCacheImpl());
+        $this->assertNotSame($cache, $config->getQueryCacheImpl());
     }
 
     /**
@@ -141,7 +151,7 @@ class SetupTest extends OrmTestCase
     public function testConfigureCacheCustomInstance()
     {
         $cache  = $this->createMock(Cache::class);
-        $config = Setup::createConfiguration(true, null, $cache);
+        $config = Setup::createConfiguration(false, null, $cache);
 
         $this->assertSame($cache, $config->getResultCacheImpl());
         $this->assertSame($cache, $config->getMetadataCacheImpl());


### PR DESCRIPTION
## Problem

The `Setup::createXXXMetadataConfiguration()` methods help end users to create the `Configuration` object for instantiating an `EntityManager`. These methods accept an optional `Cache` instance that is configured as the metadata, query and result caches. There is also an optional `$isDevMode` parameter (default `false`) to force the `Cache` to be of type `ArrayCache`, which effectively disables the Doctrine cache between requests, which in turn is the desired behavior during development.

However `Setup` gives more priority to `$cache` than `$isDevMode`, so that if a `$cache` is supplied then `$isDevMode` is ignored altogether.

Ideally the user would pass the production cache and a `$isDevMode` variable that would toggle it on and off, such as this:

```php
$config = Setup::createXMLMetadataConfiguration(
    self::METADATA_DIR,
    $isDevMode,
    new FilesystemCache(self::CACHE_DIR)
);
```

But currently this code does not work as it would be expected; the filesystem cache is always populated regardless of the value of `$isDevMode`. So instead the above snippet has to be rewritten as this, almost implementing the helper manually:

```php
$config = Setup::createXMLMetadataConfiguration(self::METADATA_DIR);

if ($isDevMode) {
    $cache = new FilesystemCache(self::CACHE_DIR);
    $config->setMetadataCacheImpl($cache);
    $config->setQueryCacheImpl($cache);
    $config->setResultCacheImpl($cache);
}
```

## Analysis

In `Setup` there is a [createCacheInstance](https://github.com/doctrine/orm/blob/8c2d090dc88f6b83c28fea4bea93c35c478710e6/lib/Doctrine/ORM/Tools/Setup.php#L160-L166) method that returns the user supplied cache if it is not null, and right after that returns a brand new `ArrayCache` if `$isDevMode` is true. Inverting these two ifs fixes the issue.

## Testing

A couple of tests in `SetupTest` broke since they were passing in a `$cache` and `$isDevMode` set to true but still expected that the caches inside the Configuration would be the same that was supplied. I've just switched `$isDevMode` to false in these tests, and added a new one that exercises the new behavior.