### PR TITLE
Ensure test is suffixed with Test

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function count;
@@ -59,7 +58,6 @@ class ClassTableInheritanceSecondTest extends OrmFunctionalTestCase
 
         $this->assertInstanceOf(CTIRelated::class, $related2);
         $this->assertInstanceOf(CTIChild::class, $related2->getCTIParent());
-        $this->assertNotInstanceOf(Proxy::class, $related2->getCTIParent());
         $this->assertEquals('hello', $related2->getCTIParent()->getData());
 
         $this->assertSame($related2, $related2->getCTIParent()->getRelated());

--- a/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceSecondTest.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use Exception;
 
 use function count;
 use function get_class;
@@ -16,23 +15,28 @@ use function get_class;
 /**
  * Functional tests for the Class Table Inheritance mapping strategy.
  */
-class ClassTableInheritanceTest2 extends OrmFunctionalTestCase
+class ClassTableInheritanceSecondTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(CTIParent::class),
-                    $this->_em->getClassMetadata(CTIChild::class),
-                    $this->_em->getClassMetadata(CTIRelated::class),
-                    $this->_em->getClassMetadata(CTIRelated2::class),
-                ]
-            );
-        } catch (Exception $ignored) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(CTIParent::class),
+            $this->_em->getClassMetadata(CTIChild::class),
+            $this->_em->getClassMetadata(CTIRelated::class),
+            $this->_em->getClassMetadata(CTIRelated2::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(CTIParent::class),
+            $this->_em->getClassMetadata(CTIChild::class),
+            $this->_em->getClassMetadata(CTIRelated::class),
+            $this->_em->getClassMetadata(CTIRelated2::class),
+        ]);
     }
 
     public function testOneToOneAssocToBaseTypeBidirectional(): void


### PR DESCRIPTION
In #8591 , I noticed that some tests were not run, and found an exhaustive list of tests that need to be renamed. Some did not require much modifications to run again, but that last one does not pass in the CI, although it passes locally on my machine.

The assertion that fails is about an entity fetched through a one-to-one relationship. It is not supposed to be a proxy but on the CI, it seems to be.

The test that fails looks like this: https://github.com/doctrine/orm/blob/7de84537f61129a96658e50799131dec779c55bd/tests/Doctrine/Tests/ORM/Functional/ClassTableInheritanceTest2.php#L38-L62

The failure looks like this: 

```
1) Doctrine\Tests\ORM\Functional\ClassTableInheritanceSecondTest::testOneToOneAssocToBaseTypeBidirectional
Failed asserting that Doctrine\Tests\Proxies\__CG__\Doctrine\Tests\ORM\Functional\CTIChild Object (...) is not an instance of interface "Doctrine\ORM\Proxy\Proxy".
```