### PR TITLE
Fix: Give workflow a name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
This PR

* [x] gives the workflow a name

### Before

![Screen Shot 2020-03-04 at 22 20 39](https://user-images.githubusercontent.com/605483/75923970-6b69ea80-5e66-11ea-9c95-8e864fab9377.png)

### After

![Screen Shot 2020-03-04 at 22 20 48](https://user-images.githubusercontent.com/605483/75923989-7290f880-5e66-11ea-8d87-7b08f48d11ec.png)

