### PR TITLE
Fix Hidden fields triggering error when using getSingleScalarResult()

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -21,6 +21,9 @@ namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\NonUniqueResultException;
+use function count;
+use function key;
+
 
 /**
  * Hydrator that hydrates a single scalar value from the result set.

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -48,9 +48,9 @@ class SingleScalarHydrator extends AbstractHydrator
         if ($numRows > 1) {
             throw new NonUniqueResultException('The query returned multiple rows. Change the query or use a different result function like getScalarResult().');
         }
-        
+
         $result = $this->gatherScalarRowData($data[key($data)]);
-        
+
         if (count($result) > 1) {
             throw new NonUniqueResultException('The query returned a row containing multiple columns. Change the query or use a different result function like getScalarResult().');
         }

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -47,11 +47,11 @@ class SingleScalarHydrator extends AbstractHydrator
             throw new NonUniqueResultException('The query returned multiple rows. Change the query or use a different result function like getScalarResult().');
         }
         
-        if (count($data[key($data)]) > 1) {
+        $result = $this->gatherScalarRowData($data[key($data)]);
+        
+        if (count($result) > 1) {
             throw new NonUniqueResultException('The query returned a row containing multiple columns. Change the query or use a different result function like getScalarResult().');
         }
-
-        $result = $this->gatherScalarRowData($data[key($data)]);
 
         return array_shift($result);
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -24,7 +24,6 @@ use Doctrine\ORM\NonUniqueResultException;
 use function count;
 use function key;
 
-
 /**
  * Hydrator that hydrates a single scalar value from the result set.
  *

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -64,7 +64,7 @@ class SingleScalarHydratorTest extends HydrationTestCase
      */
     public function testHydrateSingleScalar($name, $resultSet)
     {
-        $rsm = new ResultSetMapping;
+        $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsUser::class, 'u');
         $rsm->addFieldResult('u', 'u__id', 'id');
         $rsm->addFieldResult('u', 'u__name', 'name');
@@ -124,21 +124,20 @@ class SingleScalarHydratorTest extends HydrationTestCase
     }
 
     /**
-     *
      * @dataProvider singleScalarResultSetWithHiddenFieldProvider
      */
     public function testHydrateSingleScalarWithHiddenField($name, $resultSet)
     {
-        $rsm = new ResultSetMapping;
+        $rsm = new ResultSetMapping();
         $rsm->addScalarResult('u__id', 'id', 'string');
 
-        $stmt = new HydratorMockStatement($resultSet);
+        $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new SingleScalarHydrator($this->_em);
 
         if ($name === 'result1') {
             $result = $hydrator->hydrateAll($stmt, $rsm);
             $this->assertEquals('1', $result);
-            
+
             return;
         }
 
@@ -156,5 +155,4 @@ class SingleScalarHydratorTest extends HydrationTestCase
             return;
         }
     }
-
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -52,7 +52,7 @@ class SingleScalarHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__id', 'id');
         $rsm->addFieldResult('u', 'u__name', 'name');
 
-        $stmt = new HydratorMockStatement($resultSet);
+        $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new SingleScalarHydrator($this->_em);
 
         $result = $hydrator->hydrateAll($stmt, $rsm);
@@ -132,7 +132,7 @@ class SingleScalarHydratorTest extends HydrationTestCase
         $rsm->addFieldResult('u', 'u__id', 'id');
         $rsm->addFieldResult('u', 'u__name', 'name');
 
-        $stmt = new HydratorMockStatement($resultSet);
+        $stmt     = new HydratorMockStatement($resultSet);
         $hydrator = new SingleScalarHydrator($this->_em);
 
         $this->expectException(NonUniqueResultException::class);

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -90,4 +90,79 @@ class SingleScalarHydratorTest extends HydrationTestCase
             $hydrator->hydrateAll($stmt, $rsm);
         }
     }
+    
+    
+    
+    
+    public static function singleScalarResultSetWithHiddenFieldProvider(): array
+    {
+        return [
+            // valid
+            [
+                'name'      => 'result1',
+                'resultSet' => [
+                    [
+                        'u__id'   => '1',
+                        'u__name' => 'romanb',
+                    ],
+                ],
+            ],
+            // valid
+            [
+                'name'      => 'result2',
+                'resultSet' => [
+                    [
+                        'u__name' => 'romanb',
+                    ],
+                ],
+            ],
+            // invalid
+            [
+                'name'      => 'result3',
+                'resultSet' => [
+                    [
+                        'u__id' => '1',
+                    ],
+                    [
+                        'u__id' => '2',
+                    ],
+                ],
+            ],
+        ];
+    }
+    
+    /**
+     *
+     * @dataProvider singleScalarResultSetWithHiddenFieldProvider
+     */
+    public function testHydrateSingleScalarWithHiddenField($name, $resultSet)
+    {
+        $rsm = new ResultSetMapping;
+        $rsm->addScalarResult('u__id', 'id', 'string');
+        
+        $stmt = new HydratorMockStatement($resultSet);
+        $hydrator = new SingleScalarHydrator($this->_em);
+    
+        if ($name === 'result1') {
+            $result = $hydrator->hydrateAll($stmt, $rsm);
+            $this->assertEquals('1', $result);
+            
+            return;
+        }
+    
+        if ($name === 'result2') {
+            $result = $hydrator->hydrateAll($stmt, $rsm);
+            $this->assertEquals(null, $result);
+            
+            return;
+        }
+        
+        if ($name === 'result3') {
+            $this->expectException(NonUniqueResultException::class);
+            $hydrator->hydrateAll($stmt, $rsm);
+            
+            return;
+        }
+    }
+    
 }

--- a/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/SingleScalarHydratorTest.php
@@ -90,11 +90,11 @@ class SingleScalarHydratorTest extends HydrationTestCase
             $hydrator->hydrateAll($stmt, $rsm);
         }
     }
-    
-    
-    
-    
-    public static function singleScalarResultSetWithHiddenFieldProvider(): array
+
+
+
+
+    public static function singleScalarResultSetWithHiddenFieldProvider() : array
     {
         return [
             // valid
@@ -110,27 +110,19 @@ class SingleScalarHydratorTest extends HydrationTestCase
             // valid
             [
                 'name'      => 'result2',
-                'resultSet' => [
-                    [
-                        'u__name' => 'romanb',
-                    ],
-                ],
+                'resultSet' => [['u__name' => 'romanb']],
             ],
             // invalid
             [
                 'name'      => 'result3',
                 'resultSet' => [
-                    [
-                        'u__id' => '1',
-                    ],
-                    [
-                        'u__id' => '2',
-                    ],
+                    ['u__id' => '1'],
+                    ['u__id' => '2'],
                 ],
             ],
         ];
     }
-    
+
     /**
      *
      * @dataProvider singleScalarResultSetWithHiddenFieldProvider
@@ -139,30 +131,30 @@ class SingleScalarHydratorTest extends HydrationTestCase
     {
         $rsm = new ResultSetMapping;
         $rsm->addScalarResult('u__id', 'id', 'string');
-        
+
         $stmt = new HydratorMockStatement($resultSet);
         $hydrator = new SingleScalarHydrator($this->_em);
-    
+
         if ($name === 'result1') {
             $result = $hydrator->hydrateAll($stmt, $rsm);
             $this->assertEquals('1', $result);
             
             return;
         }
-    
+
         if ($name === 'result2') {
             $result = $hydrator->hydrateAll($stmt, $rsm);
             $this->assertEquals(null, $result);
-            
+
             return;
         }
-        
+
         if ($name === 'result3') {
             $this->expectException(NonUniqueResultException::class);
             $hydrator->hydrateAll($stmt, $rsm);
-            
+
             return;
         }
     }
-    
+
 }


### PR DESCRIPTION
Using HIDDEN fields in a request was causing the "unicity" check to fail and throw a NonUniqueResultException, because we were counting raw data instead of counting gathered row data.

See https://github.com/doctrine/orm/issues/4257  for original issue.


_PS: sorry if I've done something wrong in the contribution procedure, it's my first pull request :)_ 