### PR TITLE
Use the hydrationMode provided in function call

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -755,7 +755,7 @@ abstract class AbstractQuery
     {
         $result = $this->execute(null, $hydrationMode);
 
-        if ($this->hydrationMode !== self::HYDRATE_SINGLE_SCALAR && ! $result) {
+        if ($hydrationMode !== self::HYDRATE_SINGLE_SCALAR && ! $result) {
             throw new NoResultException();
         }
 


### PR DESCRIPTION
- less stateful
- fixes NoResultException thrown
    from AbstractQuery::getSingleScalarResult() invocation