### PR TITLE
Put into cache using root entity name

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -279,9 +279,12 @@ class DefaultQueryCache implements QueryCache
 
         $region = $persister->getCacheRegion();
 
+        $cm = $this->em->getClassMetadata($entityName);
+        assert($cm instanceof ClassMetadata);
+
         foreach ($result as $index => $entity) {
-            $identifier                     = $this->uow->getEntityIdentifier($entity);
-            $entityKey                      = new EntityCacheKey($entityName, $identifier);
+            $identifier = $this->uow->getEntityIdentifier($entity);
+            $entityKey  = new EntityCacheKey($cm->rootEntityName, $identifier);
 
             if (($key->cacheMode & Cache::MODE_REFRESH) || ! $region->contains($entityKey)) {
                 // Cancel put result if entity put fail

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC7969Test.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Cache\Region\DefaultMultiGetRegion;
+use Doctrine\Tests\Models\Cache\Attraction;
+use Doctrine\Tests\Models\Cache\Bar;
+use Doctrine\Tests\ORM\Functional\SecondLevelCacheAbstractTest;
+
+class DDC7969Test extends SecondLevelCacheAbstractTest
+{
+    public function testChildEntityRetrievedFromCache() : void
+    {
+        $this->loadFixturesCountries();
+        $this->loadFixturesStates();
+        $this->loadFixturesCities();
+        $this->loadFixturesAttractions();
+
+        // Entities are already cached due to fixtures - hence flush before testing
+        $region = $this->cache->getEntityCacheRegion(Attraction::class);
+
+        if ($region instanceof DefaultMultiGetRegion) {
+            $region->getCache()->flushAll();
+        }
+
+        /** @var Bar $bar */
+        $bar = $this->attractions[0];
+
+        $repository = $this->_em->getRepository(Bar::class);
+
+        $this->assertFalse($this->cache->containsEntity(Bar::class, $bar->getId()));
+        $this->assertFalse($this->cache->containsEntity(Attraction::class, $bar->getId()));
+
+        $repository->findOneBy([
+            'name' => $bar->getName(),
+        ]);
+
+        $this->assertTrue($this->cache->containsEntity(Bar::class, $bar->getId()));
+
+        $repository->findOneBy([
+            'name' => $bar->getName(),
+        ]);
+
+        // One hit for entity cache, one hit for query cache
+        $this->assertEquals(2, $this->secondLevelCacheLogger->getHitCount());
+    }
+}


### PR DESCRIPTION
The cache key for reading is created based on the entity root name but the cache was written with a key based on the found entity (the child in this case) resulting in cache miss.
Using the same root name when putting fixes the issue. I do believe that any extending instances should have unique identifiers as they will have to share an identifier from the base class. This will mean the key won't be ambiguous - if my thinking is correct.

https://github.com/doctrine/orm/issues/7969