### PR TITLE
Convert ScalarRowData value thanks to the field type

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -326,17 +326,13 @@ abstract class AbstractHydrator
             }
 
             $fieldName = $cacheKeyInfo['fieldName'];
-
-            // WARNING: BC break! We know this is the desired behavior to type convert values, but this
-            // erroneous behavior exists since 2.0 and we're forced to keep compatibility.
-            if (! isset($cacheKeyInfo['isScalar'])) {
+            if (isset($cacheKeyInfo['dqlAlias'])) {
                 $dqlAlias  = $cacheKeyInfo['dqlAlias'];
-                $type      = $cacheKeyInfo['type'];
                 $fieldName = $dqlAlias . '_' . $fieldName;
-                $value     = $type
-                    ? $type->convertToPHPValue($value, $this->platform)
-                    : $value;
             }
+
+            $type  = $cacheKeyInfo['type'];
+            $value = $type ? $type->convertToPHPValue($value, $this->platform) : $value;
 
             $rowData[$fieldName] = $value;
         }


### PR DESCRIPTION
## Description

This is related to the issue: https://github.com/doctrine/orm/issues/8155 

This is the intended behaviour, as we can see in this commit
https://github.com/doctrine/orm/commit/a4dac7a292cffcd48e9ac2c7680d506cd5e8ead8

But this was a BC-break so should wait Doctrine 3, that's why I made the PR on master.
There was some refactoring which lead to a less clear comment ATM.

## Impact:
```
$em->createQueryBuilder('post')->select('post.id')->getQuery()->getSingleScalarResult();
```
Previously was returning an `int` in PostgreSQL and a `string` with MariaDB.
Now always returns an `int` since the type is `IntegerType`.

```
$em->createQueryBuilder('post')->select('COUNT(post.id)')->getQuery()->getSingleScalarResult();
```
Previously was returning an `int` in PostgreSQL and a `string` with MariaDB.
Now still returns an `int` in PostgreSQL and a `string` with MariaDB since the type is `StringType`.

To improve the second behaviour, we have to resolve the type here
https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query/SqlWalker.php#L1357-L1381