### PR TITLE
Infer `datetime_immutable` DBAL type for `\DateTimeImmutable` instance parameters

### DIFF
--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -53,7 +53,11 @@ class ParameterTypeInferer
             return Type::BOOLEAN;
         }
 
-        if ($value instanceof \DateTime || $value instanceof \DateTimeInterface) {
+        if ($value instanceof \DateTimeImmutable) {
+            return Type::DATETIME_IMMUTABLE;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
             return Type::DATETIME;
         }
 

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\ORM\Query;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 
@@ -53,11 +55,11 @@ class ParameterTypeInferer
             return Type::BOOLEAN;
         }
 
-        if ($value instanceof \DateTimeImmutable) {
+        if ($value instanceof DateTimeImmutable) {
             return Type::DATETIME_IMMUTABLE;
         }
 
-        if ($value instanceof \DateTimeInterface) {
+        if ($value instanceof DateTimeInterface) {
             return Type::DATETIME;
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Tests\ORM\Query;
 
+use DateTimeImmutable;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
@@ -18,7 +19,7 @@ class ParameterTypeInfererTest extends OrmTestCase
             ["bar",             PDO::PARAM_STR],
             ["1",               PDO::PARAM_STR],
             [new \DateTime,     Type::DATETIME],
-            [new \DateTimeImmutable(), Type::DATETIME_IMMUTABLE],
+            [new DateTimeImmutable(), Type::DATETIME_IMMUTABLE],
             [new \DateInterval('P1D'), Type::DATEINTERVAL],
             [[2],          Connection::PARAM_INT_ARRAY],
             [["foo"],      Connection::PARAM_STR_ARRAY],

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -18,6 +18,7 @@ class ParameterTypeInfererTest extends OrmTestCase
             ["bar",             PDO::PARAM_STR],
             ["1",               PDO::PARAM_STR],
             [new \DateTime,     Type::DATETIME],
+            [new \DateTimeImmutable(), Type::DATETIME_IMMUTABLE],
             [new \DateInterval('P1D'), Type::DATEINTERVAL],
             [[2],          Connection::PARAM_INT_ARRAY],
             [["foo"],      Connection::PARAM_STR_ARRAY],
@@ -25,10 +26,6 @@ class ParameterTypeInfererTest extends OrmTestCase
             [[],           Connection::PARAM_STR_ARRAY],
             [true,              Type::BOOLEAN],
         ];
-
-        if (PHP_VERSION_ID >= 50500) {
-            $data[] = [new \DateTimeImmutable(), Type::DATETIME];
-        }
 
         return $data;
     }


### PR DESCRIPTION
The support for passing `\DateTimeImmutable` instance as a query parameter has been added to ORM in #1333 (the year 2015), a long time before immutable date types (`datetime_immutable` etc) were introduced to DBAL in doctrine/dbal#2450 (2017).

Back then, it made sense to treat `\DateTimeImmutable` (or any `\DateTimeInterface`) in the same way as `\DateTime` and infer parameter type as `datetime`. However, when immutable date types were later added to DBAL, it wasn't reflected anyhow in type inference in ORM and `\DateTimeImmmutable` instances are still inferred as `datetime` DBAL type.

This PR fixes this IMO incorrect behaviour of `ParameterTypeInferer::inferType()`: for a `\DateTimeImmmutable` parameter, it now returns `datetime_immutable` DBAL type; for `\DateTime` or any other types implementing `\DateTimeInterface`, it returns `datetime` DBAL type as it did before.

This behaviour is in line with [`DateTimeImmutableType` handling only `\DateTimeImmutable`](https://github.com/doctrine/dbal/blob/2.12.x/lib/Doctrine/DBAL/Types/DateTimeImmutableType.php#L32) and [`DateTimeType` handling any `\DateTimeInterface`](https://github.com/doctrine/dbal/blob/2.12.x/lib/Doctrine/DBAL/Types/DateTimeType.php#L41).


Why? In most cases, it doesn't matter and `datetime` works for `\DateTimeImmutable` parameters just fine. But it does matter if using custom implementation of `datetime_immutable` type like `UTCDateTimeImmutableType` from [simpod/doctrine-utcdatetime](https://packagist.org/packages/simpod/doctrine-utcdatetime). Then the broken type inference is revealed.


This is partially related to #6443, however, this PR isn't about custom DBAL types but about correct type inference for build-in types.