### PR TITLE
Query::toIterable() should support mixed result queries with scalar mappings

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -264,10 +264,6 @@ abstract class AbstractHydrator
             ->removeEventListener([Events::onClear], $this);
     }
 
-    protected function cleanupAfterRowIteration(): void
-    {
-    }
-
     /**
      * Hydrates a single row from the current statement instance.
      *

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -157,35 +157,10 @@ abstract class AbstractHydrator
      */
     public function toIterable(ResultStatement $stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
     {
-        $this->_stmt  = $stmt;
-        $this->_rsm   = $resultSetMapping;
-        $this->_hints = $hints;
-
-        $evm = $this->_em->getEventManager();
-
-        $evm->addEventListener([Events::onClear], $this);
-
-        $this->prepare();
-
-        while (true) {
-            $row = $this->_stmt->fetch(FetchMode::ASSOCIATIVE);
-
-            if ($row === false || $row === null) {
-                $this->cleanup();
-
-                break;
-            }
-
-            $result = [];
-
-            $this->hydrateRowData($row, $result);
-
-            $this->cleanupAfterRowIteration();
-
-            if (count($result) === 1) {
-                yield end($result);
-            } else {
-                yield $result;
+        foreach ($this->iterate($stmt, $resultSetMapping, $hints) as $results) {
+            assert(count($results) === 1);
+            foreach ($results as $key => $row) {
+                yield $key => $row;
             }
         }
     }

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -32,9 +32,9 @@ use Doctrine\ORM\UnitOfWork;
 use PDO;
 use ReflectionClass;
 
-use function assert;
 use function array_map;
 use function array_merge;
+use function assert;
 use function count;
 use function in_array;
 use function trigger_error;

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -135,17 +135,7 @@ abstract class AbstractHydrator
             E_USER_DEPRECATED
         );
 
-        $this->_stmt  = $stmt;
-        $this->_rsm   = $resultSetMapping;
-        $this->_hints = $hints;
-
-        $evm = $this->_em->getEventManager();
-
-        $evm->addEventListener([Events::onClear], $this);
-
-        $this->prepare();
-
-        return new IterableResult($this);
+        return $this->doIterate($stmt, $resultSetMapping, $hints);
     }
 
     /**
@@ -157,12 +147,27 @@ abstract class AbstractHydrator
      */
     public function toIterable(ResultStatement $stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
     {
-        foreach ($this->iterate($stmt, $resultSetMapping, $hints) as $results) {
+        foreach ($this->doIterate($stmt, $resultSetMapping, $hints) as $results) {
             assert(count($results) === 1);
             foreach ($results as $key => $row) {
                 yield $key => $row;
             }
         }
+    }
+
+    private function doIterate(object $stmt, object $resultSetMapping, array $hints = []): IterableResult
+    {
+        $this->_stmt  = $stmt;
+        $this->_rsm   = $resultSetMapping;
+        $this->_hints = $hints;
+
+        $evm = $this->_em->getEventManager();
+
+        $evm->addEventListener([Events::onClear], $this);
+
+        $this->prepare();
+
+        return new IterableResult($this);
     }
 
     /**

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -21,7 +21,6 @@
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\DBAL\Driver\ResultStatement;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,10 +32,10 @@ use Doctrine\ORM\UnitOfWork;
 use PDO;
 use ReflectionClass;
 
+use function assert;
 use function array_map;
 use function array_merge;
 use function count;
-use function end;
 use function in_array;
 use function trigger_error;
 
@@ -155,6 +154,9 @@ abstract class AbstractHydrator
         }
     }
 
+    /**
+     * @psalm-param array<string, mixed> $hints
+     */
     private function doIterate(object $stmt, object $resultSetMapping, array $hints = []): IterableResult
     {
         $this->_stmt  = $stmt;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -141,14 +141,6 @@ class ObjectHydrator extends AbstractHydrator
         $this->_uow->hydrationComplete();
     }
 
-    protected function cleanupAfterRowIteration(): void
-    {
-        $this->identifierMap          =
-        $this->initializedCollections =
-        $this->existingCollections    =
-        $this->resultPointers         = [];
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Fix #8520 and supersedes #8467.

`AbstractHydrator::toIterable` reuses `AbstractHydrator::iterate` which had as only problem , as far as I know, weirdly normalized data. The real cause here is `AbstractHydrator::hydrateRow`, but since it is not internal, it could not be fixed. Therefore, `AbstractHydrator::toIterable` normalizes rows returned by `AbstractHydrator::iterate`.
