### PR TITLE
Fetching entities with Composite Key Relations

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2761,9 +2761,7 @@ class UnitOfWork implements PropertyChangedListener
                             } else {
                                 $associatedId[$targetClass->fieldNames[$targetColumn]] = $joinColumnValue;
                             }
-                        } elseif ($targetClass->containsForeignIdentifier
-                            && in_array($targetClass->getFieldForColumn($targetColumn), $targetClass->identifier, true)
-                        ) {
+                        } elseif (in_array($targetClass->getFieldForColumn($targetColumn), $targetClass->identifier, true)) {
                             // the missing key is part of target's entity primary key
                             $associatedId = [];
                             break;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -47,6 +47,7 @@ use InvalidArgumentException;
 use Throwable;
 use UnexpectedValueException;
 use function get_class;
+use function in_array;
 use function is_object;
 use function spl_object_hash;
 

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
@@ -1,0 +1,17 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyRelations;
+
+/**
+ * @Entity
+ */
+class CustomerClass
+{
+    /** @Id @Column(type="string") */
+    public $companyCode;
+
+    /** @Id @Column(type="string") */
+    public $code;
+
+    /** @Column(type="string") */
+    public $name;
+}

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\CompositeKeyRelations;
 
 /**
@@ -6,12 +9,21 @@ namespace Doctrine\Tests\Models\CompositeKeyRelations;
  */
 class CustomerClass
 {
-    /** @Id @Column(type="string") */
+    /**
+     * @var string
+     * @Id @Column(type="string")
+     */
     public $companyCode;
 
-    /** @Id @Column(type="string") */
+    /**
+     * @var string
+     * @Id @Column(type="string")
+     */
     public $code;
 
-    /** @Column(type="string") */
+    /**
+     * @var string
+     * @Column(type="string")
+     */
     public $name;
 }

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/CustomerClass.php
@@ -10,20 +10,17 @@ namespace Doctrine\Tests\Models\CompositeKeyRelations;
 class CustomerClass
 {
     /**
-     * @var string
      * @Id @Column(type="string")
      */
-    public $companyCode;
+    public string $companyCode;
 
     /**
-     * @var string
      * @Id @Column(type="string")
      */
-    public $code;
+    public string $code;
 
     /**
-     * @var string
      * @Column(type="string")
      */
-    public $name;
+    public string $name;
 }

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
@@ -10,30 +10,26 @@ namespace Doctrine\Tests\Models\CompositeKeyRelations;
 class InvoiceClass
 {
     /**
-     * @var string
      * @Id @Column(type="string")
      */
-    public $companyCode;
+    public string $companyCode;
 
     /**
-     * @var string
      * @Id @Column(type="string")
      */
-    public $invoiceNumber;
+    public string $invoiceNumber;
 
     /**
-     * @var CustomerClass|null
      * @ManyToOne(targetEntity="CustomerClass")
      * @JoinColumns({
      *     @JoinColumn(name="companyCode", referencedColumnName="companyCode"),
      *     @JoinColumn(name="customerCode", referencedColumnName="code")
      * })
      */
-    public $customer;
+    public ?CustomerClass $customer;
 
     /**
-     * @var string|null
      * @Column(type="string", nullable=true)
      */
-    public $customerCode;
+    public ?string $customerCode;
 }

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\CompositeKeyRelations;
 
 /**
@@ -6,13 +9,20 @@ namespace Doctrine\Tests\Models\CompositeKeyRelations;
  */
 class InvoiceClass
 {
-    /** @Id @Column(type="string") */
+    /**
+     * @var string
+     * @Id @Column(type="string")
+     */
     public $companyCode;
 
-    /** @Id @Column(type="string") */
+    /**
+     * @var string
+     * @Id @Column(type="string")
+     */
     public $invoiceNumber;
 
     /**
+     * @var CustomerClass|null
      * @ManyToOne(targetEntity="CustomerClass")
      * @JoinColumns({
      *     @JoinColumn(name="companyCode", referencedColumnName="companyCode"),
@@ -21,6 +31,9 @@ class InvoiceClass
      */
     public $customer;
 
-    /** @Column(type="string", nullable=true) */
+    /**
+     * @var string|null
+     * @Column(type="string", nullable=true)
+     */
     public $customerCode;
 }

--- a/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
+++ b/tests/Doctrine/Tests/Models/CompositeKeyRelations/InvoiceClass.php
@@ -1,0 +1,26 @@
+<?php
+namespace Doctrine\Tests\Models\CompositeKeyRelations;
+
+/**
+ * @Entity
+ */
+class InvoiceClass
+{
+    /** @Id @Column(type="string") */
+    public $companyCode;
+
+    /** @Id @Column(type="string") */
+    public $invoiceNumber;
+
+    /**
+     * @ManyToOne(targetEntity="CustomerClass")
+     * @JoinColumns({
+     *     @JoinColumn(name="companyCode", referencedColumnName="companyCode"),
+     *     @JoinColumn(name="customerCode", referencedColumnName="code")
+     * })
+     */
+    public $customer;
+
+    /** @Column(type="string", nullable=true) */
+    public $customerCode;
+}

--- a/tests/Doctrine/Tests/ORM/Functional/CompositeKeyRelationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositeKeyRelationsTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass;

--- a/tests/Doctrine/Tests/ORM/Functional/CompositeKeyRelationsTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CompositeKeyRelationsTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass;
+use Doctrine\Tests\Models\CompositeKeyRelations\InvoiceClass;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class CompositeKeyRelationsTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('compositekeyrelations');
+        parent::setUp();
+    }
+
+    public function testFindEntityWithNotNullRelation(): void
+    {
+        $this->_em->getConnection()->insert('CustomerClass', [
+            'companyCode' => 'AA',
+            'code' => 'CUST1',
+            'name' => 'Customer 1',
+        ]);
+
+        $this->_em->getConnection()->insert('InvoiceClass', [
+            'companyCode' => 'AA',
+            'invoiceNumber' => 'INV1',
+            'customerCode' => 'CUST1',
+        ]);
+
+        $entity = $this->findEntity('AA', 'INV1');
+        self::assertSame('AA', $entity->companyCode);
+        self::assertSame('INV1', $entity->invoiceNumber);
+        self::assertInstanceOf(CustomerClass::class, $entity->customer);
+        self::assertSame('Customer 1', $entity->customer->name);
+    }
+
+    public function testFindEntityWithNullRelation(): void
+    {
+        $this->_em->getConnection()->insert('InvoiceClass', [
+            'companyCode' => 'BB',
+            'invoiceNumber' => 'INV1',
+        ]);
+
+        $entity = $this->findEntity('BB', 'INV1');
+        self::assertSame('BB', $entity->companyCode);
+        self::assertSame('INV1', $entity->invoiceNumber);
+        self::assertNull($entity->customer);
+    }
+
+    private function findEntity(string $companyCode, string $invoiceNumber): InvoiceClass
+    {
+        return $this->_em->find(
+            InvoiceClass::class,
+            ['companyCode' => $companyCode, 'invoiceNumber' => $invoiceNumber]
+        );
+    }
+}

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -182,6 +182,10 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             Models\CustomType\CustomTypeParent::class,
             Models\CustomType\CustomTypeUpperCase::class,
         ],
+        'compositekeyrelations' => [
+            Models\CompositeKeyRelations\InvoiceClass::class,
+            Models\CompositeKeyRelations\CustomerClass::class,
+        ],
         'compositekeyinheritance' => [
             Models\CompositeKeyInheritance\JoinedRootClass::class,
             Models\CompositeKeyInheritance\JoinedChildClass::class,


### PR DESCRIPTION
In our database design we are using entities with composite keys, and we are using composite keys relations between entities.

Let say we have the following entities with Primary Keys (PK):

- `Company` (PK: `company_code`)
- `Customer` (PK composite: `company_code` + `customer_code`)
- `Invoice` (PK composite: `company_code` + `invoice_code`)

and the following relations in `Invoice`:
 - to `Company` (using `company_code`), not nullable
 - to `Customer` (using composite key `company_code` + `customer_code`), nullable

Now we have `company_code` (not null) but no `customer_code` (null).
We want to fetch `Invoice` entity, so that we get not null `Company`, and null `Customer`.

The problem is that loading `Invoice` with null `Customer` is not working - we are getting the following exception:

```
Exception: [Doctrine\Common\Proxy\Exception\OutOfBoundsException] Missing value for primary key code on Doctrine\Tests\Models\CompositeKeyRelations\CustomerClass
```

This PR provide a fix, to load the `Customer` in the described case.
The change is pretty simply, and no other tests are affected.


NOTE: Loading `Company` is not a problem as it is using relation on just one column (not a composite key). The description includes it just for completeness of the example.