### PR TITLE
Run benchmark on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
 
     - stage: Code Quality
       env: DB=none BENCHMARK
+      php: 7.4
       before_script: wget https://phpbench.github.io/phpbench/phpbench.phar https://phpbench.github.io/phpbench/phpbench.phar.pubkey
       script: php phpbench.phar run -l dots --report=default
 


### PR DESCRIPTION
phpbench recently dropped compatibilty with PHP 7.1
When this job was introduced, 7.1 was the latest version of PHP we
supported, so it makes sense to bump to 7.4 now.
See https://github.com/phpbench/phpbench/releases/tag/0.17.0
See e07c90df4488b7b44494695e46c3505f5cf21266