### PR TITLE
Allow DQL functions to specify return type

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Query\Lexer;
 /**
  * "ABS" "(" SimpleArithmeticExpression ")"
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 use Doctrine\ORM\Query\AST\AggregateExpression;
@@ -29,7 +31,7 @@ use Doctrine\ORM\Query\AST\AggregateExpression;
  * @since   2.6
  * @author  Mathew Davies <thepixeldeveloper@icloud.com>
  */
-final class CountFunction extends FunctionNode
+final class CountFunction extends FunctionNode implements TypedExpression
 {
     /**
      * @var AggregateExpression
@@ -50,5 +52,10 @@ final class CountFunction extends FunctionNode
     public function parse(Parser $parser): void
     {
         $this->aggregateExpression = $parser->AggregateExpression();
+    }
+
+    public function getReturnType() : Type
+    {
+        return Type::getType(Type::INTEGER);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Query\AST\Node;
 /**
  * Abstract Function Node.
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>

--- a/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query\AST\Functions;
 
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Query\AST\TypedExpression;
 use Doctrine\ORM\Query\Lexer;
 
 /**
@@ -32,7 +34,7 @@ use Doctrine\ORM\Query\Lexer;
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Benjamin Eberlei <kontakt@beberlei.de>
  */
-class LengthFunction extends FunctionNode
+class LengthFunction extends FunctionNode implements TypedExpression
 {
     public $stringPrimary;
 
@@ -59,5 +61,10 @@ class LengthFunction extends FunctionNode
         $this->stringPrimary = $parser->StringPrimary();
 
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getReturnType() : Type
+    {
+        return Type::getType(Type::INTEGER);
     }
 }

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Query\Lexer;
 /**
  * "SQRT" "(" SimpleArithmeticExpression ")"
  *
- * 
+ *
  * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>

--- a/lib/Doctrine/ORM/Query/AST/TypedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/TypedExpression.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Query\AST;
+
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Provides an API for resolving the type of a Node
+ */
+interface TypedExpression
+{
+    public function getReturnType() : Type;
+}

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1339,10 +1339,20 @@ class SqlWalker implements TreeWalker
 
                 $this->scalarResultAliasMap[$resultAlias] = $columnAlias;
 
-                if ( ! $hidden) {
-                    // We cannot resolve field type here; assume 'string'.
-                    $this->rsm->addScalarResult($columnAlias, $resultAlias, 'string');
+                if ($hidden) {
+                    break;
                 }
+
+                if (! $expr instanceof Query\AST\TypedExpression) {
+                    // Conceptually we could resolve field type here by traverse through AST to retrieve field type,
+                    // but this is not a feasible solution; assume 'string'.
+                    $this->rsm->addScalarResult($columnAlias, $resultAlias, 'string');
+
+                    break;
+                }
+
+                $this->rsm->addScalarResult($columnAlias, $resultAlias, $expr->getReturnType()->getName());
+
                 break;
 
             case ($expr instanceof AST\Subselect):

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use function ltrim;
+use function strlen;
+
+/** @group GH7941 */
+final class GH7941Test extends OrmFunctionalTestCase
+{
+    private const PRODUCTS = [
+        ['name' => 'Test 1', 'price' => '100', 'square_root' => '/^10(\.0+)?$/'],
+        ['name' => 'Test 2', 'price' => '100', 'square_root' => '/^10(\.0+)?$/'],
+        ['name' => 'Test 3', 'price' => '100', 'square_root' => '/^10(\.0+)?$/'],
+        ['name' => 'Test 4', 'price' => '25', 'square_root' => '/^5(\.0+)?$/'],
+        ['name' => 'Test 5', 'price' => '25', 'square_root' => '/^5(\.0+)?$/'],
+        ['name' => 'Test 6', 'price' => '-25', 'square_root' => '/^5(\.0+)?$/'],
+    ];
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH7941Product::class]);
+
+        foreach (self::PRODUCTS as $product) {
+            $this->_em->persist(new GH7941Product($product['name'], $product['price']));
+        }
+
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    /** @test */
+    public function typesShouldBeConvertedForDQLFunctions() : void
+    {
+        $query = $this->_em->createQuery(
+            'SELECT
+                 COUNT(product.id) as count,
+                 SUM(product.price) as sales,
+                 AVG(product.price) as average
+             FROM ' . GH7941Product::class . ' product'
+        );
+
+        $result = $query->getSingleResult();
+
+        self::assertSame(6, $result['count']);
+        self::assertSame('325', $result['sales']);
+        self::assertRegExp('/^54\.16+7$/', $result['average']);
+
+        $query = $this->_em->createQuery(
+            'SELECT
+                 ABS(product.price) as absolute,
+                 SQRT(ABS(product.price)) as square_root,
+                 LENGTH(product.name) as length
+             FROM ' . GH7941Product::class . ' product'
+        );
+
+        foreach ($query->getResult() as $i => $item) {
+            $product = self::PRODUCTS[$i];
+
+            self::assertSame(ltrim($product['price'], '-'), $item['absolute']);
+            self::assertSame(strlen($product['name']), $item['length']);
+            self::assertRegExp($product['square_root'], $item['square_root']);
+        }
+    }
+}
+
+/**
+ * @Entity
+ * @Table()
+ */
+class GH7941Product
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /** @Column(type="string") */
+    public $name;
+
+    /** @Column(type="decimal") */
+    public $price;
+
+    /** @Column(type="datetime_immutable") */
+    public $createdAt;
+
+    public function __construct(string $name, string $price)
+    {
+        $this->name      = $name;
+        $this->price     = $price;
+        $this->createdAt = new DateTimeImmutable();
+    }
+}


### PR DESCRIPTION
Some functions have a predefined type and could be resolved correctly by the SQLWalker. I don't want to change things too much but it could be possible to do the same thing for other functions like SUM for instance that would be resolved to float.

This is the follow up of the #7641 PR (I won't delete it this time sorry for the inconvenience)