### PR TITLE
Improve CLI config documentation

### DIFF
--- a/docs/en/reference/tools.rst
+++ b/docs/en/reference/tools.rst
@@ -27,62 +27,32 @@ Configuration
 ~~~~~~~~~~~~~
 
 Whenever the ``doctrine`` command line tool is invoked, it can
-access all Commands that were registered by developer. There is no
+access all Commands that were registered by a developer. There is no
 auto-detection mechanism at work. The Doctrine binary
 already registers all the commands that currently ship with
 Doctrine DBAL and ORM. If you want to use additional commands you
 have to register them yourself.
 
-All the commands of the Doctrine Console require access to the ``EntityManager``
-or ``DBAL`` Connection. You have to inject them into the console application
-using so called Helper-Sets. This requires either the ``db``
-or the ``em`` helpers to be defined in order to work correctly.
+All the commands of the Doctrine Console require access to the
+``EntityManager``. You have to inject it into the console application with
+``ConsoleRunner::createHelperSet``. Whenever you invoke the Doctrine
+binary, it searches the current directory for the file ``cli-config.php``.
+This file contains the project-specific configuration.
 
-Whenever you invoke the Doctrine binary the current folder is searched for a
-``cli-config.php`` file. This file contains the project specific configuration:
-
-.. code-block:: php
-
-    <?php
-    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-        'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($conn)
-    ));
-    $cli->setHelperSet($helperSet);
-
-When dealing with the ORM package, the EntityManagerHelper is
-required:
+Here is an example of a the project-specific ``cli-config.php``:
 
 .. code-block:: php
 
     <?php
-    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-        'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($em)
-    ));
-    $cli->setHelperSet($helperSet);
+    use Doctrine\ORM\Tools\Console\ConsoleRunner;
 
-The HelperSet instance has to be generated in a separate file (i.e.
-``cli-config.php``) that contains typical Doctrine bootstrap code
-and predefines the needed HelperSet attributes mentioned above. A
-sample ``cli-config.php`` file looks as follows:
+    // replace this with the path to your own project bootstrap file.
+    require_once 'bootstrap.php';
 
-.. code-block:: php
+    // replace with mechanism to retrieve EntityManager in your app
+    $entityManager = GetEntityManager();
 
-    <?php
-    // cli-config.php
-    require_once 'my_bootstrap.php';
-
-    // Any way to access the EntityManager from  your application
-    $em = GetMyEntityManager();
-
-    $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
-        'db' => new \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper($em->getConnection()),
-        'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($em)
-    ));
-
-It is important to define a correct HelperSet that Doctrine binary
-script will ultimately use. The Doctrine Binary will automatically
-find the first instance of HelperSet in the global variable
-namespace and use this.
+    return ConsoleRunner::createHelperSet($entityManager);
 
 .. note::
 
@@ -517,4 +487,3 @@ HelperSet, like it is described in the configuration section.
 
     // Runs console application
     $cli->run();
-


### PR DESCRIPTION
Change code examples for `cli-config.php` to use
`ConsoleRunner::createHelperSet` instead of constructing the helper set
array yourself.

This is for #8129 