### PR TITLE
#7837 paginate with custom identifier types even with enabled DQL query cache

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -166,6 +166,7 @@ class Paginator implements \Countable, \IteratorAggregate
             $whereInQuery->setFirstResult(null)->setMaxResults(null);
             $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
             $whereInQuery->setCacheable($this->query->isCacheable());
+            $whereInQuery->expireQueryCache();
 
             $result = $whereInQuery->getResult($this->query->getHydrationMode());
         } else {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -98,7 +98,7 @@ class GH7820Test extends OrmFunctionalTestCase
             array_map(static function (GH7820Line $line) : string {
                 return $line->toString();
             }, iterator_to_array(new Paginator($query))),
-            'Paginator runs once, query cache is populated with DQL -> SQL translation'
+            'Expected to return expected data before query cache is populated with DQL -> SQL translation. Were SQL parameters translated?'
         );
 
         $query = $this->_em->getRepository(GH7820Line::class)
@@ -110,7 +110,7 @@ class GH7820Test extends OrmFunctionalTestCase
             array_map(static function (GH7820Line $line) : string {
                 return $line->toString();
             }, iterator_to_array(new Paginator($query))),
-            'Paginator runs again, SQL parameters are translated again, even with cached DQL -> SQL translation'
+            'Expected to return expected data even when DQL -> SQL translation is present in cache. Were SQL parameters translated again?'
         );
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\Common\Cache\ClearableCache;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
@@ -11,6 +12,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use function array_map;
+use function assert;
 use function is_string;
 use function iterator_to_array;
 
@@ -53,6 +55,9 @@ class GH7820Test extends OrmFunctionalTestCase
 
         $this->setUpEntitySchema([GH7820Line::class]);
 
+        $this->_em->createQuery('DELETE FROM ' . GH7820Line::class . ' l')
+            ->execute();
+
         foreach (self::SONG as $index => $line) {
             $this->_em->persist(new GH7820Line(GH7820LineText::fromText($line), $index));
         }
@@ -71,6 +76,41 @@ class GH7820Test extends OrmFunctionalTestCase
             array_map(static function (GH7820Line $line) : string {
                 return $line->toString();
             }, iterator_to_array(new Paginator($query)))
+        );
+    }
+
+    /** @group GH7837 */
+    public function testWillFindSongsInPaginatorEvenWithCachedQueryParsing() : void
+    {
+        $cache = $this->_em->getConfiguration()
+            ->getQueryCacheImpl();
+
+        assert($cache instanceof ClearableCache);
+
+        $cache->deleteAll();
+
+        $query = $this->_em->getRepository(GH7820Line::class)
+            ->createQueryBuilder('l')
+            ->orderBy('l.lineNumber', Criteria::ASC);
+
+        self::assertSame(
+            self::SONG,
+            array_map(static function (GH7820Line $line) : string {
+                return $line->toString();
+            }, iterator_to_array(new Paginator($query))),
+            'Paginator runs once, query cache is populated with DQL -> SQL translation'
+        );
+
+        $query = $this->_em->getRepository(GH7820Line::class)
+            ->createQueryBuilder('l')
+            ->orderBy('l.lineNumber', Criteria::ASC);
+
+        self::assertSame(
+            self::SONG,
+            array_map(static function (GH7820Line $line) : string {
+                return $line->toString();
+            }, iterator_to_array(new Paginator($query))),
+            'Paginator runs again, SQL parameters are translated again, even with cached DQL -> SQL translation'
         );
     }
 }


### PR DESCRIPTION
This patch enforces re-parsing of DQL queries used in the paginator internals, so that the `WhereInWalker` can correctly process query parameters after evaluating the AST structure (root expression, specifically).

While this isn't nice for performance, it is also true that the alternative approach would be to run the parsing manually on the DQL query (to extract the root of the selection) and then operating on that (this was already attempted in #7821 in doctrine/orm@39d21135490472ba31755a0259fbaf38ac453b9b).


Fixes #7837
