### PR TITLE
Private is not necessary

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -112,6 +112,11 @@ abstract class SQLFilter
         return serialize($this->parameters);
     }
 
+    final protected function getEntityManager() : EntityManagerInterface
+    {
+        return $this->em;
+    }
+
     /**
      * Returns the database connection used by the entity manager
      *


### PR DESCRIPTION
There is no reason for the EntityManager to not be accessible within filters.  It causes extension writers to do code gymnastics to get the EntityManager.

Example:
https://github.com/Atlantic18/DoctrineExtensions/blob/master/src/SoftDeleteable/Filter/SoftDeleteableFilter.php