### PR TITLE
Fix phpdoc of ClassMetadataInfo::getIdentifierValues

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -748,7 +748,7 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param object $entity
      *
-     * @return array<string|int, mixed>
+     * @return array<string, mixed>
      */
     public function getIdentifierValues($entity)
     {


### PR DESCRIPTION
Hi @greg0ire, this will fixed a psalm issue from SonataDoctrineORM ;)

The keys of the returned array are the values of `$this->identifier` which is a `string[]`.
So `array<string|int, mixed>` should be `array<string, mixed>`