### PR TITLE
ExtraLazy OneToMay associations indexed by metacolumn fails

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -141,7 +141,10 @@ class OneToManyPersister extends AbstractCollectionPersister
         $criteria = new Criteria();
 
         $criteria->andWhere(Criteria::expr()->eq($mapping['mappedBy'], $collection->getOwner()));
-        $criteria->andWhere(Criteria::expr()->eq($mapping['indexBy'], $key));
+
+        $targetClass = $this->em->getClassMetadata($mapping['targetEntity']);
+        $indexByExpr = $targetClass->hasField($mapping['indexBy']) ? Criteria::expr()->eq($mapping['indexBy'], $key) : Criteria::expr()->in($targetClass->getFieldForColumn($mapping['indexBy']), [$key]);
+        $criteria->andWhere($indexByExpr);
 
         return (bool) $persister->count($criteria);
     }

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
@@ -29,7 +29,7 @@ class DDC117Article
     private $translations;
 
     /**
-     * @OneToMany(targetEntity="DDC117Link", mappedBy="source", indexBy="target_id", cascade={"persist", "remove"})
+     * @OneToMany(targetEntity="DDC117Link", mappedBy="source", indexBy="target_id", cascade={"persist", "remove"}, fetch="EXTRA_LAZY")
      */
     private $links;
 


### PR DESCRIPTION
When you call `$collection->containsKey($key)` on a collection defined by a OneToMany extra lazy association. the `OneToManyPersister` fails to generate the correct criteria to execute the count statement.