### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Tools/Export/yaml/Doctrine.Tests.ORM.Tools.Export.User.dcm.yml
@@ -54,7 +54,7 @@ Doctrine\Tests\ORM\Tools\Export\User:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Interests
       mappedBy: user
       cascade: [ persist, merge, remove, refresh, detach ]
-      orphanRemoval: true            
+      orphanRemoval: true
   manyToMany:
     groups:
       targetEntity: Doctrine\Tests\ORM\Tools\Export\Group
@@ -73,8 +73,8 @@ Doctrine\Tests\ORM\Tools\Export\User:
       cascade:
         - all
   lifecycleCallbacks:
-    prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ] 
-    postPersist: [ doStuffOnPostPersist ] 
+    prePersist: [ doStuffOnPrePersist, doOtherStuffOnPrePersistToo ]
+    postPersist: [ doStuffOnPostPersist ]
   entityListeners:
     Doctrine\Tests\ORM\Tools\Export\UserListener:
       prePersist: [customPrePersist]


### PR DESCRIPTION
Stylistically, it's not great to have them, but more importantly, the
latest `symfony/yaml` version has issues with trailing whitespaces.

See https://github.com/symfony/symfony/pull/39274