### PR TITLE
Fixes Serialization of 'ReflectionProperty' is not allowed exception when using PHP >= 7.4

### DIFF
--- a/lib/Doctrine/ORM/Mapping/FieldMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/FieldMetadata.php
@@ -21,6 +21,9 @@ class FieldMetadata extends LocalColumnMetadata implements Property
     /** @var bool */
     protected $versioned = false;
 
+    /** @var string|null */
+    protected $className;
+
     public function __construct(string $name/*, string $columnName, Type $type*/)
     {
 //        @todo Leverage this implementation instead of default, simple constructor
@@ -107,5 +110,37 @@ class FieldMetadata extends LocalColumnMetadata implements Property
         $this->setReflectionProperty(
             $reflectionService->getAccessibleProperty($this->declaringClass->getClassName(), $this->name)
         );
+    }
+
+    /**
+     * __sleep
+     *
+     * Serialization of ReflectionProperty generates an exception on php >= 7.4
+     * @see https://raw.githubusercontent.com/php/php-src/PHP7.4/UPGRADING for explanation on that
+     */
+    public function __sleep()
+    {
+        $this->className = $this->reflection->class;
+        return [
+            'declaringClass',
+            'name',
+            'versioned',
+            'length',
+            'scale',
+            'precision',
+            'valueGenerator',
+            'tableName',
+            'columnName',
+            'options',
+            'primaryKey',
+            'nullable',
+            'unique',
+            'className'
+        ];
+    }
+
+    public function __wakeup()
+    {
+        $this->reflection = new ReflectionProperty($this->className, $this->name);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldMetadataTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of orm package
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Doctrine\Tests\ORM\Mapping;
+
+use Doctrine\ORM\Mapping\FieldMetadata;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class FieldMetadataTest extends TestCase
+{
+
+    public function testSerialization()
+    {
+        $name = 'property';
+        $expected = 'property value';
+        $subject = new FieldMetadata($name);
+        $subject->setReflectionProperty(new ReflectionProperty(DummyEntityClass::class, $name));
+        try {
+            $serialized = serialize($subject);
+            /** @var FieldMetadata $recovered */
+            $recovered = unserialize($serialized);
+            $this->assertInstanceOf(FieldMetadata::class, $recovered);
+            $this->assertEquals($expected, $recovered->getValue(new DummyEntityClass($expected)));
+        } catch (Exception $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+}
+
+class DummyEntityClass
+{
+    public string $property;
+
+    public function __construct(string $property)
+    {
+        $this->property = $property;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Mapping/FieldMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/FieldMetadataTest.php
@@ -37,7 +37,8 @@ class FieldMetadataTest extends TestCase
 
 class DummyEntityClass
 {
-    public string $property;
+    /** @var string */
+    public $property;
 
     public function __construct(string $property)
     {


### PR DESCRIPTION
---
Cache serialization fails with Serialization of 'ReflectionProperty' is not allowed
---
### Problem
When using a cache provider, serialization fails with an exception _Serialization of 'ReflectionProperty' is not allowed_.
Checking on [php7.4 upgrading notes](https://raw.githubusercontent.com/php/php-src/PHP-7.4/UPGRADING) you can read:
"Reflection objects will now generate an exception if an attempt is made
    to serialize them. Serialization for reflection objects was never
    supported and resulted in corrupted reflection objects. It has been"

#### Solution

This PR changes `FieldMetadata` serialization behavior by removing `FieldMetadata::$reflection` property from serialization and stores the class name before doing it.
When its recovered from serialized data, it creates a new `ReflectionProperty` instance from previously stored class name (new class property) and name.
