### PR TITLE
removed repository class from metadata

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -488,7 +488,6 @@ classes. We'll store them in ``src/Bug.php`` and ``src/User.php``, respectively.
     use Doctrine\ORM\Mapping as ORM;
 
     /**
-     * @ORM\Entity(repositoryClass="BugRepository")
      * @ORM\Table(name="bugs")
      */
     class Bug


### PR DESCRIPTION
The annotation is required only in the next chapter of the tutorial, specifically the "Entity Repositories"