### PR TITLE
Catch doctrine/persistence MappingException

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -23,10 +23,10 @@ use Countable;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
-use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
-use Doctrine\Persistence\Mapping\MappingException;
-use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Cache\QueryCacheKey;
+use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
+use Doctrine\ORM\Query\Parameter;
+use Doctrine\Persistence\Mapping\MappingException;
 use Traversable;
 use function array_map;
 use function array_shift;
@@ -446,7 +446,7 @@ abstract class AbstractQuery
             if ($value === null) {
                 throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
             }
-        } catch (ORMMappingException $e) {
+        } catch (MappingException | ORMMappingException $e) {
             // Silence any mapping exceptions. These can occur if the object in
             // question is not a mapped entity, in which case we just don't do
             // any preparation on the value.

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -452,11 +452,6 @@ abstract class AbstractQuery
             // any preparation on the value.
 
             $value = $this->potentiallyProcessIterable($value);
-        } catch (MappingException $e) {
-            // as previous, but depending on MappingDriver this exception from Persistence
-            // is thrown and not the ORM one.
-
-            $value = $this->potentiallyProcessIterable($value);
         }
 
         return $value;

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -447,9 +447,11 @@ abstract class AbstractQuery
                 throw ORMInvalidArgumentException::invalidIdentifierBindingEntity();
             }
         } catch (MappingException | ORMMappingException $e) {
-            // Silence any mapping exceptions. These can occur if the object in
-            // question is not a mapped entity, in which case we just don't do
-            // any preparation on the value.
+            /* Silence any mapping exceptions. These can occur if the object in
+               question is not a mapped entity, in which case we just don't do
+               any preparation on the value.
+               Depending on MappingDriver, either MappingException or
+               ORMMappingException is thrown. */
 
             $value = $this->potentiallyProcessIterable($value);
         }

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -3,6 +3,7 @@
 namespace Doctrine\Tests\ORM\Query;
 
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
@@ -11,6 +12,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Tests\Mocks\DriverConnectionMock;
 use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Mocks\StatementArrayMock;
@@ -228,7 +230,7 @@ class QueryTest extends OrmTestCase
     /**
      * @dataProvider provideProcessParameterValueIterable
      */
-    public function testProcessParameterValueIterable(iterable $cities) : void
+    public function testProcessParameterValueIterable(iterable $cities): void
     {
         $query = $this->_em->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.city IN (:cities)');
         self::assertEquals(
@@ -272,6 +274,19 @@ class QueryTest extends OrmTestCase
             12345,
             $query->processParameterValue($user)
         );
+    }
+
+    public function testProcessParameterValueValueObjectWithDriverChain(): void
+    {
+        $driverChain = new MappingDriverChain();
+        $driverChain->addDriver($this->createAnnotationDriver(), 'Foo');
+        $this->_em->getConfiguration()->setMetadataDriverImpl($driverChain);
+
+        $query = $this->_em->createQuery();
+
+        $vo = new DateTimeImmutable('2020-09-01 00:00:00');
+
+        self::assertSame($vo, $query->processParameterValue($vo));
     }
 
     public function testProcessParameterValueNull() : void


### PR DESCRIPTION
When driver chain is used doctrine/persistence MappingException is thrown instead of doctrine/orm MappingException