### PR TITLE
Use typed properties for default metadata for #7939

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -89,7 +89,7 @@ as part of the lifecycle of the instance variables entity-class.
 Required attributes:
 
 -  **type**: Name of the Doctrine Type which is converted between PHP
-   and Database representation.
+   and Database representation. Default to ``string`` or :ref:`Type from PHP property type <reference-php-mapping-types>`
 
 Optional attributes:
 
@@ -113,7 +113,7 @@ Optional attributes:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column. If not specified, default value is false.
+-  **nullable**: Determines if NULL values allowed for this column. If not specified, default value is false. When using typed properties on entity class defaults to true when property is nullable.
 
 -  **options**: Array of additional options:
 
@@ -635,6 +635,8 @@ Optional attributes:
    constraint level. Defaults to false.
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
+   When using typed properties on entity class defaults to false when
+   property is not nullable.
 -  **onDelete**: Cascade Action (Database-level)
 -  **columnDefinition**: DDL SQL snippet that starts after the column
    name and specifies the complete (non-portable!) column definition.
@@ -715,6 +717,7 @@ Required attributes:
 
 -  **targetEntity**: FQCN of the referenced target entity. Can be the
    unqualified class name if both classes are in the same namespace.
+   When typed properties are used it is inherited from PHP type.
    *IMPORTANT:* No leading backslash!
 
 Optional attributes:
@@ -923,6 +926,7 @@ Required attributes:
 
 -  **targetEntity**: FQCN of the referenced target entity. Can be the
    unqualified class name if both classes are in the same namespace.
+   When typed properties are used it is inherited from PHP type.
    *IMPORTANT:* No leading backslash!
 
 Optional attributes:

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -717,7 +717,7 @@ Required attributes:
 
 -  **targetEntity**: FQCN of the referenced target entity. Can be the
    unqualified class name if both classes are in the same namespace.
-   When typed properties are used it is inherited from PHP type.
+   You can omit this value if you use a PHP property type instead.
    *IMPORTANT:* No leading backslash!
 
 Optional attributes:

--- a/docs/en/reference/association-mapping.rst
+++ b/docs/en/reference/association-mapping.rst
@@ -22,9 +22,9 @@ One tip for working with relations is to read the relation from left to right, w
 - ManyToOne - Many instances of the current Entity refer to One instance of the referred Entity.
 - OneToOne - One instance of the current Entity refers to One instance of the referred Entity.
 
-See below for all the possible relations. 
+See below for all the possible relations.
 
-An association is considered to be unidirectional if only one side of the association has 
+An association is considered to be unidirectional if only one side of the association has
 a property referring to the other side.
 
 To gain a full understanding of associations you should also read about :doc:`owning and
@@ -1060,6 +1060,70 @@ classes, separated by an underscore character. The names of the
 join columns default to the simple, unqualified class name of the
 targeted class followed by "\_id". The referencedColumnName always
 defaults to "id", just as in one-to-one or many-to-one mappings.
+
+Additionally, when using typed properties with Doctrine 2.9 or newer
+you can skip ``targetEntity`` in ``ManyToOne`` and ``OneToOne``
+associations as they will be set based on type. Also ``nullable``
+attribute on ``JoinColumn`` will be inherited from PHP type. So that:
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+        /** @OneToOne */
+        private Shipment $shipment;
+
+    .. code-block:: xml
+
+        <doctrine-mapping>
+            <entity class="Product">
+                <one-to-one field="shipment" />
+            </entity>
+        </doctrine-mapping>
+
+    .. code-block:: yaml
+
+        Product:
+          type: entity
+          oneToOne:
+            shipment: ~
+
+Is essentially the same as following:
+
+.. configuration-block::
+
+    .. code-block:: php
+
+        <?php
+        /**
+         * One Product has One Shipment.
+         * @OneToOne(targetEntity="Shipment")
+         * @JoinColumn(name="shipment_id", referencedColumnName="id", nullable=false)
+         */
+        private Shipment $shipment;
+
+    .. code-block:: xml
+
+        <doctrine-mapping>
+            <entity class="Product">
+                <one-to-one field="shipment" target-entity="Shipment">
+                    <join-column name="shipment_id" referenced-column-name="id" nulable=false />
+                </one-to-one>
+            </entity>
+        </doctrine-mapping>
+
+    .. code-block:: yaml
+
+        Product:
+          type: entity
+          oneToOne:
+            shipment:
+              targetEntity: Shipment
+              joinColumn:
+                name: shipment_id
+                referencedColumnName: id
+                nullable: false
 
 If you accept these defaults, you can reduce the mapping code to a
 minimum.

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -211,6 +211,25 @@ list:
 - ``options``: (optional) Key-value pairs of options that get passed
   to the underlying database platform when generating DDL statements.
 
+.. _reference-php-mapping-types:
+
+PHP Types Mapping
+_________________
+
+Since version 2.9 Doctrine can determine usable defaults from property types
+on entity classes. When property type is nullable the default for ``nullable``
+Column attribute is set to TRUE. Additionally, Doctrine will map PHP types
+to ``type`` attribute as follows:
+
+- ``DateInterval``: ``dateinterval``
+- ``DateTime``: ``datetime``
+- ``DateTimeImmutable``: ``datetime_immutable``
+- ``array``: ``json``
+- ``bool``: ``boolean``
+- ``float``: ``float``
+- ``int``: ``integer``
+- ``string`` or any other type: ``string``
+
 .. _reference-mapping-types:
 
 Doctrine Mapping Types
@@ -328,7 +347,7 @@ annotation.
 
 In most cases using the automatic generator strategy (``@GeneratedValue``) is
 what you want. It defaults to the identifier generation mechanism your current
-database vendor prefers: AUTO_INCREMENT with MySQL, sequences with PostgreSQL 
+database vendor prefers: AUTO_INCREMENT with MySQL, sequences with PostgreSQL
 and Oracle and so on.
 
 Identifier Generation Strategies

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -26,6 +26,7 @@ use DateTime;
 use DateTimeImmutable;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Instantiator\Instantiator;
 use Doctrine\Instantiator\InstantiatorInterface;
 use Doctrine\ORM\Cache\CacheException;
@@ -1444,28 +1445,28 @@ class ClassMetadataInfo implements ClassMetadata
             ) {
                 switch ($type->getName()) {
                     case DateInterval::class:
-                        $mapping['type'] = 'dateinterval';
+                        $mapping['type'] = Types::DATEINTERVAL;
                         break;
                     case DateTime::class:
-                        $mapping['type'] = 'datetime';
+                        $mapping['type'] = Types::DATETIME_MUTABLE;
                         break;
                     case DateTimeImmutable::class:
-                        $mapping['type'] = 'datetime_immutable';
+                        $mapping['type'] = Types::DATETIME_IMMUTABLE;
                         break;
                     case 'array':
-                        $mapping['type'] = 'json';
+                        $mapping['type'] = Types::JSON;
                         break;
                     case 'bool':
-                        $mapping['type'] = 'boolean';
+                        $mapping['type'] = Types::BOOLEAN;
                         break;
                     case 'float':
-                        $mapping['type'] = 'float';
+                        $mapping['type'] = Types::FLOAT;
                         break;
                     case 'int':
-                        $mapping['type'] = 'integer';
+                        $mapping['type'] = Types::INTEGER;
                         break;
                     case 'string':
-                        $mapping['type'] = 'string';
+                        $mapping['type'] = Types::STRING;
                         break;
                 }
             }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1429,9 +1429,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param  array  $mapping The field mapping to validate & complete.
      *
-     * @return void
+     * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedFieldMapping(array &$mapping)
+    private function _validateAndCompleteTypedFieldMapping(array $mapping)
     {
         $type     = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
@@ -1472,6 +1472,8 @@ class ClassMetadataInfo implements ClassMetadata
                 }
             }
         }
+
+        return $mapping;
     }
 
     /**
@@ -1479,9 +1481,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The mapping.
      *
-     * @return void
+     * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedAssociationMapping(array &$mapping)
+    private function _validateAndCompleteTypedAssociationMapping(array $mapping)
     {
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
@@ -1500,6 +1502,8 @@ class ClassMetadataInfo implements ClassMetadata
                 }
             }
         }
+
+        return $mapping;
     }
 
     /**
@@ -1507,11 +1511,11 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param array $mapping The field mapping to validate & complete.
      *
-     * @return void
+     * @return mixed[] The updated mapping.
      *
      * @throws MappingException
      */
-    protected function _validateAndCompleteFieldMapping(array &$mapping)
+    protected function _validateAndCompleteFieldMapping(array $mapping)
     {
         // Check mandatory fields
         if (! isset($mapping['fieldName']) || ! $mapping['fieldName']) {
@@ -1519,7 +1523,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $this->_validateAndCompleteTypedFieldMapping($mapping);
+            $mapping = $this->_validateAndCompleteTypedFieldMapping($mapping);
         }
 
         if (! isset($mapping['type'])) {
@@ -1568,6 +1572,8 @@ class ClassMetadataInfo implements ClassMetadata
 
             $mapping['requireSQLConversion'] = true;
         }
+
+        return $mapping;
     }
 
     /**
@@ -1620,7 +1626,7 @@ class ClassMetadataInfo implements ClassMetadata
         $mapping['sourceEntity'] = $this->name;
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $this->_validateAndCompleteTypedAssociationMapping($mapping);
+            $mapping = $this->_validateAndCompleteTypedAssociationMapping($mapping);
         }
 
         if (isset($mapping['targetEntity'])) {
@@ -2412,7 +2418,7 @@ class ClassMetadataInfo implements ClassMetadata
         unset($this->fieldNames[$mapping['columnName']]);
         unset($this->columnNames[$mapping['fieldName']]);
 
-        $this->_validateAndCompleteFieldMapping($overrideMapping);
+        $overrideMapping = $this->_validateAndCompleteFieldMapping($overrideMapping);
 
         $this->fieldMappings[$fieldName] = $overrideMapping;
     }
@@ -2550,7 +2556,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function mapField(array $mapping)
     {
-        $this->_validateAndCompleteFieldMapping($mapping);
+        $mapping = $this->_validateAndCompleteFieldMapping($mapping);
         $this->assertFieldNotMapped($mapping['fieldName']);
 
         $this->fieldMappings[$mapping['fieldName']] = $mapping;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1514,7 +1514,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @throws MappingException
      */
-    protected function _validateAndCompleteFieldMapping(array $mapping): array
+    protected function validateAndCompleteFieldMapping(array $mapping): array
     {
         // Check mandatory fields
         if (! isset($mapping['fieldName']) || ! $mapping['fieldName']) {
@@ -2417,7 +2417,7 @@ class ClassMetadataInfo implements ClassMetadata
         unset($this->fieldNames[$mapping['columnName']]);
         unset($this->columnNames[$mapping['fieldName']]);
 
-        $overrideMapping = $this->_validateAndCompleteFieldMapping($overrideMapping);
+        $overrideMapping = $this->validateAndCompleteFieldMapping($overrideMapping);
 
         $this->fieldMappings[$fieldName] = $overrideMapping;
     }
@@ -2555,7 +2555,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function mapField(array $mapping)
     {
-        $mapping = $this->_validateAndCompleteFieldMapping($mapping);
+        $mapping = $this->validateAndCompleteFieldMapping($mapping);
         $this->assertFieldNotMapped($mapping['fieldName']);
 
         $this->fieldMappings[$mapping['fieldName']] = $mapping;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1413,10 +1413,8 @@ class ClassMetadataInfo implements ClassMetadata
      * Checks whether given property has type
      *
      * @param string $name Property name
-     *
-     * @return bool
      */
-    private function isTypedProperty($name): bool
+    private function isTypedProperty(string $name): bool
     {
         return PHP_VERSION_ID >= 70400
                && isset($this->reflClass)
@@ -1427,13 +1425,13 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the given field mapping based on typed property.
      *
-     * @param  array  $mapping The field mapping to validate & complete.
+     * @param  mixed[] $mapping The field mapping to validate & complete.
      *
      * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedFieldMapping(array $mapping)
+    private function _validateAndCompleteTypedFieldMapping(array $mapping): array
     {
-        $type     = $this->reflClass->getProperty($mapping['fieldName'])->getType();
+        $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
         if ($type) {
             if (! isset($mapping['nullable'])) {
@@ -1479,11 +1477,11 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the basic mapping information based on typed property.
      *
-     * @param array $mapping The mapping.
+     * @param mixed[] $mapping The mapping.
      *
      * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedAssociationMapping(array $mapping)
+    private function _validateAndCompleteTypedAssociationMapping(array $mapping): array
     {
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
@@ -1515,7 +1513,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @throws MappingException
      */
-    protected function _validateAndCompleteFieldMapping(array $mapping)
+    protected function _validateAndCompleteFieldMapping(array $mapping): array
     {
         // Check mandatory fields
         if (! isset($mapping['fieldName']) || ! $mapping['fieldName']) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1431,18 +1431,18 @@ class ClassMetadataInfo implements ClassMetadata
             && $this->reflClass->hasProperty($mapping['fieldName'])
         ) {
             $property = $this->reflClass->getProperty($mapping['fieldName']);
-            $type = $property->getType();
+            $type     = $property->getType();
 
             if ($type) {
-                if (!isset($mapping['nullable'])) {
+                if (! isset($mapping['nullable'])) {
                     $mapping['nullable'] = $type->allowsNull();
                 }
 
                 if (
-                    !isset($mapping['type'])
+                    ! isset($mapping['type'])
                     && ($type instanceof ReflectionNamedType)
                 ) {
-                    switch($type->getName()) {
+                    switch ($type->getName()) {
                         case DateInterval::class:
                             $mapping['type'] = 'dateinterval';
                             break;
@@ -1575,7 +1575,7 @@ class ClassMetadataInfo implements ClassMetadata
             && $this->reflClass->hasProperty($mapping['fieldName'])
         ) {
             $property = $this->reflClass->getProperty($mapping['fieldName']);
-            $type = $property->getType();
+            $type     = $property->getType();
 
             if (
                 ! isset($mapping['targetEntity'])
@@ -1587,7 +1587,7 @@ class ClassMetadataInfo implements ClassMetadata
 
             if ($type !== null && isset($mapping['joinColumns'])) {
                 foreach ($mapping['joinColumns'] as &$joinColumn) {
-                    if (!isset($joinColumn['nullable'])) {
+                    if (! isset($joinColumn['nullable'])) {
                         $joinColumn['nullable'] = $type->allowsNull();
                     }
                 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1410,6 +1410,21 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
+     * Checks whether given property has type
+     *
+     * @param string $name Property name
+     *
+     * @return bool
+     */
+    private function isTypedProperty($name): bool
+    {
+        return PHP_VERSION_ID >= 70400
+               && isset($this->reflClass)
+               && $this->reflClass->hasProperty($name)
+               && $this->reflClass->getProperty($name)->hasType();
+    }
+
+    /**
      * Validates & completes the given field mapping.
      *
      * @param array $mapping The field mapping to validate & complete.
@@ -1425,13 +1440,8 @@ class ClassMetadataInfo implements ClassMetadata
             throw MappingException::missingFieldName($this->name);
         }
 
-        if (
-            PHP_VERSION_ID >= 70400
-            && isset($this->reflClass)
-            && $this->reflClass->hasProperty($mapping['fieldName'])
-        ) {
-            $property = $this->reflClass->getProperty($mapping['fieldName']);
-            $type     = $property->getType();
+        if ($this->isTypedProperty($mapping['fieldName'])) {
+            $type     = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
             if ($type) {
                 if (! isset($mapping['nullable'])) {
@@ -1569,13 +1579,8 @@ class ClassMetadataInfo implements ClassMetadata
         // the sourceEntity.
         $mapping['sourceEntity'] = $this->name;
 
-        if (
-            PHP_VERSION_ID >= 70400
-            && isset($this->reflClass)
-            && $this->reflClass->hasProperty($mapping['fieldName'])
-        ) {
-            $property = $this->reflClass->getProperty($mapping['fieldName']);
-            $type     = $property->getType();
+        if ($this->isTypedProperty($mapping['fieldName'])) {
+            $type     = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
             if (
                 ! isset($mapping['targetEntity'])

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1430,7 +1430,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedFieldMapping(array $mapping): array
+    private function validateAndCompleteTypedFieldMapping(array $mapping): array
     {
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
@@ -1482,7 +1482,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @return mixed[] The updated mapping.
      */
-    private function _validateAndCompleteTypedAssociationMapping(array $mapping): array
+    private function validateAndCompleteTypedAssociationMapping(array $mapping): array
     {
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
@@ -1522,7 +1522,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->_validateAndCompleteTypedFieldMapping($mapping);
+            $mapping = $this->validateAndCompleteTypedFieldMapping($mapping);
         }
 
         if (! isset($mapping['type'])) {
@@ -1625,7 +1625,7 @@ class ClassMetadataInfo implements ClassMetadata
         $mapping['sourceEntity'] = $this->name;
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
-            $mapping = $this->_validateAndCompleteTypedAssociationMapping($mapping);
+            $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
         }
 
         if (isset($mapping['targetEntity'])) {

--- a/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\CMS;
@@ -30,6 +31,7 @@ class CmsUserTyped
 
     /**
      * @Column(type="string", length=255)
+     * @var string
      */
     public $name;
 

--- a/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\CMS;
+
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
+
+/**
+ * @Entity
+ * @Table(name="cms_users_typed")
+ */
+class CmsUserTyped
+{
+    /**
+     * @Id @Column
+     * @GeneratedValue
+     */
+    public int $id;
+    /**
+     * @Column(length=50)
+     */
+    public ?string $status;
+
+    /**
+     * @Column(length=255, unique=true)
+     */
+    public string $username;
+
+    /**
+     * @Column(type="string", length=255)
+     */
+    public $name;
+
+    /**
+     * @Column
+     */
+    public DateInterval $dateInterval;
+
+    /**
+     * @Column
+     */
+    public DateTime $dateTime;
+
+    /**
+     * @Column
+     */
+    public DateTimeImmutable $dateTimeImmutable;
+
+    /**
+     * @Column
+     */
+    public array $array;
+
+    /**
+     * @Column
+     */
+    public bool $boolean;
+
+    /**
+     * @Column
+     */
+    public float $float;
+
+    /**
+     * @OneToOne(cascade={"persist"}, orphanRemoval=true)
+     * @JoinColumn
+     */
+    public CmsEmail $email;
+}

--- a/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUserTyped.php
@@ -30,12 +30,6 @@ class CmsUserTyped
     public string $username;
 
     /**
-     * @Column(type="string", length=255)
-     * @var string
-     */
-    public $name;
-
-    /**
      * @Column
      */
     public DateInterval $dateInterval;

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\Models\CMS;
+namespace Doctrine\Tests\Models\TypedProperties;
 
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\Tests\Models\CMS\CmsEmail;
 
 /**
  * @Entity
  * @Table(name="cms_users_typed")
  */
-class CmsUserTyped
+class UserTyped
 {
     /**
      * @Id @Column

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -20,44 +20,28 @@ class UserTyped
      * @GeneratedValue
      */
     public int $id;
-    /**
-     * @Column(length=50)
-     */
+    /** @Column(length=50) */
     public ?string $status;
 
-    /**
-     * @Column(length=255, unique=true)
-     */
+    /** @Column(length=255, unique=true) */
     public string $username;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public DateInterval $dateInterval;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public DateTime $dateTime;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public DateTimeImmutable $dateTimeImmutable;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public array $array;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public bool $boolean;
 
-    /**
-     * @Column
-     */
+    /** @Column */
     public float $float;
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Persistence\Mapping\StaticReflectionService;
 use Doctrine\Tests\Models\CMS;
+use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\Company\CompanyContract;
 use Doctrine\Tests\Models\CustomType\CustomTypeParent;
 use Doctrine\Tests\Models\DDC117\DDC117Article;
@@ -130,6 +131,7 @@ class ClassMetadataTest extends OrmTestCase
         // Join table Nullable
         $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
         $this->assertFalse($cm->getAssociationMapping('email')['joinColumns'][0]['nullable']);
+        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -109,7 +109,7 @@ class ClassMetadataTest extends OrmTestCase
         $this->assertFalse($cm->isNullable('name'), 'By default a field should not be nullable.');
     }
 
-    public function testFieldIsNullableByType()
+    public function testFieldIsNullableByType(): void
     {
         if (PHP_VERSION_ID < 70400) {
             $this->markTestSkipped('requies PHP 7.4');
@@ -128,14 +128,14 @@ class ClassMetadataTest extends OrmTestCase
 
         // Implicit Not Nullable
         $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
-        $this->assertFalse($cm->isNullable('name'), "By default a field should not be nullable.");
+        $this->assertFalse($cm->isNullable('name'), 'By default a field should not be nullable.');
 
         // Join table Nullable
         $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
         $this->assertFalse($cm->getAssociationMapping('email')['joinColumns'][0]['nullable']);
     }
 
-    public function testFieldTypeFromReflection()
+    public function testFieldTypeFromReflection(): void
     {
         if (PHP_VERSION_ID < 70400) {
             $this->markTestSkipped('requies PHP 7.4');
@@ -154,7 +154,7 @@ class ClassMetadataTest extends OrmTestCase
 
         // Default string fallback
         $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
-        $this->assertEquals('string', $cm->getTypeOfField('name'), "By default a field should be string.");
+        $this->assertEquals('string', $cm->getTypeOfField('name'), 'By default a field should be string.');
 
         // String
         $cm->mapField(['fieldName' => 'dateInterval']);

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -126,10 +126,6 @@ class ClassMetadataTest extends OrmTestCase
         $cm->mapField(['fieldName' => 'username', 'length' => 50]);
         $this->assertFalse($cm->isNullable('username'));
 
-        // Implicit Not Nullable
-        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
-        $this->assertFalse($cm->isNullable('name'), 'By default a field should not be nullable.');
-
         // Join table Nullable
         $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
         $this->assertFalse($cm->getAssociationMapping('email')['joinColumns'][0]['nullable']);
@@ -152,31 +148,27 @@ class ClassMetadataTest extends OrmTestCase
         $cm->mapField(['fieldName' => 'username', 'length' => 50]);
         $this->assertEquals('string', $cm->getTypeOfField('username'));
 
-        // Default string fallback
-        $cm->mapField(['fieldName' => 'name', 'type' => 'string', 'length' => 50]);
-        $this->assertEquals('string', $cm->getTypeOfField('name'), 'By default a field should be string.');
-
-        // String
+        // DateInterval object
         $cm->mapField(['fieldName' => 'dateInterval']);
         $this->assertEquals('dateinterval', $cm->getTypeOfField('dateInterval'));
 
-        // String
+        // DateTime object
         $cm->mapField(['fieldName' => 'dateTime']);
         $this->assertEquals('datetime', $cm->getTypeOfField('dateTime'));
 
-        // String
+        // DateTimeImmutable object
         $cm->mapField(['fieldName' => 'dateTimeImmutable']);
         $this->assertEquals('datetime_immutable', $cm->getTypeOfField('dateTimeImmutable'));
 
-        // String
+        // array as JSON
         $cm->mapField(['fieldName' => 'array']);
         $this->assertEquals('json', $cm->getTypeOfField('array'));
 
-        // String
+        // bool
         $cm->mapField(['fieldName' => 'boolean']);
         $this->assertEquals('boolean', $cm->getTypeOfField('boolean'));
 
-        // String
+        // float
         $cm->mapField(['fieldName' => 'float']);
         $this->assertEquals('float', $cm->getTypeOfField('float'));
     }

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -21,6 +21,7 @@ use Doctrine\Tests\Models\DDC6412\DDC6412File;
 use Doctrine\Tests\Models\DDC964\DDC964Admin;
 use Doctrine\Tests\Models\DDC964\DDC964Guest;
 use Doctrine\Tests\Models\Routing\RoutingLeg;
+use Doctrine\Tests\Models\TypedProperties;
 use Doctrine\Tests\OrmTestCase;
 use DoctrineGlobal_Article;
 use ReflectionClass;
@@ -115,7 +116,7 @@ class ClassMetadataTest extends OrmTestCase
             $this->markTestSkipped('requies PHP 7.4');
         }
 
-        $cm = new ClassMetadata(CMS\CmsUserTyped::class);
+        $cm = new ClassMetadata(TypedProperties\UserTyped::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // Explicit Nullable
@@ -137,7 +138,7 @@ class ClassMetadataTest extends OrmTestCase
             $this->markTestSkipped('requies PHP 7.4');
         }
 
-        $cm = new ClassMetadata(CMS\CmsUserTyped::class);
+        $cm = new ClassMetadata(TypedProperties\UserTyped::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
         // Integer


### PR DESCRIPTION
This is simple implementation of idea outlined in #7939. During completion step of a field mapping completion or association mapping completion it looks for typed property and, when existent, uses it to determine default for `type`, `targetEntity` and `nullable` (in fields and `joinTable`).

I have added simple tests covering all cases I found.

I am not a great fan of encapsulating code in `PHP_VERSION_ID >= 70400`, but at the time of writing got no better idea.

I couldn't get master branch to work locally and that's the only reason why I target '2.9.x' (Composer has problem resolving doctrine/dbal).

This is my first PR to Doctrine project, so if anything is done wrong please let me know and I will do my best to fix it :)