### PR TITLE
Drop branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,11 +65,6 @@
         }
     },
     "bin": ["bin/doctrine"],
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.0.x-dev"
-        }
-    },
     "archive": {
         "exclude": ["!vendor", "tests", "*phpunit.xml", ".travis.yml", "build.xml", "build.properties", "composer.phar", "vendor/satooshi", "lib/vendor", "*.swp"]
     }


### PR DESCRIPTION
It should not conflict with the future, brand new 3.0.x.