### PR TITLE
Restrict EntityManagerInterface::getRepository

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -33,6 +33,15 @@ use Doctrine\Persistence\ObjectManager;
 interface EntityManagerInterface extends ObjectManager
 {
     /**
+     * {@inheritdoc}
+     *
+     * @template T
+     * @psalm-param class-string<T> $className
+     * @psalm-return EntityRepository<T>
+     */
+    public function getRepository($className);
+
+    /**
      * Returns the cache API for managing the second level cache regions or NULL if the cache is not enabled.
      *
      * @return \Doctrine\ORM\Cache|null


### PR DESCRIPTION
Currently `EntityManagerInterface::getRepository` is returning `ObjectRepository`.
But I assume it was meant to return `EntityRepository`.

It's overriden in psalm https://github.com/weirdan/doctrine-psalm-plugin/blob/master/stubs/EntityManagerInterface.phpstub#L16

And the EntityManager is returning an EntityRepository
https://github.com/doctrine/orm/blob/2.8.x/lib/Doctrine/ORM/EntityManager.php#L745