### PR TITLE
Fixes parenthesis when \n is involved

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -22,7 +22,7 @@ namespace Doctrine\ORM\Query\Expr;
 
 use function implode;
 use function is_object;
-use function stripos;
+use function preg_match;
 
 /**
  * Expression class for building DQL and parts.
@@ -63,7 +63,7 @@ class Composite extends Base
         }
 
         // Fixes DDC-1237: User may have added a where item containing nested expression (with "OR" or "AND")
-        if (stripos($queryPart, ' OR ') !== false || stripos($queryPart, ' AND ') !== false) {
+        if (preg_match('/\s(OR|AND)\s/', $queryPart)) {
             return $this->preSeparator . $queryPart . $this->postSeparator;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
@@ -40,7 +40,7 @@ class QueryBuilderParenthesis extends OrmFunctionalTestCase
         $queryBuilder->setParameter('value2', 'x');
 
         $query   = $queryBuilder->getQuery();
-        $results = $queryBuilder->getQuery()->getResult();
+        $results = $query->getResult();
         $this->assertCount(0, $results);
 
         $dql = $query->getDQL();
@@ -65,7 +65,7 @@ OR o.property2 = :value2'
         $queryBuilder->setParameter('value2', 'x');
 
         $query   = $queryBuilder->getQuery();
-        $results = $queryBuilder->getQuery()->getResult();
+        $results = $query->getResult();
         $this->assertCount(0, $results);
 
         $dql = $query->getDQL();

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class QueryBuilderParenthesis extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(QueryBuilderParenthesisEntity::class),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->_schemaTool->dropSchema(
+            [
+                $this->_em->getClassMetadata(QueryBuilderParenthesisEntity::class),
+            ]
+        );
+    }
+
+    public function testParenthesisOnSingleLine(): void
+    {
+        $queryBuilder = $this->_em->createQueryBuilder();
+        $queryBuilder->select('o')->from(QueryBuilderParenthesisEntity::class, 'o');
+        $queryBuilder->andWhere('o.property3 = :value3')->setParameter('value3', 'x');
+        $queryBuilder->andWhere('o.property1 = :value1 OR o.property2 = :value2');
+        $queryBuilder->setParameter('value1', 'x');
+        $queryBuilder->setParameter('value2', 'x');
+
+        $query   = $queryBuilder->getQuery();
+        $results = $queryBuilder->getQuery()->getResult();
+        $this->assertCount(0, $results);
+
+        $dql = $query->getDQL();
+
+        $this->assertSame(
+            'SELECT o FROM ' . QueryBuilderParenthesisEntity::class . ' o WHERE o.property3 = :value3 AND (o.property1 = :value1 OR o.property2 = :value2)',
+            $dql
+        );
+    }
+
+    public function testParenthesisOnMultiLine(): void
+    {
+        $queryBuilder = $this->_em->createQueryBuilder();
+        $queryBuilder->select('o')->from(QueryBuilderParenthesisEntity::class, 'o');
+        $queryBuilder->andWhere('o.property3 = :value3')->setParameter('value3', 'x');
+
+        $queryBuilder->andWhere(
+            'o.property1 = :value1
+OR o.property2 = :value2'
+        );
+        $queryBuilder->setParameter('value1', 'x');
+        $queryBuilder->setParameter('value2', 'x');
+
+        $query   = $queryBuilder->getQuery();
+        $results = $queryBuilder->getQuery()->getResult();
+        $this->assertCount(0, $results);
+
+        $dql = $query->getDQL();
+
+        $this->assertSame(
+            'SELECT o FROM ' . QueryBuilderParenthesisEntity::class . ' o WHERE o.property3 = :value3 AND (o.property1 = :value1
+OR o.property2 = :value2)',
+            $dql
+        );
+    }
+}
+
+
+/**
+ * @Entity
+ */
+class QueryBuilderParenthesisEntity
+{
+    /**
+     * @var int|null
+     * @Column(type="integer")
+     * @Id
+     * @GeneratedValue
+     */
+    public $id;
+
+    /**
+     * @var string|null
+     * @Column()
+     */
+    public $property1;
+
+    /**
+     * @var string|null
+     * @Column()
+     */
+    public $property2;
+
+    /**
+     * @var string|null
+     * @Column()
+     */
+    public $property3;
+}


### PR DESCRIPTION
```
JSON_CONTAINS(p.state, :positive_value, :ordered_state) = :positive_value 
OR 
JSON_CONTAINS(p.state, :positive_value, :completed_state) = :positive_value)
```

when we have OR like that (without space before OR) - it doesn't add parenthesis.