### PR TITLE
Improve documentation about naming strategy usage

### DIFF
--- a/docs/en/reference/namingstrategy.rst
+++ b/docs/en/reference/namingstrategy.rst
@@ -4,8 +4,12 @@ Implementing a NamingStrategy
 .. versionadded:: 2.3
 
 Using a naming strategy you can provide rules for generating database identifiers,
-column or table names when the column or table name is not given. This feature helps
+column or table names. This feature helps
 reduce the verbosity of the mapping document, eliminating repetitive noise (eg: ``TABLE_``).
+
+.. warning
+
+    The naming strategy is always overridden by entity mapping such as the `Table` annotation.
 
 Configuring a naming strategy
 -----------------------------


### PR DESCRIPTION
Add a note/warning that annotations override the naming strategy.