### PR TITLE
Update doctrine/dbal dep to concrete commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/annotations": "~1.5",
         "doctrine/cache": "~1.6",
         "doctrine/collections": "^1.4",
-        "doctrine/dbal": "dev-snapshot/develop/2018-11-26 as 3.x-dev",
+        "doctrine/dbal": "dev-master#0ef7d47bc5055e45c5dd3c57d2121b5807ae0917 as 3.x-dev",
         "doctrine/event-manager": "^1.0",
         "doctrine/inflector": "~1.0",
         "doctrine/instantiator": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40e0e150618318ae2189113af2cad253",
+    "content-hash": "28a5632a78fc3a537cbaae3d43c21331",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -221,7 +221,7 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "dev-snapshot/develop/2018-11-26",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
@@ -240,12 +240,12 @@
                 "php": "^7.2"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
-                "jetbrains/phpstorm-stubs": "^2018.1.2",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.4",
-                "symfony/console": "^2.0.5|^3.0|^4.0",
-                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+                "doctrine/coding-standard": "^6.0",
+                "jetbrains/phpstorm-stubs": "^2019.1",
+                "phpstan/phpstan": "^0.11.6",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpunit/phpunit": "^8.4.1",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -256,8 +256,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9.x-dev",
-                    "dev-develop": "3.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -271,16 +270,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -292,14 +291,25 @@
             "keywords": [
                 "abstraction",
                 "database",
+                "db2",
                 "dbal",
+                "mariadb",
+                "mssql",
                 "mysql",
-                "persistence",
+                "oci8",
+                "oracle",
+                "pdo",
                 "pgsql",
-                "php",
-                "queryobject"
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlanywhere",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
             ],
-            "time": "2018-11-25T02:26:02+00:00"
+            "time": "2019-11-28T08:06:52+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -3008,7 +3018,7 @@
         {
             "alias": "3.x-dev",
             "alias_normalized": "3.9999999.9999999.9999999-dev",
-            "version": "dev-snapshot/develop/2018-11-26",
+            "version": "9999999-dev",
             "package": "doctrine/dbal"
         }
     ],


### PR DESCRIPTION
dev-snapshot/develop/2018-11-26 is not found by composer

```Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - The requested package doctrine/dbal dev-snapshot/develop/2018-11-26 as 3.x-dev exists as doctrine/dbal[2.0.x-dev, 2.1.5, 2.1.6, 2.1.7, 2.1.x-dev, 2.10.x-dev, 2.2.0, 2.2.0-BETA2, 2.2.0-RC1, 2.2.0-RC2, 2.2.0-RC3, 2.2.0-beta1, 2.2.1, 2.2.2, 2.2.x-dev, 2.3.0, 2.3.0-BETA1, 2.3.0-RC1, 2.3.0-RC2, 2.3.0-RC3, 2.3.0-RC4, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.3.x-dev, 2.4.0-BETA1, 2.4.0-BETA2, 2.4.0-RC1, 2.4.0-RC2, 2.4.x-dev, 2.5.x-dev, 2.6.x-dev, 2.7.x-dev, 2.8.x-dev, 2.9.x-dev, dev-master, 3.0.x-dev, v2.10.0, v2.4.0, v2.4.1, v2.4.2, v2.4.3, v2.4.4, v2.4.5, v2.5.0, v2.5.0-BETA2, v2.5.0-BETA3, v2.5.0-RC1, v2.5.0-RC2, v2.5.1, v2.5.10, v2.5.11, v2.5.12, v2.5.13, v2.5.2, v2.5.3, v2.5.4, v2.5.5, v2.5.6, v2.5.7, v2.5.8, v2.5.9, v2.6.0, v2.6.1, v2.6.2, v2.6.3, v2.7.0, v2.7.1, v2.7.2, v2.8.0, v2.8.1, v2.9.0, v2.9.1, v2.9.2, v2.9.3] but these are rejected by your constraint.```