### PR TITLE
Identifier type is not set when many2many relations are deleted

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -515,7 +515,7 @@ class BasicEntityPersister implements EntityPersister
 
     /**
      * @param array<mixed> $identifier
-     * @param string[] $types
+     * @param string[]     $types
      *
      * @todo Add check for platform if it supports foreign keys/cascading.
      */

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -514,14 +514,12 @@ class BasicEntityPersister implements EntityPersister
     }
 
     /**
-     * @param array $identifier
-     * @param array $types
-     *
-     * @return void
+     * @param array<mixed> $identifier
+     * @param string[] $types
      *
      * @todo Add check for platform if it supports foreign keys/cascading.
      */
-    protected function deleteJoinTableRecords($identifier, $types)
+    protected function deleteJoinTableRecords(array $identifier, array $types): void
     {
         foreach ($this->class->associationMappings as $mapping) {
             if ($mapping['type'] !== ClassMetadata::MANY_TO_MANY) {

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -515,12 +515,13 @@ class BasicEntityPersister implements EntityPersister
 
     /**
      * @param array $identifier
+     * @param array $types
      *
      * @return void
      *
      * @todo Add check for platform if it supports foreign keys/cascading.
      */
-    protected function deleteJoinTableRecords($identifier)
+    protected function deleteJoinTableRecords($identifier, $types)
     {
         foreach ($this->class->associationMappings as $mapping) {
             if ($mapping['type'] !== ClassMetadata::MANY_TO_MANY) {
@@ -565,10 +566,10 @@ class BasicEntityPersister implements EntityPersister
 
             $joinTableName = $this->quoteStrategy->getJoinTableName($association, $this->class, $this->platform);
 
-            $this->conn->delete($joinTableName, array_combine($keys, $identifier));
+            $this->conn->delete($joinTableName, array_combine($keys, $identifier), $types);
 
             if ($selfReferential) {
-                $this->conn->delete($joinTableName, array_combine($otherKeys, $identifier));
+                $this->conn->delete($joinTableName, array_combine($otherKeys, $identifier), $types);
             }
         }
     }
@@ -585,7 +586,7 @@ class BasicEntityPersister implements EntityPersister
         $id         = array_combine($idColumns, $identifier);
         $types      = $this->getClassIdentifiersTypes($class);
 
-        $this->deleteJoinTableRecords($identifier);
+        $this->deleteJoinTableRecords($identifier, $types);
 
         return (bool) $this->conn->delete($tableName, $id, $types);
     }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -270,8 +270,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     {
         $identifier = $this->em->getUnitOfWork()->getEntityIdentifier($entity);
         $id         = array_combine($this->class->getIdentifierColumnNames(), $identifier);
+        $types      = $this->getClassIdentifiersTypes($this->class);
 
-        $this->deleteJoinTableRecords($identifier);
+        $this->deleteJoinTableRecords($identifier, $types);
 
         // If the database platform supports FKs, just
         // delete the row from the root table. Cascades do the rest.

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -40,6 +40,9 @@ class ConnectionMock extends Connection
     /** @var array */
     private $_executeUpdates = [];
 
+    /** @var array */
+    private $_deletes = [];
+
     /**
      * @param array $params
      */
@@ -75,6 +78,14 @@ class ConnectionMock extends Connection
     public function executeUpdate($query, array $params = [], array $types = [])
     {
         $this->_executeUpdates[] = ['query' => $query, 'params' => $params, 'types' => $types];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($table, array $criteria, array $types = [])
+    {
+        $this->_deletes[] = ['table' => $table, 'criteria' => $criteria, 'types' => $types];
     }
 
     /**
@@ -158,6 +169,14 @@ class ConnectionMock extends Connection
     public function getExecuteUpdates(): array
     {
         return $this->_executeUpdates;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDeletes(): array
+    {
+        return $this->_deletes;
     }
 
     public function reset(): void


### PR DESCRIPTION
I was trying out the new Symfony Ulid doctrine type together with Postgres and found a small bug.
For this use case the Ulid is formatted as UUID so it can be stored using the native GUID type.
In Doctrine this works fine until you want to delete an entity that has many2many relations causing error
`SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type uuid`

This PR makes sure that the identifier types are set on the delete queries so the Ulid is mapped correctly.