### PR TITLE
Use inline literals over escaping

### DIFF
--- a/docs/en/cookbook/dql-custom-walkers.rst
+++ b/docs/en/cookbook/dql-custom-walkers.rst
@@ -167,7 +167,7 @@ can be set via ``Query::setHint($name, $value)`` as shown in the
 previous example with the ``HINT_CUSTOM_TREE_WALKERS`` query hint.
 
 We will implement a custom Output Walker that allows to specify the
-SQL\_NO\_CACHE query hint.
+``SQL_NO_CACHE`` query hint.
 
 .. code-block:: php
 
@@ -180,7 +180,7 @@ SQL\_NO\_CACHE query hint.
 
 Our ``MysqlWalker`` will extend the default ``SqlWalker``. We will
 modify the generation of the SELECT clause, adding the
-SQL\_NO\_CACHE on those queries that need it:
+``SQL_NO_CACHE`` on those queries that need it:
 
 .. code-block:: php
 


### PR DESCRIPTION

Escaping underscores does not work as expected.
See https://www.doctrine-project.org/projects/doctrine-orm/en/latest/cookbook/dql-custom-walkers.html#modify-the-output-walker-to-generate-vendor-specific-sql


![Screenshot_2020-09-22 Extending DQL in Doctrine 2 Custom AST Walkers - Doctrine Object Relational Mapper (ORM)](https://user-images.githubusercontent.com/657779/93850378-3e6c1080-fcae-11ea-801c-e0586abfed03.png)