### PR TITLE
Fix bullet list not rendering correctly on Github

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -437,12 +437,16 @@ There are several advantages to using such a model:
 
 * **Entity state is always valid.** Since no setters exist, this means that we
 only update portions of the entity that should already be valid.
+
 * Instead of having plain getters and setters, our entity now has
 **real behavior**: it is much easier to determine the logic in the domain.
+
 * DTOs can be reused in other components, for example deserializing mixed
 content, using forms...
+
 * Classic and static constructors can be used to manage different ways to
 create our objects, and they can also use DTOs.
+
 * Anemic entities tend to isolate the entity from logic, whereas rich
 entities allow putting the logic in the object itself, including data
 validation.


### PR DESCRIPTION
As *rts*, if reading the tutorial on the Github repository, the items are not seen as elements of a bullet list, hence they are not rendered and they are collapsed in a single line of text.

Fix won't affect how it renders on [doctrine-project.org](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/getting-started.html).