### PR TITLE
Fix deprecation warning when using doctrine/inflector 1.4

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -21,7 +21,9 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Common\Inflector\Inflector as LegacyInflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\Persistence\ObjectRepository;
 
@@ -54,6 +56,9 @@ class EntityRepository implements ObjectRepository, Selectable
      * @var \Doctrine\ORM\Mapping\ClassMetadata
      */
     protected $_class;
+
+    /** @var Inflector */
+    private static $inflector;
 
     /**
      * Initializes a new <tt>EntityRepository</tt>.
@@ -302,12 +307,31 @@ class EntityRepository implements ObjectRepository, Selectable
             throw ORMException::findByRequiresParameter($method . $by);
         }
 
-        $fieldName = lcfirst(Inflector::classify($by));
+        $fieldName = lcfirst($this->classify($by));
 
         if (! ($this->_class->hasField($fieldName) || $this->_class->hasAssociation($fieldName))) {
             throw ORMException::invalidMagicCall($this->_entityName, $fieldName, $method . $by);
         }
 
         return $this->$method([$fieldName => $arguments[0]], ...array_slice($arguments, 1));
+    }
+
+    /**
+     * @param string $word
+     *
+     * @return string
+     */
+    private function classify($word)
+    {
+        if (class_exists(InflectorFactory::class)) {
+            if (null === self::$inflector)
+            {
+                self::$inflector = InflectorFactory::create()->build();
+            }
+
+            return self::$inflector->classify($word);
+        }
+
+        return LegacyInflector::classify($word);
     }
 }

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -20,7 +20,8 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Common\Inflector\Inflector as LegacyInflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\DBAL\Types\Type;
 use Symfony\Component\Yaml\Yaml;
 
@@ -291,6 +292,11 @@ class ConvertDoctrine1Schema
             return;
         }
 
+        $inflector = null;
+        if (class_exists(InflectorFactory::class)) {
+            $inflector = InflectorFactory::create()->build();
+        }
+
         foreach ($model['relations'] as $name => $relation) {
             if ( ! isset($relation['alias'])) {
                 $relation['alias'] = $name;
@@ -299,7 +305,11 @@ class ConvertDoctrine1Schema
                 $relation['class'] = $name;
             }
             if ( ! isset($relation['local'])) {
-                $relation['local'] = Inflector::tableize($relation['class']);
+                if ($inflector === null) {
+                    $relation['local'] = LegacyInflector::tableize($relation['class']);
+                } else {
+                    $relation['local'] = $inflector->tabelize($relation['class']);
+                }
             }
             if ( ! isset($relation['foreign'])) {
                 $relation['foreign'] = 'id';

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -20,7 +20,9 @@
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Common\Inflector\Inflector as LegacyInflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use const E_USER_DEPRECATED;
@@ -335,6 +337,9 @@ public function __construct(<params>)
 }
 ';
 
+    /** @var Inflector */
+    protected $inflector;
+
     /**
      * Constructor.
      */
@@ -344,6 +349,10 @@ public function __construct(<params>)
 
         if (version_compare(\Doctrine\Common\Version::VERSION, '2.2.0-DEV', '>=')) {
             $this->annotationsPrefix = 'ORM\\';
+        }
+
+        if (class_exists(InflectorFactory::class)) {
+            $this->inflector = InflectorFactory::create()->build();
         }
     }
 
@@ -1377,11 +1386,11 @@ public function __construct(<params>)
      */
     protected function generateEntityStubMethod(ClassMetadataInfo $metadata, $type, $fieldName, $typeHint = null, $defaultValue = null)
     {
-        $methodName = $type . Inflector::classify($fieldName);
-        $variableName = Inflector::camelize($fieldName);
+        $methodName = $type . $this->classify($fieldName);
+        $variableName = $this->camelize($fieldName);
         if (in_array($type, ["add", "remove"])) {
-            $methodName = Inflector::singularize($methodName);
-            $variableName = Inflector::singularize($variableName);
+            $methodName = $this->singularize($methodName);
+            $variableName = $this->singularize($variableName);
         }
 
         if ($this->hasMethod($methodName, $metadata)) {
@@ -1911,5 +1920,47 @@ public function __construct(<params>)
         }
 
         return implode(',', $optionsStr);
+    }
+
+    /**
+     * @param string $word
+     *
+     * @return string
+     */
+    private function camelize($word)
+    {
+        if (null !== $this->inflector) {
+            return $this->inflector->camelize($word);
+        }
+
+        return LegacyInflector::camelize($word);
+    }
+
+    /**
+     * @param string $word
+     *
+     * @return string
+     */
+    private function classify($word)
+    {
+        if (null !== $this->inflector) {
+            return $this->inflector->classify($word);
+        }
+
+        return LegacyInflector::classify($word);
+    }
+
+    /**
+     * @param string $word
+     * 
+     * @return string
+     */
+    private function singularize($word)
+    {
+        if (null !== $this->inflector) {
+            return $this->inflector->singularize($word);
+        }
+
+        return LegacyInflector::singularize($word);
     }
 }


### PR DESCRIPTION
https://github.com/doctrine/orm/pull/8147 fixed the deprecation warnings for 2.8.

This PR fixes deprecation warnings in 2.7 while keeping compatibility with PHP 7.1.

Fixed https://github.com/doctrine/orm/issues/8137

