### PR TITLE
Throw Exception when unable to locate identifier

### DIFF
--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -21,6 +21,7 @@
 namespace Doctrine\ORM;
 
 use function implode;
+use function sprintf;
 
 /**
  * Exception thrown when a Proxy fails to retrieve an Entity result.
@@ -46,5 +47,18 @@ class EntityNotFoundException extends ORMException
         return new self(
             'Entity of type \'' . $className . '\'' . ($ids ? ' for IDs ' . implode(', ', $ids) : '') . ' was not found'
         );
+    }
+
+    /**
+     * Instance for which no identifier can be found
+     *
+     * @psalm-param class-string $className
+     */
+    public static function noIdentifierFound(string $className): self
+    {
+        return new self(sprintf(
+            'Unable to find "%s" entity identifier associated with the UnitOfWork',
+            $className
+        ));
     }
 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3038,7 +3038,8 @@ class UnitOfWork implements PropertyChangedListener
      */
     public function getEntityIdentifier($entity)
     {
-        return $this->entityIdentifiers[spl_object_hash($entity)];
+        return $this->entityIdentifiers[spl_object_hash($entity)]
+            ?? EntityNotFoundException::noIdentifierFound(get_class($entity));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/EntityNotFoundExceptionTest.php
@@ -32,4 +32,12 @@ class EntityNotFoundExceptionTest extends TestCase
         $this->assertInstanceOf(EntityNotFoundException::class, $exception);
         $this->assertSame('Entity of type \'foo\' was not found', $exception->getMessage());
     }
+
+    public function testNoIdentifierFound(): void
+    {
+        $exception = EntityNotFoundException::noIdentifierFound('foo');
+
+        $this->assertInstanceOf(EntityNotFoundException::class, $exception);
+        $this->assertSame('Unable to find "foo" entity identifier associated with the UnitOfWork', $exception->getMessage());
+    }
 }


### PR DESCRIPTION
When UnitOfWork is unable to locate an entity by the `spl_object_hash`, we throw a custom Exception that includes the name of the entity that was unable to be located.