### PR TITLE
[GH-8410] Fix memory leak in new toIterable and state bug.

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -999,7 +999,7 @@ abstract class AbstractQuery
             $this->setParameters($parameters);
         }
 
-        $rsm  = $this->getResultSetMapping();
+        $rsm = $this->getResultSetMapping();
 
         if ($rsm->isMixed && count($rsm->scalarMappings) > 0) {
             throw QueryException::iterateWithMixedResultNotAllowed();

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -31,6 +31,7 @@ use Doctrine\ORM\Cache\TimestampCacheKey;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Mapping\MappingException as ORMMappingException;
 use Doctrine\ORM\Query\Parameter;
+use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\MappingException;
 use Traversable;
@@ -999,6 +1000,11 @@ abstract class AbstractQuery
         }
 
         $rsm  = $this->getResultSetMapping();
+
+        if ($rsm->isMixed && count($rsm->scalarMappings) > 0) {
+            throw QueryException::iterateWithMixedResultNotAllowed();
+        }
+
         $stmt = $this->_doExecute();
 
         return $this->_em->newHydrator($this->_hydrationMode)->toIterable($stmt, $rsm, $this->_hints);

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -35,6 +35,7 @@ use ReflectionClass;
 
 use function array_map;
 use function array_merge;
+use function count;
 use function end;
 use function in_array;
 use function trigger_error;

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -165,8 +165,6 @@ abstract class AbstractHydrator
 
         $this->prepare();
 
-        $result = [];
-
         while (true) {
             $row = $this->_stmt->fetch(FetchMode::ASSOCIATIVE);
 
@@ -176,7 +174,11 @@ abstract class AbstractHydrator
                 break;
             }
 
+            $result = [];
+
             $this->hydrateRowData($row, $result);
+
+            $this->cleanupAfterRowIteration();
 
             yield end($result);
         }
@@ -272,6 +274,10 @@ abstract class AbstractHydrator
             ->_em
             ->getEventManager()
             ->removeEventListener([Events::onClear], $this);
+    }
+
+    protected function cleanupAfterRowIteration(): void
+    {
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -180,7 +180,11 @@ abstract class AbstractHydrator
 
             $this->cleanupAfterRowIteration();
 
-            yield end($result);
+            if (count($result) === 1) {
+                yield end($result);
+            } else {
+                yield $result;
+            }
         }
     }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -141,6 +141,14 @@ class ObjectHydrator extends AbstractHydrator
         $this->_uow->hydrationComplete();
     }
 
+    protected function cleanupAfterRowIteration(): void
+    {
+        $this->identifierMap          =
+        $this->initializedCollections =
+        $this->existingCollections    =
+        $this->resultPointers         = [];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -674,6 +674,8 @@ final class Query extends AbstractQuery
      * Executes the query and returns an IterableResult that can be used to incrementally
      * iterated over the result.
      *
+     * @deprecated
+     *
      * @param ArrayCollection|mixed[]|null $parameters    The query parameters.
      * @param string|int                   $hydrationMode The hydration mode to use.
      *

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -227,6 +227,11 @@ class QueryException extends ORMException
         );
     }
 
+    public static function iterateWithMixedResultNotAllowed(): QueryException
+    {
+        return new self('Iterating a query with mixed results (using scalars) is not supported.');
+    }
+
     /**
      * @return QueryException
      */

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedDqlQueryTest.php
@@ -171,8 +171,6 @@ DQL;
         $this->assertEquals('Caramba', $result[0]['brandName']);
 
         $this->_em->clear();
-
-        IterableTester::assertResultsAreTheSame($query);
     }
 
     public function testInSubselect(): void

--- a/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryIterableTest.php
@@ -32,6 +32,8 @@ final class QueryIterableTest extends OrmFunctionalTestCase
         $users = $query->getResult();
         self::assertCount(1, $users);
 
+        $this->assertEquals('gblanco', $users[0]['user']->username);
+
         $this->_em->clear();
 
         IterableTester::assertResultsAreTheSame($query);
@@ -59,6 +61,8 @@ final class QueryIterableTest extends OrmFunctionalTestCase
 
         $users = $query->getResult();
         self::assertCount(1, $users);
+
+        $this->assertEquals('gblanco', $users[0]['user']->username);
 
         $this->_em->clear();
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -303,18 +303,18 @@ class QueryTest extends OrmFunctionalTestCase
 
     public function testToIterableWithMultipleSelectElements(): void
     {
-        $author = new CmsUser();
-        $author->name = 'Ben';
+        $author           = new CmsUser();
+        $author->name     = 'Ben';
         $author->username = 'beberlei';
 
-        $article1 = new CmsArticle();
+        $article1        = new CmsArticle();
         $article1->topic = 'Doctrine 2';
-        $article1->text = 'This is an introduction to Doctrine 2.';
+        $article1->text  = 'This is an introduction to Doctrine 2.';
         $article1->setAuthor($author);
 
-        $article2 = new CmsArticle();
+        $article2        = new CmsArticle();
         $article2->topic = 'Symfony 2';
-        $article2->text = 'This is an introduction to Symfony 2.';
+        $article2->text  = 'This is an introduction to Symfony 2.';
         $article2->setAuthor($author);
 
         $this->_em->persist($article1);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithToIterableTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7496WithToIterableTest.php
@@ -41,9 +41,20 @@ final class GH7496WithToIterableTest extends OrmFunctionalTestCase
         $bs = IterableTester::iterableToArray(
             $q->toIterable([], AbstractQuery::HYDRATE_OBJECT)
         );
+
         $this->assertCount(2, $bs);
         $this->assertInstanceOf(GH7496EntityB::class, $bs[0]);
         $this->assertInstanceOf(GH7496EntityB::class, $bs[1]);
+        $this->assertEquals(1, $bs[0]->id);
+        $this->assertEquals(1, $bs[1]->id);
+
+        $bs = IterableTester::iterableToArray(
+            $q->toIterable([], AbstractQuery::HYDRATE_ARRAY)
+        );
+
+        $this->assertCount(2, $bs);
+        $this->assertEquals(1, $bs[0]['id']);
+        $this->assertEquals(1, $bs[1]['id']);
     }
 }
 


### PR DESCRIPTION
The new AbstractQuery::toIterable() had a memory leak that AbstractQuery::iterable() did not have. This leak is now fixed.

After fixing the leak, one test failed where the identity map in ObjectHydrator triggered and lead to a notice. Introduced a new AbstractHydrator::cleanupAfterRowIteration() that the ObjectHydrator uses to cleanup the state.

When the result contains multiple entities, there must be special handling, otherwise only the last entity is returned.

In addition mixed result queries with scalar mappings don't work with iteration and are now explicitly prevented by exception.

Fixes #8410 Fixes #8413 Fixes #8387
Supersedes #8412 #8414 