### PR TITLE
Bump doctrine/deprecations to at least v0.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.10.0",
-        "doctrine/deprecations": "^0.2.0",
+        "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4|^2.0",
         "doctrine/instantiator": "^1.3",


### PR DESCRIPTION
This will be necessary to ensure compatibility with DBAL 2.13 once https://github.com/doctrine/dbal/pull/4535 is merged.