### PR TITLE
[FIX] Add custom exception for parameters parsing

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -218,7 +218,10 @@ final class Query extends AbstractQuery
         $types = [];
 
         foreach ($this->parameters as $parameter) {
-            /** @var Query\Parameter $parameter */
+            if (!$parameter instanceof Parameter) {
+                throw new QueryException('Set parameter must be instance of \Doctrine\ORM\Query\Parameter');
+            }
+
             $types[$parameter->getName()] = $parameter->getType();
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -64,6 +64,19 @@ class QueryTest extends OrmTestCase
         self::assertEquals($parameters, $query->getParameters());
     }
 
+    public function testSetParametersWithInvalidSignature() : void
+    {
+        $query = $this->em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1');
+
+        $parameters = new ArrayCollection(['key' => 'value']);
+
+        $query->setParameters($parameters);
+
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Set parameter must be instance of \Doctrine\ORM\Query\Parameter');
+        $query->getSQL();
+    }
+
     public function testFree() : void
     {
         $query = $this->em->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1');

--- a/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/QueryBuilderTest.php
@@ -662,6 +662,23 @@ class QueryBuilderTest extends OrmTestCase
         self::assertEquals($parameters->first(), $qb->getParameter('id'));
     }
 
+    public function testSetParametersWithInvalidSignature() : void
+    {
+        $qb = $this->em->createQueryBuilder()
+            ->select('u')
+            ->from(CmsUser::class, 'u')
+            ->where('u.id = :id');
+
+        $parameters = new ArrayCollection(['key' => 'value']);
+
+        $qb->setParameters($parameters);
+
+        $this->expectException(Query\QueryException::class);
+        $this->expectExceptionMessage('Set parameter must be instance of \Doctrine\ORM\Query\Parameter');
+
+        $qb->getQuery()->getSQL();
+    }
+
     public function testMultipleWhere() : void
     {
         $qb = $this->em->createQueryBuilder()


### PR DESCRIPTION
Simple reproduce example

```php
$qb->
    ...
    ->setParameters(new ArrayCollection([
        'key' => 'value',
    ])
;
```

We will catch not semantic exception `Error: Call to a member function getName() on string`.
This exception will correctly give information about valid data