### PR TITLE
note deprecation of AbstractQuery::iterator

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,7 +7,7 @@ since `Doctrine\DBAL\Connection#commit()` signature changed from returning void 
 
 ## Deprecated: `Doctrine\ORM\AbstractQuery#iterator()`
 
-The method `Doctrine\ORM\AbstractQuery#iterator()`	is deprecated in favor of `Doctrine\ORM\AbstractQuery#toIterate()`.
+The method `Doctrine\ORM\AbstractQuery#iterator()` is deprecated in favor of `Doctrine\ORM\AbstractQuery#toIterate()`.
 
 # Upgrade to 2.7
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,10 @@
 Method `Doctrine\ORM\UnitOfWork#commit()` can throw an OptimisticLockException when a commit silently fails and returns false
 since `Doctrine\DBAL\Connection#commit()` signature changed from returning void to boolean
 
+## Deprecated: `Doctrine\ORM\AbstractQuery#iterator()`
+
+The method `Doctrine\ORM\AbstractQuery#iterator()`	is deprecated in favor of `Doctrine\ORM\AbstractQuery#toIterate()`.
+
 # Upgrade to 2.7
 
 ## Added `Doctrine\ORM\AbstractQuery#enableResultCache()` and `Doctrine\ORM\AbstractQuery#disableResultCache()` methods	


### PR DESCRIPTION
#7885 and #8268 and #8293 changed to a better iterator implementation but did not mention the deprecation in the changelog.