### PR TITLE
Add test coverage for passing optimistic lock version as string

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockTest.php
@@ -32,8 +32,10 @@ class LockTest extends OrmFunctionalTestCase
     /**
      * @group DDC-178
      * @group locking
+     * @testWith [false]
+     *           [true]
      */
-    public function testLockVersionedEntity(): void
+    public function testLockVersionedEntity(bool $useStringVersion): void
     {
         $article        = new CmsArticle();
         $article->text  = 'my article';
@@ -42,7 +44,15 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
 
-        $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version);
+        $lockVersion = $article->version;
+        if ($useStringVersion) {
+            // NOTE: Officially, the lock method (and callers) do not accept a string argument. Calling code should
+            // cast the version to (int) as per the docs. However, this is not currently enforced. This may change in
+            // a future release.
+            $lockVersion = (string) $lockVersion;
+        }
+
+        $this->_em->lock($article, LockMode::OPTIMISTIC, $lockVersion);
 
         $this->addToAssertionCount(1);
     }
@@ -50,8 +60,10 @@ class LockTest extends OrmFunctionalTestCase
     /**
      * @group DDC-178
      * @group locking
+     * @testWith [false]
+     *           [true]
      */
-    public function testLockVersionedEntityMismatchThrowsException(): void
+    public function testLockVersionedEntityMismatchThrowsException(bool $useStringVersion): void
     {
         $article        = new CmsArticle();
         $article->text  = 'my article';
@@ -61,8 +73,12 @@ class LockTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         $this->expectException(OptimisticLockException::class);
+        $lockVersion = $article->version + 1;
+        if ($useStringVersion) {
+            $lockVersion = (string) $lockVersion;
+        }
 
-        $this->_em->lock($article, LockMode::OPTIMISTIC, $article->version + 1);
+        $this->_em->lock($article, LockMode::OPTIMISTIC, $lockVersion);
     }
 
     /**


### PR DESCRIPTION
As suggested by @greg0ire I have updated the tests to cover the current behaviour of passing a string `version` argument for optimistic locking.

Since #8527 was only-sort-of-a-bug and this is just a simple variation of how `->lock` is already tested, I thought it made sense to modify the existing tests to cover this case rather than the overhead of a whole separate test case. Particularly since I guess this will probably change again in a future release, and the goal is just to avoid that happening accidentally in the meantime.

If you'd prefer to have a standalone GH8527 ticket test instead I can happily do that, just let me know.