### PR TITLE
UnitOfWork::clear() misses $eagerLoadingEntities

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2483,22 +2483,23 @@ class UnitOfWork implements PropertyChangedListener
     public function clear($entityName = null)
     {
         if ($entityName === null) {
-            $this->identityMap =
-            $this->entityIdentifiers =
-            $this->originalEntityData =
-            $this->entityChangeSets =
-            $this->entityStates =
-            $this->scheduledForSynchronization =
-            $this->entityInsertions =
-            $this->entityUpdates =
-            $this->entityDeletions =
+            $this->identityMap                    =
+            $this->entityIdentifiers              =
+            $this->originalEntityData             =
+            $this->entityChangeSets               =
+            $this->entityStates                   =
+            $this->scheduledForSynchronization    =
+            $this->entityInsertions               =
+            $this->entityUpdates                  =
+            $this->entityDeletions                =
             $this->nonCascadedNewDetectedEntities =
-            $this->collectionDeletions =
-            $this->collectionUpdates =
-            $this->extraUpdates =
-            $this->readOnlyObjects =
-            $this->visitedCollections =
-            $this->orphanRemovals = [];
+            $this->collectionDeletions            =
+            $this->collectionUpdates              =
+            $this->extraUpdates                   =
+            $this->readOnlyObjects                =
+            $this->visitedCollections             =
+            $this->eagerLoadingEntities           =
+            $this->orphanRemovals                 = [];
         } else {
             $this->clearIdentityMapForEntityName($entityName);
             $this->clearEntityInsertionsForEntityName($entityName);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7869Test.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Decorator\EntityManagerDecorator;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Tests\Mocks\ConnectionMock;
+use Doctrine\Tests\Mocks\DriverMock;
+use Doctrine\Tests\Mocks\EntityManagerMock;
+use Doctrine\Tests\OrmTestCase;
+
+/**
+ * @group GH7869
+ */
+class GH7869Test extends OrmTestCase
+{
+    public function testDQLDeferredEagerLoad()
+    {
+        $decoratedEm = EntityManagerMock::create(new ConnectionMock([], new DriverMock()));
+
+        $em = $this->getMockBuilder(EntityManagerDecorator::class)
+            ->setConstructorArgs([$decoratedEm])
+            ->setMethods(['getClassMetadata'])
+            ->getMock();
+
+        $em->expects($this->exactly(2))
+            ->method('getClassMetadata')
+            ->willReturnCallback([$decoratedEm, 'getClassMetadata']);
+
+        $hints = [
+            UnitOfWork::HINT_DEFEREAGERLOAD => true,
+            'fetchMode' => [GH7869Appointment::class => ['patient' => ClassMetadata::FETCH_EAGER]],
+        ];
+
+        $uow = new UnitOfWork($em);
+        $uow->createEntity(GH7869Appointment::class, ['id' => 1, 'patient_id' => 1], $hints);
+        $uow->clear();
+        $uow->triggerEagerLoads();
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7869Appointment
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @OneToOne(targetEntity="GH7869Patient", inversedBy="appointment", fetch="EAGER") */
+    public $patient;
+}
+
+/**
+ * @Entity
+ */
+class GH7869Patient
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @OneToOne(targetEntity="GH7869Appointment", mappedBy="patient") */
+    public $appointment;
+}


### PR DESCRIPTION
AFAICS, eager loading entities should be cleared as well when the UnitOfWork is cleared.

Actually, this is [already the case](https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/UnitOfWork.php#L1982) on `master`!