### PR TITLE
Failing test for #7846: alias can't be used in functions

### DIFF
--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -2315,6 +2315,18 @@ class SelectSqlGenerationTest extends OrmTestCase
     }
 
     /**
+     * GitHub issue #7846: https://github.com/doctrine/orm/issues/7846
+     * @group 7846
+     */
+    public function testAliasCanBeUsedWithFunctions()
+    {
+        $this->assertSqlGeneration(
+            "SELECT u.name AS foo FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE LOWER(foo) = '3'",
+            "SELECT c0_.name AS name_0 FROM cms_users c0_ WHERE LOWER(name_0) = '3'"
+        );
+    }
+
+    /**
      * @return array
      */
     public function mathematicOperatorsProvider()


### PR DESCRIPTION
Hello,

Here's a failing test case for #7846
Using an alias (from WHERE) in a DQL function will cause Parser to crash.

Full stack trace:
```
1) Doctrine\Tests\ORM\Query\SelectSqlGenerationTest::testAliasCanBeUsedWithFunctions
[Syntax Error] line 0, col 74: Error: Expected '.' or '(', got 'foo'
#0 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(457): Doctrine\ORM\Query\QueryException::syntaxError('line 0, col 74:...', Object(Doctrine\ORM\Query\QueryException))
#1 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2915): Doctrine\ORM\Query\Parser->syntaxError(''.' or '('')
#2 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php(59): Doctrine\ORM\Query\Parser->StringPrimary()
#3 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(3517): Doctrine\ORM\Query\AST\Functions\LowerFunction->parse(Object(Doctrine\ORM\Query\Parser))
#4 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(3377): Doctrine\ORM\Query\Parser->FunctionsReturningStrings()
#5 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2840): Doctrine\ORM\Query\Parser->FunctionDeclaration()
#6 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2801): Doctrine\ORM\Query\Parser->ArithmeticPrimary()
#7 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2769): Doctrine\ORM\Query\Parser->ArithmeticFactor()
#8 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2743): Doctrine\ORM\Query\Parser->ArithmeticTerm()
#9 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2730): Doctrine\ORM\Query\Parser->SimpleArithmeticExpression()
#10 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(3063): Doctrine\ORM\Query\Parser->ArithmeticExpression()
#11 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2594): Doctrine\ORM\Query\Parser->ComparisonExpression()
#12 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2475): Doctrine\ORM\Query\Parser->SimpleConditionalExpression()
#13 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2451): Doctrine\ORM\Query\Parser->ConditionalPrimary()
#14 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2419): Doctrine\ORM\Query\Parser->ConditionalFactor()
#15 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(2394): Doctrine\ORM\Query\Parser->ConditionalTerm()
#16 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(1361): Doctrine\ORM\Query\Parser->ConditionalExpression()
#17 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(881): Doctrine\ORM\Query\Parser->WhereClause()
#18 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(848): Doctrine\ORM\Query\Parser->SelectStatement()
#19 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(261): Doctrine\ORM\Query\Parser->QueryLanguage()
#20 /Users/rdn/www/orm/lib/Doctrine/ORM/Query/Parser.php(360): Doctrine\ORM\Query\Parser->getAST()
#21 /Users/rdn/www/orm/lib/Doctrine/ORM/Query.php(268): Doctrine\ORM\Query\Parser->parse()
#22 /Users/rdn/www/orm/lib/Doctrine/ORM/Query.php(210): Doctrine\ORM\Query->_parse()
#23 /Users/rdn/www/orm/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php(58): Doctrine\ORM\Query->getSQL()
#24 /Users/rdn/www/orm/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php(2325): Doctrine\Tests\ORM\Query\SelectSqlGenerationTest->assertSqlGeneration('SELECT u.name A...', 'SELECT c0_.name...')
#25 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestCase.php(1154): Doctrine\Tests\ORM\Query\SelectSqlGenerationTest->testAliasCanBeUsedWithFunctions()
#26 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestCase.php(842): PHPUnit\Framework\TestCase->runTest()
#27 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestResult.php(693): PHPUnit\Framework\TestCase->runBare()
#28 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestCase.php(796): PHPUnit\Framework\TestResult->run(Object(Doctrine\Tests\ORM\Query\SelectSqlGenerationTest))
#29 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestSuite.php(746): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))
#30 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/Framework/TestSuite.php(746): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#31 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(652): PHPUnit\Framework\TestSuite->run(Object(PHPUnit\Framework\TestResult))
#32 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/TextUI/Command.php(206): PHPUnit\TextUI\TestRunner->doRun(Object(PHPUnit\Framework\TestSuite), Array, true)
#33 /Users/rdn/www/orm/vendor/phpunit/phpunit/src/TextUI/Command.php(162): PHPUnit\TextUI\Command->run(Array, true)
#34 /Users/rdn/www/orm/vendor/phpunit/phpunit/phpunit(61): PHPUnit\TextUI\Command::main()
#35 {main}
```