### PR TITLE
Prevents incorrect table aliases

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -52,6 +52,7 @@ use function is_array;
 use function is_object;
 use function sprintf;
 use function strpos;
+use function strtolower;
 use function strtoupper;
 use function trim;
 
@@ -1605,13 +1606,13 @@ class BasicEntityPersister implements EntityPersister
             $tableName .= '#' . $assocName;
         }
 
-        if (isset($this->currentPersisterContext->sqlTableAliases[$tableName])) {
-            return $this->currentPersisterContext->sqlTableAliases[$tableName];
+        if (isset($this->currentPersisterContext->sqlTableAliases[strtolower($tableName)])) {
+            return $this->currentPersisterContext->sqlTableAliases[strtolower($tableName)];
         }
 
         $tableAlias = 't' . $this->currentPersisterContext->sqlAliasCounter++;
 
-        $this->currentPersisterContext->sqlTableAliases[$tableName] = $tableAlias;
+        $this->currentPersisterContext->sqlTableAliases[strtolower($tableName)] = $tableAlias;
 
         return $tableAlias;
     }


### PR DESCRIPTION
When one uses a discriminator map with a valid, but incorrectly cased,
classname (`Foo\Bar\baz` instead of `Foo\Bar\Baz` for instance), the
class metadata won't complain (php being case insensitive when it comes
to class name). However, it will complain if the class does not exist.

This will lead to "exotic" table alias being generated when querying the
parent class because the `sqlTableAliases` won't contain the wrongly typed
classname.

Here's an error example:

```
An exception occurred while executing 'SELECT t0.a AS a_3, t0.b AS b_4, t0.c AS c_5,
t0.id AS id_6, t0.d_id AS d_7, t0.e AS e_8, t0.discr, t1.a AS a_9, t1.b AS b_10, 
t1.c AS c_11, t1.d AS d_12, t1.e AS e_13, t1.f AS f_14, t16.a AS a_15 FROM table1 t0
LEFT JOIN table2 t1 ON t0.id = t1.id LEFT JOIN table3 t2 ON t0.id = t2.id':

SQLSTATE[42S22]: Column not found: 1054 Unknown column 't16.a' in 'field list'
```
`t16` should be `t2`

This is a quite hard to debug issue as the typo is most of the time quite hard to spot and the error (triggered by the db itself) doesn't make you think about a mapping issue at first sight.

I don't think this is an issue in the metadata loader, as `class_exists` is case insensitive by design, so should probably be this internal map. EDIT: [I have switched side on this question](https://github.com/doctrine/orm/pull/8122)

I've scratched my head for a while to know where I could add a test case to show you exactly the issue, but I couldn't. Please point me to the right direction if you think this fix should make it to master.

Thanks :wave: 