### PR TITLE
Fix when SimpleArithmetic is used in Pagination order by

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -23,10 +23,10 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
-use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;
 use Doctrine\ORM\Query\TreeWalkerAdapter;
 
 /**
@@ -99,7 +99,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
         }
 
         foreach ($AST->orderByClause->orderByItems as $item) {
-            if ($item->expression instanceof PathExpression || $item->expression instanceof SimpleArithmeticExpression) {
+            if ($item->expression instanceof Node) {
                 $AST->selectClause->selectExpressions[] = new SelectExpression(
                     $this->createSelectExpressionItem($item->expression),
                     '_dctrn_ord' . $this->_aliasCounter++
@@ -159,11 +159,11 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
     /**
      * Retrieve either an IdentityFunction (IDENTITY(u.assoc)) or a state field (u.name).
      *
-     * @param mixed $expression
+     * @param Node $expression
      *
-     * @return IdentityFunction
+     * @return Node
      */
-    private function createSelectExpressionItem($expression)
+    private function createSelectExpressionItem(Node $expression)
     {
         if ($expression instanceof PathExpression && $expression->type === PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION) {
             $identity = new IdentityFunction('identity');

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -159,8 +159,6 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
     /**
      * Retrieve either an IdentityFunction (IDENTITY(u.assoc)) or a state field (u.name).
      *
-     * @param Node $expression
-     *
      * @return Node
      */
     private function createSelectExpressionItem(Node $expression)

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -104,26 +104,23 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                     $expressions = [$item->expression];
                     break;
                 case $item->expression instanceof SimpleArithmeticExpression:
-                    $expressions = $item->expression->arithmeticTerms;
+                    $expressions = array_filter(
+                        $item->expression->arithmeticTerms,
+                        function ($term) { return $term instanceof PathExpression; }
+                    );
                     break;
                 default:
                     $expressions = [];
             }
 
-            $hasPathExpression = false;
-
             foreach ($expressions as $expression) {
-                if ($expression instanceof PathExpression) {
-                    $AST->selectClause->selectExpressions[] = new SelectExpression(
-                        $this->createSelectExpressionItem($expression),
-                        '_dctrn_ord' . $this->_aliasCounter++
-                    );
-
-                    $hasPathExpression = true;
-                }
+                $AST->selectClause->selectExpressions[] = new SelectExpression(
+                    $this->createSelectExpressionItem($expression),
+                    '_dctrn_ord' . $this->_aliasCounter++
+                );
             }
 
-            if ($hasPathExpression) {
+            if ( ! empty($expressions)) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -115,8 +115,10 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
             foreach ($expressions as $expression) {
                 if ($expression instanceof PathExpression) {
                     $AST->selectClause->selectExpressions[] = new SelectExpression(
-                        $this->createSelectExpressionItem($expression), '_dctrn_ord' . $this->_aliasCounter++
+                        $this->createSelectExpressionItem($expression),
+                        '_dctrn_ord' . $this->_aliasCounter++
                     );
+
                     $hasPathExpression = true;
                 }
             }

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -104,10 +104,9 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
                     $expressions = [$item->expression];
                     break;
                 case $item->expression instanceof SimpleArithmeticExpression:
-                    $expressions = array_filter(
-                        $item->expression->arithmeticTerms,
-                        function ($term) { return $term instanceof PathExpression; }
-                    );
+                    $expressions = \array_filter($item->expression->arithmeticTerms, static function ($term) {
+                        return $term instanceof PathExpression;
+                    });
                     break;
                 default:
                     $expressions = [];

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
@@ -19,6 +19,7 @@ class GH7805Test extends OrmFunctionalTestCase
         $article = new CmsArticle;
         $article->topic = 'Test SimpleArithmetic ORDER BY';
         $article->text = 'This test fails on MySQL.';
+        $article->version = 1;
 
         $this->_em->persist($article);
         $this->_em->flush();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use function count;
+use function iterator_to_array;
 
 class GH7805Test extends OrmFunctionalTestCase
 {
@@ -16,9 +20,10 @@ class GH7805Test extends OrmFunctionalTestCase
 
     public function testPaginationWithSimpleArithmetic()
     {
-        $article = new CmsArticle;
-        $article->topic = 'Test SimpleArithmetic ORDER BY';
-        $article->text = 'This test fails on MySQL.';
+        $article = new CmsArticle();
+
+        $article->topic   = 'Test SimpleArithmetic ORDER BY';
+        $article->text    = 'This test fails on MySQL.';
         $article->version = 1;
 
         $this->_em->persist($article);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
@@ -18,12 +18,32 @@ class GH7805Test extends OrmFunctionalTestCase
         parent::setUp();
     }
 
+    public function testPaginationWithFunction()
+    {
+        $article = new CmsArticle();
+
+        $article->topic   = 'Test ORDER BY with Function';
+        $article->text    = 'This test fails on MySQL if ORDER BY part is not added to SELECT.';
+        $article->version = 1;
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a ORDER BY SQRT(a.version) ASC');
+        $query->setFirstResult(0);
+        $query->setMaxResults(1);
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+        $this->assertEquals(1, count(iterator_to_array($paginator)));
+    }
+
     public function testPaginationWithSimpleArithmetic()
     {
         $article = new CmsArticle();
 
-        $article->topic   = 'Test SimpleArithmetic ORDER BY';
-        $article->text    = 'This test fails on MySQL.';
+        $article->topic   = 'Test ORDER BY with SimpleArithmetic';
+        $article->text    = 'This test fails on MySQL if ORDER BY part is not added to SELECT.';
         $article->version = 1;
 
         $this->_em->persist($article);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
@@ -23,7 +23,7 @@ class GH7805Test extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a ORDER BY a.topic + 0 ASC');
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a ORDER BY a.version + 0 ASC');
         $query->setFirstResult(0);
         $query->setMaxResults(1);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7805Test.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Doctrine\Tests\Models\CMS\CmsArticle;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH7805Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testPaginationWithSimpleArithmetic()
+    {
+        $article = new CmsArticle;
+        $article->topic = 'Test SimpleArithmetic ORDER BY';
+        $article->text = 'This test fails on MySQL.';
+
+        $this->_em->persist($article);
+        $this->_em->flush();
+
+        $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsArticle a ORDER BY a.topic + 0 ASC');
+        $query->setFirstResult(0);
+        $query->setMaxResults(1);
+
+        $paginator = new Paginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+        $this->assertEquals(1, count(iterator_to_array($paginator)));
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -47,7 +47,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [LimitSubqueryWalker::class]);
 
         self::assertSame(
-            'SELECT DISTINCT m0_.id AS id_0 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id GROUP BY m0_.id ORDER BY COUNT(c1_.id) ASC',
+            'SELECT DISTINCT m0_.id AS id_0, COUNT(c1_.id) AS sclr_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id GROUP BY m0_.id ORDER BY COUNT(c1_.id) ASC',
             $limitQuery->getSQL()
         );
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -61,7 +61,7 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [LimitSubqueryWalker::class]);
 
         self::assertSame(
-            'SELECT DISTINCT m0_.id AS id_0, m0_.title AS title_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id GROUP BY m0_.id ORDER BY m0_.title + 0 ASC',
+            'SELECT DISTINCT m0_.id AS id_0, m0_.title + 0 AS sclr_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id GROUP BY m0_.id ORDER BY m0_.title + 0 ASC',
             $limitQuery->getSQL()
         );
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryWalkerTest.php
@@ -52,6 +52,20 @@ class LimitSubqueryWalkerTest extends PaginationTestCase
         );
     }
 
+    public function testLimitSubqueryWithSortSimpleArithmetic() : void
+    {
+        $dql   = 'SELECT p FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p JOIN p.category c GROUP BY p.id ORDER BY p.title + 0';
+        $query = $this->entityManager->createQuery($dql);
+
+        $limitQuery = clone $query;
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [LimitSubqueryWalker::class]);
+
+        self::assertSame(
+            'SELECT DISTINCT m0_.id AS id_0, m0_.title AS title_1 FROM MyBlogPost m0_ INNER JOIN Category c1_ ON m0_.category_id = c1_.id GROUP BY m0_.id ORDER BY m0_.title + 0 ASC',
+            $limitQuery->getSQL()
+        );
+    }
+
     public function testCountQuery_MixedResultsWithName()
     {
         $dql        = 'SELECT a, sum(a.name) as foo FROM Doctrine\Tests\ORM\Tools\Pagination\Author a';


### PR DESCRIPTION
This fix Pagination limit subquery when a `SimpleArithmetic` is used in the `ORDER BY`.