### PR TITLE
Fix preFlush event documentation stating incorrectly that flush can be called safely

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -548,8 +548,9 @@ preFlush
 ~~~~~~~~
 
 ``preFlush`` is called at ``EntityManager#flush()`` before
-anything else. ``EntityManager#flush()`` can be called safely
-inside its listeners.
+anything else. ``EntityManager#flush()`` should not be called inside
+its listeners, since `preFlush` event is dispatched in it, which would
+result in infinite loop.
 
 .. code-block:: php
 


### PR DESCRIPTION
Since I just caught myself on attempting to call `flush` due to docs.

Original author: @egonolieux
Supersedes #6858
Fixes: #6857