### PR TITLE
Fix psalm param typehint for OneToManyAssociationBuilder::setOrderBy method

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
@@ -30,7 +30,7 @@ class OneToManyAssociationBuilder extends AssociationBuilder
     /**
      * @return static
      *
-     * @psalm-param list<string> $fieldNames
+     * @psalm-param array<string, string> $fieldNames
      */
     public function setOrderBy(array $fieldNames)
     {


### PR DESCRIPTION
Fix psalm/phpstan error

code:
```php
$builder->createOneToMany(...)->setOrderBy(['position' => 'ASC']);
```

result
```bash
Parameter #1 $fieldNames of method Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder::setOrderBy() expects array<int, string>, array<string, string> given.
```

