### PR TITLE
fixed entity generation for numeric values

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1351,8 +1351,8 @@ public function __construct(<params>)
             if (isset($fieldMapping['options']['default'])) {
                 if ($fieldMapping['type'] === 'boolean' && $fieldMapping['options']['default'] === '1') {
                     $defaultValue = ' = true';
-                } else if (($fieldMapping['type'] === 'integer' || $fieldMapping['type'] === 'float') && !empty($fieldMapping['options']['default'])) {
-                    $defaultValue = ' = ' . (string)$fieldMapping['options']['default'];
+                } elseif (($fieldMapping['type'] === 'integer' || $fieldMapping['type'] === 'float') && ! empty($fieldMapping['options']['default'])) {
+                    $defaultValue = ' = ' . (string) $fieldMapping['options']['default'];
                 } else {
                     $defaultValue = ' = ' . var_export($fieldMapping['options']['default'], true);
                 }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1351,6 +1351,8 @@ public function __construct(<params>)
             if (isset($fieldMapping['options']['default'])) {
                 if ($fieldMapping['type'] === 'boolean' && $fieldMapping['options']['default'] === '1') {
                     $defaultValue = ' = true';
+                } else if (($fieldMapping['type'] === 'integer' || $fieldMapping['type'] === 'float') && !empty($fieldMapping['options']['default'])) {
+                    $defaultValue = ' = ' . (string)$fieldMapping['options']['default'];
                 } else {
                     $defaultValue = ' = ' . var_export($fieldMapping['options']['default'], true);
                 }


### PR DESCRIPTION
Originally doctrine adds integer and float default-values as 

`private $property = '12';`

With this fix it correctly inserts

`private $property = 12;`