### PR TITLE
Add missing @param and @return PHPDoc attributes

### DIFF
--- a/lib/Doctrine/ORM/Cache/Region.php
+++ b/lib/Doctrine/ORM/Cache/Region.php
@@ -57,7 +57,7 @@ interface Region extends MultiGetRegion
      *
      * @param CacheKey   $key   The key under which to cache the item.
      * @param CacheEntry $entry The entry to cache.
-     * @param Lock       $lock  The lock previously obtained.
+     * @param Lock|null  $lock  The lock previously obtained.
      *
      * @throws CacheException Indicates a problem accessing the region.
      */

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -155,7 +155,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Adds a new default annotation driver with a correctly configured annotation reader. If $useSimpleAnnotationReader
      * is true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
-     * @param bool $useSimpleAnnotationReader
+     * @param string|string[] $paths
+     * @param bool            $useSimpleAnnotationReader
      * @psalm-param string|list<string> $paths
      *
      * @return AnnotationDriver
@@ -391,11 +392,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name The name of the query.
      *
-     * @psalm-return array{string, ResultSetMapping} A tuple with the first
-     *                                               element being the SQL
-     *                                               string and the second
-     *                                               element being the
-     *                                               ResultSetMapping.
+     * @return mixed[]
+     * @psalm-return array{string, ResultSetMapping} A tuple with the first element being the SQL string and the second
+     *                                               element being the ResultSetMapping.
      *
      * @throws ORMException
      */
@@ -634,7 +633,8 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Adds a custom hydration mode.
      *
      * @param string $modeName The hydration mode name.
-     * @psalm-param class-string $hydrator The hydrator class name.
+     * @param string $hydrator The hydrator class name.
+     * @psalm-param class-string $hydrator
      *
      * @return void
      */

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -885,9 +885,10 @@ use function sprintf;
     /**
      * Factory method to create EntityManager instances.
      *
-     * @param array<string, mixed>|Connection $connection   An array with the connection parameters or an existing Connection instance.
-     * @param Configuration                   $config       The Configuration instance to use.
-     * @param EventManager                    $eventManager The EventManager instance to use.
+     * @param mixed[]|Connection $connection   An array with the connection parameters or an existing Connection instance.
+     * @param Configuration      $config       The Configuration instance to use.
+     * @param EventManager|null  $eventManager The EventManager instance to use.
+     * @psalm-param array<string, mixed>|Connection $connection
      *
      * @return EntityManager The created EntityManager.
      *
@@ -908,9 +909,10 @@ use function sprintf;
     /**
      * Factory method to create Connection instances.
      *
-     * @param array<string, mixed>|Connection $connection   An array with the connection parameters or an existing Connection instance.
-     * @param Configuration                   $config       The Configuration instance to use.
-     * @param EventManager                    $eventManager The EventManager instance to use.
+     * @param mixed[]|Connection $connection   An array with the connection parameters or an existing Connection instance.
+     * @param Configuration      $config       The Configuration instance to use.
+     * @param EventManager|null  $eventManager The EventManager instance to use.
+     * @psalm-param array<string, mixed>|Connection $connection
      *
      * @return Connection
      *

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -208,7 +208,8 @@ class EntityRepository implements ObjectRepository, Selectable
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, string>|null $orderBy
      *
-     * @psalm-return list<T> The objects.
+     * @return object[] The objects.
+     * @psalm-return list<T>
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
     {
@@ -250,7 +251,8 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Adds support for magic method calls.
      *
-     * @param string $method
+     * @param string  $method
+     * @param mixed[] $arguments
      * @psalm-param list<mixed> $arguments
      *
      * @return mixed The returned value from the resolved method.

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -412,9 +412,11 @@ abstract class AbstractHydrator
      * values according to their types. The resulting row has the same number
      * of elements as before.
      *
+     * @param mixed[] $data
      * @psalm-param array<string, mixed> $data
      *
-     * @psalm-return array<string, mixed> The processed row.
+     * @return mixed[] The processed row.
+     * @psalm-return array<string, mixed>
      */
     protected function gatherScalarRowData(&$data)
     {
@@ -448,6 +450,7 @@ abstract class AbstractHydrator
      *
      * @param string $key Column name
      *
+     * @return mixed[]|null
      * @psalm-return array<string, mixed>|null
      */
     protected function hydrateColumnInfo($key)

--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -99,7 +99,8 @@ class HydrationException extends ORMException
     }
 
     /**
-     * @param string $discrValue
+     * @param string   $discrValue
+     * @param string[] $discrMap
      * @psalm-param array<string, string> $discrMap
      *
      * @return HydrationException

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1314,7 +1314,8 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $fieldName The field name that represents the association in
      *                          the object model.
      *
-     * @psalm-return array<string, mixed> The mapping.
+     * @return mixed[] The mapping.
+     * @psalm-return array<string, mixed>
      *
      * @throws MappingException
      */
@@ -1388,6 +1389,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $queryName The query name.
      *
+     * @return mixed[]
      * @psalm-return array<string, mixed>
      *
      * @throws MappingException
@@ -2951,6 +2953,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $event
      *
+     * @return string[]
      * @psalm-return list<string>
      */
     public function getLifecycleCallbacks($event)
@@ -3038,7 +3041,8 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see getDiscriminatorColumn()
      *
-     * @psalm-param array<string, mixed> $columnDef
+     * @param mixed[]|null $columnDef
+     * @psalm-param array<string, mixed>|null $columnDef
      *
      * @return void
      *
@@ -3090,6 +3094,7 @@ class ClassMetadataInfo implements ClassMetadata
      * Adds one entry of the discriminator map with a new class and corresponding name.
      *
      * @param string $name
+     * @param string $className
      * @psalm-param class-string $className
      *
      * @return void
@@ -3430,6 +3435,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param AbstractPlatform $platform
      *
+     * @return string[]
      * @psalm-return list<string>
      */
     public function getQuotedIdentifierColumnNames($platform)
@@ -3532,6 +3538,7 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * @param string $targetClass
      *
+     * @return mixed[][]
      * @psalm-return array<string, array<string, mixed>>
      */
     public function getAssociationsByTargetClass($targetClass)

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -145,6 +145,8 @@ class DatabaseDriver implements MappingDriver
     /**
      * Sets tables manually instead of relying on the reverse engineering capabilities of SchemaManager.
      *
+     * @param Table[] $entityTables
+     * @param Table[] $manyToManyTables
      * @psalm-param list<Table> $entityTables
      * @psalm-param list<Table> $manyToManyTables
      *
@@ -380,21 +382,22 @@ class DatabaseDriver implements MappingDriver
     /**
      * Build field mapping from a schema column definition
      *
+     * @return mixed[]
      * @psalm-return array{
-     *                   fieldName: string,
-     *                   columnName: string,
-     *                   type: string,
-     *                   nullable: bool,
-     *                   options?: array{
-     *                       unsigned?: bool,
-     *                       fixed?: bool,
-     *                       comment?: string,
-     *                       default?: string
-     *                   },
-     *                   precision?: int,
-     *                   scale?: int,
-     *                   length?: int|null
-     *               }
+     *     fieldName: string,
+     *     columnName: string,
+     *     type: string,
+     *     nullable: bool,
+     *     options?: array{
+     *         unsigned?: bool,
+     *         fixed?: bool,
+     *         comment?: string,
+     *         default?: string
+     *     },
+     *     precision?: int,
+     *     scale?: int,
+     *     length?: int|null
+     * }
      */
     private function buildFieldMapping(string $tableName, Column $column): array
     {

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -922,6 +922,9 @@ class MappingException extends ORMException
     }
 
     /**
+     * @param string $className
+     * @param string $propertyName
+     *
      * @return self
      */
     public static function illegalOverrideOfInheritedProperty($className, $propertyName)

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -595,6 +595,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * @param int      $offset
      * @param int|null $length
      *
+     * @return mixed[]
      * @psalm-return array<TKey,T>
      */
     public function slice($offset, $length = null): array
@@ -637,7 +638,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * Selects all elements from a selectable that match the expression and
      * return a new collection containing these elements.
      *
-     * @return Collection<TKey, T>
+     * @psalm-return Collection<TKey, T>
      *
      * @throws RuntimeException
      */

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -298,7 +298,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * have to join in the actual entities table leading to additional
      * JOIN.
      *
-     * @psalm-param array<string, mixed> $mapping Array containing mapping information.
+     * @param mixed[] $mapping Array containing mapping information.
+     * @psalm-param array<string, mixed> $mapping
      *
      * @return string[] ordered tuple:
      *                   - JOIN condition to add to the SQL
@@ -350,6 +351,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
     /**
      * Generate ON condition
      *
+     * @param mixed[] $mapping
      * @psalm-param array<string, mixed> $mapping
      *
      * @return string[]
@@ -464,6 +466,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @param mixed $element
      *
+     * @return mixed[]
      * @psalm-return list<mixed>
      */
     protected function getDeleteRowSQLParameters(PersistentCollection $collection, $element)
@@ -513,6 +516,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @param mixed $element
      *
+     * @return mixed[]
      * @psalm-return list<mixed>
      */
     protected function getInsertRowSQLParameters(PersistentCollection $collection, $element)

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1722,6 +1722,7 @@ class BasicEntityPersister implements EntityPersister
      * Subclasses are supposed to override this method if they intend to change
      * or alter the criteria by which entities are selected.
      *
+     * @param mixed[]|null $assoc
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, mixed>|null $assoc
      *
@@ -2009,7 +2010,8 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Generates the appropriate join SQL for the given join column.
      *
-     * @psalm-param array<array<string, mixed>> $joinColumns The join columns definition of an association.
+     * @param array[] $joinColumns The join columns definition of an association.
+     * @psalm-param array<array<string, mixed>> $joinColumns
      *
      * @return string LEFT JOIN if one of the columns is nullable, INNER JOIN otherwise.
      */

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -103,9 +103,10 @@ interface EntityPersister
     /**
      * Gets the SQL WHERE condition for matching a field with a given value.
      *
-     * @param string      $field
-     * @param mixed       $value
-     * @param string|null $comparison
+     * @param string       $field
+     * @param mixed        $value
+     * @param mixed[]|null $assoc
+     * @param string|null  $comparison
      * @psalm-param array<string, mixed>|null  $assoc
      *
      * @return string
@@ -186,19 +187,21 @@ interface EntityPersister
     /**
      * Loads an entity by a list of field criteria.
      *
-     * @param object|null $entity   The entity to load the data into. If not specified, a new entity is created.
-     * @param int|null    $lockMode One of the \Doctrine\DBAL\LockMode::* constants
-     *                              or NULL if no specific lock mode should be used
-     *                              for loading the entity.
-     * @param int|null    $limit    Limit number of results.
-     * @psalm-param array<string, mixed>       $hints    Hints for entity creation.
-     * @psalm-param array<string, mixed>       $criteria The criteria by which
-     *                                                   to load the entity.
-     * @psalm-param array<string, mixed>|null  $assoc    The association that
-     *                                                   connects the entity to
-     *                                                   load to another entity,
-     *                                                   if any.
-     * @psalm-param array<string, string>|null $orderBy  Criteria to order by.
+     * @param mixed[]       $criteria The criteria by which to load the entity.
+     * @param object|null   $entity   The entity to load the data into. If not specified,
+     *                                a new entity is created.
+     * @param mixed[]|null  $assoc    The association that connects the entity
+     *                                to load to another entity, if any.
+     * @param mixed[]       $hints    Hints for entity creation.
+     * @param int|null      $lockMode One of the \Doctrine\DBAL\LockMode::* constants
+     *                                or NULL if no specific lock mode should be used
+     *                                for loading the entity.
+     * @param int|null      $limit    Limit number of results.
+     * @param string[]|null $orderBy  Criteria to order by.
+     * @psalm-param array<string, mixed>       $criteria
+     * @psalm-param array<string, mixed>|null  $assoc
+     * @psalm-param array<string, mixed>       $hints
+     * @psalm-param array<string, string>|null $orderBy
      *
      * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
      *

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -60,7 +60,8 @@ abstract class Base
     }
 
     /**
-     * @psalm-param list<string|object> $args
+     * @param string[]|object[]|string|object $args
+     * @psalm-param list<string|object>|string|object $args
      *
      * @return static
      */

--- a/lib/Doctrine/ORM/Query/Expr/Func.php
+++ b/lib/Doctrine/ORM/Query/Expr/Func.php
@@ -38,8 +38,9 @@ class Func
     /**
      * Creates a function, with the given argument.
      *
-     * @param string $name
-     * @psalm-param list<mixed> $arguments
+     * @param string        $name
+     * @param mixed[]|mixed $arguments
+     * @psalm-param list<mixed>|mixed $arguments
      */
     public function __construct($name, $arguments)
     {

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -262,6 +262,7 @@ class Parser
     /**
      * Adds a custom tree walker for modifying the AST.
      *
+     * @param string $className
      * @psalm-param class-string $className
      *
      * @return void
@@ -489,8 +490,9 @@ class Parser
     /**
      * Generates a new syntax error.
      *
-     * @param string $expected Expected string.
-     * @psalm-param array<string, mixed>|null $token    Got token.
+     * @param string       $expected Expected string.
+     * @param mixed[]|null $token    Got token.
+     * @psalm-param array<string, mixed>|null $token
      *
      * @return void
      * @psalm-return no-return
@@ -515,8 +517,9 @@ class Parser
     /**
      * Generates a new semantical error.
      *
-     * @param string $message Optional message.
-     * @psalm-param array<string, mixed>|null $token Optional token.
+     * @param string       $message Optional message.
+     * @param mixed[]|null $token   Optional token.
+     * @psalm-param array<string, mixed>|null $token
      *
      * @return void
      *

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -131,7 +131,8 @@ class ParserResult
      *
      * @param string|int $dqlPosition The name or position of the DQL parameter.
      *
-     * @psalm-return list<int> The positions of the corresponding SQL parameters.
+     * @return int[] The positions of the corresponding SQL parameters.
+     * @psalm-return list<int>
      */
     public function getSqlParameterPositions($dqlPosition)
     {

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -165,6 +165,7 @@ class QueryException extends ORMException
     }
 
     /**
+     * @param string[] $assoc
      * @psalm-param array<string, string> $assoc
      *
      * @return QueryException
@@ -190,6 +191,7 @@ class QueryException extends ORMException
     }
 
     /**
+     * @param string[] $assoc
      * @psalm-param array<string, string> $assoc
      *
      * @return QueryException
@@ -215,6 +217,7 @@ class QueryException extends ORMException
     }
 
     /**
+     * @param string[] $assoc
      * @psalm-param array<string, string> $assoc
      *
      * @return QueryException

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -84,10 +84,11 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds a root entity and all of its fields to the result set.
      *
-     * @param string   $class      The class name of the root entity.
-     * @param string   $alias      The unique alias to use for the root entity.
-     * @param int|null $renameMode One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
-     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param string   $class          The class name of the root entity.
+     * @param string   $alias          The unique alias to use for the root entity.
+     * @param string[] $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
+     * @psalm-param array<string, string> $renamedColumns
      *
      * @return void
      */
@@ -103,13 +104,14 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds a joined entity and all of its fields to the result set.
      *
-     * @param string   $class       The class name of the joined entity.
-     * @param string   $alias       The unique alias to use for the joined entity.
-     * @param string   $parentAlias The alias of the entity result that is the parent of this joined result.
-     * @param string   $relation    The association field that connects the parent entity result
-     *                              with the joined entity result.
-     * @param int|null $renameMode  One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
-     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param string   $class          The class name of the joined entity.
+     * @param string   $alias          The unique alias to use for the joined entity.
+     * @param string   $parentAlias    The alias of the entity result that is the parent of this joined result.
+     * @param string   $relation       The association field that connects the parent entity result
+     *                                 with the joined entity result.
+     * @param string[] $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
+     * @param int|null $renameMode     One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
+     * @psalm-param array<string, string> $renamedColumns
      *
      * @return void
      */
@@ -125,8 +127,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Adds all fields of the given class to the result set mapping (columns and meta fields).
      *
-     * @param string $class
-     * @param string $alias
+     * @param string   $class
+     * @param string   $alias
+     * @param string[] $columnAliasMap
      * @psalm-param array<string, string> $columnAliasMap
      *
      * @return void
@@ -430,6 +433,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * Works only for all the entity results. The select parts for scalar
      * expressions have to be written manually.
      *
+     * @param string[] $tableAliases
      * @psalm-param array<string, string> $tableAliases
      *
      * @return string

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -240,14 +240,15 @@ class SqlWalker implements TreeWalker
      *
      * @param string $dqlAlias The DQL alias.
      *
+     * @return mixed[]
      * @psalm-return array{
-     *                   metadata: ClassMetadata,
-     *                   parent: string,
-     *                   relation: mixed[],
-     *                   map: mixed,
-     *                   nestingLevel: int,
-     *                   token: array
-     *               }
+     *     metadata: ClassMetadata,
+     *     parent: string,
+     *     relation: mixed[],
+     *     map: mixed,
+     *     nestingLevel: int,
+     *     token: array
+     * }
      */
     public function getQueryComponent($dqlAlias)
     {

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -106,6 +106,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     }
 
     /**
+     * @param mixed $offset
      * @psalm-param array-key|null $offset
      *
      * @return TreeWalker|null

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -692,9 +692,10 @@ class QueryBuilder
      * The available parts are: 'select', 'from', 'join', 'set', 'where',
      * 'groupBy', 'having' and 'orderBy'.
      *
-     * @param string $dqlPartName The DQL part name.
-     * @param bool   $append      Whether to append (true) or replace (false).
-     * @psalm-param string|object|list<string>|array{join: array<int|string, object>} $dqlPart     An Expr object.
+     * @param string              $dqlPartName The DQL part name.
+     * @param string|object|array $dqlPart     An Expr object.
+     * @param bool                $append      Whether to append (true) or replace (false).
+     * @psalm-param string|object|list<string>|array{join: array<int|string, object>} $dqlPart
      *
      * @return static
      */
@@ -1458,6 +1459,7 @@ class QueryBuilder
     /**
      * Resets DQL parts.
      *
+     * @param string[]|null $parts
      * @psalm-param list<string>|null $parts
      *
      * @return static

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -60,6 +60,7 @@ class ConvertDoctrine1Schema
      * Constructor passes the directory or array of directories
      * to convert the Doctrine 1 schema files from.
      *
+     * @param string[]|string $from
      * @psalm-param list<string>|string $from
      */
     public function __construct($from)

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -589,6 +589,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $entity
      *
+     * @return mixed[][]
      * @psalm-return array<string, array{mixed, mixed}>
      */
     public function & getEntityChangeSet($entity)
@@ -2642,8 +2643,9 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param string  $className The name of the entity class.
      * @param mixed[] $data      The data for the entity.
+     * @param mixed[] $hints     Any hints to account for during reconstitution/lookup of the entity.
      * @psalm-param class-string $className
-     * @psalm-param array<string, mixed> $hints Any hints to account for during reconstitution/lookup of the entity.
+     * @psalm-param array<string, mixed> $hints
      *
      * @return object The managed entity instance.
      *
@@ -3006,6 +3008,7 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $entity
      *
+     * @return mixed[]
      * @psalm-return array<string, mixed>
      */
     public function getOriginalEntityData($entity)

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -62,6 +62,7 @@ final class IdentifierFlattener
      *
      * @param mixed[] $id
      *
+     * @return mixed[]
      * @psalm-return array<string, mixed>
      */
     public function flattenIdentifier(ClassMetadata $class, array $id): array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -801,26 +801,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
 
 		-
-			message: "#^Call to an undefined method ReflectionClass\\:\\:getAttributes\\(\\)\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
-
-		-
-			message: "#^Call to an undefined method ReflectionClass\\<object\\>\\:\\:getAttributes\\(\\)\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
-
-		-
-			message: "#^Call to an undefined method ReflectionMethod\\:\\:getAttributes\\(\\)\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
-
-		-
-			message: "#^Call to an undefined method ReflectionProperty\\:\\:getAttributes\\(\\)\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
-
-		-
 			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\<T of object\\>\\:\\:\\$name\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -472,8 +472,7 @@
       <code>setCacheDriver</code>
       <code>setCacheDriver</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="10">
-      <code>$connection instanceof Connection</code>
+    <DocblockTypeContradiction occurrences="9">
       <code>$entityName !== null &amp;&amp; ! is_string($entityName)</code>
       <code>$this-&gt;expressionBuilder === null</code>
       <code>$this-&gt;filterCollection === null</code>
@@ -534,7 +533,8 @@
       <code>$this-&gt;filterCollection !== null</code>
       <code>method_exists($this-&gt;metadataFactory, 'setCache')</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType occurrences="2">
+      <code>$connection instanceof Connection</code>
       <code>': "' . $connection . '"'</code>
     </TypeDoesNotContainType>
   </file>
@@ -927,8 +927,8 @@
       <code>fixSchemaElementName</code>
       <code>prefersSequences</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="4">
-      <code>! $metadata-&gt;reflClass</code>
+    <DocblockTypeContradiction occurrences="3">
+      <code>! $class-&gt;reflClass</code>
       <code>$class-&gt;reflClass</code>
       <code>$definition</code>
     </DocblockTypeContradiction>
@@ -1138,9 +1138,8 @@
       <code>$this-&gt;table</code>
       <code>$this-&gt;table</code>
     </PropertyTypeCoercion>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType occurrences="3">
       <code>$className !== null</code>
-      <code>$columnDef !== null</code>
       <code>$mapping !== false</code>
       <code>$mapping !== false</code>
     </RedundantConditionGivenDocblockType>
@@ -1311,22 +1310,6 @@
       <code>isset($column-&gt;columnDefinition)</code>
       <code>isset($column-&gt;name)</code>
     </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$attributeClassName</code>
-    </ArgumentTypeCoercion>
-    <MissingParamType occurrences="3">
-      <code>$annotationName</code>
-      <code>$annotationName</code>
-      <code>$annotationName</code>
-    </MissingParamType>
-    <UndefinedMethod occurrences="4">
-      <code>getAttributes</code>
-      <code>getAttributes</code>
-      <code>getAttributes</code>
-      <code>getAttributes</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">
     <ArgumentTypeCoercion occurrences="3">
@@ -1674,13 +1657,11 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/MappingException.php">
-    <MissingParamType occurrences="6">
-      <code>$className</code>
+    <MissingParamType occurrences="4">
       <code>$className</code>
       <code>$className</code>
       <code>$indexName</code>
       <code>$indexName</code>
-      <code>$propertyName</code>
     </MissingParamType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/NamedNativeQuery.php">
@@ -1901,10 +1882,8 @@
       <code>$owner</code>
       <code>$owner</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="35">
-      <code>$mapping[$sourceRelationMode]</code>
+    <PossiblyNullArrayAccess occurrences="32">
       <code>$mapping['indexBy']</code>
-      <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
@@ -1915,7 +1894,6 @@
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTableColumns']</code>
-      <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
@@ -1938,15 +1916,13 @@
       <code>$mapping['targetEntity']</code>
       <code>$mapping['targetEntity']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullArrayOffset occurrences="4">
+    <PossiblyNullArrayOffset occurrences="3">
       <code>$associationSourceClass-&gt;associationMappings</code>
       <code>$sourceClass-&gt;associationMappings</code>
       <code>$targetClass-&gt;associationMappings</code>
-      <code>$targetClass-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>
-    <PossiblyNullIterator occurrences="7">
+    <PossiblyNullIterator occurrences="6">
       <code>$joinColumns</code>
-      <code>$mapping[$sourceRelationMode]</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
@@ -2626,9 +2602,6 @@
     <PossiblyInvalidCast occurrences="1">
       <code>$this-&gt;parts[0]</code>
     </PossiblyInvalidCast>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $args</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/Composite.php">
     <PossiblyInvalidCast occurrences="2">
@@ -2640,11 +2613,6 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>$indexBy</code>
     </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/Expr/Func.php">
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $arguments</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/GroupBy.php">
     <NonInvariantDocblockPropertyType occurrences="1">

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -43,9 +43,6 @@ class ConnectionMock extends Connection
     /** @var array */
     private $_deletes = [];
 
-    /**
-     * @param array $params
-     */
     public function __construct(array $params, Driver $driver, ?Configuration $config = null, ?EventManager $eventManager = null)
     {
         $this->_platformMock = new DatabasePlatformMock();

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -35,9 +35,9 @@ class HydratorMockStatement implements IteratorAggregate, Statement
     /**
      * Fetches all rows from the result set.
      *
+     * @param mixed      $fetchMode
+     * @param mixed      $fetchArgument
      * @param array|null $ctorArgs
-     *
-     * @return array
      */
     public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null): array
     {

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultCacheTest.php
@@ -40,10 +40,6 @@ class DefaultCacheTest extends OrmTestCase
         $this->cache = new DefaultCache($this->em);
     }
 
-    /**
-     * @param array $identifier
-     * @param array $data
-     */
     private function putEntityCacheEntry(string $className, array $identifier, array $data): void
     {
         $metadata   = $this->em->getClassMetadata($className);
@@ -54,10 +50,6 @@ class DefaultCacheTest extends OrmTestCase
         $persister->getCacheRegion()->put($cacheKey, $cacheEntry);
     }
 
-    /**
-     * @param array $ownerIdentifier
-     * @param array $data
-     */
     private function putCollectionCacheEntry(string $className, string $association, array $ownerIdentifier, array $data): void
     {
         $metadata   = $this->em->getClassMetadata($className);

--- a/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/Persister/Collection/AbstractCollectionPersisterTest.php
@@ -55,9 +55,6 @@ abstract class AbstractCollectionPersisterTest extends OrmTestCase
         'loadCriteria',
     ];
 
-    /**
-     * @param array $mapping
-     */
     abstract protected function createPersister(EntityManager $em, CollectionPersister $persister, Region $region, array $mapping): AbstractCollectionPersister;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1163Test.php
@@ -200,9 +200,6 @@ class DDC1163Tag
         $this->name = $name;
     }
 
-    /**
-     * @param Product $product
-     */
     public function setProduct(DDC1163Product $product): void
     {
         $this->product = $product;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2138Test.php
@@ -163,8 +163,6 @@ class DDC2138UserFollowedUser extends DDC2138UserFollowedObject
 
     /**
      * Construct a UserFollowedUser entity
-     *
-     * @param bool $giveAgency
      */
     public function __construct(User $user, User $followedUser)
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -74,9 +74,6 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         return $class;
     }
 
-    /**
-     * @param EntityManager $entityClassName
-     */
     protected function createClassMetadataFactory(?EntityManager $em = null): ClassMetadataFactory
     {
         $driver  = $this->loadDriver();

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -42,9 +42,6 @@ class SelectSqlGenerationTest extends OrmTestCase
 
     /**
      * Assert a valid SQL generation.
-     *
-     * @param array $queryHints
-     * @param array $queryParams
      */
     public function assertSqlGeneration(
         string $dqlToBeTested,
@@ -82,9 +79,6 @@ class SelectSqlGenerationTest extends OrmTestCase
 
     /**
      * Asser an invalid SQL generation.
-     *
-     * @param array $queryHints
-     * @param array $queryParams
      */
     public function assertInvalidSqlGeneration(
         string $dqlToBeTested,

--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/EnsureProductionSettingsCommandTest.php
@@ -98,9 +98,6 @@ class EnsureProductionSettingsCommandTest extends DoctrineTestCase
         $this->assertSame(1, $this->executeCommand($em, ['--complete' => true]));
     }
 
-    /**
-     * @param mixed[] $options
-     */
     private function executeCommand(
         EntityManagerInterface $em,
         array $input = []

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1049,7 +1049,8 @@ class EntityGeneratorTest extends OrmTestCase
     }
 
     /**
-     * @return list<array{
+     * @return mixed[]
+     * @psalm-return list<array{
      *     fieldName: string,
      *     phpType: string,
      *     dbType: string,
@@ -1215,9 +1216,6 @@ class
         $this->assertEquals($type, $matches[1]);
     }
 
-    /**
-     * @param ReflectionProperty $method
-     */
     private function assertPhpDocParamType(string $type, ReflectionMethod $method): void
     {
         $this->assertEquals(1, preg_match('/@param\s+([^\s]+)/', $method->getDocComment(), $matches));

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -59,7 +59,6 @@ abstract class OrmTestCase extends DoctrineTestCase
     protected $secondLevelCacheDriverImpl = null;
 
     /**
-     * @param array $paths
      * @param mixed $alias
      */
     protected function createAnnotationDriver(array $paths = [], $alias = null): AnnotationDriver


### PR DESCRIPTION
After the recent CS improvement batches some `@param` attributes had been replaced by `@psalm-param` which removes information for IDEs which are not interpreting those attributes. Same goes for `@return`.

This is the first step of two or three. What imho should follow and what I am willing to do (if you like this PR) is:
* `@param` which uses `array<>` or `array{}` syntax should be changed to `@psalm-param` and like in this PR duplicated+fixed for `@param` (same goes for `@return` again).
* Fixes for `@var` and `@psalm-var` I left this out here.

/cc @greg0ire 