### PR TITLE
remove some empty() use when safe

### DIFF
--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -441,7 +441,7 @@ class DefaultQueryCache implements QueryCache
             return null;
         }
 
-        if (empty($path)) {
+        if ($path === []) {
             return $value;
         }
 

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -344,7 +344,7 @@ abstract class AbstractEntityPersister implements CachedEntityPersister
      */
     public function load(array $criteria, $entity = null, $assoc = null, array $hints = [], $lockMode = null, $limit = null, ?array $orderBy = null)
     {
-        if ($entity !== null || $assoc !== null || ! empty($hints) || $lockMode !== null) {
+        if ($entity !== null || $assoc !== null || $hints !== [] || $lockMode !== null) {
             return $this->persister->load($criteria, $entity, $assoc, $hints, $lockMode, $limit, $orderBy);
         }
 

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1208,7 +1208,7 @@ class SqlWalker implements TreeWalker
                     $conditions[] = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
                 }
 
-                $isUnconditionalJoin = empty($conditions);
+                $isUnconditionalJoin = $conditions === [];
                 $condExprConjunction = $class->isInheritanceTypeJoined() && $joinType !== AST\Join::JOIN_TYPE_LEFT && $joinType !== AST\Join::JOIN_TYPE_LEFTOUTER && $isUnconditionalJoin
                     ? ' AND '
                     : ' ON ';

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1880,7 +1880,7 @@ public function __construct(<params>)
         $lines = explode("\n", $code);
 
         foreach ($lines as $key => $value) {
-            if ($value !== '' && $value !== '0') {
+            if ($value !== '') {
                 $lines[$key] = str_repeat($this->spaces, $num) . $lines[$key];
             }
         }

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1880,7 +1880,7 @@ public function __construct(<params>)
         $lines = explode("\n", $code);
 
         foreach ($lines as $key => $value) {
-            if (! empty($value)) {
+            if ($value !== '' && $value !== '0') {
                 $lines[$key] = str_repeat($this->spaces, $num) . $lines[$key];
             }
         }

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -249,7 +249,7 @@ class SchemaTool
                         }
                     }
 
-                    if (! empty($inheritedKeyColumns)) {
+                    if ($inheritedKeyColumns !== []) {
                         // Add a FK constraint on the ID column
                         $table->addForeignKeyConstraint(
                             $this->quoteStrategy->getTableName(
@@ -262,7 +262,7 @@ class SchemaTool
                         );
                     }
 
-                    if (! empty($pkColumns)) {
+                    if ($pkColumns !== []) {
                         $table->setPrimaryKey($pkColumns);
                     }
                 }


### PR DESCRIPTION
This PR propose replacing some empty() uses by a more explicit expression when the type of the variable is known statically from signature.

Those were generated by https://github.com/orklah/psalm-not-empty