### PR TITLE
[GH-7633] disallow cache partial objects

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -260,7 +260,7 @@ class DefaultQueryCache implements QueryCache
             throw new CacheException("Second-level cache query supports only select statements.");
         }
 
-        if (isset($hints[Query::HINT_FORCE_PARTIAL_LOAD]) && $hints[Query::HINT_FORCE_PARTIAL_LOAD]) {
+        if (isset($hints[Query\SqlWalker::HINT_PARTIAL]) && $hints[Query\SqlWalker::HINT_PARTIAL]) {
             throw new CacheException("Second level cache does not support partial entities.");
         }
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -260,7 +260,7 @@ class DefaultQueryCache implements QueryCache
             throw new CacheException("Second-level cache query supports only select statements.");
         }
 
-        if (isset($hints[Query\SqlWalker::HINT_PARTIAL]) && $hints[Query\SqlWalker::HINT_PARTIAL]) {
+        if (($hints[Query\SqlWalker::HINT_PARTIAL] ?? false) === true || ($hints[Query::HINT_FORCE_PARTIAL_LOAD] ?? false) === true) {
             throw new CacheException("Second level cache does not support partial entities.");
         }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -47,9 +47,9 @@ class SqlWalker implements TreeWalker
     const HINT_DISTINCT = 'doctrine.distinct';
 
     /**
-     * @var string
+     * Used to mark a query as containing a PARTIAL expression, which needs to be known by SLC.
      */
-    const HINT_PARTIAL = 'doctrine.partial';
+    public const HINT_PARTIAL = 'doctrine.partial';
 
     /**
      * @var ResultSetMapping

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -47,6 +47,11 @@ class SqlWalker implements TreeWalker
     const HINT_DISTINCT = 'doctrine.distinct';
 
     /**
+     * @var string
+     */
+    const HINT_PARTIAL = 'doctrine.partial';
+
+    /**
      * @var ResultSetMapping
      */
     private $rsm;
@@ -1366,6 +1371,8 @@ class SqlWalker implements TreeWalker
             default:
                 // IdentificationVariable or PartialObjectExpression
                 if ($expr instanceof AST\PartialObjectExpression) {
+                    $this->query->setHint(self::HINT_PARTIAL, true);
+
                     $dqlAlias = $expr->identificationVariable;
                     $partialFieldSet = $expr->partialFieldSet;
                 } else {

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1095,7 +1095,6 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->loadFixturesCountries();
 
         $this->_em->createQuery("SELECT PARTIAL c.{id} FROM Doctrine\Tests\Models\Cache\Country c")
-            ->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true)
             ->setCacheable(true)
             ->getResult();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1108,7 +1108,7 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->evictRegions();
         $this->loadFixturesCountries();
 
-        $this->_em->createQuery("SELECT c FROM Doctrine\Tests\Models\Cache\Country c")
+        $this->_em->createQuery('SELECT c FROM Doctrine\Tests\Models\Cache\Country c')
             ->setCacheable(true)
             ->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true)
             ->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1101,6 +1101,21 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
 
     /**
      * @expectedException \Doctrine\ORM\Cache\CacheException
+     * @expectedExceptionMessage Second level cache does not support partial entities.
+     */
+    public function testCacheableForcePartialLoadHintQueryException()
+    {
+        $this->evictRegions();
+        $this->loadFixturesCountries();
+
+        $this->_em->createQuery("SELECT c FROM Doctrine\Tests\Models\Cache\Country c")
+            ->setCacheable(true)
+            ->setHint(Query::HINT_FORCE_PARTIAL_LOAD, true)
+            ->getResult();
+    }
+
+    /**
+     * @expectedException \Doctrine\ORM\Cache\CacheException
      * @expectedExceptionMessage Second-level cache query supports only select statements.
      */
     public function testNonCacheableQueryDeleteStatementException()


### PR DESCRIPTION
There was a check in DefaultQueryCache that prevented partial queries,
because they are not supported. However the checked hint
Query::HINT_FORCE_PARTIAL_LOAD is optional, so cant be used to prevent
caching partial DQL queries.

Introduce a new hint that the SqlWalker sets on detecing a PARTIAL
query and throw an exception in the DefaultQueryCache if thats found.