### PR TITLE
Fix SQL alias generation regression for simple inheritance 

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1698,7 +1698,7 @@ class BasicEntityPersister implements EntityPersister
         if (isset($this->class->fieldMappings[$field])) {
             // Fix for bug GH-8229 (id column from parent class renamed in child class):
             // Use the correct metadata and name for the id column
-            if (isset($this->class->fieldMappings[$field]['inherited'])) {
+            if (isset($this->class->fieldMappings[$field]['inherited']) && $this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {
                 $className = $this->class->fieldMappings[$field]['inherited'];
                 $class     = $this->em->getClassMetadata($className);
             } else {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8229Test.php
@@ -23,6 +23,8 @@ class GH8229Test extends OrmFunctionalTestCase
             [
                 GH8229Resource::class,
                 GH8229User::class,
+                GH8229EntityWithoutDiscriminator::class,
+                EntityExtendingGH8229EntityWithoutDiscriminator::class,
             ]
         );
     }
@@ -183,6 +185,19 @@ class GH8229Test extends OrmFunctionalTestCase
 
         self::assertEquals($identifier, $entity->id);
     }
+
+    /** this test check alias generation not altered by inheritance in ResolvedTargetEntities mapped classes
+     */
+    public function testBasicEntityPersisterAliasGenerationWithSimpleInheritance()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $entity = new EntityExtendingGH8229EntityWithoutDiscriminator();
+        $this->_em->persist($entity);
+        $this->_em->flush();
+
+        $this->_em->getRepository(EntityExtendingGH8229EntityWithoutDiscriminator::class)->findOneBy(['id' => $entity->getId()]);
+    }
 }
 
 
@@ -243,4 +258,30 @@ final class GH8229User extends GH8229Resource
 
         $this->username = $username;
     }
+}
+
+/**
+ * @Entity
+ * @Table(name="gh8229_replacedentity")
+ */
+class GH8229EntityWithoutDiscriminator
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     */
+    public $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}
+
+/**
+ * @Entity
+ */
+final class EntityExtendingGH8229EntityWithoutDiscriminator extends GH8229EntityWithoutDiscriminator
+{
 }


### PR DESCRIPTION
As asked by @ostrolucky in the #8229 issue - I'm created a PR trying to fix a edge case of what I think may be a regression in the effort of supporting Joined table inheritance with AttributeOverride.

Context:
- Entity1 extends Entity0 through ResolveTargetEntities mecanism
- Entity1 has all its fieldsMapping marked as inherited=true 
- Entity1 inheritanceType is ClassMetadata::INHERITANCE_TYPE_NONE
- Some code calls $entityManager->getRepository($entity1)->findOneBy()
- The SQL generated in the where part of the query has a bad alias because it uses Entity0 as classname for getSQLTableAlias call in BasicEntityPersister::getSelectConditionStatementSQL method
- The query crash

Proposal:
  Excluding INHERITANCE_TYPE_NONE entities to use inherited classname as parameter for getSQLTableAlias generation in BasicEntityPersister::getSelectConditionStatementSQL

As said in original comment, I'm really not sure of what I'm doing, I'm new to doctrine 2

Referenced Issue comments: https://github.com/doctrine/orm/issues/8229#issuecomment-722942180


