### PR TITLE
Stop using the DBAL extension of PHPBench

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -3,13 +3,6 @@
     "path": "tests/Doctrine/Performance",
 
     "extensions": [
-        "PhpBench\\Extensions\\Dbal\\DbalExtension",
         "PhpBench\\Extensions\\XDebug\\XDebugExtension"
-    ],
-
-    "storage": "dbal",
-    "storage.dbal.connection": {
-        "driver": "pdo_sqlite",
-        "path": "tests/Doctrine/Performance/history.db"
-    }
+    ]
 }


### PR DESCRIPTION
It has been removed, and the default XML storage driver is supposed to
be fine for our purposes.

See #8249 

[The build seems to be currently broken](https://github.com/doctrine/orm/pull/8251), that should fix it