### PR TITLE
setParameters in docs example should use new syntax

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -319,11 +319,11 @@ With Nested Conditions in WHERE Clause:
 
     <?php
     $query = $em->createQuery('SELECT u FROM ForumUser u WHERE (u.username = :name OR u.username = :name2) AND u.id = :id');
-    $query->setParameters(array(
-        'name' => 'Bob',
-        'name2' => 'Alice',
-        'id' => 321,
-    ));
+    $query->setParameters(new \Doctrine\Common\Collections\ArrayCollection([
+        new \Doctrine\ORM\Query\Parameter('name', 'Bob'),
+        new \Doctrine\ORM\Query\Parameter('name2', 'Alice'),
+        new \Doctrine\ORM\Query\Parameter('id', '321'),
+    ]));
     $users = $query->getResult(); // array of ForumUser objects
 
 With COUNT DISTINCT:
@@ -1299,7 +1299,7 @@ pass parameters to the query the following methods can be used:
 
 -  ``AbstractQuery::setParameter($param, $value)`` - Set the
    numerical or named wildcard to the given value.
--  ``AbstractQuery::setParameters(array $params)`` - Set an array
+-  ``AbstractQuery::setParameters(ArrayCollection $params)`` - Set an array
    of parameter key-value pairs.
 -  ``AbstractQuery::getParameter($param)``
 -  ``AbstractQuery::getParameters()``

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -265,7 +265,10 @@ following syntax:
     // $qb instanceof QueryBuilder
 
     // Query here...
-    $qb->setParameters(array(1 => 'value for ?1', 2 => 'value for ?2'));
+    $qb->setParameters(new \Doctrine\Common\Collections\ArrayCollection([
+        new \Doctrine\ORM\Query\Parameter(1, 'value for ?1'),
+        new \Doctrine\ORM\Query\Parameter(2, 'value for ?2'),
+    ]));
 
 Getting already bound parameters is easy - simply use the above
 mentioned syntax with "getParameter()" or "getParameters()":


### PR DESCRIPTION
Since there is only compatibility with 2.3, we should point in docs how to add params with `setParameters` in the new way.