### PR TITLE
Allow doctrine/inflector v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/common": "^2.11 || ^3.0",
         "doctrine/dbal": "^2.9.3",
         "doctrine/event-manager": "^1.1",
-        "doctrine/inflector": "^1.0",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "doctrine/instantiator": "^1.3",
         "doctrine/lexer": "^1.0",
         "doctrine/persistence": "^1.3.3 || ^2.0",


### PR DESCRIPTION
> doctrine/inflector Release 2.0.0
This release drops the deprecated legacy API. To allow installing this version, please upgrade to the new API, then change the composer constraint for inflector to "doctrine/inflector": "^1.4 || ^2.0.

but I can't because `doctrine/orm` requires only 1.4 version. Maybe `doctrine/orm` not ready yet?

not sure how to update composer.json tried like this but :( 
```
vytautas@work ~/p/g/doctrine2> composer update                                                                                                                                                                                                                                                                                                                                                                           patch-2
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - doctrine/inflector 2.0.3 requires php ^7.2 || ^8.0 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 2.0.2 requires php ^7.2 || ^8.0 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 2.0.1 requires php ^7.2 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 2.0.0 requires php ^7.2 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 1.4.x-dev requires php ^7.2 || ^8.0 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 1.4.3 requires php ^7.2 || ^8.0 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 1.4.2 requires php ^7.2 || ^8.0 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 1.4.1 requires php ^7.2 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - doctrine/inflector 1.4.0 requires php ^7.2 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1.3) does not satisfy that requirement.
    - Installation request for doctrine/inflector ^1.4 || ^2.0 -> satisfiable by doctrine/inflector[1.4.0, 1.4.1, 1.4.2, 1.4.3, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 1.4.x-dev].

vytautas@work ~/p/g/doctrine2> php -v                                                                                                                                                                                                                                                                                                                                                                                  2 patch-2
PHP 7.4.9 (cli) (built: Aug  7 2020 14:29:36) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.9, Copyright (c), by Zend Technologies
```