### PR TITLE
Add ignoreDuplicates option for ManyToMany relations

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -508,6 +508,7 @@
     <xs:attribute name="index-by" type="xs:NMTOKEN" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
     <xs:attribute name="orphan-removal" type="xs:boolean" default="false" />
+    <xs:attribute name="ignore-duplicates" type="xs:boolean" default="false" />
     <xs:anyAttribute namespace="##other"/>
   </xs:complexType>
 

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -46,6 +46,18 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     }
 
     /**
+     * @param bool $name
+     *
+     * @return static
+     */
+    public function setIgnoreDuplicates($ignoreDuplicates)
+    {
+        $this->mapping['ignoreDuplicates'] = $ignoreDuplicates;
+
+        return $this;
+    }
+
+    /**
      * Adds Inverse Join Columns.
      *
      * @param string      $columnName

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1962,6 +1962,7 @@ class ClassMetadataInfo implements ClassMetadata
         }
 
         $mapping['orphanRemoval'] = isset($mapping['orphanRemoval']) && $mapping['orphanRemoval'];
+        $mapping['ignoreDuplicates'] = isset($mapping['ignoreDuplicates']) && $mapping['ignoreDuplicates'];
 
         $this->assertMappingOrderBy($mapping);
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -575,6 +575,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
             $mapping['inversedBy']    = $manyToManyAnnot->inversedBy;
             $mapping['cascade']       = $manyToManyAnnot->cascade;
             $mapping['indexBy']       = $manyToManyAnnot->indexBy;
+            $mapping['ignoreDuplicates'] = $manyToManyAnnot->ignoreDuplicates;
             $mapping['orphanRemoval'] = $manyToManyAnnot->orphanRemoval;
             $mapping['fetch']         = $this->getFetchMode($className, $manyToManyAnnot->fetch);
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -322,6 +322,7 @@ class AttributeDriver extends AnnotationDriver
                 $mapping['inversedBy']    = $manyToManyAttribute->inversedBy;
                 $mapping['cascade']       = $manyToManyAttribute->cascade;
                 $mapping['indexBy']       = $manyToManyAttribute->indexBy;
+                $mapping['ignoreDuplicates'] = $manyToManyAttribute->ignoreDuplicates;
                 $mapping['orphanRemoval'] = $manyToManyAttribute->orphanRemoval;
                 $mapping['fetch']         = $this->getFetchMode($className, $manyToManyAttribute->fetch);
 

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -522,6 +522,10 @@ class XmlDriver extends FileDriver
                     $mapping['orphanRemoval'] = $this->evaluateBoolean($manyToManyElement['orphan-removal']);
                 }
 
+                if (isset($manyToManyElement['ignore-duplicates'])) {
+                    $mapping['ignoreDuplicates'] = $this->evaluateBoolean($manyToManyElement['ignore-duplicates']);
+                }
+
                 if (isset($manyToManyElement['mapped-by'])) {
                     $mapping['mappedBy'] = (string) $manyToManyElement['mapped-by'];
                 } elseif (isset($manyToManyElement->{'join-table'})) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -576,6 +576,10 @@ class YamlDriver extends FileDriver
                     $mapping['orphanRemoval'] = (bool) $manyToManyElement['orphanRemoval'];
                 }
 
+                if (isset($manyToManyElement['ignoreDuplicates'])) {
+                    $mapping['ignoreDuplicates'] = (bool) $manyToManyElement['ignoreDuplicates'];
+                }
+
                 // Evaluate second level cache
                 if (isset($manyToManyElement['cache'])) {
                     $mapping['cache'] = $metadata->getAssociationCacheDefaults($mapping['fieldName'], $this->cacheToArray($manyToManyElement['cache']));

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -57,6 +57,8 @@ final class ManyToMany implements Annotation
     /** @var string */
     public $indexBy;
 
+    public $ignoreDuplicates = false;
+
     /**
      * @param array<string> $cascade
      */
@@ -67,7 +69,8 @@ final class ManyToMany implements Annotation
         ?array $cascade = null,
         string $fetch = 'LAZY',
         bool $orphanRemoval = false,
-        ?string $indexBy = null
+        ?string $indexBy = null,
+        bool $ignoreDuplicates = false
     ) {
         $this->targetEntity  = $targetEntity;
         $this->mappedBy      = $mappedBy;
@@ -76,5 +79,6 @@ final class ManyToMany implements Annotation
         $this->fetch         = $fetch;
         $this->orphanRemoval = $orphanRemoval;
         $this->indexBy       = $indexBy;
+        $this->ignoreDuplicates = $ignoreDuplicates;
     }
 }

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -498,8 +498,13 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $types[]   = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
         }
 
+        $ignore = '';
+        if ($mapping['ignoreDuplicates']) {
+            $ignore = 'IGNORE'; // @todo
+        }
+
         return [
-            'INSERT INTO ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
+            'INSERT ' . $ignore . ' INTO ' . $this->quoteStrategy->getJoinTableName($mapping, $class, $this->platform)
             . ' (' . implode(', ', $columns) . ')'
             . ' VALUES'
             . ' (' . implode(', ', array_fill(0, count($columns), '?')) . ')',

--- a/tests/Doctrine/Tests/Models/CMS/CmsTag.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsTag.php
@@ -34,6 +34,11 @@ class CmsTag
      */
     public $users;
 
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
     public function setName(string $name): void
     {
         $this->name = $name;

--- a/tests/Doctrine/Tests/Models/CMS/CmsUser.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsUser.php
@@ -185,7 +185,7 @@ class CmsUser
 
     /**
      * @var Collection<int, CmsTag>
-     * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"all"})
+     * @ManyToMany(targetEntity="CmsTag", inversedBy="users", cascade={"all"}, ignoreDuplicates=true)
      * @JoinTable(name="cms_users_tags",
      *      joinColumns={@JoinColumn(name="user_id", referencedColumnName="id")},
      *      inverseJoinColumns={@JoinColumn(name="tag_id", referencedColumnName="id")}

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToManyIgnoreDuplicatesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToManyIgnoreDuplicatesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\Tests\Models\CMS\CmsTag;
+use Doctrine\Tests\Models\CMS\CmsUser;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+class ManyToManyIgnoreDuplicatesTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        $this->useModelSet('cms');
+        parent::setUp();
+    }
+
+    public function testDuplicateInsertionDoesNotResultInException()
+    {
+        $user           = new CmsUser();
+        $user->name     = 'Maciej';
+        $user->username = 'malarzm';
+        $user->status   = 'developer';
+        $this->_em->persist($user);
+
+        $tag = new CmsTag();
+        $tag->setName('A tag');
+        $this->_em->persist($tag);
+        $this->_em->flush();
+
+        $concurrentEm = $this->getEntityManager();
+        /** @var CmsUser $concurrentUser */
+        $concurrentUser = $concurrentEm->find(CmsUser::class, $user->getId());
+        $concurrentTag = $concurrentEm->find(CmsTag::class, $tag->getId());
+        self::assertEmpty($concurrentUser->tags);
+
+        $user->addTag($tag);
+        $this->_em->flush();
+        self::assertCount(1, $user->tags);
+
+        $concurrentUser->addTag($concurrentTag);
+        $concurrentEm->flush();
+        self::assertCount(1, $concurrentUser->tags);
+
+        $this->_em->clear();
+        $refreshedUser = $this->_em->find(CmsUser::class, $user->getId());
+        self::assertCount(1, $refreshedUser->tags);
+        self::assertSame($tag->getName(), $refreshedUser->tags->first()->getName());
+    }
+}


### PR DESCRIPTION
Background: our e-commerce has something called "manual categories" where operators upload a literal ton of products (like 70k). From mapping's perspective it's a simple ManyToMany relation. The process is straightforward for the operators, they upload a CSV file with a list of product codes they want to have in said category. Uploaded file gets chunked into parts and then digested asynchronously. Sadly, it happens that there are either duplicates in different chunks, or people are too eager and are uploading same file twice. Anyhow, we end up having to check whether a product was already associated (which is slow and generates a lot of queries) and even that we can't be sure that there is no concurrent worker trying to do something similar. If there is, we get a `Duplicate entry` exception thrown and entire processed batch needs to be redone. We'd be more than happy to let ORM know that we don't give a flying duck about duplicates, we're just happy the association is there and so should be ORM. Effectively this means using `INSERT IGNORE` (or other flavours) for insertion to the join table.

Out of all platforms ORM supports officially it seems that Oracle and Microsoft SQL Server don't have an easy way of doing `INSERT IGNORE` but rather some wierd `MERGE` thingies. Since the feature is an opt-in we could throw a runtime error when `ignoreDuplicates` is used, or maybe there is an option to validate mapping against used platform. I'll appreciate an opinion on where to go with this.

Final note: Ignoring duplicates is crafted specifically for ManyToMany relationship and I have no intention of moving it elsewhere. It is done this way precisely because there is no use for `ON CONFLICT` clause and other things on a ManyToMany's join table as there are only two foreign keys - you can either have them inserted or not, no other fields to update.