### PR TITLE
Add psalm template support to several types

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -387,6 +387,10 @@ use function trigger_error;
      * @throws ORMInvalidArgumentException
      * @throws TransactionRequiredException
      * @throws ORMException
+     *
+     * @template T
+     * @psalm-param class-string<T> $entityName
+     * @psalm-return ?T
      */
     public function find($entityName, $id, $lockMode = null, $lockVersion = null)
     {
@@ -732,6 +736,10 @@ use function trigger_error;
      * @param string $entityName The name of the entity.
      *
      * @return ObjectRepository|EntityRepository The repository class.
+     *
+     * @template T
+     * @psalm-param class-string<T> $entityName
+     * @psalm-return EntityRepository<T>
      */
     public function getRepository($entityName)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -153,6 +153,10 @@ interface EntityManagerInterface extends ObjectManager
      * @return object|null The entity reference.
      *
      * @throws ORMException
+     *
+     * @template T
+     * @psalm-param class-string<T> $entityName
+     * @psalm-return ?T
      */
     public function getReference($entityName, $id);
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -41,6 +41,10 @@ use function trigger_error;
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
+ *
+ * @template T
+ * @template-implements Selectable<int,T>
+ * @template-implements ObjectRepository<T>
  */
 class EntityRepository implements ObjectRepository, Selectable
 {
@@ -64,6 +68,8 @@ class EntityRepository implements ObjectRepository, Selectable
 
     /**
      * Initializes a new <tt>EntityRepository</tt>.
+     *
+     * @psalm-param Mapping\ClassMetadata<T>
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {
@@ -156,6 +162,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param int|null $lockVersion The lock version.
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
+     *
+     * @psalm-return ?T
      */
     public function find($id, $lockMode = null, $lockVersion = null)
     {
@@ -166,6 +174,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * Finds all entities in the repository.
      *
      * @return array The entities.
+     *
+     * @psalm-return list<T>
      */
     public function findAll()
     {
@@ -181,6 +191,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param int|null   $offset
      *
      * @return array The objects.
+     *
+     * @psalm-return list<T>
      */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
@@ -196,6 +208,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param array|null $orderBy
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
+     *
+     * @psalm-return ?T
      */
     public function findOneBy(array $criteria, array $orderBy = null)
     {
@@ -288,6 +302,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param \Doctrine\Common\Collections\Criteria $criteria
      *
      * @return \Doctrine\Common\Collections\Collection
+     *
+     * @psalm-return \Doctrine\Common\Collections\Collection<int, T>
      */
     public function matching(Criteria $criteria)
     {

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\ORM\Tools\Pagination;
 
+use ArrayIterator;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parser;
@@ -32,6 +33,8 @@ use function array_map;
  * @author Pablo Díez <pablodip@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  * @license New BSD
+ *
+ * @template T
  */
 class Paginator implements \Countable, \IteratorAggregate
 {
@@ -133,6 +136,8 @@ class Paginator implements \Countable, \IteratorAggregate
 
     /**
      * {@inheritdoc}
+     *
+     * @return ArrayIterator<mixed, T>
      */
     public function getIterator()
     {
@@ -155,7 +160,7 @@ class Paginator implements \Countable, \IteratorAggregate
 
             // don't do this for an empty id array
             if ($foundIdRows === []) {
-                return new \ArrayIterator([]);
+                return new ArrayIterator([]);
             }
 
             $whereInQuery = $this->cloneQuery($this->query);
@@ -178,7 +183,7 @@ class Paginator implements \Countable, \IteratorAggregate
             ;
         }
 
-        return new \ArrayIterator($result);
+        return new ArrayIterator($result);
     }
 
     /**


### PR DESCRIPTION
Hi,

This should fix #8283

I was suprised not to find all the method subbed in https://github.com/weirdan/doctrine-psalm-plugin/blob/master/stubs/EntityManagerInterface.phpstub in the EntityManagerInterface. Turns out they're defined in the parent class which is part of Doctrine\Persistence (The version installed via composer seem to already have the psalm's annotation though)

CS will probably fail. I'll fix it soon