### PR TITLE
Use LockMode::NONE as default lock mode

### DIFF
--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Cache;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\Cache\EntityCacheKey;
@@ -105,7 +106,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     public function getSelectSQL(
         $criteria,
         ?AssociationMetadata $association = null,
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         $offset = null,
         array $orderBy = []
@@ -360,11 +361,11 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
         $entity = null,
         ?AssociationMetadata $association = null,
         array $hints = [],
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         ?array $orderBy = null
     ) {
-        if ($entity !== null || $association !== null || ! empty($hints) || $lockMode !== null) {
+        if ($entity !== null || $association !== null || ! empty($hints)) {
             return $this->persister->load($criteria, $entity, $association, $hints, $lockMode, $limit, $orderBy);
         }
 
@@ -642,7 +643,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
     /**
      * {@inheritdoc}
      */
-    public function refresh(array $id, $entity, $lockMode = null)
+    public function refresh(array $id, $entity, $lockMode = LockMode::NONE)
     {
         $this->persister->refresh($id, $entity, $lockMode);
     }

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Decorator;
 
 use Doctrine\Common\Persistence\ObjectManagerDecorator;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 
@@ -136,7 +137,7 @@ abstract class EntityManagerDecorator extends ObjectManagerDecorator implements 
     /**
      * {@inheritdoc}
      */
-    public function find($entityName, $id, $lockMode = null, $lockVersion = null)
+    public function find($entityName, $id, $lockMode = LockMode::NONE, $lockVersion = null)
     {
         return $this->wrapped->find($entityName, $id, $lockMode, $lockVersion);
     }

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -362,9 +362,7 @@ final class EntityManager implements EntityManagerInterface
      *
      * @param string   $entityName  The class name of the entity to find.
      * @param mixed    $id          The identity of the entity to find.
-     * @param int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
-     *                              or NULL if no specific lock mode should be used
-     *                              during the search.
+     * @param int      $lockMode    One of the \Doctrine\DBAL\LockMode::* constants.
      * @param int|null $lockVersion The version of the entity to find when using
      *                              optimistic locking.
      *
@@ -375,12 +373,12 @@ final class EntityManager implements EntityManagerInterface
      * @throws TransactionRequiredException
      * @throws ORMException
      */
-    public function find($entityName, $id, $lockMode = null, $lockVersion = null)
+    public function find($entityName, $id, $lockMode = LockMode::NONE, $lockVersion = null)
     {
         $class     = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
         $className = $class->getClassName();
 
-        if ($lockMode !== null) {
+        if ($lockMode !== LockMode::NONE) {
             $this->checkLockRequirements($lockMode, $class);
         }
 
@@ -431,7 +429,6 @@ final class EntityManager implements EntityManagerInterface
                     $this->lock($entity, $lockMode, $lockVersion);
                     break;
 
-                case $lockMode === LockMode::NONE:
                 case $lockMode === LockMode::PESSIMISTIC_READ:
                 case $lockMode === LockMode::PESSIMISTIC_WRITE:
                     $persister = $unitOfWork->getEntityPersister($className);

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Selectable;
 use Doctrine\Common\Inflector\Inflector;
 use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\Repository\Exception\InvalidMagicMethodCall;
@@ -91,14 +92,12 @@ class EntityRepository implements ObjectRepository, Selectable
      * Finds an entity by its primary key / identifier.
      *
      * @param mixed    $id          The identifier.
-     * @param int|null $lockMode    One of the \Doctrine\DBAL\LockMode::* constants
-     *                              or NULL if no specific lock mode should be used
-     *                              during the search.
+     * @param int      $lockMode    One of the \Doctrine\DBAL\LockMode::* constants.
      * @param int|null $lockVersion The lock version.
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
      */
-    public function find($id, $lockMode = null, $lockVersion = null)
+    public function find($id, $lockMode = LockMode::NONE, $lockVersion = null)
     {
         return $this->em->find($this->entityName, $id, $lockMode, $lockVersion);
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -792,7 +792,7 @@ class BasicEntityPersister implements EntityPersister
         $entity = null,
         ?AssociationMetadata $association = null,
         array $hints = [],
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         array $orderBy = []
     ) {
@@ -905,7 +905,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * {@inheritdoc}
      */
-    public function refresh(array $id, $entity, $lockMode = null)
+    public function refresh(array $id, $entity, $lockMode = LockMode::NONE)
     {
         $sql              = $this->getSelectSQL($id, null, $lockMode);
         [$params, $types] = $this->expandParameters($id);
@@ -1151,7 +1151,7 @@ class BasicEntityPersister implements EntityPersister
     public function getSelectSQL(
         $criteria,
         ?AssociationMetadata $association = null,
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         $offset = null,
         array $orderBy = []
@@ -2179,7 +2179,7 @@ class BasicEntityPersister implements EntityPersister
         $alias = $this->getSQLTableAlias($this->class->getTableName());
 
         $sql = 'SELECT 1 '
-             . $this->getLockTablesSql(null)
+             . $this->getLockTablesSql(LockMode::NONE)
              . ' WHERE ' . $this->getSelectConditionSQL($criteria);
 
         [$params, $types] = $this->expandParameters($criteria);

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Mapping\AssociationMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyAssociationMetadata;
@@ -63,7 +64,7 @@ interface EntityPersister
      * Gets the SELECT SQL to select one or more entities by a set of field criteria.
      *
      * @param Criteria|Criteria[] $criteria
-     * @param int|null            $lockMode
+     * @param int                 $lockMode
      * @param int|null            $limit
      * @param int|null            $offset
      * @param mixed[]             $orderBy
@@ -73,7 +74,7 @@ interface EntityPersister
     public function getSelectSQL(
         $criteria,
         ?AssociationMetadata $association = null,
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         $offset = null,
         array $orderBy = []
@@ -186,16 +187,14 @@ interface EntityPersister
     /**
      * Refreshes a managed entity.
      *
-     * @param mixed[]  $id       The identifier of the entity as an associative array from
+     * @param mixed[] $id       The identifier of the entity as an associative array from
      *                           column or field names to values.
-     * @param object   $entity   The entity to refresh.
-     * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                           or NULL if no specific lock mode should be used
-     *                           for refreshing the managed entity.
+     * @param object  $entity   The entity to refresh.
+     * @param int     $lockMode One of the \Doctrine\DBAL\LockMode::* constants.
      *
      * @return void
      */
-    public function refresh(array $id, $entity, $lockMode = null);
+    public function refresh(array $id, $entity, $lockMode = LockMode::NONE);
 
     /**
      * Loads an entity by a list of field criteria.
@@ -204,8 +203,7 @@ interface EntityPersister
      * @param object|null              $entity      The entity to load the data into. If not specified, a new entity is created.
      * @param AssociationMetadata|null $association The association that connects the entity to load to another entity, if any.
      * @param mixed[]                  $hints       Hints for entity creation.
-     * @param int|null                 $lockMode    One of the \Doctrine\DBAL\LockMode::* constants or NULL if no specific lock mode
-     *                                              should be used for loading the entity.
+     * @param int                      $lockMode    One of the \Doctrine\DBAL\LockMode::* constants.
      * @param int|null                 $limit       Limit number of results.
      * @param mixed[]                  $orderBy     Criteria to order by.
      *
@@ -218,7 +216,7 @@ interface EntityPersister
         $entity = null,
         ?AssociationMetadata $association = null,
         array $hints = [],
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         array $orderBy = []
     );

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -209,7 +209,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     public function getSelectSQL(
         $criteria,
         ?AssociationMetadata $association = null,
-        $lockMode = null,
+        $lockMode = LockMode::NONE,
         $limit = null,
         $offset = null,
         array $orderBy = []

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -695,7 +695,7 @@ final class Query extends AbstractQuery
      */
     public function setLockMode($lockMode)
     {
-        if (in_array($lockMode, [LockMode::NONE, LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
+        if (in_array($lockMode, [LockMode::PESSIMISTIC_READ, LockMode::PESSIMISTIC_WRITE], true)) {
             if (! $this->em->getConnection()->isTransactionActive()) {
                 throw TransactionRequiredException::transactionRequired();
             }
@@ -709,14 +709,14 @@ final class Query extends AbstractQuery
     /**
      * Get the current lock mode for this query.
      *
-     * @return int|null The current lock mode of this query or NULL if no specific lock mode is set.
+     * @return int The current lock mode of this query.
      */
     public function getLockMode()
     {
         $lockMode = $this->getHint(self::HINT_LOCK_MODE);
 
         if ($lockMode === false) {
-            return null;
+            return LockMode::NONE;
         }
 
         return $lockMode;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -547,7 +547,7 @@ class SqlWalker implements TreeWalker
             $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset ?? 0);
         }
 
-        if ($lockMode === null || $lockMode === false || $lockMode === LockMode::NONE) {
+        if ($lockMode === false || $lockMode === LockMode::NONE) {
             return $sql;
         }
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1976,7 +1976,6 @@ class UnitOfWork implements PropertyChangedListener
 
                 break;
 
-            case $lockMode === LockMode::NONE:
             case $lockMode === LockMode::PESSIMISTIC_READ:
             case $lockMode === LockMode::PESSIMISTIC_WRITE:
                 if (! $this->em->getConnection()->isTransactionActive()) {


### PR DESCRIPTION
As discussed in https://github.com/doctrine/dbal/issues/4391, the `$lockMode` parameter should not be nullable anywhere; what should be used as a default is `LockMode::NONE`.

There was a long standing confusion in the DBAL that can be summarized to:

- in all platforms but SQL Server / SQL Anywhere, `null` was equivalent to `LockMode::NONE`;
- in SQL Server / SQL Anywhere, `LockMode::NONE` resulted in using `WITH (NOLOCK)`, which changed the effective isolation level to `READ UNCOMMITTED` for the table; this is not the contract of `LockMode::NONE`, and was qualified as a bug.

This has been fixed in https://github.com/doctrine/dbal/pull/4400, and now `null` is not a valid value anymore for lock modes.

This PR is the sequel to the above:

- `$lockMode` defaults to `LockMode::NONE` everywhere, `null` is not allowed anymore
- no transaction is required anymore when using `LockMode::NONE`, which didn't make any sense

Notes:

- the transaction requirement for `LockMode::NONE` was highly inconsistent anyway: the `Query` required one, but `EntityManager::find()` didn't
- there were many inconsistencies in the documented types for `$lockMode` as well, which did document in many places that only an `int` was acceptable, but did accept or even expect `null` at some point: [1](https://github.com/doctrine/orm/blob/e8c4d7b177b52fd2cb75522c77d601caabbb4806/lib/Doctrine/ORM/EntityManagerInterface.php#L178), [2](https://github.com/doctrine/orm/blob/e8c4d7b177b52fd2cb75522c77d601caabbb4806/lib/Doctrine/ORM/Query.php#L690), [3](https://github.com/doctrine/orm/blob/e8c4d7b177b52fd2cb75522c77d601caabbb4806/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php#L1732)