### PR TITLE
[Paginator] Fix type conversion during hydration of pagination limit subquery

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -39,10 +39,9 @@ use Doctrine\ORM\Query\AST\SelectStatement;
  */
 class LimitSubqueryWalker extends TreeWalkerAdapter
 {
-    /**
-     * ID type hint.
-     */
-    const IDENTIFIER_TYPE = 'doctrine_paginator.id.type';
+    public const IDENTIFIER_TYPE = 'doctrine_paginator.id.type';
+
+    public const FORCE_DBAL_TYPE_CONVERSION = 'doctrine_paginator.scalar_result.force_dbal_type_conversion';
 
     /**
      * Counter for generating unique order column aliases.
@@ -81,6 +80,8 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
             self::IDENTIFIER_TYPE,
             Type::getType($rootClass->fieldMappings[$identifier]['type'])
         );
+
+        $this->_getQuery()->setHint(self::FORCE_DBAL_TYPE_CONVERSION, true);
 
         $pathExpression = new PathExpression(
             PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,


### PR DESCRIPTION
Continuation of #7890 and #7903, however, using an implementation that keeps DB->PHP conversion contained in the hydrator.