### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -302,7 +302,7 @@ class Parser
      */
     public function match($token)
     {
-        $lookaheadType = $this->lexer->lookahead['type'];
+        $lookaheadType = $this->lexer->lookahead['type'] ?? null;
 
         // Short-circuit on first condition, usually types match
         if ($lookaheadType === $token) {

--- a/tests/Doctrine/Tests/ORM/Query/ParserTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParserTest.php
@@ -134,6 +134,24 @@ class ParserTest extends OrmTestCase
         ];
     }
 
+    /**
+     * PHP 7.4 would fail with Notice: Trying to access array offset on value of type null.
+     *
+     * @see https://github.com/doctrine/orm/pull/7934
+     *
+     * @group GH7934
+     */
+    public function testNullLookahead() : void
+    {
+        $query = new Query($this->_getTestEntityManager());
+        $query->setDQL('SELECT CURRENT_TIMESTAMP()');
+
+        $parser = new Parser($query);
+
+        $this->expectException(QueryException::class);
+        $parser->match(Lexer::T_SELECT);
+    }
+
     private function createParser($dql)
     {
         $query = new Query($this->_getTestEntityManager());


### PR DESCRIPTION
This error occurs on PHP 7.4, for example when you're running this (invalid) DQL from the Symfony console:

```
bin/console doctrine:query:dql "SELECT CURRENT_TIMESTAMP()"
```

> In Parser.php line 305:
> Notice: Trying to access array offset on value of type null