### PR TITLE
Address deprecation about PHPUnit annotations

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultQueryCacheTest.php
@@ -640,12 +640,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         $this->assertCount(1, $attractions[1]);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Second level cache does not support scalar results.
-     */
     public function testScalarResultException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Second level cache does not support scalar results.');
         $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
@@ -655,12 +653,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         $this->queryCache->put($key, $rsm, $result);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Second level cache does not support multiple root entities.
-     */
     public function testSupportMultipleRootEntitiesException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Second level cache does not support multiple root entities.');
         $result   = [];
         $key      = new QueryCacheKey('query.key1', 0);
         $rsm      = new ResultSetMappingBuilder($this->em);
@@ -671,12 +667,10 @@ class DefaultQueryCacheTest extends OrmTestCase
         $this->queryCache->put($key, $rsm, $result);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Entity "Doctrine\Tests\Models\Generic\BooleanModel" not configured as part of the second-level cache.
-     */
     public function testNotCacheableEntityException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Entity "Doctrine\Tests\Models\Generic\BooleanModel" not configured as part of the second-level cache.');
         $result    = [];
         $key       = new QueryCacheKey('query.key1', 0);
         $rsm       = new ResultSetMappingBuilder($this->em);

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersisterTest.php
@@ -22,12 +22,10 @@ class ReadOnlyCachedEntityPersisterTest extends AbstractEntityPersisterTest
         return new ReadOnlyCachedEntityPersister($persister, $region, $em, $metadata);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Cannot update a readonly entity "Doctrine\Tests\Models\Cache\Country"
-     */
     public function testInvokeUpdate()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Cannot update a readonly entity "Doctrine\Tests\Models\Cache\Country"');
         $persister = $this->createPersisterDefault();
         $entity    = new Country("Foo");
 

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -306,18 +306,14 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
         $this->assertSame(2, $userCount);
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\ORMException
-     */
     public function testExceptionIsThrownWhenCallingFindByWithoutParameter() {
+        $this->expectException('Doctrine\ORM\ORMException');
         $this->_em->getRepository(CmsUser::class)
                   ->findByStatus();
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\ORMException
-     */
     public function testExceptionIsThrownWhenUsingInvalidFieldName() {
+        $this->expectException('Doctrine\ORM\ORMException');
         $this->_em->getRepository(CmsUser::class)
                   ->findByThisFieldDoesNotExist('testvalue');
     }
@@ -645,11 +641,11 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-753
-     * @expectedException Doctrine\ORM\ORMException
-     * @expectedExceptionMessage Invalid repository class 'Doctrine\Tests\Models\DDC753\DDC753InvalidRepository'. It must be a Doctrine\Common\Persistence\ObjectRepository.
      */
     public function testSetDefaultRepositoryInvalidClassError()
     {
+        $this->expectException('Doctrine\ORM\ORMException');
+        $this->expectExceptionMessage('Invalid repository class \'Doctrine\Tests\Models\DDC753\DDC753InvalidRepository\'. It must be a Doctrine\Common\Persistence\ObjectRepository.');
         $this->assertEquals($this->_em->getConfiguration()->getDefaultRepositoryClassName(), EntityRepository::class);
         $this->_em->getConfiguration()->setDefaultRepositoryClassName(DDC753InvalidRepository::class);
     }
@@ -683,12 +679,11 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
 
     /**
      * @group DDC-1376
-     *
-     * @expectedException Doctrine\ORM\ORMException
-     * @expectedExceptionMessage You cannot search for the association field 'Doctrine\Tests\Models\CMS\CmsUser#address', because it is the inverse side of an association.
      */
     public function testInvalidOrderByAssociation()
     {
+        $this->expectException('Doctrine\ORM\ORMException');
+        $this->expectExceptionMessage('You cannot search for the association field \'Doctrine\Tests\Models\CMS\CmsUser#address\', because it is the inverse side of an association.');
         $this->_em->getRepository(CmsUser::class)
             ->findBy(['status' => 'test'], ['address' => 'ASC']);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -341,11 +341,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addRootEntityFromClassMetadata(CompanyContract::class, 'c');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRSMBuilderThrowsExceptionOnColumnConflict()
     {
+        $this->expectException('InvalidArgumentException');
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata(CmsUser::class, 'u');
         $rsm->addJoinedEntityFromClassMetadata(CmsAddress::class, 'a', 'u', 'address');

--- a/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NewOperatorTest.php
@@ -1047,42 +1047,34 @@ class NewOperatorTest extends OrmFunctionalTestCase
         $this->assertEquals($this->fixtures[2]->username,$result[2]['cmsUserUsername']);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\InvalidClass(u.name)': Error: Class "\InvalidClass" is not defined.
-     */
     public function testInvalidClassException()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
+        $this->expectExceptionMessage('[Semantical Error] line 0, col 11 near \'\InvalidClass(u.name)\': Error: Class "\InvalidClass" is not defined.');
         $dql = "SELECT new \InvalidClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near '\stdClass(u.name)': Error: Class "\stdClass" has not a valid constructor.
-     */
     public function testInvalidClassConstructorException()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
+        $this->expectExceptionMessage('[Semantical Error] line 0, col 11 near \'\stdClass(u.name)\': Error: Class "\stdClass" has not a valid constructor.');
         $dql = "SELECT new \stdClass(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near 'Doctrine\Tests\ORM\Functional\ClassWithTooMuchArgs(u.name)': Error: Number of arguments does not match with "Doctrine\Tests\ORM\Functional\ClassWithTooMuchArgs" constructor declaration.
-     */
     public function testInvalidClassWithoutConstructorException()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
+        $this->expectExceptionMessage('[Semantical Error] line 0, col 11 near \'Doctrine\Tests\ORM\Functional\ClassWithTooMuchArgs(u.name)\': Error: Number of arguments does not match with "Doctrine\Tests\ORM\Functional\ClassWithTooMuchArgs" constructor declaration.');
         $dql = "SELECT new Doctrine\Tests\ORM\Functional\ClassWithTooMuchArgs(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     * @expectedExceptionMessage [Semantical Error] line 0, col 11 near 'Doctrine\Tests\ORM\Functional\ClassWithPrivateConstructor(u.name)': Error: Class "Doctrine\Tests\ORM\Functional\ClassWithPrivateConstructor" can not be instantiated.
-     */
     public function testClassCantBeInstantiatedException()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
+        $this->expectExceptionMessage('[Semantical Error] line 0, col 11 near \'Doctrine\Tests\ORM\Functional\ClassWithPrivateConstructor(u.name)\': Error: Class "Doctrine\Tests\ORM\Functional\ClassWithPrivateConstructor" can not be instantiated.');
         $dql = "SELECT new Doctrine\Tests\ORM\Functional\ClassWithPrivateConstructor(u.name) FROM Doctrine\Tests\Models\CMS\CmsUser u";
         $this->_em->createQuery($dql)->getResult();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -315,38 +315,30 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->flush();
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Query\QueryException
-     */
     public function testIterateResult_FetchJoinedCollection_ThrowsException()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
         $query = $this->_em->createQuery("SELECT u, a FROM ' . CmsUser::class . ' u JOIN u.articles a");
         $articles = $query->iterate();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\NoResultException
-     */
     public function testGetSingleResultThrowsExceptionOnNoResult()
     {
+        $this->expectException('Doctrine\ORM\NoResultException');
         $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a")
              ->getSingleResult();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\NoResultException
-     */
     public function testGetSingleScalarResultThrowsExceptionOnNoResult()
     {
+        $this->expectException('Doctrine\ORM\NoResultException');
         $this->_em->createQuery("select a from Doctrine\Tests\Models\CMS\CmsArticle a")
              ->getSingleScalarResult();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\NonUniqueResultException
-     */
     public function testGetSingleScalarResultThrowsExceptionOnNonUniqueResult()
     {
+        $this->expectException('Doctrine\ORM\NonUniqueResultException');
         $user = new CmsUser;
         $user->name = 'Guilherme';
         $user->username = 'gblanco';

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheManyToManyTest.php
@@ -186,12 +186,10 @@ class SecondLevelCacheManyToManyTest extends SecondLevelCacheAbstractTest
         $this->assertEquals($queryCount1, $this->getCurrentQueryCount());
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Cannot update a readonly collection "Doctrine\Tests\Models\Cache\Travel#visitedCities
-     */
     public function testReadOnlyCollection()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Cannot update a readonly collection "Doctrine\Tests\Models\Cache\Travel#visitedCities');
         $this->evictRegions();
 
         $this->loadFixturesCountries();

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheQueryCacheTest.php
@@ -1085,12 +1085,10 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
         $this->assertFalse($this->cache->containsEntity(Country::class, $this->countries[1]->getId()));
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Second level cache does not support partial entities.
-     */
     public function testCacheablePartialQueryException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Second level cache does not support partial entities.');
         $this->evictRegions();
         $this->loadFixturesCountries();
 
@@ -1100,23 +1098,19 @@ class SecondLevelCacheQueryCacheTest extends SecondLevelCacheAbstractTest
             ->getResult();
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Second-level cache query supports only select statements.
-     */
     public function testNonCacheableQueryDeleteStatementException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Second-level cache query supports only select statements.');
         $this->_em->createQuery("DELETE Doctrine\Tests\Models\Cache\Country u WHERE u.id = 4")
             ->setCacheable(true)
             ->getResult();
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Second-level cache query supports only select statements.
-     */
     public function testNonCacheableQueryUpdateStatementException()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Second-level cache query supports only select statements.');
         $this->_em->createQuery("UPDATE Doctrine\Tests\Models\Cache\Country u SET u.name = 'foo' WHERE u.id = 4")
             ->setCacheable(true)
             ->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
@@ -49,12 +49,10 @@ class DDC2084Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->assertEquals('Foo', $e->getMyEntity2()->getValue());
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\ORMInvalidArgumentException
-     * @expectedExceptionMessage  Binding entities to query parameters only allowed for entities that have an identifier.
-     */
     public function testinvalidIdentifierBindingEntityException()
     {
+        $this->expectException('Doctrine\ORM\ORMInvalidArgumentException');
+        $this->expectExceptionMessage('Binding entities to query parameters only allowed for entities that have an identifier.');
         $this->_em->find(__NAMESPACE__ . '\DDC2084\MyEntity1', new DDC2084\MyEntity2('Foo'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ObjectHydratorTest.php
@@ -1822,12 +1822,11 @@ class ObjectHydratorTest extends HydrationTestCase
 
     /**
      * @group DDC-1470
-     *
-     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
-     * @expectedExceptionMessage The meta mapping for the discriminator column "c_discr" is missing for "Doctrine\Tests\Models\Company\CompanyFixContract" using the DQL alias "c".
      */
     public function testMissingMetaMappingException()
     {
+        $this->expectException('Doctrine\ORM\Internal\Hydration\HydrationException');
+        $this->expectExceptionMessage('The meta mapping for the discriminator column "c_discr" is missing for "Doctrine\Tests\Models\Company\CompanyFixContract" using the DQL alias "c".');
         $rsm = new ResultSetMapping;
 
         $rsm->addEntityResult(CompanyFixContract::class, 'c');
@@ -1849,12 +1848,11 @@ class ObjectHydratorTest extends HydrationTestCase
 
     /**
      * @group DDC-1470
-     *
-     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
-     * @expectedExceptionMessage The discriminator column "discr" is missing for "Doctrine\Tests\Models\Company\CompanyEmployee" using the DQL alias "e".
      */
     public function testMissingDiscriminatorColumnException()
     {
+        $this->expectException('Doctrine\ORM\Internal\Hydration\HydrationException');
+        $this->expectExceptionMessage('The discriminator column "discr" is missing for "Doctrine\Tests\Models\Company\CompanyEmployee" using the DQL alias "e".');
         $rsm = new ResultSetMapping;
 
         $rsm->addEntityResult(CompanyFixContract::class, 'c');
@@ -1883,12 +1881,11 @@ class ObjectHydratorTest extends HydrationTestCase
 
     /**
      * @group DDC-3076
-     *
-     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
-     * @expectedExceptionMessage The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".
      */
     public function testInvalidDiscriminatorValueException()
     {
+        $this->expectException('Doctrine\ORM\Internal\Hydration\HydrationException');
+        $this->expectExceptionMessage('The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".');
         $rsm = new ResultSetMapping;
 
         $rsm->addEntityResult(CompanyPerson::class, 'p');

--- a/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SimpleObjectHydratorTest.php
@@ -14,12 +14,11 @@ class SimpleObjectHydratorTest extends HydrationTestCase
 {
     /**
      * @group DDC-1470
-     *
-     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
-     * @expectedExceptionMessage The discriminator column "discr" is missing for "Doctrine\Tests\Models\Company\CompanyPerson" using the DQL alias "p".
      */
     public function testMissingDiscriminatorColumnException()
     {
+        $this->expectException('Doctrine\ORM\Internal\Hydration\HydrationException');
+        $this->expectExceptionMessage('The discriminator column "discr" is missing for "Doctrine\Tests\Models\Company\CompanyPerson" using the DQL alias "p".');
         $rsm = new ResultSetMapping;
         $rsm->addEntityResult(CompanyPerson::class, 'p');
         $rsm->addFieldResult('p', 'p__id', 'id');
@@ -64,12 +63,11 @@ class SimpleObjectHydratorTest extends HydrationTestCase
 
     /**
      * @group DDC-3076
-     *
-     * @expectedException \Doctrine\ORM\Internal\Hydration\HydrationException
-     * @expectedExceptionMessage The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".
      */
     public function testInvalidDiscriminatorValueException()
     {
+        $this->expectException('Doctrine\ORM\Internal\Hydration\HydrationException');
+        $this->expectExceptionMessage('The discriminator value "subworker" is invalid. It must be one of "person", "manager", "employee".');
         $rsm = new ResultSetMapping;
 
         $rsm->addEntityResult(CompanyPerson::class, 'p');

--- a/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AnnotationDriverTest.php
@@ -33,12 +33,10 @@ class AnnotationDriverTest extends AbstractMappingDriverTest
         $annotationDriver->loadMetadataForClass('stdClass', $cm);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Entity association field "Doctrine\Tests\ORM\Mapping\AnnotationSLC#foo" not configured as part of the second-level cache.
-     */
     public function testFailingSecondLevelCacheAssociation()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Entity association field "Doctrine\Tests\ORM\Mapping\AnnotationSLC#foo" not configured as part of the second-level cache.');
         $mappingDriver = $this->_loadDriver();
 
         $class = new ClassMetadata(AnnotationSLC::class);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -811,12 +811,10 @@ class ClassMetadataTest extends OrmTestCase
         $this->assertEquals($metadata->entityListeners, $unserialize->entityListeners);
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Query named "userById" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once
-     */
     public function testNamingCollisionNamedQueryShouldThrowException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Query named "userById" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -837,12 +835,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1663
-     *
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Query named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once
      */
     public function testNamingCollisionNamedNativeQueryShouldThrowException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Query named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -867,12 +864,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1663
-     *
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Result set mapping named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once
      */
     public function testNamingCollisionSqlResultSetMappingShouldThrowException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Result set mapping named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser" was already declared, but it must be declared only once');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -943,12 +939,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1663
-     *
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Query name on entity class 'Doctrine\Tests\Models\CMS\CmsUser' is not defined.
      */
     public function testNameIsMandatoryForNamedQueryMappingException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Query name on entity class \'Doctrine\Tests\Models\CMS\CmsUser\' is not defined.');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addNamedQuery(
@@ -960,12 +955,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1663
-     *
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Query name on entity class 'Doctrine\Tests\Models\CMS\CmsUser' is not defined.
      */
     public function testNameIsMandatoryForNameNativeQueryMappingException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Query name on entity class \'Doctrine\Tests\Models\CMS\CmsUser\' is not defined.');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addNamedQuery(
@@ -979,12 +973,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1663
-     *
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Result set mapping named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser requires a entity class name.
      */
     public function testNameIsMandatoryForEntityNameSqlResultSetMappingException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Result set mapping named "find-all" in "Doctrine\Tests\Models\CMS\CmsUser requires a entity class name.');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->addSqlResultSetMapping(
@@ -999,12 +992,10 @@ class ClassMetadataTest extends OrmTestCase
         );
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Discriminator column name on entity class 'Doctrine\Tests\Models\CMS\CmsUser' is not defined.
-     */
     public function testNameIsMandatoryForDiscriminatorColumnsMappingException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Discriminator column name on entity class \'Doctrine\Tests\Models\CMS\CmsUser\' is not defined.');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->setDiscriminatorColumn([]);
@@ -1082,11 +1073,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-964
-     * @expectedException        Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Invalid field override named 'invalidPropertyName' for class 'Doctrine\Tests\Models\DDC964\DDC964Admin
      */
     public function testInvalidPropertyAssociationOverrideNameException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Invalid field override named \'invalidPropertyName\' for class \'Doctrine\Tests\Models\DDC964\DDC964Admin');
         $cm = new ClassMetadata(DDC964Admin::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapManyToOne(['fieldName' => 'address', 'targetEntity' => 'DDC964Address']);
@@ -1096,11 +1087,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-964
-     * @expectedException        Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Invalid field override named 'invalidPropertyName' for class 'Doctrine\Tests\Models\DDC964\DDC964Guest'.
      */
     public function testInvalidPropertyAttributeOverrideNameException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Invalid field override named \'invalidPropertyName\' for class \'Doctrine\Tests\Models\DDC964\DDC964Guest\'.');
         $cm = new ClassMetadata(DDC964Guest::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapField(['fieldName' => 'name']);
@@ -1110,11 +1101,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-964
-     * @expectedException        Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage The column type of attribute 'name' on class 'Doctrine\Tests\Models\DDC964\DDC964Guest' could not be changed.
      */
     public function testInvalidOverrideAttributeFieldTypeException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('The column type of attribute \'name\' on class \'Doctrine\Tests\Models\DDC964\DDC964Guest\' could not be changed.');
         $cm = new ClassMetadata(DDC964Guest::class);
         $cm->initializeReflection(new RuntimeReflectionService());
         $cm->mapField(['fieldName' => 'name', 'type'=>'string']);
@@ -1124,12 +1115,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1955
-     *
-     * @expectedException        Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Entity Listener "\InvalidClassName" declared on "Doctrine\Tests\Models\CMS\CmsUser" not found.
      */
     public function testInvalidEntityListenerClassException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Entity Listener "\InvalidClassName" declared on "Doctrine\Tests\Models\CMS\CmsUser" not found.');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
@@ -1138,12 +1128,11 @@ class ClassMetadataTest extends OrmTestCase
 
     /**
      * @group DDC-1955
-     *
-     * @expectedException        Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage Entity Listener "\Doctrine\Tests\Models\Company\CompanyContractListener" declared on "Doctrine\Tests\Models\CMS\CmsUser" has no method "invalidMethod".
      */
     public function testInvalidEntityListenerMethodException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Entity Listener "\Doctrine\Tests\Models\Company\CompanyContractListener" declared on "Doctrine\Tests\Models\CMS\CmsUser" has no method "invalidMethod".');
         $cm = new ClassMetadata(CMS\CmsUser::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 

--- a/tests/Doctrine/Tests/ORM/Mapping/EntityListenerResolverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/EntityListenerResolverTest.php
@@ -87,12 +87,10 @@ class EntityListenerResolverTest extends OrmTestCase
         $this->assertNotSame($obj2, $this->resolver->resolve($className2));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage An object was expected, but got "string".
-     */
     public function testRegisterStringException()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('An object was expected, but got "string".');
         $this->resolver->register('CompanyContractListener');
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -35,12 +35,10 @@ class PHPMappingDriverTest extends AbstractMappingDriverTest
         self::assertInstanceOf(ClassMetadata::class, $this->createClassMetadata(DDC889Class::class));
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Entity association field "Doctrine\Tests\ORM\Mapping\PHPSLC#foo" not configured as part of the second-level cache.
-     */
     public function testFailingSecondLevelCacheAssociation()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Entity association field "Doctrine\Tests\ORM\Mapping\PHPSLC#foo" not configured as part of the second-level cache.');
         $mappingDriver = $this->_loadDriver();
 
         $class = new ClassMetadata(Mapping\PHPSLC::class);

--- a/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/XmlMappingDriverTest.php
@@ -42,12 +42,10 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
         $this->assertEquals($expectedMap, $class->discriminatorMap);
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Cache\CacheException
-     * @expectedExceptionMessage Entity association field "Doctrine\Tests\ORM\Mapping\XMLSLC#foo" not configured as part of the second-level cache.
-     */
     public function testFailingSecondLevelCacheAssociation()
     {
+        $this->expectException('Doctrine\ORM\Cache\CacheException');
+        $this->expectExceptionMessage('Entity association field "Doctrine\Tests\ORM\Mapping\XMLSLC#foo" not configured as part of the second-level cache.');
         $mappingDriver = $this->_loadDriver();
 
         $class = new ClassMetadata(XMLSLC::class);
@@ -137,12 +135,11 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
     /**
      * @group DDC-1468
-     *
-     * @expectedException \Doctrine\Common\Persistence\Mapping\MappingException
-     * @expectedExceptionMessage Invalid mapping file 'Doctrine.Tests.Models.Generic.SerializationModel.dcm.xml' for class 'Doctrine\Tests\Models\Generic\SerializationModel'.
      */
     public function testInvalidMappingFileException()
     {
+        $this->expectException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.SerializationModel.dcm.xml\' for class \'Doctrine\Tests\Models\Generic\SerializationModel\'.');
         $this->createClassMetadata(SerializationModel::class);
     }
 
@@ -211,11 +208,11 @@ class XmlMappingDriverTest extends AbstractMappingDriverTest
 
     /**
      * @group DDC-889
-     * @expectedException \Doctrine\Common\Persistence\Mapping\MappingException
-     * @expectedExceptionMessage Invalid mapping file 'Doctrine.Tests.Models.DDC889.DDC889Class.dcm.xml' for class 'Doctrine\Tests\Models\DDC889\DDC889Class'.
      */
     public function testinvalidEntityOrMappedSuperClassShouldMentionParentClasses()
     {
+        $this->expectException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.DDC889.DDC889Class.dcm.xml\' for class \'Doctrine\Tests\Models\DDC889\DDC889Class\'.');
         $this->createClassMetadata(DDC889Class::class);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -51,12 +51,11 @@ class YamlMappingDriverTest extends AbstractMappingDriverTest
 
     /**
      * @group DDC-1468
-     *
-     * @expectedException Doctrine\Common\Persistence\Mapping\MappingException
-     * @expectedExceptionMessage Invalid mapping file 'Doctrine.Tests.Models.Generic.SerializationModel.dcm.yml' for class 'Doctrine\Tests\Models\Generic\SerializationModel'.
      */
     public function testInvalidMappingFileException()
     {
+        $this->expectException('Doctrine\Common\Persistence\Mapping\MappingException');
+        $this->expectExceptionMessage('Invalid mapping file \'Doctrine.Tests.Models.Generic.SerializationModel.dcm.yml\' for class \'Doctrine\Tests\Models\Generic\SerializationModel\'.');
         $this->createClassMetadata(SerializationModel::class);
     }
 

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeSqlTest.php
@@ -48,11 +48,9 @@ class BasicEntityPersisterCompositeTypeSqlTest extends OrmTestCase
         $this->assertEquals('t0.admin1 IS NOT NULL AND t0.country IS NOT NULL', $statement);
     }
 
-    /**
-     * @expectedException Doctrine\ORM\ORMException
-     */
     public function testSelectConditionStatementIn()
     {
+        $this->expectException('Doctrine\ORM\ORMException');
         $this->_persister->getSelectConditionStatementSQL('admin1', [], [], Comparison::IN);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/ExprTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ExprTest.php
@@ -334,11 +334,9 @@ class ExprTest extends OrmTestCase
         $this->assertEquals('u.username ASC', (string) $orderExpr);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddThrowsException()
     {
+        $this->expectException('InvalidArgumentException');
         $orExpr = $this->_expr->orX();
         $orExpr->add($this->_expr->quot(5, 2));
     }

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -63,11 +63,9 @@ class FilterCollectionTest extends OrmTestCase
         $this->assertTrue($filterCollection->isEnabled('testFilter'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetFilterInvalidArgument()
     {
+        $this->expectException('InvalidArgumentException');
         $filterCollection = $this->em->getFilters();
         $filterCollection->getFilter('testFilter');
     }

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -132,20 +132,16 @@ class QueryTest extends OrmTestCase
         $this->assertSame($this->_em->getConfiguration()->getResultCacheImpl(), $q->getQueryCacheProfile()->getResultCacheDriver());
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     **/
     public function testIterateWithNoDistinctAndWrongSelectClause()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
         $q = $this->_em->createQuery("select u, a from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
         $q->iterate();
     }
 
-    /**
-     * @expectedException Doctrine\ORM\Query\QueryException
-     **/
     public function testIterateWithNoDistinctAndWithValidSelectClause()
     {
+        $this->expectException('Doctrine\ORM\Query\QueryException');
         $q = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u LEFT JOIN u.articles a");
         $q->iterate();
     }

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -901,11 +901,9 @@ class SelectSqlGenerationTest extends OrmTestCase
         );
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Query\QueryException
-     */
     public function testOrderBySupportsSingleValuedPathExpressionInverseSide()
     {
+        $this->expectException('\Doctrine\ORM\Query\QueryException');
         $q = $this->_em->createQuery("select u from Doctrine\Tests\Models\CMS\CmsUser u order by u.address");
         $q->getSQL();
     }

--- a/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/AttachEntityListenersListenerTest.php
@@ -90,12 +90,10 @@ class AttachEntityListenersListenerTest extends OrmTestCase
         $this->assertEquals(AttachEntityListenersListenerTestListener2::class, $metadata->entityListeners['postPersist'][1]['class']);
     }
 
-    /**
-     * @expectedException \Doctrine\ORM\Mapping\MappingException
-     * @expectedExceptionMessage  Entity Listener "Doctrine\Tests\ORM\Tools\AttachEntityListenersListenerTestListener#postPersist()" in "Doctrine\Tests\ORM\Tools\AttachEntityListenersListenerTestFooEntity" was already declared, but it must be declared only once.
-     */
     public function testDuplicateEntityListenerException()
     {
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Entity Listener "Doctrine\Tests\ORM\Tools\AttachEntityListenersListenerTestListener#postPersist()" in "Doctrine\Tests\ORM\Tools\AttachEntityListenersListenerTestFooEntity" was already declared, but it must be declared only once.');
         $this->listener->addEntityListener(
             AttachEntityListenersListenerTestFooEntity::class,
             AttachEntityListenersListenerTestListener::class,

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/MappingDescribeCommandTest.php
@@ -59,12 +59,10 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         self::assertContains('Root entity name', $display);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage possible matches
-     */
     public function testShowSpecificFuzzyAmbiguous()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('possible matches');
         $this->tester->execute(
             [
                 'command'    => $this->command->getName(),
@@ -73,12 +71,10 @@ class MappingDescribeCommandTest extends OrmFunctionalTestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Could not find any mapped Entity classes matching "AttractionFooBar"
-     */
     public function testShowSpecificNotFound()
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('Could not find any mapped Entity classes matching "AttractionFooBar"');
         $this->tester->execute(
             [
                 'command'    => $this->command->getName(),


### PR DESCRIPTION
These changes have been done using Rector, this might not result in the
best placement for method calls, but it is not worse than the current
situation.

I used the configuration documented at
https://github.com/rectorphp/rector/blob/b398e8740c3619525061350d4d4e1bca20dabea9/docs/HowItWorks.md#221-order-of-rectors

Fixes #8069