### PR TITLE
Query expr with array alias

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/BaseAlias.php
+++ b/lib/Doctrine/ORM/Query/Expr/BaseAlias.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\Expr;
+
+use InvalidArgumentException;
+use function is_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * Abstract base Expr class for building DQL parts.
+ */
+abstract class BaseAlias extends Base
+{
+    /**
+     * @param mixed $args
+     *
+     * @return Base
+     */
+    public function addMultiple($args = [])
+    {
+        foreach ((array) $args as $alias => $arg) {
+            if (is_string($alias)) {
+                $this->add($arg, $alias);
+
+                continue;
+            }
+            parent::add($arg);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param mixed       $arg
+     * @param string|null $alias
+     *
+     * @return Base
+     *
+     * @throws InvalidArgumentException
+     */
+    public function add($arg, $alias = null)
+    {
+        if ($alias !== null && is_array($arg) && (! $arg instanceof self || $arg->count() > 0)) {
+            foreach ($arg as $v) {
+                parent::add(sprintf('%s.%s', $alias, $v));
+            }
+
+            return $this;
+        }
+
+        return parent::add($arg);
+    }
+}

--- a/lib/Doctrine/ORM/Query/Expr/GroupBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/GroupBy.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Query\Expr;
 /**
  * Expression class for building DQL Group By parts.
  */
-class GroupBy extends Base
+class GroupBy extends BaseAlias
 {
     /** @var string */
     protected $preSeparator = '';

--- a/lib/Doctrine/ORM/Query/Expr/Select.php
+++ b/lib/Doctrine/ORM/Query/Expr/Select.php
@@ -7,7 +7,7 @@ namespace Doctrine\ORM\Query\Expr;
 /**
  * Expression class for building DQL select statements.
  */
-class Select extends Base
+class Select extends BaseAlias
 {
     /** @var string */
     protected $preSeparator = '';

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1140,13 +1140,17 @@ class QueryBuilder
      *         ->groupBy('u.id');
      * </code>
      *
-     * @param string $groupBy The grouping expression.
+     * @param string|string[] $groupBy The grouping expression.
      *
      * @return self
      */
     public function groupBy($groupBy)
     {
-        return $this->add('groupBy', new Expr\GroupBy(func_get_args()));
+        if (! is_array($groupBy)) {
+            $groupBy = func_get_args();
+        }
+
+        return $this->add('groupBy', new Expr\GroupBy($groupBy));
     }
 
     /**
@@ -1160,13 +1164,17 @@ class QueryBuilder
      *         ->addGroupBy('u.createdAt');
      * </code>
      *
-     * @param string $groupBy The grouping expression.
+     * @param string|string[] $groupBy The grouping expression.
      *
      * @return self
      */
     public function addGroupBy($groupBy)
     {
-        return $this->add('groupBy', new Expr\GroupBy(func_get_args()), true);
+        if (! is_array($groupBy)) {
+            $groupBy = func_get_args();
+        }
+
+        return $this->add('groupBy', new Expr\GroupBy($groupBy), true);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -88,6 +88,15 @@ class QueryBuilderTest extends OrmTestCase
         self::assertValidQueryBuilder($qb, 'SELECT u.id, u.username FROM Doctrine\Tests\Models\CMS\CmsUser u');
     }
 
+    public function testMultiSelectWithAlias() : void
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->from(CmsUser::class, 'u')
+            ->select(['u' => ['id', 'username'], 'e' => ['id', 'name']]);
+
+        self::assertValidQueryBuilder($qb, 'SELECT u.id, u.username, e.id, e.name FROM Doctrine\Tests\Models\CMS\CmsUser u');
+    }
+
     public function testSimpleDelete() : void
     {
         $qb = $this->em->createQueryBuilder()
@@ -335,6 +344,17 @@ class QueryBuilderTest extends OrmTestCase
             ->addGroupBy('u.username');
 
         self::assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u GROUP BY u.id, u.username');
+    }
+
+    public function testMultiGroupByWithAlias() : void
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u')
+            ->groupBy(['u' => ['id', 'name'], 'e' => ['id']])
+            ->addGroupBy('u.username');
+
+        self::assertValidQueryBuilder($qb, 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u GROUP BY u.id, u.name, e.id, u.username');
     }
 
     public function testHaving() : void


### PR DESCRIPTION
I would like to propose for the next version, a simplification of `select` & `groupBy` with an alias.

This can be interesting for a consequent query

Here a little example : 
```
$qb = $em->createQueryBuilder()
    ->select(['u' => ['id', 'name'], 'p' => ['number'])
    ->from('User', 'u')
    ->leftJoin('u.Phonenumbers', 'p')
    ->groupBy(['u' => ['lastLogin']])
    ->addGroupBy('u.createdAt');
```

Note : The example for the `groupBy` is bad but it's the idea