### PR TITLE
Fix typed properties for default metadata (#7939)

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -539,7 +539,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="target-entity" type="xs:string" use="required" />
+    <xs:attribute name="target-entity" type="xs:string" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />
     <xs:anyAttribute namespace="##other"/>

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -557,7 +557,7 @@
       <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
     </xs:sequence>
     <xs:attribute name="field" type="xs:NMTOKEN" use="required" />
-    <xs:attribute name="target-entity" type="xs:string" use="required" />
+    <xs:attribute name="target-entity" type="xs:string" />
     <xs:attribute name="mapped-by" type="xs:NMTOKEN" />
     <xs:attribute name="inversed-by" type="xs:NMTOKEN" />
     <xs:attribute name="fetch" type="orm:fetch-type" default="LAZY" />

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1763,7 +1763,7 @@ class ClassMetadataInfo implements ClassMetadata
                     [
                         'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
-                        'nullable' => true
+                        'nullable' => true,
                     ],
                 ];
             }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1642,6 +1642,13 @@ class ClassMetadataInfo implements ClassMetadata
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
             $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
+        } elseif (isset($mapping['joinColumns'])) {
+            foreach ($mapping['joinColumns'] as &$joinColumn) {
+                if (! isset($joinColumn['nullable'])) {
+                    $joinColumn['nullable'] = true;
+                }
+            }
+            unset($joinColumn);
         }
 
         if (isset($mapping['targetEntity'])) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1642,14 +1642,6 @@ class ClassMetadataInfo implements ClassMetadata
 
         if ($this->isTypedProperty($mapping['fieldName'])) {
             $mapping = $this->validateAndCompleteTypedAssociationMapping($mapping);
-        } elseif (isset($mapping['joinColumns'])) {
-            foreach ($mapping['joinColumns'] as &$joinColumn) {
-                if (! isset($joinColumn['nullable'])) {
-                    $joinColumn['nullable'] = true;
-                }
-            }
-
-            unset($joinColumn);
         }
 
         if (isset($mapping['targetEntity'])) {
@@ -1771,6 +1763,7 @@ class ClassMetadataInfo implements ClassMetadata
                     [
                         'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
+                        'nullable' => true
                     ],
                 ];
             }
@@ -1786,6 +1779,10 @@ class ClassMetadataInfo implements ClassMetadata
                     } else {
                         $uniqueConstraintColumns[] = $joinColumn['name'];
                     }
+                }
+
+                if (! isset($joinColumn['nullable'])) {
+                    $joinColumn['nullable'] = true;
                 }
 
                 if (empty($joinColumn['name'])) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1648,6 +1648,7 @@ class ClassMetadataInfo implements ClassMetadata
                     $joinColumn['nullable'] = true;
                 }
             }
+
             unset($joinColumn);
         }
 

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -35,7 +35,7 @@ final class Column implements Annotation
     public $name;
 
     /** @var mixed */
-    public $type = 'string';
+    public $type;
 
     /** @var int */
     public $length;
@@ -57,8 +57,8 @@ final class Column implements Annotation
     /** @var bool */
     public $unique = false;
 
-    /** @var bool */
-    public $nullable = false;
+    /** @var bool|null */
+    public $nullable;
 
     /** @var array<string,mixed> */
     public $options = [];
@@ -71,12 +71,12 @@ final class Column implements Annotation
      */
     public function __construct(
         ?string $name = null,
-        string $type = 'string',
+        ?string $type = null,
         ?int $length = null,
         ?int $precision = null,
         ?int $scale = null,
         bool $unique = false,
-        bool $nullable = false,
+        ?bool $nullable = null,
         array $options = [],
         ?string $columnDefinition = null
     ) {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -327,10 +327,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
             // @Column, @OneToOne, @OneToMany, @ManyToOne, @ManyToMany
             $columnAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Column::class);
             if ($columnAnnot) {
-                if ($columnAnnot->type === null) {
-                    throw MappingException::propertyTypeIsRequired($className, $property->getName());
-                }
-
                 $mapping = $this->columnToArray($property->getName(), $columnAnnot);
 
                 $idAnnot = $this->reader->getPropertyAnnotation($property, Mapping\Id::class);

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -215,10 +215,6 @@ class AttributeDriver extends AnnotationDriver
             $embeddedAttribute   = $this->reader->getPropertyAnnotation($property, Mapping\Embedded::class);
 
             if ($columnAttribute !== null) {
-                if ($columnAttribute->type === null) {
-                    throw MappingException::propertyTypeIsRequired($className, $property->getName());
-                }
-
                 $mapping = $this->columnToArray($property->getName(), $columnAttribute);
 
                 if ($this->reader->getPropertyAnnotation($property, Mapping\Id::class)) {

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -366,8 +366,11 @@ class XmlDriver extends FileDriver
             foreach ($xmlRoot->{'one-to-one'} as $oneToOneElement) {
                 $mapping = [
                     'fieldName' => (string) $oneToOneElement['field'],
-                    'targetEntity' => (string) $oneToOneElement['target-entity'],
                 ];
+
+                if (isset($oneToOneElement['target-entity'])) {
+                    $mapping['targetEntity'] = (string) $oneToOneElement['target-entity'];
+                }
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -419,9 +422,12 @@ class XmlDriver extends FileDriver
             foreach ($xmlRoot->{'one-to-many'} as $oneToManyElement) {
                 $mapping = [
                     'fieldName' => (string) $oneToManyElement['field'],
-                    'targetEntity' => (string) $oneToManyElement['target-entity'],
                     'mappedBy' => (string) $oneToManyElement['mapped-by'],
                 ];
+
+                if (isset($oneToManyElement['target-entity'])) {
+                    $mapping['targetEntity'] = (string) $oneToManyElement['target-entity'];
+                }
 
                 if (isset($oneToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $oneToManyElement['fetch']);
@@ -466,8 +472,11 @@ class XmlDriver extends FileDriver
             foreach ($xmlRoot->{'many-to-one'} as $manyToOneElement) {
                 $mapping = [
                     'fieldName' => (string) $manyToOneElement['field'],
-                    'targetEntity' => (string) $manyToOneElement['target-entity'],
                 ];
+
+                if (isset($manyToOneElement['target-entity'])) {
+                    $mapping['targetEntity'] = (string) $manyToOneElement['target-entity'];
+                }
 
                 if (isset($associationIds[$mapping['fieldName']])) {
                     $mapping['id'] = true;
@@ -511,8 +520,11 @@ class XmlDriver extends FileDriver
             foreach ($xmlRoot->{'many-to-many'} as $manyToManyElement) {
                 $mapping = [
                     'fieldName' => (string) $manyToManyElement['field'],
-                    'targetEntity' => (string) $manyToManyElement['target-entity'],
                 ];
+
+                if (isset($manyToManyElement['target-entity'])) {
+                    $mapping['targetEntity'] = (string) $manyToManyElement['target-entity'];
+                }
 
                 if (isset($manyToManyElement['fetch'])) {
                     $mapping['fetch'] = constant('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . (string) $manyToManyElement['fetch']);

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -370,7 +370,7 @@ class YamlDriver extends FileDriver
             foreach ($element['oneToOne'] as $name => $oneToOneElement) {
                 $mapping = [
                     'fieldName' => $name,
-                    'targetEntity' => $oneToOneElement['targetEntity'],
+                    'targetEntity' => $oneToOneElement['targetEntity'] ?? null,
                 ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -465,7 +465,7 @@ class YamlDriver extends FileDriver
             foreach ($element['manyToOne'] as $name => $manyToOneElement) {
                 $mapping = [
                     'fieldName' => $name,
-                    'targetEntity' => $manyToOneElement['targetEntity'],
+                    'targetEntity' => $manyToOneElement['targetEntity'] ?? null,
                 ];
 
                 if (isset($associationIds[$mapping['fieldName']])) {

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -40,8 +40,8 @@ final class JoinColumn implements Annotation
     /** @var bool */
     public $unique = false;
 
-    /** @var bool */
-    public $nullable = true;
+    /** @var bool|null */
+    public $nullable;
 
     /** @var mixed */
     public $onDelete;
@@ -60,7 +60,7 @@ final class JoinColumn implements Annotation
         ?string $name = null,
         string $referencedColumnName = 'id',
         bool $unique = false,
-        bool $nullable = true,
+        ?bool $nullable = null,
         $onDelete = null,
         ?string $columnDefinition = null,
         ?string $fieldName = null

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -52,7 +52,7 @@ final class ManyToOne implements Annotation
      * @param array<string> $cascade
      */
     public function __construct(
-        string $targetEntity,
+        ?string $targetEntity = null,
         ?array $cascade = null,
         string $fetch = 'LAZY',
         ?string $inversedBy = null

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -382,12 +382,12 @@ class MappingException extends ORMException
     }
 
     /**
+     * @deprecated 2.9 no longer in use
+     *
      * @param string $className
      * @param string $propertyName
      *
      * @return MappingException
-     *
-     * @deprecated 2.9 no longer in use
      */
     public static function propertyTypeIsRequired($className, $propertyName)
     {

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -386,6 +386,8 @@ class MappingException extends ORMException
      * @param string $propertyName
      *
      * @return MappingException
+     *
+     * @deprecated 2.9 no longer in use
      */
     public static function propertyTypeIsRequired($className, $propertyName)
     {

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -63,9 +63,7 @@ class UserTyped
     #[ORM\OneToOne(cascade: ["persist"], orphanRemoval: true), ORM\JoinColumn]
     public CmsEmail $email;
 
-    /**
-     * @ManyToOne
-     */
+    /** @ManyToOne */
     #[ORM\ManyToOne]
     public ?CmsEmail $mainEmail;
 

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\TypedProperties;
 
+use Doctrine\ORM\Mapping as ORM;
+
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
@@ -13,40 +15,51 @@ use Doctrine\Tests\Models\CMS\CmsEmail;
  * @Entity
  * @Table(name="cms_users_typed")
  */
+#[ORM\Entity, ORM\Table(name: "cms_users_typed")]
 class UserTyped
 {
     /**
      * @Id @Column
      * @GeneratedValue
      */
+    #[ORM\Id, ORM\Column, ORM\GeneratedValue]
     public int $id;
     /** @Column(length=50) */
+    #[ORM\Column(length: 50)]
     public ?string $status;
 
     /** @Column(length=255, unique=true) */
+    #[ORM\Column(length: 255, unique: true)]
     public string $username;
 
     /** @Column */
+    #[ORM\Column]
     public DateInterval $dateInterval;
 
     /** @Column */
+    #[ORM\Column]
     public DateTime $dateTime;
 
     /** @Column */
+    #[ORM\Column]
     public DateTimeImmutable $dateTimeImmutable;
 
     /** @Column */
+    #[ORM\Column]
     public array $array;
 
     /** @Column */
+    #[ORM\Column]
     public bool $boolean;
 
     /** @Column */
+    #[ORM\Column]
     public float $float;
 
     /**
      * @OneToOne(cascade={"persist"}, orphanRemoval=true)
      * @JoinColumn
      */
+    #[ORM\OneToOne(cascade: ["persist"], orphanRemoval: true), ORM\JoinColumn]
     public CmsEmail $email;
 }

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\TypedProperties;
 
-use Doctrine\ORM\Mapping as ORM;
-
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 
@@ -93,34 +92,22 @@ class UserTyped
             ]
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'dateInterval',
-            ]
+            ['fieldName' => 'dateInterval']
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'dateTime',
-            ]
+            ['fieldName' => 'dateTime']
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'dateTimeImmutable',
-            ]
+            ['fieldName' => 'dateTimeImmutable']
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'array',
-            ]
+            ['fieldName' => 'array']
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'boolean',
-            ]
+            ['fieldName' => 'boolean']
         );
         $metadata->mapField(
-            [
-                'fieldName' => 'float',
-            ]
+            ['fieldName' => 'float']
         );
 
         $metadata->mapOneToOne(

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -63,6 +63,12 @@ class UserTyped
     #[ORM\OneToOne(cascade: ["persist"], orphanRemoval: true), ORM\JoinColumn]
     public CmsEmail $email;
 
+    /**
+     * @ManyToOne
+     */
+    #[ORM\ManyToOne]
+    public ?CmsEmail $mainEmail;
+
     public static function loadMetadata(ClassMetadataInfo $metadata): void
     {
         $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
@@ -122,6 +128,10 @@ class UserTyped
                     ],
                 'orphanRemoval' => true,
             ]
+        );
+
+        $metadata->mapManyToOne(
+            ['fieldName' => 'mainEmail']
         );
     }
 }

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Tests\Models\CMS\CmsEmail;
 
 /**
@@ -62,4 +63,78 @@ class UserTyped
      */
     #[ORM\OneToOne(cascade: ["persist"], orphanRemoval: true), ORM\JoinColumn]
     public CmsEmail $email;
+
+    public static function loadMetadata(ClassMetadataInfo $metadata): void
+    {
+        $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+        $metadata->setPrimaryTable(
+            ['name' => 'cms_users']
+        );
+
+        $metadata->mapField(
+            [
+                'id' => true,
+                'fieldName' => 'id',
+            ]
+        );
+        $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+
+        $metadata->mapField(
+            [
+                'fieldName' => 'status',
+                'length' => 50,
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'username',
+                'length' => 255,
+                'unique' => true,
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'dateInterval',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'dateTime',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'dateTimeImmutable',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'array',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'boolean',
+            ]
+        );
+        $metadata->mapField(
+            [
+                'fieldName' => 'float',
+            ]
+        );
+
+        $metadata->mapOneToOne(
+            [
+                'fieldName' => 'email',
+                'cascade' =>
+                    [0 => 'persist'],
+                'joinColumns' =>
+                    [
+                        0 =>
+                            [],
+                    ],
+                'orphanRemoval' => true,
+            ]
+        );
+    }
 }

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -68,7 +68,7 @@ class UserTyped
     {
         $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
         $metadata->setPrimaryTable(
-            ['name' => 'cms_users']
+            ['name' => 'cms_users_typed']
         );
 
         $metadata->mapField(

--- a/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
+++ b/tests/Doctrine/Tests/Models/TypedProperties/UserTyped.php
@@ -15,7 +15,7 @@ use Doctrine\Tests\Models\CMS\CmsEmail;
  * @Entity
  * @Table(name="cms_users_typed")
  */
-#[ORM\Entity, ORM\Table(name: "cms_users_typed")]
+#[ORM\Entity, ORM\Table(name: 'cms_users_typed')]
 class UserTyped
 {
     /**
@@ -60,7 +60,7 @@ class UserTyped
      * @OneToOne(cascade={"persist"}, orphanRemoval=true)
      * @JoinColumn
      */
-    #[ORM\OneToOne(cascade: ["persist"], orphanRemoval: true), ORM\JoinColumn]
+    #[ORM\OneToOne(cascade: ['persist'], orphanRemoval: true), ORM\JoinColumn]
     public CmsEmail $email;
 
     /** @ManyToOne */

--- a/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
@@ -158,6 +158,7 @@ class CascadeRemoveOrderEntityG
      *     targetEntity="Doctrine\Tests\ORM\Functional\CascadeRemoveOrderEntityO",
      *     inversedBy="oneToMany"
      * )
+     * @JoinColumn(nullable=true, onDelete="SET NULL")
      */
     private $ownerO;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -268,6 +268,9 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         // Join table Nullable
         $this->assertFalse($class->getAssociationMapping('email')['joinColumns'][0]['nullable']);
         $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
+
+        $this->assertTrue($class->getAssociationMapping('mainEmail')['joinColumns'][0]['nullable']);
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -53,6 +53,7 @@ use function strpos;
 use function strtolower;
 
 use const CASE_UPPER;
+use const PHP_VERSION_ID;
 
 abstract class AbstractMappingDriverTest extends OrmTestCase
 {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -21,6 +21,7 @@ use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\Cache\City;
 use Doctrine\Tests\Models\CMS\CmsAddress;
 use Doctrine\Tests\Models\CMS\CmsAddressListener;
+use Doctrine\Tests\Models\CMS\CmsEmail;
 use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\Models\Company\CompanyContract;
 use Doctrine\Tests\Models\Company\CompanyContractListener;
@@ -41,6 +42,7 @@ use Doctrine\Tests\Models\DDC889\DDC889Class;
 use Doctrine\Tests\Models\DDC889\DDC889Entity;
 use Doctrine\Tests\Models\DDC964\DDC964Admin;
 use Doctrine\Tests\Models\DDC964\DDC964Guest;
+use Doctrine\Tests\Models\TypedProperties\UserTyped;
 use Doctrine\Tests\OrmTestCase;
 
 use function assert;
@@ -246,6 +248,43 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertTrue($class->fieldMappings['name']['unique']);
 
         return $class;
+    }
+
+    public function testFieldIsNullableByType(): void
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('requies PHP 7.4');
+        }
+
+        $class = $this->createClassMetadata(UserTyped::class);
+
+        // Explicit Nullable
+        $this->assertTrue($class->isNullable('status'));
+
+        // Explicit Not Nullable
+        $this->assertFalse($class->isNullable('username'));
+
+        // Join table Nullable
+        $this->assertFalse($class->getAssociationMapping('email')['joinColumns'][0]['nullable']);
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
+    }
+
+    public function testFieldTypeFromReflection(): void
+    {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('requies PHP 7.4');
+        }
+
+        $class = $this->createClassMetadata(UserTyped::class);
+
+        $this->assertEquals('integer', $class->getTypeOfField('id'));
+        $this->assertEquals('string', $class->getTypeOfField('username'));
+        $this->assertEquals('dateinterval', $class->getTypeOfField('dateInterval'));
+        $this->assertEquals('datetime', $class->getTypeOfField('dateTime'));
+        $this->assertEquals('datetime_immutable', $class->getTypeOfField('dateTimeImmutable'));
+        $this->assertEquals('json', $class->getTypeOfField('array'));
+        $this->assertEquals('boolean', $class->getTypeOfField('boolean'));
+        $this->assertEquals('float', $class->getTypeOfField('float'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -132,6 +132,10 @@ class ClassMetadataTest extends OrmTestCase
         $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
         $this->assertFalse($cm->getAssociationMapping('email')['joinColumns'][0]['nullable']);
         $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
+
+        $cm->mapManyToOne(['fieldName' => 'mainEmail']);
+        $this->assertTrue($cm->getAssociationMapping('mainEmail')['joinColumns'][0]['nullable']);
+        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -3,9 +3,6 @@
 declare(strict_types=1);
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Doctrine\Tests\ORM\Mapping\Address;
-use Doctrine\Tests\ORM\Mapping\Group;
-use Doctrine\Tests\ORM\Mapping\Phonenumber;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -31,46 +31,29 @@ $metadata->mapField(
     ]
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'dateInterval',
-    ]
+    ['fieldName' => 'dateInterval']
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'dateTime',
-    ]
+    ['fieldName' => 'dateTime']
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'dateTimeImmutable',
-    ]
+    ['fieldName' => 'dateTimeImmutable']
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'array',
-    ]
+    ['fieldName' => 'array']
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'boolean',
-    ]
+    ['fieldName' => 'boolean']
 );
 $metadata->mapField(
-    [
-        'fieldName' => 'float',
-    ]
+    ['fieldName' => 'float']
 );
 
 $metadata->mapOneToOne(
     [
         'fieldName' => 'email',
-        'cascade' =>
-            [0 => 'persist'],
-        'joinColumns' =>
-            [
-                0 =>
-                    [],
-            ],
+        'cascade' => [0 => 'persist'],
+        'joinColumns' => [[]],
         'orphanRemoval' => true,
     ]
 );

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Tests\ORM\Mapping\Address;
+use Doctrine\Tests\ORM\Mapping\Group;
+use Doctrine\Tests\ORM\Mapping\Phonenumber;
+
+$metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
+$metadata->setPrimaryTable(
+    ['name' => 'cms_users']
+);
+
+$metadata->mapField(
+    [
+        'id' => true,
+        'fieldName' => 'id',
+    ]
+);
+$metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_AUTO);
+
+$metadata->mapField(
+    [
+        'fieldName' => 'status',
+        'length' => 50,
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'username',
+        'length' => 255,
+        'unique' => true,
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'dateInterval',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'dateTime',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'dateTimeImmutable',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'array',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'boolean',
+    ]
+);
+$metadata->mapField(
+    [
+        'fieldName' => 'float',
+    ]
+);
+
+$metadata->mapOneToOne(
+    [
+        'fieldName' => 'email',
+        'cascade' =>
+            [0 => 'persist'],
+        'joinColumns' =>
+            [
+                0 =>
+                    [],
+            ],
+        'orphanRemoval' => true,
+    ]
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -57,3 +57,7 @@ $metadata->mapOneToOne(
         'orphanRemoval' => true,
     ]
 );
+
+$metadata->mapManyToOne(
+    ['fieldName' => 'mainEmail']
+);

--- a/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/php/Doctrine.Tests.Models.TypedProperties.UserTyped.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 $metadata->setInheritanceType(ClassMetadataInfo::INHERITANCE_TYPE_NONE);
 $metadata->setPrimaryTable(
-    ['name' => 'cms_users']
+    ['name' => 'cms_users_typed']
 );
 
 $metadata->mapField(

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                          https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+  <entity name="Doctrine\Tests\Models\TypedProperties\UserTyped" table="cms_users_typed">
+    <id name="id">
+      <generator strategy="AUTO"/>
+    </id>
+
+    <field name="status" length="50"/>
+    <field name="username" length="255" unique="true"/>
+    <field name="dateInterval"/>
+    <field name="dateTime"/>
+    <field name="dateTimeImmutable"/>
+    <field name="array"/>
+    <field name="boolean"/>
+    <field name="float"/>
+
+    <one-to-one field="email" orphan-removal="true">
+      <cascade><cascade-persist /></cascade>
+      <join-column/>
+    </one-to-one>
+  </entity>
+</doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.xml
@@ -23,5 +23,7 @@
       <cascade><cascade-persist /></cascade>
       <join-column/>
     </one-to-one>
+
+    <many-to-one field="mainEmail"/>
   </entity>
 </doctrine-mapping>

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.yml
@@ -1,0 +1,24 @@
+Doctrine\Tests\Models\TypedProperties\UserTyped:
+    type: entity
+    table: cms_users_typed
+    id:
+        id:
+            generator:
+                strategy: AUTO
+    fields:
+        status:
+            length: 50
+        username:
+            length: 255
+            unique: true
+        dateInterval: ~
+        dateTime: ~
+        dateTimeImmutable: ~
+        array: ~
+        boolean: ~
+        float: ~
+    oneToOne:
+        email:
+            cascade: [ persist ]
+            orphanRemoval: true
+            joinColumn: []

--- a/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.yml
+++ b/tests/Doctrine/Tests/ORM/Mapping/yaml/Doctrine.Tests.Models.TypedProperties.UserTyped.dcm.yml
@@ -22,3 +22,5 @@ Doctrine\Tests\Models\TypedProperties\UserTyped:
             cascade: [ persist ]
             orphanRemoval: true
             joinColumn: []
+    manyToOne:
+        mainEmail: []


### PR DESCRIPTION
This is continuation of work from #7939. Tests for real life scenarios were missing therefore inheritance from typed properties wasn't running with metadata drivers.

This PR introduces such tests, adds metadata to test object for all drivers and makes small changes in drivers to adapt. Most needed changes were changing default value to null or removing `required` from not required XML attributes.