### PR TITLE
Introduce `toGenerator()` on AbstractQuery

### DIFF
--- a/docs/en/reference/batch-processing.rst
+++ b/docs/en/reference/batch-processing.rst
@@ -75,7 +75,7 @@ Iterating results
 ~~~~~~~~~~~~~~~~~
 
 An alternative solution for bulk updates is to use the
-``Query#getIterable()`` facility to iterate over the query results step
+``Query#getIterable()`` or ``Query#toGenerator()`` facility to iterate over the query results step
 by step instead of loading the whole result into memory at once.
 The following example shows how to do this, combining the iteration
 with the batching strategy that was already used for bulk inserts:
@@ -135,7 +135,7 @@ Iterating results
 ~~~~~~~~~~~~~~~~~
 
 An alternative solution for bulk deletes is to use the
-``Query#getIterable()`` facility to iterate over the query results step
+``Query#getIterable()`` or ``Query#toGenerator()`` facility to iterate over the query results step
 by step instead of loading the whole result into memory at once.
 The following example shows how to do this:
 
@@ -165,7 +165,7 @@ The following example shows how to do this:
 Iterating Large Results for Data-Processing
 -------------------------------------------
 
-You can use the ``getIterable()`` method just to iterate over a large
+You can use the ``getIterable()`` method or ``toGenerator()`` to iterate over a large
 result and no UPDATE or DELETE intention. ``$query->getIterable()`` returns ``iterable``
 so you can process a large result without memory
 problems using the following approach:

--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -191,10 +191,10 @@ the life-time of their registered entities.
 
 .. warning::
 
-    Note that, when using ``Doctrine\ORM\AbstractQuery#getIterable()``, ``postLoad``
+    Note that, when using ``Doctrine\ORM\AbstractQuery#getIterable()`` or ``Doctrine\ORM\AbstractQuery#toGenerator()``, ``postLoad``
     events will be executed immediately after objects are being hydrated, and therefore
     associations are not guaranteed to be initialized. It is not safe to combine
-    usage of ``Doctrine\ORM\AbstractQuery#getIterable()`` and ``postLoad`` event
+    usage of ``Doctrine\ORM\AbstractQuery#getIterable()`` or ``Doctrine\ORM\AbstractQuery#toGenerator()`` with ``postLoad`` event
     handlers.
 
 .. warning::

--- a/docs/en/reference/query-builder.rst
+++ b/docs/en/reference/query-builder.rst
@@ -355,6 +355,7 @@ a querybuilder instance into a Query object:
     // Execute Query
     $result = $query->getResult();
     $iterableResult = $query->getIterable();
+    $generatorResult = $query->toGenerator();
     $single = $query->getSingleResult();
     $array = $query->getArrayResult();
     $scalar = $query->getScalarResult();

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -25,6 +25,7 @@ use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Cache\QueryCacheKey;
+use Generator;
 use Traversable;
 use function array_map;
 use function array_shift;
@@ -963,6 +964,18 @@ abstract class AbstractQuery
      */
     public function toIterable(iterable $parameters = [], $hydrationMode = null) : iterable
     {
+        return $this->toGenerator($parameters, $hydrationMode);
+    }
+
+    /**
+     * Executes the query and returns an iterable that can be used to incrementally
+     * iterate over the result.
+     *
+     * @param ArrayCollection|mixed[] $parameters    The query parameters.
+     * @param string|int|null         $hydrationMode The hydration mode to use.
+     */
+    public function toGenerator(iterable $parameters = [], $hydrationMode = null) : Generator
+    {
         if ($hydrationMode !== null) {
             $this->setHydrationMode($hydrationMode);
         }
@@ -976,7 +989,7 @@ abstract class AbstractQuery
         $rsm  = $this->getResultSetMapping();
         $stmt = $this->_doExecute();
 
-        return $this->_em->newHydrator($this->_hydrationMode)->toIterable($stmt, $rsm, $this->_hints);
+        return $this->_em->newHydrator($this->_hydrationMode)->toGenerator($stmt, $rsm, $this->_hints);
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -27,6 +27,7 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryWalker;
+use Generator;
 use PDO;
 use const E_USER_DEPRECATED;
 use function array_map;
@@ -152,6 +153,16 @@ abstract class AbstractHydrator
      * @return iterable<mixed>
      */
     public function toIterable(Statement $stmt, ResultSetMapping $resultSetMapping, array $hints = []) : iterable
+    {
+        yield from $this->toGenerator($stmt, $resultSetMapping, $hints);
+    }
+
+    /**
+     * Initiates a row-by-row hydration.
+     *
+     * @param mixed[] $hints
+     */
+    public function toGenerator(Statement $stmt, ResultSetMapping $resultSetMapping, array $hints = []) : Generator
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -32,6 +32,7 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
+use Generator;
 use function array_keys;
 use function assert;
 
@@ -700,6 +701,14 @@ final class Query extends AbstractQuery
         $this->setHint(self::HINT_INTERNAL_ITERATION, true);
 
         return parent::toIterable($parameters, $hydrationMode);
+    }
+
+    /** {@inheritDoc} */
+    public function toGenerator(iterable $parameters = [], $hydrationMode = self::HYDRATE_OBJECT) : Generator
+    {
+        $this->setHint(self::HINT_INTERNAL_ITERATION, true);
+
+        return parent::toGenerator($parameters, $hydrationMode);
     }
 
     /**


### PR DESCRIPTION
The point is to have both `toIterable()` and `toGenerator()` so consumers are able to rely on stricter type.

So if they choose `toGenerator()` in order to rely on `Generator` return type, they can assume it is not "rewindable", eg. they can analyze in code that the Generator value is not iterated more than once