### PR TITLE
Fix boolean properties default value when generating entities.

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -26,6 +26,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use const E_USER_DEPRECATED;
 use function str_replace;
 use function trigger_error;
+use function var_export;
 
 /**
  * Generic class used to generate PHP5 entity classes from ClassMetadataInfo instances.
@@ -1331,7 +1332,7 @@ public function __construct(<params>)
             $defaultValue = '';
             if (isset($fieldMapping['options']['default'])) {
                 if ($fieldMapping['type'] === 'boolean' && $fieldMapping['options']['default'] === '1') {
-                    $defaultValue = " = true";
+                    $defaultValue = ' = true';
                 } else {
                     $defaultValue = ' = ' . var_export($fieldMapping['options']['default'], true);
                 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1328,9 +1328,17 @@ public function __construct(<params>)
                 continue;
             }
 
+            $defaultValue = '';
+            if (isset($fieldMapping['options']['default'])) {
+                if ($fieldMapping['type'] === 'boolean' && $fieldMapping['options']['default'] === '1') {
+                    $defaultValue = " = true";
+                } else {
+                    $defaultValue = ' = ' . var_export($fieldMapping['options']['default'], true);
+                }
+            }
+
             $lines[] = $this->generateFieldMappingPropertyDocBlock($fieldMapping, $metadata);
-            $lines[] = $this->spaces . $this->fieldVisibility . ' $' . $fieldMapping['fieldName']
-                     . (isset($fieldMapping['options']['default']) ? ' = ' . var_export($fieldMapping['options']['default'], true) : null) . ";\n";
+            $lines[] = $this->spaces . $this->fieldVisibility . ' $' . $fieldMapping['fieldName'] . $defaultValue . ";\n";
         }
 
         return implode("\n", $lines);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\Models\DDC2372\DDC2372Admin;
 use Doctrine\Tests\Models\DDC2372\DDC2372User;
 use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\VerifyDeprecations;
-use \ReflectionClass;
+use ReflectionClass;
 
 class EntityGeneratorTest extends OrmTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -327,6 +327,26 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertEquals($isbnMetadata->name, $reflParameters[0]->getClass()->name);
     }
 
+    public function testBooleanDefaultValue()
+    {
+        $metadata = $this->generateBookEntityFixture(['isbn' => $this->generateIsbnEmbeddableFixture()]);
+
+        $metadata->mapField(['fieldName' => 'foo', 'type' => 'boolean', 'options' => ['default' => '1']]);
+
+        $testEmbeddableMetadata = $this->generateTestEmbeddableFixture();
+        $this->mapEmbedded('testEmbedded', $metadata, $testEmbeddableMetadata);
+
+        $this->_generator->writeEntityClass($metadata, $this->_tmpDir);
+
+        $this->assertFileExists($this->_tmpDir . '/' . $this->_namespace . '/EntityGeneratorBook.php~');
+
+        $book = $this->newInstance($metadata);
+        $reflClass = new \ReflectionClass($metadata->name);
+
+        $this->assertNotSame($book->getfoo(), '1');
+        $this->assertSame($book->getFoo(), true);
+    }
+
     public function testEntityUpdatingWorks()
     {
         $metadata = $this->generateBookEntityFixture(['isbn' => $this->generateIsbnEmbeddableFixture()]);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -344,8 +344,7 @@ class EntityGeneratorTest extends OrmTestCase
         $book      = $this->newInstance($metadata);
         $reflClass = new ReflectionClass($metadata->name);
 
-        $this->assertNotSame($book->getfoo(), '1');
-        $this->assertSame($book->getFoo(), true);
+        $this->assertTrue($book->getfoo());
     }
 
     public function testEntityUpdatingWorks()

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -13,6 +13,7 @@ use Doctrine\Tests\Models\DDC2372\DDC2372Admin;
 use Doctrine\Tests\Models\DDC2372\DDC2372User;
 use Doctrine\Tests\OrmTestCase;
 use Doctrine\Tests\VerifyDeprecations;
+use \ReflectionClass;
 
 class EntityGeneratorTest extends OrmTestCase
 {
@@ -340,8 +341,8 @@ class EntityGeneratorTest extends OrmTestCase
 
         $this->assertFileExists($this->_tmpDir . '/' . $this->_namespace . '/EntityGeneratorBook.php~');
 
-        $book = $this->newInstance($metadata);
-        $reflClass = new \ReflectionClass($metadata->name);
+        $book      = $this->newInstance($metadata);
+        $reflClass = new ReflectionClass($metadata->name);
 
         $this->assertNotSame($book->getfoo(), '1');
         $this->assertSame($book->getFoo(), true);


### PR DESCRIPTION
Generating entities by a generate entity tool, entity properties are set "1" that default value, despite field type is boolean.  
So, if a field type is boolean and a default value is "1", replace to "true".