### PR TITLE
Deprecate type inference in `Query::setParameter`

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -381,6 +381,13 @@ abstract class AbstractQuery
      */
     public function setParameter($key, $value, $type = null)
     {
+        if ($type === null) {
+            Deprecation::trigger(
+                'doctrine/orm',
+                'https://github.com/doctrine/orm/issues/8379',
+                'Consider adding the type as third argument since null will not be accepted anymore in Doctrine ORM 3.0.'
+            );
+        }
         $existingParameter = $this->getParameter($key);
 
         if ($existingParameter !== null) {

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -388,6 +388,7 @@ abstract class AbstractQuery
                 'Consider adding the type as third argument since null will not be accepted anymore in Doctrine ORM 3.0.'
             );
         }
+
         $existingParameter = $this->getParameter($key);
 
         if ($existingParameter !== null) {

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -44,6 +44,9 @@ class ParameterTypeInferer
      * - Type (\Doctrine\DBAL\Types\Type::*)
      * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
      *
+     * @deprecated Infer Type will be removed in the future for setParameter method,
+     * - Consider adding the type as third argument to setParameter method since null will not be accepted anymore
+     *
      * @param mixed $value Parameter value.
      *
      * @return mixed Parameter type constant.

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -44,9 +44,6 @@ class ParameterTypeInferer
      * - Type (\Doctrine\DBAL\Types\Type::*)
      * - Connection (\Doctrine\DBAL\Connection::PARAM_*)
      *
-     * @deprecated Infer Type will be removed in the future for setParameter method,
-     * - Consider adding the type as third argument to setParameter method since null will not be accepted anymore
-     *
      * @param mixed $value Parameter value.
      *
      * @return mixed Parameter type constant.

--- a/tests/Doctrine/Tests/ORM/Functional/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AbstractQueryTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
-use Doctrine\Tests\OrmFunctionalTestCase;
 use Doctrine\ORM\AbstractQuery;
+use Doctrine\Tests\OrmFunctionalTestCase;
 
 class AbstractQueryTest extends OrmFunctionalTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Functional/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AbstractQueryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\Tests\OrmFunctionalTestCase;
+use Doctrine\ORM\AbstractQuery;
+
+class AbstractQueryTest extends OrmFunctionalTestCase
+{
+    use VerifyDeprecations;
+
+    /** @var AbstractQuery */
+    private $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->query = $this->getMockForAbstractClass(AbstractQuery::class, ['em' => $this->_em]);
+    }
+
+    public function testSetParameterDeprecationForMissingInferType(): void
+    {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
+        $this->query->setParameter('test_key', 'test_value');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->query);
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Internal\Hydration\HydrationException;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query\Parameter;
@@ -33,6 +34,8 @@ use function is_numeric;
  */
 class NativeQueryTest extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     private $platform = null;
 
     protected function setUp(): void
@@ -61,6 +64,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('name'), 'name');
 
         $query = $this->_em->createNativeQuery('SELECT id, name FROM cms_users WHERE username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $users = $query->getResult();
@@ -98,6 +104,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addMetaResult('a', $this->platform->getSQLResultCasing('user_id'), 'user_id', false, 'integer');
 
         $query = $this->_em->createNativeQuery('SELECT a.id, a.country, a.zip, a.city, a.user_id FROM cms_addresses a WHERE a.id = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, $addr->id);
 
         $addresses = $query->getResult();
@@ -137,6 +146,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addFieldResult('p', $this->platform->getSQLResultCasing('phonenumber'), 'phonenumber');
 
         $query = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $users = $query->getResult();
@@ -182,6 +194,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('city'), 'city');
 
         $query = $this->_em->createNativeQuery('SELECT u.id, u.name, u.status, a.id AS a_id, a.country, a.zip, a.city FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $users = $query->getResult();
@@ -207,6 +222,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm = new ResultSetMapping();
 
         $q  = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q2 = $q->setSQL('foo')
           ->setResultSetMapping($rsm)
           ->expireResultCache(true)
@@ -240,6 +258,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addRootEntityFromClassMetadata(CmsUser::class, 'u');
         $rsm->addJoinedEntityFromClassMetadata(CmsPhonenumber::class, 'p', 'u', 'phonenumbers');
         $query = $this->_em->createNativeQuery('SELECT u.*, p.* FROM cms_users u LEFT JOIN cms_phonenumbers p ON u.id = p.user_id WHERE username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $users = $query->getResult();
@@ -258,6 +279,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata(CmsPhonenumber::class, 'p');
         $query = $this->_em->createNativeQuery('SELECT p.* FROM cms_phonenumbers p WHERE p.phonenumber = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, $phone->phonenumber);
         $phone = $query->getSingleResult();
 
@@ -289,6 +313,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addJoinedEntityFromClassMetadata(CmsAddress::class, 'a', 'u', 'address', ['id' => 'a_id']);
 
         $query = $this->_em->createNativeQuery('SELECT u.*, a.*, a.id AS a_id FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $users = $query->getResult();
@@ -309,6 +336,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm = new ResultSetMappingBuilder($this->_em);
         $rsm->addRootEntityFromClassMetadata(CmsAddress::class, 'a');
         $query = $this->_em->createNativeQuery('SELECT a.* FROM cms_addresses a WHERE a.id = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, $addr->getId());
         $address = $query->getSingleResult();
 
@@ -357,6 +387,9 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm->addJoinedEntityFromClassMetadata(CmsAddress::class, 'a', 'un', 'address', ['id' => 'a_id']);
 
         $query = $this->_em->createNativeQuery('SELECT u.*, a.*, a.id AS a_id FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(1, 'romanb');
 
         $this->expectException(HydrationException::class);
@@ -422,6 +455,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $repository = $this->_em->getRepository(CmsUser::class);
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $result = $repository->createNativeNamedQuery('fetchIdAndUsernameWithResultClass')
                             ->setParameter(1, 'FabioBatSilva')
                             ->getResult();
@@ -434,6 +469,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $this->assertEquals('FabioBatSilva', $result[0]->username);
 
         $this->_em->clear();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $result = $repository->createNativeNamedQuery('fetchAllColumns')
                             ->setParameter(1, 'FabioBatSilva')
@@ -468,6 +505,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
         $this->_em->clear();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $result = $this->_em->getRepository(CmsUser::class)
                             ->createNativeNamedQuery('fetchJoinedAddress')
@@ -507,6 +546,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository(CmsUser::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $result = $repository->createNativeNamedQuery('fetchJoinedPhonenumber')
                         ->setParameter(1, 'FabioBatSilva')->getResult();
@@ -555,6 +596,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $repository = $this->_em->getRepository(CmsUser::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $result = $repository->createNativeNamedQuery('fetchUserPhonenumberCount')
                         ->setParameter(1, ['test', 'FabioBatSilva'])->getResult();

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -222,7 +222,7 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $rsm = new ResultSetMapping();
 
-        $q  = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
+        $q = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 

--- a/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Proxy\Proxy;
@@ -29,6 +30,8 @@ use function iterator_to_array;
  */
 class QueryTest extends OrmFunctionalTestCase
 {
+    use VerifyDeprecations;
+
     protected function setUp(): void
     {
         $this->useModelSet('cms');
@@ -120,6 +123,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.username = ?0');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q->setParameter(0, 'jwage');
         $user = $q->getSingleResult();
 
@@ -132,6 +138,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->expectExceptionMessage('Invalid parameter: token 2 is not defined in the query.');
 
         $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q->setParameter(2, 'jwage');
         $user = $q->getSingleResult();
     }
@@ -142,6 +151,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->expectExceptionMessage('Too many parameters: the query defines 1 parameters and you bound 2');
 
         $q = $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q->setParameter(1, 'jwage');
         $q->setParameter(2, 'jwage');
 
@@ -160,6 +172,8 @@ class QueryTest extends OrmFunctionalTestCase
     public function testInvalidInputParameterThrowsException(): void
     {
         $this->expectException(QueryException::class);
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $this->_em->createQuery('SELECT u FROM ' . CmsUser::class . ' u WHERE u.name = ?')
                   ->setParameter(1, 'jwage')
@@ -523,6 +537,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->persist($article);
         $this->_em->flush();
         $this->_em->clear();
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
         $q = $this->_em->createQuery('select a from Doctrine\Tests\Models\CMS\CmsArticle a where a.topic = :topic and a.user = :user')
                 ->setParameter('user', $this->_em->getReference(CmsUser::class, $author->id))
@@ -690,6 +707,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username IN (?0)');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(0, ['beberlei', 'jwage']);
 
         $users = $query->execute();
@@ -735,6 +755,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $query = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u IN (?0) OR u.username = ?1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(0, [$userA, $userC]);
         $query->setParameter(1, 'beberlei');
 
@@ -788,6 +811,9 @@ class QueryTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $q = $this->_em->createQuery('SELECT DISTINCT u from Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id = ?1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q->setParameter(1, $userC);
 
         $this->assertEquals($userC, $q->getParameter(1)->getValue());
@@ -829,6 +855,9 @@ class QueryTest extends OrmFunctionalTestCase
         $userCollection->add($u3->getId());
 
         $q = $this->_em->createQuery('SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u IN (:users) ORDER BY u.id');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $q->setParameter('users', $userCollection);
         $users = $q->execute();
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -9,6 +9,7 @@ use DateTimeImmutable;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
@@ -30,6 +31,8 @@ use function count;
 
 class QueryTest extends OrmTestCase
 {
+    use VerifyDeprecations;
+
     /** @var EntityManagerMock */
     protected $entityManager;
 
@@ -50,6 +53,9 @@ class QueryTest extends OrmTestCase
     public function testGetParametersHasSomeAlready(): void
     {
         $query = $this->entityManager->createQuery('select u from Doctrine\Tests\Models\CMS\CmsUser u where u.username = ?1');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(2, 84);
 
         $parameters = new ArrayCollection();
@@ -202,6 +208,8 @@ class QueryTest extends OrmTestCase
             3 => 'Cannes',
             9 => 'St Julien',
         ];
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $query = $this->entityManager
                 ->createQuery('SELECT a FROM Doctrine\Tests\Models\CMS\CmsAddress a WHERE a.city IN (:cities)')
@@ -422,6 +430,8 @@ class QueryTest extends OrmTestCase
     {
         $query = $this->entityManager->createQuery('select u from ' . CmsUser::class . ' u where u.id = ?0');
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter(0, 0);
 
         self::assertCount(1, $query->getParameters());
@@ -435,6 +445,8 @@ class QueryTest extends OrmTestCase
     public function testSetParameterWithNameZeroIsNotOverridden(): void
     {
         $query = $this->entityManager->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $query->setParameter(0, 0);
         $query->setParameter('name', 'Doctrine');
@@ -451,6 +463,8 @@ class QueryTest extends OrmTestCase
     {
         $query = $this->entityManager->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
 
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
+
         $query->setParameter('name', 'Doctrine');
         $query->setParameter(0, 0);
 
@@ -465,6 +479,8 @@ class QueryTest extends OrmTestCase
     public function testSetParameterWithTypeJugglingWorks(): void
     {
         $query = $this->entityManager->createQuery('select u from ' . CmsUser::class . ' u where u.id != ?0 and u.username = :name');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $query->setParameter('0', 1);
         $query->setParameter('name', 'Doctrine');
@@ -524,6 +540,8 @@ class QueryTest extends OrmTestCase
     public function testGetParameterColonNormalize(): void
     {
         $query = $this->entityManager->createQuery('select u from ' . CmsUser::class . ' u where u.name = :name');
+
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8379');
 
         $query->setParameter(':name', 'Benjamin');
         $query->setParameter('name', 'Benjamin');


### PR DESCRIPTION
Deprecated type inference for `Query::setParameter` mentioned in issue #8379 