### PR TITLE
Added getHash method in SQLFilter to avoid caching the filtered queries

### DIFF
--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -103,6 +103,27 @@ abstract class SQLFilter
     }
 
     /**
+     * Return a unique hash base on filter class and his parametters
+     *
+     * @return string
+     */
+    final public function getHash()
+    {
+        $parameterCount = count($this->parameters);
+        $hash           = get_class($this).$parameterCount;
+        foreach ($this->parameters as $name => $param) {
+            if (is_object($param['value'])) {
+                $valueHash = spl_object_hash($param['value']);
+            } else {
+                $valueHash = $param['value'];
+            }
+            $hash .= $name.$param['type'].$valueHash;
+        }
+
+        return $hash;
+    }
+
+    /**
      * Returns as string representation of the SQLFilter parameters (the state).
      *
      * @return string String representation of the SQLFilter.

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -187,7 +187,7 @@ class FilterCollection
         $filterHash = '';
 
         foreach ($this->enabledFilters as $name => $filter) {
-            $filterHash .= $name . $filter;
+            $filterHash .= $name . $filter->getHash();
         }
 
         return $filterHash;

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -191,6 +191,32 @@ class SQLFilterTest extends OrmFunctionalTestCase
         self::assertFalse($em->getFilters()->isEnabled('foo_filter'));
     }
 
+    public function testGetHash() : void
+    {
+        $em = $this->getEntityManager();
+        $this->configureFilters($em);
+
+        // Check the filter hash without parameters
+        $em->getFilters()->enable("locale");
+        $filter = $em->getFilters()->getFilter("locale");
+        self::assertEquals('Doctrine\Tests\ORM\Functional\MyLocaleFilter0',$filter->getHash());
+
+        // Check the filter hash with one parameters
+        $filter->setParameter('test','string');
+        self::assertEquals('Doctrine\Tests\ORM\Functional\MyLocaleFilter1test2string',$filter->getHash());
+
+        // Check the filter hash with two parameters
+        $filter->setParameter('test2','string2');
+        self::assertEquals('Doctrine\Tests\ORM\Functional\MyLocaleFilter2test2stringtest22string2',$filter->getHash());
+
+       // Check the filter hash with three parameters one being an object
+        $stdClass = new \stdClass();
+        $splHash  = spl_object_hash($stdClass);
+        $filter->setParameter('test3', $stdClass);
+        self::assertEquals('Doctrine\Tests\ORM\Functional\MyLocaleFilter3test2stringtest22string2test32'.$splHash,$filter->getHash());
+    }
+
+
     protected function configureFilters($em)
     {
         // Add filters to the configuration of the EM
@@ -248,9 +274,7 @@ class SQLFilterTest extends OrmFunctionalTestCase
             ->method('setFiltersStateDirty');
 
         $filter = new MyLocaleFilter($em);
-
         $filter->setParameter('locale', 'en', DBALType::STRING);
-
         self::assertEquals("'en'", $filter->getParameter('locale'));
     }
 

--- a/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/FilterCollectionTest.php
@@ -95,6 +95,17 @@ class FilterCollectionTest extends OrmTestCase
 
         self::assertInstanceOf(MyFilter::class, $filterCollection->getFilter(self::TEST_FILTER));
     }
+
+    public function testGetHash()
+    {
+        $filterCollection = $this->em->getFilters();
+        $filterCollection->enable('testFilter');
+        $filterCollection->getFilter('testFilter');
+        $filterCollection->setParameter('test','string');
+        $hash = $filterCollection->getHash();
+
+        $this->assertEquals("testFilterDoctrine\Tests\ORM\Query\MyFilter1test2string",$hash);
+    }
 }
 
 class MyFilter extends SQLFilter


### PR DESCRIPTION
I introduced a new final method getHash on SQLFilter that generates a hash based on the called class name and all the parameters. Also the FilterCollection::getHash() was modified to use the getHash method from SQLFilter.

This is implemented acording to @beberlei's recomandation see the discussion bellow.

https://github.com/doctrine/orm/issues/3955#issuecomment-593161750

