### PR TITLE
Return case insensitive check

### DIFF
--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -63,7 +63,7 @@ class Composite extends Base
         }
 
         // Fixes DDC-1237: User may have added a where item containing nested expression (with "OR" or "AND")
-        if (preg_match('/\s(OR|AND)\s/', $queryPart)) {
+        if (preg_match('/\s(OR|AND)\s/i', $queryPart)) {
             return $this->preSeparator . $queryPart . $this->postSeparator;
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -23,19 +23,25 @@ class AdvancedAssociationTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(Phrase::class),
-                    $this->_em->getClassMetadata(PhraseType::class),
-                    $this->_em->getClassMetadata(Definition::class),
-                    $this->_em->getClassMetadata(Lemma::class),
-                    $this->_em->getClassMetadata(Type::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(Phrase::class),
+            $this->_em->getClassMetadata(PhraseType::class),
+            $this->_em->getClassMetadata(Definition::class),
+            $this->_em->getClassMetadata(Lemma::class),
+            $this->_em->getClassMetadata(Type::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(Phrase::class),
+            $this->_em->getClassMetadata(PhraseType::class),
+            $this->_em->getClassMetadata(Definition::class),
+            $this->_em->getClassMetadata(Lemma::class),
+            $this->_em->getClassMetadata(Type::class),
+        ]);
     }
 
     public function testIssue(): void

--- a/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/AdvancedAssociationTest.php
@@ -9,7 +9,6 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\Tests\IterableTester;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function assert;
 use function count;

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesis.php
@@ -36,6 +36,7 @@ class QueryBuilderParenthesis extends OrmFunctionalTestCase
         $queryBuilder->select('o')->from(QueryBuilderParenthesisEntity::class, 'o');
         $queryBuilder->andWhere('o.property3 = :value3')->setParameter('value3', 'x');
         $queryBuilder->andWhere('o.property1 = :value1 OR o.property2 = :value2');
+        $queryBuilder->andWhere('o.property1 = :value1 or o.property2 = :value2');
         $queryBuilder->setParameter('value1', 'x');
         $queryBuilder->setParameter('value2', 'x');
 
@@ -46,7 +47,7 @@ class QueryBuilderParenthesis extends OrmFunctionalTestCase
         $dql = $query->getDQL();
 
         $this->assertSame(
-            'SELECT o FROM ' . QueryBuilderParenthesisEntity::class . ' o WHERE o.property3 = :value3 AND (o.property1 = :value1 OR o.property2 = :value2)',
+            'SELECT o FROM ' . QueryBuilderParenthesisEntity::class . ' o WHERE o.property3 = :value3 AND (o.property1 = :value1 OR o.property2 = :value2) AND (o.property1 = :value1 or o.property2 = :value2)',
             $dql
         );
     }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryBuilderParenthesisTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-class QueryBuilderParenthesis extends OrmFunctionalTestCase
+class QueryBuilderParenthesisTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC69Test.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function assert;
 
 /**
  * Functional tests for the Single Table Inheritance mapping strategy.
  */
-class AdvancedAssociationTest extends OrmFunctionalTestCase
+class DDC69Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(Lemma::class),
-                    $this->_em->getClassMetadata(Relation::class),
-                    $this->_em->getClassMetadata(RelationType::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(Lemma::class),
+            $this->_em->getClassMetadata(Relation::class),
+            $this->_em->getClassMetadata(RelationType::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(Lemma::class),
+            $this->_em->getClassMetadata(Relation::class),
+            $this->_em->getClassMetadata(RelationType::class),
+        ]);
     }
 
     public function testIssue(): void
@@ -124,9 +128,8 @@ class Lemma
      */
     private $lemma;
 
-
     /**
-     * @var kateglo\application\utilities\collections\ArrayCollection
+     * @var Collection<int, Relation>
      * @OneToMany(targetEntity="Relation", mappedBy="parent", cascade={"persist"})
      */
     private $relations;
@@ -167,7 +170,10 @@ class Lemma
         }
     }
 
-    public function getRelations(): kateglo\application\utilities\collections\ArrayCollection
+    /**
+     * @psalm-return Collection<int, Relation>
+     */
+    public function getRelations(): Collection
     {
         return $this->relations;
     }
@@ -288,7 +294,7 @@ class RelationType
     private $abbreviation;
 
     /**
-     * @var kateglo\application\utilities\collections\ArrayCollection
+     * @var Collection<int, Relation>
      * @OneToMany(targetEntity="Relation", mappedBy="type", cascade={"persist"})
      */
     private $relations;
@@ -338,7 +344,10 @@ class RelationType
         }
     }
 
-    public function getRelations(): kateglo\application\utilities\collections\ArrayCollection
+    /**
+     * @psalm-return Collection<int, Relation>
+     */
+    public function getRelations(): Collection
     {
         return $this->relations;
     }


### PR DESCRIPTION
Return insensitive check after #8453 

Problem: `->andWhere("u.name = ?1 or u.username = ?1");` did not wrap part in parenthesis when `or` or `and` was written in lowercase anymore. It still worked for uppercase `OR` and `AND`.

Fixes #8595 