### PR TITLE
Infer return type information with Psalter

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -240,7 +240,7 @@ abstract class AbstractQuery
      *
      * @param integer $lifetime
      *
-     * @return \Doctrine\ORM\AbstractQuery This query instance.
+     * @return static This query instance.
      */
     public function setLifetime($lifetime)
     {
@@ -260,7 +260,7 @@ abstract class AbstractQuery
     /**
      * @param integer $cacheMode
      *
-     * @return \Doctrine\ORM\AbstractQuery This query instance.
+     * @return static This query instance.
      */
     public function setCacheMode($cacheMode)
     {
@@ -1068,7 +1068,7 @@ abstract class AbstractQuery
      * Will return the configured id if it exists otherwise a hash will be
      * automatically generated for you.
      *
-     * @return array ($key, $hash)
+     * @return array<string, string> ($key, $hash)
      */
     protected function getHydrationCacheId()
     {

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -348,7 +348,9 @@ class DefaultQueryCache implements QueryCache
      * @param array                             $assoc
      * @param mixed                             $assocValue
      *
-     * @return array|null
+     * @return mixed[]|null
+     *
+     * @psalm-return array{targetEntity: string, type: mixed, list?: array[], identifier?: array}|null
      */
     private function storeAssociationCache(QueryCacheKey $key, array $assoc, $assocValue)
     {

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -38,7 +38,7 @@ class OnClearEventArgs extends \Doctrine\Common\EventArgs
     private $em;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $entityClass;
 

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -40,7 +40,7 @@ abstract class AbstractIdGenerator
      * By default, this method returns FALSE. Generators that have this requirement
      * must override this method and return TRUE.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPostInsertGenerator()
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -260,8 +260,19 @@ abstract class AbstractHydrator
      * @param array &$id                 Dql-Alias => ID-Hash.
      * @param array &$nonemptyComponents Does this DQL-Alias has at least one non NULL value?
      *
-     * @return array  An array with all the fields (name => value) of the data row,
-     *                grouped by their component alias.
+     * @return array<string, array<string, mixed>> An array with all the fields
+     *                                             (name => value) of the data
+     *                                             row, grouped by their
+     *                                             component alias.
+     *
+     * @psalm-return array{
+     *                   data: array<array-key, array>,
+     *                   newObjects?: array<array-key, array{
+     *                       class: mixed,
+     *                       args?: array
+     *                   }>,
+     *                   scalars?: array
+     *               }
      */
     protected function gatherRowData(array $data, array &$id, array &$nonemptyComponents)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
@@ -58,7 +58,7 @@ class AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return AssociationBuilder
+     * @return static
      */
     public function mappedBy($fieldName)
     {
@@ -70,7 +70,7 @@ class AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return AssociationBuilder
+     * @return static
      */
     public function inversedBy($fieldName)
     {
@@ -80,7 +80,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadeAll()
     {
@@ -90,7 +90,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadePersist()
     {
@@ -100,7 +100,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadeRemove()
     {
@@ -110,7 +110,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadeMerge()
     {
@@ -120,7 +120,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadeDetach()
     {
@@ -130,7 +130,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function cascadeRefresh()
     {
@@ -140,7 +140,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function fetchExtraLazy()
     {
@@ -150,7 +150,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function fetchEager()
     {
@@ -160,7 +160,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return AssociationBuilder
+     * @return static
      */
     public function fetchLazy()
     {
@@ -179,7 +179,7 @@ class AssociationBuilder
      * @param string|null $onDelete
      * @param string|null $columnDef
      *
-     * @return AssociationBuilder
+     * @return static
      */
     public function addJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
@@ -198,7 +198,7 @@ class AssociationBuilder
     /**
      * Sets field as primary key.
      *
-     * @return self
+     * @return static
      */
     public function makePrimaryKey()
     {
@@ -210,7 +210,7 @@ class AssociationBuilder
     /**
      * Removes orphan entities when detached from their parent.
      *
-     * @return self
+     * @return static
      */
     public function orphanRemoval()
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -57,7 +57,7 @@ class ClassMetadataBuilder
     /**
      * Marks the class as mapped superclass.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setMappedSuperClass()
     {
@@ -70,7 +70,7 @@ class ClassMetadataBuilder
     /**
      * Marks the class as embeddable.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setEmbeddable()
     {
@@ -107,7 +107,7 @@ class ClassMetadataBuilder
      *
      * @param string $repositoryClassName
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setCustomRepositoryClass($repositoryClassName)
     {
@@ -119,7 +119,7 @@ class ClassMetadataBuilder
     /**
      * Marks class read only.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setReadOnly()
     {
@@ -133,7 +133,7 @@ class ClassMetadataBuilder
      *
      * @param string $name
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setTable($name)
     {
@@ -148,7 +148,7 @@ class ClassMetadataBuilder
      * @param array  $columns
      * @param string $name
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addIndex(array $columns, $name)
     {
@@ -167,7 +167,7 @@ class ClassMetadataBuilder
      * @param array  $columns
      * @param string $name
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addUniqueConstraint(array $columns, $name)
     {
@@ -186,7 +186,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @param string $dqlQuery
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addNamedQuery($name, $dqlQuery)
     {
@@ -203,7 +203,7 @@ class ClassMetadataBuilder
     /**
      * Sets class as root of a joined table inheritance hierarchy.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setJoinedTableInheritance()
     {
@@ -215,7 +215,7 @@ class ClassMetadataBuilder
     /**
      * Sets class as root of a single table inheritance hierarchy.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setSingleTableInheritance()
     {
@@ -231,7 +231,7 @@ class ClassMetadataBuilder
      * @param string $type
      * @param int    $length
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setDiscriminatorColumn($name, $type = 'string', $length = 255)
     {
@@ -252,7 +252,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @param string $class
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addDiscriminatorMapClass($name, $class)
     {
@@ -264,7 +264,7 @@ class ClassMetadataBuilder
     /**
      * Sets deferred explicit change tracking policy.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setChangeTrackingPolicyDeferredExplicit()
     {
@@ -276,7 +276,7 @@ class ClassMetadataBuilder
     /**
      * Sets notify change tracking policy.
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function setChangeTrackingPolicyNotify()
     {
@@ -291,7 +291,7 @@ class ClassMetadataBuilder
      * @param string $methodName
      * @param string $event
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addLifecycleEvent($methodName, $event)
     {
@@ -307,7 +307,7 @@ class ClassMetadataBuilder
      * @param string $type
      * @param array  $mapping
      *
-     * @return ClassMetadataBuilder
+     * @return static
      */
     public function addField($name, $type, array $mapping = [])
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -74,7 +74,7 @@ class FieldBuilder
      *
      * @param int $length
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function length($length)
     {
@@ -88,7 +88,7 @@ class FieldBuilder
      *
      * @param bool $flag
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function nullable($flag = true)
     {
@@ -102,7 +102,7 @@ class FieldBuilder
      *
      * @param bool $flag
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function unique($flag = true)
     {
@@ -116,7 +116,7 @@ class FieldBuilder
      *
      * @param string $name
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function columnName($name)
     {
@@ -130,7 +130,7 @@ class FieldBuilder
      *
      * @param int $p
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function precision($p)
     {
@@ -144,7 +144,7 @@ class FieldBuilder
      *
      * @param int $s
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function scale($s)
     {
@@ -167,7 +167,7 @@ class FieldBuilder
     /**
      * Sets field as primary key.
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function makePrimaryKey()
     {
@@ -182,7 +182,7 @@ class FieldBuilder
      * @param string $name
      * @param mixed  $value
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function option($name, $value)
     {
@@ -194,7 +194,7 @@ class FieldBuilder
     /**
      * @param string $strategy
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function generatedValue($strategy = 'AUTO')
     {
@@ -206,7 +206,7 @@ class FieldBuilder
     /**
      * Sets field versioned.
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function isVersionField()
     {
@@ -222,7 +222,7 @@ class FieldBuilder
      * @param int    $allocationSize
      * @param int    $initialValue
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function setSequenceGenerator($sequenceName, $allocationSize = 1, $initialValue = 1)
     {
@@ -240,7 +240,7 @@ class FieldBuilder
      *
      * @param string $def
      *
-     * @return FieldBuilder
+     * @return static
      */
     public function columnDefinition($def)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -42,7 +42,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     /**
      * @param string $name
      *
-     * @return ManyToManyAssociationBuilder
+     * @return static
      */
     public function setJoinTable($name)
     {
@@ -61,7 +61,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
      * @param string|null $onDelete
      * @param string|null $columnDef
      *
-     * @return ManyToManyAssociationBuilder
+     * @return static
      */
     public function addInverseJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
@@ -32,7 +32,7 @@ class OneToManyAssociationBuilder extends AssociationBuilder
     /**
      * @param array $fieldNames
      *
-     * @return OneToManyAssociationBuilder
+     * @return static
      */
     public function setOrderBy(array $fieldNames)
     {
@@ -44,7 +44,7 @@ class OneToManyAssociationBuilder extends AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return OneToManyAssociationBuilder
+     * @return static
      */
     public function setIndexBy($fieldName)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -28,6 +28,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ReflectionService;
 use InvalidArgumentException;
 use ReflectionClass;
+use ReflectionProperty;
 use RuntimeException;
 
 /**
@@ -640,7 +641,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * The ReflectionProperty instances of the mapped class.
      *
-     * @var \ReflectionProperty[]
+     * @var ReflectionProperty[]
      */
     public $reflFields = [];
 
@@ -667,7 +668,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Gets the ReflectionProperties of the mapped class.
      *
-     * @return array An array of ReflectionProperty instances.
+     * @return ReflectionProperty[] An array of ReflectionProperty instances.
      */
     public function getReflectionProperties()
     {
@@ -679,7 +680,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $name
      *
-     * @return \ReflectionProperty
+     * @return ReflectionProperty
      */
     public function getReflectionProperty($name)
     {
@@ -689,7 +690,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Gets the ReflectionProperty for the single identifier field.
      *
-     * @return \ReflectionProperty
+     * @return ReflectionProperty
      *
      * @throws BadMethodCallException If the class has a composite identifier.
      */
@@ -805,7 +806,7 @@ class ClassMetadataInfo implements ClassMetadata
      *      - reflClass (ReflectionClass)
      *      - reflFields (ReflectionProperty array)
      *
-     * @return array The names of all the fields that should be serialized.
+     * @return string[] The names of all the fields that should be serialized.
      */
     public function __sleep()
     {
@@ -1096,7 +1097,10 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $fieldName
      * @param array  $cache
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-param array{usage: mixed, region: mixed} $cache
+     * @psalm-return array{usage: mixed, region: mixed}
      */
     public function getAssociationCacheDefaults($fieldName, array $cache)
     {
@@ -1445,9 +1449,25 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The mapping.
      *
-     * @return array The updated mapping.
+     * @return mixed[] The updated mapping.
      *
      * @throws MappingException If something is wrong with the mapping.
+     *
+     * @psalm-return array{
+     *                   mappedBy: mixed,
+     *                   inversedBy: mixed,
+     *                   isOwningSide: bool,
+     *                   sourceEntity: string,
+     *                   targetEntity: string,
+     *                   fieldName: mixed,
+     *                   fetch: mixed,
+     *                   cascade: array<array-key,string>,
+     *                   isCascadeRemove: bool,
+     *                   isCascadePersist: bool,
+     *                   isCascadeRefresh: bool,
+     *                   isCascadeMerge: bool,
+     *                   isCascadeDetach: bool
+     *               }
      */
     protected function _validateAndCompleteAssociationMapping(array $mapping)
     {
@@ -1565,10 +1585,12 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The mapping to validate & complete.
      *
-     * @return array The validated & completed mapping.
+     * @return mixed[] The validated & completed mapping.
      *
      * @throws RuntimeException
      * @throws MappingException
+     *
+     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool, isCascadeRemove: bool}
      */
     protected function _validateAndCompleteOneToOneMapping(array $mapping)
     {
@@ -1656,10 +1678,27 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The mapping to validate and complete.
      *
-     * @return array The validated and completed mapping.
+     * @return mixed[] The validated and completed mapping.
      *
      * @throws MappingException
      * @throws InvalidArgumentException
+     *
+     * @psalm-return array{
+     *                   mappedBy: mixed,
+     *                   inversedBy: mixed,
+     *                   isOwningSide: bool,
+     *                   sourceEntity: string,
+     *                   targetEntity: string,
+     *                   fieldName: mixed,
+     *                   fetch: int|mixed,
+     *                   cascade: array<array-key,string>,
+     *                   isCascadeRemove: bool,
+     *                   isCascadePersist: bool,
+     *                   isCascadeRefresh: bool,
+     *                   isCascadeMerge: bool,
+     *                   isCascadeDetach: bool,
+     *                   orphanRemoval: bool
+     *               }
      */
     protected function _validateAndCompleteOneToManyMapping(array $mapping)
     {
@@ -1683,9 +1722,11 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The mapping to validate & complete.
      *
-     * @return array The validated & completed mapping.
+     * @return mixed[] The validated & completed mapping.
      *
      * @throws \InvalidArgumentException
+     *
+     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool}
      */
     protected function _validateAndCompleteManyToManyMapping(array $mapping)
     {
@@ -1862,7 +1903,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array|null $fieldNames
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return list<string>
      */
     public function getColumnNames(array $fieldNames = null)
     {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -558,7 +558,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *
      * @param \ReflectionMethod $method
      *
-     * @return array
+     * @return callable[]
      */
     private function getMethodCallbacks(\ReflectionMethod $method)
     {
@@ -606,7 +606,17 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * Parse the given JoinColumn as array
      *
      * @param Mapping\JoinColumn $joinColumn
-     * @return array
+     *
+     * @return mixed[]
+     *
+     * @psalm-return array{
+     *                   name: string,
+     *                   unique: bool,
+     *                   nullable: bool,
+     *                   onDelete: mixed,
+     *                   columnDefinition: string,
+     *                   referencedColumnName: string
+     *               }
      */
     private function joinColumnToArray(Mapping\JoinColumn $joinColumn)
     {
@@ -626,7 +636,20 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * @param string $fieldName
      * @param Mapping\Column $column
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return array{
+     *                   fieldName: string,
+     *                   type: mixed,
+     *                   scale: int,
+     *                   length: int,
+     *                   unique: bool,
+     *                   nullable: bool,
+     *                   precision: int,
+     *                   options?: mixed[],
+     *                   columnName?: string,
+     *                   columnDefinition?: string
+     *               }
      */
     private function columnToArray($fieldName, Mapping\Column $column)
     {

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -21,6 +21,7 @@ namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Schema\Column;
@@ -388,6 +389,22 @@ class DatabaseDriver implements MappingDriver
      * @param \Doctrine\DBAL\Schema\Column $column
      *
      * @return array
+     *
+     * @psalm-return array{
+     *                   fieldName: string,
+     *                   columnName: string,
+     *                   type: string,
+     *                   nullable: bool,
+     *                   options?: array{
+     *                       unsigned?: bool,
+     *                       fixed?: bool,
+     *                       comment?: string,
+     *                       default?: string
+     *                   },
+     *                   precision?: int,
+     *                   scale?: int,
+     *                   length?: int|null
+     *               }
      */
     private function buildFieldMapping($tableName, Column $column)
     {
@@ -488,7 +505,9 @@ class DatabaseDriver implements MappingDriver
      *
      * @param \Doctrine\DBAL\Schema\Table $table
      *
-     * @return array
+     * @return ForeignKeyConstraint[]
+     *
+     * @psalm-return array<string, ForeignKeyConstraint>
      */
     private function getTableForeignKeys(Table $table)
     {
@@ -502,7 +521,7 @@ class DatabaseDriver implements MappingDriver
      *
      * @param \Doctrine\DBAL\Schema\Table $table
      *
-     * @return array
+     * @return string[]
      */
     private function getTablePrimaryKeys(Table $table)
     {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -671,7 +671,7 @@ class XmlDriver extends FileDriver
      *
      * @param SimpleXMLElement $options The XML element.
      *
-     * @return array The options array.
+     * @return mixed[] The options array.
      */
     private function _parseOptions(SimpleXMLElement $options)
     {
@@ -706,7 +706,16 @@ class XmlDriver extends FileDriver
      *
      * @param SimpleXMLElement $joinColumnElement The XML element.
      *
-     * @return array The mapping array.
+     * @return mixed[] The mapping array.
+     *
+     * @psalm-return array{
+     *                   name: string,
+     *                   referencedColumnName: string,
+     *                   unique?: bool,
+     *                   nullable?: bool,
+     *                   onDelete?: string,
+     *                   columnDefinition?: string
+     *               }
      */
     private function joinColumnToArray(SimpleXMLElement $joinColumnElement)
     {
@@ -735,12 +744,24 @@ class XmlDriver extends FileDriver
     }
 
      /**
-     * Parses the given field as array.
-     *
-     * @param SimpleXMLElement $fieldMapping
-     *
-     * @return array
-     */
+      * Parses the given field as array.
+      *
+      * @return mixed[]
+      *
+      * @psalm-return array{
+      *                   fieldName: string,
+      *                   type?: string,
+      *                   columnName?: string,
+      *                   length?: int,
+      *                   precision?: int,
+      *                   scale?: int,
+      *                   unique?: bool,
+      *                   nullable?: bool,
+      *                   version?: bool,
+      *                   columnDefinition?: string,
+      *                   options?: array
+      *               }
+      */
     private function columnToArray(SimpleXMLElement $fieldMapping)
     {
         $mapping = [
@@ -795,7 +816,9 @@ class XmlDriver extends FileDriver
      *
      * @param SimpleXMLElement $cacheMapping
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return array{usage: mixed, region: string|null}
      */
     private function cacheToArray(SimpleXMLElement $cacheMapping)
     {
@@ -821,7 +844,9 @@ class XmlDriver extends FileDriver
      *
      * @param SimpleXMLElement $cascadeElement The cascade element.
      *
-     * @return array The list of cascade options.
+     * @return string[] The list of cascade options.
+     *
+     * @psalm-return list<string>
      */
     private function _getCascadeMappings(SimpleXMLElement $cascadeElement)
     {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -684,7 +684,17 @@ class YamlDriver extends FileDriver
      *
      * @param array $joinColumnElement The array join column element.
      *
-     * @return array The mapping array.
+     * @return mixed[] The mapping array.
+     *
+     * @psalm-return array{
+     *                   referencedColumnName?: string,
+     *                   name?: string,
+     *                   fieldName?: string,
+     *                   unique?: bool,
+     *                   nullable?: bool,
+     *                   onDelete?: mixed,
+     *                   columnDefinition?: mixed
+     *               }
      */
     private function joinColumnToArray($joinColumnElement)
     {
@@ -726,7 +736,21 @@ class YamlDriver extends FileDriver
      * @param string $fieldName
      * @param array  $column
      *
-     * @return  array
+     * @return mixed[]
+     *
+     * @psalm-return array{
+     *                   fieldName: string,
+     *                   type?: string,
+     *                   columnName?: mixed,
+     *                   length?: mixed,
+     *                   precision?: mixed,
+     *                   scale?: mixed,
+     *                   unique?: bool,
+     *                   options?: mixed,
+     *                   nullable?: mixed,
+     *                   version?: mixed,
+     *                   columnDefinition?: mixed
+     *               }
      */
     private function columnToArray($fieldName, $column)
     {
@@ -787,9 +811,12 @@ class YamlDriver extends FileDriver
     /**
      * Parse / Normalize the cache configuration
      *
-     * @param array $cacheMapping
+     * @param mixed[] $cacheMapping
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-param array{usage: mixed, region: null|string} $cacheMapping
+     * @psalm-return array{usage: mixed, region: null|string}
      */
     private function cacheToArray($cacheMapping)
     {

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -79,8 +79,10 @@ final class ReflectionPropertiesGetter
      * @param string $className
      *
      * @return ReflectionClass[]
+     *
+     * @psalm-return list<ReflectionClass>
      */
-    private function getHierarchyClasses($className)
+    private function getHierarchyClasses($className) : array
     {
         $classes         = [];
         $parentClassName = $className;
@@ -97,13 +99,17 @@ final class ReflectionPropertiesGetter
         return $classes;
     }
 
+    //  phpcs:disable SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
     /**
      * @param ReflectionClass $reflectionClass
      *
      * @return ReflectionProperty[]
+     *
+     * @psalm-return array<string, ReflectionProperty>
      */
-    private function getClassProperties(ReflectionClass $reflectionClass)
+    private function getClassProperties(ReflectionClass $reflectionClass) : array
     {
+        //  phpcs:enable SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod
         $properties = $reflectionClass->getProperties();
 
         return array_filter(

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -37,9 +37,9 @@ final class NativeQuery extends AbstractQuery
      *
      * @param string $sql
      *
-     * @return NativeQuery This query instance.
+     * @return self This query instance.
      */
-    public function setSQL($sql)
+    public function setSQL($sql) : self
     {
         $this->_sql = $sql;
 

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -569,9 +569,11 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * Internal note: Tried to implement Serializable first but that did not work well
      *                with circular references. This solution seems simpler and works well.
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return array{0: string, 1: string}
      */
-    public function __sleep()
+    public function __sleep() : array
     {
         return ['collection', 'initialized'];
     }

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -288,6 +288,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @return string[] ordered tuple:
      *                   - JOIN condition to add to the SQL
      *                   - WHERE condition to add to the SQL
+     *
+     * @psalm-return array{0: string, 1: string}
      */
     public function getFilterSql($mapping)
     {
@@ -335,7 +337,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @param  array $mapping
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return list<string>
      */
     protected function getOnConditionSQL($mapping)
     {
@@ -416,6 +420,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @return string[]|string[][] ordered tuple containing the SQL to be executed and an array
      *                             of types for bound parameters
+     *
+     * @psalm-return array{0: string, 1: list<string>}
      */
     protected function getDeleteRowSQL(PersistentCollection $collection)
     {
@@ -452,6 +458,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @param mixed                              $element
      *
      * @return array
+     *
+     * @psalm-return list<mixed>
      */
     protected function getDeleteRowSQLParameters(PersistentCollection $collection, $element)
     {
@@ -465,6 +473,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @return string[]|string[][] ordered tuple containing the SQL to be executed and an array
      *                             of types for bound parameters
+     *
+     * @psalm-return array{0: string, 1: list<string>}
      */
     protected function getInsertRowSQL(PersistentCollection $collection)
     {
@@ -503,6 +513,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @param mixed                              $element
      *
      * @return array
+     *
+     * @psalm-return list<mixed>
      */
     protected function getInsertRowSQLParameters(PersistentCollection $collection, $element)
     {
@@ -516,7 +528,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @param \Doctrine\ORM\PersistentCollection $collection
      * @param object                             $element
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return list<mixed>
      */
     private function collectJoinTableColumnParameters(PersistentCollection $collection, $element)
     {
@@ -564,6 +578,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - where clauses to be added for filtering
      *                - parameters to be bound for filtering
      *                - types of the parameters to be bound for filtering
+     *
+     * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
     private function getJoinTableRestrictionsWithKey(PersistentCollection $collection, $key, $addFilters)
     {
@@ -649,6 +665,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - where clauses to be added for filtering
      *                - parameters to be bound for filtering
      *                - types of the parameters to be bound for filtering
+     *
+     * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
     private function getJoinTableRestrictions(PersistentCollection $collection, $element, $addFilters)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -360,6 +360,11 @@ class BasicEntityPersister implements EntityPersister
         return Type::getType($fieldMapping['type'])->convertToPHPValue($value, $this->platform);
     }
 
+    /**
+     * @return Type[]
+     *
+     * @psalm-return list<Type>
+     */
     private function extractIdentifierTypes(array $id, ClassMetadata $versionedClass) : array
     {
         $types = [];
@@ -601,7 +606,9 @@ class BasicEntityPersister implements EntityPersister
      *
      * @param object $entity The entity for which to prepare the data.
      *
-     * @return array The prepared data.
+     * @return mixed[][] The prepared data.
+     *
+     * @psalm-return array<string, array<array-key, mixed|null>>
      */
     protected function prepareUpdateData($entity)
     {
@@ -688,9 +695,11 @@ class BasicEntityPersister implements EntityPersister
      *
      * @param object $entity The entity for which to prepare the data.
      *
-     * @return array The prepared data for the tables to update.
+     * @return mixed[][] The prepared data for the tables to update.
      *
      * @see prepareUpdateData
+     *
+     * @psalm-return array<string, mixed[]>
      */
     protected function prepareInsertData($entity)
     {
@@ -1133,7 +1142,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @throws \Doctrine\ORM\ORMException
      */
-    protected final function getOrderBySQL(array $orderBy, $baseTableAlias)
+    final protected function getOrderBySQL(array $orderBy, $baseTableAlias) : string
     {
         $orderByList = [];
 
@@ -1418,7 +1427,9 @@ class BasicEntityPersister implements EntityPersister
      * Subclasses should override this method to alter or change the list of
      * columns placed in the INSERT statements used by the persister.
      *
-     * @return array The list of columns.
+     * @return string[] The list of columns.
+     *
+     * @psalm-return list<string>
      */
     protected function getInsertColumnList()
     {
@@ -1655,6 +1666,8 @@ class BasicEntityPersister implements EntityPersister
      * @return string[]
      *
      * @throws \Doctrine\ORM\ORMException
+     *
+     * @psalm-return list<string>
      */
     private function getSelectConditionStatementColumnSQL($field, $assoc = null)
     {
@@ -1846,8 +1859,9 @@ class BasicEntityPersister implements EntityPersister
      *                             - value to be bound
      *                             - class to which the field belongs to
      *
+     * @return mixed[][]
      *
-     * @return array
+     * @psalm-return array{0: array, 1: list<mixed>}
      */
     private function expandToManyParameters($criteria)
     {
@@ -1873,9 +1887,11 @@ class BasicEntityPersister implements EntityPersister
      * @param mixed         $value
      * @param ClassMetadata $class
      *
-     * @return array
+     * @return Type[]
      *
      * @throws \Doctrine\ORM\Query\QueryException
+     *
+     * @psalm-return list<Type>
      */
     private function getTypes($field, $value, ClassMetadata $class)
     {

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -93,7 +93,9 @@ class SqlValueVisitor extends ExpressionVisitor
     /**
      * Returns the Parameters and Types necessary for matching the last visited expression.
      *
-     * @return array
+     * @return mixed[][]
+     *
+     * @psalm-return array{0: array, 1: array}
      */
     public function getParamsAndTypes()
     {

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -122,6 +122,8 @@ class ProxyFactory extends AbstractProxyFactory
      * @return \Closure
      *
      * @throws \Doctrine\ORM\EntityNotFoundException
+     *
+     * @psalm-return \Closure(BaseProxy):void
      */
     private function createInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {
@@ -173,6 +175,8 @@ class ProxyFactory extends AbstractProxyFactory
      * @return \Closure
      *
      * @throws \Doctrine\ORM\EntityNotFoundException
+     *
+     * @psalm-return \Closure(BaseProxy):void
      */
     private function createCloner(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -380,11 +380,13 @@ final class Query extends AbstractQuery
      *
      * @param array $paramMappings
      *
-     * @return array
+     * @return mixed[][]
      *
      * @throws Query\QueryException
+     *
+     * @psalm-return array{0: list<mixed>, 1: array}
      */
-    private function processParameterMappings($paramMappings)
+    private function processParameterMappings($paramMappings) : array
     {
         $sqlParams = [];
         $types     = [];
@@ -429,7 +431,11 @@ final class Query extends AbstractQuery
         return [$sqlParams, $types];
     }
 
-    /** @return mixed[] tuple of (value, type) */
+    /**
+     * @return mixed[] tuple of (value, type)
+     *
+     * @psalm-return array{0: mixed, 1: mixed}
+     */
     private function resolveParameterValue(Parameter $parameter) : array
     {
         if ($parameter->typeWasSpecified()) {
@@ -466,9 +472,9 @@ final class Query extends AbstractQuery
      *
      * @param \Doctrine\Common\Cache\Cache|null $queryCache Cache driver.
      *
-     * @return Query This query instance.
+     * @return self This query instance.
      */
-    public function setQueryCacheDriver($queryCache)
+    public function setQueryCacheDriver($queryCache) : self
     {
         $this->_queryCache = $queryCache;
 
@@ -480,9 +486,9 @@ final class Query extends AbstractQuery
      *
      * @param boolean $bool
      *
-     * @return Query This query instance.
+     * @return self This query instance.
      */
-    public function useQueryCache($bool)
+    public function useQueryCache($bool) : self
     {
         $this->_useQueryCache = $bool;
 
@@ -509,9 +515,9 @@ final class Query extends AbstractQuery
      *
      * @param integer $timeToLive How long the cache entry is valid.
      *
-     * @return Query This query instance.
+     * @return self This query instance.
      */
-    public function setQueryCacheLifetime($timeToLive)
+    public function setQueryCacheLifetime($timeToLive) : self
     {
         if ($timeToLive !== null) {
             $timeToLive = (int) $timeToLive;
@@ -537,9 +543,9 @@ final class Query extends AbstractQuery
      *
      * @param boolean $expire Whether or not to force query cache expiration.
      *
-     * @return Query This query instance.
+     * @return self This query instance.
      */
-    public function expireQueryCache($expire = true)
+    public function expireQueryCache($expire = true) : self
     {
         $this->_expireQueryCache = $expire;
 
@@ -571,10 +577,8 @@ final class Query extends AbstractQuery
      * Sets a DQL query string.
      *
      * @param string $dqlQuery DQL Query.
-     *
-     * @return \Doctrine\ORM\AbstractQuery
      */
-    public function setDQL($dqlQuery)
+    public function setDQL($dqlQuery) : self
     {
         if ($dqlQuery !== null) {
             $this->_dql = $dqlQuery;
@@ -626,9 +630,9 @@ final class Query extends AbstractQuery
      *
      * @param int|null $firstResult The first result to return.
      *
-     * @return Query This query object.
+     * @return self This query object.
      */
-    public function setFirstResult($firstResult)
+    public function setFirstResult($firstResult) : self
     {
         $this->_firstResult = $firstResult;
         $this->_state       = self::STATE_DIRTY;
@@ -652,9 +656,9 @@ final class Query extends AbstractQuery
      *
      * @param integer|null $maxResults
      *
-     * @return Query This query object.
+     * @return self This query object.
      */
-    public function setMaxResults($maxResults)
+    public function setMaxResults($maxResults) : self
     {
         $this->_maxResults = $maxResults;
         $this->_state      = self::STATE_DIRTY;
@@ -716,11 +720,9 @@ final class Query extends AbstractQuery
      *
      * @param int $lockMode
      *
-     * @return Query
-     *
      * @throws TransactionRequiredException
      */
-    public function setLockMode($lockMode)
+    public function setLockMode($lockMode) : self
     {
         if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if ( ! $this->_em->getConnection()->isTransactionActive()) {

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -105,7 +105,7 @@ class TrimFunction extends FunctionNode
     }
 
     /**
-     * @return integer
+     * @return int
      */
     private function getTrimMode()
     {

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -66,7 +66,7 @@ abstract class Base
     /**
      * @param array $args
      *
-     * @return Base
+     * @return static
      */
     public function addMultiple($args = [])
     {
@@ -80,7 +80,7 @@ abstract class Base
     /**
      * @param mixed $arg
      *
-     * @return Base
+     * @return static
      *
      * @throws \InvalidArgumentException
      */

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -67,9 +67,9 @@ abstract class SQLFilter
      *                           the type conversion of this type. This is usually not needed for
      *                           strings and numeric types.
      *
-     * @return SQLFilter The current SQL filter.
+     * @return self The current SQL filter.
      */
-    final public function setParameter($name, $value, $type = null)
+    final public function setParameter($name, $value, $type = null) : self
     {
         if (null === $type) {
             $type = ParameterTypeInferer::inferType($value);

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2683,7 +2683,7 @@ class Parser
     /**
      * InParameter ::= Literal | InputParameter
      *
-     * @return string | \Doctrine\ORM\Query\AST\InputParameter
+     * @return AST\InputParameter|AST\Literal
      */
     public function InParameter()
     {
@@ -2958,7 +2958,7 @@ class Parser
     /**
      * SimpleEntityExpression ::= IdentificationVariable | InputParameter
      *
-     * @return string | \Doctrine\ORM\Query\AST\InputParameter
+     * @return AST\InputParameter|AST\PathExpression
      */
     public function SimpleEntityExpression()
     {

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -65,8 +65,7 @@ class ParserResult
     /**
      * Gets the ResultSetMapping for the parsed query.
      *
-     * @return ResultSetMapping|null The result set mapping of the parsed query or NULL
-     *                               if the query is not a SELECT query.
+     * @return ResultSetMapping The result set mapping of the parsed query
      */
     public function getResultSetMapping()
     {

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -184,7 +184,7 @@ class ResultSetMapping
      * @param string|null $resultAlias The result alias with which the entity result should be
      *                                 placed in the result structure.
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Rename: addRootEntity
      */
@@ -209,7 +209,7 @@ class ResultSetMapping
      *                            column should be used for.
      * @param string $discrColumn The name of the discriminator column in the SQL result set.
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Rename: addDiscriminatorColumn
      */
@@ -227,7 +227,7 @@ class ResultSetMapping
      * @param string $alias     The alias of an entity result or joined entity result.
      * @param string $fieldName The name of the field to use for indexing.
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      */
     public function addIndexBy($alias, $fieldName)
     {
@@ -262,7 +262,7 @@ class ResultSetMapping
      *
      * @param string $resultColumnName
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      */
     public function addIndexByScalar($resultColumnName)
     {
@@ -277,7 +277,7 @@ class ResultSetMapping
      * @param string $alias
      * @param string $resultColumnName
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      */
     public function addIndexByColumn($alias, $resultColumnName)
     {
@@ -328,7 +328,7 @@ class ResultSetMapping
      *                                    If not specified, the field is assumed to belong to the class
      *                                    designated by $alias.
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Rename: addField
      */
@@ -357,7 +357,7 @@ class ResultSetMapping
      * @param string $relation    The association field that connects the parent entity result
      *                            with the joined entity result.
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Rename: addJoinedEntity
      */
@@ -377,7 +377,7 @@ class ResultSetMapping
      * @param string $alias      The result alias with which the scalar result should be placed in the result structure.
      * @param string $type       The column type
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Rename: addScalar
      */
@@ -564,7 +564,7 @@ class ResultSetMapping
      * @param bool   $isIdentifierColumn
      * @param string $type               The column type
      *
-     * @return ResultSetMapping This ResultSetMapping instance.
+     * @return static This ResultSetMapping instance.
      *
      * @todo Make all methods of this class require all parameters and not infer anything
      */

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -223,7 +223,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param int    $mode
      * @param array  $customRenameColumns
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return array<array-key, string>
      */
     private function getColumnAliasMap($className, $mode, array $customRenameColumns)
     {
@@ -273,7 +275,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param ClassMetadataInfo $class
      * @param string            $resultClassName
      *
-     * @return  ResultSetMappingBuilder
+     * @return self
      */
     public function addNamedNativeQueryResultClassMapping(ClassMetadataInfo $class, $resultClassName)
     {
@@ -318,7 +320,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param ClassMetadataInfo $class
      * @param string            $resultSetMappingName
      *
-     * @return ResultSetMappingBuilder
+     * @return self
      */
     public function addNamedNativeQueryResultSetMapping(ClassMetadataInfo $class, $resultSetMappingName)
     {
@@ -370,7 +372,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param array             $entityMapping
      * @param string            $alias
      *
-     * @return ResultSetMappingBuilder
+     * @return self
      *
      * @throws MappingException
      * @throws \InvalidArgumentException

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -440,7 +440,9 @@ class QueryBuilder
      *     $qb->getRootAliases(); // array('u')
      * </code>
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return list<mixed>
      */
     public function getRootAliases()
     {
@@ -473,7 +475,10 @@ class QueryBuilder
      *
      *     $qb->getAllAliases(); // array('u','a')
      * </code>
-     * @return array
+     *
+     * @return mixed[]
+     *
+     * @psalm-return list<mixed>
      */
     public function getAllAliases()
     {
@@ -492,7 +497,9 @@ class QueryBuilder
      *     $qb->getRootEntities(); // array('User')
      * </code>
      *
-     * @return array
+     * @return mixed[]
+     *
+     * @psalm-return list<mixed>
      */
     public function getRootEntities()
     {

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -135,7 +135,7 @@ EOT
      *
      * @return string[]
      */
-    private function getMappedEntities(EntityManagerInterface $entityManager)
+    private function getMappedEntities(EntityManagerInterface $entityManager) : array
     {
         $entityClassNames = $entityManager->getConfiguration()
                                           ->getMetadataDriverImpl()
@@ -237,9 +237,11 @@ EOT
      * @param string $label Label for the value
      * @param mixed  $value A Value to show
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return array{0: string, 1: string}
      */
-    private function formatField($label, $value)
+    private function formatField($label, $value) : array
     {
         if (null === $value) {
             $value = '<comment>None</comment>';
@@ -253,9 +255,11 @@ EOT
      *
      * @param array $propertyMappings
      *
-     * @return array
+     * @return string[][]
+     *
+     * @psalm-return list<array{0: string, 1: string}>
      */
-    private function formatMappings(array $propertyMappings)
+    private function formatMappings(array $propertyMappings) : array
     {
         $output = [];
 
@@ -275,9 +279,11 @@ EOT
      *
      * @param array $entityListeners
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return array{0: string, 1: string}
      */
-    private function formatEntityListeners(array $entityListeners)
+    private function formatEntityListeners(array $entityListeners) : array
     {
         return $this->formatField('Entity listeners', array_map('get_class', $entityListeners));
     }

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -68,7 +68,9 @@ class ConvertDoctrine1Schema
      * Gets an array of ClassMetadataInfo instances from the passed
      * Doctrine 1 schema.
      *
-     * @return array An array of ClassMetadataInfo instances
+     * @return ClassMetadataInfo[] An array of ClassMetadataInfo instances
+     *
+     * @psalm-return list<ClassMetadataInfo>
      */
     public function getMetadata()
     {
@@ -170,7 +172,7 @@ class ConvertDoctrine1Schema
      * @param string|array      $column
      * @param ClassMetadataInfo $metadata
      *
-     * @return array
+     * @return mixed[]
      *
      * @throws ToolsException
      */

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -23,6 +23,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use ReflectionClass;
 use const E_USER_DEPRECATED;
 use function str_replace;
 use function trigger_error;
@@ -922,9 +923,11 @@ public function __construct(<params>)
     /**
      * @param ClassMetadataInfo $metadata
      *
-     * @return array
+     * @return ReflectionClass[]
      *
      * @throws \ReflectionException
+     *
+     * @psalm-return array<trait-string, ReflectionClass>
      */
     protected function getTraits(ClassMetadataInfo $metadata)
     {
@@ -1155,7 +1158,7 @@ public function __construct(<params>)
     /**
      * @param ClassMetadataInfo $metadata
      *
-     * @return string
+     * @return string|null
      */
     protected function generateDiscriminatorMapAnnotation(ClassMetadataInfo $metadata)
     {

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -170,7 +170,7 @@ class <className> extends <repositoryName>
     /**
      * @param string $repositoryName
      *
-     * @return \Doctrine\ORM\Tools\EntityRepositoryGenerator
+     * @return self
      */
     public function setDefaultRepositoryName($repositoryName)
     {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -182,6 +182,11 @@ class PhpExporter extends AbstractExporter
         return $export;
     }
 
+    /**
+     * @return string[]
+     *
+     * @psalm-return list<string>
+     */
     private function processEntityListeners(ClassMetadataInfo $metadata) : array
     {
         $lines = [];

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -521,7 +521,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * @param SelectStatement $AST
      *
-     * @return array
+     * @return array-key[]
+     *
+     * @psalm-return array<array-key, array-key>
      */
     private function getSQLIdentifier(SelectStatement $AST)
     {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -107,7 +107,7 @@ class SchemaTool
      *
      * @param array $classes
      *
-     * @return array The SQL statements needed to create the schema for the classes.
+     * @return string[] The SQL statements needed to create the schema for the classes.
      */
     public function getCreateSchemaSql(array $classes)
     {
@@ -794,7 +794,7 @@ class SchemaTool
     /**
      * Gets the SQL needed to drop the database schema for the connections database.
      *
-     * @return array
+     * @return string[]
      */
     public function getDropDatabaseSQL()
     {
@@ -812,7 +812,7 @@ class SchemaTool
      *
      * @param array $classes
      *
-     * @return array
+     * @return string[]
      */
     public function getDropSchemaSQL(array $classes)
     {
@@ -888,7 +888,7 @@ class SchemaTool
      * @param boolean $saveMode If TRUE, only generates SQL for a partial update
      *                          that does not include SQL for dropping assets which are scheduled for deletion.
      *
-     * @return array The sequence of SQL statements.
+     * @return string[] The sequence of SQL statements.
      */
     public function getUpdateSchemaSql(array $classes, $saveMode = false)
     {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -81,7 +81,9 @@ class SchemaValidator
      *
      * @param ClassMetadataInfo $class
      *
-     * @return array
+     * @return string[]
+     *
+     * @psalm-return list<string>
      */
     public function validateClass(ClassMetadataInfo $class)
     {

--- a/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+++ b/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
@@ -18,6 +18,10 @@ final class HierarchyDiscriminatorResolver
     /**
      * This method is needed to make INSTANCEOF work correctly with inheritance: if the class at hand has inheritance,
      * it extracts all the discriminators from the child classes and returns them
+     *
+     * @return null[]
+     *
+     * @psalm-return array<array-key, null>
      */
     public static function resolveDiscriminatorsForClass(
         ClassMetadata $rootClassMetadata,

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,4 +12,12 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <ParadoxicalCondition>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/3381 -->
+                <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
+            </errorLevel>
+        </ParadoxicalCondition>
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
These changes are a subset of changes done with `vendor/bin/psalm --alter
--issues=LessSpecificReturnType
--allow-backwards-incompatible-changes=false`

If you want to see changes I rejected, you can have a look at https://github.com/greg0ire/doctrine-orm/pull/2