### PR TITLE
Introduce `getIterable()` on AbstractQuery

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -75,7 +75,7 @@ Iterating results
 ~~~~~~~~~~~~~~~~~
 
 An alternative solution for bulk updates is to use the
-``Query#iterate()`` facility to iterate over the query results step
+``Query#getIterable()`` facility to iterate over the query results step
 by step instead of loading the whole result into memory at once.
 The following example shows how to do this, combining the iteration
 with the batching strategy that was already used for bulk inserts:
@@ -86,9 +86,7 @@ with the batching strategy that was already used for bulk inserts:
     $batchSize = 20;
     $i = 1;
     $q = $em->createQuery('select u from MyProject\Model\User u');
-    $iterableResult = $q->iterate();
-    foreach ($iterableResult as $row) {
-        $user = $row[0];
+    foreach ($q->getIterable() as $user) {
         $user->increaseCredit();
         $user->calculateNewBonuses();
         if (($i % $batchSize) === 0) {
@@ -137,7 +135,7 @@ Iterating results
 ~~~~~~~~~~~~~~~~~
 
 An alternative solution for bulk deletes is to use the
-``Query#iterate()`` facility to iterate over the query results step
+``Query#getIterable()`` facility to iterate over the query results step
 by step instead of loading the whole result into memory at once.
 The following example shows how to do this:
 
@@ -147,9 +145,8 @@ The following example shows how to do this:
     $batchSize = 20;
     $i = 1;
     $q = $em->createQuery('select u from MyProject\Model\User u');
-    $iterableResult = $q->iterate();
-    while (($row = $iterableResult->next()) !== false) {
-        $em->remove($row[0]);
+    foreach($q->getIterable() as $row) {
+        $em->remove($row);
         if (($i % $batchSize) === 0) {
             $em->flush(); // Executes all deletions.
             $em->clear(); // Detaches all objects from Doctrine!
@@ -168,20 +165,18 @@ The following example shows how to do this:
 Iterating Large Results for Data-Processing
 -------------------------------------------
 
-You can use the ``iterate()`` method just to iterate over a large
-result and no UPDATE or DELETE intention. The ``IterableResult``
-instance returned from ``$query->iterate()`` implements the
-Iterator interface so you can process a large result without memory
+You can use the ``getIterable()`` method just to iterate over a large
+result and no UPDATE or DELETE intention. ``$query->getIterable()`` returns ``iterable``
+so you can process a large result without memory
 problems using the following approach:
 
 .. code-block:: php
 
     <?php
     $q = $this->_em->createQuery('select u from MyProject\Model\User u');
-    $iterableResult = $q->iterate();
-    foreach ($iterableResult as $row) {
-        // do stuff with the data in the row, $row[0] is always the object
-    
+    foreach ($q->getIterable() as $row) {
+        // do stuff with the data in the row
+
         // detach from Doctrine, so that it can be Garbage-Collected immediately
         $this->_em->detach($row[0]);
     }

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -191,10 +191,10 @@ the life-time of their registered entities.
 
 .. warning::
 
-    Note that, when using ``Doctrine\ORM\AbstractQuery#iterate()``, ``postLoad``
+    Note that, when using ``Doctrine\ORM\AbstractQuery#getIterable()``, ``postLoad``
     events will be executed immediately after objects are being hydrated, and therefore
     associations are not guaranteed to be initialized. It is not safe to combine
-    usage of ``Doctrine\ORM\AbstractQuery#iterate()`` and ``postLoad`` event
+    usage of ``Doctrine\ORM\AbstractQuery#getIterable()`` and ``postLoad`` event
     handlers.
 
 .. warning::

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -354,6 +354,7 @@ a querybuilder instance into a Query object:
 
     // Execute Query
     $result = $query->getResult();
+    $iterableResult = $query->getIterable();
     $single = $query->getSingleResult();
     $array = $query->getArrayResult();
     $scalar = $query->getScalarResult();

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -19,14 +19,20 @@
 
 namespace Doctrine\ORM\Internal\Hydration;
 
+use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
 use PDO;
+use const E_USER_DEPRECATED;
 use function array_map;
+use function end;
 use function in_array;
+use function trigger_error;
 
 /**
  * Base class for all hydrators. A hydrator is a class that provides some form
@@ -110,6 +116,8 @@ abstract class AbstractHydrator
     /**
      * Initiates a row-by-row hydration.
      *
+     * @deprecated
+     *
      * @param object $stmt
      * @param object $resultSetMapping
      * @param array  $hints
@@ -118,6 +126,11 @@ abstract class AbstractHydrator
      */
     public function iterate($stmt, $resultSetMapping, array $hints = [])
     {
+        @trigger_error(
+            'Method ' . __METHOD__ . '() is deprecated and will be removed in Doctrine ORM 3.0. Use getIterable() instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;
         $this->_hints = $hints;
@@ -129,6 +142,42 @@ abstract class AbstractHydrator
         $this->prepare();
 
         return new IterableResult($this);
+    }
+
+    /**
+     * Initiates a row-by-row hydration.
+     *
+     * @param mixed[] $hints
+     *
+     * @return iterable<mixed>
+     */
+    public function getIterable(Statement $stmt, ResultSetMapping $resultSetMapping, array $hints = []) : iterable
+    {
+        $this->_stmt  = $stmt;
+        $this->_rsm   = $resultSetMapping;
+        $this->_hints = $hints;
+
+        $evm = $this->_em->getEventManager();
+
+        $evm->addEventListener([Events::onClear], $this);
+
+        $this->prepare();
+
+        $result = [];
+
+        while (true) {
+            $row = $this->_stmt->fetch(FetchMode::ASSOCIATIVE);
+
+            if ($row === false || $row === null) {
+                $this->cleanup();
+
+                break;
+            }
+
+            $this->hydrateRowData($row, $result);
+
+            yield end($result);
+        }
     }
 
     /**
@@ -159,7 +208,7 @@ abstract class AbstractHydrator
 
     /**
      * Hydrates a single row returned by the current statement instance during
-     * row-by-row hydration with {@link iterate()}.
+     * row-by-row hydration with {@link iterate()} or {@link getIterable()}.
      *
      * @return mixed
      */
@@ -167,7 +216,7 @@ abstract class AbstractHydrator
     {
         $row = $this->_stmt->fetch(PDO::FETCH_ASSOC);
 
-        if ( ! $row) {
+        if ($row === false || $row === null) {
             $this->cleanup();
 
             return false;

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -23,8 +23,7 @@ namespace Doctrine\ORM\Internal\Hydration;
  * Represents a result structure that can be iterated over, hydrating row-by-row
  * during the iteration. An IterableResult is obtained by AbstractHydrator#iterate().
  *
- * @author robo
- * @since 2.0
+ * @deprecated
  */
 class IterableResult implements \Iterator
 {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -694,6 +694,14 @@ final class Query extends AbstractQuery
         return parent::iterate($parameters, $hydrationMode);
     }
 
+    /** {@inheritDoc} */
+    public function getIterable(iterable $parameters = [], $hydrationMode = self::HYDRATE_OBJECT) : iterable
+    {
+        $this->setHint(self::HINT_INTERNAL_ITERATION, true);
+
+        return parent::getIterable($parameters, $hydrationMode);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Doctrine/Tests/GetIterableTester.php
+++ b/tests/Doctrine/Tests/GetIterableTester.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Query;
+use PHPUnit\Framework\Assert;
+use function is_array;
+use function iterator_to_array;
+
+final class GetIterableTester
+{
+    public static function assertResultsAreTheSame(Query $query) : void
+    {
+        $result   = $query->getResult();
+        $iterable = $query->getIterable();
+
+        Assert::assertSame($result, self::iterableToArray($iterable));
+
+        $result   = $query->getResult(AbstractQuery::HYDRATE_ARRAY);
+        $iterable = $query->getIterable([], AbstractQuery::HYDRATE_ARRAY);
+
+        Assert::assertSame($result, self::iterableToArray($iterable));
+    }
+
+    /**
+     * Copy the iterable into an array. If the iterable is already an array, return it.
+     *
+     * @return mixed[]
+     */
+    public static function iterableToArray(iterable $iterable) : array
+    {
+        return is_array($iterable) ? $iterable : iterator_to_array($iterable, true);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -4,6 +4,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\PersistentCollection;
+use Doctrine\Tests\GetIterableTester;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**
@@ -72,6 +73,10 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
+        GetIterableTester::assertResultsAreTheSame($query);
+
+        $this->_em->clear();
+
         // test2 - eager load in DQL query with double-join back and forth
         $query = $this->_em->createQuery("SELECT p,t,pp FROM Doctrine\Tests\ORM\Functional\Phrase p JOIN p.type t JOIN t.phrases pp");
         $res = $query->getResult();
@@ -99,6 +104,10 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
 
         $this->assertInstanceOf(Definition::class, $definitions[0]);
         $this->assertEquals(2, $definitions->count());
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 
     public function testManyToMany()
@@ -122,6 +131,10 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
         $types = $res[0]->getTypes();
 
         $this->assertInstanceOf(Type::class, $types[0]);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Tests\GetIterableTester;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsArticle;
 use Doctrine\Tests\Models\CMS\CmsComment;
@@ -229,6 +230,10 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->assertEquals('developer', $users[0]->status);
         //$this->assertNull($users[0]->phonenumbers);
         //$this->assertNull($users[0]->articles);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
 
         $usersArray = $query->getArrayResult();
 

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest.php
@@ -5,6 +5,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Tests\GetIterableTester;
 use Doctrine\Tests\Models\Company\CompanyAuction;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\Models\Company\CompanyEvent;
@@ -62,15 +63,23 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
+        GetIterableTester::assertResultsAreTheSame($query);
+
+        $this->_em->clear();
+
         $query = $this->_em->createQuery('select p from ' . CompanyEmployee::class . ' p');
 
         $entities = $query->getResult();
 
-        $this->assertCount(1, $entities);
-        $this->assertInstanceOf(CompanyEmployee::class, $entities[0]);
+        self::assertCount(1, $entities);
+        self::assertInstanceOf(CompanyEmployee::class, $entities[0]);
         $this->assertTrue(is_numeric($entities[0]->getId()));
-        $this->assertEquals('Guilherme Blanco', $entities[0]->getName());
-        $this->assertEquals(100000, $entities[0]->getSalary());
+        self::assertEquals('Guilherme Blanco', $entities[0]->getName());
+        self::assertEquals(100000, $entities[0]->getSalary());
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
 
         $this->_em->clear();
 
@@ -170,6 +179,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->assertInstanceOf(CompanyEmployee::class, $result[0]->getSpouse());
         $this->assertEquals('John Smith', $result[0]->getSpouse()->getName());
         $this->assertSame($result[0], $result[0]->getSpouse()->getSpouse());
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 
     public function testSelfReferencingManyToMany()
@@ -242,6 +255,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
             $this->assertInstanceOf(CompanyRaffle::class, $events[0]);
             $this->assertInstanceOf(CompanyAuction::class, $events[1]);
         }
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($q);
     }
 
     public function testLazyLoading2()
@@ -264,6 +281,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
 
         $this->_em->clear();
 
+        GetIterableTester::assertResultsAreTheSame($q);
+
+        $this->_em->clear();
+
         $q = $this->_em->createQuery('select a from ' . CompanyOrganization::class . ' a where a.id = ?1');
         $q->setParameter(1, $org->getId());
 
@@ -276,6 +297,10 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         // mainEvent should have been loaded because it can't be lazy
         $this->assertInstanceOf(CompanyAuction::class, $mainEvent);
         $this->assertNotInstanceOf(Proxy::class, $mainEvent);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($q);
     }
 
     /**
@@ -286,10 +311,14 @@ class ClassTableInheritanceTest extends OrmFunctionalTestCase
         $this->_em->createQuery('UPDATE ' . CompanyEmployee::class . ' AS p SET p.salary = 1')
                   ->execute();
 
-        $result = $this->_em->createQuery('SELECT count(p.id) FROM ' . CompanyEmployee::class . ' p WHERE p.salary = 1')
-                            ->getResult();
+        $query  = $this->_em->createQuery('SELECT count(p.id) FROM ' . CompanyEmployee::class . ' p WHERE p.salary = 1');
+        $result = $query->getResult();
 
         $this->assertGreaterThan(0, count($result));
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositePrimaryKeyTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\QueryException;
+use Doctrine\Tests\GetIterableTester;
 use Doctrine\Tests\Models\Navigation\NavCountry;
 use Doctrine\Tests\Models\Navigation\NavPointOfInterest;
 use Doctrine\Tests\Models\Navigation\NavTour;
@@ -86,11 +87,16 @@ class CompositePrimaryKeyTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $dql    = "SELECT IDENTITY(p.poi, 'long') AS long, IDENTITY(p.poi, 'lat') AS lat FROM Doctrine\Tests\Models\Navigation\NavPhotos p";
-        $result = $this->_em->createQuery($dql)->getResult();
+        $query  = $this->_em->createQuery($dql);
+        $result = $query->getResult();
 
         $this->assertCount(1, $result);
         $this->assertEquals(200, $result[0]['long']);
         $this->assertEquals(100, $result[0]['lat']);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 
     public function testManyToManyCompositeRelation()
@@ -112,7 +118,10 @@ class CompositePrimaryKeyTest extends OrmFunctionalTestCase
                'INNER JOIN t.pois p INNER JOIN p.country c';
         $tours = $this->_em->createQuery($dql)->getResult();
 
-        $this->assertEquals(1, count($tours));
+        $query = $this->_em->createQuery($dql);
+        $tours = $query->getResult();
+
+        self::assertCount(1, $tours);
 
         $pois = $tours[0]->getPointOfInterests();
 
@@ -133,6 +142,10 @@ class CompositePrimaryKeyTest extends OrmFunctionalTestCase
                            ->getResult();
 
         $this->assertEquals(1, count($tours));
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
     }
 
     public function testSpecifyUnknownIdentifierPrimaryKeyFails()

--- a/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\GetIterableTester;
+use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class QueryIterableTest extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testAlias() : void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Guilherme';
+        $user->username = 'gblanco';
+        $user->status   = 'developer';
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $query = $this->_em->createQuery('SELECT u AS user FROM Doctrine\Tests\Models\CMS\CmsUser u');
+
+        $users = $query->getResult();
+        self::assertCount(1, $users);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
+    }
+
+    public function testAliasInnerJoin() : void
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Guilherme';
+        $user->username = 'gblanco';
+        $user->status   = 'developer';
+
+        $address          = new CmsAddress();
+        $address->country = 'Germany';
+        $address->city    = 'Berlin';
+        $address->zip     = '12345';
+
+        $address->user = $user;
+        $user->address = $address;
+
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $query = $this->_em->createQuery('SELECT u AS user, a AS address FROM Doctrine\Tests\Models\CMS\CmsUser u JOIN u.address a');
+
+        $users = $query->getResult();
+        self::assertCount(1, $users);
+
+        $this->_em->clear();
+
+        GetIterableTester::assertResultsAreTheSame($query);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithGetIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithGetIterableTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\Tests\GetIterableTester;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH7496WithGetIterableTest extends OrmFunctionalTestCase
+{
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema(
+            [
+                GH7496EntityA::class,
+                GH7496EntityB::class,
+                GH7496EntityAinB::class,
+            ]
+        );
+
+        $this->_em->persist($a1 = new GH7496EntityA(1, 'A#1'));
+        $this->_em->persist($a2 = new GH7496EntityA(2, 'A#2'));
+        $this->_em->persist($b1 = new GH7496EntityB(1, 'B#1'));
+        $this->_em->persist(new GH7496EntityAinB(1, $a1, $b1));
+        $this->_em->persist(new GH7496EntityAinB(2, $a2, $b1));
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    public function testNonUniqueObjectHydrationDuringIteration() : void
+    {
+        $q = $this->_em->createQuery(
+            'SELECT b FROM ' . GH7496EntityAinB::class . ' aib JOIN ' . GH7496EntityB::class . ' b WITH aib.eB = b'
+        );
+
+        $bs = GetIterableTester::iterableToArray(
+            $q->getIterable([], AbstractQuery::HYDRATE_OBJECT)
+        );
+        $this->assertCount(2, $bs);
+        $this->assertInstanceOf(GH7496EntityB::class, $bs[0]);
+        $this->assertInstanceOf(GH7496EntityB::class, $bs[1]);
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7496EntityA
+{
+    /**
+     * @Id
+     * @Column(type="integer", name="a_id")
+     */
+    public $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    public function __construct(int $id, string $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7496EntityB
+{
+    /**
+     * @Id
+     * @Column(type="integer", name="b_id")
+     */
+    public $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    public function __construct(int $id, $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH7496EntityAinB
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=GH7496EntityA::class)
+     * @JoinColumn(name="a_id", referencedColumnName="a_id", nullable=false)
+     */
+    public $eA;
+
+    /**
+     * @ManyToOne(targetEntity=GH7496EntityB::class)
+     * @JoinColumn(name="b_id", referencedColumnName="b_id", nullable=false)
+     */
+    public $eB;
+
+    public function __construct(int $id, $a, $b)
+    {
+        $this->id = $id;
+        $this->eA = $a;
+        $this->eB = $b;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Hydration;
 
+use Doctrine\ORM\Internal\Hydration\ObjectHydrator;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Proxy\ProxyFactory;
@@ -76,7 +77,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -115,7 +116,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -164,7 +165,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
@@ -218,7 +219,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
@@ -279,7 +280,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
@@ -340,7 +341,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result));
@@ -402,7 +403,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -466,7 +467,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -547,7 +548,7 @@ class ObjectHydratorTest extends HydrationTestCase
 
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -661,7 +662,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -791,7 +792,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -904,7 +905,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -947,7 +948,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(1, count($result));
@@ -980,7 +981,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1036,7 +1037,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $metadata->associationMappings['shipping']['fetch'] = ClassMetadata::FETCH_LAZY;
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         $this->assertEquals(1, count($result));
@@ -1085,7 +1086,7 @@ class ObjectHydratorTest extends HydrationTestCase
         $metadata->associationMappings['shipping']['fetch'] = ClassMetadata::FETCH_LAZY;
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         $this->assertEquals(1, count($result));
@@ -1145,7 +1146,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1208,7 +1209,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1246,9 +1247,13 @@ class ObjectHydratorTest extends HydrationTestCase
             ]
         ];
 
-        $stmt           = new HydratorMockStatement($resultSet);
-        $hydrator       = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $iterableResult = $hydrator->iterate($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $hydrator = new ObjectHydrator($this->_em);
+
+        $iterableResult = $hydrator->iterate(
+            new HydratorMockStatement($resultSet),
+            $rsm,
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+        );
         $rowNum         = 0;
 
         while (($row = $iterableResult->next()) !== false) {
@@ -1265,6 +1270,33 @@ class ObjectHydratorTest extends HydrationTestCase
 
             ++$rowNum;
         }
+
+        self::assertSame(2, $rowNum);
+
+        $iterableResult = $hydrator->getIterable(
+            new HydratorMockStatement($resultSet),
+            $rsm,
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+        );
+        $rowNum         = 0;
+
+        foreach ($iterableResult as $user) {
+            self::assertInstanceOf(CmsUser::class, $user);
+
+            if ($rowNum === 0) {
+                self::assertEquals(1, $user->id);
+                self::assertEquals('romanb', $user->name);
+            }
+
+            if ($rowNum === 1) {
+                self::assertEquals(2, $user->id);
+                self::assertEquals('jwage', $user->name);
+            }
+
+            ++$rowNum;
+        }
+
+        self::assertSame(2, $rowNum);
     }
 
     /**
@@ -1290,10 +1322,13 @@ class ObjectHydratorTest extends HydrationTestCase
             ]
         ];
 
-        $stmt           = new HydratorMockStatement($resultSet);
-        $hydrator       = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
-        $iterableResult = $hydrator->iterate($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
+        $hydrator       = new ObjectHydrator($this->_em);
         $rowNum         = 0;
+        $iterableResult = $hydrator->iterate(
+            new HydratorMockStatement($resultSet),
+            $rsm,
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+        );
 
         while (($row = $iterableResult->next()) !== false) {
             $this->assertEquals(1, count($row));
@@ -1311,6 +1346,35 @@ class ObjectHydratorTest extends HydrationTestCase
 
             ++$rowNum;
         }
+
+        self::assertSame(2, $rowNum);
+
+        $rowNum         = 0;
+        $iterableResult = $hydrator->getIterable(
+            new HydratorMockStatement($resultSet),
+            $rsm,
+            [Query::HINT_FORCE_PARTIAL_LOAD => true]
+        );
+
+        foreach ($iterableResult as $row) {
+            self::assertCount(1, $row);
+            self::assertArrayHasKey('user', $row);
+            self::assertInstanceOf(CmsUser::class, $row['user']);
+
+            if ($rowNum === 0) {
+                self::assertEquals(1, $row['user']->id);
+                self::assertEquals('romanb', $row['user']->name);
+            }
+
+            if ($rowNum === 1) {
+                self::assertEquals(2, $row['user']->id);
+                self::assertEquals('jwage', $row['user']->name);
+            }
+
+            ++$rowNum;
+        }
+
+        self::assertSame(2, $rowNum);
     }
 
     /**
@@ -1422,7 +1486,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1545,7 +1609,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1603,7 +1667,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(4, count($result), "Should hydrate four results.");
@@ -1673,7 +1737,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1727,7 +1791,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1769,7 +1833,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(2, count($result));
@@ -1807,7 +1871,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm, [Query::HINT_FORCE_PARTIAL_LOAD => true]);
 
         $this->assertEquals(
@@ -1842,7 +1906,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
 
@@ -1875,7 +1939,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
 
@@ -1902,8 +1966,8 @@ class ObjectHydratorTest extends HydrationTestCase
               ],
         ];
 
-        $stmt       = new HydratorMockStatement($resultSet);
-        $hydrator   = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $stmt     = new HydratorMockStatement($resultSet);
+        $hydrator = new ObjectHydrator($this->_em);
         $hydrator->hydrateAll($stmt, $rsm);
     }
 
@@ -1924,7 +1988,7 @@ class ObjectHydratorTest extends HydrationTestCase
         ];
 
         $stmt     = new HydratorMockStatement($resultSet);
-        $hydrator = new \Doctrine\ORM\Internal\Hydration\ObjectHydrator($this->_em);
+        $hydrator = new ObjectHydrator($this->_em);
         $result   = $hydrator->hydrateAll($stmt, $rsm);
 
         $this->assertCount(1, $result);

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -135,16 +135,34 @@ class QueryTest extends OrmTestCase
 
     public function testIterateWithNoDistinctAndWrongSelectClause()
     {
-        $this->expectException('Doctrine\ORM\Query\QueryException');
-        $q = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
+        $this->expectException(QueryException::class);
+
+        $q = $this->_em->createQuery('select u, a from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a');
         $q->iterate();
     }
 
-    public function testIterateWithNoDistinctAndWithValidSelectClause()
+    public function testGetIterableWithNoDistinctAndWrongSelectClause() : void
     {
-        $this->expectException('Doctrine\ORM\Query\QueryException');
-        $q = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
+        $this->expectException(QueryException::class);
+
+        $q = $this->_em->createQuery('select u, a from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a');
+        $q->getIterable();
+    }
+
+    public function testIterateWithNoDistinctAndWithValidSelectClause() : void
+    {
+        $this->expectException(QueryException::class);
+
+        $q = $this->_em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a');
         $q->iterate();
+    }
+
+    public function testGetIterableWithNoDistinctAndWithValidSelectClause() : void
+    {
+        $this->expectException(QueryException::class);
+
+        $q = $this->_em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a');
+        $q->getIterable();
     }
 
     public function testIterateWithDistinct()
@@ -152,6 +170,17 @@ class QueryTest extends OrmTestCase
         $q = $this->_em->createQuery("SELECT DISTINCT u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
 
         self::assertInstanceOf(IterableResult::class, $q->iterate());
+    }
+
+    public function testIterateEmptyResult() : void
+    {
+        $q = $this->_em->createQuery('SELECT u from Doctrine\Tests\Models\CMS\CmsUser u');
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        foreach ($q->getIterable() as $item) {
+        }
+
+        self::assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
I do not fancy accessing index 0 (`[0]`) while iterating `iterable` result from `iterate()` to get the entity.

```php
$results = $em->select('e')->from('entity')->getQuery()->iterate();
foreach($resuls as $result) {
   $entityIsHere = $result[0];
}
```

So  was thinking to introduce new method that gets rid of the index and returns the result same way as `getResult()` does. Only with the change that the new behaviour would keep row-by-row hydration.

```php
$generator = $em->select('e')->from('entity')->getQuery()->toIterable();
foreach($generator as $result) {
   $entityIsHere = $result;
}
```

This change deprecates `AbstractQuery::iterate` and follow up PRs renamed the new method `toIterable()`.

- [x]  Implement new row by row hydrating iterator
- [x]  Test the shapes are the same
- [x]   Add separate tests
- [x]   Find name for new method

Follow ups:
- https://github.com/doctrine/orm/pull/8268
- https://github.com/doctrine/orm/pull/8293