### PR TITLE
 Fix for bug doctrine#8229 (id column from parent class renamed in child class)

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -621,6 +621,15 @@ class BasicEntityPersister implements EntityPersister
                     break;
 
                 case $property instanceof LocalColumnMetadata:
+                    // Fix for bug GH-8229 (id column from parent class renamed in child class):
+                    // Get the correct class metadata
+                    $class = $this->class;
+                    while ($class = $class->getParent()) {
+                        if ($class->hasProperty($propertyName)) {
+                            $property = $class->getProperty($propertyName);
+                        }
+                    }
+
                     $columnTableName = $property->getTableName() ?? $tableName;
                     $columnName      = sprintf('%s%s', $columnPrefix, $property->getColumnName());
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -436,14 +437,14 @@ class BasicEntityPersister implements EntityPersister
      * Performs an UPDATE statement for an entity on a specific table.
      * The UPDATE can optionally be versioned, which requires the entity to have a version field.
      *
-     * @param object $entity          The entity object being updated.
-     * @param string $quotedTableName The quoted name of the table to apply the UPDATE on.
-     * @param mixed[] $updateData     The map of columns to update (column => value).
-     * @param bool $versioned         Whether the UPDATE should be versioned.
+     * @param object  $entity          The entity object being updated.
+     * @param string  $quotedTableName The quoted name of the table to apply the UPDATE on.
+     * @param mixed[] $updateData      The map of columns to update (column => value).
+     * @param bool    $versioned       Whether the UPDATE should be versioned.
      *
      * @throws ORMException
      * @throws OptimisticLockException
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     final protected function updateTable($entity, $quotedTableName, array $updateData, $versioned = false)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -80,7 +80,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         // Collect identifier column values
-        $id = [];
+        $id           = [];
         $idParameters = [];
 
         foreach ($this->class->getIdentifier() as $propertyName) {

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -7,11 +7,9 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Statement;
-use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ColumnMetadata;
 use Doctrine\ORM\Mapping\FieldMetadata;
-use Doctrine\ORM\Mapping\JoinColumnMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToManyAssociationMetadata;
 use Doctrine\ORM\Mapping\ToOneAssociationMetadata;
@@ -20,8 +18,8 @@ use function array_combine;
 use function array_filter;
 use function array_keys;
 use function array_merge;
+use function array_values;
 use function implode;
-use function is_array;
 
 /**
  * The joined subclass persister maps a single entity instance to several tables in the
@@ -458,7 +456,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     private function getJoinSql($baseTableAlias)
     {
         $joinSql           = '';
-        $identifierColumns = \array_values($this->class->getIdentifierColumns($this->em));
+        $identifierColumns = array_values($this->class->getIdentifierColumns($this->em));
 
         // INNER JOIN parent tables
         $parentClass = $this->class;
@@ -471,9 +469,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Fix for bug GH-8229 (id column from parent class renamed in child class):
             // Use the correct name for the id column as named in the parent class.
-            $parentIdentifierColumns = \array_values($parentClass->getIdentifierColumns($this->em));
+            $parentIdentifierColumns = array_values($parentClass->getIdentifierColumns($this->em));
             foreach ($identifierColumns as $index => $idColumn) {
-                $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
+                $quotedColumnName       = $this->platform->quoteIdentifier($idColumn->getColumnName());
                 $quotedParentColumnName = $this->platform->quoteIdentifier($parentIdentifierColumns[$index]->getColumnName());
 
                 $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedParentColumnName;
@@ -492,9 +490,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 
             // Fix for bug GH-8229 (id column from parent class renamed in child class):
             // Use the correct name for the id column as named in the parent class.
-            $subClassIdentifierColumns = \array_values($subClass->getIdentifierColumns($this->em));
+            $subClassIdentifierColumns = array_values($subClass->getIdentifierColumns($this->em));
             foreach ($identifierColumns as $index => $idColumn) {
-                $quotedColumnName = $this->platform->quoteIdentifier($idColumn->getColumnName());
+                $quotedColumnName         = $this->platform->quoteIdentifier($idColumn->getColumnName());
                 $quotedSubClassColumnName = $this->platform->quoteIdentifier($subClassIdentifierColumns[$index]->getColumnName());
 
                 $conditions[] = $baseTableAlias . '.' . $quotedColumnName . ' = ' . $tableAlias . '.' . $quotedSubClassColumnName;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -186,7 +186,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $rootClass = $this->em->getClassMetadata($this->class->getRootClassName());
             $rootTable = $rootClass->table->getQuotedQualifiedName($this->platform);
 
-            return (bool) $this->conn->delete($rootTable, $id);
+            // Fix for bug GH-8229 (id column from parent class renamed in child class):
+            // Use the correct name for the id column as named in the root class.
+            $rootId = array_combine(array_keys($rootClass->getIdentifierColumns($this->em)), $identifier);
+
+            return (bool) $this->conn->delete($rootTable, $rootId);
         }
 
         // Delete from all tables individually, starting from this class' table up to the root table.

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,8 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\ORM\Annotation\AttributeOverrides;
 use Doctrine\ORM\Annotation\AttributeOverride;
+use Doctrine\ORM\Annotation\AttributeOverrides;
 use Doctrine\ORM\Annotation\Column;
 use Doctrine\ORM\Annotation\DiscriminatorColumn;
 use Doctrine\ORM\Annotation\DiscriminatorMap;
@@ -17,7 +19,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
  */
 class GH8229Test extends OrmFunctionalTestCase
 {
-    protected function setUp(): void
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -27,7 +29,7 @@ class GH8229Test extends OrmFunctionalTestCase
     public function testCorrectColumnNameInParentClassAfterAttributeOveride()
     {
         // Test creation
-        $entity = new GH8229User('foo');
+        $entity     = new GH8229User('foo');
         $identifier = $entity->id;
         $this->em->persist($entity);
         $this->em->flush();
@@ -86,6 +88,8 @@ abstract class GH8229Resource
 final class GH8229User extends GH8229Resource
 {
     /**
+     * Additional property to test update
+     *
      * @Column(type="string", name="username", length=191, nullable=false)
      */
     public $username;

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;

--- a/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/GH8229Test.php
@@ -1,0 +1,99 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Annotation\AttributeOverrides;
+use Doctrine\ORM\Annotation\AttributeOverride;
+use Doctrine\ORM\Annotation\Column;
+use Doctrine\ORM\Annotation\DiscriminatorColumn;
+use Doctrine\ORM\Annotation\DiscriminatorMap;
+use Doctrine\ORM\Annotation\Entity;
+use Doctrine\ORM\Annotation\Id;
+use Doctrine\ORM\Annotation\InheritanceType;
+use Doctrine\ORM\Annotation\Table;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-8229
+ */
+class GH8229Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([GH8229Resource::class, GH8229User::class]);
+    }
+
+    public function testCorrectColumnNameInParentClassAfterAttributeOveride()
+    {
+        // Test creation
+        $entity = new GH8229User('foo');
+        $identifier = $entity->id;
+        $this->em->persist($entity);
+        $this->em->flush();
+        $this->em->clear();
+
+        // Test reading
+        $entity = $this->em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals($identifier, $entity->id);
+
+        // Test update
+        $entity->username = 'bar';
+        $this->em->persist($entity);
+        $this->em->flush();
+        $this->em->clear();
+        $entity = $this->em->getRepository(GH8229User::class)->find($identifier);
+        self::assertEquals('bar', $entity->username);
+
+        // Test deletion
+        $this->em->remove($entity);
+        $this->em->flush();
+        $this->em->clear();
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_resource")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="resource_type", type="string", length=191)
+ * @DiscriminatorMap({
+ *     "resource"=GH8229Resource::class,
+ *     "user"=GH8229User::class,
+ * })
+ */
+abstract class GH8229Resource
+{
+    /**
+     * @Id()
+     * @Column(name="resource_id", type="integer")
+     */
+    public $id;
+
+    private static $sequence = 0;
+
+    protected function __construct()
+    {
+        $this->id = ++self::$sequence;
+    }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_user")
+ * @AttributeOverrides({@AttributeOverride(name="id", column=@Column(name="user_id", type="integer"))})
+ */
+final class GH8229User extends GH8229Resource
+{
+    /**
+     * @Column(type="string", name="username", length=191, nullable=false)
+     */
+    public $username;
+
+    public function __construct($username)
+    {
+        parent::__construct();
+
+        $this->username = $username;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\ORM\Functional;
+namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\ORM\Annotation\AttributeOverride;
 use Doctrine\ORM\Annotation\AttributeOverrides;


### PR DESCRIPTION
This fixes problems with id columns defined in the parent class but renamed in the child class using an attribute override. Before this change always the child column name was used (which was not present in the parent class), now the correct column names are used for the parent table when creating inserts, joins and deletions for it.