### PR TITLE
php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "ext-pdo": "*",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.11.1",


### PR DESCRIPTION
doctrine/orm 2.7.4 requires php ^7.1 -> your PHP version (8.0.0) does not satisfy that requirement.
