### PR TITLE
Fix association handling when there is a MappedSuperclass in the middle of an inheritance hierarchy

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5998Test.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group GH-5998
+ */
+class GH5998Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(GH5998JTI::class),
+            $this->_em->getClassMetadata(GH5998JTIChild::class),
+            $this->_em->getClassMetadata(GH5998STI::class),
+            $this->_em->getClassMetadata(GH5998Basic::class),
+            $this->_em->getClassMetadata(GH5998Related::class),
+        ]);
+    }
+
+    /**
+     * Verifies that MappedSuperclasses work within an inheritance hierarchy.
+     */
+    public function testIssue(): void
+    {
+        // Test JTI
+        $this->classTests(GH5998JTIChild::class);
+        // Test STI
+        $this->classTests(GH5998STIChild::class);
+        // Test Basic
+        $this->classTests(GH5998Basic::class);
+    }
+
+    private function classTests($className): void
+    {
+        // Test insert
+        $child      = new $className('Sam', 0, 1);
+        $child->rel = new GH5998Related();
+        $this->_em->persist($child);
+        $this->_em->persist($child->rel);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        // Test find by rel
+        $child = $this->_em->getRepository($className)->findOneBy(['rel' => $child->rel]);
+        self::assertNotNull($child);
+        $this->_em->clear();
+
+        // Test query by id with fetch join
+        $child = $this->_em->createQuery('SELECT t, r FROM ' . $className . ' t JOIN t.rel r WHERE t.id = 1')->getOneOrNullResult();
+        self::assertNotNull($child);
+
+        // Test lock and update
+        $this->_em->transactional(static function ($em) use ($child): void {
+            $em->lock($child, LockMode::NONE);
+            $child->firstName = 'Bob';
+            $child->status    = 0;
+        });
+        $this->_em->clear();
+        $child = $this->_em->getRepository($className)->find(1);
+        self::assertEquals($child->firstName, 'Bob');
+        self::assertEquals($child->status, 0);
+
+        // Test delete
+        $this->_em->remove($child);
+        $this->_em->flush();
+        $child = $this->_em->getRepository($className)->find(1);
+        self::assertNull($child);
+    }
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH5998Common
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+    /**
+     * @ORM\ManyToOne(targetEntity=GH5998Related::class)
+     * @ORM\JoinColumn(name="related_id", referencedColumnName="id")
+     *
+     * @var GH5998Related
+     */
+    public $rel;
+    /**
+     * @ORM\Version
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $version;
+
+    /** @var mixed */
+    public $other;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorMap({"child" = GH5998JTIChild::class})
+ */
+abstract class GH5998JTI extends GH5998Common
+{
+    /**
+     * @ORM\Column(type="string", length=255)
+     *
+     * @var string
+     */
+    public $firstName;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH5998JTICommon extends GH5998JTI
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $status;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH5998JTIChild extends GH5998JTICommon
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $type;
+
+    public function __construct(string $firstName, int $type, int $status)
+    {
+        $this->firstName = $firstName;
+        $this->type      = $type;
+        $this->status    = $status;
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorMap({"child" = GH5998STIChild::class})
+ */
+abstract class GH5998STI extends GH5998Common
+{
+    /**
+     * @ORM\Column(type="string", length=255)
+     *
+     * @var string
+     */
+    public $firstName;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH5998STICommon extends GH5998STI
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $status;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH5998STIChild extends GH5998STICommon
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $type;
+
+    public function __construct(string $firstName, int $type, int $status)
+    {
+        $this->firstName = $firstName;
+        $this->type      = $type;
+        $this->status    = $status;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH5998Basic extends GH5998Common
+{
+    /**
+     * @ORM\Column(type="string", length=255)
+     *
+     * @var string
+     */
+    public $firstName;
+
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $status;
+
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
+    public $type;
+
+    public function __construct(string $firstName, int $type, int $status)
+    {
+        $this->firstName = $firstName;
+        $this->type      = $type;
+        $this->status    = $status;
+    }
+}
+
+/**
+ * @ORM\Entity()
+ */
+class GH5998Related
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415Test.php
@@ -25,12 +25,12 @@ class GH8415Test extends OrmFunctionalTestCase
 
     public function testAssociationIsBasedOnBaseClass(): void
     {
-        $target                   = new GH8415AssociationTarget();
-        $leaf                     = new GH8415LeafClass();
-        $leaf->baseField          = 'base';
-        $leaf->middleField        = 'middle';
-        $leaf->leafField          = 'leaf';
-        $leaf->target             = $target;
+        $target            = new GH8415AssociationTarget();
+        $leaf              = new GH8415LeafClass();
+        $leaf->baseField   = 'base';
+        $leaf->middleField = 'middle';
+        $leaf->leafField   = 'leaf';
+        $leaf->target      = $target;
 
         $this->_em->persist($target);
         $this->_em->persist($leaf);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415Test.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class GH8415Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEntitySchema(
+            [
+                GH8415BaseClass::class,
+                GH8415MiddleMappedSuperclass::class,
+                GH8415LeafClass::class,
+                GH8415AssociationTarget::class,
+            ]
+        );
+    }
+
+    public function testAssociationIsBasedOnBaseClass(): void
+    {
+        $target                   = new GH8415AssociationTarget();
+        $leaf                     = new GH8415LeafClass();
+        $leaf->baseField          = 'base';
+        $leaf->middleField        = 'middle';
+        $leaf->leafField          = 'leaf';
+        $leaf->target             = $target;
+
+        $this->_em->persist($target);
+        $this->_em->persist($leaf);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $query  = $this->_em->createQuery('SELECT leaf FROM Doctrine\Tests\ORM\Functional\Ticket\GH8415LeafClass leaf JOIN leaf.target t');
+        $result = $query->getOneOrNullResult();
+
+        $this->assertInstanceOf(GH8415LeafClass::class, $result);
+        $this->assertSame('base', $result->baseField);
+        $this->assertSame('middle', $result->middleField);
+        $this->assertSame('leaf', $result->leafField);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8415AssociationTarget
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ * @ORM\DiscriminatorMap({"1" = "Doctrine\Tests\ORM\Functional\Ticket\GH8415BaseClass", "2" = "Doctrine\Tests\ORM\Functional\Ticket\GH8415LeafClass"})
+ */
+class GH8415BaseClass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH8415AssociationTarget")
+     *
+     * @var GH8415AssociationTarget
+     */
+    public $target;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $baseField;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH8415MiddleMappedSuperclass extends GH8415BaseClass
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $middleField;
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8415LeafClass extends GH8415MiddleMappedSuperclass
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $leafField;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415ToManyAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8415ToManyAssociationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Tests\OrmTestCase;
+
+class GH8415ToManyAssociationTest extends OrmTestCase
+{
+    public function testToManyAssociationOnBaseClassAllowedWhenThereAreMappedSuperclassesAsChildren(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $em = $this->getTestEntityManager();
+        $em->getClassMetadata(GH8415ToManyLeafClass::class);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8415ToManyAssociationTarget
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="GH8415ToManyBaseClass", inversedBy="targets")
+     *
+     * @var GH8415ToManyBaseClass
+     */
+    public $base;
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("SINGLE_TABLE")
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ * @ORM\DiscriminatorMap({"1" = "Doctrine\Tests\ORM\Functional\Ticket\GH8415ToManyBaseClass", "2" = "Doctrine\Tests\ORM\Functional\Ticket\GH8415ToManyLeafClass"})
+ */
+class GH8415ToManyBaseClass
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="GH8415ToManyAssociationTarget", mappedBy="base")
+     *
+     * @var Collection
+     */
+    public $targets;
+}
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class GH8415ToManyMappedSuperclass extends GH8415ToManyBaseClass
+{
+}
+
+/**
+ * @ORM\Entity
+ */
+class GH8415ToManyLeafClass extends GH8415ToManyMappedSuperclass
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    public $leafField;
+}


### PR DESCRIPTION
This fixes two closely related bugs.

1. When inheriting a to-one association from a mapped superclass, update the `sourceEntity` class name to the current class only when the association is actually _declared_ in the mapped superclass.
2. Reject association types that are not allowed on mapped superclasses only when they are actually _declared_ in a mapped superclass, not when inherited from parent classes.

#### Background 

Currently, when a many-to-one association is inherited from a `MappedSuperclass`, mapping information will be updated so that the association has the current (inheriting) class as the source entity.

https://github.com/doctrine/orm/blob/2138cc93834cfae9cd3f86c991fa051a3129b693/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php#L384-L393

This was added in 7dc8ef1db9b55ab1a76f416d78e6bd882bbbd1d5 for [DDC-671](https://github.com/doctrine/orm/issues/5181).

The reason for this is that a mapped superclass is not an entity itself and has no table. 

So, in the database, associations can only be from the inheriting entities' tables towards the referred-to target. This is also the reason for the limitation that only to-one associations may be added in mapped superclasses, since for those the database foreign key can be placed on the table(s) of the inheriting entities (and there may be more than one child class).

#### Issue with the current code

Neither the decision to update the `sourceEntity` nor the validation check should be based on `$parent->isMappedSuperclass`.

This only works in the simple case where the class hierarchy is `Mapped Superclass → Entity`.

The check is wrong when we have an inheritance hierarchy set up and the class hierarchy is `Base Entity → Mapped Superclass → Child Entity`.

Bug 1: The association should keep the root entity as the source. After all, in a JTI, the root table will contain the foreign key, and we need to base joins on that table when traversing `FROM LeafClass l JOIN l.target`.

Bug 2: Do not reject the to-many association declared in the base class. It is ok to have the reverse (owning) side point back to the base entity, as it would be if there were no mapped superclasses at all. The mapped superclass does not declare, add or otherwise interfere with the to-many association at all.

#### Suggested fix

Base the decision to change the `sourceEntity` on `$mapping['inherited']` being set. This field points to the topmost _parent entity_ class in the ancestry tree where the relationship mapping appears for the first time.

When it is not set, the current class is the first _entity_ class in the hierarchy with that association. Since we are inheriting the relation, it must have been added in a mapped superclass above, but was not yet present in the nearest parent entity class.

In that case, it may only be a to-one association and the source entity needs to be updated.

(See #10396 for a clarification of the semantics of `inherited`.)

#### Example 

Here is a simplified example of the class hierarchy. 

See the two tests added for more details – one is for checking the correct usage of a to-one association against/with the base class in JTI. The other is to test that a to-many association on the base class is not rejected.

I am sure that there are other tests that (still) cover the update of `sourceEntity` is happening.

```php
/**
 * @Entity
 */
class AssociationTarget
{
    /**
     * @Column(type="integer")
     * @Id
     * @GeneratedValue
     */
    public $id;
}

/**
 * @Entity
 * @InheritanceType("JOINED")
 * @DiscriminatorColumn(name="discriminator", type="string")
 * @DiscriminatorMap({"1" = "BaseClass", "2" = "LeafClass"})
 */
class BaseClass
{
    /**
     * @Column(type="integer")
     * @Id
     * @GeneratedValue
     */
    public $id;

    /**
     * @ManyToOne(targetEntity="AssociationTarget")
     */
    public $target;
}

/**
 * @MappedSuperclass
 */
class MediumSuperclass extends BaseClass
{
}

/**
 * @Entity
 */
class LeafClass extends MediumSuperclass
{
}
```

When querying `FROM LeafClass l`, it should be possible to `JOIN l.target`. This currently leads to an SQL error because the SQL join will be made via `LeafClass.target_id` instead of `BaseClass.target_id`. `LeafClass` is considered the `sourceEntity` for the association – which is wrong–, and so the foreign key field is expected to be in the `LeafClass` table (using JTI here).

Fixes #5998, fixes #7825. 

#### Updated: 

I have removed the abstract entity class, since it is not relevant for the issue and took the discussion off course. Also, the discriminator map now contains all classes.

#### Updated 2:

Added the second variant of the bug, namely that a to-many association would wrongly be rejected in the same situation.