### PR TITLE
Don't merge PersistentCollection orderBy with criteria in matching()

### DIFF
--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -25,7 +25,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use function array_merge;
 use function get_class;
 
 /**
@@ -672,7 +671,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         $criteria = clone $criteria;
         $criteria->where($expression);
-        $criteria->orderBy(array_merge($this->association['orderBy'] ?? [], $criteria->getOrderings()));
+        $criteria->orderBy($criteria->getOrderings() ?: $this->association['orderBy'] ?? []);
 
         $persister = $this->em->getUnitOfWork()->getEntityPersister($this->association['targetEntity']);
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7836Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7836Test.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use function assert;
+
+/**
+ * @group GH7836
+ */
+class GH7836Test extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH7836ParentEntity::class, GH7836ChildEntity::class]);
+
+        $parent = new GH7836ParentEntity();
+        $parent->addChild(100, 'foo');
+        $parent->addChild(100, 'bar');
+        $parent->addChild(200, 'baz');
+
+        $this->_em->persist($parent);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testMatchingRespectsCollectionOrdering() : void
+    {
+        $parent = $this->_em->find(GH7836ParentEntity::class, 1);
+        assert($parent instanceof GH7836ParentEntity);
+
+        $children = $parent->getChildren()->matching(Criteria::create());
+
+        self::assertSame(100, $children[0]->position);
+        self::assertSame('bar', $children[0]->name);
+        self::assertSame(100, $children[1]->position);
+        self::assertSame('foo', $children[1]->name);
+        self::assertSame(200, $children[2]->position);
+        self::assertSame('baz', $children[2]->name);
+    }
+
+    public function testMatchingOverrulesCollectionOrdering() : void
+    {
+        $parent = $this->_em->find(GH7836ParentEntity::class, 1);
+        assert($parent instanceof GH7836ParentEntity);
+
+        $children = $parent->getChildren()->matching(Criteria::create()->orderBy(['position' => 'DESC', 'name' => 'ASC']));
+
+        self::assertSame(200, $children[0]->position);
+        self::assertSame('baz', $children[0]->name);
+        self::assertSame(100, $children[1]->position);
+        self::assertSame('bar', $children[1]->name);
+        self::assertSame(100, $children[2]->position);
+        self::assertSame('foo', $children[2]->name);
+    }
+
+    public function testMatchingKeepsOrderOfCriteriaOrderingKeys() : void
+    {
+        $parent = $this->_em->find(GH7836ParentEntity::class, 1);
+        assert($parent instanceof GH7836ParentEntity);
+
+        $children = $parent->getChildren()->matching(Criteria::create()->orderBy(['name' => 'ASC', 'position' => 'ASC']));
+
+        self::assertSame(100, $children[0]->position);
+        self::assertSame('bar', $children[0]->name);
+        self::assertSame(200, $children[1]->position);
+        self::assertSame('baz', $children[1]->name);
+        self::assertSame(100, $children[2]->position);
+        self::assertSame('foo', $children[2]->name);
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7836ParentEntity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    /**
+     * @OneToMany(targetEntity=GH7836ChildEntity::class, mappedBy="parent", fetch="EXTRA_LAZY", cascade={"persist"})
+     * @OrderBy({"position" = "ASC", "name" = "ASC"})
+     */
+    private $children;
+
+    public function addChild(int $position, string $name) : void
+    {
+        $this->children[] = new GH7836ChildEntity($this, $position, $name);
+    }
+
+    public function getChildren() : PersistentCollection
+    {
+        return $this->children;
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7836ChildEntity
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    /** @Column(type="integer") */
+    public $position;
+
+    /** @Column(type="string") */
+    public $name;
+
+    /** @ManyToOne(targetEntity=GH7836ParentEntity::class, inversedBy="children") */
+    private $parent;
+
+    public function __construct(GH7836ParentEntity $parent, int $position, string $name)
+    {
+        $this->parent   = $parent;
+        $this->position = $position;
+        $this->name     = $name;
+    }
+}


### PR DESCRIPTION
If no orderings are given to PersistentCollection::matching(), the
orderBy annotation will be used if present. If the criteria contains
orderings, those will be used without merging them with the orderBy.

See #7836