### PR TITLE
Associated entities are persisted when no direct persist is called or cascade is not configured #8193

### DIFF
--- a/tests/Doctrine/Tests/Models/GH8193/Event.php
+++ b/tests/Doctrine/Tests/Models/GH8193/Event.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Doctrine\Tests\Models\GH8193;
+
+/**
+ * @Entity
+ * @Table(name = "events")
+ */
+class Event
+{
+    /**
+     * @var int
+     *
+     * @Id
+     * @Column(type = "integer", options = {"unsigned" = true})
+     * @GeneratedValue
+     */
+    private $eventId;
+
+    /**
+     * @var float
+     *
+     * @Column(type = "decimal", precision = 10, scale = 2, options = {"default" = 0})
+     */
+    private $amount;
+
+    /**
+     * @var User
+     *
+     * @ManyToOne(targetEntity = "User", inversedBy = "events")
+     * @JoinColumn(name = "userId", referencedColumnName = "userId", nullable = false)
+     */
+    private $user;
+
+    public function getId(): ?int
+    {
+        return $this->eventId;
+    }
+
+    public function setAmount(float $amount): self
+    {
+        $this->amount = $amount;
+        return $this;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH8193/User.php
+++ b/tests/Doctrine/Tests/Models/GH8193/User.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Doctrine\Tests\Models\GH8193;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @Entity
+ * @Table(name = "users")
+ */
+class User
+{
+    /**
+     * @var int
+     *
+     * @Id
+     * @Column(type = "integer", options = {"unsigned" = true})
+     * @GeneratedValue
+     */
+    private $userId;
+
+    /**
+     * @var string
+     *
+     * @Column(type = "string", length = 255)
+     */
+    private $email;
+
+    /**
+     * @var Event[]|Collection
+     *
+     * @OneToMany(targetEntity = "Event", mappedBy = "user")
+     */
+    private $events;
+
+    public function __construct()
+    {
+        $this->events = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function setEmail(?string $email = null): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function addEvent(Event $event): self
+    {
+        $this->events->add($event);
+        return $this;
+    }
+
+    public function removeEvent(Event $event): self
+    {
+        $this->events->removeElement($event);
+        return $this;
+    }
+
+    /** @return Event[] */
+    public function getEvents(): Collection
+    {
+        return $this->events;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8193Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8193Test.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\Models\GH8193\User;
+use Doctrine\Tests\Models\GH8193\Event;
+
+class GH8193Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+    private const USER_EMAIL = 'nick@test.com';
+
+    protected function setUp() : void
+    {
+        $this->useModelSet('GH8193');
+        parent::setUp();
+
+        $user = new User();
+        $user->setEmail(self::USER_EMAIL);
+
+        $event = new Event();
+        $event
+            ->setAmount(10)
+            ->setUser($user);
+
+        $this->_em->persist($user);
+        $this->_em->persist($event);
+        $this->_em->flush();
+
+        $this->_em->clear();
+    }
+
+    public function testThatTheEventShouldntBeUpdated()
+    {
+        /** @var User $user */
+        $user = $this->_em->getRepository(User::class)->findOneBy([
+            'email' => self::USER_EMAIL
+        ]);
+        /** @var Event $event */
+        $event = $user->getEvents()->first();
+
+        $this->assertEquals(10, $event->getAmount());
+
+        // we only want to change the email in the database
+        $user->setEmail('updated@test.com');
+
+        // but for some reason the event is updated too (maybe its due to https://github.com/doctrine/orm/issues/5594)
+        $event->setAmount(20);
+
+        // only persist the User as the event shouldn't be updated as cascade isnt enabled between the entities
+        $this->_em->persist($user);
+        $this->_em->flush();
+
+        $this->_em->clear();
+
+        // finally fetch the event again because the amount should still be 10
+        $event = $this->_em->getRepository(Event::class)->findOneBy([]);
+
+        $this->assertEquals(10, $event->getAmount());
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -313,6 +313,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\Issue5989\Issue5989Employee::class,
             Models\Issue5989\Issue5989Manager::class,
         ],
+        'GH8193' => [
+            Models\GH8193\User::class,
+            Models\GH8193\Event::class
+        ]
     ];
 
     /**


### PR DESCRIPTION
If associated entities fetched using lazy loading are modified, they will be persisted along with the parent entity even when no persist has been called on the lazy loaded entity or any cascade configuration has been set.

As outlined under issuer here: https://github.com/doctrine/orm/issues/8193

Test run with

```bash
vendor/bin/phpunit --filter GH8193
```