### PR TITLE
Exception when loading proxy does not mark proxy as initialized

### DIFF
--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -32,6 +32,7 @@ use Doctrine\ORM\Persisters\Entity\EntityPersister;
 use Doctrine\ORM\UnitOfWork;
 use Doctrine\ORM\Utility\IdentifierFlattener;
 use Doctrine\Persistence\Mapping\ClassMetadata;
+use Throwable;
 
 /**
  * This factory is used to create proxy objects for entities at runtime.
@@ -146,15 +147,19 @@ class ProxyFactory extends AbstractProxyFactory
 
             $identifier = $classMetadata->getIdentifierValues($proxy);
 
-            if ($entityPersister->loadById($identifier, $proxy) === null) {
+            try {
+                if ($entityPersister->loadById($identifier, $proxy) === null) {
+                    throw EntityNotFoundException::fromClassNameAndIdentifier(
+                        $classMetadata->getName(),
+                        $this->identifierFlattener->flattenIdentifier($classMetadata, $identifier)
+                    );
+                }
+            } catch (Throwable $t) {
                 $proxy->__setInitializer($initializer);
                 $proxy->__setCloner($cloner);
                 $proxy->__setInitialized(false);
 
-                throw EntityNotFoundException::fromClassNameAndIdentifier(
-                    $classMetadata->getName(),
-                    $this->identifierFlattener->flattenIdentifier($classMetadata, $identifier)
-                );
+                throw $t;
             }
         };
     }


### PR DESCRIPTION
Similar issue as https://github.com/doctrine/orm/issues/3147 but with a random exception, e.g. when the connection is closed.