### PR TITLE
All CI runs are using the sqlite fallback connection instead of the expected driver

### DIFF
--- a/ci/github/phpunit/sqlite.xml
+++ b/ci/github/phpunit/sqlite.xml
@@ -7,6 +7,10 @@
          failOnRisky="true"
 >
     <php>
+        <!-- use an in-memory sqlite database -->
+        <var name="db_driver" value="pdo_sqlite"/>
+        <var name="db_memory" value="true"/>
+
         <!-- necessary change for some CLI/console output test assertions -->
         <env name="COLUMNS" value="120"/>
     </php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,14 +44,24 @@
       <var name="db_port" value="3306"/>-->
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
-    <!-- Database for temporary connections (i.e. to drop/create the main database) -->
     <!--
-    <var name="tmpdb_driver" value="pdo_mysql"/>
-    <var name="tmpdb_host" value="localhost" />
-    <var name="tmpdb_user" value="root" />
-    <var name="tmpdb_password" value="" />
-    <var name="tmpdb_dbname" value="doctrine_tests_tmp" />
-    <var name="tmpdb_port" value="3306"/>
+     At the start of each test run, we will drop and recreate the test database.
+
+     By default we assume that the `db_` config above has unrestricted access to the provided database
+     platform.
+
+     If you prefer, you can provide a restricted user above and a separate `privileged_db` config
+     block to provide details of a privileged connection to use for the setup / teardown actions.
+
+     Note that these configurations are not merged - if you specify a `privileged_db_driver` then
+     you must also specify all the other options that your driver requires.
+
+    <var name="privileged_db_driver" value="pdo_mysql"/>
+    <var name="privileged_db_host" value="localhost" />
+    <var name="privileged_db_user" value="root" />
+    <var name="privileged_db_password" value="" />
+    <var name="privileged_db_dbname" value="doctrine_tests_tmp" />
+    <var name="privileged_db_port" value="3306"/>
     -->
 
     <env name="COLUMNS" value="120"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -33,22 +33,26 @@
 
   <php>
     <!-- "Real" test database -->
-    <!-- uncomment, otherwise sqlite memory runs
-    <var name="db_type" value="pdo_mysql"/>
-    <var name="db_host" value="localhost" />
-    <var name="db_username" value="root" />
-    <var name="db_password" value="" />
-    <var name="db_name" value="doctrine_tests" />
-    <var name="db_port" value="3306"/>-->
+    <var name="db_driver" value="pdo_sqlite"/>
+    <var name="db_memory" value="true"/>
+      <!-- to use another database driver / credentials, provide them like so:
+      <var name="db_driver" value="pdo_mysql"/>
+      <var name="db_host" value="localhost" />
+      <var name="db_user" value="root" />
+      <var name="db_password" value="" />
+      <var name="db_dbname" value="doctrine_tests" />
+      <var name="db_port" value="3306"/>-->
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
 
     <!-- Database for temporary connections (i.e. to drop/create the main database) -->
-    <var name="tmpdb_type" value="pdo_mysql"/>
+    <!--
+    <var name="tmpdb_driver" value="pdo_mysql"/>
     <var name="tmpdb_host" value="localhost" />
-    <var name="tmpdb_username" value="root" />
+    <var name="tmpdb_user" value="root" />
     <var name="tmpdb_password" value="" />
-    <var name="tmpdb_name" value="doctrine_tests_tmp" />
+    <var name="tmpdb_dbname" value="doctrine_tests_tmp" />
     <var name="tmpdb_port" value="3306"/>
+    -->
 
     <env name="COLUMNS" value="120"/>
   </php>

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -181,7 +181,7 @@ class LockTest extends OrmFunctionalTestCase
 
         $query = array_pop($this->_sqlLoggerStack->queries);
         $query = array_pop($this->_sqlLoggerStack->queries);
-        $this->assertContains($writeLockSql, $query['sql']);
+        $this->assertStringContainsString($writeLockSql, $query['sql']);
     }
 
     /**
@@ -216,7 +216,7 @@ class LockTest extends OrmFunctionalTestCase
         array_pop($this->_sqlLoggerStack->queries);
         $query = array_pop($this->_sqlLoggerStack->queries);
 
-        $this->assertContains($readLockSql, $query['sql']);
+        $this->assertStringContainsString($readLockSql, $query['sql']);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -54,9 +54,9 @@ class UUIDEntity
     /**
      * Get id.
      *
-     * @return id.
+     * @return string.
      */
-    public function getId(): id
+    public function getId(): string
     {
         return $this->id;
     }

--- a/tests/dbproperties.xml.dev
+++ b/tests/dbproperties.xml.dev
@@ -14,20 +14,31 @@
 <phpunit>
   <php>
     <!-- "Real" test database -->
-    <var name="db_type" value="pdo_mysql"/>
+    <var name="db_driver" value="pdo_mysql"/>
     <var name="db_host" value="localhost" />
-    <var name="db_username" value="root" />
+    <var name="db_user" value="root" />
     <var name="db_password" value="" />
-    <var name="db_name" value="doctrine_tests" />
+    <var name="db_dbname" value="doctrine_tests" />
     <var name="db_port" value="3306"/>
     <!--<var name="db_event_subscribers" value="Doctrine\DBAL\Event\Listeners\OracleSessionInit">-->
     
-    <!-- Database for temporary connections (i.e. to drop/create the main database) -->
-    <var name="tmpdb_type" value="pdo_mysql"/>
-    <var name="tmpdb_host" value="localhost" />
-    <var name="tmpdb_username" value="root" />
-    <var name="tmpdb_password" value="" />
-    <var name="tmpdb_name" value="doctrine_tests_tmp" />
-    <var name="tmpdb_port" value="3306"/>
+    <!--
+    At the start of each test run, we will drop and recreate the test database.
+
+    By default we assume that the `db_` config above has unrestricted access to the provided database
+    platform.
+
+    If you prefer, you can provide a restricted user above and a separate `privileged_db` config
+    block to provide details of a privileged connection to use for the setup / teardown actions.
+
+    Note that these configurations are not merged - if you specify a `privileged_db_driver` then
+    you must also specify all the other options that your driver requires.
+    <var name="privileged_db_driver" value="pdo_mysql"/>
+    <var name="privileged_db_host" value="localhost" />
+    <var name="privileged_db_username" value="root" />
+    <var name="privileged_db_password" value="" />
+    <var name="privileged_db_dbname" value="doctrine_tests_tmp" />
+    <var name="privileged_db_port" value="3306"/>
+    -->
   </php>
 </phpunit>


### PR DESCRIPTION
While writing a test for an unrelated issue, I noticed that the unit tests are not loading the expected database connection details. Regardless of the config file provided, the `TestUtil` class is providing the fallback sqlite driver. 

As a result a) none of the code is being tested against other platforms and b) tests that rely on platform-specific features (e.g. pessimistic locking) are being skipped on all builds.

It looks like this has been the case ever since the migration from Travis CI. Therefore some of the consistently-skipped tests are also not valid with phpunit 9 - e.g. `Doctrine\Tests\ORM\Functional\Locking\LockTest` has two tests that fail due to using `->assertContains` with a string argument, which need to be upgraded to `->assertStringContainsString`.

The root cause is that when the driver-specific phpunit.xml files were updated for github actions, the various `tmpdb_type` / `tmpdb_username` etc with the config for the privileged temporary connection were removed. It looks like this [might be valid for doctrine/dbal because it falls back to using the main db params](https://github.com/doctrine/dbal/blob/3.1.x/tests/TestUtil.php#L158) however the [TestUtil class in doctrine/orm does not](https://github.com/doctrine/orm/blob/2.8.x/tests/Doctrine/Tests/TestUtil.php#L162) and [it has a much stricter list of required parameters before it will use the specified driver](https://github.com/doctrine/orm/blob/2.8.x/tests/Doctrine/Tests/TestUtil.php#L162).

* [x] Update test configuration to prove the issue and hard-fail if the job is not using the expected driver
* [x] *Either* reinstate the extra variables in the phpunit.xml files *or* update TestUtil to match the behaviour of the doctrine/dbal version
* [x] Identify tests that fail once the actual drivers are being used and fix (upgrade to phpunit 9) as required.

I can finish this off, but could you advise whether you'd prefer me to add the missing vars to the phpunit.xml or update TestUtil to work as expected with the current configs?

