### PR TITLE
add possibility to use sql comments in the DQL syntax (branch master)

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -713,6 +713,17 @@ The same restrictions apply for the reference of related entities.
     of the query. Additionally Deletes of specified entities are *NOT*
     cascaded to related entities even if specified in the metadata.
 
+Comments in queries
+-------------------
+
+We can use comments with the SQL syntax of comments.
+
+.. code-block:: sql
+
+    SELECT u FROM MyProject\Model\User u
+    -- my comment
+    WHERE u.age > 20 -- comment at the end of a line
+
 Functions, Operators, Aggregates
 --------------------------------
 It is possible to wrap both fields and identification values into

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -135,7 +135,7 @@ class Lexer extends AbstractLexer
      */
     protected function getNonCatchablePatterns()
     {
-        return ['\s+', '(.)'];
+        return ['\s+', '--.*', '(.)'];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -38,8 +38,7 @@ class AdvancedDqlQueryTest extends OrmFunctionalTestCase
         self::assertEquals(600000, $result[1]['avgSalary']);
     }
 
-
-    public function testCommentsInDQL()
+    public function testCommentsInDQL() : void
     {
         //same test than testAggregateWithHavingClause but with comments into the DQL
         $dql = "SELECT p.department, AVG(p.salary) AS avgSalary -- comment end of line

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -38,6 +38,25 @@ class AdvancedDqlQueryTest extends OrmFunctionalTestCase
         self::assertEquals(600000, $result[1]['avgSalary']);
     }
 
+
+    public function testCommentsInDQL()
+    {
+        //same test than testAggregateWithHavingClause but with comments into the DQL
+        $dql = "SELECT p.department, AVG(p.salary) AS avgSalary -- comment end of line
+-- comment with 'strange chars', & $
+  FROM Doctrine\\Tests\\Models\\Company\\CompanyEmployee p
+  -- comment beginning of line GROUP BY
+GROUP BY p.department HAVING SUM(p.salary) > 200000 ORDER BY p.department -- comment end of line";
+
+        $result = $this->em->createQuery($dql)->getScalarResult();
+
+        self::assertCount(2, $result);
+        self::assertEquals('IT', $result[0]['department']);
+        self::assertEquals(150000, $result[0]['avgSalary']);
+        self::assertEquals('IT2', $result[1]['department']);
+        self::assertEquals(600000, $result[1]['avgSalary']);
+    }
+
     public function testUnnamedScalarResultsAreOneBased() : void
     {
         $dql = 'SELECT p.department, AVG(p.salary) ' .


### PR DESCRIPTION
Hi,

This is the about the same PR than https://github.com/doctrine/orm/pull/8140 but for the master branch.

"Sometimes I want to add sql comments in DQL queries. This PR adds the possibility to use comments in DQL."

Best regards,
Philippe