### PR TITLE
Fix inherited embeddables and nesting after AnnotationDriver change #8006

### DIFF
--- a/docs/en/tutorials/embeddables.rst
+++ b/docs/en/tutorials/embeddables.rst
@@ -8,7 +8,9 @@ or address are the primary use case for this feature.
 
 .. note::
 
-    Embeddables can only contain properties with basic ``@Column`` mapping.
+    Embeddables can not contain references to entities. They can however compose
+    other embeddables in addition to holding properties with basic ``@Column``
+    mapping.
 
 For the purposes of this tutorial, we will assume that you have a ``User``
 class in your application and you would like to store an address in

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -776,8 +776,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function isEntity(ClassMetadataInterface $class)
     {
-        return isset($class->isMappedSuperclass) && $class->isMappedSuperclass === false
-            && isset($class->isEmbeddedClass) && $class->isEmbeddedClass === false;
+        assert($class instanceof ClassMetadata);
+
+        return $class->isMappedSuperclass === false && $class->isEmbeddedClass === false;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -401,10 +401,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
         foreach ($parentClass->fieldMappings as $mapping) {
-            if ( ! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass && ! $parentClass->isEmbeddedClass) {
+            if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass && ! $parentClass->isEmbeddedClass) {
                 $mapping['inherited'] = $parentClass->name;
             }
-            if ( ! isset($mapping['declared'])) {
+            if (! isset($mapping['declared'])) {
                 $mapping['declared'] = $parentClass->name;
             }
             $subClass->addInheritedFieldMapping($mapping);

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -469,10 +469,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addNestedEmbeddedClasses(ClassMetadata $subClass, ClassMetadata $parentClass, $prefix)
     {
         foreach ($subClass->embeddedClasses as $property => $embeddableClass) {
-            if (isset($embeddableClass['inherited'])) {
-                continue;
-            }
-
             $embeddableMetadata = $this->getMetadataFor($embeddableClass['class']);
 
             $parentClass->mapEmbedded(

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Id\BigIntegerIdentityGenerator;
 use Doctrine\ORM\Id\IdentityGenerator;
 use Doctrine\ORM\ORMException;
 use ReflectionException;
+use function assert;
 
 /**
  * The ClassMetadataFactory is used to create ClassMetadata objects that contain all the

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -401,7 +401,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass)
     {
         foreach ($parentClass->fieldMappings as $mapping) {
-            if ( ! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
+            if ( ! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass && ! $parentClass->isEmbeddedClass) {
                 $mapping['inherited'] = $parentClass->name;
             }
             if ( ! isset($mapping['declared'])) {
@@ -780,7 +780,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      */
     protected function isEntity(ClassMetadataInterface $class)
     {
-        return isset($class->isMappedSuperclass) && $class->isMappedSuperclass === false;
+        return isset($class->isMappedSuperclass) && $class->isMappedSuperclass === false
+            && isset($class->isEmbeddedClass) && $class->isEmbeddedClass === false;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -278,6 +278,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
         foreach ($class->getProperties() as $property) {
             if ($metadata->isMappedSuperclass && ! $property->isPrivate()
                 ||
+                $metadata->isEmbeddedClass && $property->getDeclaringClass()->getName() !== $class->getName()
+                ||
                 $metadata->isInheritedField($property->name)
                 ||
                 $metadata->isInheritedAssociation($property->name)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
@@ -19,7 +19,7 @@ class GH8031Test extends OrmFunctionalTestCase
 
     public function testEntityIsFetched()
     {
-        $entity = new GH8031Invoice(new GH8031InvoiceCode(1, 2020));
+        $entity = new GH8031Invoice(new GH8031InvoiceCode(1, 2020, new GH8031Nested(10)));
         $this->_em->persist($entity);
         $this->_em->flush();
         $this->_em->clear();
@@ -35,6 +35,28 @@ class GH8031Test extends OrmFunctionalTestCase
             1,
             $this->_em->getRepository(GH8031Invoice::class)->findBy([], ['code.number' => 'ASC'])
         );
+    }
+}
+
+/**
+ * @Embeddable
+ */
+class GH8031Nested
+{
+    /**
+     * @Column(type="integer", name="number", length=6)
+     * @var int
+     */
+    protected $number;
+
+    public function __construct(int $number)
+    {
+        $this->number = $number;
+    }
+
+    public function getNumber() : int
+    {
+        return $this->number;
     }
 }
 
@@ -62,10 +84,16 @@ abstract class GH8031AbstractYearSequenceValue
      */
     protected $year;
 
-    public function __construct(int $number, int $year)
+    /**
+     * @Embedded(class=GH8031Nested::class)
+     */
+    protected $nested;
+
+    public function __construct(int $number, int $year, GH8031Nested $nested)
     {
         $this->number = $number;
         $this->year   = $year;
+        $this->nested = $nested;
     }
 
     public function getNumber() : int

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
@@ -36,6 +36,28 @@ class GH8031Test extends OrmFunctionalTestCase
             $this->_em->getRepository(GH8031Invoice::class)->findBy([], ['code.number' => 'ASC'])
         );
     }
+
+    public function testEmbeddableWithAssociationNotAllowed()
+    {
+        $cm = $this->_em->getClassMetadata(GH8031EmbeddableWithAssociation::class);
+
+        $this->assertArrayHasKey('invoice', $cm->associationMappings);
+
+        $cm = $this->_em->getClassMetadata(GH8031Invoice::class);
+
+        $this->assertCount(0, $cm->associationMappings);
+    }
+}
+
+/**
+ * @Embeddable
+ */
+class GH8031EmbeddableWithAssociation
+{
+    /**
+     * @ManyToOne(targetEntity=GH8031Invoice::class)
+     */
+    public $invoice;
 }
 
 /**
@@ -122,6 +144,11 @@ class GH8031Invoice
      * @var GH8031InvoiceCode
      */
     private $code;
+
+    /**
+     * @Embedded(class=GH8031EmbeddableWithAssociation::class)
+     */
+    private $embeddedAssoc;
 
     public function __construct(GH8031InvoiceCode $code)
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
@@ -54,9 +54,7 @@ class GH8031Test extends OrmFunctionalTestCase
  */
 class GH8031EmbeddableWithAssociation
 {
-    /**
-     * @ManyToOne(targetEntity=GH8031Invoice::class)
-     */
+    /** @ManyToOne(targetEntity=GH8031Invoice::class) */
     public $invoice;
 }
 
@@ -145,9 +143,7 @@ class GH8031Invoice
      */
     private $code;
 
-    /**
-     * @Embedded(class=GH8031EmbeddableWithAssociation::class)
-     */
+    /** @Embedded(class=GH8031EmbeddableWithAssociation::class) */
     private $embeddedAssoc;
 
     public function __construct(GH8031InvoiceCode $code)

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH8031Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH8031Invoice::class,
+        ]);
+    }
+
+    public function testEntityIsFetched()
+    {
+        $entity = new GH8031Invoice(new GH8031InvoiceCode(1, 2020));
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var GH8031Invoice $fetched */
+        $fetched = $this->_em->find(GH8031Invoice::class, $entity->getId());
+        $this->assertInstanceOf(GH8031Invoice::class, $fetched);
+        $this->assertSame(1, $fetched->getCode()->getNumber());
+        $this->assertSame(2020, $fetched->getCode()->getYear());
+
+        $this->_em->clear();
+        $this->assertCount(
+            1,
+            $this->_em->getRepository(GH8031Invoice::class)->findBy([], ['code.number' => 'ASC'])
+        );
+    }
+}
+
+/**
+ * @Embeddable
+ */
+class GH8031InvoiceCode extends GH8031AbstractYearSequenceValue
+{
+}
+
+/**
+ * @Embeddable
+ */
+abstract class GH8031AbstractYearSequenceValue
+{
+    /**
+     * @Column(type="integer", name="number", length=6)
+     * @var int
+     */
+    protected $number;
+
+    /**
+     * @Column(type="smallint", name="year", length=4)
+     * @var int
+     */
+    protected $year;
+
+    public function __construct(int $number, int $year)
+    {
+        $this->number = $number;
+        $this->year   = $year;
+    }
+
+    public function getNumber() : int
+    {
+        return $this->number;
+    }
+
+    public function getYear() : int
+    {
+        return $this->year;
+    }
+}
+
+/**
+ * @Entity
+ */
+class GH8031Invoice
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @Embedded(class=GH8031InvoiceCode::class)
+     * @var GH8031InvoiceCode
+     */
+    private $code;
+
+    public function __construct(GH8031InvoiceCode $code)
+    {
+        $this->code = $code;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getCode() : GH8031InvoiceCode
+    {
+        return $this->code;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8031Test.php
@@ -84,9 +84,7 @@ abstract class GH8031AbstractYearSequenceValue
      */
     protected $year;
 
-    /**
-     * @Embedded(class=GH8031Nested::class)
-     */
+    /** @Embedded(class=GH8031Nested::class) */
     protected $nested;
 
     public function __construct(int $number, int $year, GH8031Nested $nested)


### PR DESCRIPTION
Changing `AnnotationDriver` to mark embeddables as "entities"  in #8006 caused a bunch of bugs with inheritance and nested embeddables that are fixed by this PR.