### PR TITLE
Do not pass entity name in \Doctrine\ORM\EntityManager::clear call

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -84,7 +84,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function clear()
     {
-        $this->em->clear($this->class->getRootClassName());
+        $this->em->clear();
     }
 
     /**


### PR DESCRIPTION
Hello,

Since passing the `entityName` parameter in `\Doctrine\ORM\EntityManager::clear` is deprecated, this call should be also updated to not pass the `entityName` when calling the method. In my CI/CD it triggers the following error:

```
Calling Doctrine\ORM\EntityManager::clear() with any arguments to clear specific entities is deprecated and will not be supported in Doctrine ORM 3.0.
```

Thank you 💪 