### PR TITLE
Add possibility to use fields instead of column for unique constraint and indexes (#8345)

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -513,7 +513,8 @@ Required attributes:
 
 
 -  **name**: Name of the Index
--  **columns**: Array of columns.
+-  **fields**: Array of fields. Only requires when **columns** are not defined.
+-  **columns**: Array of columns. Only requires when **fields** are not defined.
 
 Optional attributes:
 
@@ -530,6 +531,19 @@ Basic example:
     /**
      * @Entity
      * @Table(name="ecommerce_products",indexes={@Index(name="search_idx", columns={"name", "email"})})
+     */
+    class ECommerceProduct
+    {
+    }
+
+Basic example using fields:
+
+.. code-block:: php
+
+    <?php
+    /**
+     * @Entity
+     * @Table(name="ecommerce_products",indexes={@Index(name="search_idx", fields={"name", "email"})})
      */
     class ECommerceProduct
     {
@@ -1267,7 +1281,8 @@ Required attributes:
 
 
 -  **name**: Name of the Index
--  **columns**: Array of columns.
+-  **fields**: Array of fields. Only requires when **columns** are not defined.
+-  **columns**: Array of columns. Only requires when **fields** are not defined.
 
 Optional attributes:
 
@@ -1284,6 +1299,19 @@ Basic example:
     /**
      * @Entity
      * @Table(name="ecommerce_products",uniqueConstraints={@UniqueConstraint(name="search_idx", columns={"name", "email"})})
+     */
+    class ECommerceProduct
+    {
+    }
+
+Basic example using fields:
+
+.. code-block:: php
+
+    <?php
+    /**
+     * @Entity
+     * @Table(name="ecommerce_products",uniqueConstraints={@UniqueConstraint(name="search_idx", fields={"name", "email"})})
      */
     class ECommerceProduct
     {

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -513,8 +513,8 @@ Required attributes:
 
 
 -  **name**: Name of the Index
--  **fields**: Array of fields. Only requires when **columns** are not defined.
--  **columns**: Array of columns. Only requires when **fields** are not defined.
+-  **fields**: Array of fields. Exactly one of **fields**, **columns** is required.
+-  **columns**: Array of columns. Exactly one of **fields**, **columns** is required.
 
 Optional attributes:
 
@@ -1281,8 +1281,8 @@ Required attributes:
 
 
 -  **name**: Name of the Index
--  **fields**: Array of fields. Only requires when **columns** are not defined.
--  **columns**: Array of columns. Only requires when **fields** are not defined.
+-  **fields**: Array of fields. Exactly one of **fields**, **columns** is required.
+-  **columns**: Array of columns. Exactly one of **fields**, **columns** is required.
 
 Optional attributes:
 

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -333,6 +333,7 @@
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
     <xs:attribute name="columns" type="xs:string" use="required"/>
+    <xs:attribute name="fields" type="xs:string" use="optional"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 
@@ -351,6 +352,7 @@
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
     <xs:attribute name="columns" type="xs:string" use="required"/>
+    <xs:attribute name="fields" type="xs:string" use="optional"/>
     <xs:attribute name="flags" type="xs:string" use="optional"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -332,7 +332,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="name" type="xs:NMTOKEN" use="optional"/>
-    <xs:attribute name="columns" type="xs:string" use="required"/>
+    <xs:attribute name="columns" type="xs:string" use="optional"/>
     <xs:attribute name="fields" type="xs:string" use="optional"/>
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -35,6 +35,7 @@ use UnexpectedValueException;
 
 use function class_exists;
 use function constant;
+use function count;
 use function defined;
 use function get_class;
 use function is_array;
@@ -129,7 +130,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     ) {
                         throw MappingException::invalidIndexConfiguration(
                             $className,
-                            (string) ($indexAnnot->name ?: count($primaryTable['indexes']))
+                            (string) ($indexAnnot->name ?? count($primaryTable['indexes']))
                         );
                     }
 
@@ -170,7 +171,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     ) {
                         throw MappingException::invalidUniqueConstraintConfiguration(
                             $className,
-                            (string) ($uniqueConstraintAnnot->name ?: count($primaryTable['uniqueConstraints']))
+                            (string) ($uniqueConstraintAnnot->name ?? count($primaryTable['uniqueConstraints']))
                         );
                     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -110,7 +110,15 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             if ($tableAnnot->indexes !== null) {
                 foreach ($tableAnnot->indexes as $indexAnnot) {
-                    $index = ['columns' => $indexAnnot->columns];
+                    $index = [];
+
+                    if (! empty($indexAnnot->columns)) {
+                        $index['columns'] = $indexAnnot->columns;
+                    }
+
+                    if (! empty($indexAnnot->fields)) {
+                        $index['fields'] = $indexAnnot->fields;
+                    }
 
                     if (! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
@@ -130,7 +138,15 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
             if ($tableAnnot->uniqueConstraints !== null) {
                 foreach ($tableAnnot->uniqueConstraints as $uniqueConstraintAnnot) {
-                    $uniqueConstraint = ['columns' => $uniqueConstraintAnnot->columns];
+                    $uniqueConstraint = [];
+
+                    if (! empty($uniqueConstraintAnnot->columns)) {
+                        $uniqueConstraint['columns'] = $uniqueConstraintAnnot->columns;
+                    }
+
+                    if (! empty($uniqueConstraintAnnot->fields)) {
+                        $uniqueConstraint['fields'] = $uniqueConstraintAnnot->fields;
+                    }
 
                     if (! empty($uniqueConstraintAnnot->options)) {
                         $uniqueConstraint['options'] = $uniqueConstraintAnnot->options;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -120,6 +120,19 @@ class AnnotationDriver extends AbstractAnnotationDriver
                         $index['fields'] = $indexAnnot->fields;
                     }
 
+                    if (
+                        isset($index['columns'], $index['fields'])
+                        || (
+                            ! isset($index['columns'])
+                            && ! isset($index['fields'])
+                        )
+                    ) {
+                        throw MappingException::invalidIndexConfiguration(
+                            $className,
+                            (string) ($indexAnnot->name ?: count($primaryTable['indexes']))
+                        );
+                    }
+
                     if (! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
                     }
@@ -146,6 +159,19 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
                     if (! empty($uniqueConstraintAnnot->fields)) {
                         $uniqueConstraint['fields'] = $uniqueConstraintAnnot->fields;
+                    }
+
+                    if (
+                        isset($uniqueConstraint['columns'], $uniqueConstraint['fields'])
+                        || (
+                            ! isset($uniqueConstraint['columns'])
+                            && ! isset($uniqueConstraint['fields'])
+                        )
+                    ) {
+                        throw MappingException::invalidUniqueConstraintConfiguration(
+                            $className,
+                            (string) ($uniqueConstraintAnnot->name ?: count($primaryTable['uniqueConstraints']))
+                        );
                     }
 
                     if (! empty($uniqueConstraintAnnot->options)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -76,7 +76,28 @@ class AttributeDriver extends AnnotationDriver
 
             if (isset($classAttributes[Mapping\Index::class])) {
                 foreach ($classAttributes[Mapping\Index::class] as $indexAnnot) {
-                    $index = ['columns' => $indexAnnot->columns];
+                    $index = [];
+
+                    if (! empty($indexAnnot->columns)) {
+                        $index['columns'] = $indexAnnot->columns;
+                    }
+
+                    if (! empty($indexAnnot->fields)) {
+                        $index['fields'] = $indexAnnot->fields;
+                    }
+
+                    if (
+                        isset($index['columns'], $index['fields'])
+                        || (
+                            ! isset($index['columns'])
+                            && ! isset($index['fields'])
+                        )
+                    ) {
+                        throw MappingException::invalidIndexConfiguration(
+                            $className,
+                            (string) ($indexAnnot->name ?? count($primaryTable['indexes']))
+                        );
+                    }
 
                     if (! empty($indexAnnot->flags)) {
                         $index['flags'] = $indexAnnot->flags;
@@ -96,7 +117,28 @@ class AttributeDriver extends AnnotationDriver
 
             if (isset($classAttributes[Mapping\UniqueConstraint::class])) {
                 foreach ($classAttributes[Mapping\UniqueConstraint::class] as $uniqueConstraintAnnot) {
-                    $uniqueConstraint = ['columns' => $uniqueConstraintAnnot->columns];
+                    $uniqueConstraint = [];
+
+                    if (! empty($uniqueConstraintAnnot->columns)) {
+                        $uniqueConstraint['columns'] = $uniqueConstraintAnnot->columns;
+                    }
+
+                    if (! empty($uniqueConstraintAnnot->fields)) {
+                        $uniqueConstraint['fields'] = $uniqueConstraintAnnot->fields;
+                    }
+
+                    if (
+                        isset($uniqueConstraint['columns'], $uniqueConstraint['fields'])
+                        || (
+                            ! isset($uniqueConstraint['columns'])
+                            && ! isset($uniqueConstraint['fields'])
+                        )
+                    ) {
+                        throw MappingException::invalidUniqueConstraintConfiguration(
+                            $className,
+                            (string) ($uniqueConstraintAnnot->name ?? count($primaryTable['uniqueConstraints']))
+                        );
+                    }
 
                     if (! empty($uniqueConstraintAnnot->options)) {
                         $uniqueConstraint['options'] = $uniqueConstraintAnnot->options;

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -18,6 +18,7 @@ use ReflectionProperty;
 use function assert;
 use function class_exists;
 use function constant;
+use function count;
 use function defined;
 
 class AttributeDriver extends AnnotationDriver

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -222,6 +222,19 @@ class XmlDriver extends FileDriver
                     $index['fields'] = explode(',', (string) $indexXml['fields']);
                 }
 
+                if (
+                    isset($index['columns'], $index['fields'])
+                    || (
+                        ! isset($index['columns'])
+                        && ! isset($index['fields'])
+                    )
+                ) {
+                    throw MappingException::invalidIndexConfiguration(
+                        $className,
+                        (string) ($indexXml['name'] ?: count($metadata->table['indexes']))
+                    );
+                }
+
                 if (isset($indexXml['flags'])) {
                     $index['flags'] = explode(',', (string) $indexXml['flags']);
                 }
@@ -250,6 +263,19 @@ class XmlDriver extends FileDriver
 
                 if (isset($uniqueXml['fields'])) {
                     $unique['fields'] = explode(',', (string) $uniqueXml['fields']);
+                }
+
+                if (
+                    isset($unique['columns'], $unique['fields'])
+                    || (
+                        ! isset($unique['columns'])
+                        && ! isset($unique['fields'])
+                    )
+                ) {
+                    throw MappingException::invalidUniqueConstraintConfiguration(
+                        $className,
+                        (string) ($uniqueXml['name'] ?: count($metadata->table['uniqueConstraints']))
+                    );
                 }
 
                 if (isset($uniqueXml->options)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -212,7 +212,15 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->indexes)) {
             $metadata->table['indexes'] = [];
             foreach ($xmlRoot->indexes->index as $indexXml) {
-                $index = ['columns' => explode(',', (string) $indexXml['columns'])];
+                $index = [];
+
+                if (isset($indexXml['columns']) && ! empty($indexXml['columns'])) {
+                    $index['columns'] = explode(',', (string) $indexXml['columns']);
+                }
+
+                if (isset($indexXml['fields'])) {
+                    $index['fields'] = explode(',', (string) $indexXml['fields']);
+                }
 
                 if (isset($indexXml['flags'])) {
                     $index['flags'] = explode(',', (string) $indexXml['flags']);
@@ -234,7 +242,15 @@ class XmlDriver extends FileDriver
         if (isset($xmlRoot->{'unique-constraints'})) {
             $metadata->table['uniqueConstraints'] = [];
             foreach ($xmlRoot->{'unique-constraints'}->{'unique-constraint'} as $uniqueXml) {
-                $unique = ['columns' => explode(',', (string) $uniqueXml['columns'])];
+                $unique = [];
+
+                if (isset($uniqueXml['columns']) && ! empty($uniqueXml['columns'])) {
+                    $unique['columns'] = explode(',', (string) $uniqueXml['columns']);
+                }
+
+                if (isset($uniqueXml['fields'])) {
+                    $unique['fields'] = explode(',', (string) $uniqueXml['fields']);
+                }
 
                 if (isset($uniqueXml->options)) {
                     $unique['options'] = $this->parseOptions($uniqueXml->options->children());

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -31,6 +31,7 @@ use SimpleXMLElement;
 
 use function assert;
 use function constant;
+use function count;
 use function defined;
 use function explode;
 use function file_get_contents;
@@ -231,7 +232,7 @@ class XmlDriver extends FileDriver
                 ) {
                     throw MappingException::invalidIndexConfiguration(
                         $className,
-                        (string) ($indexXml['name'] ?: count($metadata->table['indexes']))
+                        (string) ($indexXml['name'] ?? count($metadata->table['indexes']))
                     );
                 }
 
@@ -274,7 +275,7 @@ class XmlDriver extends FileDriver
                 ) {
                     throw MappingException::invalidUniqueConstraintConfiguration(
                         $className,
-                        (string) ($uniqueXml['name'] ?: count($metadata->table['uniqueConstraints']))
+                        (string) ($uniqueXml['name'] ?? count($metadata->table['uniqueConstraints']))
                     );
                 }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -228,10 +228,22 @@ class YamlDriver extends FileDriver
                     $indexYml['name'] = $name;
                 }
 
-                if (is_string($indexYml['columns'])) {
-                    $index = ['columns' => array_map('trim', explode(',', $indexYml['columns']))];
-                } else {
-                    $index = ['columns' => $indexYml['columns']];
+                $index = [];
+
+                if (isset($indexYml['columns'])) {
+                    if (is_string($indexYml['columns'])) {
+                        $index['columns'] = array_map('trim', explode(',', $indexYml['columns']));
+                    } else {
+                        $index['columns'] = $indexYml['columns'];
+                    }
+                }
+
+                if (isset($indexYml['fields'])) {
+                    if (is_string($indexYml['fields'])) {
+                        $index['fields'] = array_map('trim', explode(',', $indexYml['fields']));
+                    } else {
+                        $index['fields'] = $indexYml['fields'];
+                    }
                 }
 
                 if (isset($indexYml['flags'])) {
@@ -257,10 +269,22 @@ class YamlDriver extends FileDriver
                     $uniqueYml['name'] = $name;
                 }
 
-                if (is_string($uniqueYml['columns'])) {
-                    $unique = ['columns' => array_map('trim', explode(',', $uniqueYml['columns']))];
-                } else {
-                    $unique = ['columns' => $uniqueYml['columns']];
+                $unique = [];
+
+                if (isset($uniqueYml['columns'])) {
+                    if (is_string($uniqueYml['columns'])) {
+                        $unique['columns'] = array_map('trim', explode(',', $uniqueYml['columns']));
+                    } else {
+                        $unique['columns'] = $uniqueYml['columns'];
+                    }
+                }
+
+                if (isset($uniqueYml['fields'])) {
+                    if (is_string($uniqueYml['fields'])) {
+                        $unique['fields'] = array_map('trim', explode(',', $uniqueYml['fields']));
+                    } else {
+                        $unique['fields'] = $uniqueYml['fields'];
+                    }
                 }
 
                 if (isset($uniqueYml['options'])) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -246,6 +246,19 @@ class YamlDriver extends FileDriver
                     }
                 }
 
+                if (
+                    isset($index['columns'], $index['fields'])
+                    || (
+                        ! isset($index['columns'])
+                        && ! isset($index['fields'])
+                    )
+                ) {
+                    throw MappingException::invalidIndexConfiguration(
+                        $className,
+                        $indexYml['name']
+                    );
+                }
+
                 if (isset($indexYml['flags'])) {
                     if (is_string($indexYml['flags'])) {
                         $index['flags'] = array_map('trim', explode(',', $indexYml['flags']));
@@ -285,6 +298,19 @@ class YamlDriver extends FileDriver
                     } else {
                         $unique['fields'] = $uniqueYml['fields'];
                     }
+                }
+
+                if (
+                    isset($unique['columns'], $unique['fields'])
+                    || (
+                        ! isset($unique['columns'])
+                        && ! isset($unique['fields'])
+                    )
+                ) {
+                    throw MappingException::invalidUniqueConstraintConfiguration(
+                        $className,
+                        $uniqueYml['name']
+                    );
                 }
 
                 if (isset($uniqueYml['options'])) {

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -48,16 +48,19 @@ final class Index implements Annotation
 
     /**
      * @param array<string> $columns
+     * @param array<string> $fields
      * @param array<string> $flags
      * @param array<string> $options
      */
     public function __construct(
-        array $columns,
+        ?array $columns = null,
+        ?array $fields = null,
         ?string $name = null,
         ?array $flags = null,
         ?array $options = null
     ) {
         $this->columns = $columns;
+        $this->fields  = $fields;
         $this->name    = $name;
         $this->flags   = $flags;
         $this->options = $options;

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -38,6 +38,9 @@ final class Index implements Annotation
     public $columns;
 
     /** @var array<string> */
+    public $fields;
+
+    /** @var array<string> */
     public $flags;
 
     /** @var array<string,mixed> */

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -933,4 +933,32 @@ class MappingException extends ORMException
             )
         );
     }
+
+    /**
+     * @return self
+     */
+    public static function invalidIndexConfiguration($className, $indexName)
+    {
+        return new self(
+            sprintf(
+                'Index %s for entity %s should contain columns or fields values, but not both.',
+                $indexName,
+                $className
+            )
+        );
+    }
+
+    /**
+     * @return self
+     */
+    public static function invalidUniqueConstraintConfiguration($className, $indexName)
+    {
+        return new self(
+            sprintf(
+                'Unique constraint %s for entity %s should contain columns or fields values, but not both.',
+                $indexName,
+                $className
+            )
+        );
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -37,6 +37,9 @@ final class UniqueConstraint implements Annotation
     /** @var array<string> */
     public $columns;
 
+    /** @var array<string> */
+    public $fields;
+
     /** @var array<string,mixed> */
     public $options;
 

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -50,10 +50,12 @@ final class UniqueConstraint implements Annotation
     public function __construct(
         ?string $name = null,
         ?array $columns = null,
+        ?array $fields = null,
         ?array $options = null
     ) {
         $this->name    = $name;
         $this->columns = $columns;
+        $this->fields  = $fields;
         $this->options = $options;
     }
 }

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -45,6 +45,7 @@ final class UniqueConstraint implements Annotation
 
     /**
      * @param array<string>       $columns
+     * @param array<string>       $fields
      * @param array<string,mixed> $options
      */
     public function __construct(

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -30,6 +30,7 @@ use Doctrine\DBAL\Schema\Visitor\DropSchemaSqlCollector;
 use Doctrine\DBAL\Schema\Visitor\RemoveNamespacedAssets;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
@@ -148,6 +149,19 @@ class SchemaTool
     private function getIndexColumns($class, array $indexData)
     {
         $columns = [];
+
+        if (
+            isset($indexData['columns'], $indexData['fields'])
+            || (
+                ! isset($indexData['columns'])
+                && ! isset($indexData['fields'])
+            )
+        ) {
+            throw MappingException::invalidIndexConfiguration(
+                $class,
+                $indexData['name'] ?? 'unnamed'
+            );
+        }
 
         if (isset($indexData['columns'])) {
             $columns = $indexData['columns'];

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -141,7 +141,7 @@ class SchemaTool
      * Resolves fields in index mapping to column names
      *
      * @param ClassMetadata $class
-     * @param array         $indexData index or unique constraint data
+     * @param mixed[]       $indexData index or unique constraint data
      *
      * @return string[] Column names from combined fields and columns mappings
      */

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -104,6 +104,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
             [
                 'name_idx' => ['columns' => ['name']],
                 0 => ['columns' => ['user_email']],
+                'fields' => ['fields' => ['name', 'email']],
+                'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
             ],
             $class->table['indexes']
         );
@@ -141,6 +143,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals(
             [
                 'search_idx' => ['columns' => ['name', 'user_email'], 'options' => ['where' => 'name IS NOT NULL']],
+                'phone_idx' => ['fields' => ['name', 'phone']],
             ],
             $class->table['uniqueConstraints']
         );
@@ -1067,8 +1070,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
  * @HasLifecycleCallbacks
  * @Table(
  *  name="cms_users",
- *  uniqueConstraints={@UniqueConstraint(name="search_idx", columns={"name", "user_email"}, options={"where": "name IS NOT NULL"})},
- *  indexes={@Index(name="name_idx", columns={"name"}), @Index(name="0", columns={"user_email"})},
+ *  uniqueConstraints={@UniqueConstraint(name="search_idx", columns={"name", "user_email"}, options={"where": "name IS NOT NULL"}), @UniqueConstraint(name="phone_idx", fields={"name", "phone"})},
+ *  indexes={@Index(name="name_idx", columns={"name"}), @Index(name="0", columns={"user_email"}), @index(name="fields", fields={"name", "email"}), @Index(name="column_fields", columns={"name"}, fields={"address"})},
  *  options={"foo": "bar", "baz": {"key": "val"}}
  * )
  * @NamedQueries({@NamedQuery(name="all", query="SELECT u FROM __CLASS__ u")})
@@ -1287,10 +1290,13 @@ class User
         );
         $metadata->table['uniqueConstraints'] = [
             'search_idx' => ['columns' => ['name', 'user_email'], 'options' => ['where' => 'name IS NOT NULL']],
+            'phone_idx' => ['fields' => ['name', 'phone']],
         ];
         $metadata->table['indexes']           = [
             'name_idx' => ['columns' => ['name']],
             0 => ['columns' => ['user_email']],
+            'fields' => ['fields' => ['name', 'email']],
+            'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
         ];
         $metadata->setSequenceGeneratorDefinition(
             [

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -105,12 +105,17 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
                 'name_idx' => ['columns' => ['name']],
                 0 => ['columns' => ['user_email']],
                 'fields' => ['fields' => ['name', 'email']],
-                'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
             ],
             $class->table['indexes']
         );
 
         return $class;
+    }
+
+    public function testEntityIncorrectIndexes(): void
+    {
+        $this->expectException(MappingException::class);
+        $this->createClassMetadata(UserIncorrectIndex::class);
     }
 
     public function testEntityIndexFlagsAndPartialIndexes(): void
@@ -149,6 +154,12 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         );
 
         return $class;
+    }
+
+    public function testEntityIncorrectUniqueContraint(): void
+    {
+        $this->expectException(MappingException::class);
+        $this->createClassMetadata(UserIncorrectUniqueConstraint::class);
     }
 
     /**
@@ -1071,7 +1082,7 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
  * @Table(
  *  name="cms_users",
  *  uniqueConstraints={@UniqueConstraint(name="search_idx", columns={"name", "user_email"}, options={"where": "name IS NOT NULL"}), @UniqueConstraint(name="phone_idx", fields={"name", "phone"})},
- *  indexes={@Index(name="name_idx", columns={"name"}), @Index(name="0", columns={"user_email"}), @index(name="fields", fields={"name", "email"}), @Index(name="column_fields", columns={"name"}, fields={"address"})},
+ *  indexes={@Index(name="name_idx", columns={"name"}), @Index(name="0", columns={"user_email"}), @index(name="fields", fields={"name", "email"})},
  *  options={"foo": "bar", "baz": {"key": "val"}}
  * )
  * @NamedQueries({@NamedQuery(name="all", query="SELECT u FROM __CLASS__ u")})
@@ -1296,7 +1307,6 @@ class User
             'name_idx' => ['columns' => ['name']],
             0 => ['columns' => ['user_email']],
             'fields' => ['fields' => ['name', 'email']],
-            'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
         ];
         $metadata->setSequenceGeneratorDefinition(
             [
@@ -1311,6 +1321,124 @@ class User
                 'query' => 'SELECT u FROM __CLASS__ u',
             ]
         );
+    }
+}
+
+/**
+ * @Entity
+ * @Table(
+ *  indexes={@Index(name="name_idx", columns={"name"}, fields={"email"})},
+ * )
+ */
+class UserIncorrectIndex
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @generatedValue(strategy="AUTO")
+     **/
+    public $id;
+
+    /**
+     * @var string
+     * @Column
+     */
+    public $name;
+
+    /**
+     * @var string
+     * @Column(name="user_email")
+     */
+    public $email;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    {
+        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable([]);
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+                'type' => 'integer',
+                'columnName' => 'id',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'name',
+                'type' => 'string',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'email',
+                'type' => 'string',
+                'columnName' => 'user_email',
+            ]
+        );
+        $metadata->table['indexes'] = [
+            'name_idx' => ['columns' => ['name'], 'fields' => ['email']],
+        ];
+    }
+}
+
+/**
+ * @Entity
+ * @Table(
+ *  uniqueConstraints={@UniqueConstraint(name="name_idx", columns={"name"}, fields={"email"})},
+ * )
+ */
+class UserIncorrectUniqueConstraint
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @generatedValue(strategy="AUTO")
+     **/
+    public $id;
+
+    /**
+     * @var string
+     * @Column
+     */
+    public $name;
+
+    /**
+     * @var string
+     * @Column(name="user_email")
+     */
+    public $email;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    {
+        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable([]);
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+                'type' => 'integer',
+                'columnName' => 'id',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'name',
+                'type' => 'string',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'email',
+                'type' => 'string',
+                'columnName' => 'user_email',
+            ]
+        );
+        $metadata->table['uniqueConstraints'] = [
+            'name_idx' => ['columns' => ['name'], 'fields' => ['email']],
+        ];
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -1089,8 +1089,8 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
  */
 #[ORM\Entity(), ORM\HasLifecycleCallbacks()]
 #[ORM\Table(name: "cms_users", options: ["foo" => "bar", "baz" => ["key" => "val"]])]
-#[ORM\Index(name: "name_idx", columns: ["name"]), ORM\Index(name: "0", columns: ["user_email"])]
-#[ORM\UniqueConstraint(name: "search_idx", columns: ["name", "user_email"], options: ["where" => "name IS NOT NULL"])]
+#[ORM\Index(name: "name_idx", columns: ["name"]), ORM\Index(name: "0", columns: ["user_email"]), ORM\Index(name: "fields", fields: ["name", "email"])]
+#[ORM\UniqueConstraint(name: "search_idx", columns: ["name", "user_email"], options: ["where" => "name IS NOT NULL"]), ORM\UniqueConstraint(name: "phone_idx", fields: ["name", "phone"])]
 class User
 {
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/PHPMappingDriverTest.php
@@ -49,4 +49,14 @@ class PHPMappingDriverTest extends AbstractMappingDriverTest
         $class = new ClassMetadata(Mapping\PHPSLC::class);
         $mappingDriver->loadMetadataForClass(Mapping\PHPSLC::class, $class);
     }
+
+    public function testEntityIncorrectIndexes(): void
+    {
+        self::markTestSkipped('PHP driver does not ensure index correctness');
+    }
+
+    public function testEntityIncorrectUniqueContraint(): void
+    {
+        self::markTestSkipped('PHP driver does not ensure index correctness');
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/StaticPHPMappingDriverTest.php
@@ -45,4 +45,14 @@ class StaticPHPMappingDriverTest extends AbstractMappingDriverTest
     {
         $this->markTestIncomplete();
     }
+
+    public function testEntityIncorrectIndexes(): void
+    {
+        self::markTestSkipped('Static PHP driver does not ensure index correctness');
+    }
+
+    public function testEntityIncorrectUniqueContraint(): void
+    {
+        self::markTestSkipped('Static PHP driver does not ensure index correctness');
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -130,10 +130,13 @@ $metadata->table['options']           = [
 ];
 $metadata->table['uniqueConstraints'] = [
     'search_idx' => ['columns' => ['name', 'user_email'], 'options' => ['where' => 'name IS NOT NULL']],
+    'phone_idx' => ['fields' => ['name', 'phone']],
 ];
 $metadata->table['indexes']           = [
     'name_idx' => ['columns' => ['name']],
     0 => ['columns' => ['user_email']],
+    'fields' => ['fields' => ['name', 'email']],
+    'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
 ];
 $metadata->setSequenceGeneratorDefinition(
     [

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.ORM.Mapping.User.php
@@ -136,7 +136,6 @@ $metadata->table['indexes']           = [
     'name_idx' => ['columns' => ['name']],
     0 => ['columns' => ['user_email']],
     'fields' => ['fields' => ['name', 'email']],
-    'column_fields' => ['columns' => ['name'], 'fields' => ['address']],
 ];
 $metadata->setSequenceGeneratorDefinition(
     [

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
@@ -17,7 +17,6 @@
             <index name="name_idx" columns="name"/>
             <index columns="user_email"/>
             <index name="fields" columns="" fields="name,email"/>
-            <index name="column_fields" columns="name" fields="address"/>
         </indexes>
 
         <unique-constraints>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.User.dcm.xml
@@ -16,6 +16,8 @@
         <indexes>
             <index name="name_idx" columns="name"/>
             <index columns="user_email"/>
+            <index name="fields" columns="" fields="name,email"/>
+            <index name="column_fields" columns="name" fields="address"/>
         </indexes>
 
         <unique-constraints>
@@ -24,6 +26,7 @@
                     <option name="where">name IS NOT NULL</option>
                 </options>
             </unique-constraint>
+            <unique-constraint columns="" fields="name,phone" name="phone_idx"/>
         </unique-constraints>
 
         <lifecycle-callbacks>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectIndex.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectIndex.dcm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\ORM\Mapping\UserIncorrectIndex" table="cms_users">
+    <indexes>
+      <index name="name_idx" columns="name" fields="email"/>
+    </indexes>
+
+    <id name="id" type="integer" column="id">
+      <generator strategy="AUTO"/>
+    </id>
+
+    <field name="name" column="name" type="string">
+    </field>
+    <field name="email" column="user_email" type="string"/>
+
+  </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectUniqueConstraint.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.ORM.Mapping.UserIncorrectUniqueConstraint.dcm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\ORM\Mapping\UserIncorrectUniqueConstraint" table="cms_users">
+    <unique-constraints>
+      <unique-constraint name="name_idx" columns="name" fields="email"/>
+    </unique-constraints>
+
+    <id name="id" type="integer" column="id">
+      <generator strategy="AUTO"/>
+    </id>
+
+    <field name="name" column="name" type="string">
+    </field>
+    <field name="email" column="user_email" type="string"/>
+
+  </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
@@ -78,8 +78,15 @@ Doctrine\Tests\ORM\Mapping\User:
       columns: name,user_email
       options:
         where: name IS NOT NULL
+    phone_idx:
+      fields: name,phone
   indexes:
     name_idx:
       columns: name
     0:
       columns: user_email
+    fields:
+      fields: name,email
+    column_fields:
+      columns: name
+      fields: address

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.User.dcm.yml
@@ -87,6 +87,3 @@ Doctrine\Tests\ORM\Mapping\User:
       columns: user_email
     fields:
       fields: name,email
-    column_fields:
-      columns: name
-      fields: address

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.UserIncorrectIndex.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.UserIncorrectIndex.dcm.yml
@@ -1,0 +1,17 @@
+Doctrine\Tests\ORM\Mapping\UserIncorrectIndex:
+    type: entity
+    id:
+        id:
+            type: integer
+            generator:
+                strategy: AUTO
+    fields:
+        name:
+            type: string
+        email:
+            type: string
+            column: user_email
+    indexes:
+        name_idx:
+            columns: name
+            fields: email

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.UserIncorrectUniqueConstraint.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.ORM.Mapping.UserIncorrectUniqueConstraint.dcm.yml
@@ -1,0 +1,17 @@
+Doctrine\Tests\ORM\Mapping\UserIncorrectUniqueConstraint:
+    type: entity
+    id:
+        id:
+            type: integer
+            generator:
+                strategy: AUTO
+    fields:
+        name:
+            type: string
+        email:
+            type: string
+            column: user_email
+    uniqueConstraints:
+        name_idx:
+            columns: name
+            fields: email

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -281,13 +281,13 @@ class SchemaToolTest extends OrmTestCase
 
     public function testIndexesBasedOnFields(): void
     {
-        $em         = $this->getTestEntityManager();
+        $em = $this->getTestEntityManager();
         $em->getConfiguration()->setNamingStrategy(new UnderscoreNamingStrategy());
+
         $schemaTool = new SchemaTool($em);
         $metadata   = $em->getClassMetadata(IndexByFieldEntity::class);
-        $schema = $schemaTool->getSchemaFromMetadata([$metadata]);
-
-        $table = $schema->getTable('field_index');
+        $schema     = $schemaTool->getSchemaFromMetadata([$metadata]);
+        $table      = $schema->getTable('field_index');
 
         $this->assertEquals(['index'], $table->getIndex('index')->getColumns());
         $this->assertEquals(['index', 'field_name'], $table->getIndex('table')->getColumns());
@@ -465,16 +465,19 @@ class IndexByFieldEntity
     public $id;
 
     /**
+     * @var string
      * @Column
      */
     public $index;
 
     /**
+     * @var string
      * @Column
      */
     public $table;
 
     /**
+     * @var string
      * @Column
      */
     public $fieldName;

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaToolTest.php
@@ -302,10 +302,10 @@ class SchemaToolTest extends OrmTestCase
         $em = $this->getTestEntityManager();
         $em->getConfiguration()->setNamingStrategy(new UnderscoreNamingStrategy());
 
-        $schemaTool = new SchemaTool($em);
-
+        $schemaTool    = new SchemaTool($em);
         $mappingDriver = new StaticPHPDriver([]);
-        $class = new ClassMetadata(IncorrectIndexByFieldEntity::class);
+        $class         = new ClassMetadata(IncorrectIndexByFieldEntity::class);
+
         $class->initializeReflection(new RuntimeReflectionService());
         $mappingDriver->loadMetadataForClass(IncorrectIndexByFieldEntity::class, $class);
 
@@ -318,10 +318,10 @@ class SchemaToolTest extends OrmTestCase
         $em = $this->getTestEntityManager();
         $em->getConfiguration()->setNamingStrategy(new UnderscoreNamingStrategy());
 
-        $schemaTool = new SchemaTool($em);
-
+        $schemaTool    = new SchemaTool($em);
         $mappingDriver = new StaticPHPDriver([]);
-        $class = new ClassMetadata(IncorrectUniqueConstraintByFieldEntity::class);
+        $class         = new ClassMetadata(IncorrectUniqueConstraintByFieldEntity::class);
+
         $class->initializeReflection(new RuntimeReflectionService());
         $mappingDriver->loadMetadataForClass(IncorrectUniqueConstraintByFieldEntity::class, $class);
 
@@ -519,12 +519,16 @@ class IndexByFieldEntity
 
 class IncorrectIndexByFieldEntity
 {
+    /** @var int */
     public $id;
 
+    /** @var string */
     public $index;
 
+    /** @var string */
     public $table;
 
+    /** @var string */
     public $fieldName;
 
     public static function loadMetadata(ClassMetadataInfo $metadata): void
@@ -536,23 +540,11 @@ class IncorrectIndexByFieldEntity
             ]
         );
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'index',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'index']);
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'table',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'table']);
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'fieldName',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'fieldName']);
 
         $metadata->setPrimaryTable(
             [
@@ -566,12 +558,16 @@ class IncorrectIndexByFieldEntity
 
 class IncorrectUniqueConstraintByFieldEntity
 {
+    /** @var int */
     public $id;
 
+    /** @var string */
     public $index;
 
+    /** @var string */
     public $table;
 
+    /** @var string */
     public $fieldName;
 
     public static function loadMetadata(ClassMetadataInfo $metadata): void
@@ -583,23 +579,11 @@ class IncorrectUniqueConstraintByFieldEntity
             ]
         );
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'index',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'index']);
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'table',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'table']);
 
-        $metadata->mapField(
-            [
-                'fieldName'         => 'fieldName',
-            ]
-        );
+        $metadata->mapField(['fieldName' => 'fieldName']);
 
         $metadata->setPrimaryTable(
             [


### PR DESCRIPTION
This PR implements feature requested in #8345. It handles all existing drivers (probably upcoming Annotation will need a little change if it gets merged).

I based my work on last comment by @beberlei - it translates fields and columns to indexes only in `SchemaTool::getSchemaFromMetadata`. I haven't found the need to translate them beforehand, but maybe I've missed something.

I have adapted metadata tests to cover all cases when reading entities and added simple test for translating fields to columns.

In my implementation one can use both `fields` and `columns` at the same time and they will be merged.