### PR TITLE
Add public getter for queryComponents

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -232,6 +232,16 @@ class Parser
     }
 
     /**
+     * Gets the queryComponents of the parsed query
+     *
+     * @return array
+     */
+    public function getQueryComponents()
+    {
+        return $this->queryComponents;
+    }
+
+    /**
      * Gets the lexer used by the parser.
      *
      * @return \Doctrine\ORM\Query\Lexer

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -234,7 +234,7 @@ class Parser
     /**
      * Gets the queryComponents of the parsed query
      *
-     * @return array
+     * @return mixed[]
      */
     public function getQueryComponents()
     {


### PR DESCRIPTION
I propose to add this getter to get access to the queryComponents property of the parser. The queryComponents property contains useful information about the corresponding entity class name of query aliases.