### PR TITLE
[GH-8231] Bugfix: Missed dirty check synchronization check.

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1796,6 +1796,10 @@ class UnitOfWork implements PropertyChangedListener
                 $this->addToIdentityMap($entity);
 
                 $this->entityStates[$oid] = self::STATE_MANAGED;
+
+                if ($class->isChangeTrackingDeferredExplicit()) {
+                    $this->scheduleForDirtyCheck($entity);
+                }
                 break;
 
             case self::STATE_DETACHED:

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7629Test.php
@@ -31,6 +31,20 @@ class GH7629Test extends OrmFunctionalTestCase
 
         self::assertFalse($this->_em->getUnitOfWork()->isScheduledForDirtyCheck($entity));
     }
+
+    /**
+     * @group GH-8231
+     */
+    public function testPersistAfterRemoveSchedulesForSynchronization(): void
+    {
+        $entity = $this->_em->find(GH7629Entity::class, 1);
+
+        $this->_em->remove($entity);
+
+        $this->_em->persist($entity);
+
+        self::assertTrue($this->_em->getUnitOfWork()->isScheduledForDirtyCheck($entity));
+    }
 }
 
 /**


### PR DESCRIPTION
When an entity with change tracking policy "deferred explicit" gets removed, then persisted again, it is not schedulded for a dirty check synchronization. This is not the case for entities that are persisted and are already in the managed state.

Fixes #8231 