### PR TITLE
 Fix for bug #8229 (id column from parent class renamed in child class)

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -30,6 +30,7 @@ use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionProperty;
 use RuntimeException;
+use function array_key_exists;
 use function explode;
 
 /**
@@ -2260,6 +2261,12 @@ class ClassMetadataInfo implements ClassMetadata
 
         if ($overrideMapping['type'] !== $mapping['type']) {
             throw MappingException::invalidOverrideFieldType($this->name, $fieldName);
+        }
+
+        // Fix for bug GH-8229 (id column from parent class renamed in child class):
+        // The contained 'inherited' information was accidentally deleted by the unset() call below.
+        if (array_key_exists('inherited', $this->fieldMappings[$fieldName])) {
+            $overrideMapping['inherited'] = $this->fieldMappings[$fieldName]['inherited'];
         }
 
         unset($this->fieldMappings[$fieldName]);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -37,6 +37,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\ORM\Utility\PersisterHelper;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function assert;
@@ -447,14 +448,26 @@ class BasicEntityPersister implements EntityPersister
             $types[]    = $this->columnTypes[$columnName];
         }
 
-        $where      = [];
-        $identifier = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
+        $where                = [];
+        $identifier           = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
+        $quotedClassTableName = $this->quoteStrategy->getTableName($this->class, $this->platform);
 
         foreach ($this->class->identifier as $idField) {
             if ( ! isset($this->class->associationMappings[$idField])) {
-                $params[]   = $identifier[$idField];
-                $types[]    = $this->class->fieldMappings[$idField]['type'];
-                $where[]    = $this->quoteStrategy->getColumnName($idField, $this->class, $this->platform);
+                $params[] = $identifier[$idField];
+                $types[]  = $this->class->fieldMappings[$idField]['type'];
+
+                // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                // This method is called with the updated entity, but with different table names
+                // (the entity table name or a table name of an inherited entity). In dependence
+                // of the used table, the identifier name must be adjusted.
+                $class = $this->class;
+                if (isset($class->fieldMappings[$idField]['inherited']) && $quotedTableName !== $quotedClassTableName) {
+                    $className = $this->class->fieldMappings[$idField]['inherited'];
+                    $class     = $this->em->getClassMetadata($className);
+                }
+
+                $where[] = $this->quoteStrategy->getColumnName($idField, $class, $this->platform);
 
                 continue;
             }
@@ -632,7 +645,18 @@ class BasicEntityPersister implements EntityPersister
             $newVal = $change[1];
 
             if ( ! isset($this->class->associationMappings[$field])) {
-                $fieldMapping = $this->class->fieldMappings[$field];
+                $class = $this->class;
+
+                // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                // Get the correct class metadata
+                foreach ($class->parentClasses as $parentClassName) {
+                    $parentClass = $this->em->getClassMetadata($parentClassName);
+                    if (array_key_exists($field, $parentClass->fieldMappings)) {
+                        $class = $parentClass;
+                    }
+                }
+
+                $fieldMapping = $class->fieldMappings[$field];
                 $columnName   = $fieldMapping['columnName'];
 
                 $this->columnTypes[$columnName] = $fieldMapping['type'];
@@ -1672,11 +1696,17 @@ class BasicEntityPersister implements EntityPersister
     private function getSelectConditionStatementColumnSQL($field, $assoc = null)
     {
         if (isset($this->class->fieldMappings[$field])) {
-            $className = (isset($this->class->fieldMappings[$field]['inherited']))
-                ? $this->class->fieldMappings[$field]['inherited']
-                : $this->class->name;
+            // Fix for bug GH-8229 (id column from parent class renamed in child class):
+            // Use the correct metadata and name for the id column
+            if (isset($this->class->fieldMappings[$field]['inherited'])) {
+                $className = $this->class->fieldMappings[$field]['inherited'];
+                $class     = $this->em->getClassMetadata($className);
+            } else {
+                $className = $this->class->name;
+                $class     = $this->class;
+            }
 
-            return [$this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $this->class, $this->platform)];
+            return [$this->getSQLTableAlias($className) . '.' . $this->quoteStrategy->getColumnName($field, $class, $this->platform)];
         }
 
         if (isset($this->class->associationMappings[$field])) {

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -366,8 +366,12 @@ class SqlWalker implements TreeWalker
 
             $sqlParts = [];
 
-            foreach ($this->quoteStrategy->getIdentifierColumnNames($class, $this->platform) as $columnName) {
-                $sqlParts[] = $baseTableAlias . '.' . $columnName . ' = ' . $tableAlias . '.' . $columnName;
+            // Fix for bug GH-8229 (id column from parent class renamed in child class):
+            // Use the correct name for the id column as named in the parent class.
+            $identifierColumn       = $this->quoteStrategy->getIdentifierColumnNames($class, $this->platform);
+            $parentIdentifierColumn = $this->quoteStrategy->getIdentifierColumnNames($parentClass, $this->platform);
+            foreach ($identifierColumn as $index => $idColumn) {
+                $sqlParts[] = $baseTableAlias . '.' . $idColumn . ' = ' . $tableAlias . '.' . $parentIdentifierColumn[$index];
             }
 
             // Add filters on the root class
@@ -661,11 +665,21 @@ class SqlWalker implements TreeWalker
                 $dqlAlias = $pathExpr->identificationVariable;
                 $class = $this->queryComponents[$dqlAlias]['metadata'];
 
+                // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                // Use the correct name for the id column as named in the inherited class.
+                $mapping = $class->fieldMappings[$fieldName];
+                if (isset($mapping['inherited'])) {
+                    $inheritedClass   = $this->em->getClassMetadata($mapping['inherited']);
+                    $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $inheritedClass, $this->platform);
+                } else {
+                    $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
+                }
+
                 if ($this->useSqlTableAliases) {
                     $sql .= $this->walkIdentificationVariable($dqlAlias, $fieldName) . '.';
                 }
 
-                $sql .= $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
+                $sql .= $quotedColumnName;
                 break;
 
             case AST\PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION:
@@ -1405,13 +1419,19 @@ class SqlWalker implements TreeWalker
                         continue;
                     }
 
-                    $tableName = (isset($mapping['inherited']))
-                        ? $this->em->getClassMetadata($mapping['inherited'])->getTableName()
-                        : $class->getTableName();
+                    // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                    // Use the correct name for the id column as named in the inherited class.
+                    if (isset($mapping['inherited'])) {
+                        $inheritedClass   = $this->em->getClassMetadata($mapping['inherited']);
+                        $tableName        = $inheritedClass->getTableName();
+                        $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $inheritedClass, $this->platform);
+                    } else {
+                        $tableName        = $class->getTableName();
+                        $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
+                    }
 
-                    $sqlTableAlias    = $this->getSQLTableAlias($tableName, $dqlAlias);
-                    $columnAlias      = $this->getSQLColumnAlias($mapping['columnName']);
-                    $quotedColumnName = $this->quoteStrategy->getColumnName($fieldName, $class, $this->platform);
+                    $sqlTableAlias = $this->getSQLTableAlias($tableName, $dqlAlias);
+                    $columnAlias   = $this->getSQLColumnAlias($mapping['columnName']);
 
                     $col = $sqlTableAlias . '.' . $quotedColumnName;
 

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaTableEventArgs;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use function array_intersect_key;
 
 /**
  * The SchemaTool is a tool to create/drop/update database schemas based on
@@ -248,14 +249,20 @@ class SchemaTool
                     }
 
                     if ( ! empty($inheritedKeyColumns)) {
+                        // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                        // Use the correct name for the id columns as named in the parent class.
+                        $parentClass          = $this->em->getClassMetadata($class->rootEntityName);
+                        $parentKeyColumnNames = $parentClass->getIdentifierColumnNames();
+                        $parentKeyColumns     = array_intersect_key($parentKeyColumnNames, $inheritedKeyColumns);
+
                         // Add a FK constraint on the ID column
                         $table->addForeignKeyConstraint(
                             $this->quoteStrategy->getTableName(
-                                $this->em->getClassMetadata($class->rootEntityName),
+                                $parentClass,
                                 $this->platform
                             ),
                             $inheritedKeyColumns,
-                            $inheritedKeyColumns,
+                            $parentKeyColumns,
                             ['onDelete' => 'CASCADE']
                         );
                     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use function array_values;
+use function count;
+
+/**
+ * @group GH-8229
+ */
+class GH8229Test extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema(
+            [
+                GH8229Resource::class,
+                GH8229User::class,
+            ]
+        );
+    }
+
+    /**
+     * This tests the basic functionality when working with an entity using joined
+     * table inheritance and renamed identifier columns. It tests inserts, updates
+     * and deletions.
+     */
+    public function testCorrectColumnNameInParentClassAfterAttributeOveride()
+    {
+        // Test creation
+        $entity     = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Test reading (parent)
+        $entity = $this->_em->getRepository(GH8229Resource::class)->find($identifier);
+        self::assertEquals($identifier, $entity->id);
+
+        // Test update (parent)
+        $entity->status = 2;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+        $entity = $this->_em->getRepository(GH8229Resource::class)->find($identifier);
+        self::assertEquals(2, $entity->status);
+        $this->_em->clear();
+
+        // Test reading (child)
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals($identifier, $entity->id);
+
+        // Test update (child)
+        $entity->username = 'bar';
+        $entity->status   = 3;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals('bar', $entity->username);
+        self::assertEquals(3, $entity->status);
+
+        // Test deletion
+        $this->_em->remove($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    /**
+     * This test checks if foreign keys are generated for the schema, when a joined
+     * table inheritance is used and the identifier columns in the inheriting class
+     * are renamed.
+     */
+    public function testForeignKeyInChildClassAfterAttributeOveride()
+    {
+        $schemaTool = new SchemaTool($this->_em);
+
+        $schema = $schemaTool->getSchemaFromMetadata(
+            [
+                $this->_em->getClassMetadata(GH8229Resource::class),
+                $this->_em->getClassMetadata(GH8229User::class),
+            ]
+        );
+
+        $childTable            = $schema->getTable('gh8229_user');
+        $childTableForeignKeys = $childTable->getForeignKeys();
+
+        self::assertCount(1, $childTableForeignKeys);
+    }
+
+    /**
+     * This test checks if data are completely deleted, when a joined table inheritance is used,
+     * and the DBAL component generally supports foreign keys for the current platform, but the
+     * foreign keys never existed, have been removed or disabled.
+     */
+    public function testJoinedTableDeletionWithDisabledForeignKeys()
+    {
+        // Remove foreign key (if it exists)
+        $connection = $this->_em->getConnection();
+        $platform   = $connection->getDatabasePlatform();
+        if ($platform->supportsForeignKeyConstraints()) {
+            $class       = $this->_em->getClassMetadata(GH8229User::class);
+            $table       = $this->_schemaTool->getSchemaFromMetadata([$class])->getTable('gh8229_user');
+            $foreignKeys = $table->getForeignKeys();
+
+            // Check if really set (seems to be not the case in MariaDB and MySQL)
+            if (count($foreignKeys) > 0) {
+                $statement = $platform->getDropForeignKeySQL(array_values($foreignKeys)[0], $table);
+                $connection->exec($statement);
+            }
+        }
+
+        // Create entity
+        $entity     = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Delete entity
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        $this->_em->remove($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Check if the child entry has been really deleted
+        $result    = $connection->executeQuery('SELECT 1 FROM gh8229_user WHERE user_id = ?', [$identifier]);
+        $foundRows = count($result->fetchAll()); // Note: $result->rowCount() returns 1 instead of 0 in SQLite!
+        self::assertSame(0, $foundRows);
+    }
+
+    /**
+     * This test checks the SQL generated for a DQL, because in the SELECT part, the JOIN part
+     * and the ORDER BY part the wrong column names were used.
+     */
+    public function testCorrectColumnNamesInSQLFromDQL()
+    {
+        // Create entity
+        $entity     = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Query entity
+        $dql   = 'SELECT o FROM Doctrine\Tests\ORM\Functional\Ticket\GH8229User o WHERE o.id = :id GROUP BY o.id, o.username ORDER BY o.id ASC';
+        $query = $this->_em->createQuery($dql);
+        $query = $query->setParameter('id', $identifier);
+        self::assertEquals($identifier, $query->getSingleResult()->id);
+
+        // Delete entity
+        $entity = $this->_em->getRepository(GH8229User::class)->find($identifier);
+        $this->_em->remove($entity);
+        $this->_em->flush();
+        $this->_em->clear();
+    }
+
+    /**
+     * This test checks the the right columns are used when creating a pessimistic write lock
+     * for an entity with joined table inheritance.
+     */
+    public function testCorrectColumnNamesInPessimisticWriteLock()
+    {
+        // Create entity
+        $entity     = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        // Test lock
+        $this->_em->getConnection()->beginTransaction();
+        $this->_em->lock($entity, LockMode::PESSIMISTIC_WRITE);
+        $this->_em->getConnection()->commit();
+        $this->_em->clear();
+
+        self::assertEquals($identifier, $entity->id);
+    }
+}
+
+
+/**
+ * @Entity
+ * @Table(name="gh8229_resource")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="resource_type", type="string", length=191)
+ * @DiscriminatorMap({
+ *     "resource"=GH8229Resource::class,
+ *     "user"=GH8229User::class,
+ * })
+ */
+abstract class GH8229Resource
+{
+    /**
+     * @Id()
+     * @Column(name="resource_id", type="integer")
+     */
+    public $id;
+
+    /**
+     * Additional property to test update
+     *
+     * @Column(type="integer", name="resource_status", nullable=false)
+     */
+    public $status;
+
+    private static $sequence = 0;
+
+    protected function __construct()
+    {
+        $this->id     = ++self::$sequence;
+        $this->status = 1;
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_user")
+ * @AttributeOverrides({
+ *     @AttributeOverride(name="id", column=@Column(name="user_id", type="integer")),
+ *     @AttributeOverride(name="status", column=@Column(name="user_status", type="integer"))
+ * })
+ */
+final class GH8229User extends GH8229Resource
+{
+    /**
+     * Additional property to test update
+     *
+     * @Column(type="string", name="username", length=191, nullable=false)
+     */
+    public $username;
+
+    public function __construct($username)
+    {
+        parent::__construct();
+
+        $this->username = $username;
+    }
+}


### PR DESCRIPTION
This fixes problems with id columns defined in the parent class but renamed in the child class using an attribute override. Before this change always the child column name was used (which was not present in the parent class), now the correct column names are used for the parent table when creating inserts, joins and deletions for it.