### PR TITLE
Fix issues detected by psalm on 2.7

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -442,6 +442,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
+     * @psalm-return ?class-string
      */
     public function getCustomStringFunction($name)
     {
@@ -494,6 +495,7 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
+     * @psalm-return ?class-string
      */
     public function getCustomNumericFunction($name)
     {
@@ -534,6 +536,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string|callable $className Class name or a callable that returns the function.
      *
      * @return void
+     *
+     * @psalm-param class-string|callable $className
      */
     public function addCustomDatetimeFunction($name, $className)
     {
@@ -546,6 +550,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
+     *
+     * @psalm-return ?class-string $name
      */
     public function getCustomDatetimeFunction($name)
     {
@@ -567,6 +573,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param array $functions The map of custom DQL date/time functions.
      *
      * @return void
+     *
+     * @psalm-param array<string, string> $functions
      */
     public function setCustomDatetimeFunctions(array $functions)
     {
@@ -597,6 +605,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $modeName The hydration mode name.
      *
      * @return string|null The hydrator class name.
+     *
+     * @psalm-return ?class-string
      */
     public function getCustomHydrationMode($modeName)
     {
@@ -624,6 +634,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $cmfName
      *
      * @return void
+     *
+     * @psalm-param class-string $cmfName
      */
     public function setClassMetadataFactoryName($cmfName)
     {
@@ -632,6 +644,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /**
      * @return string
+     *
+     * @psalm-return class-string
      */
     public function getClassMetadataFactoryName()
     {
@@ -658,8 +672,10 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name The name of the filter.
      *
-     * @return string The class name of the filter, or null if it is not
+     * @return string|null The class name of the filter, or null if it is not
      *  defined.
+     *
+     * @psalm-return ?class-string
      */
     public function getFilterClassName($name)
     {
@@ -696,6 +712,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @since 2.2
      *
      * @return string
+     *
+     * @psalm-return class-string
      */
     public function getDefaultRepositoryClassName()
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -252,7 +252,8 @@ class ClassMetadataInfo implements ClassMetadata
      * The name of the custom repository class used for the entity class.
      * (Optional).
      *
-     * @var string
+     * @var string|null
+     * @psalm-var ?class-string
      */
     public $customRepositoryClassName;
 
@@ -2626,6 +2627,8 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $repositoryClassName The class name of the custom mapper.
      *
      * @return void
+     *
+     * @psalm-param class-string $repositoryClassName
      */
     public function setCustomRepositoryClass($repositoryClassName)
     {
@@ -3254,6 +3257,8 @@ class ClassMetadataInfo implements ClassMetadata
      * @param  string|null $className
      *
      * @return string|null null if the input value is null
+     *
+     * @psalm-param ?class-string $className
      */
     public function fullyQualifiedClassName($className)
     {

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -30,6 +30,8 @@ class DefaultEntityListenerResolver implements EntityListenerResolver
 {
     /**
      * @var array Map to store entity listener instances.
+     *
+     * @psalm-var array<class-string, object>
      */
     private $instances = [];
 

--- a/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
@@ -34,6 +34,8 @@ interface EntityListenerResolver
      * @param string $className The fully-qualified class name
      *
      * @return void
+     *
+     * @psalm-param class-string $className
      */
     function clear($className = null);
 
@@ -43,6 +45,8 @@ interface EntityListenerResolver
      * @param string $className The fully-qualified class name
      *
      * @return object An entity listener
+     *
+     * @psalm-param class-string $className
      */
     function resolve($className);
 

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -20,6 +20,7 @@
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
+use function assert;
 
 /**
  * Collection class for all the query filters.
@@ -109,6 +110,8 @@ class FilterCollection
 
         if ( ! $this->isEnabled($name)) {
             $filterClass = $this->config->getFilterClassName($name);
+
+            assert($filterClass !== null);
 
             $this->enabledFilters[$name] = new $filterClass($this->em);
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -42,6 +42,8 @@ class Parser
      * READ-ONLY: Maps BUILT-IN string function names to AST class names.
      *
      * @var array
+     *
+     * @psalm-var class-string<Functions\FunctionNode>
      */
     private static $_STRING_FUNCTIONS = [
         'concat'    => Functions\ConcatFunction::class,
@@ -56,6 +58,8 @@ class Parser
      * READ-ONLY: Maps BUILT-IN numeric function names to AST class names.
      *
      * @var array
+     *
+     * @psalm-var class-string<Functions\FunctionNode>
      */
     private static $_NUMERIC_FUNCTIONS = [
         'length'    => Functions\LengthFunction::class,
@@ -80,6 +84,8 @@ class Parser
      * READ-ONLY: Maps BUILT-IN datetime function names to AST class names.
      *
      * @var array
+     *
+     * @psalm-var class-string<Functions\FunctionNode>
      */
     private static $_DATETIME_FUNCTIONS = [
         'current_date'      => Functions\CurrentDateFunction::class,

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -142,6 +142,8 @@ class SqlWalker implements TreeWalker
      * Map of all components/classes that appear in the DQL query.
      *
      * @var array
+     *
+     * @psalm-var array<string, array{metadata: ClassMetadata}>
      */
     private $queryComponents;
 
@@ -199,7 +201,7 @@ class SqlWalker implements TreeWalker
     /**
      * Gets the Query instance used by the walker.
      *
-     * @return Query.
+     * @return Query
      */
     public function getQuery()
     {
@@ -232,6 +234,8 @@ class SqlWalker implements TreeWalker
      * @param string $dqlAlias The DQL alias.
      *
      * @return array
+     *
+     * @psalm-return array{metadata: ClassMetadata}
      */
     public function getQueryComponent($dqlAlias)
     {
@@ -1522,7 +1526,7 @@ class SqlWalker implements TreeWalker
     /**
      * @param \Doctrine\ORM\Query\AST\ParenthesisExpression $parenthesisExpression
      *
-     * @return string.
+     * @return string
      */
     public function walkParenthesisExpression(AST\ParenthesisExpression $parenthesisExpression)
     {

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Tools\Console;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+
 /**
  * Used by CLI Tools to restrict entity-based commands to given patterns.
  *
@@ -40,10 +42,10 @@ class MetadataFilter extends \FilterIterator implements \Countable
     /**
      * Filter Metadatas by one or more filter options.
      *
-     * @param array        $metadatas
-     * @param array|string $filter
+     * @param ClassMetadata[] $metadatas
+     * @param string[]|string $filter
      *
-     * @return array
+     * @return ClassMetadata[]
      */
     static public function filter(array $metadatas, $filter)
     {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -149,7 +149,7 @@ class EntityGenerator
     /**
      * Whether or not to make generated embeddables immutable.
      *
-     * @var boolean.
+     * @var bool
      */
     protected $embeddablesImmutable = false;
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1893,7 +1893,7 @@ class UnitOfWork implements PropertyChangedListener
      * @param object      $entity
      * @param array       $visited
      * @param object|null $prevManagedCopy
-     * @param array|null  $assoc
+     * @param string[]    $assoc
      *
      * @return object The managed copy of the entity.
      *


### PR DESCRIPTION
This PR is basically #7986 but targetted on 2.8 as suggested.

I'll copy the text from there:

> Hi,
> 
> This PR is the result of fixing easy issues from the two first levels of Psalm.
> 
> This is the starting point of trying to begin #7762. If this goes smoothly, my goal is to continue fixing errors by slowly increasing the Psalm's levels. Eventually, the idea would be to add Psalm to the CI and to add template annotation to interfaces and exposed classes to help tools like phpstan and psalm understand Doctrine without the need of stubs or plugins.
> 
> I'm always trying to learn so don't hesitate to ask for changes or anything!
> 
> Thanks!

I didn't expect such difference between master and 2.8! Great job guys, I can't wait for future versions!

It seems that the CI is broken on 2.8. I tried to run phpcbf locally but there are massive changes, I didn't dare apply them here, so there may be some CS errors. If the CI is fixed and the errors are still there in the future, I'll correct them.

I'll close #7986, some changes there were specific to the master branch due to code movements but let's fix that later.