### PR TITLE
Implement expression to filter some field with IN a native temporary table

### DIFF
--- a/lib/Doctrine/ORM/Query/AST/CollectionMemberTempExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CollectionMemberTempExpression.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\ORM\Query\AST;
+
+class CollectionMemberTempExpression extends Node
+{
+    /**
+     * @var Literal
+     */
+    public $tableNameExpr;
+
+    /**
+     * @var PathExpression
+     */
+    public $entityExpr;
+
+    /**
+     * @var bool
+     */
+    public $not;
+
+    public function __construct(PathExpression $entityExpr, Literal $tableName)
+    {
+        $this->entityExpr = $entityExpr;
+        $this->tableNameExpr = $tableName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch($walker)
+    {
+        return $walker->walkCollectionMemberTempExpression($this);
+    }
+}

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -115,6 +115,7 @@ class Lexer extends AbstractLexer
     const T_WHEN                 = 254;
     const T_WHERE                = 255;
     const T_WITH                 = 256;
+    const T_MEMBERTEMP           = 257;
 
     /**
      * Creates a new query scanner object.

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2583,6 +2583,10 @@ class Parser
             return $this->CollectionMemberExpression();
         }
 
+        if ($token['type'] === Lexer::T_MEMBERTEMP) {
+            return $this->CollectionMemberTempExpression();
+        }
+
         if ($token['type'] === Lexer::T_IS && $lookahead['type'] === Lexer::T_NULL) {
             return $this->NullComparisonExpression();
         }
@@ -2614,6 +2618,31 @@ class Parser
         $this->match(Lexer::T_EMPTY);
 
         return $emptyCollectionCompExpr;
+    }
+
+    public function CollectionMemberTempExpression(): AST\CollectionMemberTempExpression
+    {
+        $not        = false;
+        $entityExpr = $this->SimpleEntityExpression();
+
+        if ($this->lexer->isNextToken(Lexer::T_NOT)) {
+            $this->match(Lexer::T_NOT);
+
+            $not = true;
+        }
+
+        $this->match(Lexer::T_MEMBERTEMP);
+
+        if ($this->lexer->isNextToken(Lexer::T_OF)) {
+            $this->match(Lexer::T_OF);
+        }
+
+        $collMemberExpr = new AST\CollectionMemberTempExpression(
+            $entityExpr, $this->StringPrimary()
+        );
+        $collMemberExpr->not = $not;
+
+        return $collMemberExpr;
     }
 
     /**


### PR DESCRIPTION
This patch is to fix a specific issue in a large project and is
submitted to doctrine/orm for proof of concept/idea and to ask for
feedback on how this issue can be resolved.  It's not intended to be a
final patch ready to be merged (missing tests and probably some coding
guideline violations) as I want some input from the doctrine developers
on how to approch this problem (which will be described later). Also...
gotta find a better name than "MEMBERTEMP OF"

To describe the problem in very simple terms: "How to use an IN
expression to select from a native table?"

In my project I have a very complicated query that 1) includes a large
section with joins and subqueryies for ACL and 2) a large IN expression
with over 8000 int IDs. This query is written with DQL and uses over 1
minute to execute which is unexceptable. I have been researching alot
and discovered that mysql is not performing the query efficiently as I
had hoped, but putting all the IDs inside a temporary table and then
later referencing that table in a IN-subquery makes the query use about
0.60 sec. DQL however does not allow someone to reference native tables
as DQL is specificly designed (in my eyes) to work with entities known
to Doctrine. I have tried several workarounds or "hacks" to allow
referencing (for instance using a "FakeEntity" where I set the table
name in runtime on ClassMetadata) the temporary table. Using a custom
string function does not work and using a custom SQL walker seem to not
be a feasable solution as we still cant reference the table name itself
without an entity.

The following patch tries to replicate the "MEMBER OF" expression but
instead allow a "string primary" for a collection. This string is never
"validated" and is just put directly into the resulting SQL as a table
name. No criteria support has been added since we put all the ids
already filtered into the temporary table.

For instance: `SELECT user FROM App\User AS user WHERE user.id
MEMBERTEMP OF 'some_table'` would become `SELECT user.id FROM users AS
user WHERE user.id IN(SELECT t0.id FROM some_table AS t0)`

