### PR TITLE
Removing "Naming convention"

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -121,25 +121,6 @@ Now you can test the ``$eventSubscriber`` instance to see if the
         echo 'pre foo invoked!';
     }
 
-Naming convention
-~~~~~~~~~~~~~~~~~
-
-Events being used with the Doctrine ORM EventManager are best named
-with camelcase and the value of the corresponding constant should
-be the name of the constant itself, even with spelling. This has
-several reasons:
-
-
--  It is easy to read.
--  Simplicity.
--  Each method within an EventSubscriber is named after the
-   corresponding constant's value. If the constant's name and value differ
-   it contradicts the intention of using the constant and makes your code
-   harder to maintain.
-
-An example for a correct notation can be found in the example
-``TestEvent`` above.
-
 .. _reference-events-lifecycle-events:
 
 Lifecycle Events


### PR DESCRIPTION
...cause the example (which newbies will copy-paste anyway :-) shows it all. Explaining something like that so high up on the page and so detailed, gives the topic a perceived importance which it doesn't really have.

Besides, I suggest to move the entire header about custom events ("The Event System") at the very bottom of that page. Reason: Before anybody will go and hack anything themselves, they will certainly first take a look at what's included out of the box ;-)