### PR TITLE
Fix documentation of default generated value behavior

### DIFF
--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -328,8 +328,8 @@ annotation.
 
 In most cases using the automatic generator strategy (``@GeneratedValue``) is
 what you want. It defaults to the identifier generation mechanism your current
-database vendor prefers: AUTO_INCREMENT with MySQL, SERIAL with PostgreSQL,
-Sequences with Oracle and so on.
+database vendor prefers: AUTO_INCREMENT with MySQL, sequences with PostgreSQL 
+and Oracle and so on.
 
 Identifier Generation Strategies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
When reading about the default behavior of `@GeneratedValue` I noticed a mismatch in the basic-mapping docs. The introduction tells that PostgreSQL uses SERIAL by default, while later on it says sequence (which is the right one). This small PR fixes this.