### PR TITLE
Make _parseOptions function protected

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -672,7 +672,7 @@ class XmlDriver extends FileDriver
      *
      * @return array The options array.
      */
-    private function _parseOptions(SimpleXMLElement $options)
+    protected function _parseOptions(SimpleXMLElement $options)
     {
         $array = [];
 


### PR DESCRIPTION
It would be nice to be able to override _parseOptions function and add some custom features to it (for example, nullable options support)