### PR TITLE
rename parameters to match parents

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -544,18 +544,18 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadManyToManyCollection(array $assoc, $sourceEntity, PersistentCollection $coll)
+    public function loadManyToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection)
     {
         $persister = $this->uow->getCollectionPersister($assoc);
         $hasCache  = ($persister instanceof CachedPersister);
 
         if ( ! $hasCache) {
-            return $this->persister->loadManyToManyCollection($assoc, $sourceEntity, $coll);
+            return $this->persister->loadManyToManyCollection($assoc, $sourceEntity, $collection);
         }
 
-        $ownerId = $this->uow->getEntityIdentifier($coll->getOwner());
+        $ownerId = $this->uow->getEntityIdentifier($collection->getOwner());
         $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
-        $list    = $persister->loadCollectionCache($coll, $key);
+        $list    = $persister->loadCollectionCache($collection, $key);
 
         if ($list !== null) {
             if ($this->cacheLogger) {
@@ -565,7 +565,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             return $list;
         }
 
-        $list = $this->persister->loadManyToManyCollection($assoc, $sourceEntity, $coll);
+        $list = $this->persister->loadManyToManyCollection($assoc, $sourceEntity, $collection);
 
         $persister->storeCollectionCache($key, $list);
 
@@ -579,18 +579,18 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToManyCollection(array $assoc, $sourceEntity, PersistentCollection $coll)
+    public function loadOneToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection)
     {
         $persister = $this->uow->getCollectionPersister($assoc);
         $hasCache  = ($persister instanceof CachedPersister);
 
         if ( ! $hasCache) {
-            return $this->persister->loadOneToManyCollection($assoc, $sourceEntity, $coll);
+            return $this->persister->loadOneToManyCollection($assoc, $sourceEntity, $collection);
         }
 
-        $ownerId = $this->uow->getEntityIdentifier($coll->getOwner());
+        $ownerId = $this->uow->getEntityIdentifier($collection->getOwner());
         $key     = $this->buildCollectionCacheKey($assoc, $ownerId);
-        $list    = $persister->loadCollectionCache($coll, $key);
+        $list    = $persister->loadCollectionCache($collection, $key);
 
         if ($list !== null) {
             if ($this->cacheLogger) {
@@ -600,7 +600,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
             return $list;
         }
 
-        $list = $this->persister->loadOneToManyCollection($assoc, $sourceEntity, $coll);
+        $list = $this->persister->loadOneToManyCollection($assoc, $sourceEntity, $collection);
 
         $persister->storeCollectionCache($key, $list);
 

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -175,9 +175,9 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritdoc}
      */
-    public function find($entityName, $id, $lockMode = null, $lockVersion = null)
+    public function find($className, $id, $lockMode = null, $lockVersion = null)
     {
-        return $this->wrapped->find($entityName, $id, $lockMode, $lockVersion);
+        return $this->wrapped->find($className, $id, $lockMode, $lockVersion);
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -373,7 +373,7 @@ use function trigger_error;
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string       $entityName  The class name of the entity to find.
+     * @param string       $className  The class name of the entity to find.
      * @param mixed        $id          The identity of the entity to find.
      * @param integer|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
      *                                  or NULL if no specific lock mode should be used
@@ -388,9 +388,9 @@ use function trigger_error;
      * @throws TransactionRequiredException
      * @throws ORMException
      */
-    public function find($entityName, $id, $lockMode = null, $lockVersion = null)
+    public function find($className, $id, $lockMode = null, $lockVersion = null)
     {
-        $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
+        $class = $this->metadataFactory->getMetadataFor(ltrim($className, '\\'));
 
         if ($lockMode !== null) {
             $this->checkLockRequirements($lockMode, $class);

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -31,6 +31,7 @@ use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\Persistence\ObjectRepository;
 use Throwable;
+use function ltrim;
 use const E_USER_DEPRECATED;
 use function trigger_error;
 
@@ -373,7 +374,7 @@ use function trigger_error;
     /**
      * Finds an Entity by its identifier.
      *
-     * @param string       $className  The class name of the entity to find.
+     * @param string       $className   The class name of the entity to find.
      * @param mixed        $id          The identity of the entity to find.
      * @param integer|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
      *                                  or NULL if no specific lock mode should be used

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -228,8 +228,8 @@ abstract class AbstractHydrator
      *
      * Template method.
      *
-     * @param array $row    The row data.
-     * @param array $result The result to fill.
+     * @param mixed[] $row    The row data.
+     * @param mixed[] $result The result to fill.
      *
      * @return void
      *

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -228,14 +228,14 @@ abstract class AbstractHydrator
      *
      * Template method.
      *
-     * @param array $data   The row data.
+     * @param array $row    The row data.
      * @param array $result The result to fill.
      *
      * @return void
      *
      * @throws HydrationException
      */
-    protected function hydrateRowData(array $data, array &$result)
+    protected function hydrateRowData(array $row, array &$result)
     {
         throw new HydrationException("hydrateRowData() not implemented by this hydrator.");
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
@@ -47,8 +47,8 @@ class ScalarHydrator extends AbstractHydrator
     /**
      * {@inheritdoc}
      */
-    protected function hydrateRowData(array $data, array &$result)
+    protected function hydrateRowData(array $row, array &$result)
     {
-        $result[] = $this->gatherScalarRowData($data);
+        $result[] = $this->gatherScalarRowData($row);
     }
 }

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -77,7 +77,7 @@ class SimpleObjectHydrator extends AbstractHydrator
     /**
      * {@inheritdoc}
      */
-    protected function hydrateRowData(array $sqlResult, array &$result)
+    protected function hydrateRowData(array $row, array &$result)
     {
         $entityName       = $this->class->name;
         $data             = [];
@@ -92,27 +92,27 @@ class SimpleObjectHydrator extends AbstractHydrator
                 $discrColumnName = $metaMappingDiscrColumnName;
             }
 
-            if ( ! isset($sqlResult[$discrColumnName])) {
+            if ( ! isset($row[$discrColumnName])) {
                 throw HydrationException::missingDiscriminatorColumn($entityName, $discrColumnName, key($this->_rsm->aliasMap));
             }
 
-            if ($sqlResult[$discrColumnName] === '') {
+            if ($row[$discrColumnName] === '') {
                 throw HydrationException::emptyDiscriminatorValue(key($this->_rsm->aliasMap));
             }
 
             $discrMap = $this->class->discriminatorMap;
 
-            if ( ! isset($discrMap[$sqlResult[$discrColumnName]])) {
-                throw HydrationException::invalidDiscriminatorValue($sqlResult[$discrColumnName], array_keys($discrMap));
+            if ( ! isset($discrMap[$row[$discrColumnName]])) {
+                throw HydrationException::invalidDiscriminatorValue($row[$discrColumnName], array_keys($discrMap));
             }
 
-            $entityName       = $discrMap[$sqlResult[$discrColumnName]];
-            $discrColumnValue = $sqlResult[$discrColumnName];
+            $entityName       = $discrMap[$row[$discrColumnName]];
+            $discrColumnValue = $row[$discrColumnName];
 
-            unset($sqlResult[$discrColumnName]);
+            unset($row[$discrColumnName]);
         }
 
-        foreach ($sqlResult as $column => $value) {
+        foreach ($row as $column => $value) {
             // An ObjectHydrator should be used instead of SimpleObjectHydrator
             if (isset($this->_rsm->relationMap[$column])) {
                 throw new \Exception(sprintf('Unable to retrieve association information for column "%s"', $column));

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Internal\Hydration;
 use PDO;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
+use function array_keys;
 use function in_array;
 
 class SimpleObjectHydrator extends AbstractHydrator
@@ -92,7 +93,7 @@ class SimpleObjectHydrator extends AbstractHydrator
                 $discrColumnName = $metaMappingDiscrColumnName;
             }
 
-            if ( ! isset($row[$discrColumnName])) {
+            if (! isset($row[$discrColumnName])) {
                 throw HydrationException::missingDiscriminatorColumn($entityName, $discrColumnName, key($this->_rsm->aliasMap));
             }
 
@@ -102,7 +103,7 @@ class SimpleObjectHydrator extends AbstractHydrator
 
             $discrMap = $this->class->discriminatorMap;
 
-            if ( ! isset($discrMap[$row[$discrColumnName]])) {
+            if (! isset($discrMap[$row[$discrColumnName]])) {
                 throw HydrationException::invalidDiscriminatorValue($row[$discrColumnName], array_keys($discrMap));
             }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -987,11 +987,11 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadManyToManyCollection(array $assoc, $sourceEntity, PersistentCollection $coll)
+    public function loadManyToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection)
     {
         $stmt = $this->getManyToManyStatement($assoc, $sourceEntity);
 
-        return $this->loadCollectionFromStatement($assoc, $stmt, $coll);
+        return $this->loadCollectionFromStatement($assoc, $stmt, $collection);
     }
 
     /**
@@ -1795,11 +1795,11 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function loadOneToManyCollection(array $assoc, $sourceEntity, PersistentCollection $coll)
+    public function loadOneToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection)
     {
         $stmt = $this->getOneToManyStatement($assoc, $sourceEntity);
 
-        return $this->loadCollectionFromStatement($assoc, $stmt, $coll);
+        return $this->loadCollectionFromStatement($assoc, $stmt, $collection);
     }
 
     /**

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3214,17 +3214,17 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Notifies this UnitOfWork of a property change in an entity.
      *
-     * @param object $entity       The entity that owns the property.
+     * @param object $sender       The entity that owns the property.
      * @param string $propertyName The name of the property that changed.
      * @param mixed  $oldValue     The old value of the property.
      * @param mixed  $newValue     The new value of the property.
      *
      * @return void
      */
-    public function propertyChanged($entity, $propertyName, $oldValue, $newValue)
+    public function propertyChanged($sender, $propertyName, $oldValue, $newValue)
     {
-        $oid   = spl_object_hash($entity);
-        $class = $this->em->getClassMetadata(get_class($entity));
+        $oid   = spl_object_hash($sender);
+        $class = $this->em->getClassMetadata(get_class($sender));
 
         $isAssocField = isset($class->associationMappings[$propertyName]);
 
@@ -3236,7 +3236,7 @@ class UnitOfWork implements PropertyChangedListener
         $this->entityChangeSets[$oid][$propertyName] = [$oldValue, $newValue];
 
         if ( ! isset($this->scheduledForSynchronization[$class->rootEntityName][$oid])) {
-            $this->scheduleForDirtyCheck($entity);
+            $this->scheduleForDirtyCheck($sender);
         }
     }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -47,6 +47,7 @@ use InvalidArgumentException;
 use Throwable;
 use UnexpectedValueException;
 use function get_class;
+use function spl_object_hash;
 
 /**
  * The UnitOfWork is responsible for tracking changes to objects during an
@@ -472,7 +473,7 @@ class UnitOfWork implements PropertyChangedListener
             : $entity;
 
         foreach ($entities as $object) {
-            $oid = \spl_object_hash($object);
+            $oid = spl_object_hash($object);
 
             $this->clearEntityChangeSet($oid);
 
@@ -897,7 +898,7 @@ class UnitOfWork implements PropertyChangedListener
                          * through the object-graph where cascade-persistence
                          * is enabled for this object.
                          */
-                        $this->nonCascadedNewDetectedEntities[\spl_object_hash($entry)] = [$assoc, $entry];
+                        $this->nonCascadedNewDetectedEntities[spl_object_hash($entry)] = [$assoc, $entry];
 
                         break;
                     }


### PR DESCRIPTION
Hi,

This PR propose changing parameter names when they don't match parents.

This is suggested by the lastest version of Psalm in preparation for PHP 8 named arguments.

Here is the rationale: https://psalm.dev/docs/running_psalm/issues/ParamNameMismatch/

This may not be something we care about or that we want to support. In that case, I will change Psalm's config to ignore those in the future.

I don't believe changing parameter names is a BC break for now so we may want to do this now rather than a few months down when PHP8 will be available.