### PR TITLE
Bump requirement to DBAL 2.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/cache": "^1.9.1",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
-        "doctrine/dbal": "^2.10.0",
+        "doctrine/dbal": "^2.13.0",
         "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.1",
         "doctrine/inflector": "^1.4|^2.0",


### PR DESCRIPTION
This updates Doctrine DBAL requirement to 2.13 - because of the PHP 7.1 dependency and to prepare for first steps to migrate to new from deprecated APIs.