### PR TITLE
[GH-8471] Deprecate Partial DQL syntax and forcing partial loads.

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1377,7 +1377,8 @@ userland:
    that contain char or binary data. Doctrine has no way of implicitly
    reloading this data. Partially loaded objects have to be passed to
    ``EntityManager::refresh()`` if they are to be reloaded fully from
-   the database.
+   the database. This query hint is deprecated and will be removed
+   in the future (`Details <https://github.com/doctrine/orm/issues/8471>`_)
 -  Query::HINT\_REFRESH - This query is used internally by
    ``EntityManager::refresh()`` and can be used in userland as well.
    If you specify this hint and a query returns the data for an entity

--- a/docs/en/reference/partial-objects.rst
+++ b/docs/en/reference/partial-objects.rst
@@ -5,7 +5,8 @@ Partial Objects
 .. warning::
 
     Creating Partial Objects through DQL is deprecated and
-    will be removed in the future (`Details
+    will be removed in the future, use data transfer object
+    support in DQL instead. (`Details
     <https://github.com/doctrine/orm/issues/8471>`_)
 
 A partial object is an object whose state is not fully initialized

--- a/docs/en/reference/partial-objects.rst
+++ b/docs/en/reference/partial-objects.rst
@@ -1,6 +1,13 @@
 Partial Objects
 ===============
 
+
+.. warning::
+
+    Creating Partial Objects through DQL is deprecated and
+    will be removed in the future (`Details
+    <https://github.com/doctrine/orm/issues/8471>`_)
+
 A partial object is an object whose state is not fully initialized
 after being reconstituted from the database and that is
 disconnected from the rest of its data. The following section will

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -20,6 +20,7 @@
 
 namespace Doctrine\ORM\Query;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
@@ -1870,6 +1871,12 @@ class Parser
      */
     public function PartialObjectExpression()
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/8471',
+            'PARTIAL syntax in DQL is deprecated.'
+        );
+
         $this->match(Lexer::T_PARTIAL);
 
         $partialFieldSet = [];

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -24,6 +24,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\LockMode;
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\Cache\Persister\CachedPersister;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\ListenersInvoker;
@@ -2750,6 +2751,13 @@ class UnitOfWork implements PropertyChangedListener
 
         // Properly initialize any unfetched associations, if partial objects are not allowed.
         if (isset($hints[Query::HINT_FORCE_PARTIAL_LOAD])) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8471',
+                'Partial Objects are deprecated (here entity %s)',
+                $className
+            );
+
             return $entity;
         }
 


### PR DESCRIPTION
Deprecates when you `SELECT PARTIAL` and when you use the query hint `Query::HINT_FORCE_PARTIAL_LOAD`.

Fixes #8471 