### PR TITLE
Update AndX and OrX methods to use variadic parameter notation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,36 @@
 # Upgrade to 3.0
 
+## BC Break: `Expr::andX()` and `Expr::orX()` now use variadics
+
+If you extend `Expr` and override these methods, you have to use the new signature.
+
+old signature:
+```php
+class CustomExpr extends \Doctrine\ORM\Query\Expr
+{
+    public function andX($x = null){
+     // code
+    }
+
+    public function orX($x = null){
+     // code
+    }
+
+}
+```
+new signature:
+```php
+class CustomExpr extends \Doctrine\ORM\Query\Expr
+{
+    public function andX(...$clauses){
+     // code
+    }
+
+    public function orX(...$clauses){
+     // code
+    }
+}
+```
 ## BC Break: Removed ability to clear cache via console with some cache drivers
 
 The console commands `orm:clear-cache:metadata`, `orm:clear-cache:result`,

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -436,14 +437,14 @@ class BasicEntityPersister implements EntityPersister
      * Performs an UPDATE statement for an entity on a specific table.
      * The UPDATE can optionally be versioned, which requires the entity to have a version field.
      *
-     * @param object $entity          The entity object being updated.
-     * @param string $quotedTableName The quoted name of the table to apply the UPDATE on.
-     * @param mixed[] $updateData     The map of columns to update (column => value).
-     * @param bool $versioned         Whether the UPDATE should be versioned.
+     * @param object  $entity          The entity object being updated.
+     * @param string  $quotedTableName The quoted name of the table to apply the UPDATE on.
+     * @param mixed[] $updateData      The map of columns to update (column => value).
+     * @param bool    $versioned       Whether the UPDATE should be versioned.
      *
      * @throws ORMException
      * @throws OptimisticLockException
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     final protected function updateTable($entity, $quotedTableName, array $updateData, $versioned = false)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -7,11 +7,9 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Statement;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
-use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
@@ -21,7 +19,6 @@ use function array_filter;
 use function array_keys;
 use function array_merge;
 use function implode;
-use function is_array;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -82,7 +79,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Collect identifier column values
-        $id = [];
+        $id           = [];
         $idParameters = [];
 
         foreach ($this->class->getIdentifier() as $propertyName) {

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -28,7 +28,7 @@ class Expr
      *     // (u.type = ?1) AND (u.role = ?2)
      *     $expr->andX($expr->eq('u.type', ':1'), $expr->eq('u.role', ':2'));
      *
-     * @param Expr\Comparison|Expr\Func|Expr\Orx|string ...$clauses Optional clauses. Defaults to an empty array, but requires at least one
+     * @param Expr\Comparison|Expr\Func|Expr\Orx|Expr\Andx|string ...$clauses Optional clauses. Defaults to an empty array, but requires at least one
      *                                                     defined when converting to string.
      *
      * @return Expr\Andx
@@ -47,7 +47,7 @@ class Expr
      *     // (u.type = ?1) OR (u.role = ?2)
      *     $q->where($q->expr()->orX('u.type = ?1', 'u.role = ?2'));
      *
-     * @param Expr\Comparison|Expr\Func|Expr\Orx|string ...$clauses Optional clauses. Defaults to an empty array, but requires
+     * @param Expr\Comparison|Expr\Func|Expr\Orx|Expr\Andx|string ...$clauses Optional clauses. Defaults to an empty array, but requires
      *                 at least one defined when converting to string.
      *
      * @return Expr\Orx

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -28,14 +28,14 @@ class Expr
      *     // (u.type = ?1) AND (u.role = ?2)
      *     $expr->andX($expr->eq('u.type', ':1'), $expr->eq('u.role', ':2'));
      *
-     * @param Expr\Comparison|Expr\Func|Expr\Orx|string $x Optional clause. Defaults to null, but requires at least one
+     * @param Expr\Comparison|Expr\Func|Expr\Orx|string ...$clauses Optional clauses. Defaults to an empty array, but requires at least one
      *                                                     defined when converting to string.
      *
      * @return Expr\Andx
      */
-    public function andX($x = null)
+    public function andX(...$clauses)
     {
-        return new Expr\Andx(func_get_args());
+        return new Expr\Andx($clauses);
     }
 
     /**
@@ -47,14 +47,14 @@ class Expr
      *     // (u.type = ?1) OR (u.role = ?2)
      *     $q->where($q->expr()->orX('u.type = ?1', 'u.role = ?2'));
      *
-     * @param mixed $x Optional clause. Defaults to null, but requires
+     * @param Expr\Comparison|Expr\Func|Expr\Orx|string ...$clauses Optional clauses. Defaults to an empty array, but requires
      *                 at least one defined when converting to string.
      *
      * @return Expr\Orx
      */
-    public function orX($x = null)
+    public function orX(...$clauses)
     {
-        return new Expr\Orx(func_get_args());
+        return new Expr\Orx($clauses);
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -334,9 +334,9 @@ class Expr
      * @param mixed $x
      * @param mixed $y
      */
-    public function mod($x, $y): Expr\Func
+    public function mod($x, $y) : Expr\Func
     {
-        return new Expr\Func('MOD', array($x, $y));
+        return new Expr\Func('MOD', [$x, $y]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3303Test.php
@@ -13,9 +13,7 @@ class DDC3303Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $this->schemaTool->createSchema([
-            $this->em->getClassMetadata(DDC3303Employee::class)
-        ]);
+        $this->schemaTool->createSchema([$this->em->getClassMetadata(DDC3303Employee::class)]);
     }
 
     /**


### PR DESCRIPTION
Use variadic parameter notation to update the method's signature but without causing BC. Also, update the PHPDOC of the methods.