### PR TITLE
Add stage that runs before Test to allow fast failures on Sqlite/phpcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 sudo: false
 language: php
 
+stages:
+    - Smoke Testing
+    - Test
+    - Code Quality
+
 php:
   - 7.1
   - 7.2
@@ -27,6 +32,32 @@ script:
 
 jobs:
   include:
+    - stage: Smoke Testing
+      env: DB=sqlite
+
+    - stage: Smoke Testing
+      if: type = pull_request
+      env: DB=none PULL_REQUEST_CODING_STANDARDS
+      install: travis_retry composer install --prefer-dist
+      script:
+        - |
+          if [ $TRAVIS_BRANCH != "master" ]; then
+            git remote set-branches --add origin $TRAVIS_BRANCH;
+            git fetch origin $TRAVIS_BRANCH;
+          fi
+        - git merge-base origin/$TRAVIS_BRANCH $TRAVIS_PULL_REQUEST_SHA || git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge --unshallow
+        - wget https://github.com/diff-sniffer/git/releases/download/0.3.2/git-phpcs.phar
+        - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
+
+    - stage: Smoke Testing
+      env: DB=none STATIC_ANALYSIS
+      install: travis_retry composer install --prefer-dist
+      before_script:
+        - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
+      script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
+
     - stage: Test
       env: DB=mariadb
       addons:
@@ -86,15 +117,6 @@ jobs:
         - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
 
     - stage: Code Quality
-      env: DB=none STATIC_ANALYSIS
-      install: travis_retry composer install --prefer-dist
-      before_script:
-        - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
-      script: vendor/bin/phpstan analyse -l 1 -c phpstan.neon lib
-
-    - stage: Code Quality
       env: DB=none BENCHMARK
       before_script: wget https://phpbench.github.io/phpbench/phpbench.phar https://phpbench.github.io/phpbench/phpbench.phar.pubkey
       script: php phpbench.phar run -l dots --report=default
@@ -106,21 +128,6 @@ jobs:
       install: travis_retry composer install --prefer-dist
       script:
         - ./vendor/bin/phpcs
-
-    - stage: Code Quality
-      if: type = pull_request
-      env: DB=none PULL_REQUEST_CODING_STANDARDS
-      php: 7.1
-      install: travis_retry composer install --prefer-dist
-      script:
-        - |
-          if [ $TRAVIS_BRANCH != "master" ]; then
-            git remote set-branches --add origin $TRAVIS_BRANCH;
-            git fetch origin $TRAVIS_BRANCH;
-          fi
-        - git merge-base origin/$TRAVIS_BRANCH $TRAVIS_PULL_REQUEST_SHA || git fetch origin +refs/pull/$TRAVIS_PULL_REQUEST/merge --unshallow
-        - wget https://github.com/diff-sniffer/git/releases/download/0.2.0/git-phpcs.phar
-        - php git-phpcs.phar origin/$TRAVIS_BRANCH...$TRAVIS_PULL_REQUEST_SHA
 
   allow_failures:
     - php: nightly


### PR DESCRIPTION
Similar to how DBAL runs Smoke Testing stage, allows Travis exit early when failures existing either SQLite testsuite or Coding Standards as found by git-differ (not against whole codebase).