### PR TITLE
Update Interface ObjectRepository newer Namespace

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Inflector\Inflector;
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Repository\Exception\InvalidMagicMethodCall;


### PR DESCRIPTION
The class `Doctrine\ORM\EntityRepository` implements `Doctrine\Common\Persistence\ObjectRepository` which itself is deprecated already since version 1.3 as its namespace changed. The interface itself hasn't changed and is emulated by providing a class alias to its new namespaced version at `\Doctrine\Persistence\ObjectRepository`.

This makes type hinting with the new interface not possible. Therefore, and because its original namespace has been deprecated for quite some time, `Doctrine\ORM\EntityRepository` should be used.