### PR TITLE
Fixed embeddable loading

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -3392,8 +3392,8 @@ class ClassMetadataInfo implements ClassMetadata
                     ->embeddedFieldToColumnName(
                         $property,
                         $fieldMapping['columnName'],
-                        $this->reflClass->name,
-                        $embeddable->reflClass->name
+                        $this->reflClass ? $this->reflClass->name : null,
+                        $embeddable->reflClass ? $embeddable->reflClass->name : null
                     );
             }
 


### PR DESCRIPTION
This fixes a bug that arises when you need to map your entity without existed appropriate class (by using DisconnectedClassMetadataFactory), which contains embeddable fields. It can help laravel-doctrine package be able to generate Entities, which have embeddable values, based on mapping files. But now there is an ErrorException, because StaticReflectionService returned by DisconnectedClassMetadataFactory returns null on getClass method in inlineEmbeddable method, which needs emmbeddable's argument refClass to not be a null too.