### PR TITLE
Add docs note that FQCN is needed for an Embeddable configured via annotations

### DIFF
--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -79,6 +79,10 @@ In terms of your database schema, Doctrine will automatically inline all
 columns from the ``Address`` class into the table of the ``User`` class,
 just as if you had declared them directly there.
 
+.. note::
+
+    The Embeddable class must be specified as fully qualified (e.g. ``Embeddable\Address``). Relying on `use` and omitting the FQCN will not work.
+
 Initializing embeddables
 ------------------------
 


### PR DESCRIPTION
By default PHP users will try to omit the namespace, importing it with `use`.
But that is not supported, at the moment.

Is possible to spare developers the time for figuring this out.