### PR TITLE
Make Embeddable not transient

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -44,6 +44,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
     protected $entityAnnotationClasses = [
         Mapping\Entity::class => 1,
         Mapping\MappedSuperclass::class => 2,
+        Mapping\Embeddable::class => 3,
     ];
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -328,6 +328,11 @@ class ValueObjectsTest extends OrmFunctionalTestCase
             ['DDCNestingEmbeddable1', 'DDCNestingEmbeddable4'],
         ];
     }
+
+    public function testEmbeddableIsNotTransient()
+    {
+        $this->assertFalse($this->_em->getMetadataFactory()->isTransient(DDC93Address::class));
+    }
 }
 
 


### PR DESCRIPTION
I believe this was an oversight during original implementation but let's see what tests will tell us. Also this made PHPStan ignore Embeddables (https://github.com/phpstan/phpstan-doctrine/pull/108#pullrequestreview-349722039)