### PR TITLE
Add two new events: initializePersistentCollection and initializeProxy

### DIFF
--- a/lib/Doctrine/ORM/Event/InitializePersistentCollectionEventArgs.php
+++ b/lib/Doctrine/ORM/Event/InitializePersistentCollectionEventArgs.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\ORM\PersistentCollection;
+
+/**
+ * Provides event arguments for the initializePersistentCollection event.
+ */
+class InitializePersistentCollectionEventArgs extends EventArgs
+{
+    /** @var PersistentCollection */
+    private $collection;
+
+    public function __construct(PersistentCollection $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Retrieve associated collection.
+     */
+    public function getCollection() : PersistentCollection
+    {
+        return $this->collection;
+    }
+}

--- a/lib/Doctrine/ORM/Event/InitializeProxyEventArgs.php
+++ b/lib/Doctrine/ORM/Event/InitializeProxyEventArgs.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\Proxy\Proxy;
+
+/**
+ * Provides event arguments for the initializeProxy event.
+ */
+class InitializeProxyEventArgs extends EventArgs
+{
+    /** @var Proxy */
+    private $proxy;
+
+    public function __construct(Proxy $proxy)
+    {
+        $this->proxy = $proxy;
+    }
+
+    /**
+     * Retrieve associated proxy.
+     */
+    public function getProxy() : Proxy
+    {
+        return $this->proxy;
+    }
+}

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -164,4 +164,14 @@ final class Events
      * @var string
      */
     const onClear = 'onClear';
+
+    /**
+     * The initializePersistentCollection event occurs after a PersistentCollection got initialized.
+     */
+    public const initializePersistentCollection = 'initializePersistentCollection';
+
+    /**
+     * The initializeProxy event occurs after a Proxy got initialized.
+     */
+    public const initializeProxy = 'initializeProxy';
 }

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -24,6 +24,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Event\InitializePersistentCollectionEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use function get_class;
 
@@ -696,6 +697,10 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
 
         if ($newlyAddedDirtyObjects) {
             $this->restoreNewObjectsInDirtyCollection($newlyAddedDirtyObjects);
+        }
+
+        if ($this->em->getEventManager()->hasListeners(Events::initializePersistentCollection)) {
+            $this->em->getEventManager()->dispatchEvent(Events::initializePersistentCollection, new InitializePersistentCollectionEventArgs($this));
         }
     }
 

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -25,6 +25,8 @@ use Doctrine\Common\Proxy\ProxyDefinition;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\InitializeProxyEventArgs;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Utility\IdentifierFlattener;
@@ -163,6 +165,10 @@ class ProxyFactory extends AbstractProxyFactory
                     $classMetadata->getName(),
                     $this->identifierFlattener->flattenIdentifier($classMetadata, $identifier)
                 );
+            }
+
+            if ($this->em->getEventManager()->hasListeners(Events::initializeProxy)) {
+                $this->em->getEventManager()->dispatchEvent(Events::initializeProxy, new InitializeProxyEventArgs($proxy));
             }
         };
     }

--- a/tests/Doctrine/Tests/ORM/Functional/InitializePersistentCollectionEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/InitializePersistentCollectionEventTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Event\InitializePersistentCollectionEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class InitializePersistentCollectionEventTest extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testEventIsCalledOnPersistentCollectionInitialization()
+    {
+        $listener = new InitializePersistentCollectionListener();
+        $this->_em->getEventManager()->addEventListener(Events::initializePersistentCollection, $listener);
+
+        // Prerequisite: create, persist and flush an entity
+        $user           = new CmsUser();
+        $user->username = 'username';
+        $user->name     = 'name';
+        $this->_em->persist($user);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        /** @var CmsUser $user */
+        $user   = $this->_em->getRepository(CmsUser::class)->findAll()[0];
+        $phones = $user->getPhonenumbers();
+        // Action: this triggers the actual collection initialization
+        $phones->first();
+
+        // Expectation: initialization event has been called
+        $this->assertTrue($listener->called);
+    }
+}
+
+class InitializePersistentCollectionListener
+{
+    public $called = false;
+
+    public function initializePersistentCollection(InitializePersistentCollectionEventArgs $args)
+    {
+        $this->called = true;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/InitializeProxyEventTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/InitializeProxyEventTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Common\Proxy\Proxy;
+use Doctrine\ORM\Event\InitializeProxyEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\Tests\Models\CMS\CmsGroup;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use function get_class;
+
+class InitializeProxyEventTest extends OrmFunctionalTestCase
+{
+    protected function setUp()
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testEventIsCalledOnProxyInitialization()
+    {
+        $listener = new InitializeProxyListener();
+        $this->_em->getEventManager()->addEventListener(Events::initializeProxy, $listener);
+
+        // Prerequisite: create, persist and flush an entity
+        $group       = new CmsGroup();
+        $group->name = 'name';
+        $this->_em->persist($group);
+        $this->_em->flush();
+        // Prerequisite: get a proxy for the persisted entity
+        $proxy = $this->getProxy($group);
+
+        // Action: this triggers the proxy initialization
+        $proxy->getName();
+
+        // Expectation: initialization event has been called
+        $this->assertTrue($listener->called);
+    }
+
+    /**
+     * @param object $object
+     *
+     * @return Proxy
+     */
+    private function getProxy($object)
+    {
+        $metadataFactory = $this->_em->getMetadataFactory();
+        $className       = get_class($object);
+        $identifier      = $metadataFactory->getMetadataFor($className)->getIdentifierValues($object);
+
+        return $this->_em->getProxyFactory()->getProxy($className, $identifier);
+    }
+}
+
+class InitializeProxyListener
+{
+    public $called = false;
+
+    public function initializeProxy(InitializeProxyEventArgs $args)
+    {
+        $this->called = true;
+    }
+}


### PR DESCRIPTION
This pull request adds two new events so that they can be observed from userland. The two new events are
- `initializeProxy`: called each time a proxy is initialized
- `initializePersistentCollection`: called each time a persistent collection is initialized.

The use case behind this PR is to provide an hook to be able to detect n+1. See [n-plus-one-detector](https://github.com/danydev/doctrine-n-plus-one-detector)