### PR TITLE
Update setParameters to conform to DocBlock for PHP 7.4

### DIFF
--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -265,7 +265,7 @@ following syntax:
     // $qb instanceof QueryBuilder
 
     // Query here...
-    $qb->setParameters(array(1 => 'value for ?1', 2 => 'value for ?2'));
+    $qb->setParameters(new ArrayCollection(array(1 => 'value for ?1', 2 => 'value for ?2')));
 
 Getting already bound parameters is easy - simply use the above
 mentioned syntax with "getParameter()" or "getParameters()":


### PR DESCRIPTION
The `setParameters` method accepts `* @param ArrayCollection|mixed[] $parameters` and as such the `array` is no longer a valid type as of `2.7.0`