### PR TITLE
Fix countBy inconsistency

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -158,6 +158,11 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function count(array $criteria)
     {
+        return $this->countBy($criteria);
+    }
+    
+    public function countBy(array $criteria)
+    {
         return $this->em->getUnitOfWork()->getEntityPersister($this->entityName)->count($criteria);
     }
 


### PR DESCRIPTION
Currently if you use something like `$repo->countBy(['visible' => true])` you'll get inarticulate error, but `$repo->findBy(['visible' => true])` will work fine. After investigation you'll find that method should named `count` not `countBy`
It is weird