### PR TITLE
ExtraLazy OneToMay associations indexed by metacolumn fails

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -123,9 +123,12 @@ class OneToManyPersister extends AbstractCollectionPersister
         // only works with single id identifier entities. Will throw an
         // exception in Entity Persisters if that is not the case for the
         // 'mappedBy' field.
+        $targetClass    = $this->em->getClassMetadata($association->getTargetEntity());
+        $indexedByField = $targetClass->hasField($association->getIndexedBy()) ? $association->getIndexedBy() : $targetClass->fieldNames[$association->getIndexedBy()];
+
         $criteria = [
-            $association->getMappedBy()  => $collection->getOwner(),
-            $association->getIndexedBy() => $key,
+            $association->getMappedBy() => $collection->getOwner(),
+            $indexedByField => $key,
         ];
 
         return (bool) $persister->count($criteria);

--- a/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
+++ b/tests/Doctrine/Tests/Models/DDC117/DDC117Article.php
@@ -27,7 +27,7 @@ class DDC117Article
     /** @ORM\OneToMany(targetEntity=DDC117Translation::class, mappedBy="article", cascade={"persist", "remove"}) */
     private $translations;
 
-    /** @ORM\OneToMany(targetEntity=DDC117Link::class, mappedBy="source", indexBy="target_id", cascade={"persist", "remove"}) */
+    /** @ORM\OneToMany(targetEntity=DDC117Link::class, mappedBy="source", indexBy="target_id", cascade={"persist", "remove"}, fetch="EXTRA_LAZY") */
     private $links;
 
     public function __construct($title)


### PR DESCRIPTION
When you call `$collection->containsKey($key)` on a collection defined by a OneToMany extra lazy association. the `OneToManyPersister` fails to generate the correct criteria to execute the count statement.