### PR TITLE
[GH-4568] A new attempt at nullable embeddables based on Luis work.

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -89,13 +89,14 @@ class ClassMetadataBuilder
      *
      * @return $this
      */
-    public function addEmbedded($fieldName, $class, $columnPrefix = null)
+    public function addEmbedded($fieldName, $class, $columnPrefix = null, bool $nullable = false)
     {
         $this->cm->mapEmbedded(
             [
                 'fieldName'    => $fieldName,
                 'class'        => $class,
-                'columnPrefix' => $columnPrefix
+                'columnPrefix' => $columnPrefix,
+                'nullable'     => $nullable,
             ]
         );
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -480,6 +480,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     'fieldName' => $prefix . '.' . $property,
                     'class' => $embeddableMetadata->name,
                     'columnPrefix' => $embeddableClass['columnPrefix'],
+                    'nullable' => $embeddableClass['nullable'],
                     'declaredField' => $embeddableClass['declaredField']
                             ? $prefix . '.' . $embeddableClass['declaredField']
                             : $prefix,

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -956,7 +956,7 @@ class ClassMetadataInfo implements ClassMetadata
                     $parentReflFields[$mapping['declaredField']],
                     $reflService->getAccessibleProperty($mapping['originalClass'], $mapping['originalField']),
                     $mapping['originalClass'],
-                    isset($mapping['nullable']) ? $mapping['nullable'] : false
+                    $mapping['nullable'] ?? false
                 );
                 continue;
             }
@@ -3299,7 +3299,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->embeddedClasses[$mapping['fieldName']] = [
             'class' => $this->fullyQualifiedClassName($mapping['class']),
             'columnPrefix' => $mapping['columnPrefix'],
-            'nullable' => isset($mapping['nullable']) ? $mapping['nullable'] : false,
+            'nullable' => $mapping['nullable'] ?? null,
             'declaredField' => $mapping['declaredField'] ?? null,
             'originalField' => $mapping['originalField'] ?? null,
         ];

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -934,7 +934,8 @@ class ClassMetadataInfo implements ClassMetadata
                         $this->embeddedClasses[$embeddedClass['declaredField']]['class'],
                         $embeddedClass['originalField']
                     ),
-                    $this->embeddedClasses[$embeddedClass['declaredField']]['class']
+                    $this->embeddedClasses[$embeddedClass['declaredField']]['class'],
+                    $embeddedClass['nullable']
                 );
 
                 continue;
@@ -954,7 +955,8 @@ class ClassMetadataInfo implements ClassMetadata
                 $this->reflFields[$field] = new ReflectionEmbeddedProperty(
                     $parentReflFields[$mapping['declaredField']],
                     $reflService->getAccessibleProperty($mapping['originalClass'], $mapping['originalField']),
-                    $mapping['originalClass']
+                    $mapping['originalClass'],
+                    isset($mapping['nullable']) ? $mapping['nullable'] : false
                 );
                 continue;
             }
@@ -3297,6 +3299,7 @@ class ClassMetadataInfo implements ClassMetadata
         $this->embeddedClasses[$mapping['fieldName']] = [
             'class' => $this->fullyQualifiedClassName($mapping['class']),
             'columnPrefix' => $mapping['columnPrefix'],
+            'nullable' => isset($mapping['nullable']) ? $mapping['nullable'] : false,
             'declaredField' => $mapping['declaredField'] ?? null,
             'originalField' => $mapping['originalField'] ?? null,
         ];
@@ -3317,6 +3320,10 @@ class ClassMetadataInfo implements ClassMetadata
                 : $property;
             $fieldMapping['originalField'] = $fieldMapping['originalField'] ?? $fieldMapping['fieldName'];
             $fieldMapping['fieldName'] = $property . "." . $fieldMapping['fieldName'];
+
+            if ($this->embeddedClasses[$property]['nullable'] === true) {
+                $fieldMapping['nullable'] = $this->embeddedClasses[$property]['nullable'];
+            }
 
             if (! empty($this->embeddedClasses[$property]['columnPrefix'])) {
                 $fieldMapping['columnName'] = $this->embeddedClasses[$property]['columnPrefix'] . $fieldMapping['columnName'];

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -423,6 +423,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             } else if ($embeddedAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Embedded::class)) {
                 $mapping['class'] = $embeddedAnnot->class;
                 $mapping['columnPrefix'] = $embeddedAnnot->columnPrefix;
+                $mapping['nullable'] = $embeddedAnnot->nullable;
 
                 $metadata->mapEmbedded($mapping);
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -421,9 +421,9 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                 $metadata->mapManyToMany($mapping);
             } else if ($embeddedAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Embedded::class)) {
-                $mapping['class'] = $embeddedAnnot->class;
+                $mapping['class']        = $embeddedAnnot->class;
                 $mapping['columnPrefix'] = $embeddedAnnot->columnPrefix;
-                $mapping['nullable'] = $embeddedAnnot->nullable;
+                $mapping['nullable']     = $embeddedAnnot->nullable;
 
                 $metadata->mapEmbedded($mapping);
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -272,10 +272,15 @@ class XmlDriver extends FileDriver
                     ? $this->evaluateBoolean($embeddedMapping['use-column-prefix'])
                     : true;
 
+                $nullable = isset($embeddedMapping['nullable'])
+                    ? $this->evaluateBoolean($embeddedMapping['nullable'])
+                    : null;
+
                 $mapping = [
                     'fieldName' => (string) $embeddedMapping['name'],
                     'class' => (string) $embeddedMapping['class'],
-                    'columnPrefix' => $useColumnPrefix ? $columnPrefix : false
+                    'columnPrefix' => $useColumnPrefix ? $columnPrefix : false,
+                    'nullable' => $nullable,
                 ];
 
                 $metadata->mapEmbedded($mapping);

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -352,6 +352,7 @@ class YamlDriver extends FileDriver
                     'fieldName' => $name,
                     'class' => $embeddedMapping['class'],
                     'columnPrefix' => $embeddedMapping['columnPrefix'] ?? null,
+                    'nullable' => isset($embeddedMapping['nullable']) ? $embeddedMapping['nullable'] : null,
                 ];
                 $metadata->mapEmbedded($mapping);
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -352,7 +352,7 @@ class YamlDriver extends FileDriver
                     'fieldName' => $name,
                     'class' => $embeddedMapping['class'],
                     'columnPrefix' => $embeddedMapping['columnPrefix'] ?? null,
-                    'nullable' => isset($embeddedMapping['nullable']) ? $embeddedMapping['nullable'] : null,
+                    'nullable' => $embeddedMapping['nullable'] ?? null,
                 ];
                 $metadata->mapEmbedded($mapping);
             }

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -31,13 +31,9 @@ final class Embedded implements Annotation
      */
     public $class;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     public $columnPrefix;
 
-    /**
-     * @var bool
-     */
-    public $nullable;
+    /** @var bool */
+    public $nullable = false;
 }

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -35,4 +35,9 @@ final class Embedded implements Annotation
      * @var mixed
      */
     public $columnPrefix;
+
+    /**
+     * @var bool
+     */
+    public $nullable;
 }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -33,42 +33,27 @@ use ReflectionProperty;
  */
 class ReflectionEmbeddedProperty extends ReflectionProperty
 {
-    /**
-     * @var ReflectionProperty reflection property of the class where the embedded object has to be put
-     */
+    /** @var ReflectionProperty reflection property of the class where the embedded object has to be put */
     private $parentProperty;
 
-    /**
-     * @var ReflectionProperty reflection property of the embedded object
-     */
+    /** @var ReflectionProperty reflection property of the embedded object */
     private $childProperty;
 
-    /**
-     * @var string name of the embedded class to be eventually instantiated
-     */
+    /** @var string name of the embedded class to be eventually instantiated */
     private $embeddedClass;
 
-    /**
-     * @var Instantiator|null
-     */
+    /** @var Instantiator|null */
     private $instantiator;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $nullable = false;
 
-    /**
-     * @param ReflectionProperty $parentProperty
-     * @param ReflectionProperty $childProperty
-     * @param string             $embeddedClass
-     */
     public function __construct(ReflectionProperty $parentProperty, ReflectionProperty $childProperty, string $embeddedClass, bool $nullable)
     {
-        $this->parentProperty  = $parentProperty;
-        $this->childProperty   = $childProperty;
-        $this->embeddedClass   = $embeddedClass;
-        $this->nullable        = $nullable;
+        $this->parentProperty = $parentProperty;
+        $this->childProperty  = $childProperty;
+        $this->embeddedClass  = $embeddedClass;
+        $this->nullable       = $nullable;
 
         parent::__construct($childProperty->getDeclaringClass()->getName(), $childProperty->getName());
     }

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -54,15 +54,21 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
     private $instantiator;
 
     /**
+     * @var bool
+     */
+    private $nullable = false;
+
+    /**
      * @param ReflectionProperty $parentProperty
      * @param ReflectionProperty $childProperty
      * @param string             $embeddedClass
      */
-    public function __construct(ReflectionProperty $parentProperty, ReflectionProperty $childProperty, $embeddedClass)
+    public function __construct(ReflectionProperty $parentProperty, ReflectionProperty $childProperty, string $embeddedClass, bool $nullable)
     {
         $this->parentProperty  = $parentProperty;
         $this->childProperty   = $childProperty;
-        $this->embeddedClass   = (string) $embeddedClass;
+        $this->embeddedClass   = $embeddedClass;
+        $this->nullable        = $nullable;
 
         parent::__construct($childProperty->getDeclaringClass()->getName(), $childProperty->getName());
     }
@@ -86,6 +92,10 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
      */
     public function setValue($object, $value = null)
     {
+        if ($value === null && $this->nullable === true) {
+            return;
+        }
+
         $embeddedObject = $this->parentProperty->getValue($object);
 
         if (null === $embeddedObject) {

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional;
+
 use DateTime;
 use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\ORM\Mapping\MappingException;

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -344,6 +344,8 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         $this->_em->persist($event);
         $this->_em->flush();
 
+        $this->assertNull($event->submissions);
+
         return $event;
     }
 
@@ -353,6 +355,8 @@ class ValueObjectsTest extends OrmFunctionalTestCase
      */
     public function testEmbeddedObjectShouldNotBeCreatedWhenIsNullableAndHaveNoData(DDC3529Event $event)
     {
+        $this->_em->clear();
+
         $event = $this->_em->find(DDC3529Event::CLASSNAME, $event->id);
 
         $this->assertEquals('PHP Conference', $event->name);
@@ -369,6 +373,10 @@ class ValueObjectsTest extends OrmFunctionalTestCase
      */
     public function testEmbeddedObjectShouldBeCreatedWhenIsNullableButHaveData(DDC3529Event $event)
     {
+        $this->_em->clear();
+
+        $event = $this->_em->find(DDC3529Event::CLASSNAME, $event->id);
+
         $event->submissions = new DDC3529DateInterval(new \DateTime('2014-11-20 08:00:00'), new \DateTime('2014-12-23 19:00:00'));
 
         $this->_em->persist($event);
@@ -389,6 +397,8 @@ class ValueObjectsTest extends OrmFunctionalTestCase
      */
     public function testFindShouldReturnNullAfterTheObjectWasRemoved(DDC3529Event $event)
     {
+        $this->_em->clear();
+
         $eventId = $event->id;
 
         $event = $this->_em->find(DDC3529Event::CLASSNAME, $eventId);

--- a/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueObjectsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Doctrine\Tests\ORM\Functional;
+use DateTime;
 use Doctrine\Common\Reflection\RuntimePublicReflectionProperty;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\ReflectionEmbeddedProperty;
@@ -17,8 +18,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         parent::setUp();
 
         try {
-            $this->_schemaTool->createSchema(
-                [
+            $this->_schemaTool->createSchema([
                 $this->_em->getClassMetadata(DDC93Person::class),
                 $this->_em->getClassMetadata(DDC93Address::class),
                 $this->_em->getClassMetadata(DDC93Vehicle::class),
@@ -26,8 +26,7 @@ class ValueObjectsTest extends OrmFunctionalTestCase
                 $this->_em->getClassMetadata(DDC3027Animal::class),
                 $this->_em->getClassMetadata(DDC3027Dog::class),
                 $this->_em->getClassMetadata(DDC3529Event::class),
-                ]
-            );
+            ]);
         } catch(\Exception $e) {
         }
     }
@@ -337,9 +336,9 @@ class ValueObjectsTest extends OrmFunctionalTestCase
 
     public function testNoErrorsShouldHappenWhenPersistingAnEntityWithNullableEmbedded()
     {
-        $event = new DDC3529Event();
-        $event->name = 'PHP Conference';
-        $event->period = new DDC3529DateInterval(new \DateTime('2015-01-20 08:00:00'), new \DateTime('2015-01-23 19:00:00'));
+        $event         = new DDC3529Event();
+        $event->name   = 'PHP Conference';
+        $event->period = new DDC3529DateInterval(new DateTime('2015-01-20 08:00:00'), new DateTime('2015-01-23 19:00:00'));
 
         $this->_em->persist($event);
         $this->_em->flush();
@@ -349,15 +348,12 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         return $event;
     }
 
-    /**
-     * @depends testNoErrorsShouldHappenWhenPersistingAnEntityWithNullableEmbedded
-     * @param DDC3529Event $event
-     */
+    /** @depends testNoErrorsShouldHappenWhenPersistingAnEntityWithNullableEmbedded */
     public function testEmbeddedObjectShouldNotBeCreatedWhenIsNullableAndHaveNoData(DDC3529Event $event)
     {
         $this->_em->clear();
 
-        $event = $this->_em->find(DDC3529Event::CLASSNAME, $event->id);
+        $event = $this->_em->find(DDC3529Event::class, $event->id);
 
         $this->assertEquals('PHP Conference', $event->name);
         $this->assertEquals('2015-01-20 08:00:00', $event->period->begin->format('Y-m-d H:i:s'));
@@ -367,23 +363,20 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         return $event;
     }
 
-    /**
-     * @depends testEmbeddedObjectShouldNotBeCreatedWhenIsNullableAndHaveNoData
-     * @param DDC3529Event $event
-     */
+    /** @depends testEmbeddedObjectShouldNotBeCreatedWhenIsNullableAndHaveNoData */
     public function testEmbeddedObjectShouldBeCreatedWhenIsNullableButHaveData(DDC3529Event $event)
     {
         $this->_em->clear();
 
-        $event = $this->_em->find(DDC3529Event::CLASSNAME, $event->id);
+        $event = $this->_em->find(DDC3529Event::class, $event->id);
 
-        $event->submissions = new DDC3529DateInterval(new \DateTime('2014-11-20 08:00:00'), new \DateTime('2014-12-23 19:00:00'));
+        $event->submissions = new DDC3529DateInterval(new DateTime('2014-11-20 08:00:00'), new DateTime('2014-12-23 19:00:00'));
 
         $this->_em->persist($event);
         $this->_em->flush();
         $this->_em->clear();
 
-        $event = $this->_em->find(DDC3529Event::CLASSNAME, $event->id);
+        $event = $this->_em->find(DDC3529Event::class, $event->id);
 
         $this->assertEquals('2014-11-20 08:00:00', $event->submissions->begin->format('Y-m-d H:i:s'));
         $this->assertEquals('2014-12-23 19:00:00', $event->submissions->end->format('Y-m-d H:i:s'));
@@ -391,21 +384,18 @@ class ValueObjectsTest extends OrmFunctionalTestCase
         return $event;
     }
 
-    /**
-     * @depends testEmbeddedObjectShouldBeCreatedWhenIsNullableButHaveData
-     * @param DDC3529Event $event
-     */
+    /** @depends testEmbeddedObjectShouldBeCreatedWhenIsNullableButHaveData */
     public function testFindShouldReturnNullAfterTheObjectWasRemoved(DDC3529Event $event)
     {
         $this->_em->clear();
 
         $eventId = $event->id;
 
-        $event = $this->_em->find(DDC3529Event::CLASSNAME, $eventId);
+        $event = $this->_em->find(DDC3529Event::class, $eventId);
         $this->_em->remove($event);
         $this->_em->flush();
 
-        $this->assertNull($this->_em->find(DDC3529Event::CLASSNAME, $eventId));
+        $this->assertNull($this->_em->find(DDC3529Event::class, $eventId));
     }
 }
 
@@ -735,10 +725,10 @@ class DDC3529DateInterval
     /** @Column(type = "datetime") */
     public $end;
 
-    public function __construct(\DateTime $begin, \DateTime $end)
+    public function __construct(DateTime $begin, DateTime $end)
     {
         $this->begin = $begin;
-        $this->end = $end;
+        $this->end   = $end;
     }
 }
 
@@ -747,8 +737,6 @@ class DDC3529DateInterval
  */
 class DDC3529Event
 {
-    const CLASSNAME = __CLASS__;
-
     /** @Id @GeneratedValue @Column(type="integer") */
     public $id;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataBuilderTest.php
@@ -58,6 +58,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'columnPrefix' => null,
                 'declaredField' => null,
                 'originalField' => null,
+                'nullable'      => false,
             ]
             ], $this->cm->embeddedClasses);
     }
@@ -79,6 +80,7 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'columnPrefix' => 'nm_',
                 'declaredField' => null,
                 'originalField' => null,
+                'nullable'      => false,
             ]
             ], $this->cm->embeddedClasses);
     }
@@ -96,7 +98,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'class' => Name::class,
                 'columnPrefix' => null,
                 'declaredField' => null,
-                'originalField' => null
+                'originalField' => null,
+                'nullable'      => false,
             ],
             $this->cm->embeddedClasses['name']
         );
@@ -115,7 +118,8 @@ class ClassMetadataBuilderTest extends OrmTestCase
                 'class' => Name::class,
                 'columnPrefix' => 'nm_',
                 'declaredField' => null,
-                'originalField' => null
+                'originalField' => null,
+                'nullable'      => false,
             ],
             $this->cm->embeddedClasses['name']
         );

--- a/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ReflectionEmbeddedPropertyTest.php
@@ -31,7 +31,7 @@ class ReflectionEmbeddedPropertyTest extends TestCase
         ReflectionProperty $childProperty,
         $embeddableClass
     ) {
-        $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass);
+        $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass, false);
 
         $instantiator = new Instantiator();
 
@@ -58,7 +58,7 @@ class ReflectionEmbeddedPropertyTest extends TestCase
         ReflectionProperty $childProperty,
         $embeddableClass
     ) {
-        $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass);
+        $embeddedPropertyReflection = new ReflectionEmbeddedProperty($parentProperty, $childProperty, $embeddableClass, false);
 
         $instantiator = new Instantiator();
 

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -129,6 +129,7 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
                     'columnPrefix' => 'nm_',
                     'declaredField' => null,
                     'originalField' => null,
+                    'nullable'      => false,
                 ]
             ],
             $class->embeddedClasses


### PR DESCRIPTION
This is a new attempt at solving #4568 which becomes a more present requirement to solve because of typed properties, see #8014 

Its based of @lcobucci work on #1275, which was closed. The implementation of that PR put the burden on the UnitOfWork and introduced additional work in the hotpath. This new PR moves the logic into the `ReflectionEmbeddedProperty`.

TODO:
- [ ] Add tests for the mapping drivers
- [ ] Add more tests for the embeddable part, also nested embeddables.

Related https://github.com/doctrine/orm/pull/8015