### PR TITLE
Add SchemaIgnoreClasses property for #8195.

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -936,4 +936,28 @@ class Configuration extends \Doctrine\DBAL\Configuration
     {
         $this->_attributes['defaultQueryHints'][$name] = $value;
     }
+
+    /**
+     * Gets a list of entity class names to be ignored by the SchemaTool
+     *
+     * @since 2.8
+     *
+     * @return array
+     */
+    public function getSchemaIgnoreClasses() : array
+    {
+        return isset($this->_attributes['schemaIgnoreClasses']) ? $this->_attributes['schemaIgnoreClasses'] : [];
+    }
+    
+    /**
+     * Sets a list of entity class names to be ignored by the SchemaTool
+     *
+     * @since 2.8
+     *
+     * @param array $schemaIgnoreClasses Array of entity class names
+     */
+    public function setSchemaIgnoreClasses(array $schemaIgnoreClasses)
+    {
+        $this->_attributes['schemaIgnoreClasses'] = $schemaIgnoreClasses;
+    }
 }

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -940,21 +940,17 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Gets a list of entity class names to be ignored by the SchemaTool
      *
-     * @since 2.8
-     *
-     * @return array
+     * @return string[]
      */
     public function getSchemaIgnoreClasses() : array
     {
-        return isset($this->_attributes['schemaIgnoreClasses']) ? $this->_attributes['schemaIgnoreClasses'] : [];
+        return isset($this->_attributes['schemaIgnoreClasses']) === true ? $this->_attributes['schemaIgnoreClasses'] : [];
     }
-    
+
     /**
      * Sets a list of entity class names to be ignored by the SchemaTool
      *
-     * @since 2.8
-     *
-     * @param array $schemaIgnoreClasses Array of entity class names
+     * @param string[] $schemaIgnoreClasses Array of entity class names
      */
     public function setSchemaIgnoreClasses(array $schemaIgnoreClasses)
     {

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -942,18 +942,18 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @return string[]
      */
-    public function getSchemaIgnoreClasses() : array
+    public function getEntitiesIgnoredDuringSchemaGeneration() : array
     {
-        return isset($this->_attributes['schemaIgnoreClasses']) === true ? $this->_attributes['schemaIgnoreClasses'] : [];
+        return isset($this->_attributes['entitiesIgnoredDuringSchemaGeneration']) === true ? $this->_attributes['entitiesIgnoredDuringSchemaGeneration'] : [];
     }
 
     /**
      * Sets a list of entity class names to be ignored by the SchemaTool
      *
-     * @param string[] $schemaIgnoreClasses Array of entity class names
+     * @param string[] $entitiesIgnoredDuringSchemaGeneration Array of entity class names
      */
-    public function setSchemaIgnoreClasses(array $schemaIgnoreClasses)
+    public function setEntitiesIgnoredDuringSchemaGeneration(array $entitiesIgnoredDuringSchemaGeneration)
     {
-        $this->_attributes['schemaIgnoreClasses'] = $schemaIgnoreClasses;
+        $this->_attributes['entitiesIgnoredDuringSchemaGeneration'] = $entitiesIgnoredDuringSchemaGeneration;
     }
 }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use function in_array;
 
 /**
  * The SchemaTool is a tool to create/drop/update database schemas based on
@@ -119,20 +120,18 @@ class SchemaTool
     /**
      * Detects instances of ClassMetadata that don't need to be processed in the SchemaTool context.
      *
-     * @param ClassMetadata $class
-     * @param array         $processedClasses
+     * @param ClassMetadata   $class
+     * @param ClassMetadata[] $processedClasses
      *
      * @return bool
      */
     private function processingNotRequired($class, array $processedClasses)
     {
-        return (
-            isset($processedClasses[$class->name]) ||
+        return isset($processedClasses[$class->name]) ||
             $class->isMappedSuperclass ||
             $class->isEmbeddedClass ||
-            ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName) ||
-            in_array($class->name, $this->em->getConfiguration()->getSchemaIgnoreClasses())
-        );
+            ($class->isInheritanceTypeSingleTable() && $class->name !== $class->rootEntityName) ||
+            in_array($class->name, $this->em->getConfiguration()->getSchemaIgnoreClasses());
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -131,7 +131,7 @@ class SchemaTool
             $class->isMappedSuperclass ||
             $class->isEmbeddedClass ||
             ($class->isInheritanceTypeSingleTable() && $class->name !== $class->rootEntityName) ||
-            in_array($class->name, $this->em->getConfiguration()->getSchemaIgnoreClasses());
+            in_array($class->name, $this->em->getConfiguration()->getEntitiesIgnoredDuringSchemaGeneration());
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -130,7 +130,8 @@ class SchemaTool
             isset($processedClasses[$class->name]) ||
             $class->isMappedSuperclass ||
             $class->isEmbeddedClass ||
-            ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName)
+            ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName) ||
+            in_array($class->name, $this->em->getConfiguration()->getSchemaIgnoreClasses())
         );
     }
 

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -272,6 +272,34 @@ class SchemaToolTest extends OrmTestCase
             self::assertSame($foreignColumns, $foreignKey->getForeignColumns());
         }
     }
+
+    /**
+     * @group schema-configuration
+     */
+    public function testConfigurationSchemaIgnoredEntity() : void
+    {
+        $em         = $this->_getTestEntityManager();
+        $schemaTool = new SchemaTool($em);
+
+        $classes = [
+            $em->getClassMetadata(FirstEntity::class),
+            $em->getClassMetadata(SecondEntity::class),
+        ];
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('first_entity'), 'Table first_entity should exist.');
+        self::assertTrue($schema->hasTable('second_entity'), 'Table second_entity should exist.');
+
+        $em->getConfiguration()->setSchemaIgnoreClasses([
+            SecondEntity::class,
+        ]);
+
+        $schema = $schemaTool->getSchemaFromMetadata($classes);
+
+        self::assertTrue($schema->hasTable('first_entity'), 'Table first_entity should exist.');
+        self::assertFalse($schema->hasTable('second_entity'), 'Table second_entity should not exist.');
+    }
 }
 
 /**

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -291,7 +291,7 @@ class SchemaToolTest extends OrmTestCase
         self::assertTrue($schema->hasTable('first_entity'), 'Table first_entity should exist.');
         self::assertTrue($schema->hasTable('second_entity'), 'Table second_entity should exist.');
 
-        $em->getConfiguration()->setSchemaIgnoreClasses([
+        $em->getConfiguration()->setEntitiesIgnoredDuringSchemaGeneration([
             SecondEntity::class,
         ]);
 


### PR DESCRIPTION
Add schemaIgnoreClasses property, this list of entity classes is ignored by the schema tool when building a schema from metadata.

Fixes #8195 