### PR TITLE
Remove internal tag from computeChangeSet

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -629,8 +629,6 @@ class UnitOfWork implements PropertyChangedListener
      * If a PersistentCollection has been de-referenced in a fully MANAGED entity,
      * then this collection is marked for deletion.
      *
-     * @internal Don't call from the outside.
-     *
      * @param ClassMetadata $class  The class descriptor of the entity.
      * @param object        $entity The entity for which to compute the changes.
      *


### PR DESCRIPTION
In the doctrine https://www.doctrine-project.org/projects/doctrine-orm/en/2.8/reference/events.html#onflush

The `computeChangeSet` is recommended to be used
```
If you create and persist a new entity in onFlush, then calling EntityManager#persist() is not enough. You have to execute an additional call to $unitOfWork->computeChangeSet($classMetadata, $entity).
Changing primitive fields or associations requires you to explicitly trigger a re-computation of the changeset of the affected entity. This can be done by calling $unitOfWork->recomputeSingleEntityChangeSet($classMetadata, $entity).
```

So the method shouldn't be flag as internal:
- To provide a BC-promise
- To avoid psalm error with internal method