### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,6 @@ jobs:
         - ./vendor/bin/phpcs
 
   allow_failures:
-    - php: 7.4snapshot
     # temporarily disabled
     - env: DB=mysql
     - env: DB=mariadb


### PR DESCRIPTION
removed PHP-7.4 from .travis.yml allow_failures to make it compatible with PHP 7.4
See #7844