### PR TITLE
Bug/#8011 ordering with arithmetic expression

### DIFF
--- a/src/Query/Parser.php
+++ b/src/Query/Parser.php
@@ -1554,7 +1554,7 @@ class Parser
 
         assert($this->lexer->lookahead !== null);
         switch (true) {
-            case $this->isMathOperator($peek):
+            case $this->isMathOperator($peek) || $this->isMathOperator($glimpse):
                 $expr = $this->SimpleArithmeticExpression();
                 break;
 

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -22,16 +22,102 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->generateFixture();
     }
 
-    public function testOrderWithArithmeticExpression()
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpression()
     {
-        $dql = 'SELECT p, ' .
-            '(SELECT SUM(p2.salary) FROM Doctrine\Tests\Models\Company\CompanyEmployee p2 WHERE p2.department = p.department) AS HIDDEN s ' .
+        $dql = 'SELECT p ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY s + s DESC';
+            'ORDER BY p.id + p.id ASC';
 
+        /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
 
         $this->assertEquals(2, count($result));
+        $this->assertEquals('Benjamin E.', $result[0]->getName());
+        $this->assertEquals('Guilherme B.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression()
+    {
+        $dql = 'SELECT p ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY 1 + p.id ASC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Benjamin E.', $result[0]->getName());
+        $this->assertEquals('Guilherme B.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndLiteral()
+    {
+        $dql = 'SELECT p ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY p.id + 1 ASC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Benjamin E.', $result[0]->getName());
+        $this->assertEquals('Guilherme B.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY s + 1 DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY 1 + s DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY s + p.id DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndResultVariable()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY p.id + s DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
     public function generateFixture()

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\Company\CompanyEmployee;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * Functional tests for ordering with arithmetic expression.
+ *
+ * @group GH8011
+ */
+class GH8011Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->useModelSet('company');
+        parent::setUp();
+
+        $this->generateFixture();
+    }
+
+    public function testOrderWithArithmeticExpression()
+    {
+        $dql = 'SELECT p, ' .
+            '(SELECT SUM(p2.salary) FROM Doctrine\Tests\Models\Company\CompanyEmployee p2 WHERE p2.department = p.department) AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY s + s DESC';
+
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+    }
+
+    public function generateFixture()
+    {
+        $person1 = new CompanyEmployee();
+        $person1->setName('Benjamin E.');
+        $person1->setDepartment('IT');
+        $person1->setSalary(200000);
+
+        $person2 = new CompanyEmployee();
+        $person2->setName('Guilherme B.');
+        $person2->setDepartment('IT2');
+        $person2->setSalary(400000);
+
+        $this->_em->persist($person1);
+        $this->_em->persist($person2);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -50,6 +50,20 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Guilherme B.', $result[1]->getName());
     }
 
+    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression2()
+    {
+        $dql = 'SELECT p ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY ((1 + p.id)) ASC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Benjamin E.', $result[0]->getName());
+        $this->assertEquals('Guilherme B.', $result[1]->getName());
+    }
+
     public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndLiteral()
     {
         $dql = 'SELECT p ' .
@@ -78,6 +92,20 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
+    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral2()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY ((s + 1)) DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
     public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable()
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
@@ -92,11 +120,39 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
+    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable2()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY ((1 + s)) DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
     public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression()
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
             'ORDER BY s + p.id DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression2()
+    {
+        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
+            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+            'ORDER BY ((s + p.id)) DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmFunctionalTestCase;
-
 use function count;
 
 /**
@@ -25,11 +25,21 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->generateFixture();
     }
 
+    private function skipIfPostgres(string $test): void
+    {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+        if ($platform instanceof PostgreSQLPlatform) {
+            self::markTestSkipped(
+                'The ' . $test . ' test does not work on postgresql (see https://github.com/doctrine/orm/pull/8012).'
+            );
+        }
+    }
+
     public function testOrderWithArithmeticExpressionWithSingleValuedPathExpression(): void
     {
         $dql = 'SELECT p ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY p.id + p.id ASC';
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY p.id + p.id ASC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -42,8 +52,8 @@ class GH8011Test extends OrmFunctionalTestCase
     public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression(): void
     {
         $dql = 'SELECT p ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY 1 + p.id ASC';
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY 1 + p.id ASC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -56,8 +66,8 @@ class GH8011Test extends OrmFunctionalTestCase
     public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression2(): void
     {
         $dql = 'SELECT p ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY ((1 + p.id)) ASC';
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY ((1 + p.id)) ASC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -70,8 +80,8 @@ class GH8011Test extends OrmFunctionalTestCase
     public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndLiteral(): void
     {
         $dql = 'SELECT p ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY p.id + 1 ASC';
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY p.id + 1 ASC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -83,9 +93,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY s + 1 DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY s + 1 DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -97,9 +109,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral2(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY ((s + 1)) DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY ((s + 1)) DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -111,9 +125,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY 1 + s DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY 1 + s DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -125,9 +141,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable2(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY ((1 + s)) DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY ((1 + s)) DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -139,9 +157,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY s + p.id DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY s + p.id DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -153,9 +173,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression2(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY ((s + p.id)) DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY ((s + p.id)) DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();
@@ -167,9 +189,11 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndResultVariable(): void
     {
-        $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
-            'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
-            'ORDER BY p.id + s DESC';
+        $this->skipIfPostgres(__FUNCTION__);
+
+        $dql = 'SELECT p, p.salary AS HIDDEN s ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY p.id + s DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -206,7 +206,7 @@ class GH8011Test extends OrmFunctionalTestCase
 
     public function testOrderWithArithmeticExpressionWithLiteralAndResultVariableUsingHiddenResultVariable(): void
     {
-        $dql = 'SELECT p, p.salary AS HIDDEN s, 1 + s AS HIDDEN _order ' .
+        $dql = 'SELECT p, 1 + p.salary AS HIDDEN _order ' .
                'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
                'ORDER BY _order DESC';
 

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -7,6 +7,8 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function count;
+
 /**
  * Functional tests for ordering with arithmetic expression.
  *
@@ -14,15 +16,16 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class GH8011Test extends OrmFunctionalTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->useModelSet('company');
+        
         parent::setUp();
 
         $this->generateFixture();
     }
 
-    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpression()
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpression(): void
     {
         $dql = 'SELECT p ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -36,7 +39,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Guilherme B.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression()
+    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression(): void
     {
         $dql = 'SELECT p ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -50,7 +53,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Guilherme B.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression2()
+    public function testOrderWithArithmeticExpressionWithLiteralAndSingleValuedPathExpression2(): void
     {
         $dql = 'SELECT p ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -64,7 +67,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Guilherme B.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndLiteral()
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndLiteral(): void
     {
         $dql = 'SELECT p ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -78,7 +81,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Guilherme B.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral()
+    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -92,7 +95,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral2()
+    public function testOrderWithArithmeticExpressionWithResultVariableAndLiteral2(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -106,7 +109,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable()
+    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -120,7 +123,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable2()
+    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariable2(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -134,7 +137,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression()
+    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -148,7 +151,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression2()
+    public function testOrderWithArithmeticExpressionWithResultVariableAndSingleValuedPathExpression2(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -162,7 +165,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndResultVariable()
+    public function testOrderWithArithmeticExpressionWithSingleValuedPathExpressionAndResultVariable(): void
     {
         $dql = 'SELECT p,  p.salary AS HIDDEN s ' .
             'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
@@ -176,7 +179,7 @@ class GH8011Test extends OrmFunctionalTestCase
         $this->assertEquals('Benjamin E.', $result[1]->getName());
     }
 
-    public function generateFixture()
+    public function generateFixture(): void
     {
         $person1 = new CompanyEmployee();
         $person1->setName('Benjamin E.');

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmFunctionalTestCase;
-
 use function count;
 
 /**
@@ -195,6 +194,20 @@ class GH8011Test extends OrmFunctionalTestCase
         $dql = 'SELECT p, p.salary AS HIDDEN s ' .
                'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
                'ORDER BY p.id + s DESC';
+
+        /** @var CompanyEmployee[] $result */
+        $result = $this->_em->createQuery($dql)->getResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('Guilherme B.', $result[0]->getName());
+        $this->assertEquals('Benjamin E.', $result[1]->getName());
+    }
+
+    public function testOrderWithArithmeticExpressionWithLiteralAndResultVariableUsingHiddenResultVariable(): void
+    {
+        $dql = 'SELECT p, p.salary AS HIDDEN s, 1 + s AS HIDDEN _order ' .
+               'FROM Doctrine\Tests\Models\Company\CompanyEmployee p ' .
+               'ORDER BY _order DESC';
 
         /** @var CompanyEmployee[] $result */
         $result = $this->_em->createQuery($dql)->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -19,7 +19,7 @@ class GH8011Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         $this->useModelSet('company');
-        
+
         parent::setUp();
 
         $this->generateFixture();

--- a/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8011Test.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\Tests\Models\Company\CompanyEmployee;
 use Doctrine\Tests\OrmFunctionalTestCase;
+
 use function count;
 
 /**


### PR DESCRIPTION
This is the PR requested for issue #8011.

It includes tests for some arithmetic expressions being used in `ORDER BY` clauses of a DQL query.

- `ORDER BY p.id + p.id ASC ` ✅
- `ORDER BY 1 + p.id ASC` 🚫
- `ORDER BY p.id + 1 ASC` ✅
- `ORDER BY s + 1 DESC` 🚫 (where `s` is a `ResultVariable`)
- `ORDER BY 1 + s DESC` 🚫 (where `s` is a `ResultVariable`)
- `ORDER BY s + p.id DESC` 🚫 (where `s` is a `ResultVariable`)
- `ORDER BY p.id + s DESC` ✅ (where `s` is a `ResultVariable`)