### PR TITLE
Fix single scalar hydrator memory leak on exception

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -205,12 +205,13 @@ abstract class AbstractHydrator
         $this->_hints = $hints;
 
         $this->_em->getEventManager()->addEventListener([Events::onClear], $this);
-
         $this->prepare();
 
-        $result = $this->hydrateAllData();
-
-        $this->cleanup();
+        try {
+            $result = $this->hydrateAllData();
+        } finally {
+            $this->cleanup();
+        }
 
         return $result;
     }

--- a/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Driver\Statement;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -72,17 +73,26 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
      */
     public function testOnClearEventListenerIsDetachedOnCleanup(): void
     {
-        $this
-            ->mockEventManager
-            ->expects(self::at(0))
-            ->method('addEventListener')
-            ->with([Events::onClear], $this->hydrator);
+        $eventListenerHasBeenRegistered = false;
 
         $this
             ->mockEventManager
-            ->expects(self::at(1))
+            ->expects(self::once())
+            ->method('addEventListener')
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertFalse($eventListenerHasBeenRegistered);
+                $eventListenerHasBeenRegistered = true;
+            });
+
+        $this
+            ->mockEventManager
+            ->expects(self::once())
             ->method('removeEventListener')
-            ->with([Events::onClear], $this->hydrator);
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertTrue($eventListenerHasBeenRegistered);
+            });
 
         iterator_to_array($this->hydrator->iterate($this->mockStatement, $this->mockResultMapping));
     }
@@ -92,18 +102,63 @@ class AbstractHydratorTest extends OrmFunctionalTestCase
      */
     public function testHydrateAllRegistersAndClearsAllAttachedListeners(): void
     {
+        $eventListenerHasBeenRegistered = false;
+
         $this
             ->mockEventManager
-            ->expects(self::at(0))
+            ->expects(self::once())
             ->method('addEventListener')
-            ->with([Events::onClear], $this->hydrator);
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertFalse($eventListenerHasBeenRegistered);
+                $eventListenerHasBeenRegistered = true;
+            });
 
         $this
             ->mockEventManager
-            ->expects(self::at(1))
+            ->expects(self::once())
             ->method('removeEventListener')
-            ->with([Events::onClear], $this->hydrator);
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertTrue($eventListenerHasBeenRegistered);
+            });
 
+        $this->hydrator->hydrateAll($this->mockStatement, $this->mockResultMapping);
+    }
+
+    /**
+     * @group #8482
+     */
+    public function testHydrateAllClearsAllAttachedListenersEvenOnError(): void
+    {
+        $eventListenerHasBeenRegistered = false;
+
+        $this
+            ->mockEventManager
+            ->expects(self::once())
+            ->method('addEventListener')
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertFalse($eventListenerHasBeenRegistered);
+                $eventListenerHasBeenRegistered = true;
+            });
+
+        $this
+            ->mockEventManager
+            ->expects(self::once())
+            ->method('removeEventListener')
+            ->with([Events::onClear], $this->hydrator)
+            ->willReturnCallback(function () use (&$eventListenerHasBeenRegistered): void {
+                $this->assertTrue($eventListenerHasBeenRegistered);
+            });
+
+        $this
+            ->hydrator
+            ->expects(self::once())
+            ->method('hydrateAllData')
+            ->willThrowException(new ORMException());
+
+        $this->expectException(ORMException::class);
         $this->hydrator->hydrateAll($this->mockStatement, $this->mockResultMapping);
     }
 }


### PR DESCRIPTION
Resolves #8482, Closes https://github.com/doctrine/orm/pull/7315

> I have encountered an issue with a memory leak in SingleScalarHydrator.
> 
> AbstractHydrator::hydrateAll() method does not take into account the possibility of an exception being thrown so when SingleScalarHydrator::hydrateAllData throws NoResultException/NonUniqueResultException, the event listener for onClear event is not removed and the hydrator is stuck in the memory.
> 
> It's been solved here once but not merged due to missing test cases.
> 
> Original issue: Fix memory leak in AbstractHydrator
> 
> I'll try to provide a fix and appropriate test case for this issue so it can be finally merged.