### PR TITLE
Property access on metadata Interface

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -414,7 +414,7 @@ abstract class AbstractQuery
         }
 
         if ($value instanceof Mapping\ClassMetadata) {
-            return $value->name;
+            return $value->getName();
         }
 
         if (! is_object($value)) {

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -148,7 +148,7 @@ class DefaultEntityHydrator implements EntityHydrator
             $data[$name] = new AssociationCacheEntry($assoc['targetEntity'], $targetId);
         }
 
-        return new EntityCacheEntry($metadata->name, $data);
+        return new EntityCacheEntry($metadata->getName(), $data);
     }
 
     /**

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -186,7 +186,7 @@ abstract class AbstractCollectionPersister implements CachedCollectionPersister
             $class      = $this->targetEntity;
             $className  = ClassUtils::getClass($elements[$index]);
 
-            if ($className !== $this->targetEntity->name) {
+            if ($className !== $this->targetEntity->getName()) {
                 $class = $this->metadataFactory->getMetadataFor($className);
             }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -229,7 +229,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $class      = $this->class;
         $className  = ClassUtils::getClass($entity);
 
-        if ($className !== $this->class->name) {
+        if ($className !== $this->class->getName()) {
             $class = $this->metadataFactory->getMetadataFor($className);
         }
 
@@ -448,7 +448,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $class      = $this->class;
 
         if ($cacheEntry !== null) {
-            if ($cacheEntry->class !== $this->class->name) {
+            if ($cacheEntry->class !== $this->class->getName()) {
                 $class = $this->metadataFactory->getMetadataFor($cacheEntry->class);
             }
 
@@ -472,7 +472,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $class      = $this->class;
         $className  = ClassUtils::getClass($entity);
 
-        if ($className !== $this->class->name) {
+        if ($className !== $this->class->getName()) {
             $class = $this->metadataFactory->getMetadataFor($className);
         }
 

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -418,7 +418,7 @@ use function trigger_error;
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
-                throw ORMException::missingIdentifierField($class->name, $identifier);
+                throw ORMException::missingIdentifierField($class->getName(), $identifier);
             }
 
             $sortedId[$identifier] = $id[$identifier];
@@ -426,7 +426,7 @@ use function trigger_error;
         }
 
         if ($id) {
-            throw ORMException::unrecognizedIdentifierFields($class->name, array_keys($id));
+            throw ORMException::unrecognizedIdentifierFields($class->getName(), array_keys($id));
         }
 
         $unitOfWork = $this->getUnitOfWork();
@@ -445,7 +445,7 @@ use function trigger_error;
                 case LockMode::NONE === $lockMode:
                 case LockMode::PESSIMISTIC_READ === $lockMode:
                 case LockMode::PESSIMISTIC_WRITE === $lockMode:
-                    $persister = $unitOfWork->getEntityPersister($class->name);
+                    $persister = $unitOfWork->getEntityPersister($class->getName());
                     $persister->refresh($sortedId, $entity, $lockMode);
                     break;
             }
@@ -453,7 +453,7 @@ use function trigger_error;
             return $entity; // Hit!
         }
 
-        $persister = $unitOfWork->getEntityPersister($class->name);
+        $persister = $unitOfWork->getEntityPersister($class->getName());
 
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
@@ -487,7 +487,7 @@ use function trigger_error;
 
         foreach ($class->identifier as $identifier) {
             if ( ! isset($id[$identifier])) {
-                throw ORMException::missingIdentifierField($class->name, $identifier);
+                throw ORMException::missingIdentifierField($class->getName(), $identifier);
             }
 
             $sortedId[$identifier] = $id[$identifier];
@@ -495,7 +495,7 @@ use function trigger_error;
         }
 
         if ($id) {
-            throw ORMException::unrecognizedIdentifierFields($class->name, array_keys($id));
+            throw ORMException::unrecognizedIdentifierFields($class->getName(), array_keys($id));
         }
 
         // Check identity map first, if its already in there just return it.
@@ -507,7 +507,7 @@ use function trigger_error;
             return $this->find($entityName, $sortedId);
         }
 
-        $entity = $this->proxyFactory->getProxy($class->name, $sortedId);
+        $entity = $this->proxyFactory->getProxy($class->getName(), $sortedId);
 
         $this->unitOfWork->registerManaged($entity, $sortedId, []);
 
@@ -949,7 +949,7 @@ use function trigger_error;
         switch ($lockMode) {
             case LockMode::OPTIMISTIC:
                 if (!$class->isVersioned) {
-                    throw OptimisticLockException::notVersioned($class->name);
+                    throw OptimisticLockException::notVersioned($class->getName());
                 }
                 break;
             case LockMode::PESSIMISTIC_READ:

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -31,6 +31,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectRepository;
 use Throwable;
+use function array_keys;
 use const E_USER_DEPRECATED;
 use function trigger_error;
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -60,7 +60,7 @@ class EntityRepository implements ObjectRepository, Selectable
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {
-        $this->_entityName = $class->name;
+        $this->_entityName = $class->getName();
         $this->_em         = $em;
         $this->_class      = $class;
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -79,7 +79,7 @@ class SimpleObjectHydrator extends AbstractHydrator
      */
     protected function hydrateRowData(array $sqlResult, array &$result)
     {
-        $entityName       = $this->class->name;
+        $entityName       = $this->class->getName();
         $data             = [];
         $discrColumnValue = null;
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -34,6 +34,7 @@ use Doctrine\Persistence\Mapping\ReflectionService;
 use ReflectionClass;
 use ReflectionException;
 use function assert;
+use function count;
 use function interface_exists;
 
 /**
@@ -285,7 +286,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     }
                 }
             }
-        } else if ($class->isMappedSuperclass && $class->getName() == $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
+        } elseif ($class->isMappedSuperclass && $class->getName() === $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
             throw MappingException::noInheritanceOnMappedSuperClass($class->getName());
         }
@@ -358,8 +359,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     private function addDefaultDiscriminatorMap(ClassMetadata $class)
     {
         $allClasses = $this->driver->getAllClassNames();
-        $fqcn = $class->getName();
-        $map = [$this->getShortName($class->getName()) => $fqcn];
+        $fqcn       = $class->getName();
+        $map        = [$this->getShortName($class->getName()) => $fqcn];
 
         $duplicates = [];
         foreach ($allClasses as $subClassCandidate) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -178,10 +178,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 }
 
                 if (isset($this->embeddablesActiveNesting[$embeddableClass['class']])) {
-                    throw MappingException::infiniteEmbeddableNesting($class->name, $property);
+                    throw MappingException::infiniteEmbeddableNesting($class->getName(), $property);
                 }
 
-                $this->embeddablesActiveNesting[$class->name] = true;
+                $this->embeddablesActiveNesting[$class->getName()] = true;
 
                 $embeddableMetadata = $this->getMetadataFor($embeddableClass['class']);
 
@@ -197,7 +197,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 $class->inlineEmbeddable($property, $embeddableMetadata);
 
-                unset($this->embeddablesActiveNesting[$class->name]);
+                unset($this->embeddablesActiveNesting[$class->getName()]);
             }
         }
 
@@ -274,20 +274,20 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         if ( ! $class->isMappedSuperclass && !$class->isInheritanceTypeNone()) {
             if ( ! $parent) {
                 if (count($class->discriminatorMap) == 0) {
-                    throw MappingException::missingDiscriminatorMap($class->name);
+                    throw MappingException::missingDiscriminatorMap($class->getName());
                 }
                 if ( ! $class->discriminatorColumn) {
-                    throw MappingException::missingDiscriminatorColumn($class->name);
+                    throw MappingException::missingDiscriminatorColumn($class->getName());
                 }
                 foreach ($class->subClasses as $subClass) {
                     if ((new ReflectionClass($subClass))->name !== $subClass) {
-                        throw MappingException::invalidClassInDiscriminatorMap($subClass, $class->name);
+                        throw MappingException::invalidClassInDiscriminatorMap($subClass, $class->getName());
                     }
                 }
             }
-        } else if ($class->isMappedSuperclass && $class->name == $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
+        } else if ($class->isMappedSuperclass && $class->getName() == $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
-            throw MappingException::noInheritanceOnMappedSuperClass($class->name);
+            throw MappingException::noInheritanceOnMappedSuperClass($class->getName());
         }
     }
 
@@ -322,7 +322,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         // minor optimization: avoid loading related metadata when not needed
         foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-            if ($discriminatorClass === $metadata->name) {
+            if ($discriminatorClass === $metadata->getName()) {
                 $metadata->discriminatorValue = $discriminatorValue;
 
                 return;
@@ -331,14 +331,14 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
         // iterate over discriminator mappings and resolve actual referenced classes according to existing metadata
         foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-            if ($metadata->name === $this->getMetadataFor($discriminatorClass)->getName()) {
+            if ($metadata->getName() === $this->getMetadataFor($discriminatorClass)->getName()) {
                 $metadata->discriminatorValue = $discriminatorValue;
 
                 return;
             }
         }
 
-        throw MappingException::mappedClassNotPartOfDiscriminatorMap($metadata->name, $metadata->rootEntityName);
+        throw MappingException::mappedClassNotPartOfDiscriminatorMap($metadata->getName(), $metadata->rootEntityName);
     }
 
     /**
@@ -359,7 +359,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         $allClasses = $this->driver->getAllClassNames();
         $fqcn = $class->getName();
-        $map = [$this->getShortName($class->name) => $fqcn];
+        $map = [$this->getShortName($class->getName()) => $fqcn];
 
         $duplicates = [];
         foreach ($allClasses as $subClassCandidate) {
@@ -375,7 +375,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         if ($duplicates) {
-            throw MappingException::duplicateDiscriminatorEntry($class->name, $duplicates, $map);
+            throw MappingException::duplicateDiscriminatorEntry($class->getName(), $duplicates, $map);
         }
 
         $class->setDiscriminatorMap($map);
@@ -411,10 +411,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->fieldMappings as $mapping) {
             if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
-                $mapping['inherited'] = $parentClass->name;
+                $mapping['inherited'] = $parentClass->getName();
             }
             if (! isset($mapping['declared'])) {
-                $mapping['declared'] = $parentClass->name;
+                $mapping['declared'] = $parentClass->getName();
             }
             $subClass->addInheritedFieldMapping($mapping);
         }
@@ -438,17 +438,17 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         foreach ($parentClass->associationMappings as $field => $mapping) {
             if ($parentClass->isMappedSuperclass) {
                 if ($mapping['type'] & ClassMetadata::TO_MANY && !$mapping['isOwningSide']) {
-                    throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->name, $field);
+                    throw MappingException::illegalToManyAssociationOnMappedSuperclass($parentClass->getName(), $field);
                 }
-                $mapping['sourceEntity'] = $subClass->name;
+                $mapping['sourceEntity'] = $subClass->getName();
             }
 
             //$subclassMapping = $mapping;
             if ( ! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
-                $mapping['inherited'] = $parentClass->name;
+                $mapping['inherited'] = $parentClass->getName();
             }
             if ( ! isset($mapping['declared'])) {
-                $mapping['declared'] = $parentClass->name;
+                $mapping['declared'] = $parentClass->getName();
             }
             $subClass->addInheritedAssociationMapping($mapping);
         }
@@ -458,10 +458,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     {
         foreach ($parentClass->embeddedClasses as $field => $embeddedClass) {
             if ( ! isset($embeddedClass['inherited']) && ! $parentClass->isMappedSuperclass) {
-                $embeddedClass['inherited'] = $parentClass->name;
+                $embeddedClass['inherited'] = $parentClass->getName();
             }
             if ( ! isset($embeddedClass['declared'])) {
-                $embeddedClass['declared'] = $parentClass->name;
+                $embeddedClass['declared'] = $parentClass->getName();
             }
 
             $subClass->embeddedClasses[$field] = $embeddedClass;
@@ -487,7 +487,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
             $parentClass->mapEmbedded(
                 [
                     'fieldName' => $prefix . '.' . $property,
-                    'class' => $embeddableMetadata->name,
+                    'class' => $embeddableMetadata->getName(),
                     'columnPrefix' => $embeddableClass['columnPrefix'],
                     'declaredField' => $embeddableClass['declaredField']
                             ? $prefix . '.' . $embeddableClass['declaredField']
@@ -569,7 +569,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         'query'             => $query['query'],
                         'isSelfClass'       => $query['isSelfClass'],
                         'resultSetMapping'  => $query['resultSetMapping'],
-                        'resultClass'       => $query['isSelfClass'] ? $subClass->name : $query['resultClass'],
+                        'resultClass'       => $query['isSelfClass'] ? $subClass->getName() : $query['resultClass'],
                     ]
                 );
             }
@@ -596,7 +596,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         'fields'                => $entity['fields'],
                         'isSelfClass'           => $entity['isSelfClass'],
                         'discriminatorColumn'   => $entity['discriminatorColumn'],
-                        'entityClass'           => $entity['isSelfClass'] ? $subClass->name : $entity['entityClass'],
+                        'entityClass'           => $entity['isSelfClass'] ? $subClass->getName() : $entity['entityClass'],
                     ];
                 }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -504,8 +504,8 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     throw MappingException::entityListenerClassNotFound($listenerClassName, $className);
                 }
 
-                $hasMapping     = false;
-                $listenerClass  = new ReflectionClass($listenerClassName);
+                $hasMapping    = false;
+                $listenerClass = new ReflectionClass($listenerClassName);
 
                 /* @var $method \ReflectionMethod */
                 foreach ($listenerClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -26,6 +26,8 @@ use Doctrine\ORM\Mapping\Builder\EntityListenerBuilder;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver as AbstractAnnotationDriver;
+use ReflectionClass;
+
 use function interface_exists;
 
 /**
@@ -58,7 +60,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if ( ! $class) {
             // this happens when running annotation driver in combination with
             // static reflection services. This is not the nicest fix
-            $class = new \ReflectionClass($metadata->getName());
+            $class = new ReflectionClass($metadata->getName());
         }
 
         $classAnnotations = $this->reader->getClassAnnotations($class);
@@ -503,7 +505,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                 }
 
                 $hasMapping     = false;
-                $listenerClass  = new \ReflectionClass($listenerClassName);
+                $listenerClass  = new ReflectionClass($listenerClassName);
 
                 /* @var $method \ReflectionMethod */
                 foreach ($listenerClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -58,7 +58,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
         if ( ! $class) {
             // this happens when running annotation driver in combination with
             // static reflection services. This is not the nicest fix
-            $class = new \ReflectionClass($metadata->name);
+            $class = new \ReflectionClass($metadata->getName());
         }
 
         $classAnnotations = $this->reader->getClassAnnotations($class);

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -424,7 +424,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             && isset($this->association['indexBy'])
         ) {
             if (!$this->typeClass->isIdentifierComposite && $this->typeClass->isIdentifier($this->association['indexBy'])) {
-                return $this->em->find($this->typeClass->name, $key);
+                return $this->em->find($this->typeClass->getName(), $key);
             }
 
             return $this->em->getUnitOfWork()->getCollectionPersister($this->association)->get($this, $key);

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -262,7 +262,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $joinTable    = $this->quoteStrategy->getJoinTableName($mapping, $associationSourceClass, $this->platform);
 
         $rsm = new Query\ResultSetMappingBuilder($this->em);
-        $rsm->addRootEntityFromClassMetadata($targetClass->name, 'te');
+        $rsm->addRootEntityFromClassMetadata($targetClass->getName(), 'te');
 
         $sql = 'SELECT ' . $rsm->generateSelectClause()
             . ' FROM ' . $tableName . ' te'

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -241,7 +241,7 @@ class OneToManyPersister extends AbstractCollectionPersister
         // 2) Build insert table records into temporary table
         $query = $this->em->createQuery(
             ' SELECT t0.' . implode(', t0.', $rootClass->getIdentifierFieldNames())
-            . ' FROM ' . $targetClass->name . ' t0 WHERE t0.' . $mapping['mappedBy'] . ' = :owner'
+            . ' FROM ' . $targetClass->getName() . ' t0 WHERE t0.' . $mapping['mappedBy'] . ' = :owner'
         )->setParameter('owner', $collection->getOwner());
 
         $statement  = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ') ' . $query->getSQL();
@@ -249,7 +249,7 @@ class OneToManyPersister extends AbstractCollectionPersister
         $numDeleted = $this->conn->executeUpdate($statement, $parameters);
 
         // 3) Delete records on each table in the hierarchy
-        $classNames = array_merge($targetClass->parentClasses, [$targetClass->name], $targetClass->subClasses);
+        $classNames = array_merge($targetClass->parentClasses, [$targetClass->getName()], $targetClass->subClasses);
 
         foreach (array_reverse($classNames) as $className) {
             $tableName = $this->quoteStrategy->getTableName($this->em->getClassMetadata($className), $this->platform);

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -24,6 +24,8 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Utility\PersisterHelper;
 
+use function array_merge;
+
 /**
  * Persister for one-to-many collections.
  *

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -23,7 +23,6 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Utility\PersisterHelper;
-
 use function array_merge;
 
 /**

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -65,11 +65,11 @@ abstract class AbstractEntityInheritancePersister extends BasicEntityPersister
         $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
         $sql          = sprintf(
             '%s.%s',
-            $this->getSQLTableAlias($class->name, $tableAlias),
+            $this->getSQLTableAlias($class->getName(), $tableAlias),
             $this->quoteStrategy->getColumnName($field, $class, $this->platform)
         );
 
-        $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field, $class->name);
+        $this->currentPersisterContext->rsm->addFieldResult($alias, $columnAlias, $field, $class->getName());
 
         if (isset($fieldMapping['requireSQLConversion'])) {
             $type   = Type::getType($fieldMapping['type']);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -791,7 +791,8 @@ class BasicEntityPersister implements EntityPersister
         foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
             if ( ! isset($sourceClass->fieldNames[$sourceKeyColumn])) {
                 throw MappingException::joinColumnMustPointToMappedField(
-                    $sourceClass->getName(), $sourceKeyColumn
+                    $sourceClass->getName(),
+                    $sourceKeyColumn
                 );
             }
 
@@ -1025,7 +1026,8 @@ class BasicEntityPersister implements EntityPersister
 
                 default:
                     throw MappingException::joinColumnMustPointToMappedField(
-                        $sourceClass->getName(), $sourceKeyColumn
+                        $sourceClass->getName(),
+                        $sourceKeyColumn
                     );
             }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -791,7 +791,7 @@ class BasicEntityPersister implements EntityPersister
         foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
             if ( ! isset($sourceClass->fieldNames[$sourceKeyColumn])) {
                 throw MappingException::joinColumnMustPointToMappedField(
-                    $sourceClass->name, $sourceKeyColumn
+                    $sourceClass->getName(), $sourceKeyColumn
                 );
             }
 
@@ -1025,7 +1025,7 @@ class BasicEntityPersister implements EntityPersister
 
                 default:
                     throw MappingException::joinColumnMustPointToMappedField(
-                        $sourceClass->name, $sourceKeyColumn
+                        $sourceClass->getName(), $sourceKeyColumn
                     );
             }
 
@@ -1063,7 +1063,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         if ($orderBy) {
-            $orderBySql = $this->getOrderBySQL($orderBy, $this->getSQLTableAlias($this->class->name));
+            $orderBySql = $this->getOrderBySQL($orderBy, $this->getSQLTableAlias($this->class->getName()));
         }
 
         $conditionSql = ($criteria instanceof Criteria)
@@ -1081,7 +1081,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $columnList = $this->getSelectColumnsSQL();
-        $tableAlias = $this->getSQLTableAlias($this->class->name);
+        $tableAlias = $this->getSQLTableAlias($this->class->getName());
         $filterSql  = $this->generateFilterConditionSQL($this->class, $tableAlias);
         $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
 
@@ -1111,7 +1111,7 @@ class BasicEntityPersister implements EntityPersister
     public function getCountSQL($criteria = [])
     {
         $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
-        $tableAlias = $this->getSQLTableAlias($this->class->name);
+        $tableAlias = $this->getSQLTableAlias($this->class->getName());
 
         $conditionSql = ($criteria instanceof Criteria)
             ? $this->getSelectConditionCriteriaSQL($criteria)
@@ -1151,7 +1151,7 @@ class BasicEntityPersister implements EntityPersister
             $orientation = strtoupper(trim($orientation));
 
             if ($orientation != 'ASC' && $orientation != 'DESC') {
-                throw ORMException::invalidOrientation($this->class->name, $fieldName);
+                throw ORMException::invalidOrientation($this->class->getName(), $fieldName);
             }
 
             if (isset($this->class->fieldMappings[$fieldName])) {
@@ -1168,7 +1168,7 @@ class BasicEntityPersister implements EntityPersister
             if (isset($this->class->associationMappings[$fieldName])) {
 
                 if ( ! $this->class->associationMappings[$fieldName]['isOwningSide']) {
-                    throw ORMException::invalidFindByInverseAssociation($this->class->name, $fieldName);
+                    throw ORMException::invalidFindByInverseAssociation($this->class->getName(), $fieldName);
                 }
 
                 $tableAlias = isset($this->class->associationMappings[$fieldName]['inherited'])
@@ -1207,7 +1207,7 @@ class BasicEntityPersister implements EntityPersister
         }
 
         $columnList = [];
-        $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r'); // r for root
+        $this->currentPersisterContext->rsm->addEntityResult($this->class->getName(), 'r'); // r for root
 
         // Add regular columns to select list
         foreach ($this->class->fieldNames as $field) {
@@ -1270,7 +1270,7 @@ class BasicEntityPersister implements EntityPersister
                 $association = $eagerEntity->getAssociationMapping($assoc['mappedBy']);
             }
 
-            $joinTableAlias = $this->getSQLTableAlias($eagerEntity->name, $assocAlias);
+            $joinTableAlias = $this->getSQLTableAlias($eagerEntity->getName(), $assocAlias);
             $joinTableName  = $this->quoteStrategy->getTableName($eagerEntity, $this->platform);
 
             if ($assoc['isOwningSide']) {
@@ -1330,7 +1330,7 @@ class BasicEntityPersister implements EntityPersister
         $columnList    = [];
         $targetClass   = $this->em->getClassMetadata($assoc['targetEntity']);
         $isIdentifier  = isset($assoc['id']) && $assoc['id'] === true;
-        $sqlTableAlias = $this->getSQLTableAlias($class->name, ($alias == 'r' ? '' : $alias));
+        $sqlTableAlias = $this->getSQLTableAlias($class->getName(), ($alias == 'r' ? '' : $alias));
 
         foreach ($assoc['joinColumns'] as $joinColumn) {
             $quotedColumn     = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
@@ -1357,7 +1357,7 @@ class BasicEntityPersister implements EntityPersister
     {
         $conditions         = [];
         $association        = $manyToMany;
-        $sourceTableAlias   = $this->getSQLTableAlias($this->class->name);
+        $sourceTableAlias   = $this->getSQLTableAlias($this->class->getName());
 
         if ( ! $manyToMany['isOwningSide']) {
             $targetEntity   = $this->em->getClassMetadata($manyToMany['targetEntity']);
@@ -1478,7 +1478,7 @@ class BasicEntityPersister implements EntityPersister
     protected function getSelectColumnSQL($field, ClassMetadata $class, $alias = 'r')
     {
         $root         = $alias == 'r' ? '' : $alias ;
-        $tableAlias   = $this->getSQLTableAlias($class->name, $root);
+        $tableAlias   = $this->getSQLTableAlias($class->getName(), $root);
         $fieldMapping = $class->fieldMappings[$field];
         $sql          = sprintf('%s.%s', $tableAlias, $this->quoteStrategy->getColumnName($field, $class, $this->platform));
         $columnAlias  = $this->getSQLColumnAlias($fieldMapping['columnName']);
@@ -1563,7 +1563,7 @@ class BasicEntityPersister implements EntityPersister
         return $this->platform->appendLockHint(
             'FROM '
             . $this->quoteStrategy->getTableName($this->class, $this->platform) . ' '
-            . $this->getSQLTableAlias($this->class->name),
+            . $this->getSQLTableAlias($this->class->getName()),
             $lockMode
         );
     }
@@ -1674,7 +1674,7 @@ class BasicEntityPersister implements EntityPersister
         if (isset($this->class->fieldMappings[$field])) {
             $className = (isset($this->class->fieldMappings[$field]['inherited']))
                 ? $this->class->fieldMappings[$field]['inherited']
-                : $this->class->name;
+                : $this->class->getName();
 
             return [$this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $this->class, $this->platform)];
         }
@@ -1702,12 +1702,12 @@ class BasicEntityPersister implements EntityPersister
 
             } else {
                 if ( ! $association['isOwningSide']) {
-                    throw ORMException::invalidFindByInverseAssociation($this->class->name, $field);
+                    throw ORMException::invalidFindByInverseAssociation($this->class->getName(), $field);
                 }
 
                 $className  = (isset($association['inherited']))
                     ? $association['inherited']
-                    : $this->class->name;
+                    : $this->class->getName();
 
                 foreach ($association['joinColumns'] as $joinColumn) {
                     $columns[] = $this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
@@ -1790,7 +1790,7 @@ class BasicEntityPersister implements EntityPersister
         $parameters  = [];
         $owningAssoc = $this->class->associationMappings[$assoc['mappedBy']];
         $sourceClass = $this->em->getClassMetadata($assoc['sourceEntity']);
-        $tableAlias  = $this->getSQLTableAlias($owningAssoc['inherited'] ?? $this->class->name);
+        $tableAlias  = $this->getSQLTableAlias($owningAssoc['inherited'] ?? $this->class->getName());
 
         foreach ($owningAssoc['targetToSourceKeyColumns'] as $sourceKeyColumn => $targetKeyColumn) {
             if ($sourceClass->containsForeignIdentifier) {
@@ -1998,7 +1998,7 @@ class BasicEntityPersister implements EntityPersister
             return false;
         }
 
-        $alias = $this->getSQLTableAlias($this->class->name);
+        $alias = $this->getSQLTableAlias($this->class->getName());
 
         $sql = 'SELECT 1 '
              . $this->getLockTablesSql(null)

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1357,9 +1357,9 @@ class BasicEntityPersister implements EntityPersister
      */
     protected function getSelectManyToManyJoinSQL(array $manyToMany)
     {
-        $conditions         = [];
-        $association        = $manyToMany;
-        $sourceTableAlias   = $this->getSQLTableAlias($this->class->getName());
+        $conditions       = [];
+        $association      = $manyToMany;
+        $sourceTableAlias = $this->getSQLTableAlias($this->class->getName());
 
         if ( ! $manyToMany['isOwningSide']) {
             $targetEntity   = $this->em->getClassMetadata($manyToMany['targetEntity']);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1332,7 +1332,7 @@ class BasicEntityPersister implements EntityPersister
         $columnList    = [];
         $targetClass   = $this->em->getClassMetadata($assoc['targetEntity']);
         $isIdentifier  = isset($assoc['id']) && $assoc['id'] === true;
-        $sqlTableAlias = $this->getSQLTableAlias($class->getName(), ($alias == 'r' ? '' : $alias));
+        $sqlTableAlias = $this->getSQLTableAlias($class->getName(), ($alias === 'r' ? '' : $alias));
 
         foreach ($assoc['joinColumns'] as $joinColumn) {
             $quotedColumn     = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -59,7 +59,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      */
     protected function getDiscriminatorColumnTableName()
     {
-        $class = ($this->class->getName() !== $this->class->rootEntityName)
+        $class = $this->class->getName() !== $this->class->rootEntityName
             ? $this->em->getClassMetadata($this->class->rootEntityName)
             : $this->class;
 
@@ -401,9 +401,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      */
     protected function getLockTablesSql($lockMode)
     {
-        $joinSql            = '';
-        $identifierColumns  = $this->class->getIdentifierColumnNames();
-        $baseTableAlias     = $this->getSQLTableAlias($this->class->getName());
+        $joinSql           = '';
+        $identifierColumns = $this->class->getIdentifierColumnNames();
+        $baseTableAlias    = $this->getSQLTableAlias($this->class->getName());
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
@@ -434,11 +434,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList         = [];
-        $discrColumn        = $this->class->discriminatorColumn['name'];
-        $discrColumnType    = $this->class->discriminatorColumn['type'];
-        $baseTableAlias     = $this->getSQLTableAlias($this->class->getName());
-        $resultColumnName   = $this->platform->getSQLResultCasing($discrColumn);
+        $columnList       = [];
+        $discrColumn      = $this->class->discriminatorColumn['name'];
+        $discrColumnType  = $this->class->discriminatorColumn['type'];
+        $baseTableAlias   = $this->getSQLTableAlias($this->class->getName());
+        $resultColumnName = $this->platform->getSQLResultCasing($discrColumn);
 
         $this->currentPersisterContext->rsm->addEntityResult($this->class->getName(), 'r');
         $this->currentPersisterContext->rsm->setDiscriminatorColumn('r', $resultColumnName);
@@ -476,7 +476,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Add discriminator column (DO NOT ALIAS, see AbstractEntityInheritancePersister#processSQLResult).
-        $tableAlias = ($this->class->rootEntityName == $this->class->getName())
+        $tableAlias = $this->class->rootEntityName === $this->class->getName()
             ? $baseTableAlias
             : $this->getSQLTableAlias($this->class->rootEntityName);
 

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -59,7 +59,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
      */
     protected function getDiscriminatorColumnTableName()
     {
-        $class = ($this->class->name !== $this->class->rootEntityName)
+        $class = ($this->class->getName() !== $this->class->rootEntityName)
             ? $this->em->getClassMetadata($this->class->rootEntityName)
             : $this->class;
 
@@ -133,12 +133,12 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
-        $rootClass      = ($this->class->name !== $this->class->rootEntityName)
+        $rootClass      = ($this->class->getName() !== $this->class->rootEntityName)
             ? $this->em->getClassMetadata($this->class->rootEntityName)
             : $this->class;
 
         // Prepare statement for the root table
-        $rootPersister = $this->em->getUnitOfWork()->getEntityPersister($rootClass->name);
+        $rootPersister = $this->em->getUnitOfWork()->getEntityPersister($rootClass->getName());
         $rootTableName = $rootClass->getTableName();
         $rootTableStmt = $this->conn->prepare($rootPersister->getInsertSQL());
 
@@ -309,7 +309,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     {
         $this->switchPersisterContext($offset, $limit);
 
-        $baseTableAlias = $this->getSQLTableAlias($this->class->name);
+        $baseTableAlias = $this->getSQLTableAlias($this->class->getName());
         $joinSql        = $this->getJoinSql($baseTableAlias);
 
         if ($assoc != null && $assoc['type'] == ClassMetadata::MANY_TO_MANY) {
@@ -373,7 +373,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     public function getCountSQL($criteria = [])
     {
         $tableName      = $this->quoteStrategy->getTableName($this->class, $this->platform);
-        $baseTableAlias = $this->getSQLTableAlias($this->class->name);
+        $baseTableAlias = $this->getSQLTableAlias($this->class->getName());
         $joinSql        = $this->getJoinSql($baseTableAlias);
 
         $conditionSql = ($criteria instanceof Criteria)
@@ -403,7 +403,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     {
         $joinSql            = '';
         $identifierColumns  = $this->class->getIdentifierColumnNames();
-        $baseTableAlias     = $this->getSQLTableAlias($this->class->name);
+        $baseTableAlias     = $this->getSQLTableAlias($this->class->getName());
 
         // INNER JOIN parent tables
         foreach ($this->class->parentClasses as $parentClassName) {
@@ -437,10 +437,10 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $columnList         = [];
         $discrColumn        = $this->class->discriminatorColumn['name'];
         $discrColumnType    = $this->class->discriminatorColumn['type'];
-        $baseTableAlias     = $this->getSQLTableAlias($this->class->name);
+        $baseTableAlias     = $this->getSQLTableAlias($this->class->getName());
         $resultColumnName   = $this->platform->getSQLResultCasing($discrColumn);
 
-        $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r');
+        $this->currentPersisterContext->rsm->addEntityResult($this->class->getName(), 'r');
         $this->currentPersisterContext->rsm->setDiscriminatorColumn('r', $resultColumnName);
         $this->currentPersisterContext->rsm->addMetaResult('r', $resultColumnName, $discrColumn, false, $discrColumnType);
 
@@ -476,7 +476,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Add discriminator column (DO NOT ALIAS, see AbstractEntityInheritancePersister#processSQLResult).
-        $tableAlias = ($this->class->rootEntityName == $this->class->name)
+        $tableAlias = ($this->class->rootEntityName == $this->class->getName())
             ? $baseTableAlias
             : $this->getSQLTableAlias($this->class->rootEntityName);
 
@@ -548,7 +548,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                         $columns[] = $sourceCol;
                     }
                 }
-            } else if ($this->class->name != $this->class->rootEntityName ||
+            } else if ($this->class->getName() != $this->class->rootEntityName ||
                     ! $this->class->isIdGeneratorIdentity() || $this->class->identifier[0] != $name) {
                 $columns[]                  = $this->quoteStrategy->getColumnName($name, $this->class, $this->platform);
                 $this->columnTypes[$name]   = $this->class->fieldMappings[$name]['type'];
@@ -556,7 +556,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Add discriminator column if it is the topmost class.
-        if ($this->class->name == $this->class->rootEntityName) {
+        if ($this->class->getName() == $this->class->rootEntityName) {
             $columns[] = $this->class->discriminatorColumn['name'];
         }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -133,7 +133,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $postInsertIds  = [];
         $idGenerator    = $this->class->idGenerator;
         $isPostInsertId = $idGenerator->isPostInsertGenerator();
-        $rootClass      = ($this->class->getName() !== $this->class->rootEntityName)
+        $rootClass      = $this->class->getName() !== $this->class->rootEntityName
             ? $this->em->getClassMetadata($this->class->rootEntityName)
             : $this->class;
 
@@ -548,7 +548,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                         $columns[] = $sourceCol;
                     }
                 }
-            } else if ($this->class->getName() != $this->class->rootEntityName ||
+            } elseif ($this->class->getName() !== $this->class->rootEntityName ||
                     ! $this->class->isIdGeneratorIdentity() || $this->class->identifier[0] != $name) {
                 $columns[]                  = $this->quoteStrategy->getColumnName($name, $this->class, $this->platform);
                 $this->columnTypes[$name]   = $this->class->fieldMappings[$name]['type'];
@@ -556,7 +556,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Add discriminator column if it is the topmost class.
-        if ($this->class->getName() == $this->class->rootEntityName) {
+        if ($this->class->getName() === $this->class->rootEntityName) {
             $columns[] = $this->class->discriminatorColumn['name'];
         }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -55,7 +55,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $columnList[] = parent::getSelectColumnsSQL();
 
         $rootClass  = $this->em->getClassMetadata($this->class->rootEntityName);
-        $tableAlias = $this->getSQLTableAlias($rootClass->name);
+        $tableAlias = $this->getSQLTableAlias($rootClass->getName());
 
          // Append discriminator column
         $discrColumn     = $this->class->discriminatorColumn['name'];
@@ -173,7 +173,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
         $values     = implode(', ', $values);
         $discColumn = $this->class->discriminatorColumn['name'];
-        $tableAlias = $this->getSQLTableAlias($this->class->name);
+        $tableAlias = $this->getSQLTableAlias($this->class->getName());
 
         return $tableAlias . '.' . $discColumn . ' IN (' . $values . ')';
     }

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -72,7 +72,7 @@ class SqlExpressionVisitor extends ExpressionVisitor
             ! is_object($value) &&
             ! in_array($comparison->getOperator(), [Comparison::IN, Comparison::NIN])) {
 
-            throw PersisterException::matchingAssocationFieldRequiresObject($this->classMetadata->name, $field);
+            throw PersisterException::matchingAssocationFieldRequiresObject($this->classMetadata->getName(), $field);
         }
 
         return $this->persister->getSelectConditionStatementSQL($field, $value, null, $comparison->getOperator());

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -82,8 +82,8 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $this->_insertSql = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ')'
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
-        $rangeDecl        = new AST\RangeVariableDeclaration($primaryClass->getName(), $primaryDqlAlias);
-        $fromClause       = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
+        $rangeDecl         = new AST\RangeVariableDeclaration($primaryClass->getName(), $primaryDqlAlias);
+        $fromClause        = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
         // Append WHERE clause, if there is one.

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -81,7 +81,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $this->_insertSql = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ')'
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
-        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $primaryDqlAlias);
+        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->getName(), $primaryDqlAlias);
         $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
@@ -94,7 +94,7 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store DELETE statements
-        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->getName()], $primaryClass->subClasses);
         foreach (array_reverse($classNames) as $className) {
             $tableName = $quoteStrategy->getTableName($em->getClassMetadata($className), $platform);
             $this->_sqlStatements[] = 'DELETE FROM ' . $tableName

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Utility\PersisterHelper;
 use Throwable;
+use function array_merge;
 
 /**
  * Executes the SQL statements for bulk DQL DELETE statements on classes in
@@ -81,8 +82,8 @@ class MultiTableDeleteExecutor extends AbstractSqlExecutor
         $this->_insertSql = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ')'
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
-        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->getName(), $primaryDqlAlias);
-        $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
+        $rangeDecl        = new AST\RangeVariableDeclaration($primaryClass->getName(), $primaryDqlAlias);
+        $fromClause       = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
 
         // Append WHERE clause, if there is one.

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -92,7 +92,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $this->_insertSql = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ')'
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
-        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->name, $updateClause->aliasIdentificationVariable);
+        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->getName(), $updateClause->aliasIdentificationVariable);
         $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
 
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);
@@ -101,7 +101,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $idSubselect = 'SELECT ' . $idColumnList . ' FROM ' . $tempTable;
 
         // 3. Create and store UPDATE statements
-        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->name], $primaryClass->subClasses);
+        $classNames = array_merge($primaryClass->parentClasses, [$primaryClass->getName()], $primaryClass->subClasses);
         $i = -1;
 
         foreach (array_reverse($classNames) as $className) {

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -25,6 +25,7 @@ use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query\AST;
 use Doctrine\ORM\Utility\PersisterHelper;
 use Throwable;
+use function array_merge;
 
 /**
  * Executes the SQL statements for bulk DQL UPDATE statements on classes in
@@ -92,7 +93,7 @@ class MultiTableUpdateExecutor extends AbstractSqlExecutor
         $this->_insertSql = 'INSERT INTO ' . $tempTable . ' (' . $idColumnList . ')'
                 . ' SELECT t0.' . implode(', t0.', $idColumnNames);
 
-        $rangeDecl = new AST\RangeVariableDeclaration($primaryClass->getName(), $updateClause->aliasIdentificationVariable);
+        $rangeDecl  = new AST\RangeVariableDeclaration($primaryClass->getName(), $updateClause->aliasIdentificationVariable);
         $fromClause = new AST\FromClause([new AST\IdentificationVariableDeclaration($rangeDecl, null, [])]);
 
         $this->_insertSql .= $sqlWalker->walkFromClause($fromClause);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -23,6 +23,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
+use InvalidArgumentException;
+
 use function explode;
 use function in_array;
 
@@ -139,7 +141,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @return void
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function addAllClassFields($class, $alias, $columnAliasMap = [])
     {
@@ -147,7 +149,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         $platform      = $this->em->getConnection()->getDatabasePlatform();
 
         if ( ! $this->isInheritanceSupported($classMetadata)) {
-            throw new \InvalidArgumentException('ResultSetMapping builder does not currently support your inheritance scheme.');
+            throw new InvalidArgumentException('ResultSetMapping builder does not currently support your inheritance scheme.');
         }
 
 
@@ -156,7 +158,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             $columnAlias  = $platform->getSQLResultCasing($columnAliasMap[$columnName]);
 
             if (isset($this->fieldMappings[$columnAlias])) {
-                throw new \InvalidArgumentException("The column '$columnName' conflicts with another column in the mapper.");
+                throw new InvalidArgumentException("The column '$columnName' conflicts with another column in the mapper.");
             }
 
             $this->addFieldResult($alias, $columnAlias, $propertyName);
@@ -173,7 +175,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
                     $columnType = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
                     if (isset($this->metaMappings[$columnAlias])) {
-                        throw new \InvalidArgumentException("The column '$columnAlias' conflicts with another column in the mapper.");
+                        throw new InvalidArgumentException("The column '$columnAlias' conflicts with another column in the mapper.");
                     }
 
                     $this->addMetaResult($alias, $columnAlias, $columnName, $isIdentifier, $columnType);
@@ -340,9 +342,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
                     $this->addEntityResult($classMetadata->getName(), $rootAlias);
                     $this->addNamedNativeQueryEntityResultMapping($classMetadata, $entityMapping, $rootAlias);
                 } else {
-                    $shortName      = $classMetadata->reflClass->getShortName();
-                    $joinAlias      = strtolower($shortName[0]) . ++ $counter;
-                    $associations   = $class->getAssociationsByTargetClass($classMetadata->getName());
+                    $shortName    = $classMetadata->reflClass->getShortName();
+                    $joinAlias    = strtolower($shortName[0]) . ++ $counter;
+                    $associations = $class->getAssociationsByTargetClass($classMetadata->getName());
 
                     $this->addNamedNativeQueryEntityResultMapping($classMetadata, $entityMapping, $joinAlias);
 
@@ -377,7 +379,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @return self
      *
      * @throws MappingException
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function addNamedNativeQueryEntityResultMapping(ClassMetadataInfo $classMetadata, array $entityMapping, $alias)
     {
@@ -411,7 +413,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
                     }
                 } else {
                     if ( ! isset($classMetadata->fieldMappings[$fieldName])) {
-                        throw new \InvalidArgumentException("Entity '".$classMetadata->getName()."' has no field '".$fieldName."'. ");
+                        throw new InvalidArgumentException("Entity '" . $classMetadata->getName() . "' has no field '" . $fieldName . "'. ");
                     }
 
                     $this->addFieldResult($alias, $field['column'], $fieldName, $classMetadata->getName());

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -27,6 +27,7 @@ use InvalidArgumentException;
 
 use function explode;
 use function in_array;
+use function strtolower;
 
 /**
  * A ResultSetMappingBuilder uses the EntityManager to automatically populate entity fields.
@@ -158,7 +159,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
             $columnAlias  = $platform->getSQLResultCasing($columnAliasMap[$columnName]);
 
             if (isset($this->fieldMappings[$columnAlias])) {
-                throw new InvalidArgumentException("The column '$columnName' conflicts with another column in the mapper.");
+                throw new InvalidArgumentException("The column '" . $columnName . "' conflicts with another column in the mapper.");
             }
 
             $this->addFieldResult($alias, $columnAlias, $propertyName);
@@ -175,7 +176,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
                     $columnType = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
                     if (isset($this->metaMappings[$columnAlias])) {
-                        throw new InvalidArgumentException("The column '$columnAlias' conflicts with another column in the mapper.");
+                        throw new InvalidArgumentException("The column '" . $columnAlias . "' conflicts with another column in the mapper.");
                     }
 
                     $this->addMetaResult($alias, $columnAlias, $columnName, $isIdentifier, $columnType);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -184,7 +184,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
     private function isInheritanceSupported(ClassMetadataInfo $classMetadata)
     {
         if ($classMetadata->isInheritanceTypeSingleTable()
-            && in_array($classMetadata->name, $classMetadata->discriminatorMap, true)) {
+            && in_array($classMetadata->getName(), $classMetadata->discriminatorMap, true)) {
             return true;
         }
 
@@ -284,7 +284,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
         $shortName      = $classMetadata->reflClass->getShortName();
         $alias          = strtolower($shortName[0]).'0';
 
-        $this->addEntityResult($class->name, $alias);
+        $this->addEntityResult($class->getName(), $alias);
 
         if ($classMetadata->discriminatorColumn) {
             $discrColumn = $classMetadata->discriminatorColumn;
@@ -336,12 +336,12 @@ class ResultSetMappingBuilder extends ResultSetMapping
                 $classMetadata  = $this->em->getClassMetadata($entityMapping['entityClass']);
 
                 if ($class->reflClass->name == $classMetadata->reflClass->name) {
-                    $this->addEntityResult($classMetadata->name, $rootAlias);
+                    $this->addEntityResult($classMetadata->getName(), $rootAlias);
                     $this->addNamedNativeQueryEntityResultMapping($classMetadata, $entityMapping, $rootAlias);
                 } else {
                     $shortName      = $classMetadata->reflClass->getShortName();
                     $joinAlias      = strtolower($shortName[0]) . ++ $counter;
-                    $associations   = $class->getAssociationsByTargetClass($classMetadata->name);
+                    $associations   = $class->getAssociationsByTargetClass($classMetadata->getName());
 
                     $this->addNamedNativeQueryEntityResultMapping($classMetadata, $entityMapping, $joinAlias);
 
@@ -406,14 +406,14 @@ class ResultSetMappingBuilder extends ResultSetMapping
                         $this->addJoinedEntityResult($associationMapping['targetEntity'], $joinAlias, $parentAlias, $relation);
                         $this->addFieldResult($joinAlias, $field['column'], $fieldName);
                     } else {
-                        $this->addFieldResult($alias, $field['column'], $fieldName, $classMetadata->name);
+                        $this->addFieldResult($alias, $field['column'], $fieldName, $classMetadata->getName());
                     }
                 } else {
                     if ( ! isset($classMetadata->fieldMappings[$fieldName])) {
-                        throw new \InvalidArgumentException("Entity '".$classMetadata->name."' has no field '".$fieldName."'. ");
+                        throw new \InvalidArgumentException("Entity '".$classMetadata->getName()."' has no field '".$fieldName."'. ");
                     }
 
-                    $this->addFieldResult($alias, $field['column'], $fieldName, $classMetadata->name);
+                    $this->addFieldResult($alias, $field['column'], $fieldName, $classMetadata->getName());
                 }
             }
 

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
 use function explode;
+use function in_array;
 
 /**
  * A ResultSetMappingBuilder uses the EntityManager to automatically populate entity fields.

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -499,7 +499,7 @@ class SqlWalker implements TreeWalker
             case ClassMetadata::INHERITANCE_TYPE_JOINED:
                 // The classes in the inheritance will be added to the query one by one,
                 // but only the root node is getting filtered
-                if ($targetEntity->name !== $targetEntity->rootEntityName) {
+                if ($targetEntity->getName() !== $targetEntity->rootEntityName) {
                     return '';
                 }
                 break;
@@ -2328,8 +2328,8 @@ class SqlWalker implements TreeWalker
 
             $metadata = $this->em->getClassMetadata($parameter);
 
-            if ($metadata->getName() !== $rootClass->name && ! $metadata->getReflectionClass()->isSubclassOf($rootClass->name)) {
-                throw QueryException::instanceOfUnrelatedClass($parameter, $rootClass->name);
+            if ($metadata->getName() !== $rootClass->getName() && ! $metadata->getReflectionClass()->isSubclassOf($rootClass->getName())) {
+                throw QueryException::instanceOfUnrelatedClass($parameter, $rootClass->getName());
             }
 
             $discriminators += HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($metadata, $this->em);

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -67,7 +67,7 @@ class AttachEntityListenersListener
         /** @var ClassMetadata $metadata */
         $metadata = $event->getClassMetadata();
 
-        if ( ! isset($this->entityListeners[$metadata->getName()])) {
+        if (! isset($this->entityListeners[$metadata->getName()])) {
             return;
         }
 

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -67,14 +67,14 @@ class AttachEntityListenersListener
         /** @var ClassMetadata $metadata */
         $metadata = $event->getClassMetadata();
 
-        if ( ! isset($this->entityListeners[$metadata->name])) {
+        if ( ! isset($this->entityListeners[$metadata->getName()])) {
             return;
         }
 
-        foreach ($this->entityListeners[$metadata->name] as $listener) {
+        foreach ($this->entityListeners[$metadata->getName()] as $listener) {
             $metadata->addEntityListener($listener['event'], $listener['class'], $listener['method']);
         }
 
-        unset($this->entityListeners[$metadata->name]);
+        unset($this->entityListeners[$metadata->getName()]);
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -198,7 +198,7 @@ class ConvertDoctrine1SchemaCommand extends Command
             $output->writeln('');
 
             foreach ($metadata as $class) {
-                $output->writeln(sprintf('Processing entity "<info>%s</info>"', $class->name));
+                $output->writeln(sprintf('Processing entity "<info>%s</info>"', $class->getName()));
             }
 
             $exporter->setMetadata($metadata);

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to convert a Doctrine 1 schema to a Doctrine 2 mapping file.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -153,7 +153,7 @@ EOT
         }
 
         foreach ($metadata as $class) {
-            $ui->text(sprintf('Processing entity "<info>%s</info>"', $class->name));
+            $ui->text(sprintf('Processing entity "<info>%s</info>"', $class->getName()));
         }
 
         $exporter->setMetadata($metadata);

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to convert your mapping information between the various formats.

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to generate entity classes and method stubs from your mapping information.

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -132,7 +132,7 @@ EOT
         }
 
         foreach ($metadatas as $metadata) {
-            $ui->text(sprintf('Processing entity "<info>%s</info>"', $metadata->name));
+            $ui->text(sprintf('Processing entity "<info>%s</info>"', $metadata->getName()));
         }
 
         // Generating Entities

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function sprintf;
 
 /**
  * Command to (re)generate the proxy classes used by doctrine.

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -95,7 +95,7 @@ class GenerateProxiesCommand extends Command
         }
 
         foreach ($metadatas as $metadata) {
-            $ui->text(sprintf('Processing entity "<info>%s</info>"', $metadata->name));
+            $ui->text(sprintf('Processing entity "<info>%s</info>"', $metadata->getName()));
         }
 
         // Generating Proxies

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -90,7 +90,7 @@ EOT
             ['Field', 'Value'],
             array_merge(
                 [
-                    $this->formatField('Name', $metadata->name),
+                    $this->formatField('Name', $metadata->getName()),
                     $this->formatField('Root entity name', $metadata->rootEntityName),
                     $this->formatField('Custom generator definition', $metadata->customGeneratorDefinition),
                     $this->formatField('Custom repository class', $metadata->customRepositoryClassName),

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -24,6 +24,8 @@ use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use ReflectionClass;
+use function class_exists;
+use const DIRECTORY_SEPARATOR;
 use const E_USER_DEPRECATED;
 use function str_replace;
 use function trigger_error;
@@ -869,9 +871,9 @@ public function __construct(<params>)
      */
     protected function hasProperty($property, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->getName()))) {
+        if ($this->extendsClass() || (! $this->isNew && class_exists($metadata->getName()))) {
             // don't generate property if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
+            $reflClass = new ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
             if ($reflClass->hasProperty($property)) {
                 return true;
             }
@@ -900,7 +902,7 @@ public function __construct(<params>)
     {
         if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->getName()))) {
             // don't generate method if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
+            $reflClass = new ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
 
             if ($reflClass->hasMethod($method)) {
                 return true;
@@ -935,7 +937,7 @@ public function __construct(<params>)
             return [];
         }
 
-        $reflClass = $metadata->reflClass ?? new \ReflectionClass($metadata->getName());
+        $reflClass = $metadata->reflClass ?? new ReflectionClass($metadata->getName());
 
         $traits = [];
 
@@ -979,7 +981,7 @@ public function __construct(<params>)
      */
     protected function getClassToExtendName()
     {
-        $refl = new \ReflectionClass($this->getClassToExtend());
+        $refl = new ReflectionClass($this->getClassToExtend());
 
         return '\\' . $refl->getName();
     }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -24,9 +24,13 @@ use Doctrine\Common\Inflector\Inflector;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use ReflectionClass;
-use function class_exists;
+use function in_array;
+use function strlen;
+use function strpos;
+use function strtolower;
 use const DIRECTORY_SEPARATOR;
 use const E_USER_DEPRECATED;
+use function class_exists;
 use function str_replace;
 use function trigger_error;
 use function var_export;
@@ -900,7 +904,7 @@ public function __construct(<params>)
      */
     protected function hasMethod($method, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->getName()))) {
+        if ($this->extendsClass() || (! $this->isNew && class_exists($metadata->getName()))) {
             // don't generate method if its already on the base class.
             $reflClass = new ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
 
@@ -993,7 +997,7 @@ public function __construct(<params>)
      */
     protected function getClassName(ClassMetadataInfo $metadata)
     {
-        return ($pos = strrpos($metadata->getName(), '\\'))
+        return $pos = strrpos($metadata->getName(), '\\')
             ? substr($metadata->getName(), $pos + 1, strlen($metadata->getName())) : $metadata->getName();
     }
 

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -373,7 +373,7 @@ public function __construct(<params>)
      */
     public function writeEntityClass(ClassMetadataInfo $metadata, $outputDirectory)
     {
-        $path = $outputDirectory . '/' . str_replace('\\', DIRECTORY_SEPARATOR, $metadata->name) . $this->extension;
+        $path = $outputDirectory . '/' . str_replace('\\', DIRECTORY_SEPARATOR, $metadata->getName()) . $this->extension;
         $dir = dirname($path);
 
         if ( ! is_dir($dir)) {
@@ -385,7 +385,7 @@ public function __construct(<params>)
         if ( ! $this->isNew) {
             $this->parseTokensInEntityFile(file_get_contents($path));
         } else {
-            $this->staticReflection[$metadata->name] = ['properties' => [], 'methods' => []];
+            $this->staticReflection[$metadata->getName()] = ['properties' => [], 'methods' => []];
         }
 
         if ($this->backupExisting && file_exists($path)) {
@@ -869,9 +869,9 @@ public function __construct(<params>)
      */
     protected function hasProperty($property, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->name))) {
+        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->getName()))) {
             // don't generate property if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
+            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
             if ($reflClass->hasProperty($property)) {
                 return true;
             }
@@ -885,8 +885,8 @@ public function __construct(<params>)
         }
 
         return (
-            isset($this->staticReflection[$metadata->name]) &&
-            in_array($property, $this->staticReflection[$metadata->name]['properties'], true)
+            isset($this->staticReflection[$metadata->getName()]) &&
+            in_array($property, $this->staticReflection[$metadata->getName()]['properties'], true)
         );
     }
 
@@ -898,9 +898,9 @@ public function __construct(<params>)
      */
     protected function hasMethod($method, ClassMetadataInfo $metadata)
     {
-        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->name))) {
+        if ($this->extendsClass() || (!$this->isNew && class_exists($metadata->getName()))) {
             // don't generate method if its already on the base class.
-            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->name);
+            $reflClass = new \ReflectionClass($this->getClassToExtend() ?: $metadata->getName());
 
             if ($reflClass->hasMethod($method)) {
                 return true;
@@ -915,8 +915,8 @@ public function __construct(<params>)
         }
 
         return (
-            isset($this->staticReflection[$metadata->name]) &&
-            in_array(strtolower($method), $this->staticReflection[$metadata->name]['methods'], true)
+            isset($this->staticReflection[$metadata->getName()]) &&
+            in_array(strtolower($method), $this->staticReflection[$metadata->getName()]['methods'], true)
         );
     }
 
@@ -931,11 +931,11 @@ public function __construct(<params>)
      */
     protected function getTraits(ClassMetadataInfo $metadata)
     {
-        if (! ($metadata->reflClass !== null || class_exists($metadata->name))) {
+        if (! ($metadata->reflClass !== null || class_exists($metadata->getName()))) {
             return [];
         }
 
-        $reflClass = $metadata->reflClass ?? new \ReflectionClass($metadata->name);
+        $reflClass = $metadata->reflClass ?? new \ReflectionClass($metadata->getName());
 
         $traits = [];
 
@@ -955,7 +955,7 @@ public function __construct(<params>)
      */
     protected function hasNamespace(ClassMetadataInfo $metadata)
     {
-        return (bool) strpos($metadata->name, '\\');
+        return (bool) strpos($metadata->getName(), '\\');
     }
 
     /**
@@ -991,8 +991,8 @@ public function __construct(<params>)
      */
     protected function getClassName(ClassMetadataInfo $metadata)
     {
-        return ($pos = strrpos($metadata->name, '\\'))
-            ? substr($metadata->name, $pos + 1, strlen($metadata->name)) : $metadata->name;
+        return ($pos = strrpos($metadata->getName(), '\\'))
+            ? substr($metadata->getName(), $pos + 1, strlen($metadata->getName())) : $metadata->getName();
     }
 
     /**
@@ -1002,7 +1002,7 @@ public function __construct(<params>)
      */
     protected function getNamespace(ClassMetadataInfo $metadata)
     {
-        return substr($metadata->name, 0, strrpos($metadata->name, '\\'));
+        return substr($metadata->getName(), 0, strrpos($metadata->getName(), '\\'));
     }
 
     /**
@@ -1390,7 +1390,7 @@ public function __construct(<params>)
         if ($this->hasMethod($methodName, $metadata)) {
             return '';
         }
-        $this->staticReflection[$metadata->name]['methods'][] = strtolower($methodName);
+        $this->staticReflection[$metadata->getName()]['methods'][] = strtolower($methodName);
 
         $var = sprintf('%sMethodTemplate', $type);
         $template = static::$$var;
@@ -1437,7 +1437,7 @@ public function __construct(<params>)
             return '';
         }
 
-        $this->staticReflection[$metadata->name]['methods'][] = $methodName;
+        $this->staticReflection[$metadata->getName()]['methods'][] = $methodName;
 
         $replacements = [
             '<name>'        => $this->annotationsPrefix . ucfirst($name),

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -997,7 +997,7 @@ public function __construct(<params>)
      */
     protected function getClassName(ClassMetadataInfo $metadata)
     {
-        return $pos = strrpos($metadata->getName(), '\\')
+        return ($pos = strrpos($metadata->getName(), '\\'))
             ? substr($metadata->getName(), $pos + 1, strlen($metadata->getName())) : $metadata->getName();
     }
 

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -165,7 +165,7 @@ abstract class AbstractExporter
      */
     protected function _generateOutputPath(ClassMetadataInfo $metadata)
     {
-        return $this->_outputDir . '/' . str_replace('\\', '.', $metadata->name) . $this->_extension;
+        return $this->_outputDir . '/' . str_replace('\\', '.', $metadata->getName()) . $this->_extension;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
@@ -67,7 +67,7 @@ class AnnotationExporter extends AbstractExporter
      */
     protected function _generateOutputPath(ClassMetadataInfo $metadata)
     {
-        return $this->_outputDir . '/' . str_replace('\\', '/', $metadata->name) . $this->_extension;
+        return $this->_outputDir . '/' . str_replace('\\', '/', $metadata->getName()) . $this->_extension;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -58,7 +58,7 @@ class XmlExporter extends AbstractExporter
             $root->addAttribute('repository-class', $metadata->customRepositoryClassName);
         }
 
-        $root->addAttribute('name', $metadata->name);
+        $root->addAttribute('name', $metadata->getName());
 
         if (isset($metadata->table['name'])) {
             $root->addAttribute('table', $metadata->table['name']);

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -219,7 +219,7 @@ class YamlExporter extends AbstractExporter
 
         $array = $this->processEntityListeners($metadata, $array);
 
-        return $this->yamlDump([$metadata->name => $array], 10);
+        return $this->yamlDump([$metadata->getName() => $array], 10);
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -127,10 +127,10 @@ class SchemaTool
     private function processingNotRequired($class, array $processedClasses)
     {
         return (
-            isset($processedClasses[$class->name]) ||
+            isset($processedClasses[$class->getName()]) ||
             $class->isMappedSuperclass ||
             $class->isEmbeddedClass ||
-            ($class->isInheritanceTypeSingleTable() && $class->name != $class->rootEntityName)
+            ($class->isInheritanceTypeSingleTable() && $class->getName() != $class->rootEntityName)
         );
     }
 
@@ -195,7 +195,7 @@ class SchemaTool
                 $this->gatherRelationsSql($class, $table, $schema, $addedFks, $blacklistedFks);
 
                 // Add the discriminator column only to the root table
-                if ($class->name == $class->rootEntityName) {
+                if ($class->getName() == $class->rootEntityName) {
                     $this->addDiscriminatorColumnDefinition($class, $table);
                 } else {
                     // Add an ID FK column to child tables
@@ -227,7 +227,7 @@ class SchemaTool
                                 array_filter(
                                     $classes,
                                     function (ClassMetadata $class) use ($idMapping) : bool {
-                                        return $class->name === $idMapping['targetEntity'];
+                                        return $class->getName() === $idMapping['targetEntity'];
                                     }
                                 )
                             );
@@ -332,9 +332,9 @@ class SchemaTool
                 }
             }
 
-            $processedClasses[$class->name] = true;
+            $processedClasses[$class->getName()] = true;
 
-            if ($class->isIdGeneratorSequence() && $class->name == $class->rootEntityName) {
+            if ($class->isIdGeneratorSequence() && $class->getName() == $class->rootEntityName) {
                 $seqDef     = $class->sequenceGeneratorDefinition;
                 $quotedName = $this->quoteStrategy->getSequenceName($seqDef, $class, $this->platform);
                 if ( ! $schema->hasSequence($quotedName)) {
@@ -476,7 +476,7 @@ class SchemaTool
         if ($class->isIdGeneratorIdentity() && $class->getIdentifierFieldNames() == [$mapping['fieldName']]) {
             $options['autoincrement'] = true;
         }
-        if ($class->isInheritanceTypeJoined() && $class->name !== $class->rootEntityName) {
+        if ($class->isInheritanceTypeJoined() && $class->getName() !== $class->rootEntityName) {
             $options['autoincrement'] = false;
         }
 

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -69,7 +69,7 @@ class SchemaValidator
 
         foreach ($classes as $class) {
             if ($ce = $this->validateClass($class)) {
-                $errors[$class->name] = $ce;
+                $errors[$class->getName()] = $ce;
             }
         }
 
@@ -92,13 +92,13 @@ class SchemaValidator
 
         foreach ($class->fieldMappings as $fieldName => $mapping) {
             if (!Type::hasType($mapping['type'])) {
-                $ce[] = "The field '" . $class->name . "#" . $fieldName."' uses a non-existent type '" . $mapping['type'] . "'.";
+                $ce[] = "The field '" . $class->getName() . "#" . $fieldName."' uses a non-existent type '" . $mapping['type'] . "'.";
             }
         }
 
         foreach ($class->associationMappings as $fieldName => $assoc) {
             if (!class_exists($assoc['targetEntity']) || $cmf->isTransient($assoc['targetEntity'])) {
-                $ce[] = "The target entity '" . $assoc['targetEntity'] . "' specified on " . $class->name . '#' . $fieldName . ' is unknown or not an entity.';
+                $ce[] = "The target entity '" . $assoc['targetEntity'] . "' specified on " . $class->getName() . '#' . $fieldName . ' is unknown or not an entity.';
 
                 return $ce;
             }
@@ -110,25 +110,25 @@ class SchemaValidator
             $targetMetadata = $cmf->getMetadataFor($assoc['targetEntity']);
 
             if (isset($assoc['id']) && $targetMetadata->containsForeignIdentifier) {
-                $ce[] = "Cannot map association '" . $class->name. "#". $fieldName ." as identifier, because " .
-                        "the target entity '". $targetMetadata->name . "' also maps an association as identifier.";
+                $ce[] = "Cannot map association '" . $class->getName(). "#". $fieldName ." as identifier, because " .
+                        "the target entity '". $targetMetadata->getName() . "' also maps an association as identifier.";
             }
 
             if ($assoc['mappedBy']) {
                 if ($targetMetadata->hasField($assoc['mappedBy'])) {
-                    $ce[] = "The association " . $class->name . "#" . $fieldName . " refers to the owning side ".
+                    $ce[] = "The association " . $class->getName() . "#" . $fieldName . " refers to the owning side ".
                             "field " . $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " which is not defined as association, but as field.";
                 }
                 if (!$targetMetadata->hasAssociation($assoc['mappedBy'])) {
-                    $ce[] = "The association " . $class->name . "#" . $fieldName . " refers to the owning side ".
+                    $ce[] = "The association " . $class->getName() . "#" . $fieldName . " refers to the owning side ".
                             "field " . $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " which does not exist.";
                 } elseif ($targetMetadata->associationMappings[$assoc['mappedBy']]['inversedBy'] == null) {
-                    $ce[] = "The field " . $class->name . "#" . $fieldName . " is on the inverse side of a ".
+                    $ce[] = "The field " . $class->getName() . "#" . $fieldName . " is on the inverse side of a ".
                             "bi-directional relationship, but the specified mappedBy association on the target-entity ".
                             $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " does not contain the required ".
                             "'inversedBy=\"" . $fieldName . "\"' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc['mappedBy']]['inversedBy'] != $fieldName) {
-                    $ce[] = "The mappings " . $class->name . "#" . $fieldName . " and " .
+                    $ce[] = "The mappings " . $class->getName() . "#" . $fieldName . " and " .
                             $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " are ".
                             "inconsistent with each other.";
                 }
@@ -136,20 +136,20 @@ class SchemaValidator
 
             if ($assoc['inversedBy']) {
                 if ($targetMetadata->hasField($assoc['inversedBy'])) {
-                    $ce[] = "The association " . $class->name . "#" . $fieldName . " refers to the inverse side ".
+                    $ce[] = "The association " . $class->getName() . "#" . $fieldName . " refers to the inverse side ".
                             "field " . $assoc['targetEntity'] . "#" . $assoc['inversedBy'] . " which is not defined as association.";
                 }
 
                 if (!$targetMetadata->hasAssociation($assoc['inversedBy'])) {
-                    $ce[] = "The association " . $class->name . "#" . $fieldName . " refers to the inverse side ".
+                    $ce[] = "The association " . $class->getName() . "#" . $fieldName . " refers to the inverse side ".
                             "field " . $assoc['targetEntity'] . "#" . $assoc['inversedBy'] . " which does not exist.";
                 } elseif ($targetMetadata->associationMappings[$assoc['inversedBy']]['mappedBy'] == null) {
-                    $ce[] = "The field " . $class->name . "#" . $fieldName . " is on the owning side of a ".
+                    $ce[] = "The field " . $class->getName() . "#" . $fieldName . " is on the owning side of a ".
                             "bi-directional relationship, but the specified mappedBy association on the target-entity ".
                             $assoc['targetEntity'] . "#" . $assoc['mappedBy'] . " does not contain the required ".
                             "'inversedBy' attribute.";
                 } elseif ($targetMetadata->associationMappings[$assoc['inversedBy']]['mappedBy'] != $fieldName) {
-                    $ce[] = "The mappings " . $class->name . "#" . $fieldName . " and " .
+                    $ce[] = "The mappings " . $class->getName() . "#" . $fieldName . " and " .
                             $assoc['targetEntity'] . "#" . $assoc['inversedBy'] . " are ".
                             "inconsistent with each other.";
                 }
@@ -158,14 +158,14 @@ class SchemaValidator
                 if (array_key_exists($assoc['inversedBy'], $targetMetadata->associationMappings)) {
                     $targetAssoc = $targetMetadata->associationMappings[$assoc['inversedBy']];
                     if ($assoc['type'] == ClassMetadataInfo::ONE_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_ONE) {
-                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is one-to-one, then the inversed " .
-                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-one as well.";
+                        $ce[] = "If association " . $class->getName() . "#" . $fieldName . " is one-to-one, then the inversed " .
+                                "side " . $targetMetadata->getName() . "#" . $assoc['inversedBy'] . " has to be one-to-one as well.";
                     } elseif ($assoc['type'] == ClassMetadataInfo::MANY_TO_ONE && $targetAssoc['type'] !== ClassMetadataInfo::ONE_TO_MANY) {
-                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-one, then the inversed " .
-                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be one-to-many.";
+                        $ce[] = "If association " . $class->getName() . "#" . $fieldName . " is many-to-one, then the inversed " .
+                                "side " . $targetMetadata->getName() . "#" . $assoc['inversedBy'] . " has to be one-to-many.";
                     } elseif ($assoc['type'] == ClassMetadataInfo::MANY_TO_MANY && $targetAssoc['type'] !== ClassMetadataInfo::MANY_TO_MANY) {
-                        $ce[] = "If association " . $class->name . "#" . $fieldName . " is many-to-many, then the inversed " .
-                                "side " . $targetMetadata->name . "#" . $assoc['inversedBy'] . " has to be many-to-many as well.";
+                        $ce[] = "If association " . $class->getName() . "#" . $fieldName . " is many-to-many, then the inversed " .
+                                "side " . $targetMetadata->getName() . "#" . $assoc['inversedBy'] . " has to be many-to-many as well.";
                     }
                 }
             }
@@ -176,7 +176,7 @@ class SchemaValidator
                     foreach ($assoc['joinTable']['joinColumns'] as $joinColumn) {
                         if (!in_array($joinColumn['referencedColumnName'], $identifierColumns)) {
                             $ce[] = "The referenced column name '" . $joinColumn['referencedColumnName'] . "' " .
-                                "has to be a primary key column on the target entity class '".$class->name."'.";
+                                "has to be a primary key column on the target entity class '".$class->getName()."'.";
                             break;
                         }
                     }
@@ -185,21 +185,21 @@ class SchemaValidator
                     foreach ($assoc['joinTable']['inverseJoinColumns'] as $inverseJoinColumn) {
                         if (! in_array($inverseJoinColumn['referencedColumnName'], $identifierColumns)) {
                             $ce[] = "The referenced column name '" . $inverseJoinColumn['referencedColumnName'] . "' " .
-                                "has to be a primary key column on the target entity class '" .$targetMetadata->name . "'.";
+                                "has to be a primary key column on the target entity class '" .$targetMetadata->getName() . "'.";
                             break;
                         }
                     }
 
                     if (count($targetMetadata->getIdentifierColumnNames()) != count($assoc['joinTable']['inverseJoinColumns'])) {
                         $ce[] = "The inverse join columns of the many-to-many table '" . $assoc['joinTable']['name'] . "' " .
-                                "have to contain to ALL identifier columns of the target entity '". $targetMetadata->name . "', " .
+                                "have to contain to ALL identifier columns of the target entity '". $targetMetadata->getName() . "', " .
                                 "however '" . implode(", ", array_diff($targetMetadata->getIdentifierColumnNames(), array_values($assoc['relationToTargetKeyColumns']))) .
                                 "' are missing.";
                     }
 
                     if (count($class->getIdentifierColumnNames()) != count($assoc['joinTable']['joinColumns'])) {
                         $ce[] = "The join columns of the many-to-many table '" . $assoc['joinTable']['name'] . "' " .
-                                "have to contain to ALL identifier columns of the source entity '". $class->name . "', " .
+                                "have to contain to ALL identifier columns of the source entity '". $class->getName() . "', " .
                                 "however '" . implode(", ", array_diff($class->getIdentifierColumnNames(), array_values($assoc['relationToSourceKeyColumns']))) .
                                 "' are missing.";
                     }
@@ -209,7 +209,7 @@ class SchemaValidator
                     foreach ($assoc['joinColumns'] as $joinColumn) {
                         if (!in_array($joinColumn['referencedColumnName'], $identifierColumns)) {
                             $ce[] = "The referenced column name '" . $joinColumn['referencedColumnName'] . "' " .
-                                    "has to be a primary key column on the target entity class '".$targetMetadata->name."'.";
+                                    "has to be a primary key column on the target entity class '".$targetMetadata->getName()."'.";
                         }
                     }
 
@@ -221,7 +221,7 @@ class SchemaValidator
                         }
 
                         $ce[] = "The join columns of the association '" . $assoc['fieldName'] . "' " .
-                                "have to match to ALL identifier columns of the target entity '". $targetMetadata->name . "', " .
+                                "have to match to ALL identifier columns of the target entity '". $targetMetadata->getName() . "', " .
                                 "however '" . implode(", ", array_diff($targetMetadata->getIdentifierColumnNames(), $ids)) .
                                 "' are missing.";
                     }
@@ -231,18 +231,18 @@ class SchemaValidator
             if (isset($assoc['orderBy']) && $assoc['orderBy'] !== null) {
                 foreach ($assoc['orderBy'] as $orderField => $orientation) {
                     if (!$targetMetadata->hasField($orderField) && !$targetMetadata->hasAssociation($orderField)) {
-                        $ce[] = "The association " . $class->name."#".$fieldName." is ordered by a foreign field " .
-                                $orderField . " that is not a field on the target entity " . $targetMetadata->name . ".";
+                        $ce[] = "The association " . $class->getName()."#".$fieldName." is ordered by a foreign field " .
+                                $orderField . " that is not a field on the target entity " . $targetMetadata->getName() . ".";
                         continue;
                     }
                     if ($targetMetadata->isCollectionValuedAssociation($orderField)) {
-                        $ce[] = "The association " . $class->name."#".$fieldName." is ordered by a field " .
-                                $orderField . " on " . $targetMetadata->name . " that is a collection-valued association.";
+                        $ce[] = "The association " . $class->getName()."#".$fieldName." is ordered by a field " .
+                                $orderField . " on " . $targetMetadata->getName() . " that is a collection-valued association.";
                         continue;
                     }
                     if ($targetMetadata->isAssociationInverseSide($orderField)) {
-                        $ce[] = "The association " . $class->name."#".$fieldName." is ordered by a field " .
-                                $orderField . " on " . $targetMetadata->name . " that is the inverse side of an association.";
+                        $ce[] = "The association " . $class->getName()."#".$fieldName." is ordered by a field " .
+                                $orderField . " on " . $targetMetadata->getName() . " that is the inverse side of an association.";
                         continue;
                     }
                 }
@@ -250,9 +250,9 @@ class SchemaValidator
         }
 
         foreach ($class->subClasses as $subClass) {
-            if (!in_array($class->name, class_parents($subClass))) {
+            if (!in_array($class->getName(), class_parents($subClass))) {
                 $ce[] = "According to the discriminator map class '" . $subClass . "' has to be a child ".
-                        "of '" . $class->name . "' but these entities are not related through inheritance.";
+                        "of '" . $class->getName() . "' but these entities are not related through inheritance.";
             }
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1061,7 +1061,7 @@ class UnitOfWork implements PropertyChangedListener
     private function executeInserts($class)
     {
         $entities   = [];
-        $className  = $class->name;
+        $className  = $class->getName();
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postPersist);
 
@@ -1069,7 +1069,7 @@ class UnitOfWork implements PropertyChangedListener
 
         foreach ($this->entityInsertions as $oid => $entity) {
 
-            if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
+            if ($this->em->getClassMetadata(get_class($entity))->getName() !== $className) {
                 continue;
             }
 
@@ -1151,13 +1151,13 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeUpdates($class)
     {
-        $className          = $class->name;
+        $className          = $class->getName();
         $persister          = $this->getEntityPersister($className);
         $preUpdateInvoke    = $this->listenersInvoker->getSubscribedSystems($class, Events::preUpdate);
         $postUpdateInvoke   = $this->listenersInvoker->getSubscribedSystems($class, Events::postUpdate);
 
         foreach ($this->entityUpdates as $oid => $entity) {
-            if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
+            if ($this->em->getClassMetadata(get_class($entity))->getName() !== $className) {
                 continue;
             }
 
@@ -1188,12 +1188,12 @@ class UnitOfWork implements PropertyChangedListener
      */
     private function executeDeletions($class)
     {
-        $className  = $class->name;
+        $className  = $class->getName();
         $persister  = $this->getEntityPersister($className);
         $invoke     = $this->listenersInvoker->getSubscribedSystems($class, Events::postRemove);
 
         foreach ($this->entityDeletions as $oid => $entity) {
-            if ($this->em->getClassMetadata(get_class($entity))->name !== $className) {
+            if ($this->em->getClassMetadata(get_class($entity))->getName() !== $className) {
                 continue;
             }
 
@@ -1244,11 +1244,11 @@ class UnitOfWork implements PropertyChangedListener
         foreach ($entityChangeSet as $entity) {
             $class = $this->em->getClassMetadata(get_class($entity));
 
-            if ($calc->hasNode($class->name)) {
+            if ($calc->hasNode($class->getName())) {
                 continue;
             }
 
-            $calc->addNode($class->name, $class);
+            $calc->addNode($class->getName(), $class);
 
             $newNodes[] = $class;
         }
@@ -1262,15 +1262,15 @@ class UnitOfWork implements PropertyChangedListener
 
                 $targetClass = $this->em->getClassMetadata($assoc['targetEntity']);
 
-                if ( ! $calc->hasNode($targetClass->name)) {
-                    $calc->addNode($targetClass->name, $targetClass);
+                if ( ! $calc->hasNode($targetClass->getName())) {
+                    $calc->addNode($targetClass->getName(), $targetClass);
 
                     $newNodes[] = $targetClass;
                 }
 
                 $joinColumns = reset($assoc['joinColumns']);
 
-                $calc->addDependency($targetClass->name, $class->name, (int)empty($joinColumns['nullable']));
+                $calc->addDependency($targetClass->getName(), $class->name, (int)empty($joinColumns['nullable']));
 
                 // If the target class has mapped subclasses, these share the same dependency.
                 if ( ! $targetClass->subClasses) {
@@ -1281,12 +1281,12 @@ class UnitOfWork implements PropertyChangedListener
                     $targetSubClass = $this->em->getClassMetadata($subClassName);
 
                     if ( ! $calc->hasNode($subClassName)) {
-                        $calc->addNode($targetSubClass->name, $targetSubClass);
+                        $calc->addNode($targetSubClass->getName(), $targetSubClass);
 
                         $newNodes[] = $targetSubClass;
                     }
 
-                    $calc->addDependency($targetSubClass->name, $class->name, 1);
+                    $calc->addDependency($targetSubClass->getName(), $class->name, 1);
                 }
             }
         }
@@ -1515,7 +1515,7 @@ class UnitOfWork implements PropertyChangedListener
         $identifier    = $this->entityIdentifiers[spl_object_hash($entity)];
 
         if (empty($identifier) || in_array(null, $identifier, true)) {
-            throw ORMInvalidArgumentException::entityWithoutIdentity($classMetadata->name, $entity);
+            throw ORMInvalidArgumentException::entityWithoutIdentity($classMetadata->getName(), $entity);
         }
 
         $idHash    = implode(' ', $identifier);
@@ -1583,7 +1583,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 // db lookup
-                if ($this->getEntityPersister($class->name)->exists($entity)) {
+                if ($this->getEntityPersister($class->getName())->exists($entity)) {
                     return self::STATE_DETACHED;
                 }
 
@@ -1600,7 +1600,7 @@ class UnitOfWork implements PropertyChangedListener
                 }
 
                 // db lookup
-                if ($this->getEntityPersister($class->name)->exists($entity)) {
+                if ($this->getEntityPersister($class->getName())->exists($entity)) {
                     return self::STATE_DETACHED;
                 }
 
@@ -1948,7 +1948,7 @@ class UnitOfWork implements PropertyChangedListener
                     }
                 } else {
                     // We need to fetch the managed copy in order to merge.
-                    $managedCopy = $this->em->find($class->name, $flatId);
+                    $managedCopy = $this->em->find($class->getName(), $flatId);
                 }
 
                 if ($managedCopy === null) {
@@ -2165,7 +2165,7 @@ class UnitOfWork implements PropertyChangedListener
             throw ORMInvalidArgumentException::entityNotManaged($entity);
         }
 
-        $this->getEntityPersister($class->name)->refresh(
+        $this->getEntityPersister($class->getName())->refresh(
             array_combine($class->getIdentifierFieldNames(), $this->entityIdentifiers[$oid]),
             $entity
         );
@@ -2436,7 +2436,7 @@ class UnitOfWork implements PropertyChangedListener
         switch (true) {
             case LockMode::OPTIMISTIC === $lockMode:
                 if ( ! $class->isVersioned) {
-                    throw OptimisticLockException::notVersioned($class->name);
+                    throw OptimisticLockException::notVersioned($class->getName());
                 }
 
                 if ($lockVersion === null) {
@@ -2464,7 +2464,7 @@ class UnitOfWork implements PropertyChangedListener
 
                 $oid = spl_object_hash($entity);
 
-                $this->getEntityPersister($class->name)->lock(
+                $this->getEntityPersister($class->getName())->lock(
                     array_combine($class->getIdentifierFieldNames(), $this->entityIdentifiers[$oid]),
                     $lockMode
                 );
@@ -2764,8 +2764,8 @@ class UnitOfWork implements PropertyChangedListener
                         break;
                     }
 
-                    if ( ! isset($hints['fetchMode'][$class->name][$field])) {
-                        $hints['fetchMode'][$class->name][$field] = $assoc['fetch'];
+                    if ( ! isset($hints['fetchMode'][$class->getName()][$field])) {
+                        $hints['fetchMode'][$class->getName()][$field] = $assoc['fetch'];
                     }
 
                     // Foreign key is set
@@ -2781,7 +2781,7 @@ class UnitOfWork implements PropertyChangedListener
                             // If this is an uninitialized proxy, we are deferring eager loads,
                             // this association is marked as eager fetch, and its an uninitialized proxy (wtf!)
                             // then we can append this entity for eager loading!
-                            if ($hints['fetchMode'][$class->name][$field] == ClassMetadata::FETCH_EAGER &&
+                            if ($hints['fetchMode'][$class->getName()][$field] == ClassMetadata::FETCH_EAGER &&
                                 isset($hints[self::HINT_DEFEREAGERLOAD]) &&
                                 !$targetClass->isIdentifierComposite &&
                                 $newValue instanceof Proxy &&
@@ -2802,7 +2802,7 @@ class UnitOfWork implements PropertyChangedListener
                         default:
                             switch (true) {
                                 // We are negating the condition here. Other cases will assume it is valid!
-                                case ($hints['fetchMode'][$class->name][$field] !== ClassMetadata::FETCH_EAGER):
+                                case ($hints['fetchMode'][$class->getName()][$field] !== ClassMetadata::FETCH_EAGER):
                                     $newValue = $this->em->getProxyFactory()->getProxy($assoc['targetEntity'], $associatedId);
                                     break;
 
@@ -3482,7 +3482,7 @@ class UnitOfWork implements PropertyChangedListener
 
         $class = $this->em->getClassMetadata(get_class($entity));
 
-        foreach ($this->reflectionPropertiesGetter->getProperties($class->name) as $prop) {
+        foreach ($this->reflectionPropertiesGetter->getProperties($class->getName()) as $prop) {
             $name = $prop->name;
 
             $prop->setAccessible(true);
@@ -3510,7 +3510,7 @@ class UnitOfWork implements PropertyChangedListener
                                 $relatedId   = $targetClass->getIdentifierValues($other);
 
                                 if ($targetClass->subClasses) {
-                                    $other = $this->em->find($targetClass->name, $relatedId);
+                                    $other = $this->em->find($targetClass->getName(), $relatedId);
                                 } else {
                                     $other = $this->em->getProxyFactory()->getProxy(
                                         $assoc2['targetEntity'],

--- a/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+++ b/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
@@ -28,7 +28,7 @@ final class HierarchyDiscriminatorResolver
         EntityManagerInterface $entityManager
     ): array {
         $hierarchyClasses = $rootClassMetadata->subClasses;
-        $hierarchyClasses[] = $rootClassMetadata->name;
+        $hierarchyClasses[] = $rootClassMetadata->getName();
 
         $discriminators = [];
 

--- a/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
+++ b/tests/Doctrine/Tests/EventListener/CacheMetadataListener.php
@@ -28,7 +28,7 @@ class CacheMetadataListener
         $em = $event->getObjectManager();
 
         /** @var $metadata \Doctrine\ORM\Mapping\ClassMetadata */
-        if (strstr($metadata->name, 'Doctrine\Tests\Models\Cache')) {
+        if (strstr($metadata->getName(), 'Doctrine\Tests\Models\Cache')) {
             return;
         }
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -45,8 +45,8 @@ class DefaultCacheTest extends OrmTestCase
     private function putEntityCacheEntry($className, array $identifier, array $data)
     {
         $metadata   = $this->em->getClassMetadata($className);
-        $cacheKey   = new EntityCacheKey($metadata->name, $identifier);
-        $cacheEntry = new EntityCacheEntry($metadata->name, $data);
+        $cacheKey   = new EntityCacheKey($metadata->getName(), $identifier);
+        $cacheEntry = new EntityCacheEntry($metadata->getName(), $data);
         $persister  = $this->em->getUnitOfWork()->getEntityPersister($metadata->rootEntityName);
 
         $persister->getCacheRegion()->put($cacheKey, $cacheEntry);
@@ -61,7 +61,7 @@ class DefaultCacheTest extends OrmTestCase
     private function putCollectionCacheEntry($className, $association, array $ownerIdentifier, array $data)
     {
         $metadata   = $this->em->getClassMetadata($className);
-        $cacheKey   = new CollectionCacheKey($metadata->name, $association, $ownerIdentifier);
+        $cacheKey   = new CollectionCacheKey($metadata->getName(), $association, $ownerIdentifier);
         $cacheEntry = new CollectionCacheEntry($data);
         $persister  = $this->em->getUnitOfWork()->getCollectionPersister($metadata->getAssociationMapping($association));
 

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCollectionHydratorTest.php
@@ -55,7 +55,7 @@ class DefaultCollectionHydratorTest extends OrmFunctionalTestCase
 
         $sourceClass    = $this->_em->getClassMetadata(State::class);
         $targetClass    = $this->_em->getClassMetadata(City::class);
-        $key            = new CollectionCacheKey($sourceClass->name, 'cities', ['id'=>21]);
+        $key            = new CollectionCacheKey($sourceClass->getName(), 'cities', ['id'=>21]);
         $collection     = new PersistentCollection($this->_em, $targetClass, new ArrayCollection());
         $list           = $this->structure->loadCacheEntry($sourceClass, $key, $entry, $collection);
 
@@ -63,10 +63,10 @@ class DefaultCollectionHydratorTest extends OrmFunctionalTestCase
         $this->assertCount(2, $list);
         $this->assertCount(2, $collection);
 
-        $this->assertInstanceOf($targetClass->name, $list[0]);
-        $this->assertInstanceOf($targetClass->name, $list[1]);
-        $this->assertInstanceOf($targetClass->name, $collection[0]);
-        $this->assertInstanceOf($targetClass->name, $collection[1]);
+        $this->assertInstanceOf($targetClass->getName(), $list[0]);
+        $this->assertInstanceOf($targetClass->getName(), $list[1]);
+        $this->assertInstanceOf($targetClass->getName(), $collection[0]);
+        $this->assertInstanceOf($targetClass->getName(), $collection[1]);
 
         $this->assertSame($list[0], $collection[0]);
         $this->assertSame($list[1], $collection[1]);

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultEntityHydratorTest.php
@@ -43,11 +43,11 @@ class DefaultEntityHydratorTest extends OrmTestCase
     public function testCreateEntity()
     {
         $metadata = $this->em->getClassMetadata(Country::class);
-        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
-        $entry    = new EntityCacheEntry($metadata->name, ['id'=>1, 'name'=>'Foo']);
+        $key      = new EntityCacheKey($metadata->getName(), ['id'=>1]);
+        $entry    = new EntityCacheEntry($metadata->getName(), ['id'=>1, 'name'=>'Foo']);
         $entity   = $this->structure->loadCacheEntry($metadata, $key, $entry);
 
-        $this->assertInstanceOf($metadata->name, $entity);
+        $this->assertInstanceOf($metadata->getName(), $entity);
 
         $this->assertEquals(1, $entity->getId());
         $this->assertEquals('Foo', $entity->getName());
@@ -57,12 +57,12 @@ class DefaultEntityHydratorTest extends OrmTestCase
     public function testLoadProxy()
     {
         $metadata = $this->em->getClassMetadata(Country::class);
-        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
-        $entry    = new EntityCacheEntry($metadata->name, ['id'=>1, 'name'=>'Foo']);
-        $proxy    = $this->em->getReference($metadata->name, $key->identifier);
+        $key      = new EntityCacheKey($metadata->getName(), ['id'=>1]);
+        $entry    = new EntityCacheEntry($metadata->getName(), ['id'=>1, 'name'=>'Foo']);
+        $proxy    = $this->em->getReference($metadata->getName(), $key->identifier);
         $entity   = $this->structure->loadCacheEntry($metadata, $key, $entry, $proxy);
 
-        $this->assertInstanceOf($metadata->name, $entity);
+        $this->assertInstanceOf($metadata->getName(), $entity);
         $this->assertSame($proxy, $entity);
 
         $this->assertEquals(1, $entity->getId());
@@ -76,7 +76,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $uow      = $this->em->getUnitOfWork();
         $data     = ['id'=>1, 'name'=>'Foo'];
         $metadata = $this->em->getClassMetadata(Country::class);
-        $key      = new EntityCacheKey($metadata->name, ['id'=>1]);
+        $key      = new EntityCacheKey($metadata->getName(), ['id'=>1]);
 
         $entity->setId(1);
         $uow->registerManaged($entity, $key->identifier, $data);
@@ -103,7 +103,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $countryData    = ['id'=>11, 'name'=>'Foo'];
         $stateData      = ['id'=>12, 'name'=>'Bar', 'country' => $country];
         $metadata       = $this->em->getClassMetadata(State::class);
-        $key            = new EntityCacheKey($metadata->name, ['id'=>11]);
+        $key            = new EntityCacheKey($metadata->getName(), ['id'=>11]);
 
         $country->setId(11);
         $state->setId(12);
@@ -134,7 +134,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $uow            = $this->em->getUnitOfWork();
         $entityData     = ['id'=>12, 'name'=>'Bar', 'country' => $proxy];
         $metadata       = $this->em->getClassMetadata(State::class);
-        $key            = new EntityCacheKey($metadata->name, ['id'=>11]);
+        $key            = new EntityCacheKey($metadata->getName(), ['id'=>11]);
 
         $entity->setId(12);
 
@@ -163,7 +163,7 @@ class DefaultEntityHydratorTest extends OrmTestCase
         $uow            = $this->em->getUnitOfWork();
         $entityData     = ['id'=> 12, 'name'=>'Bar', 'country' => $proxy];
         $metadata       = $this->em->getClassMetadata(State::class);
-        $key            = new EntityCacheKey($metadata->name, ['id'=>'12']);
+        $key            = new EntityCacheKey($metadata->getName(), ['id'=>'12']);
 
         $entity->setId(12);
 

--- a/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
+++ b/tests/Doctrine/Tests/ORM/CommitOrderCalculatorTest.php
@@ -30,16 +30,16 @@ class CommitOrderCalculatorTest extends OrmTestCase
         $class4 = new ClassMetadata(NodeClass4::class);
         $class5 = new ClassMetadata(NodeClass5::class);
 
-        $this->_calc->addNode($class1->name, $class1);
-        $this->_calc->addNode($class2->name, $class2);
-        $this->_calc->addNode($class3->name, $class3);
-        $this->_calc->addNode($class4->name, $class4);
-        $this->_calc->addNode($class5->name, $class5);
+        $this->_calc->addNode($class1->getName(), $class1);
+        $this->_calc->addNode($class2->getName(), $class2);
+        $this->_calc->addNode($class3->getName(), $class3);
+        $this->_calc->addNode($class4->getName(), $class4);
+        $this->_calc->addNode($class5->getName(), $class5);
 
-        $this->_calc->addDependency($class1->name, $class2->name, 1);
-        $this->_calc->addDependency($class2->name, $class3->name, 1);
-        $this->_calc->addDependency($class3->name, $class4->name, 1);
-        $this->_calc->addDependency($class5->name, $class1->name, 1);
+        $this->_calc->addDependency($class1->getName(), $class2->getName(), 1);
+        $this->_calc->addDependency($class2->getName(), $class3->getName(), 1);
+        $this->_calc->addDependency($class3->getName(), $class4->getName(), 1);
+        $this->_calc->addDependency($class5->getName(), $class1->getName(), 1);
 
         $sorted = $this->_calc->sort();
 
@@ -54,11 +54,11 @@ class CommitOrderCalculatorTest extends OrmTestCase
         $class1 = new ClassMetadata(NodeClass1::class);
         $class2 = new ClassMetadata(NodeClass2::class);
 
-        $this->_calc->addNode($class1->name, $class1);
-        $this->_calc->addNode($class2->name, $class2);
+        $this->_calc->addNode($class1->getName(), $class1);
+        $this->_calc->addNode($class2->getName(), $class2);
 
-        $this->_calc->addDependency($class1->name, $class2->name, 0);
-        $this->_calc->addDependency($class2->name, $class1->name, 1);
+        $this->_calc->addDependency($class1->getName(), $class2->getName(), 0);
+        $this->_calc->addDependency($class2->getName(), $class1->getName(), 1);
 
         $sorted = $this->_calc->sort();
 
@@ -76,15 +76,15 @@ class CommitOrderCalculatorTest extends OrmTestCase
         $class3 = new ClassMetadata(NodeClass3::class);
         $class4 = new ClassMetadata(NodeClass4::class);
 
-        $this->_calc->addNode($class1->name, $class1);
-        $this->_calc->addNode($class2->name, $class2);
-        $this->_calc->addNode($class3->name, $class3);
-        $this->_calc->addNode($class4->name, $class4);
+        $this->_calc->addNode($class1->getName(), $class1);
+        $this->_calc->addNode($class2->getName(), $class2);
+        $this->_calc->addNode($class3->getName(), $class3);
+        $this->_calc->addNode($class4->getName(), $class4);
 
-        $this->_calc->addDependency($class4->name, $class1->name, 1);
-        $this->_calc->addDependency($class1->name, $class2->name, 1);
-        $this->_calc->addDependency($class4->name, $class3->name, 1);
-        $this->_calc->addDependency($class1->name, $class4->name, 0);
+        $this->_calc->addDependency($class4->getName(), $class1->getName(), 1);
+        $this->_calc->addDependency($class1->getName(), $class2->getName(), 1);
+        $this->_calc->addDependency($class4->getName(), $class3->getName(), 1);
+        $this->_calc->addDependency($class1->getName(), $class4->getName(), 0);
 
         $sorted = $this->_calc->sort();
 

--- a/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ReferenceProxyTest.php
@@ -71,7 +71,7 @@ class ReferenceProxyTest extends OrmFunctionalTestCase
         $entity = $this->_em->getReference(ECommerceProduct::class , $id);
         $class = $this->_em->getClassMetadata(get_class($entity));
 
-        $this->assertEquals(ECommerceProduct::class, $class->name);
+        $this->assertEquals(ECommerceProduct::class, $class->getName());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -1094,7 +1094,7 @@ class MySoftDeleteFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        if ($targetEntity->name != "MyEntity\SoftDeleteNewsItem") {
+        if ($targetEntity->getName() != "MyEntity\SoftDeleteNewsItem") {
             return "";
         }
 
@@ -1118,7 +1118,7 @@ class CMSCountryFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        if ($targetEntity->name != CmsAddress::class) {
+        if ($targetEntity->getName() != CmsAddress::class) {
             return "";
         }
 
@@ -1130,7 +1130,7 @@ class CMSGroupPrefixFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        if ($targetEntity->name != CmsGroup::class) {
+        if ($targetEntity->getName() != CmsGroup::class) {
             return "";
         }
 
@@ -1142,7 +1142,7 @@ class CMSArticleTopicFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias)
     {
-        if ($targetEntity->name != CmsArticle::class) {
+        if ($targetEntity->getName() != CmsArticle::class) {
             return "";
         }
 
@@ -1154,7 +1154,7 @@ class CompanyPersonNameFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias, $targetTable = '')
     {
-        if ($targetEntity->name != CompanyPerson::class) {
+        if ($targetEntity->getName() != CompanyPerson::class) {
             return "";
         }
 
@@ -1166,7 +1166,7 @@ class CompletedContractFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias, $targetTable = '')
     {
-        if ($targetEntity->name != CompanyContract::class) {
+        if ($targetEntity->getName() != CompanyContract::class) {
             return "";
         }
 
@@ -1178,7 +1178,7 @@ class CompanyEventFilter extends SQLFilter
 {
     public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias, $targetTable = '')
     {
-        if ($targetEntity->name != CompanyEvent::class) {
+        if ($targetEntity->getName() != CompanyEvent::class) {
             return "";
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -301,11 +301,11 @@ class SQLFilterTest extends OrmFunctionalTestCase
         $filter = new MySoftDeleteFilter($this->getMockEntityManager());
 
         // Test for an entity that gets extra filter data
-        $targetEntity->name = 'MyEntity\SoftDeleteNewsItem';
+        $targetEntity->method('getName')
+                     ->willReturn('MyEntity\SoftDeleteNewsItem', 'MyEntity\NoSoftDeleteNewsItem');
         $this->assertEquals('t1_.deleted = 0', $filter->addFilterConstraint($targetEntity, 't1_'));
 
         // Test for an entity that doesn't get extra filter data
-        $targetEntity->name = 'MyEntity\NoSoftDeleteNewsItem';
         $this->assertEquals('', $filter->addFilterConstraint($targetEntity, 't1_'));
 
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaValidatorTest.php
@@ -70,7 +70,7 @@ class SchemaValidatorTest extends OrmFunctionalTestCase
         foreach ($classes as $class) {
             $ce = $validator->validateClass($class);
 
-            $this->assertEmpty($ce, "Invalid Modelset: " . $modelSet . " class " . $class->name . ": ". implode("\n", $ce));
+            $this->assertEmpty($ce, "Invalid Modelset: " . $modelSet . " class " . $class->getName() . ": ". implode("\n", $ce));
         }
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -80,7 +80,7 @@ class DDC1163Test extends \Doctrine\Tests\OrmFunctionalTestCase
         // this screams violation of law of demeter ;)
         $this->assertEquals(
             DDC1163SpecialProduct::class,
-            $this->_em->getUnitOfWork()->getEntityPersister(get_class($specialProduct))->getClassMetadata()->name
+            $this->_em->getUnitOfWork()->getEntityPersister(get_class($specialProduct))->getClassMetadata()->getName()
         );
 
         $tag = new DDC1163Tag('Foo');

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -662,7 +662,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(['name'=>'address.city','column'=>'city'],         $mapping['entities'][0]['fields'][4]);
         $this->assertEquals(['name'=>'address.country','column'=>'country'],   $mapping['entities'][0]['fields'][5]);
         $this->assertEquals(['name'=>'address.id','column'=>'a_id'],           $mapping['entities'][0]['fields'][6]);
-        $this->assertEquals($userMetadata->name,                                    $mapping['entities'][0]['entityClass']);
+        $this->assertEquals($userMetadata->getName(),                          $mapping['entities'][0]['entityClass']);
 
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingJoinedPhonenumber');
@@ -673,7 +673,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(['name'=>'name','column'=>'name'],                         $mapping['entities'][0]['fields'][1]);
         $this->assertEquals(['name'=>'status','column'=>'status'],                     $mapping['entities'][0]['fields'][2]);
         $this->assertEquals(['name'=>'phonenumbers.phonenumber','column'=>'number'],   $mapping['entities'][0]['fields'][3]);
-        $this->assertEquals($userMetadata->name,                                            $mapping['entities'][0]['entityClass']);
+        $this->assertEquals($userMetadata->getName(),                                  $mapping['entities'][0]['entityClass']);
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingUserPhonenumberCount');
         $this->assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
@@ -682,7 +682,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(['name'=>'id','column'=>'id'],         $mapping['entities'][0]['fields'][0]);
         $this->assertEquals(['name'=>'name','column'=>'name'],     $mapping['entities'][0]['fields'][1]);
         $this->assertEquals(['name'=>'status','column'=>'status'], $mapping['entities'][0]['fields'][2]);
-        $this->assertEquals($userMetadata->name,                        $mapping['entities'][0]['entityClass']);
+        $this->assertEquals($userMetadata->getName(),              $mapping['entities'][0]['entityClass']);
 
         $mapping = $userMetadata->getSqlResultSetMapping('mappingMultipleJoinsEntityResults');
         $this->assertEquals(['name'=>'numphones'],$mapping['columns'][0]);
@@ -691,12 +691,12 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(['name'=>'id','column'=>'u_id'],           $mapping['entities'][0]['fields'][0]);
         $this->assertEquals(['name'=>'name','column'=>'u_name'],       $mapping['entities'][0]['fields'][1]);
         $this->assertEquals(['name'=>'status','column'=>'u_status'],   $mapping['entities'][0]['fields'][2]);
-        $this->assertEquals($userMetadata->name,                            $mapping['entities'][0]['entityClass']);
+        $this->assertEquals($userMetadata->getName(),                  $mapping['entities'][0]['entityClass']);
         $this->assertNull($mapping['entities'][1]['discriminatorColumn']);
         $this->assertEquals(['name'=>'id','column'=>'a_id'],           $mapping['entities'][1]['fields'][0]);
         $this->assertEquals(['name'=>'zip','column'=>'a_zip'],         $mapping['entities'][1]['fields'][1]);
         $this->assertEquals(['name'=>'country','column'=>'a_country'], $mapping['entities'][1]['fields'][2]);
-        $this->assertEquals(CmsAddress::class,         $mapping['entities'][1]['entityClass']);
+        $this->assertEquals(CmsAddress::class,                 $mapping['entities'][1]['entityClass']);
 
         //person asserts
         $this->assertCount(1, $personMetadata->getSqlResultSetMappings());
@@ -704,10 +704,10 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $mapping = $personMetadata->getSqlResultSetMapping('mappingFetchAll');
         $this->assertEquals([],$mapping['columns']);
         $this->assertEquals('mappingFetchAll', $mapping['name']);
-        $this->assertEquals('discriminator',                            $mapping['entities'][0]['discriminatorColumn']);
+        $this->assertEquals('discriminator',               $mapping['entities'][0]['discriminatorColumn']);
         $this->assertEquals(['name'=>'id','column'=>'id'],         $mapping['entities'][0]['fields'][0]);
         $this->assertEquals(['name'=>'name','column'=>'name'],     $mapping['entities'][0]['fields'][1]);
-        $this->assertEquals($personMetadata->name,                      $mapping['entities'][0]['entityClass']);
+        $this->assertEquals($personMetadata->getName(),            $mapping['entities'][0]['entityClass']);
     }
 
     /*

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -47,7 +47,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         // SUT
         $cmf = new ClassMetadataFactory();
         $cmf->setEntityManager($entityManager);
-        $cmf->setMetadataFor($cm1->name, $cm1);
+        $cmf->setMetadataFor($cm1->getName(), $cm1);
 
         // Prechecks
         $this->assertEquals([], $cm1->parentClasses);
@@ -58,7 +58,7 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $this->assertEquals('group', $cm1->table['name']);
 
         // Go
-        $cmMap1 = $cmf->getMetadataFor($cm1->name);
+        $cmMap1 = $cmf->getMetadataFor($cm1->getName());
 
         $this->assertSame($cm1, $cmMap1);
         $this->assertEquals('group', $cmMap1->table['name']);
@@ -73,9 +73,9 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $cm1->customGeneratorDefinition = ['class' => CustomIdGenerator::class];
         $cmf = $this->_createTestFactory();
-        $cmf->setMetadataForClass($cm1->name, $cm1);
+        $cmf->setMetadataForClass($cm1->getName(), $cm1);
 
-        $actual = $cmf->getMetadataFor($cm1->name);
+        $actual = $cmf->getMetadataFor($cm1->getName());
 
         $this->assertEquals(ClassMetadata::GENERATOR_TYPE_CUSTOM, $actual->generatorType);
         $this->assertInstanceOf(CustomIdGenerator::class, $actual->idGenerator);
@@ -87,10 +87,10 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $cm1->customGeneratorDefinition = ["class" => "NotExistingGenerator"];
         $cmf = $this->_createTestFactory();
-        $cmf->setMetadataForClass($cm1->name, $cm1);
+        $cmf->setMetadataForClass($cm1->getName(), $cm1);
         $this->expectException(ORMException::class);
 
-        $actual = $cmf->getMetadataFor($cm1->name);
+        $actual = $cmf->getMetadataFor($cm1->getName());
     }
 
     public function testGetMetadataFor_ThrowsExceptionOnMissingCustomGeneratorDefinition()
@@ -98,10 +98,10 @@ class ClassMetadataFactoryTest extends OrmTestCase
         $cm1 = $this->_createValidClassMetadata();
         $cm1->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_CUSTOM);
         $cmf = $this->_createTestFactory();
-        $cmf->setMetadataForClass($cm1->name, $cm1);
+        $cmf->setMetadataForClass($cm1->getName(), $cm1);
         $this->expectException(ORMException::class);
 
-        $actual = $cmf->getMetadataFor($cm1->name);
+        $actual = $cmf->getMetadataFor($cm1->getName());
     }
 
     public function testHasGetMetadata_NamespaceSeparatorIsNotNormalized()
@@ -431,12 +431,12 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $cmf = $this->_createTestFactory();
 
-        $cmf->setMetadataForClass($metadata->name, $metadata);
+        $cmf->setMetadataForClass($metadata->getName(), $metadata);
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('The embed mapping \'embedded\' misses the \'class\' attribute.');
 
-        $cmf->getMetadataFor($metadata->name);
+        $cmf->getMetadataFor($metadata->getName());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -33,7 +33,7 @@ class ClassMetadataTest extends OrmTestCase
         // Test initial state
         $this->assertTrue(count($cm->getReflectionProperties()) == 0);
         $this->assertInstanceOf('ReflectionClass', $cm->reflClass);
-        $this->assertEquals(CMS\CmsUser::class, $cm->name);
+        $this->assertEquals(CMS\CmsUser::class, $cm->getName());
         $this->assertEquals(CMS\CmsUser::class, $cm->rootEntityName);
         $this->assertEquals([], $cm->subClasses);
         $this->assertEquals([], $cm->parentClasses);
@@ -908,7 +908,7 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(strtoupper(CMS\CmsUser::class));
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        $this->assertEquals(CMS\CmsUser::class, $cm->name);
+        $this->assertEquals(CMS\CmsUser::class, $cm->getName());
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/ConvertDoctrine1SchemaTest.php
@@ -68,8 +68,8 @@ class ConvertDoctrine1SchemaTest extends OrmTestCase
         $userClass = $cmf->getMetadataFor('User');
 
         $this->assertEquals(2, count($metadata));
-        $this->assertEquals('Profile', $profileClass->name);
-        $this->assertEquals('User', $userClass->name);
+        $this->assertEquals('Profile', $profileClass->getName());
+        $this->assertEquals('User', $userClass->getName());
         $this->assertEquals(4, count($profileClass->fieldMappings));
         $this->assertEquals(5, count($userClass->fieldMappings));
         $this->assertEquals('text', $userClass->fieldMappings['clob']['type']);

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -179,7 +179,7 @@ class EntityGeneratorTest extends OrmTestCase
         $columnPrefix = false
     ) {
         $classMetadata->mapEmbedded(
-            ['fieldName' => $fieldName, 'class' => $embeddableMetadata->name, 'columnPrefix' => $columnPrefix]
+            ['fieldName' => $fieldName, 'class' => $embeddableMetadata->getName(), 'columnPrefix' => $columnPrefix]
         );
     }
 
@@ -213,7 +213,7 @@ class EntityGeneratorTest extends OrmTestCase
      */
     private function loadEntityClass(ClassMetadataInfo $metadata)
     {
-        $className = basename(str_replace('\\', '/', $metadata->name));
+        $className = basename(str_replace('\\', '/', $metadata->getName()));
         $path = $this->_tmpDir . '/' . $this->_namespace . '/' . $className . '.php';
 
         $this->assertFileExists($path);
@@ -230,7 +230,7 @@ class EntityGeneratorTest extends OrmTestCase
     {
         $this->loadEntityClass($metadata);
 
-        return new $metadata->name;
+        return new $metadata->name();
     }
 
     /**
@@ -246,7 +246,7 @@ class EntityGeneratorTest extends OrmTestCase
         self::assertTrue($refClass->hasProperty('testEmbedded'));
 
         $docComment = $refClass->getProperty('testEmbedded')->getDocComment();
-        $needle = sprintf('@Embedded(class="%s", columnPrefix="%s")', $testMetadata->name, $columnPrefix);
+        $needle = sprintf('@Embedded(class="%s", columnPrefix="%s")', $testMetadata->getName(), $columnPrefix);
         self::assertContains($needle, $docComment);
     }
 
@@ -262,7 +262,7 @@ class EntityGeneratorTest extends OrmTestCase
         self::assertTrue($refClass->hasProperty('testEmbedded'));
 
         $docComment = $refClass->getProperty('testEmbedded')->getDocComment();
-        $needle = sprintf('@Embedded(class="%s", columnPrefix=false)', $testMetadata->name);
+        $needle = sprintf('@Embedded(class="%s", columnPrefix=false)', $testMetadata->getName());
         self::assertContains($needle, $docComment);
     }
 
@@ -273,7 +273,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata = $this->generateBookEntityFixture(['isbn' => $isbnMetadata]);
 
         $book = $this->newInstance($metadata);
-        $this->assertTrue(class_exists($metadata->name), "Class does not exist.");
+        $this->assertTrue(class_exists($metadata->getName()), "Class does not exist.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', '__construct'), "EntityGeneratorBook::__construct() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getId'), "EntityGeneratorBook::getId() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'setName'), "EntityGeneratorBook::setName() missing.");
@@ -288,7 +288,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'setIsbn'), "EntityGeneratorBook::setIsbn() missing.");
         $this->assertTrue(method_exists($metadata->namespace . '\EntityGeneratorBook', 'getIsbn'), "EntityGeneratorBook::getIsbn() missing.");
 
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertCount(6, $reflClass->getProperties());
         $this->assertCount(15, $reflClass->getMethods());
@@ -298,11 +298,11 @@ class EntityGeneratorTest extends OrmTestCase
         $book->setName('Jonathan H. Wage');
         $this->assertEquals('Jonathan H. Wage', $book->getName());
 
-        $reflMethod = new \ReflectionMethod($metadata->name, 'addComment');
+        $reflMethod = new \ReflectionMethod($metadata->getName(), 'addComment');
         $addCommentParameters = $reflMethod->getParameters();
         $this->assertEquals('comment', $addCommentParameters[0]->getName());
 
-        $reflMethod = new \ReflectionMethod($metadata->name, 'removeComment');
+        $reflMethod = new \ReflectionMethod($metadata->getName(), 'removeComment');
         $removeCommentParameters = $reflMethod->getParameters();
         $this->assertEquals('comment', $removeCommentParameters[0]->getName());
 
@@ -311,7 +311,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertEquals($author, $book->getAuthor());
 
         $comment = new EntityGeneratorComment();
-        $this->assertInstanceOf($metadata->name, $book->addComment($comment));
+        $this->assertInstanceOf($metadata->getName(), $book->addComment($comment));
         $this->assertInstanceOf(ArrayCollection::class, $book->getComments());
         $this->assertEquals(new ArrayCollection([$comment]), $book->getComments());
         $this->assertInternalType('boolean', $book->removeComment($comment));
@@ -323,9 +323,9 @@ class EntityGeneratorTest extends OrmTestCase
         $book->setIsbn($isbn);
         $this->assertSame($isbn, $book->getIsbn());
 
-        $reflMethod = new \ReflectionMethod($metadata->name, 'setIsbn');
+        $reflMethod = new \ReflectionMethod($metadata->getName(), 'setIsbn');
         $reflParameters = $reflMethod->getParameters();
-        $this->assertEquals($isbnMetadata->name, $reflParameters[0]->getClass()->name);
+        $this->assertEquals($isbnMetadata->getName(), $reflParameters[0]->getClass()->name);
     }
 
     public function testBooleanDefaultValue()
@@ -342,7 +342,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($this->_tmpDir . '/' . $this->_namespace . '/EntityGeneratorBook.php~');
 
         $book      = $this->newInstance($metadata);
-        $reflClass = new ReflectionClass($metadata->name);
+        $reflClass = new ReflectionClass($metadata->getName());
 
         $this->assertTrue($book->getfoo());
     }
@@ -361,7 +361,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($this->_tmpDir . "/" . $this->_namespace . "/EntityGeneratorBook.php~");
 
         $book = $this->newInstance($metadata);
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertTrue($reflClass->hasProperty('name'), "Regenerating keeps property 'name'.");
         $this->assertTrue($reflClass->hasProperty('status'), "Regenerating keeps property 'status'.");
@@ -406,7 +406,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($this->_tmpDir . "/" . $this->_namespace . "/EntityGeneratorBook.php~");
 
         $this->newInstance($metadata);
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertTrue($reflClass->hasProperty('status'));
         $this->assertTrue($reflClass->hasProperty('STATUS'));
@@ -438,7 +438,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertPhpDocReturnType('\Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor|null', new \ReflectionMethod($book, 'getAuthor'));
         $this->assertPhpDocParamType('\Doctrine\Tests\ORM\Tools\EntityGeneratorAuthor|null', new \ReflectionMethod($book, 'setAuthor'));
 
-        $expectedClassName = '\\' . $embeddedMetadata->name;
+        $expectedClassName = '\\' . $embeddedMetadata->getName();
         $this->assertPhpDocVarType($expectedClassName, new \ReflectionProperty($book, 'isbn'));
         $this->assertPhpDocReturnType($expectedClassName, new \ReflectionMethod($book, 'getIsbn'));
         $this->assertPhpDocParamType($expectedClassName, new \ReflectionMethod($book, 'setIsbn'));
@@ -462,7 +462,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata = $this->generateBookEntityFixture();
 
         $book = $this->newInstance($metadata);
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertTrue($reflClass->hasMethod('loading'), "Check for postLoad lifecycle callback.");
         $this->assertTrue($reflClass->hasMethod('willBeRemoved'), "Check for preRemove lifecycle callback.");
@@ -477,11 +477,11 @@ class EntityGeneratorTest extends OrmTestCase
 
         $reflectionService = new RuntimeReflectionService();
 
-        $cm = new ClassMetadataInfo($metadata->name);
+        $cm = new ClassMetadataInfo($metadata->getName());
         $cm->initializeReflection($reflectionService);
 
         $driver = $this->createAnnotationDriver();
-        $driver->loadMetadataForClass($cm->name, $cm);
+        $driver->loadMetadataForClass($cm->getName(), $cm);
 
         $this->assertEquals($cm->columnNames, $metadata->columnNames);
         $this->assertEquals($cm->getTableName(), $metadata->getTableName());
@@ -496,10 +496,10 @@ class EntityGeneratorTest extends OrmTestCase
 
         $isbn = $this->newInstance($embeddedMetadata);
 
-        $cm = new ClassMetadataInfo($embeddedMetadata->name);
+        $cm = new ClassMetadataInfo($embeddedMetadata->getName());
         $cm->initializeReflection($reflectionService);
 
-        $driver->loadMetadataForClass($cm->name, $cm);
+        $driver->loadMetadataForClass($cm->getName(), $cm);
 
         $this->assertEquals($cm->columnNames, $embeddedMetadata->columnNames);
         $this->assertEquals($cm->embeddedClasses, $embeddedMetadata->embeddedClasses);
@@ -519,10 +519,10 @@ class EntityGeneratorTest extends OrmTestCase
 
         $reflectionService = new RuntimeReflectionService();
 
-        $cm = new ClassMetadataInfo($metadata->name);
+        $cm = new ClassMetadataInfo($metadata->getName());
         $cm->initializeReflection($reflectionService);
 
-        $driver->loadMetadataForClass($cm->name, $cm);
+        $driver->loadMetadataForClass($cm->getName(), $cm);
 
         $this->assertEquals($cm->columnNames, $metadata->columnNames);
         $this->assertEquals($cm->getTableName(), $metadata->getTableName());
@@ -533,10 +533,10 @@ class EntityGeneratorTest extends OrmTestCase
 
         $isbn = $this->newInstance($embeddedMetadata);
 
-        $cm = new ClassMetadataInfo($embeddedMetadata->name);
+        $cm = new ClassMetadataInfo($embeddedMetadata->getName());
         $cm->initializeReflection($reflectionService);
 
-        $driver->loadMetadataForClass($cm->name, $cm);
+        $driver->loadMetadataForClass($cm->getName(), $cm);
 
         $this->assertEquals($cm->columnNames, $embeddedMetadata->columnNames);
         $this->assertEquals($cm->embeddedClasses, $embeddedMetadata->embeddedClasses);
@@ -557,10 +557,10 @@ class EntityGeneratorTest extends OrmTestCase
         $this->newInstance($metadata); // force instantiation (causes autoloading to kick in)
 
         $driver = new AnnotationDriver(new AnnotationReader(), []);
-        $cm     = new ClassMetadataInfo($metadata->name);
+        $cm     = new ClassMetadataInfo($metadata->getName());
 
         $cm->initializeReflection(new RuntimeReflectionService);
-        $driver->loadMetadataForClass($cm->name, $cm);
+        $driver->loadMetadataForClass($cm->getName(), $cm);
 
         $this->assertTrue($cm->isMappedSuperclass);
     }
@@ -606,7 +606,7 @@ class EntityGeneratorTest extends OrmTestCase
         require_once $filename;
 
 
-        $reflection = new \ReflectionProperty($metadata->name, 'id');
+        $reflection = new \ReflectionProperty($metadata->getName(), 'id');
         $docComment = $reflection->getDocComment();
 
         $this->assertContains('@Id', $docComment);
@@ -649,7 +649,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($filename);
         require_once $filename;
 
-        $property   = new \ReflectionProperty($metadata->name, 'centroCustos');
+        $property   = new \ReflectionProperty($metadata->getName(), 'centroCustos');
         $docComment = $property->getDocComment();
 
         //joinColumns
@@ -761,8 +761,8 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($path);
         require_once $path;
 
-        $entity     = new $metadata->name;
-        $reflClass  = new \ReflectionClass($metadata->name);
+        $entity     = new $metadata->name();
+        $reflClass  = new \ReflectionClass($metadata->getName());
 
         $type   = $field['phpType'];
         $name   = $field['fieldName'];
@@ -797,7 +797,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($this->_tmpDir . "/" . $this->_namespace . "/DDC2372User.php");
         require $this->_tmpDir . "/" . $this->_namespace . "/DDC2372User.php";
 
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertSame($reflClass->hasProperty('address'), false);
         $this->assertSame($reflClass->hasMethod('setAddress'), false);
@@ -823,7 +823,7 @@ class EntityGeneratorTest extends OrmTestCase
         $this->assertFileExists($this->_tmpDir . "/" . $this->_namespace . "/DDC2372Admin.php");
         require $this->_tmpDir . "/" . $this->_namespace . "/DDC2372Admin.php";
 
-        $reflClass = new \ReflectionClass($metadata->name);
+        $reflClass = new \ReflectionClass($metadata->getName());
 
         $this->assertSame($reflClass->hasProperty('address'), false);
         $this->assertSame($reflClass->hasMethod('setAddress'), false);
@@ -913,20 +913,20 @@ class EntityGeneratorTest extends OrmTestCase
 
         $isbn = $this->newInstance($metadata);
 
-        $this->assertTrue(class_exists($metadata->name), "Class does not exist.");
-        $this->assertFalse(method_exists($metadata->name, '__construct'), "EntityGeneratorIsbn::__construct present.");
-        $this->assertTrue(method_exists($metadata->name, 'getPrefix'), "EntityGeneratorIsbn::getPrefix() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setPrefix'), "EntityGeneratorIsbn::setPrefix() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getGroupNumber'), "EntityGeneratorIsbn::getGroupNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setGroupNumber'), "EntityGeneratorIsbn::setGroupNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getPublisherNumber'), "EntityGeneratorIsbn::getPublisherNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setPublisherNumber'), "EntityGeneratorIsbn::setPublisherNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getTitleNumber'), "EntityGeneratorIsbn::getTitleNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setTitleNumber'), "EntityGeneratorIsbn::setTitleNumber() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getCheckDigit'), "EntityGeneratorIsbn::getCheckDigit() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setCheckDigit'), "EntityGeneratorIsbn::setCheckDigit() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getTest'), "EntityGeneratorIsbn::getTest() missing.");
-        $this->assertTrue(method_exists($metadata->name, 'setTest'), "EntityGeneratorIsbn::setTest() missing.");
+        $this->assertTrue(class_exists($metadata->getName()), "Class does not exist.");
+        $this->assertFalse(method_exists($metadata->getName(), '__construct'), "EntityGeneratorIsbn::__construct present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getPrefix'), "EntityGeneratorIsbn::getPrefix() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setPrefix'), "EntityGeneratorIsbn::setPrefix() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getGroupNumber'), "EntityGeneratorIsbn::getGroupNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setGroupNumber'), "EntityGeneratorIsbn::setGroupNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getPublisherNumber'), "EntityGeneratorIsbn::getPublisherNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setPublisherNumber'), "EntityGeneratorIsbn::setPublisherNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getTitleNumber'), "EntityGeneratorIsbn::getTitleNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setTitleNumber'), "EntityGeneratorIsbn::setTitleNumber() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getCheckDigit'), "EntityGeneratorIsbn::getCheckDigit() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setCheckDigit'), "EntityGeneratorIsbn::setCheckDigit() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getTest'), "EntityGeneratorIsbn::getTest() missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'setTest'), "EntityGeneratorIsbn::setTest() missing.");
 
         $isbn->setPrefix(978);
         $this->assertSame(978, $isbn->getPrefix());
@@ -937,9 +937,9 @@ class EntityGeneratorTest extends OrmTestCase
         $isbn->setTest($test);
         $this->assertSame($test, $isbn->getTest());
 
-        $reflMethod = new \ReflectionMethod($metadata->name, 'setTest');
+        $reflMethod = new \ReflectionMethod($metadata->getName(), 'setTest');
         $reflParameters = $reflMethod->getParameters();
-        $this->assertEquals($embeddedMetadata->name, $reflParameters[0]->getClass()->name);
+        $this->assertEquals($embeddedMetadata->getName(), $reflParameters[0]->getClass()->name);
     }
 
     /**
@@ -954,20 +954,20 @@ class EntityGeneratorTest extends OrmTestCase
         $this->loadEntityClass($embeddedMetadata);
         $this->loadEntityClass($metadata);
 
-        $this->assertTrue(class_exists($metadata->name), "Class does not exist.");
-        $this->assertTrue(method_exists($metadata->name, '__construct'), "EntityGeneratorIsbn::__construct missing.");
-        $this->assertTrue(method_exists($metadata->name, 'getPrefix'), "EntityGeneratorIsbn::getPrefix() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setPrefix'), "EntityGeneratorIsbn::setPrefix() present.");
-        $this->assertTrue(method_exists($metadata->name, 'getGroupNumber'), "EntityGeneratorIsbn::getGroupNumber() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setGroupNumber'), "EntityGeneratorIsbn::setGroupNumber() present.");
-        $this->assertTrue(method_exists($metadata->name, 'getPublisherNumber'), "EntityGeneratorIsbn::getPublisherNumber() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setPublisherNumber'), "EntityGeneratorIsbn::setPublisherNumber() present.");
-        $this->assertTrue(method_exists($metadata->name, 'getTitleNumber'), "EntityGeneratorIsbn::getTitleNumber() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setTitleNumber'), "EntityGeneratorIsbn::setTitleNumber() present.");
-        $this->assertTrue(method_exists($metadata->name, 'getCheckDigit'), "EntityGeneratorIsbn::getCheckDigit() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setCheckDigit'), "EntityGeneratorIsbn::setCheckDigit() present.");
-        $this->assertTrue(method_exists($metadata->name, 'getTest'), "EntityGeneratorIsbn::getTest() missing.");
-        $this->assertFalse(method_exists($metadata->name, 'setTest'), "EntityGeneratorIsbn::setTest() present.");
+        $this->assertTrue(class_exists($metadata->getName()), "Class does not exist.");
+        $this->assertTrue(method_exists($metadata->getName(), '__construct'), "EntityGeneratorIsbn::__construct missing.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getPrefix'), "EntityGeneratorIsbn::getPrefix() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setPrefix'), "EntityGeneratorIsbn::setPrefix() present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getGroupNumber'), "EntityGeneratorIsbn::getGroupNumber() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setGroupNumber'), "EntityGeneratorIsbn::setGroupNumber() present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getPublisherNumber'), "EntityGeneratorIsbn::getPublisherNumber() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setPublisherNumber'), "EntityGeneratorIsbn::setPublisherNumber() present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getTitleNumber'), "EntityGeneratorIsbn::getTitleNumber() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setTitleNumber'), "EntityGeneratorIsbn::setTitleNumber() present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getCheckDigit'), "EntityGeneratorIsbn::getCheckDigit() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setCheckDigit'), "EntityGeneratorIsbn::setCheckDigit() present.");
+        $this->assertTrue(method_exists($metadata->getName(), 'getTest'), "EntityGeneratorIsbn::getTest() missing.");
+        $this->assertFalse(method_exists($metadata->getName(), 'setTest'), "EntityGeneratorIsbn::setTest() present.");
 
         $test = new $embeddedMetadata->name(1, new \DateTime());
         $isbn = new $metadata->name($test, 978, 3, 12, 732320, 83);
@@ -977,7 +977,7 @@ class EntityGeneratorTest extends OrmTestCase
 
         $this->assertCount(6, $reflParameters);
 
-        $this->assertSame($embeddedMetadata->name, $reflParameters[0]->getClass()->name);
+        $this->assertSame($embeddedMetadata->getName(), $reflParameters[0]->getClass()->name);
         $this->assertSame('test', $reflParameters[0]->getName());
         $this->assertFalse($reflParameters[0]->isOptional());
 
@@ -1021,7 +1021,7 @@ class EntityGeneratorTest extends OrmTestCase
         $metadata = $this->generateBookEntityFixture();
         $this->loadEntityClass($metadata);
 
-        $className = basename(str_replace('\\', '/', $metadata->name));
+        $className = basename(str_replace('\\', '/', $metadata->getName()));
         $path = $this->_tmpDir . '/' . $this->_namespace . '/' . $className . '.php';
         $classTest = file_get_contents($path);
 
@@ -1230,7 +1230,7 @@ class
         self::assertFileExists($filename);
         require_once $filename;
 
-        $property   = new \ReflectionProperty($metadata->name, 'test');
+        $property   = new \ReflectionProperty($metadata->getName(), 'test');
         $docComment = $property->getDocComment();
 
         self::assertContains($expectedAnnotation, $docComment);

--- a/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/AbstractClassMetadataExporterTest.php
@@ -95,7 +95,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
 
         $metadata[0]->name = ExportedUser::class;
 
-        $this->assertEquals(ExportedUser::class, $metadata[0]->name);
+        $this->assertEquals(ExportedUser::class, $metadata[0]->getName());
 
         $type = $this->_getType();
         $cme = new ClassMetadataExporter();
@@ -138,7 +138,7 @@ abstract class AbstractClassMetadataExporterTest extends OrmTestCase
 
         $class = current($metadata);
 
-        $this->assertEquals(ExportedUser::class, $class->name);
+        $this->assertEquals(ExportedUser::class, $class->getName());
 
         return $class;
     }

--- a/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
@@ -17,15 +17,15 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $childClassMetadata->discriminatorValue = 'child-discriminator';
         
         $classMetadata = new ClassMetadata('Entity');
-        $classMetadata->subClasses = [$childClassMetadata->name];
+        $classMetadata->subClasses = [$childClassMetadata->getName()];
         $classMetadata->name = 'Some\Class\Name';
         $classMetadata->discriminatorValue = 'discriminator';
 
         $em = $this->prophesize(EntityManagerInterface::class);
-        $em->getClassMetadata($classMetadata->name)
+        $em->getClassMetadata($classMetadata->getName())
             ->shouldBeCalled()
             ->willReturn($classMetadata);
-        $em->getClassMetadata($childClassMetadata->name)
+        $em->getClassMetadata($childClassMetadata->getName())
             ->shouldBeCalled()
             ->willReturn($childClassMetadata);
 
@@ -44,7 +44,7 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $classMetadata->discriminatorValue = 'discriminator';
 
         $em = $this->prophesize(EntityManagerInterface::class);
-        $em->getClassMetadata($classMetadata->name)
+        $em->getClassMetadata($classMetadata->getName())
             ->shouldBeCalled()
             ->willReturn($classMetadata);
 


### PR DESCRIPTION
this PR replace invalid access to name property on the Metadata Interface. The property is actually defined in its implementation MetadataInfo. The replacement is getName() function that is defined in the interface so it's valid.

There are still some read access to name that can't be replace as easily that I will look into if this PR is well received. Also there are write access and more properties that will have to be replaced.

Note: this is a good chunk of issues in the next level of PHPStan and future levels of Psalm