### PR TITLE
Do not modify UOW on PersistentCollection::clear() when owner has DEFFERED_EXPLICIT change tracking policy 

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -564,7 +564,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         if ($this->association->isOwningSide() && $this->owner) {
             $this->changed();
 
-            $uow->scheduleCollectionDeletion($this);
+            if ($this->em->getClassMetadata(get_class($this->owner))->changeTrackingPolicy !== ChangeTrackingPolicy::DEFERRED_EXPLICIT) {
+                $uow->scheduleCollectionDeletion($this);
+            }
 
             $this->takeSnapshot();
         }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7761Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7761Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH7761Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH7761Entity::class,
+            GH7761ChildEntity::class,
+        ]);
+
+        $parent = new GH7761Entity();
+        $child  = new GH7761ChildEntity();
+        $parent->children->add($child);
+
+        $this->em->persist($parent);
+        $this->em->persist($child);
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    public function testCollectionClearDoesNotClearIfNotPersisted() : void
+    {
+        /** @var GH7761Entity $entity */
+        $entity = $this->em->find(GH7761Entity::class, 1);
+        $entity->children->clear();
+        $this->em->persist(new GH7761Entity());
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $entity = $this->em->find(GH7761Entity::class, 1);
+        self::assertCount(1, $entity->children);
+
+        $this->em->clear();
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
+ */
+class GH7761Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="Doctrine\Tests\ORM\Functional\Ticket\GH7761ChildEntity", cascade={"all"})
+     * @ORM\JoinTable(name="gh7761_to_child",
+     *     joinColumns={@ORM\JoinColumn(name="entity_id")},
+     *     inverseJoinColumns={@ORM\JoinColumn(name="child_id")}
+     * )
+     */
+    public $children;
+
+    public function __construct()
+    {
+        $this->children = new ArrayCollection();
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\ChangeTrackingPolicy("DEFERRED_EXPLICIT")
+ */
+class GH7761ChildEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping\ChangeTrackingPolicy;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\Tests\Mocks\ConnectionMock;
@@ -268,5 +269,26 @@ class PersistentCollectionTest extends OrmTestCase
         );
         self::assertTrue($this->collection->isInitialized());
         self::assertFalse($this->collection->isDirty());
+    }
+
+    public function testModifyUOWForDeferredImplicitOwnerOnClear() : void
+    {
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork->expects(self::once())->method('scheduleCollectionDeletion');
+        $this->emMock->setUnitOfWork($unitOfWork);
+
+        $this->collection->clear();
+    }
+
+    public function testDoNotModifyUOWForDeferredExplicitOwnerOnClear() : void
+    {
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork->expects(self::never())->method('scheduleCollectionDeletion');
+        $this->emMock->setUnitOfWork($unitOfWork);
+
+        $classMetaData = $this->emMock->getClassMetadata(ECommerceCart::class);
+        $classMetaData->setChangeTrackingPolicy(ChangeTrackingPolicy::DEFERRED_EXPLICIT);
+
+        $this->collection->clear();
     }
 }


### PR DESCRIPTION
Same as #7761 