### PR TITLE
[GH-8527] Revert cs fixes for entity version compares in lock+merge

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2054,7 +2054,8 @@ class UnitOfWork implements PropertyChangedListener
         $entityVersion      = $reflField->getValue($entity);
 
         // Throw exception if versions don't match.
-        if ($managedCopyVersion === $entityVersion) {
+        // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
+        if ($managedCopyVersion == $entityVersion) {
             return;
         }
 
@@ -2479,11 +2480,8 @@ class UnitOfWork implements PropertyChangedListener
 
                 $entityVersion = $class->reflFields[$class->versionField]->getValue($entity);
 
-                if ($entityVersion instanceof DateTimeInterface && $lockVersion instanceof DateTimeInterface) {
-                    if ($entityVersion->getTimestamp() !== $lockVersion->getTimestamp()) {
-                        throw OptimisticLockException::lockFailedVersionMismatch($entity, $lockVersion, $entityVersion);
-                    }
-                } elseif ($entityVersion !== $lockVersion) {
+                // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator
+                if ($entityVersion != $lockVersion) {
                     throw OptimisticLockException::lockFailedVersionMismatch($entity, $lockVersion, $entityVersion);
                 }
 


### PR DESCRIPTION
Two automatic coding style fixes broke comparison operations in 2.8.2. One was independently fixed in https://github.com/doctrine/orm/pull/8508 - but another one in `UnitOfWork::merge` was missed.

This PR reverts these fixes for now to get back the old 2.8.1 behavior.