### PR TITLE
Ported PR #7325 (making code php 7.3 lint-compatible) to v2.5

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2633,7 +2633,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
-                        continue;
+                        break;
                     }
 
                     $associatedId = array();
@@ -2662,7 +2662,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        break;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
Although branch 2.5 is not maintained anymore I would like to port the PR #7325 to this branch, because it is the last one that supports PHP 7.0 which is still needed in one of our projects.

If you don't like to merge this PR I can understand. But I thought it's worth sharing it.