### PR TITLE
Added check for empty SELECT expression

### DIFF
--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -250,4 +250,25 @@ class QueryException extends LogicException implements ORMException
             "requires 'metadata', 'parent', 'relation', 'map', 'nestingLevel' and 'token' keys."
         );
     }
+
+    public static function missingSelectExpression(): QueryException
+    {
+        return new self(
+            'SELECT expression is required for building DQL'
+        );
+    }
+
+    public static function noAliasesBeforeInvokingCriteria(): QueryException
+    {
+        return new self(
+            'No aliases are set before invoking addCriteria().'
+        );
+    }
+
+    public static function specifiedRootAliasMustBeSetBeforeInvokingIndexBy($dqlAlias): QueryException
+    {
+        return new self(
+            sprintf('Specified root alias %s must be set before invoking indexBy().', $dqlAlias)
+        );
+    }
 }

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -251,21 +251,21 @@ class QueryException extends LogicException implements ORMException
         );
     }
 
-    public static function missingSelectExpression(): QueryException
+    public static function missingSelectExpression() : QueryException
     {
         return new self(
             'SELECT expression is required for building DQL'
         );
     }
 
-    public static function noAliasesBeforeInvokingCriteria(): QueryException
+    public static function noAliasesBeforeInvokingCriteria() : QueryException
     {
         return new self(
             'No aliases are set before invoking addCriteria().'
         );
     }
 
-    public static function specifiedRootAliasMustBeSetBeforeInvokingIndexBy($dqlAlias): QueryException
+    public static function specifiedRootAliasMustBeSetBeforeInvokingIndexBy($dqlAlias) : QueryException
     {
         return new self(
             sprintf('Specified root alias %s must be set before invoking indexBy().', $dqlAlias)

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\QueryExpressionVisitor;
 use InvalidArgumentException;
 use RuntimeException;
@@ -893,16 +894,14 @@ class QueryBuilder
      *
      * @return self
      *
-     * @throws Query\QueryException
+     * @throws QueryException
      */
     public function indexBy($alias, $indexBy)
     {
         $rootAliases = $this->getRootAliases();
 
         if (! in_array($alias, $rootAliases, true)) {
-            throw new Query\QueryException(
-                sprintf('Specified root alias %s must be set before invoking indexBy().', $alias)
-            );
+            throw QueryException::specifiedRootAliasMustBeSetBeforeInvokingIndexBy($alias);
         }
 
         foreach ($this->dqlParts['from'] as &$fromClause) {
@@ -1272,13 +1271,13 @@ class QueryBuilder
      *
      * @return self
      *
-     * @throws Query\QueryException
+     * @throws QueryException
      */
     public function addCriteria(Criteria $criteria)
     {
         $allAliases = $this->getAllAliases();
         if (! isset($allAliases[0])) {
-            throw new Query\QueryException('No aliases are set before invoking addCriteria().');
+            throw QueryException::noAliasesBeforeInvokingCriteria();
         }
 
         $visitor         = new QueryExpressionVisitor($this->getAllAliases());
@@ -1377,7 +1376,7 @@ class QueryBuilder
     {
         $selectPart = $this->getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
         if (! $selectPart) {
-            throw new Query\QueryException('SELECT expression is required for building DQL');
+            throw QueryException::missingSelectExpression();
         }
 
         $dql = 'SELECT' . ($this->dqlParts['distinct']===true ? ' DISTINCT' : '') . $selectPart;

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1376,7 +1376,7 @@ class QueryBuilder
     private function getDQLForSelect()
     {
         $selectPart = $this->getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
-        if (!$selectPart) {
+        if (! $selectPart) {
             throw new Query\QueryException('SELECT expression is required for building DQL');
         }
 

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -24,7 +24,6 @@ use function is_object;
 use function is_string;
 use function key;
 use function reset;
-use function sprintf;
 use function strpos;
 use function strrpos;
 use function substr;

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1375,9 +1375,12 @@ class QueryBuilder
      */
     private function getDQLForSelect()
     {
-        $dql = 'SELECT'
-             . ($this->dqlParts['distinct']===true ? ' DISTINCT' : '')
-             . $this->getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
+        $selectPart = $this->getReducedDQLQueryPart('select', ['pre' => ' ', 'separator' => ', ']);
+        if (!$selectPart) {
+            throw new Query\QueryException('SELECT expression is required for building DQL');
+        }
+
+        $dql = 'SELECT' . ($this->dqlParts['distinct']===true ? ' DISTINCT' : '') . $selectPart;
 
         $fromParts   = $this->getDQLPart('from');
         $joinParts   = $this->getDQLPart('join');

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Cache;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ParameterTypeInferer;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Models\Cache\State;
@@ -77,6 +78,29 @@ class QueryBuilderTest extends OrmTestCase
             ->update();
 
         self::assertEquals($qb->getType(), QueryBuilder::UPDATE);
+    }
+
+    public function testRequiredSelectExpr() : void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('SELECT expression is required for building DQL');
+
+        $qb = $this->em->createQueryBuilder()
+            ->from(CmsUser::class, 'u');
+
+        $qb->getDQL();
+    }
+
+    public function testRequiredSelectDistinctExpr() : void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('SELECT expression is required for building DQL');
+
+        $qb = $this->em->createQueryBuilder()
+            ->distinct()
+            ->from(CmsUser::class, 'u');
+
+        $qb->getDQL();
     }
 
     public function testSimpleSelect() : void


### PR DESCRIPTION
While working on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/938 noticed that it's possible to generate DQL (eventually a SQL) with an empty SELECT expression which should not be possible 