### PR TITLE
[GH-6394] Bugfix: IdentifierFlattener support for association non-object values.

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -394,7 +394,7 @@ class BasicEntityPersister implements EntityPersister
         $this->updateTable($entity, $quotedTableName, $data, $isVersioned);
 
         if ($isVersioned) {
-            $id = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
+            $id = $this->class->getIdentifierValues($entity);
 
             $this->assignDefaultVersionValue($entity, $id);
         }

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -71,15 +71,13 @@ final class IdentifierFlattener
         $flatId = [];
 
         foreach ($class->identifier as $field) {
-            if (isset($class->associationMappings[$field]) && isset($id[$field])) {
+            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_object($id[$field])) {
                 /* @var $targetClassMetadata ClassMetadata */
                 $targetClassMetadata = $this->metadataFactory->getMetadataFor(
                     $class->associationMappings[$field]['targetEntity']
                 );
 
-                if (!is_object($id[$field])) {
-                    $associatedId = [$id[$field]];
-                } elseif ($this->unitOfWork->isInIdentityMap($id[$field])) {
+                if ($this->unitOfWork->isInIdentityMap($id[$field])) {
                     $associatedId = $this->flattenIdentifier($targetClassMetadata, $this->unitOfWork->getEntityIdentifier($id[$field]));
                 } else {
                     $associatedId = $this->flattenIdentifier($targetClassMetadata, $targetClassMetadata->getIdentifierValues($id[$field]));

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -71,13 +71,15 @@ final class IdentifierFlattener
         $flatId = [];
 
         foreach ($class->identifier as $field) {
-            if (isset($class->associationMappings[$field]) && isset($id[$field]) && is_object($id[$field])) {
+            if (isset($class->associationMappings[$field]) && isset($id[$field])) {
                 /* @var $targetClassMetadata ClassMetadata */
                 $targetClassMetadata = $this->metadataFactory->getMetadataFor(
                     $class->associationMappings[$field]['targetEntity']
                 );
 
-                if ($this->unitOfWork->isInIdentityMap($id[$field])) {
+                if (!is_object($id[$field])) {
+                    $associatedId = [$id[$field]];
+                } elseif ($this->unitOfWork->isInIdentityMap($id[$field])) {
                     $associatedId = $this->flattenIdentifier($targetClassMetadata, $this->unitOfWork->getEntityIdentifier($id[$field]));
                 } else {
                     $associatedId = $this->flattenIdentifier($targetClassMetadata, $targetClassMetadata->getIdentifierValues($id[$field]));

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,7 @@
     <rule ref="Doctrine">
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
+{
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(A::class),
+                $this->_em->getClassMetadata(B::class)
+            ]
+        );
+    }
+
+    /**
+     * Test the the version of an entity can be fetched, when the id field and
+     * the id column are different.
+     * @group 6393
+     */
+    public function testFetchVersionValueForDifferentIdFieldAndColumn(): void
+    {
+        $a = new A(1);
+        $this->_em->persist($a);
+
+        $b = new B($a, 'foo');
+        $this->_em->persist($b);
+        $this->_em->flush();
+
+        self::assertSame(1, $b->version);
+
+        $b->something = 'bar';
+        $this->_em->flush();
+
+        self::assertSame(2, $b->version);
+    }
+
+}
+
+/**
+ * @Entity
+ */
+class A
+{
+
+    /**
+     * @Id
+     * @Column(type="integer")
+     */
+    public $id;
+
+    /**
+     * @Version
+     * @Column(type="integer")
+     */
+    public $version;
+
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+}
+
+/**
+ * @Entity
+ */
+class B
+{
+
+    /**
+     * @Id
+     * @ManyToOne(targetEntity="A")
+     * @JoinColumn(name="aid", referencedColumnName="id")
+     */
+    public $a;
+
+    /**
+     * @Column(type="string")
+     */
+    public $something;
+
+    /**
+     * @Version
+     * @Column(type="integer")
+     */
+    public $version;
+
+    public function __construct(A $a, string $something)
+    {
+        $this->a = $a;
+        $this->something = $something;
+    }
+
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
-{
+use Doctrine\Tests\OrmFunctionalTestCase;
 
+class GH6394Test extends OrmFunctionalTestCase
+{
     protected function setUp(): void
     {
         parent::setUp();
@@ -12,7 +15,7 @@ class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
         $this->_schemaTool->createSchema(
             [
                 $this->_em->getClassMetadata(A::class),
-                $this->_em->getClassMetadata(B::class)
+                $this->_em->getClassMetadata(B::class),
             ]
         );
     }
@@ -20,6 +23,7 @@ class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
     /**
      * Test the the version of an entity can be fetched, when the id field and
      * the id column are different.
+     *
      * @group 6393
      */
     public function testFetchVersionValueForDifferentIdFieldAndColumn(): void
@@ -38,7 +42,6 @@ class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
 
         self::assertSame(2, $b->version);
     }
-
 }
 
 /**
@@ -46,16 +49,17 @@ class GH6394Test extends \Doctrine\Tests\OrmFunctionalTestCase
  */
 class A
 {
-
     /**
      * @Id
      * @Column(type="integer")
+     * @var int
      */
     public $id;
 
     /**
      * @Version
      * @Column(type="integer")
+     * @var int
      */
     public $version;
 
@@ -63,7 +67,6 @@ class A
     {
         $this->id = $id;
     }
-
 }
 
 /**
@@ -71,29 +74,30 @@ class A
  */
 class B
 {
-
     /**
      * @Id
      * @ManyToOne(targetEntity="A")
      * @JoinColumn(name="aid", referencedColumnName="id")
+     * @var A
      */
     public $a;
 
     /**
      * @Column(type="string")
+     * @var string
      */
     public $something;
 
     /**
      * @Version
      * @Column(type="integer")
+     * @var int
      */
     public $version;
 
     public function __construct(A $a, string $something)
     {
-        $this->a = $a;
+        $this->a         = $a;
         $this->something = $something;
     }
-
 }


### PR DESCRIPTION
Fixes #6394 Fixes #6393

`BasicEntityPersister::update` passes the wrong representation of identifiers to `assignDefaultVersionValue`. Instead of grabbing the values from `UnitOfWork::getEntityIdentifier` the method `ClassMetadataInfo::getIdentifierValues` must be used as in all other places where the identify flattener is ultimately used.

The difference is that `UnitOfWork` identifiers contain the scalar values representing an association identifier, but `ClassMetadataInfo` representation returns the actual entity object.

/cc @goetas 