### PR TITLE
change list() syntax to array destructuring (short list syntax)

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -969,7 +969,7 @@ abstract class AbstractQuery
         $setCacheEntry = function() {};
 
         if ($this->_hydrationCacheProfile !== null) {
-            list($cacheKey, $realCacheKey) = $this->getHydrationCacheId();
+            [$cacheKey, $realCacheKey] = $this->getHydrationCacheId();
 
             $queryCacheProfile = $this->getHydrationCacheProfile();
             $cache             = $queryCacheProfile->getResultCacheDriver();

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -293,7 +293,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     protected function getHash($query, $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        list($params) = ($criteria instanceof Criteria)
+        [$params] = ($criteria instanceof Criteria)
             ? $this->persister->expandCriteriaParameters($criteria)
             : $this->persister->expandParameters($criteria);
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -293,7 +293,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     protected function getHash($query, $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        [$params] = ($criteria instanceof Criteria)
+        [$params] = $criteria instanceof Criteria
             ? $this->persister->expandCriteriaParameters($criteria)
             : $this->persister->expandParameters($criteria);
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -327,7 +327,7 @@ use function trigger_error;
      */
     public function createNamedNativeQuery($name)
     {
-        list($sql, $rsm) = $this->config->getNamedNativeQuery($name);
+        [$sql, $rsm] = $this->config->getNamedNativeQuery($name);
 
         return $this->createNativeQuery($sql, $rsm);
     }

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -89,7 +89,7 @@ final class HydrationCompleteHandler
         $this->deferredPostLoadInvocations = [];
 
         foreach ($toInvoke as $classAndEntity) {
-            list($class, $invoke, $entity) = $classAndEntity;
+            [$class, $invoke, $entity] = $classAndEntity;
 
             $this->listenersInvoker->invoke(
                 $class,

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -30,6 +30,7 @@ use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionProperty;
 use RuntimeException;
+use function explode;
 
 /**
  * A <tt>ClassMetadata</tt> instance holds all the object-relational mapping metadata

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2342,7 +2342,7 @@ class ClassMetadataInfo implements ClassMetadata
         if (isset($table['name'])) {
             // Split schema and table name from a table name like "myschema.mytable"
             if (strpos($table['name'], '.') !== false) {
-                list($this->table['schema'], $table['name']) = explode('.', $table['name'], 2);
+                [$this->table['schema'], $table['name']] = explode('.', $table['name'], 2);
             }
 
             if ($table['name'][0] === '`') {
@@ -2568,7 +2568,7 @@ class ClassMetadataInfo implements ClassMetadata
                         if (!isset($field['column'])) {
                             $fieldName = $field['name'];
                             if (strpos($fieldName, '.')) {
-                                list(, $fieldName) = explode('.', $fieldName);
+                                [, $fieldName] = explode('.', $fieldName);
                             }
 
                             $resultMapping['entities'][$key]['fields'][$k]['column'] = $fieldName;

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -68,8 +68,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
             return; // ignore inverse side
         }
 
-        list($deleteSql, $deleteTypes) = $this->getDeleteRowSQL($collection);
-        list($insertSql, $insertTypes) = $this->getInsertRowSQL($collection);
+        [$deleteSql, $deleteTypes] = $this->getDeleteRowSQL($collection);
+        [$insertSql, $insertTypes] = $this->getInsertRowSQL($collection);
 
         foreach ($collection->getDeleteDiff() as $element) {
             $this->conn->executeUpdate(
@@ -136,7 +136,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]        = PersisterHelper::getTypeOfColumn($referencedName, $sourceClass, $this->em);
         }
 
-        list($joinTargetEntitySQL, $filterSql) = $this->getFilterSql($mapping);
+        [$joinTargetEntitySQL, $filterSql] = $this->getFilterSql($mapping);
 
         if ($filterSql) {
             $conditions[] = $filterSql;
@@ -188,7 +188,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             throw new \BadMethodCallException("Selecting a collection by index is only supported on indexed collections.");
         }
 
-        list($quotedJoinTable, $whereClauses, $params, $types) = $this->getJoinTableRestrictionsWithKey($collection, $key, true);
+        [$quotedJoinTable, $whereClauses, $params, $types] = $this->getJoinTableRestrictionsWithKey(
+            $collection,
+            $key,
+            true
+        );
 
         $sql = 'SELECT 1 FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
 
@@ -204,7 +208,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
             return false;
         }
 
-        list($quotedJoinTable, $whereClauses, $params, $types) = $this->getJoinTableRestrictions($collection, $element, true);
+        [$quotedJoinTable, $whereClauses, $params, $types] = $this->getJoinTableRestrictions(
+            $collection,
+            $element,
+            true
+        );
 
         $sql = 'SELECT 1 FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
 
@@ -644,7 +652,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         }
 
         if ($addFilters) {
-            list($joinTargetEntitySQL, $filterSql) = $this->getFilterSql($filterMapping);
+            [$joinTargetEntitySQL, $filterSql] = $this->getFilterSql($filterMapping);
 
             if ($filterSql) {
                 $quotedJoinTable .= ' ' . $joinTargetEntitySQL;
@@ -712,7 +720,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         if ($addFilters) {
             $quotedJoinTable .= ' t';
 
-            list($joinTargetEntitySQL, $filterSql) = $this->getFilterSql($filterMapping);
+            [$joinTargetEntitySQL, $filterSql] = $this->getFilterSql($filterMapping);
 
             if ($filterSql) {
                 $quotedJoinTable .= ' ' . $joinTargetEntitySQL;
@@ -743,7 +751,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         $valueVisitor->dispatch($expression);
 
-        list(, $types) = $valueVisitor->getParamsAndTypes();
+        [, $types] = $valueVisitor->getParamsAndTypes();
 
         return $types;
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -828,7 +828,7 @@ class BasicEntityPersister implements EntityPersister
     {
         $sql = $this->getCountSQL($criteria);
 
-        [$params, $types] = ($criteria instanceof Criteria)
+        [$params, $types] = $criteria instanceof Criteria
             ? $this->expandCriteriaParameters($criteria)
             : $this->expandParameters($criteria);
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -722,7 +722,7 @@ class BasicEntityPersister implements EntityPersister
         $this->switchPersisterContext(null, $limit);
 
         $sql = $this->getSelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
-        list($params, $types) = $this->expandParameters($criteria);
+        [$params, $types] = $this->expandParameters($criteria);
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         if ($entity !== null) {
@@ -814,7 +814,7 @@ class BasicEntityPersister implements EntityPersister
     public function refresh(array $id, $entity, $lockMode = null)
     {
         $sql = $this->getSelectSQL($id, null, $lockMode);
-        list($params, $types) = $this->expandParameters($id);
+        [$params, $types] = $this->expandParameters($id);
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         $hydrator = $this->em->newHydrator(Query::HYDRATE_OBJECT);
@@ -828,7 +828,7 @@ class BasicEntityPersister implements EntityPersister
     {
         $sql = $this->getCountSQL($criteria);
 
-        list($params, $types) = ($criteria instanceof Criteria)
+        [$params, $types] = ($criteria instanceof Criteria)
             ? $this->expandCriteriaParameters($criteria)
             : $this->expandParameters($criteria);
 
@@ -845,7 +845,7 @@ class BasicEntityPersister implements EntityPersister
         $offset  = $criteria->getFirstResult();
         $query   = $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
 
-        list($params, $types) = $this->expandCriteriaParameters($criteria);
+        [$params, $types] = $this->expandCriteriaParameters($criteria);
 
         $stmt       = $this->conn->executeQuery($query, $params, $types);
         $hydrator   = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
@@ -871,14 +871,14 @@ class BasicEntityPersister implements EntityPersister
 
         $valueVisitor->dispatch($expression);
 
-        list($params, $types) = $valueVisitor->getParamsAndTypes();
+        [$params, $types] = $valueVisitor->getParamsAndTypes();
 
         foreach ($params as $param) {
             $sqlParams = array_merge($sqlParams, $this->getValues($param));
         }
 
         foreach ($types as $type) {
-            list ($field, $value) = $type;
+            [$field, $value] = $type;
             $sqlTypes = array_merge($sqlTypes, $this->getTypes($field, $value, $this->class));
         }
 
@@ -893,7 +893,7 @@ class BasicEntityPersister implements EntityPersister
         $this->switchPersisterContext($offset, $limit);
 
         $sql = $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
-        list($params, $types) = $this->expandParameters($criteria);
+        [$params, $types] = $this->expandParameters($criteria);
         $stmt = $this->conn->executeQuery($sql, $params, $types);
 
         $hydrator = $this->em->newHydrator(($this->currentPersisterContext->selectJoinSql) ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
@@ -1038,7 +1038,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $sql = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
-        list($params, $types) = $this->expandToManyParameters($parameters);
+        [$params, $types] = $this->expandToManyParameters($parameters);
 
         return $this->conn->executeQuery($sql, $params, $types);
     }
@@ -1546,7 +1546,7 @@ class BasicEntityPersister implements EntityPersister
              . $where
              . $lockSql;
 
-        list($params, $types) = $this->expandParameters($criteria);
+        [$params, $types] = $this->expandParameters($criteria);
 
         $this->conn->executeQuery($sql, $params, $types);
     }
@@ -1825,7 +1825,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $sql                  = $this->getSelectSQL($criteria, $assoc, null, $limit, $offset);
-        list($params, $types) = $this->expandToManyParameters($parameters);
+        [$params, $types] = $this->expandToManyParameters($parameters);
 
         return $this->conn->executeQuery($sql, $params, $types);
     }
@@ -2004,11 +2004,11 @@ class BasicEntityPersister implements EntityPersister
              . $this->getLockTablesSql(null)
              . ' WHERE ' . $this->getSelectConditionSQL($criteria);
 
-        list($params, $types) = $this->expandParameters($criteria);
+        [$params, $types] = $this->expandParameters($criteria);
 
         if (null !== $extraConditions) {
             $sql                                 .= ' AND ' . $this->getSelectConditionCriteriaSQL($extraConditions);
-            list($criteriaParams, $criteriaTypes) = $this->expandCriteriaParameters($extraConditions);
+            [$criteriaParams, $criteriaTypes] = $this->expandCriteriaParameters($extraConditions);
 
             $params = array_merge($params, $criteriaParams);
             $types  = array_merge($types, $criteriaTypes);

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -325,7 +325,7 @@ final class Query extends AbstractQuery
             $this->evictEntityCacheRegion();
         }
 
-        list($sqlParams, $types) = $this->processParameterMappings($paramMappings);
+        [$sqlParams, $types] = $this->processParameterMappings($paramMappings);
 
         $this->evictResultSetCache(
             $executor,

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function explode;
 
 /**
  * A ResultSetMappingBuilder uses the EntityManager to automatically populate entity fields.

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -393,7 +393,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
                 $relation  = null;
 
                 if (strpos($fieldName, '.') !== false) {
-                    list($relation, $fieldName) = explode('.', $fieldName);
+                    [$relation, $fieldName] = explode('.', $fieldName);
                 }
 
                 if (isset($classMetadata->associationMappings[$relation])) {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -639,7 +639,7 @@ class SchemaTool
 
         foreach ($joinColumns as $joinColumn) {
 
-            list($definingClass, $referencedFieldName) = $this->getDefiningClass(
+            [$definingClass, $referencedFieldName] = $this->getDefiningClass(
                 $class,
                 $joinColumn['referencedColumnName']
             );

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -548,7 +548,7 @@ class UnitOfWork implements PropertyChangedListener
     private function executeExtraUpdates()
     {
         foreach ($this->extraUpdates as $oid => $update) {
-            list ($entity, $changeset) = $update;
+            [$entity, $changeset] = $update;
 
             $this->entityChangeSets[$oid] = $changeset;
             $this->getEntityPersister(get_class($entity))->update($entity);
@@ -1393,7 +1393,7 @@ class UnitOfWork implements PropertyChangedListener
         $extraUpdate = [$entity, $changeset];
 
         if (isset($this->extraUpdates[$oid])) {
-            list(, $changeset2) = $this->extraUpdates[$oid];
+            [, $changeset2] = $this->extraUpdates[$oid];
 
             $extraUpdate = [$entity, $changeset + $changeset2];
         }

--- a/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/EntityRepositoryTest.php
@@ -409,7 +409,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindByAssociationKey_ExceptionOnInverseSide()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository(CmsUser::class);
 
         $this->expectException(ORMException::class);
@@ -423,7 +423,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindOneByAssociationKey()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository(CmsAddress::class);
         $address = $repos->findOneBy(['user' => $userId]);
 
@@ -450,7 +450,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindByAssociationKey()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository(CmsAddress::class);
         $addresses = $repos->findBy(['user' => $userId]);
 
@@ -464,7 +464,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindAssociationByMagicCall()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository(CmsAddress::class);
         $addresses = $repos->findByUser($userId);
 
@@ -478,7 +478,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testFindOneAssociationByMagicCall()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
         $repos = $this->_em->getRepository(CmsAddress::class);
         $address = $repos->findOneByUser($userId);
 
@@ -856,7 +856,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testMatchingCriteriaAssocationByObjectInMemory()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
 
         $user = $this->_em->find(CmsUser::class, $userId);
 
@@ -879,7 +879,7 @@ class EntityRepositoryTest extends OrmFunctionalTestCase
      */
     public function testMatchingCriteriaAssocationInWithArray()
     {
-        list($userId, $addressId) = $this->loadAssociatedFixture();
+        [$userId, $addressId] = $this->loadAssociatedFixture();
 
         $user = $this->_em->find(CmsUser::class, $userId);
 

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyBidirectionalAssociationTest.php
@@ -130,7 +130,7 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
 
     public function assertLazyLoadFromInverseSide($products)
     {
-        list ($firstProduct, $secondProduct) = $products;
+        [$firstProduct, $secondProduct] = $products;
 
         $firstProductCategories = $firstProduct->getCategories();
         $secondProductCategories = $secondProduct->getCategories();
@@ -165,7 +165,7 @@ class ManyToManyBidirectionalAssociationTest extends AbstractManyToManyAssociati
 
     public function assertLazyLoadFromOwningSide($categories)
     {
-        list ($firstCategory, $secondCategory) = $categories;
+        [$firstCategory, $secondCategory] = $categories;
 
         $firstCategoryProducts = $firstCategory->getProducts();
         $secondCategoryProducts = $secondCategory->getProducts();

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManySelfReferentialAssociationTest.php
@@ -82,7 +82,7 @@ class ManyToManySelfReferentialAssociationTest extends AbstractManyToManyAssocia
 
     public function assertLoadingOfOwningSide($products)
     {
-        list ($firstProduct, $secondProduct) = $products;
+        [$firstProduct, $secondProduct] = $products;
         $this->assertEquals(2, count($firstProduct->getRelated()));
         $this->assertEquals(2, count($secondProduct->getRelated()));
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -17,8 +17,8 @@ class DDC1884Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->useModelSet('taxi');
         parent::setUp();
 
-        list($bimmer, $crysler, $merc, $volvo) = $this->createCars(Car::class);
-        list($john, $foo) = $this->createDrivers(Driver::class);
+        [$bimmer, $crysler, $merc, $volvo] = $this->createCars(Car::class);
+        [$john, $foo] = $this->createDrivers(Driver::class);
         $this->_em->flush();
 
         $ride1 = new Ride($john, $bimmer);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -18,7 +18,7 @@ class DDC1884Test extends \Doctrine\Tests\OrmFunctionalTestCase
         parent::setUp();
 
         [$bimmer, $crysler, $merc, $volvo] = $this->createCars(Car::class);
-        [$john, $foo] = $this->createDrivers(Driver::class);
+        [$john, $foo]                      = $this->createDrivers(Driver::class);
         $this->_em->flush();
 
         $ride1 = new Ride($john, $bimmer);

--- a/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
+++ b/tests/Doctrine/Tests/ORM/Persisters/BasicEntityPersisterCompositeTypeParametersTest.php
@@ -43,7 +43,7 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
         $country = new Country("IT", "Italy");
         $admin1  = new Admin1(10, "Rome", $country);
 
-        list ($values, $types) = $this->_persister->expandParameters(['admin1' => $admin1]);
+        [$values, $types] = $this->_persister->expandParameters(['admin1' => $admin1]);
 
         $this->assertEquals(['integer', 'string'], $types);
         $this->assertEquals([10, 'IT'], $values);
@@ -57,7 +57,7 @@ class BasicEntityPersisterCompositeTypeParametersTest extends OrmTestCase
         $criteria = Criteria::create();
         $criteria->andWhere(Criteria::expr()->eq("admin1", $admin1));
 
-        list ($values, $types) = $this->_persister->expandCriteriaParameters($criteria);
+        [$values, $types] = $this->_persister->expandCriteriaParameters($criteria);
 
         $this->assertEquals(['integer', 'string'], $types);
         $this->assertEquals([10, 'IT'], $values);


### PR DESCRIPTION
After a quick discussion here: https://github.com/doctrine/orm/pull/8199#discussion_r450444924, I started a PR to propose changing this syntax. It's supported starting from PHP 7.1 which is the lowest requirement of ORM 2.7