### PR TITLE
Fix remaining warnings from the phpunit9 upgrade

### DIFF
--- a/tests/Doctrine/Tests/DoctrineTestCase.php
+++ b/tests/Doctrine/Tests/DoctrineTestCase.php
@@ -4,52 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests;
 
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Version;
-
 /**
  * Base testcase class for all Doctrine testcases.
  */
-abstract class DoctrineTestCase extends TestCase
+abstract class DoctrineTestCase extends PolyfillableTestCase
 {
-    public static function assertDoesNotMatchRegularExpression(
-        string $pattern,
-        string $string,
-        string $message = ''
-    ): void {
-        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
-        if (self::isPhpunit9()) {
-            parent::assertDoesNotMatchRegularExpression($pattern, $string, $message);
-        } else {
-            self::assertNotRegExp($pattern, $string, $message);
-        }
-    }
-
-    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
-    {
-        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
-        if (self::isPhpunit9()) {
-            parent::assertMatchesRegularExpression($pattern, $string, $message);
-        } else {
-            self::assertRegExp($pattern, $string, $message);
-        }
-    }
-
-    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
-    {
-        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
-        if (self::isPhpunit9()) {
-            parent::assertFileDoesNotExist($filename, $message);
-        } else {
-            self::assertFileNotExists($filename, $message);
-        }
-    }
-
-    /**
-     * Check if we're running in phpunit >= 9.0
-     */
-    private static function isPhpunit9(): bool
-    {
-        return (int) Version::series() >= 9;
-    }
 }

--- a/tests/Doctrine/Tests/DoctrineTestCase.php
+++ b/tests/Doctrine/Tests/DoctrineTestCase.php
@@ -5,10 +5,51 @@ declare(strict_types=1);
 namespace Doctrine\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 
 /**
  * Base testcase class for all Doctrine testcases.
  */
 abstract class DoctrineTestCase extends TestCase
 {
+    public static function assertDoesNotMatchRegularExpression(
+        string $pattern,
+        string $string,
+        string $message = ''
+    ): void {
+        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
+        if (self::isPhpunit9()) {
+            parent::assertDoesNotMatchRegularExpression($pattern, $string, $message);
+        } else {
+            self::assertNotRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
+        if (self::isPhpunit9()) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            self::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        // Forward-compatibility wrapper for phpunit 9 : can be removed once phpunit 8 / php 7.2 support is dropped.
+        if (self::isPhpunit9()) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            self::assertFileNotExists($filename, $message);
+        }
+    }
+
+    /**
+     * Check if we're running in phpunit >= 9.0
+     */
+    private static function isPhpunit9(): bool
+    {
+        return (int) Version::series() >= 9;
+    }
 }

--- a/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/CacheLoggerChainTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Cache\Logging\CacheLoggerChain;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Tests\Models\Cache\State;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group DDC-2183
@@ -20,7 +21,7 @@ class CacheLoggerChainTest extends DoctrineTestCase
     /** @var CacheLoggerChain */
     private $logger;
 
-    /** @var PHPUnit_Framework_MockObject_MockObject|CacheLogger */
+    /** @var MockObject|CacheLogger */
     private $mock;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -88,7 +88,7 @@ class FileLockRegionTest extends AbstractRegionTest
         $this->assertNull($this->region->get($key));
 
         $this->assertTrue($this->region->unlock($key, $lock));
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
     }
 
     public function testLockWithExistingLock(): void
@@ -183,7 +183,7 @@ class FileLockRegionTest extends AbstractRegionTest
         $this->assertFalse($this->region->contains($key));
         $this->assertTrue($this->region->evict($key));
         $this->assertFalse($this->region->contains($key));
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
     }
 
     public function testLockedEvictAll(): void
@@ -215,8 +215,8 @@ class FileLockRegionTest extends AbstractRegionTest
 
         $this->assertTrue($this->region->evictAll());
 
-        $this->assertFileNotExists($file1);
-        $this->assertFileNotExists($file2);
+        $this->assertFileDoesNotExist($file1);
+        $this->assertFileDoesNotExist($file2);
 
         $this->assertFalse($this->region->contains($key1));
         $this->assertFalse($this->region->contains($key2));
@@ -243,7 +243,7 @@ class FileLockRegionTest extends AbstractRegionTest
         // outdated lock should be removed
         $this->assertTrue($this->region->contains($key));
         $this->assertNotNull($this->region->get($key));
-        $this->assertFileNotExists($file);
+        $this->assertFileDoesNotExist($file);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Decorator/EntityManagerDecoratorTest.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Decorator\EntityManagerDecorator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\VerifyDeprecations;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -35,7 +35,7 @@ class EntityManagerDecoratorTest extends TestCase
         'lock',
     ];
 
-    /** @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EntityManagerInterface|MockObject */
     private $wrapped;
 
     /** @before */

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -59,7 +59,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
     /**
      * @param <type> $query
      *
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnFirstResult($query): void
     {
@@ -76,7 +76,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
     /**
      * @param <type> $query
      *
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnMaxResults($query): void
     {
@@ -92,7 +92,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
     /**
      * @param <type> $query
      *
-     * @depends testQueryCache_DependsOnHints
+     * @depends testQueryCacheDependsOnHints
      */
     public function testQueryCacheDependsOnHydrationMode($query): void
     {
@@ -146,11 +146,16 @@ class QueryCacheTest extends OrmFunctionalTestCase
                       ->setMethods(['doFetch', 'doContains', 'doSave', 'doDelete', 'doFlush', 'doGetStats'])
                       ->getMock();
 
-        $cache->expects($this->at(0))->method('doFetch')->will($this->returnValue(1));
-        $cache->expects($this->at(1))
-              ->method('doFetch')
-              ->with($this->isType('string'))
-              ->will($this->returnValue($parserResultMock));
+        $cache->expects($this->exactly(2))
+            ->method('doFetch')
+            ->withConsecutive(
+                [$this->isType('string')],
+                [$this->isType('string')]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->returnValue(1),
+                $this->returnValue($parserResultMock)
+            );
 
         $cache->expects($this->never())
               ->method('doSave');

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2359Test.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 
 use function assert;
 
@@ -34,7 +34,7 @@ class DDC2359Test extends TestCase
         $metadataFactory = $this->getMockBuilder(ClassMetadataFactory::class)
                                 ->setMethods(['newClassMetadataInstance', 'wakeupReflection'])
                                 ->getMock();
-        assert($metadataFactory instanceof ClassMetadataFactory || $metadataFactory instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($metadataFactory instanceof ClassMetadataFactory || $metadataFactory instanceof MockObject);
 
         $configuration = $this->getMockBuilder(Configuration::class)
                               ->setMethods(['getMetadataDriverImpl'])

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6464Test.php
@@ -36,7 +36,7 @@ class GH6464Test extends OrmFunctionalTestCase
             ->innerJoin(GH6464Author::class, 'a', 'WITH', 'p.authorId = a.id')
             ->getQuery();
 
-        $this->assertNotRegExp(
+        $this->assertDoesNotMatchRegularExpression(
             '/INNER JOIN \w+ \w+ INNER JOIN/',
             $query->getSQL(),
             'As of GH-6464, every INNER JOIN should have an ON clause, which is missing here'

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8061Test.php
@@ -26,7 +26,7 @@ final class GH8061Test extends OrmTestCase
         $entityManager = $this->getTestEntityManager();
         $query         = $entityManager->createQuery($dql);
 
-        self::assertRegExp('/SELECT DatabaseFunction\(\w+\.field\) AS /', $query->getSQL());
+        self::assertMatchesRegularExpression('/SELECT DatabaseFunction\(\w+\.field\) AS /', $query->getSQL());
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/AbstractHydratorTest.php
@@ -13,7 +13,7 @@ use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 
 use function iterator_to_array;
 
@@ -22,13 +22,13 @@ use function iterator_to_array;
  */
 class AbstractHydratorTest extends OrmFunctionalTestCase
 {
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $mockEventManager;
 
-    /** @var Statement|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Statement|MockObject */
     private $mockStatement;
 
-    /** @var ResultSetMapping|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ResultSetMapping|MockObject */
     private $mockResultMapping;
 
     /** @var AbstractHydrator */

--- a/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
+++ b/tests/Doctrine/Tests/ORM/Internal/HydrationCompleteHandlerTest.php
@@ -28,8 +28,8 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Internal\HydrationCompleteHandler;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
 
 use function assert;
@@ -42,10 +42,10 @@ use function in_array;
  */
 class HydrationCompleteHandlerTest extends TestCase
 {
-    /** @var ListenersInvoker|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ListenersInvoker|MockObject */
     private $listenersInvoker;
 
-    /** @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EntityManagerInterface|MockObject */
     private $entityManager;
 
     /** @var HydrationCompleteHandler */

--- a/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/LazyCriteriaCollectionTest.php
@@ -8,8 +8,8 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\LazyCriteriaCollection;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
 
 /**
@@ -17,7 +17,7 @@ use stdClass;
  */
 class LazyCriteriaCollectionTest extends TestCase
 {
-    /** @var EntityPersister|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EntityPersister|MockObject */
     private $persister;
 
     /** @var Criteria */

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -141,14 +141,18 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $cmf    = new ClassMetadataFactory();
         $driver = $this->createMock(MappingDriver::class);
-        $driver->expects($this->at(0))
-               ->method('isTransient')
-               ->with($this->equalTo(CmsUser::class))
-               ->will($this->returnValue(true));
-        $driver->expects($this->at(1))
-               ->method('isTransient')
-               ->with($this->equalTo(CmsArticle::class))
-               ->will($this->returnValue(false));
+        $driver->expects($this->exactly(2))
+            ->method('isTransient')
+            ->withConsecutive(
+                [CmsUser::class],
+                [CmsArticle::class]
+            )
+            ->willReturnMap(
+                [
+                    [CmsUser::class, true],
+                    [CmsArticle::class, false],
+                ]
+            );
 
         $em = $this->createEntityManager($driver);
 
@@ -163,14 +167,18 @@ class ClassMetadataFactoryTest extends OrmTestCase
     {
         $cmf    = new ClassMetadataFactory();
         $driver = $this->createMock(MappingDriver::class);
-        $driver->expects($this->at(0))
-               ->method('isTransient')
-               ->with($this->equalTo(CmsUser::class))
-               ->will($this->returnValue(true));
-        $driver->expects($this->at(1))
-               ->method('isTransient')
-               ->with($this->equalTo(CmsArticle::class))
-               ->will($this->returnValue(false));
+        $driver->expects($this->exactly(2))
+            ->method('isTransient')
+            ->withConsecutive(
+                [CmsUser::class],
+                [CmsArticle::class]
+            )
+            ->willReturnMap(
+                [
+                    [CmsUser::class, true],
+                    [CmsArticle::class, false],
+                ]
+            );
 
         $em = $this->createEntityManager($driver);
         $em->getConfiguration()->addEntityNamespace('CMS', 'Doctrine\Tests\Models\CMS');

--- a/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Reflection/ReflectionPropertiesGetterTest.php
@@ -9,8 +9,8 @@ use Doctrine\Persistence\Mapping\ReflectionService;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\Reflection\ClassWithMixedProperties;
 use Doctrine\Tests\Models\Reflection\ParentClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass;
 
 use function assert;
@@ -95,7 +95,7 @@ class ReflectionPropertiesGetterTest extends TestCase
     public function testPropertyGetterWillSkipPropertiesNotRetrievedByTheRuntimeReflectionService(): void
     {
         $reflectionService = $this->createMock(ReflectionService::class);
-        assert($reflectionService instanceof ReflectionService || $reflectionService instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($reflectionService instanceof ReflectionService || $reflectionService instanceof MockObject);
 
         $reflectionService
             ->expects($this->exactly(2))
@@ -118,7 +118,7 @@ class ReflectionPropertiesGetterTest extends TestCase
     public function testPropertyGetterWillSkipClassesNotRetrievedByTheRuntimeReflectionService(): void
     {
         $reflectionService = $this->createMock(ReflectionService::class);
-        assert($reflectionService instanceof ReflectionService || $reflectionService instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($reflectionService instanceof ReflectionService || $reflectionService instanceof MockObject);
 
         $reflectionService
             ->expects($this->once())

--- a/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/PersistentCollectionTest.php
@@ -13,7 +13,7 @@ use Doctrine\Tests\Mocks\EntityManagerMock;
 use Doctrine\Tests\Models\ECommerce\ECommerceCart;
 use Doctrine\Tests\Models\ECommerce\ECommerceProduct;
 use Doctrine\Tests\OrmTestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 use function array_keys;
@@ -153,7 +153,7 @@ class PersistentCollectionTest extends OrmTestCase
     public function testWillKeepNewItemsInDirtyCollectionAfterInitialization(): void
     {
         $unitOfWork = $this->createMock(UnitOfWork::class);
-        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof MockObject);
 
         $this->_emMock->setUnitOfWork($unitOfWork);
 
@@ -188,7 +188,7 @@ class PersistentCollectionTest extends OrmTestCase
     public function testWillDeDuplicateNewItemsThatWerePreviouslyPersistedInDirtyCollectionAfterInitialization(): void
     {
         $unitOfWork = $this->createMock(UnitOfWork::class);
-        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof MockObject);
 
         $this->_emMock->setUnitOfWork($unitOfWork);
 
@@ -232,7 +232,7 @@ class PersistentCollectionTest extends OrmTestCase
     public function testWillNotMarkCollectionAsDirtyAfterInitializationIfNoElementsWereAdded(): void
     {
         $unitOfWork = $this->createMock(UnitOfWork::class);
-        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($unitOfWork instanceof UnitOfWork || $unitOfWork instanceof MockObject);
 
         $this->_emMock->setUnitOfWork($unitOfWork);
 

--- a/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Repository/DefaultRepositoryFactoryTest.php
@@ -10,8 +10,8 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
 use Doctrine\Tests\Models\DDC753\DDC753DefaultRepository;
 use Doctrine\Tests\Models\DDC869\DDC869PaymentRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 
 use function assert;
 
@@ -22,10 +22,10 @@ use function assert;
  */
 class DefaultRepositoryFactoryTest extends TestCase
 {
-    /** @var EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EntityManagerInterface|MockObject */
     private $entityManager;
 
-    /** @var Configuration|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Configuration|MockObject */
     private $configuration;
 
     /** @var DefaultRepositoryFactory */
@@ -108,14 +108,14 @@ class DefaultRepositoryFactoryTest extends TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|ClassMetadata
+     * @return MockObject|ClassMetadata
      *
      * @private
      */
     public function buildClassMetadata(string $className)
     {
         $metadata = $this->createMock(ClassMetadata::class);
-        assert($metadata instanceof ClassMetadata || $metadata instanceof PHPUnit_Framework_MockObject_MockObject);
+        assert($metadata instanceof ClassMetadata || $metadata instanceof MockObject);
 
         $metadata->expects($this->any())->method('getName')->will($this->returnValue($className));
 
@@ -125,7 +125,7 @@ class DefaultRepositoryFactoryTest extends TestCase
     }
 
     /**
-     * @return EntityManagerInterface|PHPUnit_Framework_MockObject_MockObject
+     * @return EntityManagerInterface|MockObject
      */
     private function createEntityManager(): EntityManagerInterface
     {

--- a/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityGeneratorTest.php
@@ -1209,7 +1209,7 @@ class
         $docComment = $property->getDocComment();
         $regex      = '/@var\s+([\S]+)$/m';
 
-        $this->assertRegExp($regex, $docComment);
+        $this->assertMatchesRegularExpression($regex, $docComment);
         $this->assertEquals(1, preg_match($regex, $docComment, $matches));
         $this->assertEquals($type, $matches[1]);
     }
@@ -1219,7 +1219,7 @@ class
         $docComment = $method->getDocComment();
         $regex      = '/@return\s+([\S]+)(\s+.*)$/m';
 
-        $this->assertRegExp($regex, $docComment);
+        $this->assertMatchesRegularExpression($regex, $docComment);
         $this->assertEquals(1, preg_match($regex, $docComment, $matches));
         $this->assertEquals($type, $matches[1]);
     }

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/PaginatorTest.php
@@ -62,19 +62,14 @@ class PaginatorTest extends OrmTestCase
         $query->setMaxResults(1);
         $paginator = (new Paginator($query, true))->setUseOutputWalkers(false);
 
-        $this->connection->expects($this->exactly(3))->method('executeQuery');
-
-        $this->connection->expects($this->at(0))
+        $this->connection
+            ->expects($this->exactly(3))
             ->method('executeQuery')
-            ->with($this->anything(), [$paramInWhere]);
-
-        $this->connection->expects($this->at(1))
-            ->method('executeQuery')
-            ->with($this->anything(), [$paramInWhere]);
-
-        $this->connection->expects($this->at(2))
-            ->method('executeQuery')
-            ->with($this->anything(), [$paramInSubSelect, $paramInWhere, $returnedIds]);
+            ->withConsecutive(
+                [$this->anything(), [$paramInWhere]],
+                [$this->anything(), [$paramInWhere]],
+                [$this->anything(), [$paramInSubSelect, $paramInWhere, $returnedIds]]
+            );
 
         $paginator->count();
         $paginator->getIterator();

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -27,7 +27,7 @@ use Doctrine\Tests\Models\Forum\ForumUser;
 use Doctrine\Tests\Models\GeoNames\City;
 use Doctrine\Tests\Models\GeoNames\Country;
 use Doctrine\Tests\OrmTestCase;
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 
 use function assert;
@@ -64,7 +64,7 @@ class UnitOfWorkTest extends OrmTestCase
      */
     private $_emMock;
 
-    /** @var EventManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var EventManager|MockObject */
     private $eventManager;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
@@ -22,7 +22,7 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $classMetadata->name               = 'Some\Class\Name';
         $classMetadata->discriminatorValue = 'discriminator';
 
-        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $em = $this->createMock(EntityManagerInterface::class);
         $em->expects($this->exactly(2))
             ->method('getClassMetadata')
             ->willReturnMap(
@@ -46,7 +46,7 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $classMetadata->name               = 'Some\Class\Name';
         $classMetadata->discriminatorValue = 'discriminator';
 
-        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $em = $this->createMock(EntityManagerInterface::class);
         $em->expects($this->exactly(1))
             ->method('getClassMetadata')
             ->with($classMetadata->name)

--- a/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
+++ b/tests/Doctrine/Tests/ORM/Utility/HierarchyDiscriminatorResolverTest.php
@@ -22,15 +22,17 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $classMetadata->name               = 'Some\Class\Name';
         $classMetadata->discriminatorValue = 'discriminator';
 
-        $em = $this->prophesize(EntityManagerInterface::class);
-        $em->getClassMetadata($classMetadata->name)
-            ->shouldBeCalled()
-            ->willReturn($classMetadata);
-        $em->getClassMetadata($childClassMetadata->name)
-            ->shouldBeCalled()
-            ->willReturn($childClassMetadata);
+        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $em->expects($this->exactly(2))
+            ->method('getClassMetadata')
+            ->willReturnMap(
+                [
+                    [$classMetadata->name, $classMetadata],
+                    [$childClassMetadata->name, $childClassMetadata],
+                ]
+            );
 
-        $discriminators = HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($classMetadata, $em->reveal());
+        $discriminators = HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($classMetadata, $em);
 
         $this->assertCount(2, $discriminators);
         $this->assertArrayHasKey($classMetadata->discriminatorValue, $discriminators);
@@ -44,12 +46,13 @@ class HierarchyDiscriminatorResolverTest extends TestCase
         $classMetadata->name               = 'Some\Class\Name';
         $classMetadata->discriminatorValue = 'discriminator';
 
-        $em = $this->prophesize(EntityManagerInterface::class);
-        $em->getClassMetadata($classMetadata->name)
-            ->shouldBeCalled()
+        $em = $this->getMockBuilder(EntityManagerInterface::class)->getMock();
+        $em->expects($this->exactly(1))
+            ->method('getClassMetadata')
+            ->with($classMetadata->name)
             ->willReturn($classMetadata);
 
-        $discriminators = HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($classMetadata, $em->reveal());
+        $discriminators = HierarchyDiscriminatorResolver::resolveDiscriminatorsForClass($classMetadata, $em);
 
         $this->assertCount(1, $discriminators);
         $this->assertArrayHasKey($classMetadata->discriminatorValue, $discriminators);

--- a/tests/Doctrine/Tests/PHPUnit8PolyfilledTestCase.php
+++ b/tests/Doctrine/Tests/PHPUnit8PolyfilledTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Adds methods for phpunit 8 that were introduced / renamed in later versions
+ */
+class PHPUnit8PolyfilledTestCase extends TestCase
+{
+    public static function assertDoesNotMatchRegularExpression(
+        string $pattern,
+        string $string,
+        string $message = ''
+    ): void {
+        self::assertNotRegExp($pattern, $string, $message);
+    }
+
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        self::assertRegExp($pattern, $string, $message);
+    }
+
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        self::assertFileNotExists($filename, $message);
+    }
+}

--- a/tests/Doctrine/Tests/PolyfillableTestCase.php
+++ b/tests/Doctrine/Tests/PolyfillableTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
+
+use function class_alias;
+use function preg_match;
+
+/**
+ * This provides a forward-compatibility layer so that test cases can always call methods from the
+ * latest-supported phpunit version, while still running on older versions.
+ */
+
+if (preg_match('/^8\./', Version::series())) {
+    class_alias(PHPUnit8PolyfilledTestCase::class, 'Doctrine\Tests\PolyfillableTestCase');
+} else {
+    // No polyfill required for this PHPUnit version - just alias the default PHPUnit TestCase class
+    class_alias(TestCase::class, 'Doctrine\Tests\PolyfillableTestCase');
+}


### PR DESCRIPTION
Some tests were still using deprecated assertion and mocking methods,
resulting in a long list of warnings in the phpunit output.

This commit resolves all the warnings:

* Fixes a couple of test names in `@depends` tags (presumably these
  tests were renamed at some point for coding standards).

* Changes how mocks are configured when asserting the same method
  is called multiple times with a sequence of arguments / sequence
  of return values. The old `->at` expectation is deprecated because
  it can be brittle and give unreliable results. Some of this
  mocking could probably still be refactored further, but my focus
  was on solving the deprecation with the existing setup.

* Removes one use of prophecy for mocking, in favour of using
  phpunit mock objects. Prophecy now requires an extra composer
  dependency and a trait which seems overkill given it was only
  used in one place.

* Updates to the new names for assertFileExists and assertRegExp
  (and their `not` versions) - these are functionally equivalent.

* Replaces the last few references to old PHPUnit_Framework_XXX
  classes with their namespaced equivalent. These were mostly in
  comments, or in native php `assert()` statements that were sanity
  checking mocked object types. These asserts are probably redundant
  (and are clearly not running in CI since the classes they referenced
  no longer exist).