### PR TITLE
Mention SQL logger impact on batch processing

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -18,8 +18,8 @@ especially what the strategies presented here provide help with.
 
 .. note::
 
-    Logger can have a serious memory and time impact on bulk treatments. 
-    Deactivating it can be a solution.
+    Having an SQL logger enabled when processing batches can have a serious impact on performance and resource usage.
+    To avoid that you should disable it in the DBAL configuration:
 .. code-block:: php
 
     <?php

--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -16,6 +16,15 @@ especially what the strategies presented here provide help with.
     operations.
 
 
+.. note::
+
+    Logger can have a serious memory and time impact on bulk treatments. 
+    Deactivating it can be a solution.
+.. code-block:: php
+
+    <?php
+    $em->getConnection()->getConfiguration()->setSQLLogger(null);
+
 Bulk Inserts
 ------------
 


### PR DESCRIPTION
Looking for a way to improve one of our bulk update treatment, I went back to this page then found elsewhere that setting logger to null was a really effective way to improve time and memory consumption. Might be a right place to state it ? Don't know if my edit style is ok