### PR TITLE
Fix regression in 2.7.1 when `mysqli` is used with discriminator column that is not a string

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -138,7 +138,7 @@ class SimpleObjectHydrator extends AbstractHydrator
             // Prevent overwrite in case of inherit classes using same property name (See AbstractHydrator)
             if ( ! isset($data[$fieldName]) || ! $valueIsNull) {
                 // If we have inheritance in resultset, make sure the field belongs to the correct class
-                if (isset($cacheKeyInfo['discriminatorValues']) && ! in_array($discrColumnValue, $cacheKeyInfo['discriminatorValues'], true)) {
+                if (isset($cacheKeyInfo['discriminatorValues']) && ! in_array((string) $discrColumnValue, $cacheKeyInfo['discriminatorValues'], true)) {
                     continue;
                 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH8055
+ */
+final class GH8055Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH8055BaseClass::class,
+            GH8055SubClass::class,
+        ]);
+    }
+
+    public function testNumericDescriminatorColumn() : void
+    {
+        $entity = new GH8055SubClass();
+        $entity->value = 'test';
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $repository = $this->_em->getRepository(GH8055SubClass::class);
+        $hydrated = $repository->find($entity->id);
+
+        self::assertSame('test', $hydrated->value);
+    }
+}
+
+/**
+ * @Entity()
+ * @Table(name="gh8055")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="integer")
+ * @DiscriminatorMap({
+ *     "1" = GH8055BaseClass::class,
+ *     "2" = GH8055SubClass::class
+ * })
+ */
+class GH8055BaseClass
+{
+    /**
+     * @Id @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+}
+
+/**
+ * @Entity()
+ */
+class GH8055SubClass extends GH8055BaseClass
+{
+    /**
+     * @Column(name="test", type="string")
+     * @var string
+     */
+    public $value;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8055Test.php
@@ -26,14 +26,14 @@ final class GH8055Test extends OrmFunctionalTestCase
 
     public function testNumericDescriminatorColumn() : void
     {
-        $entity = new GH8055SubClass();
+        $entity        = new GH8055SubClass();
         $entity->value = 'test';
         $this->_em->persist($entity);
         $this->_em->flush();
         $this->_em->clear();
 
         $repository = $this->_em->getRepository(GH8055SubClass::class);
-        $hydrated = $repository->find($entity->id);
+        $hydrated   = $repository->find($entity->id);
 
         self::assertSame('test', $hydrated->value);
     }


### PR DESCRIPTION
In 2.7.1, #7974 was included as the fix for #7505. Basically, the change made was that when hydrating entities with inheritance, only the fields/data that belong to the particular inheritance type must be passed to `UoW::createEntity()`.

To do so, the `SimpleObjectHydrator` will compare the discriminator column value against the list of known types/mappings.

https://github.com/doctrine/orm/blob/927305764930d714f7c6d8e3727bdfdc910c9703/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php#L140-L143

While the descriminator types in `$cacheKeyInfo['discriminatorValues']` are always strings, the actual `$discrColumnValue` may be an `int`, at least when the discriminator column is defined as int and the `mysqli` driver is used. 

The problem seems not to occur with `pdo_mysql`: In that case, the values returned from the result set/query are (always?) strings.

My suggested fix is to `(string)` cast the discriminator value, as it already happens in the `AbstractHydrator`:

https://github.com/doctrine/orm/blob/927305764930d714f7c6d8e3727bdfdc910c9703/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php#L300-L306

*Update:* 

It seems Travis is running MySQL tests with `pdo_mysql` only, so the test case does not even show the issue. I am also sure that the issue would have surfaced with the existing tests.

I still believe the fix is correct, given the similarity to the code in `AbstractHydrator`. 

Anyway, could someone advise if this `pdo_mysql`/`mysqli` discrepancy is something worth looking into?
 