### PR TITLE
AbstractQuery::getSingleScalarResult() throws exception when no result

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -822,8 +822,9 @@ abstract class AbstractQuery
      *
      * Alias for getSingleResult(HYDRATE_SINGLE_SCALAR).
      *
-     * @return mixed The scalar result, or NULL if the query returned no result.
+     * @return mixed The scalar result.
      *
+     * @throws NoResultException        If the query returned no result.
      * @throws NonUniqueResultException If the query result is not unique.
      */
     public function getSingleScalarResult()


### PR DESCRIPTION
**Please don't merge this PR yet, I think there's a lot of confusion around the current behaviour, that must be cleared first.**

---

The current doc for `AbstractQuery::getSingleScalarResult()` says:

```
@return mixed The scalar result, or NULL if the query returned no result.
```

Even though it currently throws an exception in this case. I tested this myself, and it is confirmed by this test:

https://github.com/doctrine/orm/blob/v2.6.4/tests/Doctrine/Tests/ORM/Functional/QueryTest.php#L339

```php
    /**
     * @expectedException Doctrine\ORM\NoResultException
     */
    public function testGetSingleScalarResultThrowsExceptionOnNoResult()
    {
        $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a")
             ->getSingleScalarResult();
    }
```

**This PR fixes the docblock.**

---

That being said, I'm really confused by this code:


https://github.com/doctrine/orm/blob/v2.6.4/lib/Doctrine/ORM/AbstractQuery.php#L805

```php
if ($this->_hydrationMode !== self::HYDRATE_SINGLE_SCALAR && ! $result) {
    throw new NoResultException;
}
```

This looks like the method wants to behave as the doc says, by *not* throwing when the hydration mode is `HYDRATE_SINGLE_SCALAR`, but because **it does not test against the `$hydrationMode` parameter, but against `$this->_hydrationMode`**, the behaviour is not as expected.

From what I can see in the code, it *should*, deeply nested in some method calls, `setHydrationMode()` to the value provided as a parameter at some point, but it looks like it doesn't.

So in summary:

- `getSingleScalarResult()` throws an exception by default,
- but it does return `null` instead, if `setHydrationMode(HYDRATE_SINGLE_SCALAR)` has been called on the Query before that

So I'm not sure whether fixing the docblock is the right thing to do, we should probably fix the code so that it behaves consistently instead, by always returning `null` for `HYDRATE_SINGLE_SCALAR`; but this could break existing code that, despite the doc, may now rely on this "feature", which is even backed by a test.

**Thoughts?**