### PR TITLE
Fix deleting an element with index 0 from select expression in query AST due to casting false to 0

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -437,6 +437,10 @@ class Parser
             $expr = $this->identVariableExpressions[$dqlAlias];
             $key  = array_search($expr, $AST->selectClause->selectExpressions);
 
+            if ($key === false) {
+                continue;
+            }
+
             unset($AST->selectClause->selectExpressions[$key]);
 
             $AST->selectClause->selectExpressions[] = $expr;


### PR DESCRIPTION
@greg0ire If `identVariableExpression`doesn't exist in `$AST->selectClause->selectExpressions`, function `array_search` returns false. Then, the `unset` function deletes the invalid item (see https://3v4l.org/t1Ybf).