### PR TITLE
Add support for INDEX BY an associated entity

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1647,7 +1647,7 @@ From, Join and Index by
     RangeVariableDeclaration                   ::= AbstractSchemaName ["AS"] AliasIdentificationVariable
     JoinAssociationDeclaration                 ::= JoinAssociationPathExpression ["AS"] AliasIdentificationVariable [IndexBy]
     Join                                       ::= ["LEFT" ["OUTER"] | "INNER"] "JOIN" (JoinAssociationDeclaration | RangeVariableDeclaration) ["WITH" ConditionalExpression]
-    IndexBy                                    ::= "INDEX" "BY" StateFieldPathExpression
+    IndexBy                                    ::= "INDEX" "BY" SingleValuedPathExpression
 
 Select Expressions
 ~~~~~~~~~~~~~~~~~~

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query\AST;
 
 /**
- * IndexBy ::= "INDEX" "BY" SimpleStateFieldPathExpression
+ * IndexBy ::= "INDEX" "BY" SingleValuedPathExpression
  */
 class IndexBy extends Node
 {
     /** @var PathExpression */
-    public $simpleStateFieldPathExpression;
+    public $singleValuedPathExpression;
 
     /**
-     * @param PathExpression $simpleStateFieldPathExpression
+     * @param PathExpression $singleValuedPathExpression
      */
-    public function __construct($simpleStateFieldPathExpression)
+    public function __construct($singleValuedPathExpression)
     {
-        $this->simpleStateFieldPathExpression = $simpleStateFieldPathExpression;
+        $this->singleValuedPathExpression = $singleValuedPathExpression;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1890,7 +1890,7 @@ class Parser
     }
 
     /**
-     * IndexBy ::= "INDEX" "BY" StateFieldPathExpression
+     * IndexBy ::= "INDEX" "BY" SingleValuedPathExpression
      *
      * @return AST\IndexBy
      */
@@ -1898,7 +1898,7 @@ class Parser
     {
         $this->match(Lexer::T_INDEX);
         $this->match(Lexer::T_BY);
-        $pathExpr = $this->StateFieldPathExpression();
+        $pathExpr = $this->SingleValuedPathExpression();
 
         // Add the INDEX BY info to the query component
         $this->queryComponents[$pathExpr->identificationVariable]['map'] = $pathExpr->field;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7661Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7661Test.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Annotation as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use function array_keys;
+
+/**
+ * @group GH-7661
+ */
+class GH7661Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH7661User::class,
+            GH7661Event::class,
+            GH7661Participant::class,
+        ]);
+
+        $u1 = new GH7661User();
+        $u2 = new GH7661User();
+        $e  = new GH7661Event();
+        $this->em->persist($u1);
+        $this->em->persist($u2);
+        $this->em->persist($e);
+        $this->em->persist(new GH7661Participant($u1, $e));
+        $this->em->persist(new GH7661Participant($u2, $e));
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    public function testIndexByAssociation() : void
+    {
+        $e    = $this->em->find(GH7661Event::class, 1);
+        $keys = $e->participants->getKeys();
+        self::assertEquals([1, 2], $keys);
+
+        $participants = $this->em->createQuery('SELECT p FROM ' . GH7661Participant::class . ' p INDEX BY p.user')->getResult();
+        $keys         = array_keys($participants);
+        self::assertEquals([1, 2], $keys);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7661User
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7661Event
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+    /** @ORM\OneToMany(targetEntity=GH7661Participant::class, mappedBy="event", indexBy="user_id") */
+    public $participants;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH7661Participant
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
+    public $id;
+    /** @ORM\ManyToOne(targetEntity=GH7661User::class) */
+    public $user;
+    /** @ORM\ManyToOne(targetEntity=GH7661Event::class) */
+    public $event;
+
+    public function __construct(GH7661User $user, GH7661Event $event)
+    {
+        $this->user  = $user;
+        $this->event = $event;
+    }
+}


### PR DESCRIPTION
This allows specifying an association in the INDEX BY clause of a query
which will index by the association's join column.

Related to #7661.

Note I haven't added support for specifying the name of a related entity in an indexed association ("indexBy" annotation) as I couldn't see a good way of doing so. Using the name of the join column does work here though, so it may not be necessary.