### PR TITLE
Fix build issues

### DIFF
--- a/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/Command/ClearCacheCollectionRegionCommandTest.php
@@ -91,7 +91,7 @@ class ClearCacheCollectionRegionCommandTest extends OrmFunctionalTestCase
             $tester->getDisplay()
         );
 
-        self::assertStringContainsString(' // entity identified by "1"', $tester->getDisplay());
+        self::assertStringContainsString('identified by "1"', $tester->getDisplay());
     }
 
     public function testFlushRegionName(): void


### PR DESCRIPTION
Decorated text used to be wrapped too early in SymfonyStyle->block()
See https://github.com/symfony/symfony/pull/40348