### PR TITLE
Change DocBlock to be compatible with PHPStan

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -336,7 +336,7 @@ abstract class AbstractQuery
     /**
      * Sets a collection of query parameters.
      *
-     * @param ArrayCollection|mixed[] $parameters
+     * @param ArrayCollection|array<mixed> $parameters
      *
      * @return static This query instance.
      */


### PR DESCRIPTION
The current ArrayCollection|mixed[] DocBlock causes PHPStan to fail the current behaviour of
passing an array on setParameters()

Related issue: https://github.com/doctrine/orm/pull/7994