### PR TITLE
Minor rewording

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -659,9 +659,8 @@ postFlush
 preUpdate
 ~~~~~~~~~
 
-PreUpdate is the most restrictive to use event, since it is called
-right before an update statement is called for an entity inside the
-``EntityManager#flush()`` method. Note that this event is not
+PreUpdate is called inside the ``EntityManager#flush()`` method,
+right before an SQL ``UPDATE`` statement. This event is not
 triggered when the computed changeset is empty.
 
 Changes to associations of the updated entity are never allowed in


### PR DESCRIPTION
Emphasizing the (counter-intuitive) fact that preUpdate is called inside **flush** - cause this was causing me some confusion, see https://github.com/symfony/symfony/issues/39894

In general: This entire page is confusing, for two reasons:
* The list of events appears *twice* (as "overview" list on top, then as separate headings below), with neither being complete.
* The description of each event is inconsistent.

To improve this, I'm suggesting an **overview table** on top, with the events being the rows (linked to their respective heading below), and the following columns:
* called inside which of *my* function calls (i.e. `em->persist` or `$em->flush`)
* Is allowed to change the *current* entity?
* Is allowed to change *associated* entities?
* Is allowed to create *new* entities?
* Is calling `persist` or `flush` inside it allowed/required?
* Can access ID?
* ...?

I can start the table, but I'd need some help, since I don't know all the details myself.