### PR TITLE
SimpleObjectHydrator: skip unsuit custom type before convert it

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -133,6 +133,11 @@ class SimpleObjectHydrator extends AbstractHydrator
                 continue;
             }
 
+            // If we have inheritance in resultset, make sure the field belongs to the correct class
+            if (isset($cacheKeyInfo['discriminatorValues']) && ! in_array((string) $discrColumnValue, $cacheKeyInfo['discriminatorValues'], true)) {
+                continue;
+            }
+
             // Check if value is null before conversion (because some types convert null to something else)
             $valueIsNull = $value === null;
 
@@ -146,11 +151,6 @@ class SimpleObjectHydrator extends AbstractHydrator
 
             // Prevent overwrite in case of inherit classes using same property name (See AbstractHydrator)
             if (! isset($data[$fieldName]) || ! $valueIsNull) {
-                // If we have inheritance in resultset, make sure the field belongs to the correct class
-                if (isset($cacheKeyInfo['discriminatorValues']) && ! in_array((string) $discrColumnValue, $cacheKeyInfo['discriminatorValues'], true)) {
-                    continue;
-                }
-
                 $data[$fieldName] = $value;
             }
         }

--- a/tests/Doctrine/Tests/DbalTypes/GH8565EmployeePayloadType.php
+++ b/tests/Doctrine/Tests/DbalTypes/GH8565EmployeePayloadType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
+use Exception;
+
+class GH8565EmployeePayloadType extends JsonType
+{
+    public const NAME = 'GH8565EmployeePayloadType';
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): string
+    {
+        if (! isset($value['GH8565EmployeePayloadRequiredField'])) {
+            throw new Exception('GH8565EmployeePayloadType cannot be initialized without required field');
+        }
+
+        return $value['GH8565EmployeePayloadRequiredField'];
+    }
+}

--- a/tests/Doctrine/Tests/DbalTypes/GH8565ManagerPayloadType.php
+++ b/tests/Doctrine/Tests/DbalTypes/GH8565ManagerPayloadType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\DbalTypes;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
+
+class GH8565ManagerPayloadType extends JsonType
+{
+    public const NAME = 'GH8565ManagerPayloadType';
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): string
+    {
+        return $value;
+    }
+}

--- a/tests/Doctrine/Tests/Models/GH8565/GH8565Employee.php
+++ b/tests/Doctrine/Tests/Models/GH8565/GH8565Employee.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH8565;
+
+use Doctrine\Tests\DbalTypes\GH8565EmployeePayloadType;
+
+/**
+ * @Entity
+ * @Table(name="gh8565_employees")
+ */
+class GH8565Employee extends GH8565Person
+{
+    /**
+     * @Column(type="GH8565EmployeePayloadType", nullable=false)
+     * @var GH8565EmployeePayloadType
+     */
+    public $type;
+}

--- a/tests/Doctrine/Tests/Models/GH8565/GH8565Manager.php
+++ b/tests/Doctrine/Tests/Models/GH8565/GH8565Manager.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH8565;
+
+use Doctrine\Tests\DbalTypes\GH8565ManagerPayloadType;
+
+/**
+ * @Entity
+ * @Table(name="gh8565_managers")
+ */
+class GH8565Manager extends GH8565Person
+{
+    /**
+     * @Column(type="GH8565ManagerPayloadType", nullable=false)
+     * @var GH8565ManagerPayloadType
+     */
+    public $type;
+}

--- a/tests/Doctrine/Tests/Models/GH8565/GH8565Person.php
+++ b/tests/Doctrine/Tests/Models/GH8565/GH8565Person.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\GH8565;
+
+/**
+ * @Entity
+ * @Table(name="gh8565_persons")
+ * @InheritanceType("JOINED")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({
+ *      "person"    = "GH8565Person",
+ *      "manager"   = "GH8565Manager",
+ *      "employee"  = "GH8565Employee"
+ * })
+ */
+class GH8565Person
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+}


### PR DESCRIPTION
SimpleObjectHydrator tries to convert the value, and only then checks if we need it.
This results in an error if our custom type does not get expected data to initialize php value.