### PR TITLE
[WIP] Introduces 3.0 annotation namespace

### DIFF
--- a/lib/Doctrine/ORM/Annotation/Annotation.php
+++ b/lib/Doctrine/ORM/Annotation/Annotation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Annotation;
+
+interface Annotation
+{
+}

--- a/lib/Doctrine/ORM/Annotation/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Annotation/AssociationOverride.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Annotation;
+
+/**
+ * This annotation is used to override association mapping of property for an entity relationship.
+ *
+ * @Annotation
+ * @Target("ANNOTATION")
+ */
+/* final */ class AssociationOverride implements Annotation
+{
+    /**
+     * The name of the relationship property whose mapping is being overridden.
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * The join column that is being mapped to the persistent attribute.
+     *
+     * @var array<\Doctrine\ORM\Annotation\JoinColumn>
+     */
+    public $joinColumns;
+
+    /**
+     * The join table that maps the relationship.
+     *
+     * @var \Doctrine\ORM\Annotation\JoinTable
+     */
+    public $joinTable;
+
+    /**
+     * The name of the association-field on the inverse-side.
+     *
+     * @var string
+     */
+    public $inversedBy;
+
+    /**
+     * The fetching strategy to use for the association.
+     *
+     * @var string
+     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
+     */
+    public $fetch;
+}

--- a/lib/Doctrine/ORM/Annotation/JoinColumn.php
+++ b/lib/Doctrine/ORM/Annotation/JoinColumn.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY","ANNOTATION"})
+ */
+final class JoinColumn implements Annotation
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $referencedColumnName = 'id';
+
+    /** @var bool */
+    public $unique = false;
+
+    /** @var bool */
+    public $nullable = true;
+
+    /** @var mixed */
+    public $onDelete;
+
+    /** @var string */
+    public $columnDefinition;
+
+    /**
+     * Field name used in non-object hydration (array/scalar).
+     *
+     * @var string
+     */
+    public $fieldName;
+}

--- a/lib/Doctrine/ORM/Annotation/JoinTable.php
+++ b/lib/Doctrine/ORM/Annotation/JoinTable.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY","ANNOTATION"})
+ */
+final class JoinTable implements Annotation
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $schema;
+
+    /** @var array<\Doctrine\ORM\Annotation\JoinColumn> */
+    public $joinColumns = [];
+
+    /** @var array<\Doctrine\ORM\Annotation\JoinColumn> */
+    public $inverseJoinColumns = [];
+}

--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -1,69 +1,15 @@
 <?php
-/*
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the MIT license. For more information, see
- * <http://www.doctrine-project.org>.
- */
 
 namespace Doctrine\ORM\Mapping;
 
-/**
- * This annotation is used to override association mapping of property for an entity relationship.
- *
- * @author  Fabio B. Silva <fabio.bat.silva@gmail.com>
- * @since   2.3
- *
- * @Annotation
- * @Target("ANNOTATION")
- */
-final class AssociationOverride implements Annotation
+use Doctrine\ORM\Annotation\AssociationOverride as NewAssociationOverride;
+use function class_exists;
+use function trigger_error;
+
+class_exists('Doctrine\ORM\Annotation\AssociationOverride');
+
+trigger_error('Doctrine\ORM\Annotation\AssociationOverride', \E_USER_DEPRECATED);
+
+class AssociationOverride extends NewAssociationOverride
 {
-    /**
-     * The name of the relationship property whose mapping is being overridden.
-     * 
-     * @var string 
-     */
-    public $name;
-
-    /**
-     * The join column that is being mapped to the persistent attribute.
-     *
-     * @var array<\Doctrine\ORM\Mapping\JoinColumn>
-     */
-    public $joinColumns;
-
-    /**
-     * The join table that maps the relationship.
-     *
-     * @var \Doctrine\ORM\Mapping\JoinTable
-     */
-    public $joinTable;
-
-    /**
-     * The name of the association-field on the inverse-side.
-     *
-     * @var string
-     */
-    public $inversedBy;
-
-    /**
-     * The fetching strategy to use for the association.
-     *
-     * @var string
-     *
-     * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
-     */
-    public $fetch;
 }

--- a/tests/Doctrine/Tests/Annotation/AssociationOverrideTest.php
+++ b/tests/Doctrine/Tests/Annotation/AssociationOverrideTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\Tests\Annotation;
+
+use Doctrine\ORM\Annotation\AssociationOverride as NewAssociationOverride;
+use Doctrine\ORM\Mapping\AssociationOverride as LegacyAssociationOverride;
+use PHPUnit\Framework\Error\Deprecated;
+use PHPUnit\Framework\TestCase;
+
+class AssociationOverrideTest extends TestCase
+{
+    public function test_annotation_can_be_loaded()
+    {
+        $newOverride = new NewAssociationOverride();
+
+        self::assertInstanceOf(NewAssociationOverride::class, $newOverride);
+    }
+
+    public function test_deprecated_annotation_can_be_loaded()
+    {
+        $this->expectException(Deprecated::class);
+
+        $legacyOverride = new LegacyAssociationOverride();
+
+        self::assertInstanceOf(LegacyAssociationOverride::class, $legacyOverride);
+    }
+}


### PR DESCRIPTION
This is just a proof of concept before fully committing to this. Basically, I did a git checkout of the annotations from the 3.0 branch and then replaced the current version with a deprecation, similar to how Twig did when upgrading the class names.

Let me know what you think of this and if I should finish it.

Annotation-interface, JoinColumn and JoinTable are only in here so all dependencies of AssociationOverride are met.