### PR TITLE
Put into cache using root entity name

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -279,12 +279,12 @@ class DefaultQueryCache implements QueryCache
 
         $region = $persister->getCacheRegion();
 
-        $cm             = $this->em->getClassMetadata($entityName);
-        $rootEntityName = $cm->getMetadataValue('rootEntityName');
+        $cm = $this->em->getClassMetadata($entityName);
+        assert($cm instanceof ClassMetadata);
 
         foreach ($result as $index => $entity) {
             $identifier = $this->uow->getEntityIdentifier($entity);
-            $entityKey  = new EntityCacheKey($rootEntityName, $identifier);
+            $entityKey  = new EntityCacheKey($cm->rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -279,11 +279,12 @@ class DefaultQueryCache implements QueryCache
 
         $region = $persister->getCacheRegion();
 
-        $cm = $this->em->getClassMetadata($entityName);
+        $cm             = $this->em->getClassMetadata($entityName);
+        $rootEntityName = $cm->getMetadataValue('rootEntityName');
 
         foreach ($result as $index => $entity) {
-            $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey  = new EntityCacheKey($cm->getMetadataValue('rootEntityName'), $identifier);
+            $identifier = $this->uow->getEntityIdentifier($entity);
+            $entityKey  = new EntityCacheKey($rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -279,9 +279,11 @@ class DefaultQueryCache implements QueryCache
 
         $region = $persister->getCacheRegion();
 
+        $cm = $this->em->getClassMetadata($entityName);
+
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey                      = new EntityCacheKey($entityName, $identifier);
+            $entityKey                      = new EntityCacheKey($cm->rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -283,7 +283,7 @@ class DefaultQueryCache implements QueryCache
 
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey  = new EntityCacheKey($cm->rootEntityName, $identifier);
+            $entityKey  = new EntityCacheKey($cm->getMetadataValue('rootEntityName'), $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -283,7 +283,7 @@ class DefaultQueryCache implements QueryCache
 
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey                      = new EntityCacheKey($cm->rootEntityName, $identifier);
+            $entityKey = new EntityCacheKey($cm->rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -283,7 +283,7 @@ class DefaultQueryCache implements QueryCache
 
         foreach ($result as $index => $entity) {
             $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey = new EntityCacheKey($cm->rootEntityName, $identifier);
+            $entityKey  = new EntityCacheKey($cm->rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
 
 class DDC7969Test extends SecondLevelCacheAbstractTest
 {
-    public function testChildEntityRetrievedFromCache()
+    public function testChildEntityRetrievedFromCache(): void
     {
         $this->loadFixturesCountries();
         $this->loadFixturesStates();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\Cache\Attraction;
+use Doctrine\Tests\Models\Cache\Bar;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+
+class DDC7969Test extends SecondLevelCacheAbstractTest
+{
+    public function testChildEntityRetrievedFromCache()
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+
+        // Entities are already cached due to fixtures - hence flush before testing
+        $this->cache->getEntityCacheRegion(Attraction::class)->getCache()->flushAll();
+
+        /** @var Bar $bar */
+        $bar = $this->attractions[0];
+
+        $repository = $this->_em->getRepository(Bar::class);
+
+        $this->assertFalse($this->cache->containsEntity(Bar::class, $bar->getId()));
+
+        $repository->findOneBy([
+            'name' => $bar->getName(),
+        ]);
+
+        $this->assertTrue($this->cache->containsEntity(Bar::class, $bar->getId()));
+
+        $repository->findOneBy([
+            'name' => $bar->getName(),
+        ]);
+
+        // One hit for entity cache, one hit for query cache
+        $this->assertEquals(2, $this->secondLevelCacheLogger->getHitCount());
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -11,7 +11,7 @@ use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
 
 class DDC7969Test extends SecondLevelCacheAbstractTest
 {
-    public function testChildEntityRetrievedFromCache(): void
+    public function testChildEntityRetrievedFromCache() : void
     {
         $this->loadFixturesCountries();
         $this->loadFixturesStates();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\Models\Cache\Attraction;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -31,6 +31,7 @@ class DDC7969Test extends SecondLevelCacheAbstractTest
         $repository = $this->_em->getRepository(Bar::class);
 
         $this->assertFalse($this->cache->containsEntity(Bar::class, $bar->getId()));
+        $this->assertFalse($this->cache->containsEntity(Attraction::class, $bar->getId()));
 
         $repository->findOneBy([
             'name' => $bar->getName(),

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\Cache\Region\DefaultMultiGetRegion;
 use Doctrine\Tests\Models\Cache\Attraction;
 use Doctrine\Tests\Models\Cache\Bar;
 use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
@@ -18,7 +19,11 @@ class DDC7969Test extends SecondLevelCacheAbstractTest
         $this->loadFixturesAttractions();
 
         // Entities are already cached due to fixtures - hence flush before testing
-        $this->cache->getEntityCacheRegion(Attraction::class)->getCache()->flushAll();
+        $region = $this->cache->getEntityCacheRegion(Attraction::class);
+
+        if ($region instanceof DefaultMultiGetRegion) {
+            $region->getCache()->flushAll();
+        }
 
         /** @var Bar $bar */
         $bar = $this->attractions[0];


### PR DESCRIPTION
The cache key for reading is created based on the entity root name but the cache was written with a key based on the found entity (the child in this case) resulting in cache miss.

Using the same root name when putting fixes the issue. I do believe that any extending instances should have unique identifiers as they will have to share an identifier from the base class. This will mean the key won't be ambiguous - if my thinking is correct.

https://github.com/doctrine/orm/issues/7969