### PR TITLE
Add missing imports of annotations.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * This annotation is used to override association mapping of property for an entity relationship.
  *

--- a/lib/Doctrine/ORM/Mapping/Cache.php
+++ b/lib/Doctrine/ORM/Mapping/Cache.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * Caching to an entity or a collection.
  *

--- a/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("CLASS")

--- a/lib/Doctrine/ORM/Mapping/GeneratedValue.php
+++ b/lib/Doctrine/ORM/Mapping/GeneratedValue.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("PROPERTY")

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("CLASS")

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("PROPERTY")

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("PROPERTY")

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("PROPERTY")

--- a/lib/Doctrine/ORM/Mapping/OneToOne.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOne.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Mapping;
 
+use Doctrine\Common\Annotations\Annotation\Enum;
+
 /**
  * @Annotation
  * @Target("PROPERTY")

--- a/tests/Doctrine/Tests/ORM/Mapping/ImportsAnnotationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ImportsAnnotationsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Mapping\AssociationOverride;
+use Doctrine\ORM\Mapping\Cache;
+use Doctrine\ORM\Mapping\ChangeTrackingPolicy;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\ManyToMany;
+use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\Tests\OrmTestCase;
+use ReflectionClass;
+
+class ImportsAnnotationsTest extends OrmTestCase
+{
+    /**
+     * @var AnnotationReader
+     */
+    private $annotationReader;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        // If using non-default annotation reader, everything working.
+        //$this->annotationReader = $this->createAnnotationDriver()->getReader();
+
+        // ... but if use a default annotation reader is there a problem.
+        $this->annotationReader = new AnnotationReader();
+    }
+
+    /**
+     * If exception was thrown so is there a error during parsing something with class.
+     *
+     * @dataProvider dataProviderReflectionClass
+     *
+     * @param ReflectionClass $reflectionClass
+     *
+     * @return void
+     */
+    public function testClassShouldValidImportedAnnotations($reflectionClass)
+    {
+        $this->assertIsArray($this->annotationReader->getClassAnnotations($reflectionClass));
+
+        foreach ($reflectionClass->getMethods() as $reflectionMethod) {
+            $this->assertIsArray($this->annotationReader->getMethodAnnotations($reflectionMethod));
+        }
+
+        foreach ($reflectionClass->getProperties() as $reflectionProperty) {
+            $this->assertIsArray($this->annotationReader->getPropertyAnnotations($reflectionProperty));
+        }
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @return ReflectionClass[]
+     */
+    public function dataProviderReflectionClass()
+    {
+        return [
+            [new ReflectionClass(AssociationOverride::class)],
+            [new ReflectionClass(Cache::class)],
+            [new ReflectionClass(ChangeTrackingPolicy::class)],
+            [new ReflectionClass(GeneratedValue::class)],
+            [new ReflectionClass(InheritanceType::class)],
+            [new ReflectionClass(ManyToMany::class)],
+            [new ReflectionClass(ManyToOne::class)],
+            [new ReflectionClass(OneToMany::class)],
+            [new ReflectionClass(OneToOne::class)],
+        ];
+    }
+}


### PR DESCRIPTION
Hello. 

It's my first PR for ORM project.
I found (I think) a some little issue with annotations. Using defualt new AnnotationReader(), we can get a error about missing import like: 

`Doctrine\Common\Annotations\AnnotationException : [Semantical Error] The annotation "@Enum" in property Doctrine\ORM\Mapping\Cache::$usage was never imported. Did you maybe forget to add a "use" statement for this annotation?`

This PR fix this on 2.6