### PR TITLE
Do not try loading ClassMetadata for DateTimeInterface parameters

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -432,7 +432,7 @@ final class Query extends AbstractQuery
     /** @return mixed[] tuple of (value, type) */
     private function resolveParameterValue(Parameter $parameter) : array
     {
-        if ($parameter->typeWasSpecified()) {
+        if ($parameter->typeWasSpecified() || $this->isEarlyInferredType($parameter)) {
             return [$parameter->getValue(), $parameter->getType()];
         }
 
@@ -790,5 +790,15 @@ final class Query extends AbstractQuery
         parent::__clone();
 
         $this->_state = self::STATE_DIRTY;
+    }
+
+    /**
+     * @param Parameter $parameter
+     *
+     * @return bool
+     */
+    private function isEarlyInferredType(Parameter $parameter)
+    {
+        return $parameter->getValue() instanceof \DateTimeInterface;
     }
 }

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -421,6 +421,24 @@ class QueryTest extends OrmTestCase
         self::assertEmpty($query->getResult());
     }
 
+    /** @group 8113 */
+    public function testValuesAreNotBeingResolvedForDateTimeParameterTypes() : void
+    {
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+
+        $this->_em->setUnitOfWork($unitOfWork);
+
+        $unitOfWork
+            ->expects(self::never())
+            ->method('getSingleIdentifierValue');
+
+        $query = $this->_em->createQuery('SELECT d FROM ' . DateTimeModel::class . ' d WHERE d.datetime = :value');
+
+        $query->setParameter('value', new DateTime());
+
+        self::assertEmpty($query->getResult());
+    }
+
     /** @group 7982 */
     public function testNonExistentExecutor()
     {


### PR DESCRIPTION
Fixes #8113

* Happy with the test that is failing now
* Not happy with the implementation. This is more like a call to discuss a possible solution, if it's needed, keeping in mind the following tweets:

https://twitter.com/Ocramius/status/1251463806770872322?s=20

> Object-alike types are always checked for metadata existence first (by design). If a DBAL type is needed for an object, it is to be passed in as parameter (also by design).

> Otherwise, the ORM doesn't know if we're talking about a mapped type or a DBAL type.

> Note: this is a flaw in the architecture of DBAL types. DBAL types were initially sufficient, but as more complex mappings (such as association-as-identifier) came up, they became mostly obsolete.

So, @Ocramius, do you mean that we **can't** do optimization for `DateTimeInterface` implemented in this PR?

I'm not sure I got it, because `ParameterTypeInferer` in case of date time objects returns DBAL type right from the start (early).

So, we immediately know that `DateTimeInterface` has DBAL's `Doctrine\DBAL\Types\Type::DATETIME` type.

tl;dr

* Do we want a fix for #8113? If we do, could you please advice with the implementation, as I had many of them but not sure what is the right one
* If we don't, probably makes sense to merge Doc PR to warn users about this performance issue: https://github.com/doctrine/orm/pull/8114