### PR TITLE
Throw LogicException if region is tried to use for READ_WRITE

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -196,7 +196,14 @@ class DefaultCacheFactory implements CacheFactory
     public function getRegion(array $cache)
     {
         if (isset($this->regions[$cache['region']])) {
-            return $this->regions[$cache['region']];
+            $region = $this->regions[$cache['region']];
+            if ($cache['usage'] === ClassMetadata::CACHE_USAGE_READ_WRITE &&
+                !($region instanceof ConcurrentRegion)
+            ) {
+                throw new \LogicException('If you want to use a "READ_WRITE" cache an implementation of "Doctrine\ORM\Cache\ConcurrentRegion" is required');
+            }
+
+            return $region;
         }
 
         $name         = $cache['region'];


### PR DESCRIPTION
Proposing patch: Throw LogicException if region is tried to use for READ_WRITE while implementation doesn't implement ConcurrentRegion.

This PR is missing Tests as this is draft. I will be adding them later, if this is approved approach to handle this case.