### PR TITLE
docs: detach deprecated

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -183,7 +183,7 @@ problems using the following approach:
         // do stuff with the data in the row, $row[0] is always the object
     
         // detach from Doctrine, so that it can be Garbage-Collected immediately
-        $this->_em->detach($row[0]);
+        $this->_em->clear($row[0]);
     }
 
 .. note::


### PR DESCRIPTION
>      * @deprecated Detach operation is deprecated and will be removed in Persistence 2.0. Please use @see ObjectManager::clear()} instead.