### PR TITLE
Convert PHP to SQL for new object expression

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -27,6 +27,7 @@ use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function trim;
 
 /**
  * The SqlWalker is a TreeWalker that walks over a DQL AST and constructs
@@ -1546,12 +1547,20 @@ class SqlWalker implements TreeWalker
                     break;
 
                 case ($e instanceof AST\PathExpression):
-                    $dqlAlias  = $e->identificationVariable;
-                    $qComp     = $this->queryComponents[$dqlAlias];
-                    $class     = $qComp['metadata'];
-                    $fieldType = $class->fieldMappings[$e->field]['type'];
+                    $dqlAlias     = $e->identificationVariable;
+                    $qComp        = $this->queryComponents[$dqlAlias];
+                    $class        = $qComp['metadata'];
+                    $fieldType    = $class->fieldMappings[$e->field]['type'];
+                    $fieldName    = $e->field;
+                    $fieldMapping = $class->fieldMappings[$fieldName];
+                    $col          = trim($e->dispatch($this));
 
-                    $sqlSelectExpressions[] = trim($e->dispatch($this)) . ' AS ' . $columnAlias;
+                    if (isset($fieldMapping['requireSQLConversion'])) {
+                        $type = Type::getType($fieldType);
+                        $col  = $type->convertToPHPValueSQL($col, $this->platform);
+                    }
+
+                    $sqlSelectExpressions[] = $col . ' AS ' . $columnAlias;
                     break;
 
                 case ($e instanceof AST\Literal):

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Tests\OrmTestCase;
+use function sprintf;
+
+/**
+ * @group GH8061
+ */
+final class GH8061Test extends OrmTestCase
+{
+    public static function setUpBeforeClass() : void
+    {
+        Type::addType('GH8061Type', GH8061Type::class);
+    }
+
+    public function testConvertToPHPValueSQLForNewObjectExpression() : void
+    {
+        $dql           = 'SELECT NEW ' . GH8061Class::class . '(e.field) FROM ' . GH8061Entity::class . ' e';
+        $entityManager = $this->_getTestEntityManager();
+        $query         = $entityManager->createQuery($dql);
+
+        self::assertRegExp('/SELECT DatabaseFunction\(\w+\.field\) AS /', $query->getSQL());
+    }
+}
+
+/**
+ * @Entity
+ */
+final class GH8061Entity
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+
+    /** @Column(type="GH8061Type") */
+    public $field;
+}
+
+final class GH8061Type extends Type
+{
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform) : string
+    {
+        return $platform->getVarcharTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function getName() : string
+    {
+        return 'GH8061';
+    }
+
+    public function canRequireSQLConversion() : bool
+    {
+        return true;
+    }
+
+    public function convertToPHPValueSQL($sqlExpr, $platform) : string
+    {
+        return sprintf('DatabaseFunction(%s)', $sqlExpr);
+    }
+}
+
+final class GH8061Class
+{
+    /** @var string */
+    public $field;
+
+    public function __construct(string $field)
+    {
+        $this->field = $field;
+    }
+}


### PR DESCRIPTION
Fields used in the new object expression. Were not yet converted to via
their configured type/convertToPHPValueSQL. This can lead to incorrect
arguments being injected into the new object.

This is fixed by calling convertToPHPValueSQL while creating the SQL
query.

This fixes issue #8061