### PR TITLE
Use correct target branch info in PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/New_Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/New_Feature.md
@@ -6,8 +6,8 @@ about: You have implemented some neat idea that you want to make part of Doctrin
 <!--
 Thank you for submitting new feature!
 Pick the target branch based according to these criteria:
-  * submitting a bugfix: target the lowest active stable branch: 2.6
-  * submitting a new feature: target the master branch.
+  * submitting a bugfix: target the lowest active stable branch: 2.7
+  * submitting a new feature: target the next minor branch: 2.8.x
   * submitting a BC-breaking change: target the master branch
 -->
 


### PR DESCRIPTION
The current branch for bugfixes is 2.7, and new features should go on
2.8.x, not master.