### PR TITLE
Fix --complete flag in orm:ensure-production-settings command

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -62,7 +62,7 @@ class EnsureProductionSettingsCommand extends Command
         try {
             $em->getConfiguration()->ensureProductionSettings();
 
-            if ($input->getOption('complete') !== null) {
+            if ($input->getOption('complete') !== false) {
                 $em->getConnection()->connect();
             }
         } catch (Throwable $e) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -62,7 +62,7 @@ class EnsureProductionSettingsCommand extends Command
         try {
             $em->getConfiguration()->ensureProductionSettings();
 
-            if ($input->getOption('complete') !== false) {
+            if (!$input->getOption('complete')) {
                 $em->getConnection()->connect();
             }
         } catch (Throwable $e) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -62,7 +62,7 @@ class EnsureProductionSettingsCommand extends Command
         try {
             $em->getConfiguration()->ensureProductionSettings();
 
-            if (! $input->getOption('complete')) {
+            if ($input->getOption('complete') === true) {
                 $em->getConnection()->connect();
             }
         } catch (Throwable $e) {

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -62,7 +62,7 @@ class EnsureProductionSettingsCommand extends Command
         try {
             $em->getConfiguration()->ensureProductionSettings();
 
-            if (!$input->getOption('complete')) {
+            if (! $input->getOption('complete')) {
                 $em->getConnection()->connect();
             }
         } catch (Throwable $e) {

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
-use Doctrine\Tests\OrmTestCase;
+use Doctrine\Tests\DoctrineTestCase;
 use RuntimeException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 use function array_merge;
 
-class EnsureProductionSettingsCommandTest extends OrmTestCase
+class EnsureProductionSettingsCommandTest extends DoctrineTestCase
 {
     public function testExecute(): void
     {

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Tools\Console\Command;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Doctrine\Tests\OrmTestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class EnsureProductionSettingsCommandTest extends OrmTestCase
+{
+    public function testExecute()
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->expects($this->once())
+            ->method('ensureProductionSettings');
+
+        $em->method('getConfiguration')
+            ->willReturn($configuration);
+
+        $em->expects($this->never())
+            ->method('getConnection');
+
+        $this->assertSame(0, $this->executeCommand($em));
+    }
+
+    public function testExecuteFailed()
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->expects($this->once())
+            ->method('ensureProductionSettings')
+            ->willThrowException(new \RuntimeException());
+
+        $em->method('getConfiguration')
+            ->willReturn($configuration);
+
+        $em->expects($this->never())
+            ->method('getConnection');
+
+        $this->assertSame(1, $this->executeCommand($em));
+    }
+
+    public function testExecuteWithComplete()
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->expects($this->once())
+            ->method('ensureProductionSettings');
+
+        $em->method('getConfiguration')
+            ->willReturn($configuration);
+
+        $connection = $this->createMock(Connection::class);
+
+        $connection->expects($this->once())
+            ->method('connect');
+
+        $em->method('getConnection')
+            ->willReturn($connection);
+
+        $this->assertSame(0, $this->executeCommand($em, ['--complete' => true]));
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    private function executeCommand(
+        EntityManagerInterface $em,
+        array $input = []
+    ): int {
+        $application = new Application();
+        $application->setHelperSet(new HelperSet(['em' => new EntityManagerHelper($em)]));
+        $application->add(new EnsureProductionSettingsCommand());
+
+        $command = $application->find('orm:ensure-production-settings');
+        $tester  = new CommandTester($command);
+
+        return $tester->execute(
+            \array_merge([
+                'command'   => $command->getName(),
+            ], $input),
+        );
+    }
+}


### PR DESCRIPTION
$input->getOption('complete') returns `false` and not `null` if not set.