### PR TITLE
Add type declarations where backwards-compatible

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -506,10 +506,8 @@ abstract class AbstractQuery
 
     /**
      * Allows to translate entity namespaces to full qualified names.
-     *
-     * @return void
      */
-    private function translateNamespaces(Query\ResultSetMapping $rsm)
+    private function translateNamespaces(Query\ResultSetMapping $rsm): void
     {
         $translate = function ($alias): string {
             return $this->_em->getClassMetadata($alias)->getName();
@@ -1132,10 +1130,7 @@ abstract class AbstractQuery
         return $result;
     }
 
-    /**
-     * @return TimestampCacheKey|null
-     */
-    private function getTimestampKey()
+    private function getTimestampKey(): ?TimestampCacheKey
     {
         $entityName = reset($this->_resultSetMapping->aliasMap);
 

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -278,10 +278,8 @@ class DefaultCache implements Cache
      /**
       * @param ClassMetadata $metadata   The entity metadata.
       * @param mixed         $identifier The entity identifier.
-      *
-      * @return EntityCacheKey
       */
-    private function buildEntityCacheKey(ClassMetadata $metadata, $identifier)
+    private function buildEntityCacheKey(ClassMetadata $metadata, $identifier): EntityCacheKey
     {
         if (! is_array($identifier)) {
             $identifier = $this->toIdentifierArray($metadata, $identifier);
@@ -294,11 +292,12 @@ class DefaultCache implements Cache
      * @param ClassMetadata $metadata        The entity metadata.
      * @param string        $association     The field name that represents the association.
      * @param mixed         $ownerIdentifier The identifier of the owning entity.
-     *
-     * @return CollectionCacheKey
      */
-    private function buildCollectionCacheKey(ClassMetadata $metadata, $association, $ownerIdentifier)
-    {
+    private function buildCollectionCacheKey(
+        ClassMetadata $metadata,
+        string $association,
+        $ownerIdentifier
+    ): CollectionCacheKey {
         if (! is_array($ownerIdentifier)) {
             $ownerIdentifier = $this->toIdentifierArray($metadata, $ownerIdentifier);
         }
@@ -312,7 +311,7 @@ class DefaultCache implements Cache
      *
      * @return array<string, mixed>
      */
-    private function toIdentifierArray(ClassMetadata $metadata, $identifier)
+    private function toIdentifierArray(ClassMetadata $metadata, $identifier): array
     {
         if (is_object($identifier) && $this->em->getMetadataFactory()->hasMetadataFor(ClassUtils::getClass($identifier))) {
             $identifier = $this->uow->getSingleIdentifierValue($identifier);

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -215,12 +215,7 @@ class DefaultCacheFactory implements CacheFactory
         return $this->regions[$cache['region']] = $region;
     }
 
-    /**
-     * @param string $name
-     *
-     * @return CacheAdapter
-     */
-    private function createRegionCache($name)
+    private function createRegionCache(string $name): CacheAdapter
     {
         $cacheAdapter = clone $this->cache;
 

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -347,7 +347,7 @@ class DefaultQueryCache implements QueryCache
      * @return mixed[]|null
      * @psalm-return array{targetEntity: class-string, type: mixed, list?: array[], identifier?: array}|null
      */
-    private function storeAssociationCache(QueryCacheKey $key, array $assoc, $assocValue)
+    private function storeAssociationCache(QueryCacheKey $key, array $assoc, $assocValue): ?array
     {
         $assocPersister = $this->uow->getEntityPersister($assoc['targetEntity']);
         $assocMetadata  = $assocPersister->getClassMetadata();
@@ -397,13 +397,15 @@ class DefaultQueryCache implements QueryCache
     }
 
     /**
-     * @param string $assocAlias
      * @param object $entity
      *
      * @return array<object>|object
      */
-    private function getAssociationValue(ResultSetMapping $rsm, $assocAlias, $entity)
-    {
+    private function getAssociationValue(
+        ResultSetMapping $rsm,
+        string $assocAlias,
+        $entity
+    ) {
         $path  = [];
         $alias = $assocAlias;
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -225,10 +225,8 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
 
     /**
      * @param object $entity
-     *
-     * @return void
      */
-    private function storeJoinedAssociations($entity)
+    private function storeJoinedAssociations($entity): void
     {
         if ($this->joinedAssociations === null) {
             $associations = [];

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -100,17 +100,14 @@ class NonStrictReadWriteCachedEntityPersister extends AbstractEntityPersister
 
     /**
      * @param object $entity
-     * @param bool   $isChanged
-     *
-     * @return bool
      */
-    private function updateCache($entity, $isChanged)
+    private function updateCache($entity, bool $isChanged): bool
     {
         $class     = $this->metadataFactory->getMetadataFor(get_class($entity));
         $key       = new EntityCacheKey($class->rootEntityName, $this->uow->getEntityIdentifier($entity));
         $entry     = $this->hydrator->buildCacheEntry($class, $key, $entity);
         $cached    = $this->region->put($key, $entry);
-        $isChanged = $isChanged ?: $cached;
+        $isChanged = $isChanged || $cached;
 
         if ($this->cacheLogger && $cached) {
             $this->cacheLogger->entityCachePut($this->regionName, $key);

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -83,10 +83,7 @@ class FileLockRegion implements ConcurrentRegion
         $this->lockLifetime = $lockLifetime;
     }
 
-    /**
-     * @return bool
-     */
-    private function isLocked(CacheKey $key, ?Lock $lock = null)
+    private function isLocked(CacheKey $key, ?Lock $lock = null): bool
     {
         $filename = $this->getLockFileName($key);
 
@@ -117,30 +114,23 @@ class FileLockRegion implements ConcurrentRegion
         return true;
     }
 
-    /**
-     * @return string
-     */
-    private function getLockFileName(CacheKey $key)
+    private function getLockFileName(CacheKey $key): string
     {
         return $this->directory . DIRECTORY_SEPARATOR . $key->hash . '.' . self::LOCK_EXTENSION;
     }
 
     /**
-     * @param string $filename
-     *
-     * @return false|string
+     * @return string|false
      */
-    private function getLockContent($filename)
+    private function getLockContent(string $filename)
     {
         return @file_get_contents($filename);
     }
 
     /**
-     * @param string $filename
-     *
-     * @return false|int
+     * @return int|false
      */
-    private function getLockTime($filename)
+    private function getLockTime(string $filename)
     {
         return @fileatime($filename);
     }

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -48,10 +48,7 @@ class TimestampQueryCacheValidator implements QueryCacheValidator
         return $entry->time + $key->lifetime > microtime(true);
     }
 
-    /**
-     * @return bool
-     */
-    private function regionUpdated(QueryCacheKey $key, QueryCacheEntry $entry)
+    private function regionUpdated(QueryCacheKey $key, QueryCacheEntry $entry): bool
     {
         if ($key->timestampKey === null) {
             return false;

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -799,11 +799,9 @@ use function sprintf;
     /**
      * Throws an exception if the EntityManager is closed or currently not active.
      *
-     * @return void
-     *
      * @throws ORMException If the EntityManager is closed.
      */
-    private function errorIfClosed()
+    private function errorIfClosed(): void
     {
         if ($this->closed) {
             throw ORMException::entityManagerClosed();

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -113,13 +113,9 @@ class PreUpdateEventArgs extends LifecycleEventArgs
     /**
      * Asserts the field exists in changeset.
      *
-     * @param string $field
-     *
-     * @return void
-     *
      * @throws InvalidArgumentException
      */
-    private function assertValidField($field)
+    private function assertValidField(string $field): void
     {
         if (! isset($this->entityChangeSet[$field])) {
             throw new InvalidArgumentException(sprintf(

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -146,12 +146,8 @@ class CommitOrderCalculator
      * Visit a given node definition for reordering.
      *
      * {@internal Highly performance-sensitive method.}
-     *
-     * @param stdClass $vertex
-     *
-     * @return void
      */
-    private function visit($vertex)
+    private function visit(stdClass $vertex): void
     {
         $vertex->state = self::IN_PROGRESS;
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -259,15 +259,16 @@ class ArrayHydrator extends AbstractHydrator
      * Updates the result pointer for an Entity. The result pointers point to the
      * last seen instance of each Entity type. This is used for graph construction.
      *
-     * @param mixed[]  $coll     The element.
-     * @param bool|int $index    Index of the element in the collection.
-     * @param string   $dqlAlias
-     * @param bool     $oneToOne Whether it is a single-valued association or not.
-     *
-     * @return void
+     * @param mixed[]|null $coll     The element.
+     * @param bool|int     $index    Index of the element in the collection.
+     * @param bool         $oneToOne Whether it is a single-valued association or not.
      */
-    private function updateResultPointer(array &$coll, $index, $dqlAlias, $oneToOne)
-    {
+    private function updateResultPointer(
+        ?array &$coll,
+        $index,
+        string $dqlAlias,
+        bool $oneToOne
+    ): void {
         if ($coll === null) {
             unset($this->_resultPointers[$dqlAlias]); // Ticket #1228
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -171,15 +171,16 @@ class ObjectHydrator extends AbstractHydrator
     /**
      * Initializes a related collection.
      *
-     * @param object        $entity         The entity to which the collection belongs.
-     * @param ClassMetadata $class
-     * @param string        $fieldName      The name of the field on the entity that holds the collection.
-     * @param string        $parentDqlAlias Alias of the parent fetch joining this collection.
-     *
-     * @return PersistentCollection
+     * @param object $entity         The entity to which the collection belongs.
+     * @param string $fieldName      The name of the field on the entity that holds the collection.
+     * @param string $parentDqlAlias Alias of the parent fetch joining this collection.
      */
-    private function initRelatedCollection($entity, $class, $fieldName, $parentDqlAlias)
-    {
+    private function initRelatedCollection(
+        $entity,
+        ClassMetadata $class,
+        string $fieldName,
+        string $parentDqlAlias
+    ): PersistentCollection {
         $oid      = spl_object_hash($entity);
         $relation = $class->associationMappings[$fieldName];
         $value    = $class->reflFields[$fieldName]->getValue($entity);
@@ -225,11 +226,11 @@ class ObjectHydrator extends AbstractHydrator
      * @param string $dqlAlias The DQL alias of the entity's class.
      * @psalm-param array<string, mixed> $data     The instance data.
      *
-     * @return object The entity.
+     * @return object
      *
      * @throws HydrationException
      */
-    private function getEntity(array $data, $dqlAlias)
+    private function getEntity(array $data, string $dqlAlias)
     {
         $className = $this->_rsm->aliasMap[$dqlAlias];
 
@@ -272,12 +273,12 @@ class ObjectHydrator extends AbstractHydrator
     }
 
     /**
-     * @param string $className
+     * @psalm-param class-string $className
      * @psalm-param array<string, mixed> $data
      *
      * @return mixed
      */
-    private function getEntityFromIdentityMap($className, array $data)
+    private function getEntityFromIdentityMap(string $className, array $data)
     {
         // TODO: Abstract this code and UnitOfWork::createEntity() equivalent?
         $class = $this->_metadataCache[$className];

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -54,10 +54,8 @@ final class HydrationCompleteHandler
      * Method schedules invoking of postLoad entity to the very end of current hydration cycle.
      *
      * @param object $entity
-     *
-     * @return void
      */
-    public function deferPostLoadInvoking(ClassMetadata $class, $entity)
+    public function deferPostLoadInvoking(ClassMetadata $class, $entity): void
     {
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::postLoad);
 
@@ -72,10 +70,8 @@ final class HydrationCompleteHandler
      * This method should me called after any hydration cycle completed.
      *
      * Method fires all deferred invocations of postLoad events
-     *
-     * @return void
      */
-    public function hydrationComplete()
+    public function hydrationComplete(): void
     {
         $toInvoke                          = $this->deferredPostLoadInvocations;
         $this->deferredPostLoadInvocations = [];

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -61,7 +61,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /** @var EntityManagerInterface|null */
     private $em;
 
-    /** @var AbstractPlatform */
+    /** @var AbstractPlatform|null */
     private $targetPlatform;
 
     /** @var MappingDriver */
@@ -310,11 +310,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * Populates the discriminator value of the given metadata (if not set) by iterating over discriminator
      * map classes and looking for a fitting one.
      *
-     * @return void
-     *
      * @throws MappingException
      */
-    private function resolveDiscriminatorValue(ClassMetadata $metadata)
+    private function resolveDiscriminatorValue(ClassMetadata $metadata): void
     {
         if (
             $metadata->discriminatorValue
@@ -357,11 +355,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * The automatically generated discriminator map contains the lowercase short name of
      * each class as key.
      *
-     * @return void
-     *
      * @throws MappingException
      */
-    private function addDefaultDiscriminatorMap(ClassMetadata $class)
+    private function addDefaultDiscriminatorMap(ClassMetadata $class): void
     {
         $allClasses = $this->driver->getAllClassNames();
         $fqcn       = $class->getName();
@@ -390,11 +386,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * Gets the lower-case short name of a class.
      *
-     * @param string $className
-     *
-     * @return string
+     * @psalm-param class-string $className
      */
-    private function getShortName($className)
+    private function getShortName(string $className): string
     {
         if (strpos($className, '\\') === false) {
             return strtolower($className);
@@ -407,10 +401,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Adds inherited fields to the subclass mapping.
-     *
-     * @return void
      */
-    private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedFields(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->fieldMappings as $mapping) {
             if (! isset($mapping['inherited']) && ! $parentClass->isMappedSuperclass) {
@@ -432,11 +424,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
     /**
      * Adds inherited association mappings to the subclass mapping.
      *
-     * @return void
-     *
      * @throws MappingException
      */
-    private function addInheritedRelations(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedRelations(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->associationMappings as $field => $mapping) {
             if ($parentClass->isMappedSuperclass) {
@@ -460,10 +450,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         }
     }
 
-    /**
-     * @return void
-     */
-    private function addInheritedEmbeddedClasses(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedEmbeddedClasses(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->embeddedClasses as $field => $embeddedClass) {
             if (! isset($embeddedClass['inherited']) && ! $parentClass->isMappedSuperclass) {
@@ -484,11 +471,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * @param ClassMetadata $subClass    Sub embedded class metadata to add nested embedded classes metadata from.
      * @param ClassMetadata $parentClass Parent class to add nested embedded classes metadata to.
      * @param string        $prefix      Embedded classes' prefix to use for nested embedded classes field names.
-     *
-     * @return void
      */
-    private function addNestedEmbeddedClasses(ClassMetadata $subClass, ClassMetadata $parentClass, $prefix)
-    {
+    private function addNestedEmbeddedClasses(
+        ClassMetadata $subClass,
+        ClassMetadata $parentClass,
+        string $prefix
+    ): void {
         foreach ($subClass->embeddedClasses as $property => $embeddableClass) {
             if (isset($embeddableClass['inherited'])) {
                 continue;
@@ -512,10 +500,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Copy the table indices from the parent class superclass to the child class
-     *
-     * @return void
      */
-    private function addInheritedIndexes(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedIndexes(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         if (! $parentClass->isMappedSuperclass) {
             return;
@@ -536,10 +522,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Adds inherited named queries to the subclass mapping.
-     *
-     * @return void
      */
-    private function addInheritedNamedQueries(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedNamedQueries(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->namedQueries as $name => $query) {
             if (! isset($subClass->namedQueries[$name])) {
@@ -555,10 +539,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Adds inherited named native queries to the subclass mapping.
-     *
-     * @return void
      */
-    private function addInheritedNamedNativeQueries(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedNamedNativeQueries(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->namedNativeQueries as $name => $query) {
             if (! isset($subClass->namedNativeQueries[$name])) {
@@ -577,10 +559,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Adds inherited sql result set mappings to the subclass mapping.
-     *
-     * @return void
      */
-    private function addInheritedSqlResultSetMappings(ClassMetadata $subClass, ClassMetadata $parentClass)
+    private function addInheritedSqlResultSetMappings(ClassMetadata $subClass, ClassMetadata $parentClass): void
     {
         foreach ($parentClass->sqlResultSetMappings as $name => $mapping) {
             if (! isset($subClass->sqlResultSetMappings[$name])) {
@@ -609,11 +589,9 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
      * Completes the ID generator mapping. If "auto" is specified we choose the generator
      * most appropriate for the targeted database platform.
      *
-     * @return void
-     *
      * @throws ORMException
      */
-    private function completeIdGeneratorMapping(ClassMetadataInfo $class)
+    private function completeIdGeneratorMapping(ClassMetadataInfo $class): void
     {
         $idGenType = $class->generatorType;
         if ($idGenType === ClassMetadata::GENERATOR_TYPE_AUTO) {
@@ -724,10 +702,8 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     /**
      * Inherits the ID generator mapping from a parent class.
-     *
-     * @return void
      */
-    private function inheritIdGeneratorMapping(ClassMetadataInfo $class, ClassMetadataInfo $parent)
+    private function inheritIdGeneratorMapping(ClassMetadataInfo $class, ClassMetadataInfo $parent): void
     {
         if ($parent->isIdGeneratorSequence()) {
             $class->setSequenceGeneratorDefinition($parent->sequenceGeneratorDefinition);
@@ -786,10 +762,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
         return isset($class->isMappedSuperclass) && $class->isMappedSuperclass === false;
     }
 
-    /**
-     * @return Platforms\AbstractPlatform
-     */
-    private function getTargetPlatform()
+    private function getTargetPlatform(): Platforms\AbstractPlatform
     {
         if (! $this->targetPlatform) {
             $this->targetPlatform = $this->em->getConnection()->getDatabasePlatform();

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -2613,11 +2613,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Checks whether the given type identifies an inheritance type.
      *
-     * @param int $type
-     *
-     * @return bool TRUE if the given type identifies an inheritance type, FALSe otherwise.
+     * @return bool TRUE if the given type identifies an inheritance type, FALSE otherwise.
      */
-    private function isInheritanceType($type)
+    private function isInheritanceType(int $type): bool
     {
         return $type === self::INHERITANCE_TYPE_NONE ||
                 $type === self::INHERITANCE_TYPE_SINGLE_TABLE ||

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -636,14 +636,11 @@ class AnnotationDriver extends AbstractAnnotationDriver
     /**
      * Attempts to resolve the fetch mode.
      *
-     * @param string $className The class name.
-     * @param string $fetchMode The fetch mode.
-     *
-     * @return int The fetch mode as defined in ClassMetadata.
+     * @psalm-return \Doctrine\ORM\Mapping\ClassMetadata::FETCH_* The fetch mode as defined in ClassMetadata.
      *
      * @throws MappingException If the fetch mode is not valid.
      */
-    private function getFetchMode($className, $fetchMode)
+    private function getFetchMode(string $className, string $fetchMode): int
     {
         if (! defined('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $fetchMode)) {
             throw MappingException::invalidFetchMode($className, $fetchMode);
@@ -658,7 +655,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * @return callable[]
      * @psalm-return list<callable-array>
      */
-    private function getMethodCallbacks(ReflectionMethod $method)
+    private function getMethodCallbacks(ReflectionMethod $method): array
     {
         $callbacks   = [];
         $annotations = $this->reader->getMethodAnnotations($method);
@@ -713,7 +710,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *                   referencedColumnName: string
      *               }
      */
-    private function joinColumnToArray(Mapping\JoinColumn $joinColumn)
+    private function joinColumnToArray(Mapping\JoinColumn $joinColumn): array
     {
         return [
             'name' => $joinColumn->name,
@@ -727,8 +724,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
     /**
      * Parse the given Column as array
-     *
-     * @param string $fieldName
      *
      * @return mixed[]
      * @psalm-return array{
@@ -744,7 +739,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
      *                   columnDefinition?: string
      *               }
      */
-    private function columnToArray($fieldName, Mapping\Column $column)
+    private function columnToArray(string $fieldName, Mapping\Column $column): array
     {
         $mapping = [
             'fieldName' => $fieldName,

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -259,11 +259,9 @@ class DatabaseDriver implements MappingDriver
     }
 
     /**
-     * @return void
-     *
      * @throws MappingException
      */
-    private function reverseEngineerMappingFromDatabase()
+    private function reverseEngineerMappingFromDatabase(): void
     {
         if ($this->tables !== null) {
             return;
@@ -315,10 +313,8 @@ class DatabaseDriver implements MappingDriver
 
     /**
      * Build indexes from a class metadata.
-     *
-     * @return void
      */
-    private function buildIndexes(ClassMetadataInfo $metadata)
+    private function buildIndexes(ClassMetadataInfo $metadata): void
     {
         $tableName = $metadata->table['name'];
         $indexes   = $this->tables[$tableName]->getIndexes();
@@ -340,10 +336,8 @@ class DatabaseDriver implements MappingDriver
 
     /**
      * Build field mapping from class metadata.
-     *
-     * @return void
      */
-    private function buildFieldMappings(ClassMetadataInfo $metadata)
+    private function buildFieldMappings(ClassMetadataInfo $metadata): void
     {
         $tableName      = $metadata->table['name'];
         $columns        = $this->tables[$tableName]->getColumns();
@@ -386,8 +380,6 @@ class DatabaseDriver implements MappingDriver
     /**
      * Build field mapping from a schema column definition
      *
-     * @param string $tableName
-     *
      * @psalm-return array{
      *                   fieldName: string,
      *                   columnName: string,
@@ -404,7 +396,7 @@ class DatabaseDriver implements MappingDriver
      *                   length?: int|null
      *               }
      */
-    private function buildFieldMapping($tableName, Column $column)
+    private function buildFieldMapping(string $tableName, Column $column): array
     {
         $fieldMapping = [
             'fieldName'  => $this->getFieldNameForColumn($tableName, $column->getName(), false),
@@ -506,7 +498,7 @@ class DatabaseDriver implements MappingDriver
      * @return ForeignKeyConstraint[]
      * @psalm-return array<string, ForeignKeyConstraint>
      */
-    private function getTableForeignKeys(Table $table)
+    private function getTableForeignKeys(Table $table): array
     {
         return $this->_sm->getDatabasePlatform()->supportsForeignKeyConstraints()
             ? $table->getForeignKeys()
@@ -518,7 +510,7 @@ class DatabaseDriver implements MappingDriver
      *
      * @return string[]
      */
-    private function getTablePrimaryKeys(Table $table)
+    private function getTablePrimaryKeys(Table $table): array
     {
         try {
             return $table->getPrimaryKey()->getColumns();
@@ -532,11 +524,9 @@ class DatabaseDriver implements MappingDriver
     /**
      * Returns the mapped class name for a table if it exists. Otherwise return "classified" version.
      *
-     * @param string $tableName
-     *
-     * @return string
+     * @psalm-return class-string
      */
-    private function getClassNameForTable($tableName)
+    private function getClassNameForTable(string $tableName): string
     {
         if (isset($this->classNamesForTables[$tableName])) {
             return $this->namespace . $this->classNamesForTables[$tableName];
@@ -548,14 +538,13 @@ class DatabaseDriver implements MappingDriver
     /**
      * Return the mapped field name for a column, if it exists. Otherwise return camelized version.
      *
-     * @param string $tableName
-     * @param string $columnName
-     * @param bool   $fk         Whether the column is a foreignkey or not.
-     *
-     * @return string
+     * @param bool $fk Whether the column is a foreignkey or not.
      */
-    private function getFieldNameForColumn($tableName, $columnName, $fk = false)
-    {
+    private function getFieldNameForColumn(
+        string $tableName,
+        string $columnName,
+        bool $fk = false
+    ): string {
         if (isset($this->fieldNamesForColumns[$tableName]) && isset($this->fieldNamesForColumns[$tableName][$columnName])) {
             return $this->fieldNamesForColumns[$tableName][$columnName];
         }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -737,7 +737,7 @@ class XmlDriver extends FileDriver
      * @return mixed[] The options array.
      * @psalm-return array<int|string, array<int|string, mixed|string>|bool|string>
      */
-    private function parseOptions(SimpleXMLElement $options)
+    private function parseOptions(SimpleXMLElement $options): array
     {
         $array = [];
 
@@ -779,7 +779,7 @@ class XmlDriver extends FileDriver
      *                   columnDefinition?: string
      *               }
      */
-    private function joinColumnToArray(SimpleXMLElement $joinColumnElement)
+    private function joinColumnToArray(SimpleXMLElement $joinColumnElement): array
     {
         $joinColumn = [
             'name' => (string) $joinColumnElement['name'],
@@ -823,7 +823,7 @@ class XmlDriver extends FileDriver
       *                   options?: array
       *               }
       */
-    private function columnToArray(SimpleXMLElement $fieldMapping)
+    private function columnToArray(SimpleXMLElement $fieldMapping): array
     {
         $mapping = [
             'fieldName' => (string) $fieldMapping['name'],
@@ -878,7 +878,7 @@ class XmlDriver extends FileDriver
      * @return mixed[]
      * @psalm-return array{usage: int|null, region?: string}
      */
-    private function cacheToArray(SimpleXMLElement $cacheMapping)
+    private function cacheToArray(SimpleXMLElement $cacheMapping): array
     {
         $region = isset($cacheMapping['region']) ? (string) $cacheMapping['region'] : null;
         $usage  = isset($cacheMapping['usage']) ? strtoupper($cacheMapping['usage']) : null;
@@ -905,7 +905,7 @@ class XmlDriver extends FileDriver
      * @return string[] The list of cascade options.
      * @psalm-return list<string>
      */
-    private function getCascadeMappings(SimpleXMLElement $cascadeElement)
+    private function getCascadeMappings(SimpleXMLElement $cascadeElement): array
     {
         $cascades = [];
         foreach ($cascadeElement->children() as $action) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -887,7 +887,7 @@ class YamlDriver extends FileDriver
      * @return mixed[]
      * @psalm-return array{usage: int, region: string|null}
      */
-    private function cacheToArray($cacheMapping)
+    private function cacheToArray(array $cacheMapping): array
     {
         $region = isset($cacheMapping['region']) ? (string) $cacheMapping['region'] : null;
         $usage  = isset($cacheMapping['usage']) ? strtoupper($cacheMapping['usage']) : null;

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -55,7 +55,7 @@ final class ReflectionPropertiesGetter
      *
      * @return ReflectionProperty[] indexed by property internal name
      */
-    public function getProperties($className)
+    public function getProperties($className): array
     {
         if (isset($this->properties[$className])) {
             return $this->properties[$className];
@@ -75,12 +75,10 @@ final class ReflectionPropertiesGetter
     }
 
     /**
-     * @param string $className
-     *
      * @return ReflectionClass[]
      * @psalm-return list<ReflectionClass<object>>
      */
-    private function getHierarchyClasses($className): array
+    private function getHierarchyClasses(string $className): array
     {
         $classes         = [];
         $parentClassName = $className;
@@ -121,18 +119,12 @@ final class ReflectionPropertiesGetter
         );
     }
 
-    /**
-     * @return bool
-     */
-    private function isInstanceProperty(ReflectionProperty $reflectionProperty)
+    private function isInstanceProperty(ReflectionProperty $reflectionProperty): bool
     {
         return ! $reflectionProperty->isStatic();
     }
 
-    /**
-     * @return ReflectionProperty|null
-     */
-    private function getAccessibleProperty(ReflectionProperty $property)
+    private function getAccessibleProperty(ReflectionProperty $property): ?ReflectionProperty
     {
         return $this->reflectionService->getAccessibleProperty(
             $property->getDeclaringClass()->getName(),
@@ -140,10 +132,7 @@ final class ReflectionPropertiesGetter
         );
     }
 
-    /**
-     * @return string
-     */
-    private function getLogicalName(ReflectionProperty $property)
+    private function getLogicalName(ReflectionProperty $property): string
     {
         $propertyName = $property->getName();
 

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -64,7 +64,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * The entity that owns this collection.
      *
-     * @var object
+     * @var object|null
      */
     private $owner;
 
@@ -72,7 +72,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * The association mapping the collection belongs to.
      * This is currently either a OneToManyMapping or a ManyToManyMapping.
      *
-     * @psalm-var array<string, mixed>
+     * @psalm-var array<string, mixed>|null
      */
     private $association;
 
@@ -128,10 +128,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @param object $entity
      * @psalm-param array<string, mixed> $assoc
-     *
-     * @return void
      */
-    public function setOwner($entity, array $assoc)
+    public function setOwner($entity, array $assoc): void
     {
         $this->owner            = $entity;
         $this->association      = $assoc;
@@ -142,7 +140,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * INTERNAL:
      * Gets the collection owner.
      *
-     * @return object
+     * @return object|null
      */
     public function getOwner()
     {
@@ -152,7 +150,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * @return Mapping\ClassMetadata
      */
-    public function getTypeClass()
+    public function getTypeClass(): Mapping\ClassMetadataInfo
     {
         return $this->typeClass;
     }
@@ -163,10 +161,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * complete bidirectional associations in the case of a one-to-many association.
      *
      * @param mixed $element The element to add.
-     *
-     * @return void
      */
-    public function hydrateAdd($element)
+    public function hydrateAdd($element): void
     {
         $this->collection->add($element);
 
@@ -193,10 +189,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @param mixed $key     The key to set.
      * @param mixed $element The element to set.
-     *
-     * @return void
      */
-    public function hydrateSet($key, $element)
+    public function hydrateSet($key, $element): void
     {
         $this->collection->set($key, $element);
 
@@ -214,10 +208,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * Initializes the collection by loading its contents from the database
      * if the collection is not yet initialized.
-     *
-     * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
         if ($this->initialized || ! $this->association) {
             return;
@@ -231,10 +223,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * INTERNAL:
      * Tells this collection to take a snapshot of its current state.
-     *
-     * @return void
      */
-    public function takeSnapshot()
+    public function takeSnapshot(): void
     {
         $this->snapshot = $this->collection->toArray();
         $this->isDirty  = false;
@@ -246,7 +236,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @psalm-return array<string|int, mixed> The last snapshot of the elements.
      */
-    public function getSnapshot()
+    public function getSnapshot(): array
     {
         return $this->snapshot;
     }
@@ -257,7 +247,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @return mixed[]
      */
-    public function getDeleteDiff()
+    public function getDeleteDiff(): array
     {
         return array_udiff_assoc(
             $this->snapshot,
@@ -274,7 +264,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @return mixed[]
      */
-    public function getInsertDiff()
+    public function getInsertDiff(): array
     {
         return array_udiff_assoc(
             $this->collection->toArray(),
@@ -288,19 +278,17 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * INTERNAL: Gets the association mapping of the collection.
      *
-     * @psalm-return array<string, mixed>
+     * @psalm-return array<string, mixed>|null
      */
-    public function getMapping()
+    public function getMapping(): ?array
     {
         return $this->association;
     }
 
     /**
      * Marks this collection as changed/dirty.
-     *
-     * @return void
      */
-    private function changed()
+    private function changed(): void
     {
         if ($this->isDirty) {
             return;
@@ -325,7 +313,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @return bool TRUE if the collection is dirty, FALSE otherwise.
      */
-    public function isDirty()
+    public function isDirty(): bool
     {
         return $this->isDirty;
     }
@@ -334,10 +322,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * Sets a boolean flag, indicating whether this collection is dirty.
      *
      * @param bool $dirty Whether the collection should be marked dirty or not.
-     *
-     * @return void
      */
-    public function setDirty($dirty)
+    public function setDirty($dirty): void
     {
         $this->isDirty = $dirty;
     }
@@ -346,10 +332,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * Sets the initialized flag of the collection, forcing it into that state.
      *
      * @param bool $bool
-     *
-     * @return void
      */
-    public function setInitialized($bool)
+    public function setInitialized($bool): void
     {
         $this->initialized = $bool;
     }
@@ -388,7 +372,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function removeElement($element)
+    public function removeElement($element): bool
     {
         $removed = parent::removeElement($element);
 
@@ -413,7 +397,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function containsKey($key)
+    public function containsKey($key): bool
     {
         if (
             ! $this->initialized && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY
@@ -430,7 +414,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         if (! $this->initialized && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
@@ -461,10 +445,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
         return parent::get($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function count()
+    public function count(): int
     {
         if (! $this->initialized && $this->association !== null && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
@@ -478,7 +459,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         parent::set($key, $value);
 
@@ -492,7 +473,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function add($value)
+    public function add($value): bool
     {
         $this->collection->add($value);
 
@@ -510,7 +491,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->containsKey($offset);
     }
@@ -526,7 +507,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (! isset($offset)) {
             $this->add($value);
@@ -540,25 +521,19 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * {@inheritdoc}
      *
-     * @return object
+     * @return object|null
      */
     public function offsetUnset($offset)
     {
         return $this->remove($offset);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->collection->isEmpty() && $this->count() === 0;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function clear()
+    public function clear(): void
     {
         if ($this->initialized && $this->isEmpty()) {
             $this->collection->clear();
@@ -622,7 +597,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @psalm-return array<TKey,T>
      */
-    public function slice($offset, $length = null)
+    public function slice($offset, $length = null): array
     {
         if (! $this->initialized && ! $this->isDirty && $this->association['fetch'] === ClassMetadata::FETCH_EXTRA_LAZY) {
             $persister = $this->em->getUnitOfWork()->getCollectionPersister($this->association);
@@ -643,8 +618,6 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * 3. Snapshot leads to invalid diffs being generated.
      * 4. Lazy loading grabs entities from old owner object.
      * 5. New collection is connected to old owner and leads to duplicate keys.
-     *
-     * @return void
      */
     public function __clone()
     {
@@ -668,7 +641,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @throws RuntimeException
      */
-    public function matching(Criteria $criteria)
+    public function matching(Criteria $criteria): Collection
     {
         if ($this->isDirty) {
             $this->initialize();
@@ -705,15 +678,12 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @return Collection<TKey, T>
      */
-    public function unwrap()
+    public function unwrap(): Collection
     {
         return $this->collection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function doInitialize()
+    protected function doInitialize(): void
     {
         // Has NEW objects added through add(). Remember them.
         $newlyAddedDirtyObjects = [];

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -529,8 +529,10 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @return mixed[]
      * @psalm-return list<mixed>
      */
-    private function collectJoinTableColumnParameters(PersistentCollection $collection, $element)
-    {
+    private function collectJoinTableColumnParameters(
+        PersistentCollection $collection,
+        $element
+    ): array {
         $params      = [];
         $mapping     = $collection->getMapping();
         $isComposite = count($mapping['joinTableColumns']) > 2;
@@ -566,8 +568,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * @param string $key
-     * @param bool   $addFilters Whether the filter SQL should be included or not.
+     * @param bool $addFilters Whether the filter SQL should be included or not.
      *
      * @return mixed[] ordered vector:
      *                - quoted join table name
@@ -576,8 +577,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - types of the parameters to be bound for filtering
      * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
-    private function getJoinTableRestrictionsWithKey(PersistentCollection $collection, $key, $addFilters)
-    {
+    private function getJoinTableRestrictionsWithKey(
+        PersistentCollection $collection,
+        string $key,
+        bool $addFilters
+    ): array {
         $filterMapping = $collection->getMapping();
         $mapping       = $filterMapping;
         $indexBy       = $mapping['indexBy'];
@@ -651,8 +655,8 @@ class ManyToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * @param object $element
      * @param bool   $addFilters Whether the filter SQL should be included or not.
+     * @param object $element
      *
      * @return mixed[] ordered vector:
      *                - quoted join table name
@@ -661,8 +665,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - types of the parameters to be bound for filtering
      * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
-    private function getJoinTableRestrictions(PersistentCollection $collection, $element, $addFilters)
-    {
+    private function getJoinTableRestrictions(
+        PersistentCollection $collection,
+        $element,
+        bool $addFilters
+    ): array {
         $filterMapping = $collection->getMapping();
         $mapping       = $filterMapping;
 
@@ -722,7 +729,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @return mixed[][]
      */
-    private function expandCriteriaParameters(Criteria $criteria)
+    private function expandCriteriaParameters(Criteria $criteria): array
     {
         $expression = $criteria->getWhereExpression();
 
@@ -739,10 +746,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         return $types;
     }
 
-    /**
-     * @return string
-     */
-    private function getOrderingSql(Criteria $criteria, ClassMetadata $targetClass)
+    private function getOrderingSql(Criteria $criteria, ClassMetadata $targetClass): string
     {
         $orderings = $criteria->getOrderings();
         if ($orderings) {
@@ -763,11 +767,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * @return string
-     *
      * @throws DBALException
      */
-    private function getLimitSql(Criteria $criteria)
+    private function getLimitSql(Criteria $criteria): string
     {
         $limit  = $criteria->getMaxResults();
         $offset = $criteria->getFirstResult();

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -180,11 +180,9 @@ class OneToManyPersister extends AbstractCollectionPersister
     }
 
     /**
-     * @return int
-     *
      * @throws DBALException
      */
-    private function deleteEntityCollection(PersistentCollection $collection)
+    private function deleteEntityCollection(PersistentCollection $collection): int
     {
         $mapping     = $collection->getMapping();
         $identifier  = $this->uow->getEntityIdentifier($collection->getOwner());
@@ -210,11 +208,9 @@ class OneToManyPersister extends AbstractCollectionPersister
      *
      * Thanks Steve Ebersole (Hibernate) for idea on how to tackle reliably this scenario, we owe him a beer! =)
      *
-     * @return int
-     *
      * @throws DBALException
      */
-    private function deleteJoinedEntityCollection(PersistentCollection $collection)
+    private function deleteJoinedEntityCollection(PersistentCollection $collection): int
     {
         $mapping     = $collection->getMapping();
         $sourceClass = $this->em->getClassMetadata($mapping['sourceEntity']);

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -24,9 +24,9 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\ResultStatement as DriverStatement;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Statement;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -414,13 +414,15 @@ class BasicEntityPersister implements EntityPersister
      * @param mixed[] $updateData      The map of columns to update (column => value).
      * @param bool    $versioned       Whether the UPDATE should be versioned.
      *
-     * @return void
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    final protected function updateTable($entity, $quotedTableName, array $updateData, $versioned = false)
-    {
+    final protected function updateTable(
+        $entity,
+        $quotedTableName,
+        array $updateData,
+        $versioned = false
+    ): void {
         $set    = [];
         $types  = [];
         $params = [];
@@ -913,12 +915,11 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Loads an array of entities from a given DBAL statement.
      *
-     * @param mixed[]   $assoc
-     * @param Statement $stmt
+     * @param mixed[] $assoc
      *
      * @return mixed[]
      */
-    private function loadArrayFromStatement($assoc, $stmt)
+    private function loadArrayFromStatement(array $assoc, DriverStatement $stmt): array
     {
         $rsm   = $this->currentPersisterContext->rsm;
         $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
@@ -934,14 +935,15 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Hydrates a collection from a given DBAL statement.
      *
-     * @param mixed[]              $assoc
-     * @param Statement            $stmt
-     * @param PersistentCollection $coll
+     * @param mixed[] $assoc
      *
      * @return mixed[]
      */
-    private function loadCollectionFromStatement($assoc, $stmt, $coll)
-    {
+    private function loadCollectionFromStatement(
+        array $assoc,
+        DriverStatement $stmt,
+        PersistentCollection $coll
+    ): array {
         $rsm   = $this->currentPersisterContext->rsm;
         $hints = [
             UnitOfWork::HINT_DEFEREAGERLOAD => true,
@@ -970,7 +972,7 @@ class BasicEntityPersister implements EntityPersister
      * @param object $sourceEntity
      * @psalm-param array<string, mixed> $assoc
      *
-     * @return \Doctrine\DBAL\Driver\Statement
+     * @return DriverStatement
      *
      * @throws MappingException
      */
@@ -1651,7 +1653,6 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Builds the left-hand-side of a where condition statement.
      *
-     * @param string $field
      * @psalm-param array<string, mixed>|null $assoc
      *
      * @return string[]
@@ -1659,8 +1660,10 @@ class BasicEntityPersister implements EntityPersister
      *
      * @throws ORMException
      */
-    private function getSelectConditionStatementColumnSQL($field, $assoc = null)
-    {
+    private function getSelectConditionStatementColumnSQL(
+        string $field,
+        ?array $assoc = null
+    ): array {
         if (isset($this->class->fieldMappings[$field])) {
             $className = $this->class->fieldMappings[$field]['inherited'] ?? $this->class->name;
 
@@ -1760,15 +1763,15 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Builds criteria and execute SQL statement to fetch the one to many entities from.
      *
-     * @param object   $sourceEntity
-     * @param int|null $offset
-     * @param int|null $limit
+     * @param object $sourceEntity
      * @psalm-param array<string, mixed> $assoc
-     *
-     * @return Statement
      */
-    private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
-    {
+    private function getOneToManyStatement(
+        array $assoc,
+        $sourceEntity,
+        ?int $offset = null,
+        ?int $limit = null
+    ): DriverStatement {
         $this->switchPersisterContext($offset, $limit);
 
         $criteria    = [];
@@ -1846,7 +1849,7 @@ class BasicEntityPersister implements EntityPersister
      * @return mixed[][]
      * @psalm-return array{0: array, 1: list<int|string|null>}
      */
-    private function expandToManyParameters($criteria)
+    private function expandToManyParameters(array $criteria): array
     {
         $params = [];
         $types  = [];
@@ -1866,15 +1869,14 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Infers field types to be used by parameter type casting.
      *
-     * @param string $field
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return int[]|null[]|string[]
      * @psalm-return list<int|string|null>
      *
      * @throws QueryException
      */
-    private function getTypes($field, $value, ClassMetadata $class)
+    private function getTypes(string $field, $value, ClassMetadata $class): array
     {
         $types = [];
 
@@ -1925,7 +1927,7 @@ class BasicEntityPersister implements EntityPersister
      *
      * @return mixed[]
      */
-    private function getValues($value)
+    private function getValues($value): array
     {
         if (is_array($value)) {
             $newValue = [];

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -68,10 +68,8 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
     /**
      * This function finds the ClassMetadata instance in an inheritance hierarchy
      * that is responsible for enabling versioning.
-     *
-     * @return ClassMetadata
      */
-    private function getVersionedClassMetadata()
+    private function getVersionedClassMetadata(): ClassMetadata
     {
         if (isset($this->class->fieldMappings[$this->class->versionField]['inherited'])) {
             $definingClassName = $this->class->fieldMappings[$this->class->versionField]['inherited'];
@@ -576,12 +574,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $this->class->setFieldValue($entity, $this->class->versionField, $value);
     }
 
-    /**
-     * @param string $baseTableAlias
-     *
-     * @return string
-     */
-    private function getJoinSql($baseTableAlias)
+    private function getJoinSql(string $baseTableAlias): string
     {
         $joinSql          = '';
         $identifierColumn = $this->class->getIdentifierColumnNames();

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -109,12 +109,11 @@ class ProxyFactory extends AbstractProxyFactory
     /**
      * Creates a closure capable of initializing a proxy
      *
-     * @return Closure
      * @psalm-return Closure(BaseProxy):void
      *
      * @throws EntityNotFoundException
      */
-    private function createInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister)
+    private function createInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister): Closure
     {
         $wakeupProxy = $classMetadata->getReflectionClass()->hasMethod('__wakeup');
 
@@ -161,12 +160,11 @@ class ProxyFactory extends AbstractProxyFactory
     /**
      * Creates a closure capable of finalizing state a cloned proxy
      *
-     * @return Closure
      * @psalm-return Closure(BaseProxy):void
      *
      * @throws EntityNotFoundException
      */
-    private function createCloner(ClassMetadata $classMetadata, EntityPersister $entityPersister)
+    private function createCloner(ClassMetadata $classMetadata, EntityPersister $entityPersister): Closure
     {
         return function (BaseProxy $proxy) use ($entityPersister, $classMetadata): void {
             if ($proxy->__isInitialized()) {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
@@ -234,10 +235,8 @@ final class Query extends AbstractQuery
      * Parses the DQL query, if necessary, and stores the parser result.
      *
      * Note: Populates $this->_parserResult as a side-effect.
-     *
-     * @return ParserResult
      */
-    private function parse()
+    private function parse(): ParserResult
     {
         $types = [];
 
@@ -335,15 +334,13 @@ final class Query extends AbstractQuery
      * @param array<string,mixed> $sqlParams
      * @param array<string,Type>  $types
      * @param array<string,mixed> $connectionParams
-     *
-     * @return void
      */
     private function evictResultSetCache(
         AbstractSqlExecutor $executor,
         array $sqlParams,
         array $types,
         array $connectionParams
-    ) {
+    ): void {
         if ($this->_queryCacheProfile === null || ! $this->getExpireResultCache()) {
             return;
         }
@@ -360,10 +357,8 @@ final class Query extends AbstractQuery
 
     /**
      * Evict entity cache region
-     *
-     * @return void
      */
-    private function evictEntityCacheRegion()
+    private function evictEntityCacheRegion(): void
     {
         $AST = $this->getAST();
 
@@ -502,7 +497,7 @@ final class Query extends AbstractQuery
      * @return Cache|null The cache driver used for query caching or NULL, if
      * this Query does not use query caching.
      */
-    public function getQueryCacheDriver()
+    public function getQueryCacheDriver(): ?Cache
     {
         if ($this->queryCache) {
             return $this->queryCache;
@@ -531,10 +526,8 @@ final class Query extends AbstractQuery
 
     /**
      * Retrieves the lifetime of resultset cache.
-     *
-     * @return int
      */
-    public function getQueryCacheLifetime()
+    public function getQueryCacheLifetime(): ?int
     {
         return $this->queryCacheTTL;
     }
@@ -555,20 +548,16 @@ final class Query extends AbstractQuery
 
     /**
      * Retrieves if the query cache is active or not.
-     *
-     * @return bool
      */
-    public function getExpireQueryCache()
+    public function getExpireQueryCache(): bool
     {
         return $this->expireQueryCache;
     }
 
     /**
-     * @return void
-     *
      * @override
      */
-    public function free()
+    public function free(): void
     {
         parent::free();
 
@@ -593,10 +582,8 @@ final class Query extends AbstractQuery
 
     /**
      * Returns the DQL query that is represented by this query object.
-     *
-     * @return string|null
      */
-    public function getDQL()
+    public function getDQL(): ?string
     {
         return $this->dql;
     }
@@ -611,7 +598,7 @@ final class Query extends AbstractQuery
      *
      * @return int The query state.
      */
-    public function getState()
+    public function getState(): int
     {
         return $this->_state;
     }
@@ -620,10 +607,8 @@ final class Query extends AbstractQuery
      * Method to check if an arbitrary piece of DQL exists
      *
      * @param string $dql Arbitrary piece of DQL to check for.
-     *
-     * @return bool
      */
-    public function contains($dql)
+    public function contains($dql): bool
     {
         return stripos($this->getDQL(), $dql) !== false;
     }
@@ -649,7 +634,7 @@ final class Query extends AbstractQuery
      *
      * @return int|null The position of the first result.
      */
-    public function getFirstResult()
+    public function getFirstResult(): ?int
     {
         return $this->firstResult;
     }
@@ -675,7 +660,7 @@ final class Query extends AbstractQuery
      *
      * @return int|null Maximum number of results.
      */
-    public function getMaxResults()
+    public function getMaxResults(): ?int
     {
         return $this->maxResults;
     }
@@ -689,10 +674,8 @@ final class Query extends AbstractQuery
      * @param ArrayCollection|mixed[]|null $parameters    The query parameters.
      * @param string|int                   $hydrationMode The hydration mode to use.
      * @psalm-param ArrayCollection<int, Parameter>|array<string, mixed>|null $parameters
-     *
-     * @return IterableResult
      */
-    public function iterate($parameters = null, $hydrationMode = self::HYDRATE_OBJECT)
+    public function iterate($parameters = null, $hydrationMode = self::HYDRATE_OBJECT): IterableResult
     {
         $this->setHint(self::HINT_INTERNAL_ITERATION, true);
 
@@ -710,7 +693,7 @@ final class Query extends AbstractQuery
     /**
      * {@inheritdoc}
      */
-    public function setHint($name, $value)
+    public function setHint($name, $value): self
     {
         $this->_state = self::STATE_DIRTY;
 
@@ -720,7 +703,7 @@ final class Query extends AbstractQuery
     /**
      * {@inheritdoc}
      */
-    public function setHydrationMode($hydrationMode)
+    public function setHydrationMode($hydrationMode): self
     {
         $this->_state = self::STATE_DIRTY;
 
@@ -754,7 +737,7 @@ final class Query extends AbstractQuery
      *
      * @return int|null The current lock mode of this query or NULL if no specific lock mode is set.
      */
-    public function getLockMode()
+    public function getLockMode(): ?int
     {
         $lockMode = $this->getHint(self::HINT_LOCK_MODE);
 
@@ -786,18 +769,13 @@ final class Query extends AbstractQuery
         );
     }
 
-     /**
-      * {@inheritdoc}
-      */
-    protected function getHash()
+    protected function getHash(): string
     {
         return sha1(parent::getHash() . '-' . $this->firstResult . '-' . $this->maxResults);
     }
 
     /**
      * Cleanup Query resource when clone is called.
-     *
-     * @return void
      */
     public function __clone()
     {

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -93,10 +93,9 @@ class TrimFunction extends FunctionNode
     }
 
     /**
-     * @return int
      * @psalm-return AbstractPlatform::TRIM_*
      */
-    private function getTrimMode()
+    private function getTrimMode(): int
     {
         if ($this->leading) {
             return AbstractPlatform::TRIM_LEADING;
@@ -113,10 +112,7 @@ class TrimFunction extends FunctionNode
         return AbstractPlatform::TRIM_UNSPECIFIED;
     }
 
-    /**
-     * @return void
-     */
-    private function parseTrimMode(Parser $parser)
+    private function parseTrimMode(Parser $parser): void
     {
         $lexer = $parser->getLexer();
         $value = $lexer->lookahead['value'];

--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -51,10 +51,8 @@ class Composite extends Base
 
     /**
      * @param string|object $part
-     *
-     * @return string
      */
-    private function processQueryPart($part)
+    private function processQueryPart($part): string
     {
         $queryPart = (string) $part;
 

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -135,10 +135,8 @@ abstract class SQLFilter
 
     /**
      * Returns the database connection used by the entity manager
-     *
-     * @return Connection
      */
-    final protected function getConnection()
+    final protected function getConnection(): Connection
     {
         return $this->em->getConnection();
     }

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -463,10 +463,8 @@ class Parser
      * as the hydration process relies on that order for proper operation.
      *
      * @param AST\SelectStatement|AST\DeleteStatement|AST\UpdateStatement $AST
-     *
-     * @return void
      */
-    private function fixIdentificationVariableOrder($AST)
+    private function fixIdentificationVariableOrder(Node $AST): void
     {
         if (count($this->identVariableExpressions) <= 1) {
             return;
@@ -557,7 +555,7 @@ class Parser
      * @return mixed[]
      * @psalm-return array{value: string, type: int|null|string, position: int}|null
      */
-    private function peekBeyondClosingParenthesis(bool $resetPeek = true)
+    private function peekBeyondClosingParenthesis(bool $resetPeek = true): ?array
     {
         $token        = $this->lexer->peek();
         $numUnmatched = 1;
@@ -589,9 +587,9 @@ class Parser
     /**
      * Checks if the given token indicates a mathematical operator.
      *
-     * @psalm-param array<string, mixed> $token
+     * @psalm-param array<string, mixed>|null $token
      */
-    private function isMathOperator($token): bool
+    private function isMathOperator(?array $token): bool
     {
         return $token !== null && in_array($token['type'], [Lexer::T_PLUS, Lexer::T_MINUS, Lexer::T_DIVIDE, Lexer::T_MULTIPLY]);
     }
@@ -1039,11 +1037,9 @@ class Parser
      *
      * @param string $schemaName The name to validate.
      *
-     * @return void
-     *
      * @throws QueryException if the name does not exist.
      */
-    private function validateAbstractSchemaName($schemaName)
+    private function validateAbstractSchemaName(string $schemaName): void
     {
         if (! (class_exists($schemaName, true) || interface_exists($schemaName, true))) {
             $this->semanticalError(
@@ -3488,10 +3484,8 @@ class Parser
 
     /**
      * Helper function for FunctionDeclaration grammar rule.
-     *
-     * @return FunctionNode
      */
-    private function CustomFunctionDeclaration()
+    private function CustomFunctionDeclaration(): ?FunctionNode
     {
         $token    = $this->lexer->lookahead;
         $funcName = strtolower($token['value']);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -194,13 +194,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
     /**
      * Gets column alias for a given column.
      *
-     * @param string $columnName
-     * @param int    $mode
      * @psalm-param array<string, string>  $customRenameColumns
-     *
-     * @return string
      */
-    private function getColumnAlias($columnName, $mode, array $customRenameColumns)
+    private function getColumnAlias(string $columnName, int $mode, array $customRenameColumns): string
     {
         switch ($mode) {
             case self::COLUMN_RENAMING_INCREMENT:
@@ -211,6 +207,12 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
             case self::COLUMN_RENAMING_NONE:
                 return $columnName;
+
+            default:
+                throw new InvalidArgumentException(sprintf(
+                    '%d is not a valid value for $mode',
+                    $mode
+                ));
         }
     }
 
@@ -219,15 +221,18 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * This depends on the renaming mode selected by the user.
      *
-     * @param string $className
-     * @param int    $mode
+     * @psalm-param class-string $className
+     * @psalm-param self::COLUMN_RENAMING_* $mode
      * @psalm-param array<string, string> $customRenameColumns
      *
      * @return string[]
      * @psalm-return array<array-key, string>
      */
-    private function getColumnAliasMap($className, $mode, array $customRenameColumns)
-    {
+    private function getColumnAliasMap(
+        string $className,
+        int $mode,
+        array $customRenameColumns
+    ): array {
         if ($customRenameColumns) { // for BC with 2.2-2.3 API
             $mode = self::COLUMN_RENAMING_CUSTOM;
         }

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -934,11 +934,11 @@ class SqlWalker implements TreeWalker
 
     /**
      * Generate appropriate SQL for RangeVariableDeclaration AST node
-     *
-     * @param AST\RangeVariableDeclaration $rangeVariableDeclaration
      */
-    private function generateRangeVariableDeclarationSQL($rangeVariableDeclaration, bool $buildNestedJoins): string
-    {
+    private function generateRangeVariableDeclarationSQL(
+        AST\RangeVariableDeclaration $rangeVariableDeclaration,
+        bool $buildNestedJoins
+    ): string {
         $class    = $this->em->getClassMetadata($rangeVariableDeclaration->abstractSchemaName);
         $dqlAlias = $rangeVariableDeclaration->aliasIdentificationVariable;
 
@@ -2352,8 +2352,10 @@ class SqlWalker implements TreeWalker
      *
      * @throws QueryException
      */
-    private function getChildDiscriminatorsFromClassMetadata(ClassMetadataInfo $rootClass, AST\InstanceOfExpression $instanceOfExpr): string
-    {
+    private function getChildDiscriminatorsFromClassMetadata(
+        ClassMetadataInfo $rootClass,
+        AST\InstanceOfExpression $instanceOfExpr
+    ): string {
         $sqlParameterList = [];
         $discriminators   = [];
         foreach ($instanceOfExpr->value as $parameter) {

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -292,7 +292,7 @@ class QueryBuilder
     /**
      * Gets the associated EntityManager for this query builder.
      *
-     * @return EntityManager
+     * @return EntityManagerInterface
      */
     public function getEntityManager()
     {
@@ -393,10 +393,8 @@ class QueryBuilder
      *
      * @param string $alias       The alias of the new join entity
      * @param string $parentAlias The parent entity alias of the join relationship
-     *
-     * @return string
      */
-    private function findRootAlias($alias, $parentAlias)
+    private function findRootAlias(string $alias, string $parentAlias): string
     {
         $rootAlias = null;
 
@@ -1388,10 +1386,7 @@ class QueryBuilder
         return $this->_dqlParts;
     }
 
-    /**
-     * @return string
-     */
-    private function getDQLForDelete()
+    private function getDQLForDelete(): string
     {
          return 'DELETE'
               . $this->getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
@@ -1399,10 +1394,7 @@ class QueryBuilder
               . $this->getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
-    /**
-     * @return string
-     */
-    private function getDQLForUpdate()
+    private function getDQLForUpdate(): string
     {
          return 'UPDATE'
               . $this->getReducedDQLQueryPart('from', ['pre' => ' ', 'separator' => ', '])
@@ -1411,10 +1403,7 @@ class QueryBuilder
               . $this->getReducedDQLQueryPart('orderBy', ['pre' => ' ORDER BY ', 'separator' => ', ']);
     }
 
-    /**
-     * @return string
-     */
-    private function getDQLForSelect()
+    private function getDQLForSelect(): string
     {
         $dql = 'SELECT'
              . ($this->_dqlParts['distinct'] === true ? ' DISTINCT' : '')

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -40,7 +40,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
     /**
      * {@inheritdoc}
      */
-    public function getRepository(EntityManagerInterface $entityManager, $entityName)
+    public function getRepository(EntityManagerInterface $entityManager, $entityName): ObjectRepository
     {
         $repositoryHash = $entityManager->getClassMetadata($entityName)->getName() . spl_object_hash($entityManager);
 
@@ -56,11 +56,11 @@ final class DefaultRepositoryFactory implements RepositoryFactory
      *
      * @param EntityManagerInterface $entityManager The EntityManager instance.
      * @param string                 $entityName    The name of the entity.
-     *
-     * @return ObjectRepository
      */
-    private function createRepository(EntityManagerInterface $entityManager, $entityName)
-    {
+    private function createRepository(
+        EntityManagerInterface $entityManager,
+        string $entityName
+    ): ObjectRepository {
         $metadata            = $entityManager->getClassMetadata($entityName);
         $repositoryClassName = $metadata->customRepositoryClassName
             ?: $entityManager->getConfiguration()->getDefaultRepositoryClassName();

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -58,10 +58,7 @@ use const JSON_UNESCAPED_UNICODE;
  */
 final class MappingDescribeCommand extends AbstractEntityManagerCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName('orm:mapping:describe')
              ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
@@ -79,10 +76,7 @@ EOT
              );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ui = new SymfonyStyle($input, $output);
 
@@ -97,11 +91,12 @@ EOT
      * Display all the mapping information for a single Entity.
      *
      * @param string $entityName Full or partial entity class name
-     *
-     * @return void
      */
-    private function displayEntity($entityName, EntityManagerInterface $entityManager, SymfonyStyle $ui)
-    {
+    private function displayEntity(
+        string $entityName,
+        EntityManagerInterface $entityManager,
+        SymfonyStyle $ui
+    ): void {
         $metadata = $this->getClassMetadata($entityName, $entityManager);
 
         $ui->table(
@@ -172,11 +167,11 @@ EOT
      * name
      *
      * @param string $entityName Full or partial entity name
-     *
-     * @return ClassMetadata
      */
-    private function getClassMetadata($entityName, EntityManagerInterface $entityManager)
-    {
+    private function getClassMetadata(
+        string $entityName,
+        EntityManagerInterface $entityManager
+    ): ClassMetadata {
         try {
             return $entityManager->getClassMetadata($entityName);
         } catch (MappingException $e) {
@@ -211,10 +206,8 @@ EOT
      * Format the given value for console output
      *
      * @param mixed $value
-     *
-     * @return string
      */
-    private function formatValue($value)
+    private function formatValue($value): string
     {
         if ($value === '') {
             return '';
@@ -256,7 +249,7 @@ EOT
      * @return string[]
      * @psalm-return array{0: string, 1: string}
      */
-    private function formatField($label, $value): array
+    private function formatField(string $label, $value): array
     {
         if ($value === null) {
             $value = '<comment>None</comment>';

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -106,8 +106,10 @@ class ConvertDoctrine1Schema
     /**
      * @param mixed[] $mappingInformation
      */
-    private function convertToClassMetadataInfo(string $className, $mappingInformation): ClassMetadataInfo
-    {
+    private function convertToClassMetadataInfo(
+        string $className,
+        array $mappingInformation
+    ): ClassMetadataInfo {
         $metadata = new ClassMetadataInfo($className);
 
         $this->convertTableName($className, $mappingInformation, $metadata);
@@ -136,13 +138,13 @@ class ConvertDoctrine1Schema
     }
 
     /**
-     * @param string  $className
      * @param mixed[] $model
-     *
-     * @return void
      */
-    private function convertColumns($className, array $model, ClassMetadataInfo $metadata)
-    {
+    private function convertColumns(
+        string $className,
+        array $model,
+        ClassMetadataInfo $metadata
+    ): void {
         $id = false;
 
         if (isset($model['columns']) && $model['columns']) {
@@ -168,16 +170,18 @@ class ConvertDoctrine1Schema
     }
 
     /**
-     * @param string         $className
-     * @param string         $name
      * @param string|mixed[] $column
      *
      * @return mixed[]
      *
      * @throws ToolsException
      */
-    private function convertColumn($className, $name, $column, ClassMetadataInfo $metadata)
-    {
+    private function convertColumn(
+        string $className,
+        string $name,
+        $column,
+        ClassMetadataInfo $metadata
+    ): array {
         if (is_string($column)) {
             $string         = $column;
             $column         = [];
@@ -258,13 +262,13 @@ class ConvertDoctrine1Schema
     }
 
     /**
-     * @param string  $className
      * @param mixed[] $model
-     *
-     * @return void
      */
-    private function convertIndexes($className, array $model, ClassMetadataInfo $metadata)
-    {
+    private function convertIndexes(
+        string $className,
+        array $model,
+        ClassMetadataInfo $metadata
+    ): void {
         if (empty($model['indexes'])) {
             return;
         }
@@ -280,13 +284,13 @@ class ConvertDoctrine1Schema
     }
 
     /**
-     * @param string  $className
      * @param mixed[] $model
-     *
-     * @return void
      */
-    private function convertRelations($className, array $model, ClassMetadataInfo $metadata)
-    {
+    private function convertRelations(
+        string $className,
+        array $model,
+        ClassMetadataInfo $metadata
+    ): void {
         if (empty($model['relations'])) {
             return;
         }

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -137,10 +137,8 @@ class DebugUnitOfWorkListener
 
     /**
      * @param mixed $var
-     *
-     * @return string
      */
-    private function getType($var)
+    private function getType($var): string
     {
         if (is_object($var)) {
             $refl = new ReflectionObject($var);
@@ -153,10 +151,8 @@ class DebugUnitOfWorkListener
 
     /**
      * @param object $entity
-     *
-     * @return string
      */
-    private function getIdString($entity, UnitOfWork $uow)
+    private function getIdString($entity, UnitOfWork $uow): string
     {
         if ($uow->isInIdentityMap($entity)) {
             $ids      = $uow->getEntityIdentifier($entity);

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -747,10 +747,7 @@ public function __construct(<params>)
         return '';
     }
 
-    /**
-     * @return string
-     */
-    private function generateEmbeddableConstructor(ClassMetadataInfo $metadata)
+    private function generateEmbeddableConstructor(ClassMetadataInfo $metadata): string
     {
         $paramTypes     = [];
         $paramVariables = [];

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -96,11 +96,9 @@ class <className> extends <repositoryName>
     /**
      * Generates the namespace, if class do not have namespace, return empty string instead.
      *
-     * @param string $fullClassName
-     *
-     * @return string $namespace
+     * @psalm-param class-string $fullClassName
      */
-    private function getClassNamespace($fullClassName)
+    private function getClassNamespace(string $fullClassName): string
     {
         return substr($fullClassName, 0, strrpos($fullClassName, '\\'));
     }
@@ -108,11 +106,9 @@ class <className> extends <repositoryName>
     /**
      * Generates the class name
      *
-     * @param string $fullClassName
-     *
-     * @return string
+     * @psalm-param class-string $fullClassName
      */
-    private function generateClassName($fullClassName)
+    private function generateClassName(string $fullClassName): string
     {
         $namespace = $this->getClassNamespace($fullClassName);
 
@@ -128,23 +124,16 @@ class <className> extends <repositoryName>
     /**
      * Generates the namespace statement, if class do not have namespace, return empty string instead.
      *
-     * @param string $fullClassName The full repository class name.
-     *
-     * @return string
+     * @psalm-param class-string $fullClassName The full repository class name.
      */
-    private function generateEntityRepositoryNamespace($fullClassName)
+    private function generateEntityRepositoryNamespace(string $fullClassName): string
     {
         $namespace = $this->getClassNamespace($fullClassName);
 
         return $namespace ? 'namespace ' . $namespace . ';' : '';
     }
 
-    /**
-     * @param string $fullClassName
-     *
-     * @return string $repositoryName
-     */
-    private function generateEntityRepositoryName($fullClassName)
+    private function generateEntityRepositoryName(string $fullClassName): string
     {
         $namespace = $this->getClassNamespace($fullClassName);
 

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -128,10 +128,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
     /**
      * Check if the platform supports the ROW_NUMBER window function.
-     *
-     * @return bool
      */
-    private function platformSupportsRowNumber()
+    private function platformSupportsRowNumber(): bool
     {
         return $this->platform instanceof PostgreSqlPlatform
             || $this->platform instanceof SQLServerPlatform
@@ -145,10 +143,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * Rebuilds a select statement's order by clause for use in a
      * ROW_NUMBER() OVER() expression.
-     *
-     * @return void
      */
-    private function rebuildOrderByForRowNumber(SelectStatement $AST)
+    private function rebuildOrderByForRowNumber(SelectStatement $AST): void
     {
         $orderByClause              = $AST->orderByClause;
         $selectAliasToExpressionMap = [];
@@ -307,10 +303,8 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * Finds all PathExpressions in an AST's OrderByClause, and ensures that
      * the referenced fields are present in the SelectClause of the passed AST.
-     *
-     * @return void
      */
-    private function addMissingItemsFromOrderByToSelect(SelectStatement $AST)
+    private function addMissingItemsFromOrderByToSelect(SelectStatement $AST): void
     {
         $this->orderByPathExpressions = [];
 
@@ -490,12 +484,10 @@ class LimitSubqueryOutputWalker extends SqlWalker
     }
 
     /**
-     * @return string
-     *
      * @throws OptimisticLockException
      * @throws QueryException
      */
-    private function getInnerSQL(SelectStatement $AST)
+    private function getInnerSQL(SelectStatement $AST): string
     {
         // Set every select expression as visible(hidden = false) to
         // make $AST have scalar mappings properly - this is relevant for referencing selected
@@ -520,7 +512,7 @@ class LimitSubqueryOutputWalker extends SqlWalker
     /**
      * @return string[]
      */
-    private function getSQLIdentifier(SelectStatement $AST)
+    private function getSQLIdentifier(SelectStatement $AST): array
     {
         // Find out the SQL alias of the identifier column of the root entity.
         // It may be possible to make this work with multiple root entities but that

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\Functions\IdentityFunction;
+use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
 use Doctrine\ORM\Query\AST\SelectStatement;
@@ -121,10 +122,8 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
 
     /**
      * Validate the AST to ensure that this walker is able to properly manipulate it.
-     *
-     * @return void
      */
-    private function validate(SelectStatement $AST)
+    private function validate(SelectStatement $AST): void
     {
         // Prevent LimitSubqueryWalker from being used with queries that include
         // a limit, a fetched to-many join, and an order by condition that
@@ -165,7 +164,7 @@ class LimitSubqueryWalker extends TreeWalkerAdapter
      *
      * @return IdentityFunction|PathExpression
      */
-    private function createSelectExpressionItem(PathExpression $pathExpression)
+    private function createSelectExpressionItem(PathExpression $pathExpression): Node
     {
         if ($pathExpression->type === PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION) {
             $identity = new IdentityFunction('identity');

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -181,14 +181,7 @@ class Paginator implements Countable, IteratorAggregate
         return new ArrayIterator($result);
     }
 
-    /**
-     * Clones a query.
-     *
-     * @param Query $query The query.
-     *
-     * @return Query The cloned query.
-     */
-    private function cloneQuery(Query $query)
+    private function cloneQuery(Query $query): Query
     {
         $cloneQuery = clone $query;
 
@@ -204,12 +197,8 @@ class Paginator implements Countable, IteratorAggregate
 
     /**
      * Determines whether to use an output walker for the query.
-     *
-     * @param Query $query The query.
-     *
-     * @return bool
      */
-    private function useOutputWalker(Query $query)
+    private function useOutputWalker(Query $query): bool
     {
         if ($this->useOutputWalkers === null) {
             return (bool) $query->getHint(Query::HINT_CUSTOM_OUTPUT_WALKER) === false;
@@ -221,11 +210,9 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * Appends a custom tree walker to the tree walkers hint.
      *
-     * @param string $walkerClass
-     *
-     * @return void
+     * @psalm-param class-string $walkerClass
      */
-    private function appendTreeWalker(Query $query, $walkerClass)
+    private function appendTreeWalker(Query $query, string $walkerClass): void
     {
         $hints = $query->getHint(Query::HINT_CUSTOM_TREE_WALKERS);
 
@@ -239,10 +226,8 @@ class Paginator implements Countable, IteratorAggregate
 
     /**
      * Returns Query prepared to count.
-     *
-     * @return Query
      */
-    private function getCountQuery()
+    private function getCountQuery(): Query
     {
         $countQuery = $this->cloneQuery($this->query);
 

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -25,7 +25,6 @@ use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Event\OnClassMetadataNotFoundEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 use function array_key_exists;
 use function array_replace_recursive;
@@ -109,12 +108,9 @@ class ResolveTargetEntityListener implements EventSubscriber
     }
 
     /**
-     * @param ClassMetadataInfo $classMetadata
-     * @param mixed[]           $mapping
-     *
-     * @return void
+     * @param mixed[] $mapping
      */
-    private function remapAssociation($classMetadata, $mapping)
+    private function remapAssociation(ClassMetadata $classMetadata, array $mapping): void
     {
         $newMapping              = $this->resolveTargetEntities[$mapping['targetEntity']];
         $newMapping              = array_replace_recursive($mapping, $newMapping);

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -422,12 +422,8 @@ class SchemaTool
     /**
      * Gets a portable column definition as required by the DBAL for the discriminator
      * column of a class.
-     *
-     * @param ClassMetadata $class
-     *
-     * @return void
      */
-    private function addDiscriminatorColumnDefinition($class, Table $table)
+    private function addDiscriminatorColumnDefinition(ClassMetadata $class, Table $table): void
     {
         $discrColumn = $class->discriminatorColumn;
 
@@ -454,12 +450,8 @@ class SchemaTool
     /**
      * Gathers the column definitions as required by the DBAL of all field mappings
      * found in the given class.
-     *
-     * @param ClassMetadata $class
-     *
-     * @return void
      */
-    private function gatherColumns($class, Table $table)
+    private function gatherColumns(ClassMetadata $class, Table $table): void
     {
         $pkColumns = [];
 

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -513,10 +513,8 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Computes the changesets of all entities scheduled for insertion.
-     *
-     * @return void
      */
-    private function computeScheduleInsertsChangeSets()
+    private function computeScheduleInsertsChangeSets(): void
     {
         foreach ($this->entityInsertions as $entity) {
             $class = $this->em->getClassMetadata(get_class($entity));
@@ -535,11 +533,9 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $entity
      *
-     * @return void
-     *
      * @throws InvalidArgumentException
      */
-    private function computeSingleEntityChangeSet($entity)
+    private function computeSingleEntityChangeSet($entity): void
     {
         $state = $this->getEntityState($entity);
 
@@ -964,12 +960,9 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * @param ClassMetadata $class
-     * @param object        $entity
-     *
-     * @return void
+     * @param object $entity
      */
-    private function persistNew($class, $entity)
+    private function persistNew(ClassMetadata $class, $entity): void
     {
         $oid    = spl_object_hash($entity);
         $invoke = $this->listenersInvoker->getSubscribedSystems($class, Events::prePersist);
@@ -1091,12 +1084,8 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Executes all entity insertions for entities of the specified type.
-     *
-     * @param ClassMetadata $class
-     *
-     * @return void
      */
-    private function executeInserts($class)
+    private function executeInserts(ClassMetadata $class): void
     {
         $entities  = [];
         $className = $class->name;
@@ -1158,8 +1147,11 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * @param object $entity
      */
-    private function addToEntityIdentifiersAndEntityMap(ClassMetadata $class, string $oid, $entity): void
-    {
+    private function addToEntityIdentifiersAndEntityMap(
+        ClassMetadata $class,
+        string $oid,
+        $entity
+    ): void {
         $identifier = [];
 
         foreach ($class->getIdentifierFieldNames() as $idField) {
@@ -1181,12 +1173,8 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Executes all entity updates for entities of the specified type.
-     *
-     * @param ClassMetadata $class
-     *
-     * @return void
      */
-    private function executeUpdates($class)
+    private function executeUpdates(ClassMetadata $class): void
     {
         $className        = $class->name;
         $persister        = $this->getEntityPersister($className);
@@ -1218,12 +1206,8 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * Executes all entity deletions for entities of the specified type.
-     *
-     * @param ClassMetadata $class
-     *
-     * @return void
      */
-    private function executeDeletions($class)
+    private function executeDeletions(ClassMetadata $class): void
     {
         $className = $class->name;
         $persister = $this->getEntityPersister($className);
@@ -1931,6 +1915,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Executes a merge operation on an entity.
      *
+     * @param object   $entity
      * @param string[] $assoc
      * @psalm-param array<string, object> $visited
      *
@@ -2038,12 +2023,13 @@ class UnitOfWork implements PropertyChangedListener
      * @param object $entity
      * @param object $managedCopy
      *
-     * @return void
-     *
      * @throws OptimisticLockException
      */
-    private function ensureVersionMatch(ClassMetadata $class, $entity, $managedCopy)
-    {
+    private function ensureVersionMatch(
+        ClassMetadata $class,
+        $entity,
+        $managedCopy
+    ): void {
         if (! ($class->isVersioned && $this->isLoaded($managedCopy) && $this->isLoaded($entity))) {
             return;
         }
@@ -2065,10 +2051,8 @@ class UnitOfWork implements PropertyChangedListener
      * Tests if an entity is loaded - must either be a loaded proxy or not a proxy
      *
      * @param object $entity
-     *
-     * @return bool
      */
-    private function isLoaded($entity)
+    private function isLoaded($entity): bool
     {
         return ! ($entity instanceof Proxy) || $entity->__isInitialized();
     }
@@ -2076,6 +2060,7 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Sets/adds associated managed copies into the previous entity's association field
      *
+     * @param object   $entity
      * @param string[] $association
      */
     private function updateAssociationWithMergedEntity(
@@ -2124,11 +2109,12 @@ class UnitOfWork implements PropertyChangedListener
      * @param object  $entity
      * @param mixed[] $visited
      * @param bool    $noCascade if true, don't cascade detach operation.
-     *
-     * @return void
      */
-    private function doDetach($entity, array &$visited, $noCascade = false)
-    {
+    private function doDetach(
+        $entity,
+        array &$visited,
+        bool $noCascade = false
+    ): void {
         $oid = spl_object_hash($entity);
 
         if (isset($visited[$oid])) {
@@ -2302,6 +2288,8 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Cascades a merge operation to associated entities.
      *
+     * @param object $entity
+     * @param object $managedCopy
      * @psalm-param array<string, object> $visited
      */
     private function cascadeMerge($entity, $managedCopy, array &$visited): void
@@ -2615,11 +2603,9 @@ class UnitOfWork implements PropertyChangedListener
     }
 
     /**
-     * @param ClassMetadata $class
-     *
-     * @return ObjectManagerAware|object
+     * @return object
      */
-    private function newInstance($class)
+    private function newInstance(ClassMetadata $class)
     {
         $entity = $class->newInstance();
 

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -64,7 +64,7 @@ final class IdentifierFlattener
      *
      * @psalm-return array<string, mixed>
      */
-    public function flattenIdentifier(ClassMetadata $class, array $id)
+    public function flattenIdentifier(ClassMetadata $class, array $id): array
     {
         $flatId = [];
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -396,11 +396,6 @@ parameters:
 			path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and null will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
-
-		-
 			message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Proxy\\\\Proxy\\:\\:\\$__isInitialized__\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -607,7 +602,7 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 4
+			count: 3
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-
@@ -1386,13 +1381,8 @@ parameters:
 			path: lib/Doctrine/ORM/PersistentCollection.php
 
 		-
-			message: "#^Property Doctrine\\\\ORM\\\\PersistentCollection\\<TKey,T\\>\\:\\:\\$owner \\(object\\) does not accept null\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/PersistentCollection.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
-			count: 7
+			count: 2
 			path: lib/Doctrine/ORM/PersistentCollection.php
 
 		-
@@ -1411,27 +1401,7 @@ parameters:
 			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Persisters\\\\Entity\\\\BasicEntityPersister\\:\\:getManyToManyStatement\\(\\) should return Doctrine\\\\DBAL\\\\Driver\\\\Statement but returns Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement&Doctrine\\\\DBAL\\\\Result\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: "#^Method Doctrine\\\\ORM\\\\Persisters\\\\Entity\\\\BasicEntityPersister\\:\\:getOneToManyStatement\\(\\) should return Doctrine\\\\DBAL\\\\Statement but returns Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement&Doctrine\\\\DBAL\\\\Result\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
-
-		-
 			message: "#^Parameter \\#1 \\$em of method Doctrine\\\\ORM\\\\Id\\\\AbstractIdGenerator\\:\\:generate\\(\\) expects Doctrine\\\\ORM\\\\EntityManager, Doctrine\\\\ORM\\\\EntityManagerInterface given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: "#^Parameter \\#2 \\$stmt of method Doctrine\\\\ORM\\\\Persisters\\\\Entity\\\\BasicEntityPersister\\:\\:loadArrayFromStatement\\(\\) expects Doctrine\\\\DBAL\\\\Statement, Doctrine\\\\DBAL\\\\Driver\\\\Statement given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
-
-		-
-			message: "#^Parameter \\#2 \\$stmt of method Doctrine\\\\ORM\\\\Persisters\\\\Entity\\\\BasicEntityPersister\\:\\:loadCollectionFromStatement\\(\\) expects Doctrine\\\\DBAL\\\\Statement, Doctrine\\\\DBAL\\\\Driver\\\\Statement given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
 
@@ -1504,21 +1474,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$sqlParams of method Doctrine\\\\ORM\\\\Query\\:\\:evictResultSetCache\\(\\) expects array\\<string, mixed\\>, array\\<int, mixed\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query.php
-
-		-
-			message: "#^Method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManager but returns Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/QueryBuilder.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$where$#"
-			count: 2
-			path: lib/Doctrine/ORM/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
-			count: 2
-			path: lib/Doctrine/ORM/QueryBuilder.php
 
 		-
 			message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node\\:\\:\\$value\\.$#"
@@ -1686,11 +1641,6 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\Parser\\:\\:CustomFunctionDeclaration\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\AST\\\\Functions\\\\FunctionNode but returns null\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
 			message:
 				"""
 					#^PHPDoc tag @return has invalid value \\(AST\\\\BetweenExpression\\|
@@ -1727,13 +1677,13 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\ResultSetMappingBuilder\\:\\:getColumnAlias\\(\\) should return string but return statement is missing\\.$#"
+			message: "#^Parameter \\#2 \\$class of static method Doctrine\\\\ORM\\\\Utility\\\\PersisterHelper\\:\\:getTypeOfColumn\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
 
 		-
-			message: "#^Parameter \\#2 \\$class of static method Doctrine\\\\ORM\\\\Utility\\\\PersisterHelper\\:\\:getTypeOfColumn\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo given\\.$#"
-			count: 1
+			message: "#^Parameter \\#2 \\$mode of method Doctrine\\\\ORM\\\\Query\\\\ResultSetMappingBuilder\\:\\:getColumnAliasMap\\(\\) expects 1\\|2\\|3, int given\\.$#"
+			count: 2
 			path: lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
 
 		-
@@ -2277,6 +2227,16 @@ parameters:
 			path: lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
 
 		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$where$#"
+			count: 2
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
+			count: 2
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -2533,11 +2493,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$changeSet of class Doctrine\\\\ORM\\\\Event\\\\PreUpdateEventArgs constructor is passed by reference, so it expects variables only$#"
-			count: 1
-			path: lib/Doctrine/ORM/UnitOfWork.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between object and null will always evaluate to false\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/UnitOfWork.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -368,10 +368,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query.php">
-    <InvalidArgument occurrences="2">
-      <code>$paramMappings</code>
-      <code>$sqlPositions</code>
-    </InvalidArgument>
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
@@ -379,9 +375,6 @@
       <code>$hydrationMode</code>
       <code>$parameters</code>
     </MoreSpecificImplementedParamType>
-    <UndefinedMethod occurrences="1">
-      <code>$sqlPositions</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php">
     <UndefinedPropertyFetch occurrences="1">
@@ -426,8 +419,7 @@
       <code>$this-&gt;identVariableExpressions[$dqlAlias]</code>
       <code>$this-&gt;queryComponents[$dqlAlias]</code>
     </InvalidArrayOffset>
-    <InvalidNullableReturnType occurrences="2">
-      <code>FunctionNode</code>
+    <InvalidNullableReturnType occurrences="1">
       <code>SelectStatement|UpdateStatement|DeleteStatement</code>
     </InvalidNullableReturnType>
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -448,7 +440,7 @@
       <code>AST\BetweenExpression|</code>
       <code>ArithmeticFactor</code>
     </InvalidReturnType>
-    <NullableReturnStatement occurrences="10">
+    <NullableReturnStatement occurrences="9">
       <code>$aliasIdentVariable</code>
       <code>$factors[0]</code>
       <code>$identVariable</code>
@@ -458,13 +450,7 @@
       <code>$terms[0]</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>null</code>
     </NullableReturnStatement>
-  </file>
-  <file src="lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php">
-    <InvalidNullableReturnType occurrences="1">
-      <code>string</code>
-    </InvalidNullableReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
     <InvalidArgument occurrences="1">


### PR DESCRIPTION
This includes:
- private methods
- return type declarations of final protected methods
- return type declarations of public and protected methods of final classes

Parameter type declarations are a more delicate matter and should
probably be handled separately to make it easier to catch issues during
code review.

Type declarations can be more trusted than simple phpdoc when it
comes to static analysis, having them means we can infer the phpdoc of
calling methods with confidence.

Note that it seems that some of the phpdoc I initially inferred these
declarations from were apparently wrong, in particular some mentioning
`Doctrine\Dbal\Statement` when was is really passed around is
`Doctrine\Dbal\Driver\Statement`.

Closes #8538 