### PR TITLE
Fix ambiguous case where an entity is also a Traversable

### DIFF
--- a/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
@@ -2,6 +2,9 @@
 
 namespace Doctrine\Tests\Models\CMS;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use IteratorAggregate;
+
 /**
  * Description of CmsGroup
  *
@@ -9,7 +12,7 @@ namespace Doctrine\Tests\Models\CMS;
  * @Entity
  * @Table(name="cms_groups")
  */
-class CmsGroup
+class CmsGroup implements IteratorAggregate
 {
     /**
      * @Id
@@ -26,6 +29,11 @@ class CmsGroup
      */
     public $users;
 
+    public function __construct()
+    {
+        $this->users = new ArrayCollection();
+    }
+
     public function setName($name) {
         $this->name = $name;
     }
@@ -40,6 +48,11 @@ class CmsGroup
 
     public function getUsers() {
         return $this->users;
+    }
+
+    public function getIterator()
+    {
+        return $this->getUsers();
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -14,6 +14,7 @@ use Doctrine\Tests\Mocks\DriverConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\StatementArrayMock;
 use Doctrine\Tests\Models\CMS\CmsAddress;
+use Doctrine\Tests\Models\CMS\CmsGroup;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Tests\OrmTestCase;
@@ -207,6 +208,15 @@ class QueryTest extends OrmTestCase
             ],
             $query->processParameterValue($cities)
         );
+    }
+
+    public function testProcessParameterValueWithIterableEntityShouldNotBeTreatedAsIterable() : void
+    {
+        $group     = new CmsGroup();
+        $group->id = 1;
+
+        $query = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.group IN (:group)');
+        self::assertEquals(1, $query->processParameterValue($group));
     }
 
     /**


### PR DESCRIPTION
I've just realized that #8162 could cause a BC break when an entity passed as parameter is also traversable. This PR aims to fix that, trying to process a parameter as a Traversable only if the parameter isn't an entity.