### PR TITLE
[Docs] Make clear that calling remove() detaches the object

### DIFF
--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -330,6 +330,13 @@ in multiple ways with very different performance impacts.
    because Doctrine will fetch and remove all associated entities
    explicitly nevertheless.
 
+.. note::
+
+    Calling ``remove`` on an entity will remove the object from the identiy
+    map and therefore detach it. Querying the same entity again, for example 
+    via a lazy loaded relation, will return a new object. 
+
+
 Detaching entities
 ------------------
 


### PR DESCRIPTION
I changed a relationship from eager to lazy loading which broke the behavior of my application in regards to object removal. It was not clear for me that removing an object detaches it and subsequent calls like contains() in a OneToMany relationship, with the object scheduled for removal, will return false afterwards. This together with a lazy loaded relation might lead to unexpected behavior.

Example:

```php
$event = $repo->find(1);

$user = $event->getUser();
$this->em->remove($event);

$contains = $user->getEvents()->contains($event); //false, (lazy loaded list)
$count = $user->getEvents()->count(); //1 (the removed one, but different object / hash)
```

In combination with the Symfony Entity Generator it gets more confusing, since it provides a useful `removeEvent` function in the user object. This checks with a `contain()` if the object is there and does nothing otherwise.

```php
$event = $repo->find(1);

$user = $event->getUser();
$this->em->remove($event);
$user->removeEvent($event); //From the Symfony entity generator, does nothing in this case since the contains check fails

$count = count($user->getEvents());  //Still 1, containing the lazy-loaded event object

```
Feel free to change the text to make the problem more clear, thanks!