### PR TITLE
Fix OrderByItem parser to proceed with SimpleArithmetic expression before function

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1510,10 +1510,6 @@ class Parser
         $glimpse = $this->lexer->glimpse();
 
         switch (true) {
-            case ($this->isFunction()):
-                $expr = $this->FunctionDeclaration();
-                break;
-
             case ($this->isMathOperator($peek)):
                 $expr = $this->SimpleArithmeticExpression();
                 break;
@@ -1524,6 +1520,10 @@ class Parser
 
             case ($this->lexer->peek() && $this->isMathOperator($this->peekBeyondClosingParenthesis())):
                 $expr = $this->ScalarExpression();
+                break;
+
+            case $this->isFunction():
+                $expr = $this->FunctionDeclaration();
                 break;
 
             default:

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -281,11 +281,20 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT f0_.id AS id_0, f0_.username AS username_1 FROM forum_users f0_ ORDER BY f0_.id ASC'
         );
     }
+
     public function testSupportsOrderByDesc()
     {
         $this->assertSqlGeneration(
             'SELECT u FROM Doctrine\Tests\Models\Forum\ForumUser u ORDER BY u.id desc',
             'SELECT f0_.id AS id_0, f0_.username AS username_1 FROM forum_users f0_ ORDER BY f0_.id DESC'
+        );
+    }
+
+    public function testSupportsOrderByWithSimpleArithmeticExpression() : void
+    {
+        $this->assertSqlGeneration(
+            'SELECT u FROM Doctrine\Tests\Models\Forum\ForumUser u ORDER BY LENGTH(u.username) + LENGTH(u.username) asc',
+            'SELECT f0_.id AS id_0, f0_.username AS username_1 FROM forum_users f0_ ORDER BY LENGTH(f0_.username) + LENGTH(f0_.username) ASC'
         );
     }
 


### PR DESCRIPTION
Hi,

Fix #7626 

There is parser bug for `OrderByItem()`, where a **function** is detected before a **SimpleArithmeticExpression** while it should be the reverse: simple arithmetic expressions can start with a **function** too, and thus they should be matched first if present.

This fix enables the use of expression in sorting and with window functions.

