### PR TITLE
Fix QueryBuilder::getParameter() on parameter names with colons

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -321,11 +321,13 @@ abstract class AbstractQuery
      */
     public function getParameter($key)
     {
+        $key = Query\Parameter::normalizeName($key);
+
         $filteredParameters = $this->parameters->filter(
             function (Query\Parameter $parameter) use ($key) : bool {
                 $parameterName = $parameter->getName();
 
-                return $key === $parameterName || (string) $key === (string) $parameterName;
+                return $key === $parameterName;
             }
         );
 

--- a/lib/Doctrine/ORM/Query/Parameter.php
+++ b/lib/Doctrine/ORM/Query/Parameter.php
@@ -31,6 +31,18 @@ use function trim;
 class Parameter
 {
     /**
+     * Returns the internal representation of a parameter name.
+     *
+     * @param string|int $name The parameter name or position.
+     *
+     * @return string The normalized parameter name.
+     */
+    public static function normalizeName($name)
+    {
+        return trim((string) $name, ':');
+    }
+
+    /**
      * The parameter name.
      *
      * @var string
@@ -67,7 +79,7 @@ class Parameter
      */
     public function __construct($name, $value, $type = null)
     {
-        $this->name          = trim((string) $name, ':');
+        $this->name          = self::normalizeName($name);
         $this->typeSpecified = $type !== null;
 
         $this->setValue($value, $type);

--- a/lib/Doctrine/ORM/Query/Parameter.php
+++ b/lib/Doctrine/ORM/Query/Parameter.php
@@ -67,7 +67,7 @@ class Parameter
      */
     public function __construct($name, $value, $type = null)
     {
-        $this->name          = trim($name, ':');
+        $this->name          = trim((string) $name, ':');
         $this->typeSpecified = $type !== null;
 
         $this->setValue($value, $type);

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -602,11 +602,13 @@ class QueryBuilder
      */
     public function getParameter($key)
     {
+        $key = Query\Parameter::normalizeName($key);
+
         $filteredParameters = $this->parameters->filter(
             function (Query\Parameter $parameter) use ($key) : bool {
                 $parameterName = $parameter->getName();
 
-                return $key === $parameterName || (string) $key === (string) $parameterName;
+                return $key === $parameterName;
             }
         );
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8106Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8106Test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-8106
+ */
+class GH8106Test extends OrmFunctionalTestCase
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(GH8106User::class),
+            ]
+        );
+    }
+
+    public function testIssue() : void
+    {
+        $user = new GH8106User();
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $qb = $this->_em->createQueryBuilder();
+        $qb
+            ->select('u')
+            ->from(GH8106User::class, 'u')
+            ->where('u.id = :id')
+            ->setParameter(':id', 1)
+            ->setParameter(':id', 1);
+
+        $result = $qb->getQuery()->getResult(); // should not throw QueryException
+
+        self::assertCount(1, $result);
+    }
+}
+
+/** @Entity */
+class GH8106User
+{
+    /** @Id @Column(type="integer") @GeneratedValue */
+    public $id;
+}


### PR DESCRIPTION
Fixes #8106.

This change can be backported to the stable release (2.7), but will cause a small merge conflict because it builds on commit [17e7c2a42](https://github.com/doctrine/orm/commit/17e7c2a42e0ee49781e60d6facdd2efc9e1f86b3#diff-01ac4deedc780ada53097bd3bd8d5be2) which hasn't been backported.
*Update: has been backported from master to 2.7 as requested.*