### PR TITLE
Fix behaviour when using CONTAINS on json fields

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -928,8 +928,8 @@ class BasicEntityPersister implements EntityPersister
 
         foreach ($types as $type) {
             [$field, $value, $operator] = $type;
-            $sqlType = $this->getTypes($field, $value, $this->class);
-            if($operator === Comparison::CONTAINS && $sqlType[0] === Type::JSON) {
+            $sqlType                    = $this->getTypes($field, $value, $this->class);
+            if ($operator === Comparison::CONTAINS && $sqlType[0] === Type::JSON) {
                 $sqlType[0] = Type::STRING;
             }
             $sqlTypes = array_merge($sqlTypes, $sqlType);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -920,15 +920,19 @@ class BasicEntityPersister implements EntityPersister
 
         $valueVisitor->dispatch($expression);
 
-        [$params, $types] = $valueVisitor->getParamsAndTypes();
+        list($params, $types) = $valueVisitor->getParamsAndTypes();
 
         foreach ($params as $param) {
             $sqlParams = array_merge($sqlParams, $this->getValues($param));
         }
 
         foreach ($types as $type) {
-            [$field, $value] = $type;
-            $sqlTypes        = array_merge($sqlTypes, $this->getTypes($field, $value, $this->class));
+            list ($field, $value, $operator) = $type;
+            $sqlType = $this->getTypes($field, $value, $this->class);
+            if($operator === Comparison::CONTAINS && $sqlType[0] === Type::JSON) {
+                $sqlType[0] = Type::STRING;
+            }
+            $sqlTypes = array_merge($sqlTypes, $sqlType);
         }
 
         return [$sqlParams, $sqlTypes];

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -920,14 +920,14 @@ class BasicEntityPersister implements EntityPersister
 
         $valueVisitor->dispatch($expression);
 
-        list($params, $types) = $valueVisitor->getParamsAndTypes();
+        [$params, $types] = $valueVisitor->getParamsAndTypes();
 
         foreach ($params as $param) {
             $sqlParams = array_merge($sqlParams, $this->getValues($param));
         }
 
         foreach ($types as $type) {
-            list ($field, $value, $operator) = $type;
+            [$field, $value, $operator] = $type;
             $sqlType = $this->getTypes($field, $value, $this->class);
             if($operator === Comparison::CONTAINS && $sqlType[0] === Type::JSON) {
                 $sqlType[0] = Type::STRING;


### PR DESCRIPTION
Fix issues when using CONTAINS on json fields related with the json_encode during the hydration phase acting as if the field was string instead.

Basically when using CONTAINS Doctrine Criteria on a json field the behaviour and the query generated was not correct since it's encoded with json_encode.