### PR TITLE
Relax contract of EntityListenerResolver so it doesn't require class name

### DIFF
--- a/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
@@ -29,24 +29,20 @@ namespace Doctrine\ORM\Mapping;
 interface EntityListenerResolver
 {
     /**
-     * Clear all instances from the set, or a specific class when given.
+     * Clear all instances from the set, or a specific instance when given its identifier.
      *
-     * @param string $className The fully-qualified class name
+     * @param string $className May be arbitrary string. Name kept for BC only.
      *
      * @return void
-     *
-     * @psalm-param class-string $className
      */
     function clear($className = null);
 
     /**
-     * Returns a entity listener instance for the given class name.
+     * Returns a entity listener instance for the given identifier.
      *
-     * @param string $className The fully-qualified class name
+     * @param string $className May be arbitrary string. Name kept for BC only.
      *
      * @return object An entity listener
-     *
-     * @psalm-param class-string $className
      */
     function resolve($className);
 

--- a/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
@@ -31,7 +31,7 @@ interface EntityListenerResolver
     /**
      * Clear all instances from the set, or a specific instance when given its identifier.
      *
-     * @param string $className May be arbitrary string. Name kept for BC only.
+     * @param string $className May be any arbitrary string. Name kept for BC only.
      *
      * @return void
      */
@@ -40,7 +40,7 @@ interface EntityListenerResolver
     /**
      * Returns a entity listener instance for the given identifier.
      *
-     * @param string $className May be arbitrary string. Name kept for BC only.
+     * @param string $className May be any arbitrary string. Name kept for BC only.
      *
      * @return object An entity listener
      */


### PR DESCRIPTION
There is actually no technical reason why interface should require FQCN

Rel: https://github.com/doctrine/DoctrineBundle/issues/1224