### PR TITLE
Resolving target entity in discriminator map omits fields from subtables

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -329,24 +329,26 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
 
         // minor optimization: avoid loading related metadata when not needed
-        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-            if ($discriminatorClass === $metadata->name) {
-                $metadata->discriminatorValue = $discriminatorValue;
+//        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
+//            if ($discriminatorClass === $metadata->name) {
+//                $metadata->discriminatorValue = $discriminatorValue;
+//
+//                return;
+//            }
+//        }
+//
+//        // iterate over discriminator mappings and resolve actual referenced classes according to existing metadata
+//        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
+//            if ($metadata->name === $this->getMetadataFor($discriminatorClass)->getName()) {
+//                $metadata->discriminatorValue = $discriminatorValue;
+//
+//                return;
+//            }
+//        }
 
-                return;
-            }
+        if (! in_array($metadata->name, $metadata->discriminatorMap)) {
+            throw MappingException::mappedClassNotPartOfDiscriminatorMap($metadata->name, $metadata->rootEntityName);
         }
-
-        // iterate over discriminator mappings and resolve actual referenced classes according to existing metadata
-        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-            if ($metadata->name === $this->getMetadataFor($discriminatorClass)->getName()) {
-                $metadata->discriminatorValue = $discriminatorValue;
-
-                return;
-            }
-        }
-
-        throw MappingException::mappedClassNotPartOfDiscriminatorMap($metadata->name, $metadata->rootEntityName);
     }
 
     /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -41,7 +41,6 @@ use Doctrine\Persistence\Mapping\ReflectionService;
 use ReflectionClass;
 use ReflectionException;
 
-use function array_map;
 use function assert;
 use function class_exists;
 use function count;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -284,7 +284,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                     }
                 }
             } else {
-                assert($parent instanceof ClassMetadataInfo); // make static code analysis happy, see https://github.com/doctrine/orm/pull/8402#issuecomment-855805708
+                assert($parent instanceof ClassMetadataInfo); // https://github.com/doctrine/orm/issues/8746
                 if ((! $class->reflClass || ! $class->reflClass->isAbstract()) && ! in_array($class->name, $parent->discriminatorMap)) {
                     throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
                 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -283,8 +283,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         throw MappingException::invalidClassInDiscriminatorMap($subClass, $class->name);
                     }
                 }
-            } elseif ((! $class->reflClass || ! $class->reflClass->isAbstract()) && ! in_array($class->name, $parent->discriminatorMap)) {
-                throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
+            } else {
+                assert($parent instanceof ClassMetadataInfo); // make static code analysis happy, see https://github.com/doctrine/orm/pull/8402#issuecomment-855805708
+                if ((! $class->reflClass || ! $class->reflClass->isAbstract()) && ! in_array($class->name, $parent->discriminatorMap)) {
+                    throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
+                }
             }
         } elseif ($class->isMappedSuperclass && $class->name === $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -47,6 +47,7 @@ use function class_exists;
 use function count;
 use function end;
 use function explode;
+use function in_array;
 use function is_subclass_of;
 use function strpos;
 use function strtolower;
@@ -76,18 +77,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /** @var mixed[] */
     private $embeddablesActiveNesting = [];
-
-    /**
-     * {@inheritDoc}
-     */
-    protected function loadMetadata($name)
-    {
-        $loaded = parent::loadMetadata($name);
-
-        array_map([$this, 'resolveDiscriminatorValue'], array_map([$this, 'getMetadataFor'], $loaded));
-
-        return $loaded;
-    }
 
     /**
      * @return void
@@ -295,6 +284,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                         throw MappingException::invalidClassInDiscriminatorMap($subClass, $class->name);
                     }
                 }
+            } elseif ((! $class->reflClass || ! $class->reflClass->isAbstract()) && ! in_array($class->name, $parent->discriminatorMap)) {
+                throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
             }
         } elseif ($class->isMappedSuperclass && $class->name === $class->rootEntityName && (count($class->discriminatorMap) || $class->discriminatorColumn)) {
             // second condition is necessary for mapped superclasses in the middle of an inheritance hierarchy
@@ -308,47 +299,6 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     protected function newClassMetadataInstance($className)
     {
         return new ClassMetadata($className, $this->em->getConfiguration()->getNamingStrategy());
-    }
-
-    /**
-     * Populates the discriminator value of the given metadata (if not set) by iterating over discriminator
-     * map classes and looking for a fitting one.
-     *
-     * @throws MappingException
-     */
-    private function resolveDiscriminatorValue(ClassMetadata $metadata): void
-    {
-        if (
-            $metadata->discriminatorValue
-            || ! $metadata->discriminatorMap
-            || $metadata->isMappedSuperclass
-            || ! $metadata->reflClass
-            || $metadata->reflClass->isAbstract()
-        ) {
-            return;
-        }
-
-        // minor optimization: avoid loading related metadata when not needed
-//        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-//            if ($discriminatorClass === $metadata->name) {
-//                $metadata->discriminatorValue = $discriminatorValue;
-//
-//                return;
-//            }
-//        }
-//
-//        // iterate over discriminator mappings and resolve actual referenced classes according to existing metadata
-//        foreach ($metadata->discriminatorMap as $discriminatorValue => $discriminatorClass) {
-//            if ($metadata->name === $this->getMetadataFor($discriminatorClass)->getName()) {
-//                $metadata->discriminatorValue = $discriminatorValue;
-//
-//                return;
-//            }
-//        }
-
-        if (! in_array($metadata->name, $metadata->discriminatorMap)) {
-            throw MappingException::mappedClassNotPartOfDiscriminatorMap($metadata->name, $metadata->rootEntityName);
-        }
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -105,6 +105,12 @@ class ResolveTargetEntityListener implements EventSubscriber
                 $args->getEntityManager()->getMetadataFactory()->setMetadataFor($interface, $cm);
             }
         }
+
+        foreach ($cm->discriminatorMap as $value => $class) {
+            if (isset($this->resolveTargetEntities[$class])) {
+                $cm->addDiscriminatorMapClass($value, $this->resolveTargetEntities[$class]['targetEntity']);
+            }
+        }
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -262,7 +262,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$discriminatorMap\\.$#"
-			count: 2
+			count: 3
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -262,7 +262,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$discriminatorMap\\.$#"
-			count: 3
+			count: 2
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -36,8 +36,8 @@ class DDC3300Test extends OrmFunctionalTestCase
             ]
         );
 
-        $boss     = new DDC3300HumanBoss();
-        $employee = new DDC3300HumanEmployee();
+        $boss     = new DDC3300HumanBoss('boss');
+        $employee = new DDC3300HumanEmployee('employee');
 
         $this->_em->persist($boss);
         $this->_em->persist($employee);
@@ -53,7 +53,7 @@ class DDC3300Test extends OrmFunctionalTestCase
 /**
  * @Entity
  * @InheritanceType("SINGLE_TABLE")
- * @DdiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorColumn(name="discr", type="string")
  * @DiscriminatorMap({
  *      "boss"     = "Doctrine\Tests\ORM\Functional\Ticket\DDC3300Boss",
  *      "employee" = "Doctrine\Tests\ORM\Functional\Ticket\DDC3300Employee"
@@ -77,6 +77,13 @@ interface DDC3300Boss
 /** @Entity */
 class DDC3300HumanBoss extends DDC3300Person implements DDC3300Boss
 {
+    /** @Column(type="string") */
+    public $bossCol;
+
+    public function __construct($bossCol)
+    {
+        $this->bossCol = $bossCol;
+    }
 }
 
 interface DDC3300Employee
@@ -86,4 +93,11 @@ interface DDC3300Employee
 /** @Entity */
 class DDC3300HumanEmployee extends DDC3300Person implements DDC3300Employee
 {
+    /** @Column(type="string") */
+    public $employeeCol;
+
+    public function __construct($employeeCol)
+    {
+        $this->employeeCol = $employeeCol;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3300Test.php
@@ -77,7 +77,10 @@ interface DDC3300Boss
 /** @Entity */
 class DDC3300HumanBoss extends DDC3300Person implements DDC3300Boss
 {
-    /** @Column(type="string") */
+    /**
+     * @var string
+     * @Column(type="string")
+     */
     public $bossCol;
 
     public function __construct($bossCol)
@@ -93,7 +96,10 @@ interface DDC3300Employee
 /** @Entity */
 class DDC3300HumanEmployee extends DDC3300Person implements DDC3300Employee
 {
-    /** @Column(type="string") */
+    /**
+     * @var string
+     * @Column(type="string")
+     */
     public $employeeCol;
 
     public function __construct($employeeCol)


### PR DESCRIPTION
#1257 introduced the possibility to use interfaces instead of concrete classes also in the DiscriminatorMap. Here's an example config:

```php
/** @DiscriminatorMap({"foo" = "FooInterface", "bar" = "BarConcreteImpl"}) */
```

The `ResolveTargetEntityListener` would be used to resolve such interface references to concrete classes at runtime.

The feature is currently broken. Core of the issue seems to be that `\Doctrine\ORM\Mapping\ClassMetadataInfo::$subClasses` is not populated with the concrete classes. This proably has to do with the resolution taking place too late, although I do not fully understand where this happens.

Example test failure before the change: https://github.com/doctrine/orm/pull/8402/checks?check_run_id=1587762816#step:7:73. The test case failed because the columns necessary for the subclasses are not created, but if they were (in an existing schema), the loaded entities would also lack data for their respective fields.

PR is against 2.7.x where the feature was introduced, since I did not find any documentation on PR policies/target branches.