### PR TITLE
[GH-7486] Bugfix: failing when clearing empty cache is wrong semantics

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -99,12 +99,6 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        if ( ! $result) {
-            $ui->error($message);
-
-            return 1;
-        }
-
         $ui->success($message);
 
         return 0;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -98,12 +98,6 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        if ( ! $result) {
-            $ui->error($message);
-
-            return 1;
-        }
-
         $ui->success($message);
 
         return 0;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -99,12 +99,6 @@ EOT
             $message = ($result) ? 'Successfully flushed cache entries.' : $message;
         }
 
-        if ( ! $result) {
-            $ui->error($message);
-
-            return 1;
-        }
-
         $ui->success($message);
 
         return 0;


### PR DESCRIPTION
When you call clear cache on result, query, metadata caches, then clearing an empty cache is also semantically clearing the cache. As such it should not fail with an error as it currently does. This could be considered a BC break, but this behavior is completly bogus, so I consider it a bug to be fixed.

Fixes #7486 