### PR TITLE
Add alert to "avoid persisting detached entities"

### DIFF
--- a/docs/en/reference/working-with-objects.rst
+++ b/docs/en/reference/working-with-objects.rst
@@ -250,6 +250,12 @@ as follows:
 -  If X is a detached entity, an exception will be thrown on
    flush.
 
+.. caution::
+
+    Do not pass detached entities to the persist operation. The persist operation always
+    considers entities that are not yet known to the ``EntityManager`` as new entities
+    (refer to the ``STATE_NEW`` constant inside the ``UnitOfWork``).
+
 Removing entities
 -----------------
 


### PR DESCRIPTION
The alert is hidden into the code

https://github.com/doctrine/orm/blob/8c259ea5cb632dbb57001b2262048ae7fa52b102/lib/Doctrine/ORM/EntityManager.php#L619-L620

while it's useful to be mentioned in the documentation, the same way it is done for the [documentation from Doctrine ODM](https://github.com/doctrine/mongodb-odm/blob/2.0.x/docs/en/reference/working-with-objects.rst#persisting-documents), as caution alert at the end of the section.