### PR TITLE
Cache id "[*_1 1][2]" contains unauthorized character " " #8066

### DIFF
--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -38,6 +38,6 @@ class EntityCacheKey extends CacheKey
 
         $this->identifier  = $identifier;
         $this->entityClass = $entityClass;
-        $this->hash        = str_replace('\\', '.', strtolower($entityClass) . '_' . implode(' ', $identifier));
+        $this->hash        = str_replace('\\', '.', strtolower($entityClass) . '_' . implode('_', $identifier));
     }
 }


### PR DESCRIPTION
According to discussion with issue #8066 creating a pull request with the fix.