### PR TITLE
[GH-8043] Make IdentityFunction handle primary keys when they are part of an association

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -58,15 +58,18 @@ class IdentityFunction extends FunctionNode
         $joinColumn    = reset($assoc['joinColumns']);
 
         if ($this->fieldMapping !== null) {
-            if (! isset($targetEntity->fieldMappings[$this->fieldMapping])) {
-                throw new QueryException(sprintf('Undefined reference field mapping "%s"', $this->fieldMapping));
-            }
-
-            $field      = $targetEntity->fieldMappings[$this->fieldMapping];
             $joinColumn = null;
 
+            if (isset($targetEntity->fieldMappings[$this->fieldMapping])) {
+                $columnName = $targetEntity->fieldMappings[$this->fieldMapping]['columnName'];
+            } elseif (isset($targetEntity->associationMappings[$this->fieldMapping])) {
+                $columnName = reset($targetEntity->associationMappings[$this->fieldMapping]['joinColumns'])['name'];
+            } else {
+                throw new QueryException(sprintf('Undefined reference mapping "%s"', $this->fieldMapping));
+            }
+
             foreach ($assoc['joinColumns'] as $mapping) {
-                if ($mapping['referencedColumnName'] === $field['columnName']) {
+                if ($mapping['referencedColumnName'] === $columnName) {
                     $joinColumn = $mapping;
 
                     break;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8043Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8043Test.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH8043Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema([
+            GH8043FirstEntity::class,
+            GH8043SecondEntity::class,
+            GH8043CompositeEntity::class,
+            GH8043ChildEntity::class,
+        ]);
+    }
+
+    public function testCompositeForeignEntityIdentity(): void
+    {
+        $this->assertSQLEquals(
+            'SELECT g0_.composite_first_id AS sclr_0 FROM GH8043ChildEntity g0_',
+            $this->_em->createQuery("SELECT IDENTITY(e.composite, 'first') FROM " . GH8043ChildEntity::class . ' e')->getSQL()
+        );
+    }
+}
+
+/** @Entity */
+class GH8043FirstEntity
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     */
+    private $id;
+}
+
+/** @Entity */
+class GH8043SecondEntity
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     */
+    private $id;
+}
+
+/** @Entity */
+class GH8043CompositeEntity
+{
+    /**
+     * @var GH8043FirstEntity
+     * @Id
+     * @ManyToOne(targetEntity="GH8043FirstEntity")
+     */
+    private $first;
+
+    /**
+     * @var GH8043SecondEntity
+     * @Id
+     * @ManyToOne(targetEntity="GH8043SecondEntity")
+     */
+    private $second;
+}
+
+/** @Entity */
+class GH8043ChildEntity
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var GH8043CompositeEntity
+     * @ManyToOne(targetEntity="GH8043CompositeEntity")
+     * @JoinColumns({
+     *  @JoinColumn(name="composite_first_id", referencedColumnName="first_id"),
+     *  @JoinColumn(name="composite_second_id", referencedColumnName="second_id"),
+     * })
+     */
+    private $composite;
+}


### PR DESCRIPTION
Fix https://github.com/doctrine/orm/issues/8043

When primary keys are part of an association they won’t be found in `fieldMappings` but in `associationMappings` so I refactored `IdentityFunction` to handle this case.

I’m not completely sure about the logic (especially the `reset` which I copied from line 61) but it worked for every case I thought of.