### PR TITLE
Document actual return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "doctrine/coding-standard": "^8.0",
         "phpstan/phpstan": "^0.12.18",
         "phpunit/phpunit": "^8.5|^9.4",
+        "squizlabs/php_codesniffer": "3.6.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",
         "vimeo/psalm": "4.1.1"
     },

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -24,7 +24,7 @@ use Countable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\ORM\Cache\Logging\CacheLogger;
 use Doctrine\ORM\Cache\QueryCacheKey;
 use Doctrine\ORM\Cache\TimestampCacheKey;
@@ -1203,7 +1203,9 @@ abstract class AbstractQuery
     /**
      * Executes the query and returns a the resulting Statement object.
      *
-     * @return Statement The executed database statement that holds the results.
+     * @return ResultStatement|int The executed database statement that holds
+     *                             the results, or an integer indicating how
+     *                             many rows were affected.
      */
     abstract protected function _doExecute();
 

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -22,7 +22,7 @@ namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Statement;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -73,7 +73,7 @@ abstract class AbstractSqlExecutor
      *
      * @param Connection $conn The database connection that is used to execute the queries.
      *
-     * @return Statement
+     * @return ResultStatement|int
      *
      * @psalm-param array<int, mixed>|array<string, mixed> $params The parameters.
      * @psalm-param array<int, int|string|Type|null>|

--- a/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
@@ -21,6 +21,7 @@
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\SqlWalker;
 
@@ -38,6 +39,8 @@ class SingleSelectExecutor extends AbstractSqlExecutor
 
     /**
      * {@inheritDoc}
+     *
+     * @return ResultStatement
      */
     public function execute(Connection $conn, array $params, array $types)
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -252,7 +252,7 @@
         <exclude-pattern>tests/Doctrine/Tests/DbalFunctionalTestCase.php</exclude-pattern>
         <exclude-pattern>tests/Doctrine/Tests/OrmFunctionalTestCase.php</exclude-pattern>
     </rule>
-    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+    <rule ref="Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps">
         <!-- accessing public property __isInitialized__ of a proxy -->
         <exclude-pattern>lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/UnitOfWork.php</exclude-pattern>


### PR DESCRIPTION
Some executors may return integers, for instance executors that only
execute update or delete statements.
Also, in case an integer is not returned, what's actually returned is a
`Doctrine\DBAL\Driver\ResultStatement`, and not a `Doctrine\DBAL\Driver\Statement`