### PR TITLE
Ignore Doctrine\Common\Persistence\ObjectManagerDecorator deprecation

### DIFF
--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -28,6 +28,12 @@ class EntityManagerDecoratorTest extends TestCase
      */
     private $wrapped;
 
+    /** @before */
+    public function ignoreDeprecationMessagesFromDoctrinePersistence() : void
+    {
+        $this->ignoreDeprecationMessage('The Doctrine\Common\Persistence\ObjectManagerDecorator class is deprecated since doctrine/persistence 1.3 and will be removed in 2.0. Use \Doctrine\Persistence\ObjectManagerDecorator instead.');
+    }
+
     public function setUp()
     {
         $this->wrapped = $this->createMock(EntityManagerInterface::class);

--- a/tests/Doctrine/Tests/VerifyDeprecations.php
+++ b/tests/Doctrine/Tests/VerifyDeprecations.php
@@ -1,10 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests;
 
-use function set_error_handler;
 use const E_USER_DEPRECATED;
+use function in_array;
+use function set_error_handler;
 
 trait VerifyDeprecations
 {

--- a/tests/Doctrine/Tests/VerifyDeprecations.php
+++ b/tests/Doctrine/Tests/VerifyDeprecations.php
@@ -16,6 +16,9 @@ trait VerifyDeprecations
     /** @var string[] */
     private $actualDeprecations = [];
 
+    /** @var string[] */
+    private $ignoredDeprecations = [];
+
     /** @var callable|null */
     private $originalHandler;
 
@@ -24,9 +27,14 @@ trait VerifyDeprecations
     {
         $this->actualDeprecations   = [];
         $this->expectedDeprecations = [];
+        $this->ignoredDeprecations  = [];
 
         $this->originalHandler = set_error_handler(
             function (int $errorNumber, string $errorMessage) : void {
+                if (in_array($errorMessage, $this->ignoredDeprecations, true)) {
+                    return;
+                }
+
                 $this->actualDeprecations[] = $errorMessage;
             },
             E_USER_DEPRECATED
@@ -52,6 +60,11 @@ trait VerifyDeprecations
             $this->actualDeprecations,
             'Triggered deprecation messages do not match with expected ones.'
         );
+    }
+
+    protected function ignoreDeprecationMessage(string $message) : void
+    {
+        $this->ignoredDeprecations[] = $message;
     }
 
     protected function expectDeprecationMessage(string $message) : void


### PR DESCRIPTION
Since applying the fixes requires bumping up the dependency, which isn't done in a patch release.

This should be removed in v2.8.0.