### PR TITLE
Fix bug when using Result Cache with Query::toIterable

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -20,7 +20,7 @@
 
 namespace Doctrine\ORM\Internal\Hydration;
 
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -93,7 +93,7 @@ abstract class AbstractHydrator
     /**
      * The statement that provides the data to hydrate.
      *
-     * @var Statement
+     * @var ResultStatement
      */
     protected $_stmt;
 
@@ -154,7 +154,7 @@ abstract class AbstractHydrator
      *
      * @return iterable<mixed>
      */
-    public function toIterable(Statement $stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
+    public function toIterable(ResultStatement $stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
     {
         $this->_stmt  = $stmt;
         $this->_rsm   = $resultSetMapping;

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -12,13 +12,14 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 use ReflectionProperty;
 
 use function count;
+use function iterator_to_array;
 
 /**
  * ResultCacheTest
  */
 class ResultCacheTest extends OrmFunctionalTestCase
 {
-   /** @var ReflectionProperty */
+    /** @var ReflectionProperty */
     private $cacheDataReflection;
 
     protected function setUp(): void
@@ -164,6 +165,40 @@ class ResultCacheTest extends OrmFunctionalTestCase
         $query->getResult();
 
         $this->assertTrue($cache->contains('testing_result_cache_id'));
+
+        $this->_em->getConfiguration()->setResultCacheImpl(new ArrayCache());
+    }
+
+    public function testEnableResultCacheWithIterable(): void
+    {
+        $cache            = new ArrayCache();
+        $expectedSQLCount = count($this->_sqlLoggerStack->queries) + 1;
+
+        $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
+        $query->enableResultCache();
+        $query->setResultCacheDriver($cache);
+        $query->setResultCacheId('testing_iterable_result_cache_id');
+        iterator_to_array($query->toIterable());
+
+        $this->_em->clear();
+
+        $this->assertCount(
+            $expectedSQLCount,
+            $this->_sqlLoggerStack->queries
+        );
+        $this->assertTrue($cache->contains('testing_iterable_result_cache_id'));
+
+        $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
+        $query->enableResultCache();
+        $query->setResultCacheDriver($cache);
+        $query->setResultCacheId('testing_iterable_result_cache_id');
+        iterator_to_array($query->toIterable());
+
+        $this->assertCount(
+            $expectedSQLCount,
+            $this->_sqlLoggerStack->queries,
+            'Expected query to be cached'
+        );
 
         $this->_em->getConfiguration()->setResultCacheImpl(new ArrayCache());
     }


### PR DESCRIPTION
`Argument 1 passed to Doctrine\ORM\Internal\Hydration\AbstractHydrator::toIterable() must implement interface Doctrine\DBAL\Driver\Statement, instance of Doctrine\DBAL\Cache\ResultCacheStatement given, called in /app/vendor/doctrine/orm/lib/Doctrine/ORM/AbstractQuery.php on line 1010`