### PR TITLE
Optimize paginator removing useless left joins in subselect

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -146,6 +146,7 @@ class Paginator implements \Countable, \IteratorAggregate
                 $subQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
             } else {
                 $this->appendTreeWalker($subQuery, LimitSubqueryWalker::class);
+                $this->appendTreeWalker($subQuery, RemoveUselessLeftJoinsWalker::class);
                 $this->unbindUnusedQueryParams($subQuery);
             }
 

--- a/lib/Doctrine/ORM/Tools/Pagination/RemoveUselessLeftJoinsWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RemoveUselessLeftJoinsWalker.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Doctrine\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Query\AST\SelectStatement;
+use Doctrine\ORM\Query\TreeWalkerAdapter;
+
+class RemoveUselessLeftJoinsWalker extends TreeWalkerAdapter
+{
+    public function walkSelectStatement(SelectStatement $AST)
+    {
+        $queryComponents = $this->_getQueryComponents();
+        $this->removeUnusedJoins($AST);
+    }
+
+    private function removeUnusedJoins(SelectStatement $AST)
+    {
+        $from = $AST->fromClause->identificationVariableDeclarations;
+        $fromRoot = reset($from);
+
+        if (!isset($AST->whereClause) || !isset($AST->whereClause->conditionalExpression) || !isset($AST->whereClause->conditionalExpression->simpleConditionalExpression)) {
+            return;
+        }
+
+        $expr = $AST->whereClause->conditionalExpression->simpleConditionalExpression;
+
+        if (!isset($expr->subselect)) {
+            return;
+        }
+
+        $subSelect = $expr->subselect;
+        $subSelectUsages = $this->findSubSelectUsages($subSelect);
+
+        foreach ($subSelect->subselectFromClause->identificationVariableDeclarations as $declaration) {
+            $declaration->joins = $this->filterJoins($declaration->joins, $this->findUnusedJoins($declaration->joins, $subSelectUsages));
+        }
+
+        $usages = $this->findSubSelectUsages($AST);
+        $fromRoot->joins = $this->filterJoins($fromRoot->joins, $this->findUnusedJoins($fromRoot->joins, $usages));
+    }
+
+    private function recursiveAddUsages($usages, $parents)
+    {
+        foreach ($usages as $id) {
+            if (array_key_exists($id, $parents) && !in_array($parents[$id], $usages)) {
+                $usages = $this->recursiveAddUsages(array_merge($usages, [$parents[$id]]), $parents);
+            }
+        }
+
+        return $usages;
+    }
+
+    private function findUnusedJoins($joins, $usages)
+    {
+        $parents = [];
+        foreach ($joins as $join) {
+            $parents[$join->joinAssociationDeclaration->aliasIdentificationVariable] = $join->joinAssociationDeclaration->joinAssociationPathExpression->identificationVariable;
+        }
+
+        $usages = $this->recursiveAddUsages($usages, $parents);
+
+        $unused = [];
+        foreach ($joins as $join) {
+            if (Query\AST\Join::JOIN_TYPE_LEFT === $join->joinType && !in_array($join->joinAssociationDeclaration->aliasIdentificationVariable, $usages)) {
+                $unused[] = $join;
+            }
+        }
+
+        return array_unique($unused);
+    }
+
+    private function filterJoins($joins, $toRemove)
+    {
+        return array_filter($joins, function (Query\AST\Join $join) use ($toRemove) {
+            return !in_array($join, $toRemove);
+        });
+    }
+
+    private function extractIdentificationVariable($expression)
+    {
+        if ($expression->simpleArithmeticExpression instanceof Query\AST\Literal) {
+            return null;
+        }
+
+        return $expression->simpleArithmeticExpression->identificationVariable;
+    }
+
+    private function extractIdentificationVariableFromExpression($expr): array
+    {
+        $usages = [];
+
+        if ($expr instanceof Query\AST\ComparisonExpression) {
+            $usages[] = $this->extractIdentificationVariable($expr->leftExpression);
+            $usages[] = $this->extractIdentificationVariable($expr->rightExpression);
+        } else {
+            $usages[] = $this->extractIdentificationVariable($expr->expression);
+        }
+
+        return $usages;
+    }
+
+    private function findSubSelectUsages($select)
+    {
+        $usages = [];
+
+        if (isset($select->whereClause)) {
+            if ($select->whereClause->conditionalExpression instanceof Query\AST\ConditionalTerm) {
+                foreach ($select->whereClause->conditionalExpression->conditionalFactors as $factor) {
+                    $expr = $factor->simpleConditionalExpression;
+                    $usages = array_merge($usages, $this->extractIdentificationVariableFromExpression($expr));
+                }
+            } elseif ($select->whereClause->conditionalExpression instanceof Query\AST\ConditionalPrimary) {
+                $usages = array_merge($usages, $this->extractIdentificationVariableFromExpression($select->whereClause->conditionalExpression->simpleConditionalExpression));
+            }
+        }
+
+        if (isset($select->orderByClause)) {
+            foreach ($select->orderByClause->orderByItems as $item) {
+                if ($item->expression instanceof Query\AST\OrderByItem || $item->expression instanceof Query\AST\PathExpression) {
+                    $usages[] = $item->expression->identificationVariable;
+                }
+            }
+        }
+
+        $usages = array_unique($usages);
+
+        return $usages;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query;
-use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
 use Doctrine\ORM\Tools\Pagination\RemoveUselessLeftJoinsWalker;
 
 /**
@@ -27,7 +28,7 @@ DQL;
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
 
         $this->assertEquals(
-            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_)",
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_)',
             $limitQuery->getSQL()
         );
     }
@@ -48,7 +49,7 @@ DQL;
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
 
         $this->assertEquals(
-            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id ORDER BY a4_.id DESC)",
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id ORDER BY a4_.id DESC)',
             $limitQuery->getSQL()
         );
     }
@@ -69,7 +70,7 @@ DQL;
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
 
         $this->assertEquals(
-            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id WHERE 2 = a4_.id)",
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id WHERE 2 = a4_.id)',
             $limitQuery->getSQL()
         );
     }
@@ -90,7 +91,7 @@ DQL;
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
 
         $this->assertEquals(
-            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Category c4_ ON m3_.category_id = c4_.id LEFT JOIN Author a5_ ON m3_.author_id = a5_.id WHERE 2 = a5_.id AND c4_.id = 1)",
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Category c4_ ON m3_.category_id = c4_.id LEFT JOIN Author a5_ ON m3_.author_id = a5_.id WHERE 2 = a5_.id AND c4_.id = 1)',
             $limitQuery->getSQL()
         );
     }
@@ -111,9 +112,8 @@ DQL;
         $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
 
         $this->assertEquals(
-            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id HAVING a4_.id > 2)",
+            'SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id HAVING a4_.id > 2)',
             $limitQuery->getSQL()
         );
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Pagination;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
+use Doctrine\ORM\Tools\Pagination\RemoveUselessLeftJoinsWalker;
+
+/**
+ * @group DDC-1613
+ */
+class RemoveUselessLeftJoinWalkerTest extends PaginationTestCase
+{
+    public function testUselessLeftJoinsAreRemoved()
+    {
+        $dql        = <<<DQL
+SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p 
+LEFT JOIN p.category c 
+LEFT JOIN p.author a
+WHERE p.id IN (SELECT DISTINCT(p2.id) FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p2 
+LEFT JOIN p2.category c2 
+LEFT JOIN p2.author a2)
+DQL;
+        $query      = $this->entityManager->createQuery($dql);
+        $limitQuery = clone $query;
+
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
+
+        $this->assertEquals(
+            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_)",
+            $limitQuery->getSQL()
+        );
+    }
+
+    public function testOrderByLeftJoinsAreKept()
+    {
+        $dql        = <<<DQL
+SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p 
+LEFT JOIN p.category c 
+LEFT JOIN p.author a
+WHERE p.id IN (SELECT DISTINCT(p2.id) FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p2 
+LEFT JOIN p2.category c2 
+LEFT JOIN p2.author a2 ORDER BY a2.id DESC)
+DQL;
+        $query      = $this->entityManager->createQuery($dql);
+        $limitQuery = clone $query;
+
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
+
+        $this->assertEquals(
+            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id ORDER BY a4_.id DESC)",
+            $limitQuery->getSQL()
+        );
+    }
+
+    public function testWhereLeftJoinsAreKept()
+    {
+        $dql        = <<<DQL
+SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p 
+LEFT JOIN p.category c 
+LEFT JOIN p.author a
+WHERE p.id IN (SELECT DISTINCT(p2.id) FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p2 
+LEFT JOIN p2.category c2 
+LEFT JOIN p2.author a2 WHERE 2 = a2.id)
+DQL;
+        $query      = $this->entityManager->createQuery($dql);
+        $limitQuery = clone $query;
+
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
+
+        $this->assertEquals(
+            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id WHERE 2 = a4_.id)",
+            $limitQuery->getSQL()
+        );
+    }
+
+    public function testMultipleWhereLeftJoinsAreKept()
+    {
+        $dql        = <<<DQL
+SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p 
+LEFT JOIN p.category c 
+LEFT JOIN p.author a
+WHERE p.id IN (SELECT DISTINCT(p2.id) FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p2 
+LEFT JOIN p2.category c2 
+LEFT JOIN p2.author a2 WHERE 2 = a2.id AND c2.id = 1)
+DQL;
+        $query      = $this->entityManager->createQuery($dql);
+        $limitQuery = clone $query;
+
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
+
+        $this->assertEquals(
+            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Category c4_ ON m3_.category_id = c4_.id LEFT JOIN Author a5_ ON m3_.author_id = a5_.id WHERE 2 = a5_.id AND c4_.id = 1)",
+            $limitQuery->getSQL()
+        );
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/RemoveUselessLeftJoinWalkerTest.php
@@ -94,4 +94,26 @@ DQL;
             $limitQuery->getSQL()
         );
     }
+
+    public function testHavingLeftJoinsAreKept()
+    {
+        $dql        = <<<DQL
+SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p 
+LEFT JOIN p.category c 
+LEFT JOIN p.author a
+WHERE p.id IN (SELECT DISTINCT(p2.id) FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p2 
+LEFT JOIN p2.category c2 
+LEFT JOIN p2.author a2 HAVING a2.id > 2)
+DQL;
+        $query      = $this->entityManager->createQuery($dql);
+        $limitQuery = clone $query;
+
+        $limitQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [RemoveUselessLeftJoinsWalker::class]);
+
+        $this->assertEquals(
+            "SELECT m0_.id AS id_0, m0_.title AS title_1, c1_.id AS id_2, a2_.id AS id_3, a2_.name AS name_4, m0_.author_id AS author_id_5, m0_.category_id AS category_id_6 FROM MyBlogPost m0_ WHERE m0_.id IN (SELECT DISTINCT (m3_.id) FROM MyBlogPost m3_ LEFT JOIN Author a4_ ON m3_.author_id = a4_.id HAVING a4_.id > 2)",
+            $limitQuery->getSQL()
+        );
+    }
+
 }


### PR DESCRIPTION
Hi

Here is a draft of what could be a huge performance boost for Paginator

Actually, to optimize database db queries, we could join nested fields but, when using it with the Paginator and some filters, the distinct subselect injected suffer of all that left joined data that could be removed on that subselect returning ids

I am not hoping that could be merge like this but it opens the discussion

Thanks in advance for your opinion and tips