### PR TITLE
Additional psalm param typehint for orderBy argument in findBy method

### DIFF
--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -185,7 +185,7 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param int|null $offset
      *
      * @psalm-param array<string, mixed> $criteria
-     * @psalm-param list<string>|null $orderBy
+     * @psalm-param array<string, string>|null $orderBy
      * @psalm-return list<T> The objects.
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -273,8 +273,8 @@ interface EntityPersister
      * @param int|null $limit
      * @param int|null $offset
      *
-     * @psalm-param list<string>|null $orderBy
-     * @psalm-param array<string, mixed> $criteria
+     * @psalm-param array<string, string>|null $orderBy
+     * @psalm-param array<string, mixed>       $criteria
      */
     public function loadAll(array $criteria = [], ?array $orderBy = null, $limit = null, $offset = null);
 


### PR DESCRIPTION
Because of `findBy([], ['somField' => 'DESC']...);`