### PR TITLE
Add support for ORDER BY CASE

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1489,7 +1489,7 @@ class Parser
 
     /**
      * OrderByItem ::= (
-     *      SimpleArithmeticExpression | SingleValuedPathExpression |
+     *      SimpleArithmeticExpression | SingleValuedPathExpression | CaseExpression |
      *      ScalarExpression | ResultVariable | FunctionDeclaration
      * ) ["ASC" | "DESC"]
      *
@@ -1521,6 +1521,10 @@ class Parser
 
             case ($this->lexer->peek() && $this->isMathOperator($this->peekBeyondClosingParenthesis())):
                 $expr = $this->ScalarExpression();
+                break;
+
+            case $this->lexer->lookahead['type'] === Lexer::T_CASE:
+                $expr = $this->CaseExpression();
                 break;
 
             default:

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -93,6 +93,52 @@ GROUP BY p.department HAVING SUM(p.salary) > 200000 ORDER BY p.department -- com
         $this->assertEquals(1, $result[3]['friends']);
     }
 
+    public function testOrderBySimpleCaseExpression() : void
+    {
+        $dql = <<<'DQL'
+            SELECT p.name
+            FROM Doctrine\Tests\Models\Company\CompanyEmployee p
+            ORDER BY CASE p.name
+            WHEN 'Jonathan W.' THEN 1
+            WHEN 'Roman B.' THEN 2
+            WHEN 'Guilherme B.' THEN 3
+            ELSE 4
+            END DESC
+DQL;
+
+        $result = $this->_em->createQuery($dql)->getScalarResult();
+
+        self::assertCount(4, $result);
+
+        self::assertEquals('Benjamin E.', $result[0]['name']);
+        self::assertEquals('Guilherme B.', $result[1]['name']);
+        self::assertEquals('Roman B.', $result[2]['name']);
+        self::assertEquals('Jonathan W.', $result[3]['name']);
+    }
+
+    public function testOrderByGeneralCaseExpression() : void
+    {
+        $dql = <<<'DQL'
+            SELECT p.name
+            FROM Doctrine\Tests\Models\Company\CompanyEmployee p
+            ORDER BY CASE
+            WHEN p.name='Jonathan W.' THEN 1
+            WHEN p.name='Roman B.' THEN 2
+            WHEN p.name='Guilherme B.' THEN 3
+            ELSE 4
+            END DESC
+DQL;
+
+        $result = $this->_em->createQuery($dql)->getScalarResult();
+
+        self::assertCount(4, $result);
+
+        self::assertEquals('Benjamin E.', $result[0]['name']);
+        self::assertEquals('Guilherme B.', $result[1]['name']);
+        self::assertEquals('Roman B.', $result[2]['name']);
+        self::assertEquals('Jonathan W.', $result[3]['name']);
+    }
+
     public function testIsNullAssociation()
     {
         $dql = 'SELECT p FROM Doctrine\Tests\Models\Company\CompanyPerson p '.


### PR DESCRIPTION
I would like to propose the feature of custom ordering by utilizing a case expression. The most common platforms all support it.

```sql
SELECT e.name
FROM employees e
ORDER BY CASE e.position
WHEN 'manager' THEN 1
WHEN 'reporter' THEN 2
WHEN 'intern' THEN 3
ELSE 4
END
```

At the moment when custom ordering is needed most of the time one must fall back to platform specific functions (like `FIELD` for mysql). This feature would provide custom ordering out of the box for all supported platforms.

Validated platforms:
- mysql
- mariadb
- postgres
- sqlite
- oracle
- sql server

I've added 2 tests that validates using a simple and generic case expressions.

Any thoughts?