### PR TITLE
Ignore non-nullable typed property for Embeddable when hydrating

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -96,6 +96,8 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
             $this->parentProperty->setValue($object, $embeddedObject);
         }
 
-        $this->childProperty->setValue($embeddedObject, $value);
+        if (null !== $value || null === $this->childProperty->getType() || true === $this->childProperty->getType()->allowsNull()) {
+            $this->childProperty->setValue($embeddedObject, $value);
+        }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8014Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8014Test.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\Test\ORM\Functional\Ticket;
+
+use DateTimeImmutable;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+final class GH8014Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (PHP_VERSION_ID >= 70400) {
+            $this->_schemaTool->createSchema(
+                [
+                    $this->_em->getClassMetadata(GH8014Foo::class),
+                ]
+            );
+        }
+    }
+
+    public function testNonNullablePropertyOfEmbeddableCanBeHydratedWithNullValueInDatabase()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            self::markTestSkipped('This test only applies to PHP versions higher than 7.4');
+
+            return;
+        }
+
+        $foo = $this->createEntityWithoutTheNullablePropertySet();
+        $foo = $this->_em->find(
+            GH8014Foo::class,
+            $foo->id
+        ); // Used to throw "Typed property Doctrine\Test\ORM\Functional\Ticket\GH8014Bar::$startDate must be an instance of DateTimeImmutable, null used"
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Typed property Doctrine\Test\ORM\Functional\Ticket\GH8014Bar::$startDate must not be accessed before initialization');
+        $foo->bar->startDate;
+
+        $foo = $this->createEntityWithTheNullablePropertySet();
+        $foo = $this->_em->find(GH8014Foo::class, $foo->id);
+
+        $this->assertNotNull($foo->bar->startDate);
+    }
+
+    private function createEntityWithoutTheNullablePropertySet(): GH8014Foo
+    {
+        $foo = new GH8014Foo();
+        $this->_em->persist($foo);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return $foo;
+    }
+
+    private function createEntityWithTheNullablePropertySet(): GH8014Foo
+    {
+        $foo = new GH8014Foo();
+        $foo->bar = new GH8014Bar();
+        $foo->bar->startDate = new DateTimeImmutable();
+        $this->_em->persist($foo);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return $foo;
+    }
+}
+
+if (PHP_VERSION_ID >= 70400) {
+    require_once __DIR__.'/GH8014_php74.php';
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8014_php74.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8014_php74.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Test\ORM\Functional\Ticket;
+
+/**
+ * @Entity()
+ */
+class GH8014Foo
+{
+    /**
+     * @var integer
+     *
+     * @Id()
+     * @Column(name="id", type="integer")
+     * @GeneratedValue(strategy="IDENTITY")
+     */
+    public $id;
+
+    /**
+     * @Embedded(class="Doctrine\Test\ORM\Functional\Ticket\GH8014Bar")
+     */
+    public ?GH8014Bar $bar = null;
+}
+
+/**
+ * @Embeddable()
+ */
+class GH8014Bar
+{
+    /**
+     * @Column(type="datetime_immutable", nullable=true)
+     */
+    public DateTimeImmutable $startDate;
+}


### PR DESCRIPTION
This is the PR requested for issue #8014.

Following the explanation in the bug report, when you have a null value in the database (which is valid because the parent property containing the Embeddable can be null, i.e. all the properties o f the Embeddable are null in the database), but the typed property is required (does not allow null), the hydrator should skip setting that null value to the typed property.