### PR TITLE
[Paginator] Fix regression when using Custom ID type

### DIFF
--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -19,6 +19,12 @@
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\MappingException;
+use function array_keys;
+use function array_values;
+use function assert;
+
 /**
  * A ResultSetMapping describes how a result set of an SQL query maps to a Doctrine result.
  *
@@ -582,5 +588,41 @@ class ResultSetMapping
         }
 
         return $this;
+    }
+
+    /**
+     * Retrieves the DBAL type name for the single identifier column of the root of a selection.
+     * Composite identifiers not supported!
+     *
+     * @internal only to be used by ORM internals: do not use in downstream projects! This API is a minimal abstraction
+     *           that only ORM internals need, and it tries to make sense of the very complex and squishy array-alike
+     *           structure inside this class. Some assumptions are coded in here, so here be dragons.
+     *
+     * @throws MappingException If the identifier is not a single field, or if metadata for its
+     *                          owner is incorrect/missing.
+     */
+    final public function getTypeOfSelectionRootSingleIdentifierColumn(EntityManagerInterface $em) : string
+    {
+        assert($this->isSelect);
+
+        if ($this->isIdentifierColumn !== []) {
+            // Identifier columns are already discovered here: we can use the first one directly.
+            assert($this->typeMappings !== []);
+
+            return $this->typeMappings[array_keys(array_values($this->isIdentifierColumn)[0])[0]];
+        }
+
+        // We are selecting entities, and the first selected entity is our root of the selection.
+        if ($this->aliasMap !== []) {
+            $metadata = $em->getClassMetadata($this->aliasMap[array_keys($this->aliasMap)[0]]);
+
+            return $metadata->getTypeOfField($metadata->getSingleIdentifierFieldName());
+        }
+
+        // We are selecting scalar fields - the first selected field will be assumed (!!! assumption !!!) as identifier
+        assert($this->scalarMappings !== []);
+        assert($this->typeMappings !== []);
+
+        return $this->typeMappings[array_keys($this->scalarMappings)[0]];
     }
 }

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -19,12 +19,15 @@
 
 namespace Doctrine\ORM\Tools\Pagination;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;
 use function array_map;
+use function assert;
 
 /**
  * The paginator can handle various complex scenarios with DQL.
@@ -284,5 +287,26 @@ class Paginator implements \Countable, \IteratorAggregate
         }
 
         $query->setParameters($parameters);
+    }
+
+    /**
+     * Parses a query that is supposed to fetch a set of entity identifier only,
+     * and retrieves the type of said identifier.
+     *
+     * @throws MappingException If metadata couldn't be loaded, or if there isn't a single
+     *                          identifier for the given query.
+     */
+    private function getIdentifiersQueryScalarResultType(
+        Query $query,
+        EntityManagerInterface $em
+    ) : ?string {
+        $rsm = (new Parser($query))
+            ->parse()
+            ->getResultSetMapping();
+
+        assert($rsm !== null);
+        assert($rsm->isSelect);
+
+        return $rsm->getTypeOfSelectionRootSingleIdentifierColumn($em);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ResultSetMappingTest.php
@@ -3,12 +3,15 @@
 namespace Doctrine\Tests\ORM\Hydration;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsPhonenumber;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Legacy\LegacyUser;
 use Doctrine\Tests\Models\Legacy\LegacyUserReference;
+use Doctrine\Tests\Models\ValueConversionType\AuxiliaryEntity;
+use Doctrine\Tests\Models\ValueConversionType\OwningManyToOneIdForeignKeyEntity;
 
 /**
  * Description of ResultSetMappingTest
@@ -65,6 +68,7 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals('status', $this->_rsm->getFieldName('status'));
         $this->assertEquals('username', $this->_rsm->getFieldName('username'));
         $this->assertEquals('name', $this->_rsm->getFieldName('name'));
+        $this->assertSame('integer', $this->_rsm->getTypeOfSelectionRootSingleIdentifierColumn($this->_em));
     }
 
     /**
@@ -94,6 +98,7 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertTrue($rms->isRelation('p'));
         $this->assertTrue($rms->hasParentAlias('p'));
         $this->assertTrue($rms->isMixedResult());
+        $this->assertSame('integer', $this->_rsm->getTypeOfSelectionRootSingleIdentifierColumn($this->_em));
     }
 
     /**
@@ -268,6 +273,26 @@ class ResultSetMappingTest extends \Doctrine\Tests\OrmTestCase
         $this->assertEquals(CmsUser::class, $rsm->getDeclaringClass('name'));
         $this->assertEquals(CmsUser::class, $rsm->getDeclaringClass('status'));
         $this->assertEquals(CmsUser::class, $rsm->getDeclaringClass('username'));
+    }
+
+    public function testIdentifierTypeForScalarExpression() : void
+    {
+        $rsm = (new Parser($this->_em->createQuery('SELECT e.id4 FROM ' . AuxiliaryEntity::class . ' e')))
+            ->parse()
+            ->getResultSetMapping();
+
+        self::assertNotNull($rsm);
+        self::assertSame('rot13', $rsm->getTypeOfSelectionRootSingleIdentifierColumn($this->_em));
+    }
+
+    public function testIdentifierTypeForRootEntityColumnThatHasAssociationAsIdentifier() : void
+    {
+        $rsm = (new Parser($this->_em->createQuery('SELECT e FROM ' . OwningManyToOneIdForeignKeyEntity::class . ' e')))
+            ->parse()
+            ->getResultSetMapping();
+
+        self::assertNotNull($rsm);
+        self::assertSame('rot13', $rsm->getTypeOfSelectionRootSingleIdentifierColumn($this->_em));
     }
 
     /**


### PR DESCRIPTION
Continuation of https://github.com/doctrine/orm/pull/7890. Created new PR to clean the mess with huge diff, though I still left attributions via co-authors.

I have reused previous code from @Ocramius for getting id type, however if preferred, I can replace it with this smaller piece of code:
```php
$AST           = $subQuery->getAST();
$entityManager = $subQuery->getEntityManager();
$connection    = $this->query->getEntityManager()->getConnection();
$classMetadata = $entityManager->getClassMetadata(
    $AST->fromClause->identificationVariableDeclarations[0]->rangeVariableDeclaration->abstractSchemaName
);

$identifierType = PersisterHelper::getTypeOfField(
    $classMetadata->getSingleIdentifierFieldName(),
    $classMetadata,
    $entityManager
)[0];

$ids =  array_map(static function(array $row) use ($identifierType, $connection) {
    return current($row);
    return $connection->convertToPHPValue(current($row), $identifierType);
}, $foundIdRows);
```

Please check if this approach is right one, as it's weird that we are now doing PHP<>DB conversions in both Paginator and WhereInWalker