### PR TITLE
Fix invalid psalm annotation

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -69,7 +69,7 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Initializes a new <tt>EntityRepository</tt>.
      *
-     * @psalm-param Mapping\ClassMetadata<T>
+     * @psalm-param Mapping\ClassMetadata<T> $class
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {


### PR DESCRIPTION
The psalm annotation is currently invalid and psalm outputs an error:
`ERROR: InvalidDocblock - vendor/doctrine/orm/lib/Doctrine/ORM/EntityRepository.php:74:5 - Badly-formatted @param in docblock for Doctrine\ORM\EntityRepository::__construct (see https://psalm.dev/008)`