### PR TITLE
Fix for bug #8229 (id column from parent class renamed in child class)

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -37,6 +37,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function assert;
@@ -631,7 +632,7 @@ class BasicEntityPersister implements EntityPersister
                 // Get the correct class metadata
                 foreach ($class->parentClasses as $parentClassName) {
                     $parentClass = $this->em->getClassMetadata($parentClassName);
-                    if (\array_key_exists($field, $parentClass->fieldMappings)) {
+                    if (array_key_exists($field, $parentClass->fieldMappings)) {
                         $class = $parentClass;
                     }
                 }
@@ -646,10 +647,10 @@ class BasicEntityPersister implements EntityPersister
                 // and there the wrong class metadata in property "class" is used.
                 // By temporarily overwriting it, we get the correct values (the property
                 // "owningTableMap" must be correctly initialized there for entity updates).
-                $previousClass = $this->class;
-                $this->class = $class;
+                $previousClass                                      = $this->class;
+                $this->class                                        = $class;
                 $result[$this->getOwningTable($field)][$columnName] = $newVal;
-                $this->class = $previousClass;
+                $this->class                                        = $previousClass;
 
                 continue;
             }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -282,7 +282,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $rootTable = $this->quoteStrategy->getTableName($rootClass, $this->platform);
             $rootTypes = $this->getClassIdentifiersTypes($rootClass);
 
-            return (bool) $this->conn->delete($rootTable, $id, $rootTypes);
+            // Fix for bug GH-8229 (id column from parent class renamed in child class):
+            // Use the correct name for the id column as named in the root class.
+            $rootId = array_combine($rootClass->getIdentifierColumnNames(), $identifier);
+
+            return (bool) $this->conn->delete($rootTable, $rootId, $rootTypes);
         }
 
         // Delete from all tables individually, starting from this class' table up to the root table.

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -26,7 +26,6 @@ use Doctrine\DBAL\Types\Type;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Utility\PersisterHelper;
-
 use function array_combine;
 
 /**

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -27,6 +27,8 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\Utility\PersisterHelper;
 
+use function array_combine;
+
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
  * database as it is defined by the <tt>Class Table Inheritance</tt> strategy.
@@ -302,7 +304,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Fix for bug GH-8229 (id column from parent class renamed in child class):
             // Use the correct name for the id column as named in the parent class.
-            $parentId       = array_combine($parentMetadata->getIdentifierColumnNames(), $identifier);
+            $parentId = array_combine($parentMetadata->getIdentifierColumnNames(), $identifier);
 
             $this->conn->delete($parentTable, $parentId, $parentTypes);
         }

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,0 +1,90 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-8229
+ */
+class GH8229Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH8229Resource::class, GH8229User::class]);
+    }
+
+    public function testCorrectColumnNameInParentClassAfterAttributeOveride()
+    {
+        // Test creation
+        $entity = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Test reading
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals($identifier, $entity->id);
+
+        // Test update
+        $entity->username = 'bar';
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals('bar', $entity->username);
+
+        // Test deletion
+        $this->_em->remove($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_resource")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="resource_type", type="string", length=191)
+ * @DiscriminatorMap({
+ *     "resource"=GH8229Resource::class,
+ *     "user"=GH8229User::class,
+ * })
+ */
+abstract class GH8229Resource
+{
+    /**
+     * @Id()
+     * @Column(name="resource_id", type="integer")
+     */
+    public $id;
+
+    private static $sequence = 0;
+
+    protected function __construct()
+    {
+        $this->id = ++self::$sequence;
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_user")
+ * @AttributeOverrides({@AttributeOverride(name="id", column=@Column(name="user_id", type="integer"))})
+ */
+final class GH8229User extends GH8229Resource
+{
+    /**
+     * @Column(type="string", name="username", length=191, nullable=false)
+     */
+    public $username;
+
+    public function __construct($username)
+    {
+        parent::__construct();
+
+        $this->username = $username;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -18,7 +20,7 @@ class GH8229Test extends OrmFunctionalTestCase
     public function testCorrectColumnNameInParentClassAfterAttributeOveride()
     {
         // Test creation
-        $entity = new GH8229User('foo');
+        $entity     = new GH8229User('foo');
         $identifier = $entity->id;
         $this->_em->persist($entity);
         $this->_em->flush();
@@ -77,6 +79,8 @@ abstract class GH8229Resource
 final class GH8229User extends GH8229Resource
 {
     /**
+     * Additional property to test update
+     *
      * @Column(type="string", name="username", length=191, nullable=false)
      */
     public $username;

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\ORM\Functional;
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Tests\OrmFunctionalTestCase;
 


### PR DESCRIPTION
This fixes problems with id columns defined in the parent class but renamed in the child class using an attribute override. Before this change always the child column name was used (which was not present in the parent class), now the correct column names are used for the parent table when creating inserts, joins and deletions for it.