### PR TITLE
Fixes error Property "PropertyName" in "TableName" was already declar…

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -187,6 +187,16 @@ class DatabaseDriver implements MappingDriver
                 $associationMapping['fieldName']    = $this->getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
                 $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
 
+		if (isset($metadata->fieldMappings[$associationMapping['fieldName']])
+                        || isset($metadata->associationMappings[$associationMapping['fieldName']])) {
+                        $ii=2;
+                        while ( isset($metadata->fieldMappings[$associationMapping['fieldName'].(string)$ii]) ||
+                                isset($metadata->associationMappings[$associationMapping['fieldName'].(string)$ii])) {
+                                $ii++;
+                        }
+                        $associationMapping['fieldName'] .= (string)$ii; 
+                }
+
                 if (current($manyTable->getColumns())->getName() === $localColumn) {
                     $associationMapping['inversedBy'] = $this->getFieldNameForColumn($manyTable->getName(), current($myFk->getColumns()), true);
                     $associationMapping['joinTable']  = new Mapping\JoinTableMetadata();

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -188,11 +188,11 @@ class DatabaseDriver implements MappingDriver
                 $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
 
                 if (isset($metadata->fieldMappings[$associationMapping['fieldName']]) || isset($metadata->associationMappings[$associationMapping['fieldName']])) {
-                        $ii=2;
-                        while ( isset($metadata->fieldMappings[$associationMapping['fieldName'].(string)$ii]) || isset($metadata->associationMappings[$associationMapping['fieldName'].(string)$ii])) {
-                                $ii++;
-                        }
-                        $associationMapping['fieldName'] .= (string)$ii; 
+                        $ii =2;
+                    while (isset($metadata->fieldMappings[$associationMapping['fieldName'] . (string) $ii]) || isset($metadata->associationMappings[$associationMapping['fieldName'] . (string) $ii])) {
+                            $ii++;
+                    }
+                        $associationMapping['fieldName'] .= (string) $ii;
                 }
 
                 if (current($manyTable->getColumns())->getName() === $localColumn) {

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -187,11 +187,9 @@ class DatabaseDriver implements MappingDriver
                 $associationMapping['fieldName']    = $this->getFieldNameForColumn($manyTable->getName(), current($otherFk->getColumns()), true);
                 $associationMapping['targetEntity'] = $this->getClassNameForTable($otherFk->getForeignTableName());
 
-		if (isset($metadata->fieldMappings[$associationMapping['fieldName']])
-                        || isset($metadata->associationMappings[$associationMapping['fieldName']])) {
+                if (isset($metadata->fieldMappings[$associationMapping['fieldName']]) || isset($metadata->associationMappings[$associationMapping['fieldName']])) {
                         $ii=2;
-                        while ( isset($metadata->fieldMappings[$associationMapping['fieldName'].(string)$ii]) ||
-                                isset($metadata->associationMappings[$associationMapping['fieldName'].(string)$ii])) {
+                        while ( isset($metadata->fieldMappings[$associationMapping['fieldName'].(string)$ii]) || isset($metadata->associationMappings[$associationMapping['fieldName'].(string)$ii])) {
                                 $ii++;
                         }
                         $associationMapping['fieldName'] .= (string)$ii; 


### PR DESCRIPTION
This PR fixes :
https://github.com/doctrine/orm/issues/4726
https://github.com/doctrine/orm/issues/6019
https://github.com/doctrine/orm/issues/2739

I discussed this on Slack last saturday with "Gregoire Paris" : he suggested that i submit a PR with a mean to test it properly.

The problem appears when there are multiple links between tables. SQL does not forbid such practices.

Of course common sense and good practices might not advice such moves but sometimes we have to upgrade applications and first start with code generation before dealing with technical debt.

I found a typical case : a relation between user and group tables with group being recursive/hierarchical : often a "flat" cache table is created and automatically updated to optimize checks.

Here is  a postgres SQL creation script for a database that presents this use case :
```SQL
-- Drop table

-- DROP TABLE public.groups

CREATE TABLE public.groups (
	group_id serial NOT NULL,
	group_name varchar NULL,
	group_type varchar NULL,
	parent_group_id int4 NULL,
	CONSTRAINT groups_pk PRIMARY KEY (group_id),
	CONSTRAINT groups_groups_fk FOREIGN KEY (parent_group_id) REFERENCES groups(group_id)
)
WITH (
	OIDS=FALSE
) ;

-- Drop table

-- DROP TABLE public.user_group_admin

CREATE TABLE public.user_group_admin (
	group_id int4 NOT NULL,
	user_id int4 NOT NULL,
	start_date date NOT NULL DEFAULT now(),
	end_date date NOT NULL,
	CONSTRAINT user_group_admin_pk PRIMARY KEY (group_id, user_id),
	CONSTRAINT user_group_membership_groups_fk FOREIGN KEY (group_id) REFERENCES groups(group_id),
	CONSTRAINT user_group_membership_users_fk FOREIGN KEY (user_id) REFERENCES users(user_id)
)
WITH (
	OIDS=FALSE
) ;

-- Drop table

-- DROP TABLE public.user_group_admin_flat_cache

CREATE TABLE public.user_group_admin_flat_cache (
	group_id int4 NOT NULL,
	user_id int4 NOT NULL,
	start_date date NOT NULL DEFAULT now(),
	end_date date NOT NULL,
	CONSTRAINT user_group_admin_flat_cache_pk PRIMARY KEY (group_id, user_id),
	CONSTRAINT user_group_membership_groups_fk FOREIGN KEY (group_id) REFERENCES groups(group_id),
	CONSTRAINT user_group_membership_users_fk FOREIGN KEY (user_id) REFERENCES users(user_id)
)
WITH (
	OIDS=FALSE
) ;

-- Drop table

-- DROP TABLE public.user_group_membership

CREATE TABLE public.user_group_membership (
	group_id int4 NOT NULL,
	user_id int4 NOT NULL,
	start_date date NOT NULL DEFAULT now(),
	end_date date NOT NULL,
	CONSTRAINT user_group_membership_pk PRIMARY KEY (group_id, user_id),
	CONSTRAINT user_group_membership_groups_fk FOREIGN KEY (group_id) REFERENCES groups(group_id),
	CONSTRAINT user_group_membership_users_fk FOREIGN KEY (user_id) REFERENCES users(user_id)
)
WITH (
	OIDS=FALSE
) ;

-- Drop table

-- DROP TABLE public.user_group_membership_flat_cache

CREATE TABLE public.user_group_membership_flat_cache (
	group_id int4 NOT NULL,
	user_id int4 NOT NULL,
	start_date date NOT NULL DEFAULT now(),
	end_date date NOT NULL,
	CONSTRAINT user_group_membership_flat_cache_pk PRIMARY KEY (group_id, user_id),
	CONSTRAINT user_group_membership_groups_fk FOREIGN KEY (group_id) REFERENCES groups(group_id),
	CONSTRAINT user_group_membership_users_fk FOREIGN KEY (user_id) REFERENCES users(user_id)
)
WITH (
	OIDS=FALSE
) ;

-- Drop table

-- DROP TABLE public.users

CREATE TABLE public.users (
	user_name varchar(255) NOT NULL,
	email varchar(255) NOT NULL,
	user_id serial NOT NULL,
	main_group_id int4 NOT NULL,
	CONSTRAINT users_pk PRIMARY KEY (user_id),
	CONSTRAINT users_groups_fk FOREIGN KEY (main_group_id) REFERENCES groups(group_id)
)
WITH (
	OIDS=FALSE
) ;
```

Without the patch Doctrine reacts like that :
```bash
php bin/console doctrine:mapping:import App\\Entity annotation --path=src/Entity -vv

In MappingException.php line 381:
                                                                                       
  [Doctrine\ORM\Mapping\MappingException]                                              
  Property "group" in "Users" was already declared, but it must be declared only once  
                                                                                       

Exception trace:
  at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/MappingException.php:381
 Doctrine\ORM\Mapping\MappingException::duplicateFieldMapping() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:3347                                                                                    
 Doctrine\ORM\Mapping\ClassMetadataInfo->assertFieldNotMapped() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:2617                                                                                    
 Doctrine\ORM\Mapping\ClassMetadataInfo->_storeAssociationMapping() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php:2601                                                                                
 Doctrine\ORM\Mapping\ClassMetadataInfo->mapManyToMany() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php:261                                                                                        
 Doctrine\ORM\Mapping\Driver\DatabaseDriver->loadMetadataForClass() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php:151                                                                              
 Doctrine\ORM\Mapping\ClassMetadataFactory->doLoadMetadata() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php:304                                                      
 Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->loadMetadata() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php:78                                                                 
 Doctrine\ORM\Mapping\ClassMetadataFactory->loadMetadata() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php:191                                                        
 Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->getMetadataFor() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/persistence/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php:89                                
 Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->getAllMetadata() at /home/some_path/to/somewhere/doctrine_patch/vendor/doctrine/doctrine-bundle/Command/ImportMappingDoctrineCommand.php:131                                                           
 Doctrine\Bundle\DoctrineBundle\Command\ImportMappingDoctrineCommand->execute() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/console/Command/Command.php:255                                                                                             
 Symfony\Component\Console\Command\Command->run() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/console/Application.php:952                                                                                                                               
 Symfony\Component\Console\Application->doRunCommand() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/framework-bundle/Console/Application.php:87                                                                                                          
 Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/console/Application.php:273                                                                                                             
 Symfony\Component\Console\Application->doRun() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/framework-bundle/Console/Application.php:73                                                                                                                 
 Symfony\Bundle\FrameworkBundle\Console\Application->doRun() at /home/some_path/to/somewhere/doctrine_patch/vendor/symfony/console/Application.php:149                                                                                                                    
 Symfony\Component\Console\Application->run() at /home/some_path/to/somewhere/doctrine_patch/bin/console:42

doctrine:mapping:import [--em [EM]] [--shard SHARD] [--filter FILTER] [--force] [--path PATH] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> <name> [<mapping-type>]
```
And with the patch  Doctrine reacts like that :
```bash
php bin/console doctrine:mapping:import App\\Entity annotation --path=src/Entity -vv
Importing mapping information from "default" entity manager
  > writing src/Entity/Users.php
  > writing src/Entity/Groups.php
```
I got my inspiration from this attempt : https://github.com/doctrine/orm/pull/5965/commits
but in my real case there are more than 2 links so the hardcoded part '2' could not solve my problem hence i had to make it more "universal'

Thanks in advance for your comments and feedback.
P