### PR TITLE
Throw exception with more meaningful details

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2478,7 +2478,7 @@ class UnitOfWork implements PropertyChangedListener
         if (!isset($this->entityIdentifiers[$id])) {
             throw new EntityNotFoundException(sprintf(
                 'Unable to find "%s" entity identifier associated with the UnitOfWork',
-                get_class($entity),
+                get_class($entity)
             ));
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2474,7 +2474,15 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function getEntityIdentifier($entity)
     {
-        return $this->entityIdentifiers[spl_object_id($entity)];
+        $id = spl_object_id($entity);
+        if (!isset($this->entityIdentifiers[$id])) {
+            throw new EntityNotFoundException(sprintf(
+                'Unable to find "%s" entity identifier associated with the UnitOfWork',
+                get_class($entity),
+            ));
+        }
+
+        return $this->entityIdentifiers[$id];
     }
 
     /**


### PR DESCRIPTION
Currently an undefined index is thrown.  This error is confusing and not helpful, so we perform a check to see if the key is set and throw a more meaningful exception.