### PR TITLE
Run Static analysis and coding standards in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
-        extensions: mbstring
-        tools: composer, cs2pr
-
-    - name: composer install
-      run: "composer install --no-progress"
-
-    - name: phpcs
-      run: "php vendor/bin/phpcs -q --report=checkstyle --no-colors | cs2pr"
-
-  static-analysis:
-    name: "Static Analysis"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -39,7 +19,27 @@ jobs:
         tools: composer, cs2pr
 
     - name: composer install
-      run: "composer install --no-progress"
+      run: "composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader"
+
+    - name: phpcs
+      run: "php vendor/bin/phpcs -q --report=checkstyle --no-colors | cs2pr"
+
+  static-analysis:
+    name: "Static Analysis"
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.2'
+        extensions: mbstring
+        tools: composer, cs2pr
+
+    - name: composer install
+      run: "composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader"
 
     - name: phpstan
       run: "php vendor/bin/phpstan analyse --error-format=checkstyle --no-progress | cs2pr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '7.2'
         extensions: mbstring
         tools: composer, cs2pr
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   coding-standards:
+    name: "Coding Standards"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -24,6 +25,7 @@ jobs:
       run: "php vendor/bin/phpcs -q --report=checkstyle --no-colors | cs2pr"
 
   static-analysis:
+    name: "Static Analysis"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+on: push
+jobs:
+  coding-standards:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        extensions: mbstring
+        tools: composer, cs2pr
+
+    - name: composer install
+      run: "composer install --no-progress"
+
+    - name: phpcs
+      run: "php vendor/bin/phpcs -q --report=checkstyle --no-colors | cs2pr"
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+        extensions: mbstring
+        tools: composer, cs2pr
+
+    - name: composer install
+      run: "composer install --no-progress"
+
+    - name: phpstan
+      run: "php vendor/bin/phpstan analyse --error-format=checkstyle --no-progress | cs2pr"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 jobs:
   coding-standards:
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,24 +72,9 @@ jobs:
         - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
 
     - stage: Code Quality
-      env: DB=none STATIC_ANALYSIS
-      install: travis_retry composer install --prefer-dist
-      before_script:
-        - echo "extension=memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-        - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-      script: vendor/bin/phpstan analyse
-
-    - stage: Code Quality
       env: DB=none BENCHMARK
       before_script: wget https://phpbench.github.io/phpbench/phpbench.phar https://phpbench.github.io/phpbench/phpbench.phar.pubkey
       script: php phpbench.phar run --bootstrap=tests/Doctrine/Tests/TestInit.php -l dots --report=default
-
-    - stage: Code Quality
-      env: DB=none CODING_STANDARDS
-      install: travis_retry composer install --prefer-dist
-      php: 7.2
-      script:
-        - ./vendor/bin/phpcs
 
   allow_failures:
     - php: 7.4snapshot


### PR DESCRIPTION
This moves static analysis runs from Travis-CI to Github Actions, because it allows sending violations directly into the PR files as annotations very easily.

This will look like this:

![Screenshot_2020-03-01 Run Static analysis and coding standards in Github Actions by beberlei · Pull Request #8049 · doctrin](https://user-images.githubusercontent.com/26936/75625500-0e004000-5bbf-11ea-8e45-b8de4b39e5a0.png)

I haven't moved phpbench yet, because it looks like the history.db isn't even cached on Travis, so I don't know if this step can fail the build?