### PR TITLE
[GH-8137] Update doctrine/inflector dependency to 1.4|2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/dbal": "^2.10.0",
         "doctrine/event-manager": "^1.1",
         "doctrine/instantiator": "^1.3",
+        "doctrine/inflector": "^1.4|^2.0",
         "doctrine/persistence": "~1.2.0",
         "ocramius/package-versions": "^1.2",
         "symfony/console": "^3.0|^4.0|^5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,6 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
+    "content-hash": "ab47245919cf0877139f99910035d04a",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3302,8 +3303,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3dcaeb2e750556bde2637a32bec5e58",
+    "content-hash": "3c209382e1588da0e6b986553602a34d",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -477,33 +477,38 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "1.3.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1"
+                "reference": "4111f6853aea6f28b2b1dcfdde83d12dd3d5e6e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
-                "reference": "ec3a55242203ffa6a4b27c58176da97ff0a7aec1",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4111f6853aea6f28b2b1dcfdde83d12dd3d5e6e3",
+                "reference": "4111f6853aea6f28b2b1dcfdde83d12dd3d5e6e3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "doctrine/coding-standard": "^7.0",
+                "phpstan/phpstan": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector",
+                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -532,15 +537,35 @@
                     "email": "schmittjoh@gmail.com"
                 }
             ],
-            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-            "homepage": "http://www.doctrine-project.org",
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
             "keywords": [
                 "inflection",
-                "pluralize",
-                "singularize",
-                "string"
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
             ],
-            "time": "2019-10-30T19:59:35+00:00"
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-09T15:09:09+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2794,10 +2819,11 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
-    "prefer-lowest": true,
+    "prefer-lowest": false,
     "platform": {
         "php": "^7.2",
         "ext-pdo": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -58,7 +58,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     protected $_class;
 
-    /** @var Inflector */
+    /** @var \Doctrine\Inflector\Inflector */
     private static $inflector;
 
     /**

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -25,6 +25,7 @@ use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Persistence\ObjectRepository;
 use const E_USER_DEPRECATED;
+use function lcfirst;
 use function trigger_error;
 
 /**
@@ -57,10 +58,8 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     protected $_class;
 
-    /**
-     * @var \Doctrine\Inflector\Inflector
-     */
-    static private $inflector;
+    /** @var Inflector */
+    private static $inflector;
 
     /**
      * Initializes a new <tt>EntityRepository</tt>.

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
+use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Persistence\ObjectRepository;
@@ -58,7 +59,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     protected $_class;
 
-    /** @var \Doctrine\Inflector\Inflector */
+    /** @var Inflector */
     private static $inflector;
 
     /**

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -19,7 +19,7 @@
 
 namespace Doctrine\ORM;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\Common\Collections\Selectable;
@@ -56,6 +56,11 @@ class EntityRepository implements ObjectRepository, Selectable
      * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
+
+    /**
+     * @var \Doctrine\Inflector\Inflector
+     */
+    static private $inflector;
 
     /**
      * Initializes a new <tt>EntityRepository</tt>.
@@ -308,7 +313,11 @@ class EntityRepository implements ObjectRepository, Selectable
             throw ORMException::findByRequiresParameter($method . $by);
         }
 
-        $fieldName = lcfirst(Inflector::classify($by));
+        if (self::$inflector === null) {
+            self::$inflector = InflectorFactory::create()->build();
+        }
+
+        $fieldName = lcfirst(self::$inflector->classify($by));
 
         if (! ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName))) {
             throw ORMException::invalidMagicCall($this->_entityName, $fieldName, $method . $by);

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -82,7 +82,7 @@ class DatabaseDriver implements MappingDriver
      */
     private $namespace;
 
-    /** @var \Doctrine\Inflector\Inflector */
+    /** @var Inflector */
     private $inflector;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -19,7 +19,6 @@
 
 namespace Doctrine\ORM\Mapping\Driver;
 
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -27,6 +26,8 @@ use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use function preg_replace;
@@ -80,11 +81,17 @@ class DatabaseDriver implements MappingDriver
     private $namespace;
 
     /**
+     * @var \Doctrine\Inflector\Inflector
+     */
+    protected $inflector;
+
+    /**
      * @param AbstractSchemaManager $schemaManager
      */
     public function __construct(AbstractSchemaManager $schemaManager)
     {
         $this->_sm = $schemaManager;
+        $this->inflector = InflectorFactory::create()->build();
     }
 
     /**
@@ -166,6 +173,16 @@ class DatabaseDriver implements MappingDriver
         foreach ($manyToManyTables as $table) {
             $this->manyToManyTables[$table->getName()] = $table;
         }
+    }
+
+    public function setInflector(Inflector $inflector) : void
+    {
+        $this->inflector = $inflector;
+    }
+
+    public function getInflector() : Inflector
+    {
+        return $this->Inflector;
     }
 
     /**
@@ -527,7 +544,7 @@ class DatabaseDriver implements MappingDriver
             return $this->namespace . $this->classNamesForTables[$tableName];
         }
 
-        return $this->namespace . Inflector::classify(strtolower($tableName));
+        return $this->namespace . $this->inflector->classify(strtolower($tableName));
     }
 
     /**
@@ -552,6 +569,6 @@ class DatabaseDriver implements MappingDriver
             $columnName = preg_replace('/_id$/', '', $columnName);
         }
 
-        return Inflector::camelize($columnName);
+        return $this->inflector->camelize($columnName);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -81,9 +81,9 @@ class DatabaseDriver implements MappingDriver
     private $namespace;
 
     /**
-     * @var \Doctrine\Inflector\Inflector
+     * @var Inflector
      */
-    protected $inflector;
+    private $inflector;
 
     /**
      * @param AbstractSchemaManager $schemaManager
@@ -178,11 +178,6 @@ class DatabaseDriver implements MappingDriver
     public function setInflector(Inflector $inflector) : void
     {
         $this->inflector = $inflector;
-    }
-
-    public function getInflector() : Inflector
-    {
-        return $this->Inflector;
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -82,7 +82,7 @@ class DatabaseDriver implements MappingDriver
      */
     private $namespace;
 
-    /** @var Inflector */
+    /** @var \Doctrine\Inflector\Inflector */
     private $inflector;
 
     /**

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -19,8 +19,6 @@
 
 namespace Doctrine\ORM\Mapping\Driver;
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
@@ -34,6 +32,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use function interface_exists;
 use function preg_replace;
+use function strtolower;
 
 /**
  * The DatabaseDriver reverse engineers the mapping metadata from a database.
@@ -83,9 +82,7 @@ class DatabaseDriver implements MappingDriver
      */
     private $namespace;
 
-    /**
-     * @var Inflector
-     */
+    /** @var Inflector */
     private $inflector;
 
     /**

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -291,6 +291,8 @@ class ConvertDoctrine1Schema
             return;
         }
 
+        $inflector = InflectorFactory::create()->build();
+
         foreach ($model['relations'] as $name => $relation) {
             if ( ! isset($relation['alias'])) {
                 $relation['alias'] = $name;
@@ -299,7 +301,6 @@ class ConvertDoctrine1Schema
                 $relation['class'] = $name;
             }
             if ( ! isset($relation['local'])) {
-                $inflector = InflectorFactory::create()->build();
                 $relation['local'] = $inflector->tableize($relation['class']);
             }
             if ( ! isset($relation['foreign'])) {

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -20,8 +20,8 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Inflector\InflectorFactory;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -299,7 +299,8 @@ class ConvertDoctrine1Schema
                 $relation['class'] = $name;
             }
             if ( ! isset($relation['local'])) {
-                $relation['local'] = Inflector::tableize($relation['class']);
+                $inflector = InflectorFactory::create()->build();
+                $relation['local'] = $inflector->tableize($relation['class']);
             }
             if ( ! isset($relation['foreign'])) {
                 $relation['foreign'] = 'id';

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -337,7 +337,7 @@ public function __construct(<params>)
 ';
 
     /**
-     * @var \Doctrine\Inflector\Inflector
+     * @var Inflector
      */
     protected $inflector;
 
@@ -603,11 +603,6 @@ public function __construct(<params>)
     public function setInflector(Inflector $inflector) : void
     {
         $this->inflector = $inflector;
-    }
-
-    public function getInflector() : Inflector
-    {
-        return $this->Inflector;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -20,8 +20,9 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use const E_USER_DEPRECATED;
 use function str_replace;
@@ -336,6 +337,11 @@ public function __construct(<params>)
 ';
 
     /**
+     * @var \Doctrine\Inflector\Inflector
+     */
+    protected $inflector;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -345,6 +351,8 @@ public function __construct(<params>)
         if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             $this->annotationsPrefix = 'ORM\\';
         }
+
+        $this->inflector = InflectorFactory::create()->build();
     }
 
     /**
@@ -590,6 +598,16 @@ public function __construct(<params>)
     public function setBackupExisting($bool)
     {
         $this->backupExisting = $bool;
+    }
+
+    public function setInflector(Inflector $inflector) : void
+    {
+        $this->inflector = $inflector;
+    }
+
+    public function getInflector() : Inflector
+    {
+        return $this->Inflector;
     }
 
     /**
@@ -1377,11 +1395,11 @@ public function __construct(<params>)
      */
     protected function generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null, $defaultValue = null)
     {
-        $methodName = $type . Inflector::classify($fieldName);
-        $variableName = Inflector::camelize($fieldName);
+        $methodName = $type . $this->inflector->classify($fieldName);
+        $variableName = $this->inflector->camelize($fieldName);
         if (in_array($type, ["add", "remove"])) {
-            $methodName = Inflector::singularize($methodName);
-            $variableName = Inflector::singularize($variableName);
+            $methodName = $this->inflector->singularize($methodName);
+            $variableName = $this->inflector->singularize($variableName);
         }
 
         if ($this->hasMethod($methodName, $metadata)) {

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -336,9 +336,7 @@ public function __construct(<params>)
 }
 ';
 
-    /**
-     * @var Inflector
-     */
+    /** @var Inflector */
     protected $inflector;
 
     /**
@@ -1390,10 +1388,11 @@ public function __construct(<params>)
      */
     protected function generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null, $defaultValue = null)
     {
-        $methodName = $type . $this->inflector->classify($fieldName);
+        $methodName   = $type . $this->inflector->classify($fieldName);
         $variableName = $this->inflector->camelize($fieldName);
+
         if (in_array($type, ["add", "remove"])) {
-            $methodName = $this->inflector->singularize($methodName);
+            $methodName   = $this->inflector->singularize($methodName);
             $variableName = $this->inflector->singularize($variableName);
         }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -336,7 +336,7 @@ public function __construct(<params>)
 }
 ';
 
-    /** @var Inflector */
+    /** @var \Doctrine\Inflector\Inflector */
     protected $inflector;
 
     /**

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -336,7 +336,7 @@ public function __construct(<params>)
 }
 ';
 
-    /** @var \Doctrine\Inflector\Inflector */
+    /** @var Inflector */
     protected $inflector;
 
     /**


### PR DESCRIPTION
Resolve the deprecations by instantiating default inflector.

This cannot go into 2.7, because it would raise PHP dependency from 7.1 to 7.2.

Fixes #8137 