### PR TITLE
[GH-8366] Catch additional Persistence MappingException

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -23,6 +23,7 @@ use Countable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
+use Doctrine\Persistence\Mapping\MappingException;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Traversable;
@@ -451,6 +452,9 @@ abstract class AbstractQuery
             // Silence any mapping exceptions. These can occur if the object in
             // question is not a mapped entity, in which case we just don't do
             // any preparation on the value.
+        } catch (MappingException $e) {
+            // as previous, but depending on MappingDriver this exception from Persistence
+            // is thrown and not the ORM one.
         }
 
         return $value;


### PR DESCRIPTION
Depending on the mapping drivers, different kinds of exceptions are thrown. We did not catch this in the testsuite, because we don't have the DriverChain configured when testing parameter type inferring and setting this up is a bit much. The inheritence hierachy here would benefit from an interface.

Fixes #8366 