### PR TITLE
add possibility to use sql comments in the DQL syntax

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -649,6 +649,16 @@ The same restrictions apply for the reference of related entities.
     of the query. Additionally Deletes of specified entities are *NOT*
     cascaded to related entities even if specified in the metadata.
 
+Comments in queries
+-------------------
+
+We can use comments with the SQL syntax of comments.
+
+.. code-block:: sql
+
+    SELECT u FROM MyProject\Model\User u
+    -- my comment
+    WHERE u.age > 20 -- comment at the end of a line
 
 Functions, Operators, Aggregates
 --------------------------------

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -145,7 +145,7 @@ class Lexer extends AbstractLexer
      */
     protected function getNonCatchablePatterns()
     {
-        return ['\s+', '(.)'];
+        return ['\s+', '--.*', '(.)'];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -37,6 +37,24 @@ class AdvancedDqlQueryTest extends OrmFunctionalTestCase
         $this->assertEquals(600000, $result[1]['avgSalary']);
     }
 
+    public function testCommentsInDQL()
+    {
+        //same test than testAggregateWithHavingClause but with comments into the DQL
+        $dql = "SELECT p.department, AVG(p.salary) AS avgSalary -- comment end of line
+-- comment with 'strange chars', & $
+  FROM Doctrine\\Tests\\Models\\Company\\CompanyEmployee p
+  -- comment beginning of line GROUP BY
+GROUP BY p.department HAVING SUM(p.salary) > 200000 ORDER BY p.department -- comment end of line";
+
+        $result = $this->_em->createQuery($dql)->getScalarResult();
+
+        $this->assertEquals(2, count($result));
+        $this->assertEquals('IT', $result[0]['department']);
+        $this->assertEquals(150000, $result[0]['avgSalary']);
+        $this->assertEquals('IT2', $result[1]['department']);
+        $this->assertEquals(600000, $result[1]['avgSalary']);
+    }
+
     public function testUnnamedScalarResultsAreOneBased()
     {
         $dql = 'SELECT p.department, AVG(p.salary) '.

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -6,6 +6,7 @@ use Doctrine\Tests\Models\Company\CompanyEmployee,
     Doctrine\Tests\Models\Company\CompanyManager,
     Doctrine\Tests\Models\Company\CompanyCar;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use function count;
 
 /**
  * Functional Query tests.


### PR DESCRIPTION
Hi,

Sometimes I want to add sql comments in DQL queries. This PR adds the possibility to use comments in DQL.

:warning: this PR is for the branch 2.8.x

Best regards,
Philippe