### PR TITLE
Improved support for Mapped Superclasses

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -263,9 +263,13 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
 
     public function getRootClassName() : string
     {
-        return $this->parent instanceof ClassMetadata && ! $this->parent->isMappedSuperclass
-            ? $this->parent->getRootClassName()
-            : $this->className;
+        $rootClass = $parentClass = $this;
+        while (($parentClass = $parentClass->getParent()) !== null) {
+            if (! $parentClass->isMappedSuperclass) {
+                $rootClass = $parentClass;
+            }
+        }
+        return $rootClass->className;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -720,7 +720,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
     public function isInheritedProperty($fieldName)
     {
         $declaringClass = $this->properties[$fieldName]->getDeclaringClass();
-        if ($declaringClass === $this) {
+        if ($declaringClass->className === $this->className) {
             return false;
         } else if (! $declaringClass->isMappedSuperclass) {
             return true;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -269,6 +269,7 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
                 $rootClass = $parentClass;
             }
         }
+
         return $rootClass->className;
     }
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -715,8 +715,20 @@ class ClassMetadata extends ComponentMetadata implements TableOwner
     public function isInheritedProperty($fieldName)
     {
         $declaringClass = $this->properties[$fieldName]->getDeclaringClass();
+        if ($declaringClass === $this) {
+            return false;
+        } else if (! $declaringClass->isMappedSuperclass) {
+            return true;
+        }
 
-        return $declaringClass->className !== $this->className;
+        $parentClass = $this;
+        while (($parentClass = $parentClass->getParent()) !== $declaringClass) {
+            if (! $parentClass->isMappedSuperclass) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -291,7 +291,7 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function fetchVersionValue(FieldMetadata $versionProperty, array $id)
     {
-        $versionedClass = $versionProperty->getDeclaringClass();
+        $versionedClass = $this->class->getPropertyTableClass($versionProperty->getName());
         $tableName      = $versionedClass->table->getQuotedQualifiedName($this->platform);
         $columnName     = $this->platform->quoteIdentifier($versionProperty->getColumnName());
         $identifier     = array_map(
@@ -1233,9 +1233,7 @@ class BasicEntityPersister implements EntityPersister
                     );
                 }
 
-                $class      = $this->class->isInheritedProperty($fieldName)
-                    ? $property->getDeclaringClass()
-                    : $this->class;
+                $class = $this->class->getPropertyTableClass($fieldName);
                 $tableAlias = $this->getSQLTableAlias($class->getTableName());
 
                 foreach ($property->getJoinColumns() as $joinColumn) {
@@ -1800,9 +1798,7 @@ class BasicEntityPersister implements EntityPersister
                     );
                 }
 
-                $class      = $this->class->isInheritedProperty($field)
-                    ? $owningAssociation->getDeclaringClass()
-                    : $this->class;
+                $class = $this->class->getPropertyTableClass($field);
                 $tableAlias = $this->getSQLTableAlias($class->getTableName());
 
                 foreach ($owningAssociation->getJoinColumns() as $joinColumn) {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -432,20 +432,15 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     protected function getInsertColumnList()
     {
         // Identifier columns must always come first in the column list of subclasses.
-        $columns     = [];
-        $parentClass = $this->class;
-        while (($parentClass = $parentClass->getParent()) !== null) {
-            if (! $parentClass->isMappedSuperclass) {
-                $parentColumns = $parentClass->getIdentifierColumns($this->em);
+        $columns       = [];
+        $parentColumns = $this->class->getRootClassName() !== $this->class->getClassName()
+            ? $this->class->getIdentifierColumns($this->em)
+            : [];
 
-                foreach ($parentColumns as $columnName => $column) {
-                    $columns[] = $columnName;
+        foreach ($parentColumns as $columnName => $column) {
+            $columns[] = $columnName;
 
-                    $this->columns[$columnName] = $column;
-                }
-
-                break;
-            }
+            $this->columns[$columnName] = $column;
         }
 
         foreach ($this->class->getPropertiesIterator() as $name => $property) {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -150,7 +150,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Make sure the table with the version column is updated even if no columns on that
         // table were affected.
         if ($isVersioned) {
-            $versionedClass = $this->class->versionProperty->getDeclaringClass();
+            $versionedClass = $this->class->getPropertyTableClass($this->class->versionProperty->getName());
             $versionedTable = $versionedClass->getTableName();
 
             if (! isset($updateData[$versionedTable])) {
@@ -346,12 +346,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Add columns
         foreach ($this->class->getPropertiesIterator() as $fieldName => $property) {
             if ($property instanceof FieldMetadata) {
-                $tableClass = $parentClass = $this->class;
-                while ($parentClass !== $property->getDeclaringClass() && ($parentClass = $parentClass->getParent()) !== null) {
-                    if (! $parentClass->isMappedSuperclass) {
-                        $tableClass = $parentClass;
-                    }
-                }
+                $tableClass = $this->class->getPropertyTableClass($fieldName);
                 $columnList[] = $this->getSelectColumnSQL($fieldName, $tableClass);
 
                 continue;
@@ -394,7 +389,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Add columns
             foreach ($subClass->getPropertiesIterator() as $fieldName => $property) {
-                if ($subClass->isInheritedProperty($fieldName)) {
+                if ($subClass->isInheritedColumn($fieldName)) {
                     continue;
                 }
 
@@ -445,8 +440,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         foreach ($this->class->getPropertiesIterator() as $name => $property) {
-            if (($property instanceof FieldMetadata && ($property->isVersioned() || $this->class->isInheritedProperty($name)))
-                || ($property instanceof AssociationMetadata && $this->class->isInheritedProperty($name)
+            if (($property instanceof FieldMetadata && ($property->isVersioned() || $this->class->isInheritedColumn($name)))
+                || ($property instanceof AssociationMetadata && $this->class->isInheritedColumn($name)
                 || $property instanceof TransientMetadata)
                 /*|| isset($this->class->embeddedClasses[$name])*/) {
                 continue;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -189,9 +189,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $parentClass  = $this->class;
 
         while (($parentClass = $parentClass->getParent()) !== null) {
-            $parentTable = $parentClass->table->getQuotedQualifiedName($this->platform);
+            if (! $parentClass->isMappedSuperclass) {
+                $parentTable = $parentClass->table->getQuotedQualifiedName($this->platform);
 
-            $this->conn->delete($parentTable, $id);
+                $this->conn->delete($parentTable, $id);
+            }
         }
 
         return (bool) $affectedRows;
@@ -305,18 +307,20 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $parentClass = $this->class;
 
         while (($parentClass = $parentClass->getParent()) !== null) {
-            $conditions = [];
-            $tableName  = $parentClass->table->getQuotedQualifiedName($this->platform);
-            $tableAlias = $this->getSQLTableAlias($parentClass->getTableName());
-            $joinSql   .= ' INNER JOIN ' . $tableName . ' ' . $tableAlias . ' ON ';
+            if (! $parentClass->isMappedSuperclass) {
+                $conditions = [];
+                $tableName  = $parentClass->table->getQuotedQualifiedName($this->platform);
+                $tableAlias = $this->getSQLTableAlias($parentClass->getTableName());
+                $joinSql   .= ' INNER JOIN ' . $tableName . ' ' . $tableAlias . ' ON ';
 
-            foreach ($identifierColumns as $idColumn) {
-                $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
+                foreach ($identifierColumns as $idColumn) {
+                    $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
 
-                $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedColumnName;
+                    $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedColumnName;
+                }
+
+                $joinSql .= implode(' AND ', $conditions);
             }
-
-            $joinSql .= implode(' AND ', $conditions);
         }
 
         return parent::getLockTablesSql($lockMode) . $joinSql;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -433,9 +433,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     {
         // Identifier columns must always come first in the column list of subclasses.
         $columns       = [];
-        $parentColumns = $this->class->getRootClassName() !== $this->class->getClassName()
-            ? $this->class->getIdentifierColumns($this->em)
-            : [];
+        $parentColumns = $this->class->isRootEntity()
+            ? []
+            : $this->class->getIdentifierColumns($this->em);
 
         foreach ($parentColumns as $columnName => $column) {
             $columns[] = $columnName;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -341,7 +341,13 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         // Add columns
         foreach ($this->class->getPropertiesIterator() as $fieldName => $property) {
             if ($property instanceof FieldMetadata) {
-                $columnList[] = $this->getSelectColumnSQL($fieldName, $property->getDeclaringClass());
+                $tableClass = $parentClass = $this->class;
+                while ($parentClass !== $property->getDeclaringClass() && ($parentClass = $parentClass->getParent()) !== null) {
+                    if (! $parentClass->isMappedSuperclass) {
+                        $tableClass = $parentClass;
+                    }
+                }
+                $columnList[] = $this->getSelectColumnSQL($fieldName, $tableClass);
 
                 continue;
             }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -500,18 +500,20 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $parentClass = $this->class;
 
         while (($parentClass = $parentClass->getParent()) !== null) {
-            $conditions = [];
-            $tableName  = $parentClass->table->getQuotedQualifiedName($this->platform);
-            $tableAlias = $this->getSQLTableAlias($parentClass->getTableName());
-            $joinSql   .= ' INNER JOIN ' . $tableName . ' ' . $tableAlias . ' ON ';
+            if (! $parentClass->isMappedSuperclass) {
+                $conditions = [];
+                $tableName  = $parentClass->table->getQuotedQualifiedName($this->platform);
+                $tableAlias = $this->getSQLTableAlias($parentClass->getTableName());
+                $joinSql   .= ' INNER JOIN ' . $tableName . ' ' . $tableAlias . ' ON ';
 
-            foreach ($identifierColumns as $idColumn) {
-                $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
+                foreach ($identifierColumns as $idColumn) {
+                    $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
 
-                $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedColumnName;
+                    $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedColumnName;
+                }
+
+                $joinSql .= implode(' AND ', $conditions);
             }
-
-            $joinSql .= implode(' AND ', $conditions);
         }
 
         // OUTER JOIN sub tables

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -53,7 +53,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
             // Subclass columns
             foreach ($subClass->getPropertiesIterator() as $fieldName => $property) {
-                if ($subClass->isInheritedProperty($fieldName)) {
+                if ($subClass->isInheritedColumn($fieldName)) {
                     continue;
                 }
 

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -104,7 +104,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
                 $field    = $updateItem->pathExpression->field;
                 $property = $class->getProperty($field);
 
-                if ($property && ! $class->isInheritedProperty($field)) {
+                if ($property && ! $class->isInheritedColumn($field)) {
                     $updateSQLParts[] = $sqlWalker->walkUpdateItem($updateItem);
                     $newValue         = $updateItem->newValue;
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -638,11 +638,7 @@ class SqlWalker implements TreeWalker
             return $this->getSQLTableAlias($class->getTableName(), $identificationVariable);
         }
 
-        $property = $class->getProperty($fieldName);
-
-        if ($class->inheritanceType === InheritanceType::JOINED && $class->isInheritedProperty($fieldName)) {
-            $class = $property->getDeclaringClass();
-        }
+        $class = $class->getPropertyTableClass($fieldName);
 
         return $this->getSQLTableAlias($class->getTableName(), $identificationVariable);
     }
@@ -803,7 +799,7 @@ class SqlWalker implements TreeWalker
 
                 foreach ($subClass->getPropertiesIterator() as $association) {
                     // Skip if association is inherited
-                    if ($subClass->isInheritedProperty($association->getName())) {
+                    if ($subClass->isInheritedColumn($association->getName())) {
                         continue;
                     }
 
@@ -1475,7 +1471,7 @@ class SqlWalker implements TreeWalker
                                 continue;
                             }
 
-                            if ($subClass->isInheritedProperty($fieldName) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
+                            if ($subClass->isInheritedColumn($fieldName) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
                                 continue;
                             }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -184,7 +184,7 @@ class SchemaTool
                             continue;
                         }
 
-                        if (! $class->isInheritedProperty($fieldName)) {
+                        if (! $class->isInheritedColumn($fieldName)) {
                             $columnName = $this->platform->quoteIdentifier($property->getColumnName());
 
                             $this->gatherColumn($class, $property, $table);
@@ -207,7 +207,7 @@ class SchemaTool
                         foreach ($class->identifier as $identifierField) {
                             $idProperty = $class->getProperty($identifierField);
 
-                            if ($class->isInheritedProperty($identifierField)) {
+                            if ($class->isInheritedColumn($identifierField)) {
                                 $column     = $this->gatherColumn($class, $idProperty, $table);
                                 $columnName = $column->getQuotedName($this->platform);
 
@@ -408,7 +408,7 @@ class SchemaTool
                 continue;
             }
 
-            if ($class->inheritanceType === InheritanceType::SINGLE_TABLE && $class->isInheritedProperty($fieldName)) {
+            if ($class->inheritanceType === InheritanceType::SINGLE_TABLE && $class->isInheritedColumn($fieldName)) {
                 continue;
             }
 
@@ -512,7 +512,7 @@ class SchemaTool
                 continue;
             }
 
-            if ($class->isInheritedProperty($fieldName)) {
+            if ($class->isInheritedColumn($fieldName)) {
                 continue;
             }
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -512,7 +512,7 @@ class SchemaTool
                 continue;
             }
 
-            if ($class->isInheritedProperty($fieldName) && ! $property->getDeclaringClass()->isMappedSuperclass) {
+            if ($class->isInheritedProperty($fieldName)) {
                 continue;
             }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
@@ -46,7 +46,7 @@ class GH5998Test extends OrmFunctionalTestCase
         $this->em->clear();
 
         // Test find
-        $child = $this->em->getRepository($className)->find(1);
+        $child = $this->em->createQuery("SELECT t FROM $className t WHERE t.status = 1")->getOneOrNullResult();
         self::assertNotNull($child);
 
         // Test lock and update

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
@@ -75,10 +75,6 @@ class GH5998Common
      * @ORM\GeneratedValue
      */
     public $id;
-    /**
-     * @ORM\Column(type="integer");
-     */
-    public $status;
 }
 
 /**
@@ -95,9 +91,20 @@ abstract class GH5998JTI extends GH5998Common
 }
 
 /**
+ * @ORM\MappedSuperclass
+ */
+class GH5998JTICommon extends GH5998JTI
+{
+    /**
+     * @ORM\Column(type="integer");
+     */
+    public $status;
+}
+
+/**
  * @ORM\Entity
  */
-class GH5998JTIChild extends GH5998JTI
+class GH5998JTIChild extends GH5998JTICommon
 {
     /**
      * @ORM\Column(type="integer")
@@ -122,17 +129,28 @@ abstract class GH5998STI extends GH5998Common
      * @ORM\Column(type="string", length=255);
      */
     public $firstName;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH5998STICommon extends GH5998STI
+{
     /**
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="integer");
      */
-    public $type;
+    public $status;
 }
 
 /**
  * @ORM\Entity
  */
-class GH5998STIChild extends GH5998STI
+class GH5998STIChild extends GH5998STICommon
 {
+    /**
+     * @ORM\Column(type="integer")
+     */
+    public $type;
     function __construct(string $firstName, int $type, int $status)
     {
         $this->firstName = $firstName;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-5998
+ */
+class GH5998Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->schemaTool->createSchema(
+            [
+            $this->em->getClassMetadata(GH5998Main::class),
+            $this->em->getClassMetadata(GH5998Child::class),
+            ]
+        );
+    }
+
+    /**
+     * Verifies that MappedSuperclasses work within a JTI hierarchy.
+     */
+    public function testIssue()
+    {
+        // Test insert
+        $child = new GH5998Child('Sam', 0, 1);
+        $this->em->persist($child);
+        $this->em->flush();
+        $this->em->clear();
+
+        // Test find
+        $child = $this->em->getRepository(GH5998Child::class)->find(1);
+        self::assertNotNull($child);
+
+        // Test lock and update
+        $this->em->transactional(function($em) use ($child) {
+            $em->lock($child, LockMode::NONE);
+            $child->firstName = 'Bob';
+            $child->status = 0;
+        });
+        $this->em->clear();
+        $child = $this->em->getRepository(GH5998Child::class)->find(1);
+        self::assertEquals($child->firstName, 'Bob');
+        self::assertEquals($child->status, 0);
+
+        // Test delete
+        $this->em->remove($child);
+        $this->em->flush();
+        $child = $this->em->getRepository(GH5998Child::class)->find(1);
+        self::assertNull($child);
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH5998Common
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+    /**
+     * @ORM\Column(type="integer");
+     */
+    public $status;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({"child" = "Doctrine\Tests\ORM\Functional\Ticket\GH5998Child"})
+ */
+abstract class GH5998Main extends GH5998Common
+{
+    /**
+     * @ORM\Column(type="string", length=255);
+     */
+    public $firstName;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH5998Child extends GH5998Main
+{
+    /**
+     * @ORM\Column(type="integer")
+     */
+    public $type;
+    function __construct(string $firstName, int $type, int $status)
+    {
+        $this->firstName = $firstName;
+        $this->type = $type;
+        $this->status = $status;
+    }
+}


### PR DESCRIPTION
This PR makes improvements to support Mapped Superclasses in a number of ways that didn't work previously.
- Support for version property declared in mapped superclass
- Better support for to-one relationships declared in mapped superclass
- Support for mapped superclasses both above and within JTI/STI hierarchies

Fixes #5998.