### PR TITLE
Fix for TransientMetadata on joined subclass

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
+use Doctrine\ORM\Mapping\TransientMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 use function array_combine;
 use function array_keys;
@@ -433,7 +434,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
         foreach ($this->class->getPropertiesIterator() as $name => $property) {
             if (($property instanceof FieldMetadata && ($property->isVersioned() || $this->class->isInheritedProperty($name)))
-                || ($property instanceof AssociationMetadata && $this->class->isInheritedProperty($name))
+                || ($property instanceof AssociationMetadata && $this->class->isInheritedProperty($name)
+                || $property instanceof TransientMetadata)
                 /*|| isset($this->class->embeddedClasses[$name])*/) {
                 continue;
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7824Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7824Test.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-7824
+ */
+class GH7824Test extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+        $this->schemaTool->createSchema([
+            $this->em->getClassMetadata(GH7824Main::class),
+            $this->em->getClassMetadata(GH7824Child::class),
+        ]);
+    }
+
+    /**
+     * Verifies that joined subclasses can contain non-ORM properties.
+     */
+    public function testIssue()
+    {
+        // Test insert
+        $child               = new GH7824Child();
+        $child->name         = 'Sam';
+        $child->someProperty = 'foo';
+        $this->em->persist($child);
+        $this->em->flush();
+        self::assertEquals($child->someProperty, 'foo');
+
+        // Test update
+        $child->name = 'Bob';
+        $this->em->flush();
+        $this->em->clear();
+
+        // Test find
+        $child = $this->em->getRepository(GH7824Child::class)->find(1);
+        self::assertEquals($child->name, 'Bob');
+        self::assertEquals($child->someProperty, null);
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({"child" = "Doctrine\Tests\ORM\Functional\Ticket\GH7824Child"})
+ */
+abstract class GH7824Main
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7824Child extends GH7824Main
+{
+    /** @ORM\Column(type="string") */
+    public $name;
+    public $someProperty; // Not a column
+}


### PR DESCRIPTION
This PR changes JoinedSubclassPersister to check for and skip TransientMetadata properties while inserting. This prevents an exception being thrown if a non-ORM property is declared on a joined subclass.
Fixes #7824.