### PR TITLE
remove `T` from class metadata

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -69,7 +69,7 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Initializes a new <tt>EntityRepository</tt>.
      *
-     * @psalm-param Mapping\ClassMetadata<T> $class
+     * @psalm-param Mapping\ClassMetadata $class
      */
     public function __construct(EntityManagerInterface $em, Mapping\ClassMetadata $class)
     {


### PR DESCRIPTION
while there's no releasing containing #8374, applying it locally causes the following issue, as  `ClassMetadata` has no generic parameter `T`.

```
ERROR: MixedArgumentTypeCoercion - src/Repository/UserRepository.php:48:39 - Argument 2 of Doctrine\ORM\EntityRepository::__construct expects Doctrine\ORM\Mapping\ClassMetadata<App\Entity\User>, parent type Doctrine\ORM\Mapping\ClassMetadata provided (see https://psalm.dev/194)
        parent::__construct($manager, $metadata);

```
