### PR TITLE
Upgrade to doctrine/coding-standard 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/console": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^8.0",
+        "doctrine/coding-standard": "^9.0",
         "phpstan/phpstan": "^0.12.18",
         "phpunit/phpunit": "^8.5|^9.4",
         "squizlabs/php_codesniffer": "3.6.0",

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -346,10 +346,9 @@ abstract class AbstractQuery
      * Sets a collection of query parameters.
      *
      * @param ArrayCollection|mixed[] $parameters
+     * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
      *
      * @return static This query instance.
-     *
-     * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
      */
     public function setParameters($parameters)
     {
@@ -402,10 +401,9 @@ abstract class AbstractQuery
      * @param mixed $value
      *
      * @return mixed[]|string|int|float|bool
+     * @psalm-return array|scalar
      *
      * @throws ORMInvalidArgumentException
-     *
-     * @psalm-return array|scalar
      */
     public function processParameterValue($value)
     {

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -345,7 +345,6 @@ class DefaultQueryCache implements QueryCache
      * @param mixed               $assocValue
      *
      * @return mixed[]|null
-     *
      * @psalm-return array{targetEntity: string, type: mixed, list?: array[], identifier?: array}|null
      */
     private function storeAssociationCache(QueryCacheKey $key, array $assoc, $assocValue)

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -151,10 +151,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * is true, the notation `@Entity` will work, otherwise, the notation `@ORM\Entity` will be supported.
      *
      * @param bool $useSimpleAnnotationReader
+     * @psalm-param string|list<string> $paths
      *
      * @return AnnotationDriver
-     *
-     * @psalm-param string|list<string> $paths
      */
     public function newDefaultAnnotationDriver($paths = [], $useSimpleAnnotationReader = true)
     {
@@ -209,9 +208,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
     /**
      * Sets the entity alias map.
      *
-     * @return void
-     *
      * @psalm-param array<string, string> $entityNamespaces
+     *
+     * @return void
      */
     public function setEntityNamespaces(array $entityNamespaces)
     {
@@ -350,13 +349,13 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string $name The name of the query.
      *
-     * @throws ORMException
-     *
      * @psalm-return array{string, ResultSetMapping} A tuple with the first
      *                                               element being the SQL
      *                                               string and the second
      *                                               element being the
      *                                               ResultSetMapping.
+     *
+     * @throws ORMException
      */
     public function getNamedNativeQuery($name)
     {
@@ -426,7 +425,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
-     *
      * @psalm-return ?class-string
      */
     public function getCustomStringFunction($name)
@@ -444,10 +442,10 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * Any previously added string functions are discarded.
      *
-     * @return void
-     *
      * @psalm-param array<string, class-string> $functions The map of custom
      *                                                     DQL string functions.
+     *
+     * @return void
      */
     public function setCustomStringFunctions(array $functions)
     {
@@ -479,7 +477,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
-     *
      * @psalm-return ?class-string
      */
     public function getCustomNumericFunction($name)
@@ -497,10 +494,10 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * Any previously added numeric functions are discarded.
      *
-     * @return void
-     *
      * @psalm-param array<string, class-string> $functions The map of custom
      *                                                     DQL numeric functions.
+     *
+     * @return void
      */
     public function setCustomNumericFunctions(array $functions)
     {
@@ -518,10 +515,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @param string          $name      Function name.
      * @param string|callable $className Class name or a callable that returns the function.
+     * @psalm-param class-string|callable $className
      *
      * @return void
-     *
-     * @psalm-param class-string|callable $className
      */
     public function addCustomDatetimeFunction($name, $className)
     {
@@ -534,7 +530,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $name
      *
      * @return string|null
-     *
      * @psalm-return ?class-string $name
      */
     public function getCustomDatetimeFunction($name)
@@ -553,10 +548,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Any previously added date/time functions are discarded.
      *
      * @param array $functions The map of custom DQL date/time functions.
+     * @psalm-param array<string, string> $functions
      *
      * @return void
-     *
-     * @psalm-param array<string, string> $functions
      */
     public function setCustomDatetimeFunctions(array $functions)
     {
@@ -587,7 +581,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * @param string $modeName The hydration mode name.
      *
      * @return string|null The hydrator class name.
-     *
      * @psalm-return ?class-string
      */
     public function getCustomHydrationMode($modeName)
@@ -599,10 +592,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Adds a custom hydration mode.
      *
      * @param string $modeName The hydration mode name.
+     * @psalm-param class-string $hydrator The hydrator class name.
      *
      * @return void
-     *
-     * @psalm-param class-string $hydrator The hydrator class name.
      */
     public function addCustomHydrationMode($modeName, $hydrator)
     {
@@ -613,10 +605,9 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Sets a class metadata factory.
      *
      * @param string $cmfName
+     * @psalm-param class-string $cmfName
      *
      * @return void
-     *
-     * @psalm-param class-string $cmfName
      */
     public function setClassMetadataFactoryName($cmfName)
     {
@@ -625,7 +616,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
 
     /**
      * @return string
-     *
      * @psalm-return class-string
      */
     public function getClassMetadataFactoryName()
@@ -655,7 +645,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      *
      * @return string|null The class name of the filter, or null if it is not
      *  defined.
-     *
      * @psalm-return ?class-string
      */
     public function getFilterClassName($name)
@@ -687,7 +676,6 @@ class Configuration extends \Doctrine\DBAL\Configuration
      * Get default repository class.
      *
      * @return string
-     *
      * @psalm-return class-string
      */
     public function getDefaultRepositoryClassName()

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -386,8 +386,10 @@ use const E_USER_DEPRECATED;
      *    during the search.
      * @param int|null $lockVersion The version of the entity to find when using
      * optimistic locking.
+     * @psalm-param class-string<T> $className
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
+     * @psalm-return ?T
      *
      * @throws OptimisticLockException
      * @throws ORMInvalidArgumentException
@@ -395,8 +397,6 @@ use const E_USER_DEPRECATED;
      * @throws ORMException
      *
      * @template T
-     * @psalm-param class-string<T> $className
-     * @psalm-return ?T
      */
     public function find($className, $id, $lockMode = null, $lockVersion = null)
     {
@@ -746,12 +746,12 @@ use const E_USER_DEPRECATED;
      * Gets the repository for an entity class.
      *
      * @param string $entityName The name of the entity.
+     * @psalm-param class-string<T> $entityName
      *
      * @return ObjectRepository|EntityRepository The repository class.
+     * @psalm-return EntityRepository<T>
      *
      * @template T
-     * @psalm-param class-string<T> $entityName
-     * @psalm-return EntityRepository<T>
      */
     public function getRepository($entityName)
     {

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -155,14 +155,14 @@ interface EntityManagerInterface extends ObjectManager
      *
      * @param string $entityName The name of the entity type.
      * @param mixed  $id         The entity identifier.
+     * @psalm-param class-string<T> $entityName
      *
      * @return object|null The entity reference.
+     * @psalm-return ?T
      *
      * @throws ORMException
      *
      * @template T
-     * @psalm-param class-string<T> $entityName
-     * @psalm-return ?T
      */
     public function getReference($entityName, $id);
 

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -160,7 +160,6 @@ class EntityRepository implements ObjectRepository, Selectable
      * @param int|null $lockVersion The lock version.
      *
      * @return object|null The entity instance or NULL if the entity can not be found.
-     *
      * @psalm-return ?T
      */
     public function find($id, $lockMode = null, $lockVersion = null)
@@ -183,9 +182,9 @@ class EntityRepository implements ObjectRepository, Selectable
      *
      * @param int|null $limit
      * @param int|null $offset
-     *
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, string>|null $orderBy
+     *
      * @psalm-return list<T> The objects.
      */
     public function findBy(array $criteria, ?array $orderBy = null, $limit = null, $offset = null)
@@ -198,10 +197,10 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Finds a single entity by a set of criteria.
      *
-     * @return object|null The entity instance or NULL if the entity can not be found.
-     *
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, string>|null $orderBy
+     *
+     * @return object|null The entity instance or NULL if the entity can not be found.
      * @psalm-return ?T
      */
     public function findOneBy(array $criteria, ?array $orderBy = null)
@@ -214,9 +213,10 @@ class EntityRepository implements ObjectRepository, Selectable
     /**
      * Counts entities by a set of criteria.
      *
+     * @psalm-param array<string, mixed> $criteria
+     *
      * @return int The cardinality of the objects that match the given criteria.
      *
-     * @psalm-param array<string, mixed> $criteria
      * @todo Add this method to `ObjectRepository` interface in the next major release
      */
     public function count(array $criteria)
@@ -228,13 +228,12 @@ class EntityRepository implements ObjectRepository, Selectable
      * Adds support for magic method calls.
      *
      * @param string $method
+     * @psalm-param list<mixed> $arguments
      *
      * @return mixed The returned value from the resolved method.
      *
      * @throws ORMException
      * @throws BadMethodCallException If the method called is invalid.
-     *
-     * @psalm-param list<mixed> $arguments
      */
     public function __call($method, $arguments)
     {
@@ -307,12 +306,11 @@ class EntityRepository implements ObjectRepository, Selectable
      *
      * @param string $method The method to call
      * @param string $by     The property name used as condition
+     * @psalm-param list<mixed> $arguments The arguments to pass at method call
      *
      * @return mixed
      *
      * @throws ORMException If the method called is invalid or the requested field/association does not exist.
-     *
-     * @psalm-param list<mixed> $arguments The arguments to pass at method call
      */
     private function resolveMagicCall(string $method, string $by, array $arguments)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -123,10 +123,9 @@ abstract class AbstractHydrator
      *
      * @param object $stmt
      * @param object $resultSetMapping
+     * @psalm-param array<string, mixed> $hints
      *
      * @return IterableResult
-     *
-     * @psalm-param array<string, mixed> $hints
      */
     public function iterate($stmt, $resultSetMapping, array $hints = [])
     {
@@ -151,9 +150,9 @@ abstract class AbstractHydrator
     /**
      * Initiates a row-by-row hydration.
      *
-     * @return iterable<mixed>
-     *
      * @psalm-param array<string, mixed> $hints
+     *
+     * @return iterable<mixed>
      */
     public function toIterable(ResultStatement $stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
     {
@@ -195,10 +194,9 @@ abstract class AbstractHydrator
      *
      * @param object $stmt
      * @param object $resultSetMapping
+     * @psalm-param array<string, string> $hints
      *
      * @return mixed[]
-     *
-     * @psalm-param array<string, string> $hints
      */
     public function hydrateAll($stmt, $resultSetMapping, array $hints = [])
     {
@@ -322,14 +320,13 @@ abstract class AbstractHydrator
      * the values applied. Scalar values are kept in a specific key 'scalars'.
      *
      * @param mixed[] $data SQL Result Row.
+     * @psalm-param array<string, string> $id                 Dql-Alias => ID-Hash.
+     * @psalm-param array<string, bool>   $nonemptyComponents Does this DQL-Alias has at least one non NULL value?
      *
      * @return array<string, array<string, mixed>> An array with all the fields
      *                                             (name => value) of the data
      *                                             row, grouped by their
      *                                             component alias.
-     *
-     * @psalm-param array<string, string> $id                 Dql-Alias => ID-Hash.
-     * @psalm-param array<string, bool>   $nonemptyComponents Does this DQL-Alias has at least one non NULL value?
      * @psalm-return array{
      *                   data: array<array-key, array>,
      *                   newObjects?: array<array-key, array{
@@ -415,6 +412,7 @@ abstract class AbstractHydrator
      * of elements as before.
      *
      * @psalm-param array<string, mixed> $data
+     *
      * @psalm-return array<string, mixed> The processed row.
      */
     protected function gatherScalarRowData(&$data)

--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -100,10 +100,9 @@ class HydrationException extends ORMException
 
     /**
      * @param string $discrValue
+     * @psalm-param array<string, string> $discrMap
      *
      * @return HydrationException
-     *
-     * @psalm-param array<string, string> $discrMap
      */
     public static function invalidDiscriminatorValue($discrValue, $discrMap)
     {

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -223,12 +223,11 @@ class ObjectHydrator extends AbstractHydrator
      * Gets an entity instance.
      *
      * @param string $dqlAlias The DQL alias of the entity's class.
+     * @psalm-param array<string, mixed> $data     The instance data.
      *
      * @return object The entity.
      *
      * @throws HydrationException
-     *
-     * @psalm-param array<string, mixed> $data     The instance data.
      */
     private function getEntity(array $data, $dqlAlias)
     {
@@ -274,10 +273,9 @@ class ObjectHydrator extends AbstractHydrator
 
     /**
      * @param string $className
+     * @psalm-param array<string, mixed> $data
      *
      * @return mixed
-     *
-     * @psalm-param array<string, mixed> $data
      */
     private function getEntityFromIdentityMap($className, array $data)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -138,10 +138,9 @@ class ClassMetadataBuilder
      * Adds Index.
      *
      * @param string $name
+     * @psalm-param list<string> $columns
      *
      * @return static
-     *
-     * @psalm-param list<string> $columns
      */
     public function addIndex(array $columns, $name)
     {
@@ -158,10 +157,9 @@ class ClassMetadataBuilder
      * Adds Unique Constraint.
      *
      * @param string $name
+     * @psalm-param list<string> $columns
      *
      * @return static
-     *
-     * @psalm-param list<string> $columns
      */
     public function addUniqueConstraint(array $columns, $name)
     {
@@ -299,10 +297,9 @@ class ClassMetadataBuilder
      *
      * @param string $name
      * @param string $type
+     * @psalm-param array<string, mixed> $mapping
      *
      * @return static
-     *
-     * @psalm-param array<string, mixed> $mapping
      */
     public function addField($name, $type, array $mapping = [])
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
@@ -28,9 +28,9 @@ namespace Doctrine\ORM\Mapping\Builder;
 class OneToManyAssociationBuilder extends AssociationBuilder
 {
     /**
-     * @return static
-     *
      * @psalm-param array<string, string> $fieldNames
+     *
+     * @return static
      */
     public function setOrderBy(array $fieldNames)
     {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -704,7 +704,6 @@ class ClassMetadataInfo implements ClassMetadata
      * Gets the ReflectionProperties of the mapped class.
      *
      * @return ReflectionProperty[]|null[] An array of ReflectionProperty instances.
-     *
      * @psalm-return array<ReflectionProperty|null>
      */
     public function getReflectionProperties()
@@ -780,10 +779,10 @@ class ClassMetadataInfo implements ClassMetadata
      * Populates the entity identifier of an entity.
      *
      * @param object $entity
+     * @psalm-param array<string, mixed> $id
      *
      * @return void
      *
-     * @psalm-param array<string, mixed> $id
      * @todo Rename to assignIdentifier()
      */
     public function setIdentifierValues($entity, array $id)
@@ -1102,9 +1101,9 @@ class ClassMetadataInfo implements ClassMetadata
     }
 
     /**
-     * @return void
-     *
      * @psalm-param array{usage?: mixed, region?: mixed} $cache
+     *
+     * @return void
      */
     public function enableCache(array $cache)
     {
@@ -1121,10 +1120,9 @@ class ClassMetadataInfo implements ClassMetadata
 
     /**
      * @param string $fieldName
+     * @psalm-param array{usage?: mixed, region?: mixed} $cache
      *
      * @return void
-     *
-     * @psalm-param array{usage?: mixed, region?: mixed} $cache
      */
     public function enableAssociationCache($fieldName, array $cache)
     {
@@ -1134,10 +1132,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * @param string $fieldName
      * @param array  $cache
+     * @psalm-param array{usage?: mixed, region?: mixed} $cache
      *
      * @return mixed[]
-     *
-     * @psalm-param array{usage?: mixed, region?: mixed} $cache
      * @psalm-return array{usage: mixed, region: mixed}
      */
     public function getAssociationCacheDefaults($fieldName, array $cache)
@@ -1264,9 +1261,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $fieldName The field name.
      *
-     * @throws MappingException
-     *
      * @psalm-return array<string, mixed> The field mapping.
+     *
+     * @throws MappingException
      */
     public function getFieldMapping($fieldName)
     {
@@ -1285,9 +1282,9 @@ class ClassMetadataInfo implements ClassMetadata
      * @param string $fieldName The field name that represents the association in
      *                          the object model.
      *
-     * @throws MappingException
-     *
      * @psalm-return array<string, mixed> The mapping.
+     *
+     * @throws MappingException
      */
     public function getAssociationMapping($fieldName)
     {
@@ -1358,9 +1355,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $queryName The query name.
      *
-     * @throws MappingException
-     *
      * @psalm-return array<string, mixed>
+     *
+     * @throws MappingException
      */
     public function getNamedNativeQuery($queryName)
     {
@@ -1388,9 +1385,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @param string $name The result set mapping name.
      *
-     * @throws MappingException
-     *
      * @psalm-return array<string, mixed>
+     *
+     * @throws MappingException
      */
     public function getSqlResultSetMapping($name)
     {
@@ -1414,11 +1411,11 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes the given field mapping.
      *
+     * @psalm-param array<string, mixed> $mapping The field mapping to validate & complete.
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping The field mapping to validate & complete.
      */
     protected function _validateAndCompleteFieldMapping(array &$mapping)
     {
@@ -1479,11 +1476,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Validates & completes the basic mapping information that is common to all
      * association mappings (one-to-one, many-ot-one, one-to-many, many-to-many).
      *
-     * @return mixed[] The updated mapping.
-     *
-     * @throws MappingException If something is wrong with the mapping.
-     *
      * @psalm-param array<string, mixed> $mapping The mapping.
+     *
+     * @return mixed[] The updated mapping.
      * @psalm-return array{
      *                   mappedBy: mixed,
      *                   inversedBy: mixed,
@@ -1500,6 +1495,8 @@ class ClassMetadataInfo implements ClassMetadata
      *                   isCascadeDetach: bool,
      *                   ?orphanRemoval: bool
      *               }
+     *
+     * @throws MappingException If something is wrong with the mapping.
      */
     protected function _validateAndCompleteAssociationMapping(array $mapping)
     {
@@ -1617,13 +1614,13 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes a one-to-one association mapping.
      *
+     * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
+     *
      * @return mixed[] The validated & completed mapping.
+     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool, isCascadeRemove: bool}
      *
      * @throws RuntimeException
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
-     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool, isCascadeRemove: bool}
      */
     protected function _validateAndCompleteOneToOneMapping(array $mapping)
     {
@@ -1707,12 +1704,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes a one-to-many association mapping.
      *
-     * @return mixed[] The validated and completed mapping.
-     *
-     * @throws MappingException
-     * @throws InvalidArgumentException
-     *
      * @psalm-param array<string, mixed> $mapping The mapping to validate and complete.
+     *
+     * @return mixed[] The validated and completed mapping.
      * @psalm-return array{
      *                   mappedBy: mixed,
      *                   inversedBy: mixed,
@@ -1729,6 +1723,9 @@ class ClassMetadataInfo implements ClassMetadata
      *                   isCascadeDetach: bool,
      *                   orphanRemoval: bool
      *               }
+     *
+     * @throws MappingException
+     * @throws InvalidArgumentException
      */
     protected function _validateAndCompleteOneToManyMapping(array $mapping)
     {
@@ -1750,12 +1747,12 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Validates & completes a many-to-many association mapping.
      *
+     * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
+     *
      * @return mixed[] The validated & completed mapping.
+     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool}
      *
      * @throws InvalidArgumentException
-     *
-     * @psalm-param array<string, mixed> $mapping The mapping to validate & complete.
-     * @psalm-return array{isOwningSide: mixed, orphanRemoval: bool}
      */
     protected function _validateAndCompleteManyToManyMapping(array $mapping)
     {
@@ -1901,9 +1898,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the mapped identifier/primary key fields of this class.
      * Mainly used by the ClassMetadataFactory to assign inherited identifiers.
      *
-     * @return void
-     *
      * @psalm-param list<mixed> $identifier
+     *
+     * @return void
      */
     public function setIdentifier(array $identifier)
     {
@@ -1930,9 +1927,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Gets an array containing all the column names.
      *
-     * @return mixed[]
-     *
      * @psalm-param list<string>|null $fieldNames
+     *
+     * @return mixed[]
      * @psalm-return list<string>
      */
     public function getColumnNames(?array $fieldNames = null)
@@ -2151,9 +2148,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Sets the mapped subclasses of this class.
      *
-     * @return void
-     *
      * @psalm-param list<string> $subclasses The names of all mapped subclasses.
+     *
+     * @return void
      */
     public function setSubclasses(array $subclasses)
     {
@@ -2167,9 +2164,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Assumes that the class names in the passed array are in the order:
      * directParent -> directParentParent -> directParentParentParent ... -> root.
      *
-     * @return void
-     *
      * @psalm-param list<class-string> $classNames
+     *
+     * @return void
      */
     public function setParentClasses(array $classNames)
     {
@@ -2202,12 +2199,11 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the association to override association mapping of property for an entity relationship.
      *
      * @param string $fieldName
+     * @psalm-param array<string, mixed> $overrideMapping
      *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $overrideMapping
      */
     public function setAssociationOverride($fieldName, array $overrideMapping)
     {
@@ -2268,12 +2264,11 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the override for a mapped field.
      *
      * @param string $fieldName
+     * @psalm-param array<string, mixed> $overrideMapping
      *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $overrideMapping
      */
     public function setAttributeOverride($fieldName, array $overrideMapping)
     {
@@ -2381,9 +2376,9 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * If a key is omitted, the current value is kept.
      *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $table The table description.
+     *
+     * @return void
      */
     public function setPrimaryTable(array $table)
     {
@@ -2440,11 +2435,11 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds a mapped field to the class.
      *
+     * @psalm-param array<string, mixed> $mapping The field mapping.
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping The field mapping.
      */
     public function mapField(array $mapping)
     {
@@ -2459,11 +2454,11 @@ class ClassMetadataInfo implements ClassMetadata
      * Adds an association mapping without completing/validating it.
      * This is mainly used to add inherited association mappings to derived classes.
      *
+     * @psalm-param array<string, mixed> $mapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping
      */
     public function addInheritedAssociationMapping(array $mapping/*, $owningClassName = null*/)
     {
@@ -2479,9 +2474,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Adds a field mapping without completing/validating it.
      * This is mainly used to add inherited field mappings to derived classes.
      *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $fieldMapping
+     *
+     * @return void
      */
     public function addInheritedFieldMapping(array $fieldMapping)
     {
@@ -2494,11 +2489,11 @@ class ClassMetadataInfo implements ClassMetadata
      * INTERNAL:
      * Adds a named query to this class.
      *
+     * @psalm-param array<string, mixed> $queryMapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $queryMapping
      */
     public function addNamedQuery(array $queryMapping)
     {
@@ -2529,11 +2524,11 @@ class ClassMetadataInfo implements ClassMetadata
      * INTERNAL:
      * Adds a named native query to this class.
      *
+     * @psalm-param array<string, mixed> $queryMapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $queryMapping
      */
     public function addNamedNativeQuery(array $queryMapping)
     {
@@ -2572,11 +2567,11 @@ class ClassMetadataInfo implements ClassMetadata
      * INTERNAL:
      * Adds a sql result set mapping to this class.
      *
+     * @psalm-param array<string, mixed> $resultMapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $resultMapping
      */
     public function addSqlResultSetMapping(array $resultMapping)
     {
@@ -2646,9 +2641,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds a one-to-many mapping.
      *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $mapping The mapping.
+     *
+     * @return void
      */
     public function mapOneToMany(array $mapping)
     {
@@ -2662,9 +2657,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds a many-to-one mapping.
      *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $mapping The mapping.
+     *
+     * @return void
      */
     public function mapManyToOne(array $mapping)
     {
@@ -2679,9 +2674,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Adds a many-to-many mapping.
      *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $mapping The mapping.
+     *
+     * @return void
      */
     public function mapManyToMany(array $mapping)
     {
@@ -2695,11 +2690,11 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Stores the association mapping.
      *
+     * @psalm-param array<string, mixed> $assocMapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $assocMapping
      */
     protected function _storeAssociationMapping(array $assocMapping)
     {
@@ -2714,10 +2709,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Registers a custom repository class for the entity class.
      *
      * @param string $repositoryClassName The class name of the custom mapper.
+     * @psalm-param class-string $repositoryClassName
      *
      * @return void
-     *
-     * @psalm-param class-string $repositoryClassName
      */
     public function setCustomRepositoryClass($repositoryClassName)
     {
@@ -2787,9 +2781,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the lifecycle callbacks for entities of this class.
      * Any previously registered callbacks are overwritten.
      *
-     * @return void
-     *
      * @psalm-param array<string, list<string>> $callbacks
+     *
+     * @return void
      */
     public function setLifecycleCallbacks(array $callbacks)
     {
@@ -2834,11 +2828,11 @@ class ClassMetadataInfo implements ClassMetadata
      *
      * @see getDiscriminatorColumn()
      *
+     * @psalm-param array<string, mixed> $columnDef
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $columnDef
      */
     public function setDiscriminatorColumn($columnDef)
     {
@@ -2871,9 +2865,9 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the discriminator values used by this class.
      * Used for JOINED and SINGLE_TABLE inheritance mapping strategies.
      *
-     * @return void
-     *
      * @psalm-param array<string, class-string> $map
+     *
+     * @return void
      */
     public function setDiscriminatorMap(array $map)
     {
@@ -2886,12 +2880,11 @@ class ClassMetadataInfo implements ClassMetadata
      * Adds one entry of the discriminator map with a new class and corresponding name.
      *
      * @param string $name
+     * @psalm-param class-string $className
      *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param class-string $className
      */
     public function addDiscriminatorMapClass($name, $className)
     {
@@ -3071,9 +3064,9 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Sets definition.
      *
-     * @return void
-     *
      * @psalm-param array<string, string> $definition
+     *
+     * @return void
      */
     public function setCustomGeneratorDefinition(array $definition)
     {
@@ -3093,11 +3086,11 @@ class ClassMetadataInfo implements ClassMetadata
      * )
      * </code>
      *
+     * @psalm-param array<string, string> $definition
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, string> $definition
      */
     public function setSequenceGeneratorDefinition(array $definition)
     {
@@ -3125,11 +3118,11 @@ class ClassMetadataInfo implements ClassMetadata
      * Sets the version field mapping used for versioning. Sets the default
      * value to use depending on the column type.
      *
+     * @psalm-param array<string, mixed> $mapping The version field mapping array.
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping The version field mapping array.
      */
     public function setVersionMapping(array &$mapping)
     {
@@ -3346,10 +3339,9 @@ class ClassMetadataInfo implements ClassMetadata
 
     /**
      * @param  string|null $className
+     * @psalm-param ?class-string $className
      *
      * @return string|null null if the input value is null
-     *
-     * @psalm-param ?class-string $className
      */
     public function fullyQualifiedClassName($className)
     {
@@ -3381,11 +3373,11 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * Map Embedded Class
      *
+     * @psalm-param array<string, mixed> $mapping
+     *
      * @return void
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $mapping
      */
     public function mapEmbedded(array $mapping)
     {

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -488,7 +488,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
 
     /**
      * @param mixed[] $joinColumns
-     *
      * @psalm-param array<string, mixed> $mapping
      */
     private function loadRelationShipMapping(
@@ -665,7 +664,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * Parse the given JoinColumn as array
      *
      * @return mixed[]
-     *
      * @psalm-return array{
      *                   name: string,
      *                   unique: bool,
@@ -693,7 +691,6 @@ class AnnotationDriver extends AbstractAnnotationDriver
      * @param string $fieldName
      *
      * @return mixed[]
-     *
      * @psalm-return array{
      *                   fieldName: string,
      *                   type: mixed,

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -145,10 +145,10 @@ class DatabaseDriver implements MappingDriver
     /**
      * Sets tables manually instead of relying on the reverse engineering capabilities of SchemaManager.
      *
-     * @return void
-     *
      * @psalm-param list<Table> $entityTables
      * @psalm-param list<Table> $manyToManyTables
+     *
+     * @return void
      */
     public function setTables($entityTables, $manyToManyTables)
     {
@@ -498,7 +498,6 @@ class DatabaseDriver implements MappingDriver
      * Retrieve schema table definition foreign keys.
      *
      * @return ForeignKeyConstraint[]
-     *
      * @psalm-return array<string, ForeignKeyConstraint>
      */
     private function getTableForeignKeys(Table $table)

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -714,7 +714,6 @@ class XmlDriver extends FileDriver
      * @param SimpleXMLElement $joinColumnElement The XML element.
      *
      * @return mixed[] The mapping array.
-     *
      * @psalm-return array{
      *                   name: string,
      *                   referencedColumnName: string,
@@ -754,7 +753,6 @@ class XmlDriver extends FileDriver
       * Parses the given field as array.
       *
       * @return mixed[]
-      *
       * @psalm-return array{
       *                   fieldName: string,
       *                   type?: string,
@@ -822,7 +820,6 @@ class XmlDriver extends FileDriver
      * Parse / Normalize the cache configuration
      *
      * @return mixed[]
-     *
      * @psalm-return array{usage: mixed, region: string|null}
      */
     private function cacheToArray(SimpleXMLElement $cacheMapping)
@@ -850,7 +847,6 @@ class XmlDriver extends FileDriver
      * @param SimpleXMLElement $cascadeElement The cascade element.
      *
      * @return string[] The list of cascade options.
-     *
      * @psalm-return list<string>
      */
     private function getCascadeMappings(SimpleXMLElement $cascadeElement)

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -689,8 +689,6 @@ class YamlDriver extends FileDriver
      * Constructs a joinColumn mapping array based on the information
      * found in the given join column element.
      *
-     * @return mixed[] The mapping array.
-     *
      * @psalm-param array{
      *                   referencedColumnName?: mixed,
      *                   name?: mixed,
@@ -700,6 +698,8 @@ class YamlDriver extends FileDriver
      *                   onDelete?: mixed,
      *                   columnDefinition?: mixed
      *              } $joinColumnElement The array join column element.
+     *
+     * @return mixed[] The mapping array.
      * @psalm-return array{
      *                   referencedColumnName?: string,
      *                   name?: string,
@@ -747,8 +747,6 @@ class YamlDriver extends FileDriver
     /**
      * Parses the given column as array.
      *
-     * @return mixed[]
-     *
      * @psalm-param array{
      *                   type?: string,
      *                   column?: string,
@@ -760,6 +758,8 @@ class YamlDriver extends FileDriver
      *                   version?: mixed,
      *                   columnDefinition?: mixed
      *              }|null $column
+     *
+     * @return mixed[]
      * @psalm-return array{
      *                   fieldName: string,
      *                   type?: string,
@@ -832,10 +832,9 @@ class YamlDriver extends FileDriver
      * Parse / Normalize the cache configuration
      *
      * @param mixed[] $cacheMapping
+     * @psalm-param array{usage: mixed, region: (string|null)} $cacheMapping
      *
      * @return mixed[]
-     *
-     * @psalm-param array{usage: mixed, region: (string|null)} $cacheMapping
      * @psalm-return array{usage: mixed, region: (string|null)}
      */
     private function cacheToArray($cacheMapping)

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -51,10 +51,9 @@ final class ReflectionPropertiesGetter
 
     /**
      * @param string $className
+     * @psalm-param class-string $className
      *
      * @return ReflectionProperty[] indexed by property internal name
-     *
-     * @psalm-param class-string $className
      */
     public function getProperties($className)
     {
@@ -79,7 +78,6 @@ final class ReflectionPropertiesGetter
      * @param string $className
      *
      * @return ReflectionClass[]
-     *
      * @psalm-return list<ReflectionClass>
      */
     private function getHierarchyClasses($className): array
@@ -104,7 +102,6 @@ final class ReflectionPropertiesGetter
 
     /**
      * @return ReflectionProperty[]
-     *
      * @psalm-return array<string, ReflectionProperty>
      */
     private function getClassProperties(ReflectionClass $reflectionClass): array

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -123,10 +123,9 @@ class ORMInvalidArgumentException extends InvalidArgumentException
 
     /**
      * @param object $entry
+     * @psalm-param array<string, string> $associationMapping
      *
      * @return ORMInvalidArgumentException
-     *
-     * @psalm-param array<string, string> $associationMapping
      */
     public static function newEntityFoundThroughRelationship(array $associationMapping, $entry)
     {
@@ -135,10 +134,9 @@ class ORMInvalidArgumentException extends InvalidArgumentException
 
     /**
      * @param object $entry
+     * @psalm-param array<string, string> $assoc
      *
      * @return ORMInvalidArgumentException
-     *
-     * @psalm-param array<string, string> $assoc
      */
     public static function detachedEntityFoundThroughRelationship(array $assoc, $entry)
     {

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -111,7 +111,6 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *
      * @param EntityManagerInterface $em    The EntityManager the collection will be associated with.
      * @param ClassMetadata          $class The class descriptor of the entity type of this collection.
-     *
      * @psalm-param Collection<TKey, T> $collection The collection elements.
      */
     public function __construct(EntityManagerInterface $em, $class, Collection $collection)
@@ -128,10 +127,9 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      * describes the association between the owner and the elements of the collection.
      *
      * @param object $entity
+     * @psalm-param array<string, mixed> $assoc
      *
      * @return void
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     public function setOwner($entity, array $assoc)
     {
@@ -605,7 +603,6 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
      *                with circular references. This solution seems simpler and works well.
      *
      * @return string[]
-     *
      * @psalm-return array{0: string, 1: string}
      */
     public function __sleep(): array

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -298,11 +298,11 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * have to join in the actual entities table leading to additional
      * JOIN.
      *
+     * @psalm-param array<string, mixed> $mapping Array containing mapping information.
+     *
      * @return string[] ordered tuple:
      *                   - JOIN condition to add to the SQL
      *                   - WHERE condition to add to the SQL
-     *
-     * @psalm-param array<string, mixed> $mapping Array containing mapping information.
      * @psalm-return array{0: string, 1: string}
      */
     public function getFilterSql($mapping)
@@ -350,9 +350,9 @@ class ManyToManyPersister extends AbstractCollectionPersister
     /**
      * Generate ON condition
      *
-     * @return string[]
-     *
      * @psalm-param array<string, mixed> $mapping
+     *
+     * @return string[]
      * @psalm-return list<string>
      */
     protected function getOnConditionSQL($mapping)
@@ -429,7 +429,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @return string[]|string[][] ordered tuple containing the SQL to be executed and an array
      *                             of types for bound parameters
-     *
      * @psalm-return array{0: string, 1: list<string>}
      */
     protected function getDeleteRowSQL(PersistentCollection $collection)
@@ -477,7 +476,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *
      * @return string[]|string[][] ordered tuple containing the SQL to be executed and an array
      *                             of types for bound parameters
-     *
      * @psalm-return array{0: string, 1: list<string>}
      */
     protected function getInsertRowSQL(PersistentCollection $collection)
@@ -529,7 +527,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      * @param object $element
      *
      * @return mixed[]
-     *
      * @psalm-return list<mixed>
      */
     private function collectJoinTableColumnParameters(PersistentCollection $collection, $element)
@@ -577,7 +574,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - where clauses to be added for filtering
      *                - parameters to be bound for filtering
      *                - types of the parameters to be bound for filtering
-     *
      * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
     private function getJoinTableRestrictionsWithKey(PersistentCollection $collection, $key, $addFilters)
@@ -663,7 +659,6 @@ class ManyToManyPersister extends AbstractCollectionPersister
      *                - where clauses to be added for filtering
      *                - parameters to be bound for filtering
      *                - types of the parameters to be bound for filtering
-     *
      * @psalm-return array{0: string, 1: list<string>, 2: list<mixed>, 3: list<string>}
      */
     private function getJoinTableRestrictions(PersistentCollection $collection, $element, $addFilters)

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -362,7 +362,6 @@ class BasicEntityPersister implements EntityPersister
      * @param mixed[] $id
      *
      * @return int[]|null[]|string[]
-     *
      * @psalm-return list<(int|string|null)>
      */
     private function extractIdentifierTypes(array $id, ClassMetadata $versionedClass): array
@@ -611,7 +610,6 @@ class BasicEntityPersister implements EntityPersister
      * @param object $entity The entity for which to prepare the data.
      *
      * @return mixed[][] The prepared data.
-     *
      * @psalm-return array<string, array<array-key, mixed|null>>
      */
     protected function prepareUpdateData($entity)
@@ -703,7 +701,6 @@ class BasicEntityPersister implements EntityPersister
      * @param object $entity The entity for which to prepare the data.
      *
      * @return mixed[][] The prepared data for the tables to update.
-     *
      * @psalm-return array<string, mixed[]>
      */
     protected function prepareInsertData($entity)
@@ -976,11 +973,11 @@ class BasicEntityPersister implements EntityPersister
     }
 
     /**
+     * @psalm-param array<string, mixed> $assoc
+     *
      * @return \Doctrine\DBAL\Driver\Statement
      *
      * @throws MappingException
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     private function getManyToManyStatement(
         array $assoc,
@@ -1140,9 +1137,9 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Gets the ORDER BY SQL snippet for ordered collections.
      *
-     * @throws ORMException
-     *
      * @psalm-param array<string, string> $orderBy
+     *
+     * @throws ORMException
      */
     final protected function getOrderBySQL(array $orderBy, string $baseTableAlias): string
     {
@@ -1350,9 +1347,9 @@ class BasicEntityPersister implements EntityPersister
      * Gets the SQL join fragment used when selecting entities from a
      * many-to-many association.
      *
-     * @return string
-     *
      * @psalm-param array<string, mixed> $manyToMany
+     *
+     * @return string
      */
     protected function getSelectManyToManyJoinSQL(array $manyToMany)
     {
@@ -1431,7 +1428,6 @@ class BasicEntityPersister implements EntityPersister
      * columns placed in the INSERT statements used by the persister.
      *
      * @return string[] The list of columns.
-     *
      * @psalm-return list<string>
      */
     protected function getInsertColumnList()
@@ -1661,13 +1657,12 @@ class BasicEntityPersister implements EntityPersister
      * Builds the left-hand-side of a where condition statement.
      *
      * @param string $field
+     * @psalm-param array<string, mixed>|null $assoc
      *
      * @return string[]
+     * @psalm-return list<string>
      *
      * @throws ORMException
-     *
-     * @psalm-param array<string, mixed>|null $assoc
-     * @psalm-return list<string>
      */
     private function getSelectConditionStatementColumnSQL($field, $assoc = null)
     {
@@ -1729,10 +1724,10 @@ class BasicEntityPersister implements EntityPersister
      * Subclasses are supposed to override this method if they intend to change
      * or alter the criteria by which entities are selected.
      *
-     * @return string
-     *
      * @psalm-param array<string, mixed> $criteria
      * @psalm-param array<string, mixed>|null $assoc
+     *
+     * @return string
      */
     protected function getSelectConditionSQL(array $criteria, $assoc = null)
     {
@@ -1773,10 +1768,9 @@ class BasicEntityPersister implements EntityPersister
      * @param object   $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
+     * @psalm-param array<string, mixed> $assoc
      *
      * @return Statement
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     private function getOneToManyStatement(array $assoc, $sourceEntity, $offset = null, $limit = null)
     {
@@ -1855,7 +1849,6 @@ class BasicEntityPersister implements EntityPersister
      *                             - class to which the field belongs to
      *
      * @return mixed[][]
-     *
      * @psalm-return array{0: array, 1: list<mixed>}
      */
     private function expandToManyParameters($criteria)
@@ -1882,10 +1875,9 @@ class BasicEntityPersister implements EntityPersister
      * @param mixed  $value
      *
      * @return int[]|null[]|string[]
+     * @psalm-return list<(int|string|null)>
      *
      * @throws QueryException
-     *
-     * @psalm-return list<(int|string|null)>
      */
     private function getTypes($field, $value, ClassMetadata $class)
     {
@@ -2020,9 +2012,9 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Generates the appropriate join SQL for the given join column.
      *
-     * @return string LEFT JOIN if one of the columns is nullable, INNER JOIN otherwise.
-     *
      * @psalm-param array<array<string, mixed>> $joinColumns The join columns definition of an association.
+     *
+     * @return string LEFT JOIN if one of the columns is nullable, INNER JOIN otherwise.
      */
     protected function getJoinSQLForJoinColumns($joinColumns)
     {

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -106,10 +106,9 @@ interface EntityPersister
      * @param string      $field
      * @param mixed       $value
      * @param string|null $comparison
+     * @psalm-param array<string, mixed>|null  $assoc
      *
      * @return string
-     *
-     * @psalm-param array<string, mixed>|null  $assoc
      */
     public function getSelectConditionStatementSQL($field, $value, $assoc = null, $comparison = null);
 
@@ -192,9 +191,6 @@ interface EntityPersister
      *                              or NULL if no specific lock mode should be used
      *                              for loading the entity.
      * @param int|null    $limit    Limit number of results.
-     *
-     * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
-     *
      * @psalm-param array<string, mixed>       $hints    Hints for entity creation.
      * @psalm-param array<string, mixed>       $criteria The criteria by which
      *                                                   to load the entity.
@@ -203,6 +199,9 @@ interface EntityPersister
      *                                                   load to another entity,
      *                                                   if any.
      * @psalm-param array<string, string>|null $orderBy  Criteria to order by.
+     *
+     * @return object|null The loaded and managed entity instance or NULL if the entity can not be found.
+     *
      * @todo Check identity map? loadById method? Try to guess whether $criteria is the id?
      */
     public function load(
@@ -219,10 +218,10 @@ interface EntityPersister
      * Loads an entity by identifier.
      *
      * @param object|null $entity The entity to load the data into. If not specified, a new entity is created.
+     * @psalm-param array<string, mixed> $identifier The entity identifier.
      *
      * @return object The loaded and managed entity instance or NULL if the entity can not be found.
      *
-     * @psalm-param array<string, mixed> $identifier The entity identifier.
      * @todo Check parameters
      */
     public function loadById(array $identifier, $entity = null);
@@ -232,15 +231,14 @@ interface EntityPersister
      * association from another entity.
      *
      * @param object $sourceEntity The entity that owns the association (not necessarily the "owning side").
-     *
-     * @return object The loaded and managed entity instance or NULL if the entity can not be found.
-     *
-     * @throws MappingException
-     *
      * @psalm-param array<string, mixed> $identifier The identifier of the entity to load. Must be provided if
      *                                               the association to load represents the owning side, otherwise
      *                                               the identifier is derived from the $sourceEntity.
      * @psalm-param array<string, mixed> $assoc        The association to load.
+     *
+     * @return object The loaded and managed entity instance or NULL if the entity can not be found.
+     *
+     * @throws MappingException
      */
     public function loadOneToOneEntity(array $assoc, $sourceEntity, array $identifier = []);
 
@@ -251,12 +249,11 @@ interface EntityPersister
      * @param int|null $lockMode One of the \Doctrine\DBAL\LockMode::* constants
      *                           or NULL if no specific lock mode should be used
      *                           for refreshing the managed entity.
-     *
-     * @return void
-     *
      * @psalm-param array<string, mixed> $id The identifier of the entity as an
      *                                       associative array from column or
      *                                       field names to values.
+     *
+     * @return void
      */
     public function refresh(array $id, $entity, $lockMode = null);
 
@@ -272,7 +269,6 @@ interface EntityPersister
      *
      * @param int|null $limit
      * @param int|null $offset
-     *
      * @psalm-param array<string, string>|null $orderBy
      * @psalm-param array<string, mixed>       $criteria
      */
@@ -284,10 +280,9 @@ interface EntityPersister
      * @param object   $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
+     * @psalm-param array<string, mixed> $assoc
      *
      * @return mixed[]
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     public function getManyToManyCollection(array $assoc, $sourceEntity, $offset = null, $limit = null);
 
@@ -296,10 +291,9 @@ interface EntityPersister
      *
      * @param object               $sourceEntity The entity that owns the collection.
      * @param PersistentCollection $collection   The collection to fill.
+     * @psalm-param array<string, mixed> $assoc The association mapping of the association being loaded.
      *
      * @return mixed[]
-     *
-     * @psalm-param array<string, mixed> $assoc The association mapping of the association being loaded.
      */
     public function loadManyToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection);
 
@@ -308,10 +302,9 @@ interface EntityPersister
      *
      * @param object               $sourceEntity
      * @param PersistentCollection $collection   The collection to load/fill.
+     * @psalm-param array<string, mixed> $assoc
      *
      * @return mixed
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     public function loadOneToManyCollection(array $assoc, $sourceEntity, PersistentCollection $collection);
 
@@ -319,10 +312,9 @@ interface EntityPersister
      * Locks all rows of this entity matching the given criteria with the specified pessimistic lock mode.
      *
      * @param int $lockMode One of the Doctrine\DBAL\LockMode::* constants.
+     * @psalm-param array<string, mixed> $criteria
      *
      * @return void
-     *
-     * @psalm-param array<string, mixed> $criteria
      */
     public function lock(array $criteria, $lockMode);
 
@@ -332,10 +324,9 @@ interface EntityPersister
      * @param object   $sourceEntity
      * @param int|null $offset
      * @param int|null $limit
+     * @psalm-param array<string, mixed> $assoc
      *
      * @return mixed[]
-     *
-     * @psalm-param array<string, mixed> $assoc
      */
     public function getOneToManyCollection(array $assoc, $sourceEntity, $offset = null, $limit = null);
 

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -83,7 +83,6 @@ class SqlValueVisitor extends ExpressionVisitor
      * Returns the Parameters and Types necessary for matching the last visited expression.
      *
      * @return mixed[][]
-     *
      * @psalm-return array{0: array, 1: array}
      */
     public function getParamsAndTypes()

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -110,10 +110,9 @@ class ProxyFactory extends AbstractProxyFactory
      * Creates a closure capable of initializing a proxy
      *
      * @return Closure
+     * @psalm-return Closure(BaseProxy ): void
      *
      * @throws EntityNotFoundException
-     *
-     * @psalm-return Closure(BaseProxy ): void
      */
     private function createInitializer(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {
@@ -163,10 +162,9 @@ class ProxyFactory extends AbstractProxyFactory
      * Creates a closure capable of finalizing state a cloned proxy
      *
      * @return Closure
+     * @psalm-return Closure(BaseProxy ): void
      *
      * @throws EntityNotFoundException
-     *
-     * @psalm-return Closure(BaseProxy ): void
      */
     private function createCloner(ClassMetadata $classMetadata, EntityPersister $entityPersister)
     {

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -374,10 +374,9 @@ final class Query extends AbstractQuery
      * @param Parameter[] $paramMappings
      *
      * @return mixed[][]
+     * @psalm-return array{0: list<mixed>, 1: array}
      *
      * @throws Query\QueryException
-     *
-     * @psalm-return array{0: list<mixed>, 1: array}
      */
     private function processParameterMappings(array $paramMappings): array
     {
@@ -426,7 +425,6 @@ final class Query extends AbstractQuery
 
     /**
      * @return mixed[] tuple of (value, type)
-     *
      * @psalm-return array{0: mixed, 1: mixed}
      */
     private function resolveParameterValue(Parameter $parameter): array

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -72,12 +72,11 @@ abstract class AbstractSqlExecutor
      * Executes all sql statements.
      *
      * @param Connection $conn The database connection that is used to execute the queries.
-     *
-     * @return ResultStatement|int
-     *
      * @psalm-param array<int, mixed>|array<string, mixed> $params The parameters.
      * @psalm-param array<int, int|string|Type|null>|
      *              array<string, int|string|Type|null> $types The parameter types.
+     *
+     * @return ResultStatement|int
      */
     abstract public function execute(Connection $conn, array $params, array $types);
 }

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -60,9 +60,9 @@ abstract class Base
     }
 
     /**
-     * @return static
-     *
      * @psalm-param list<string|object> $args
+     *
+     * @return static
      */
     public function addMultiple($args = [])
     {

--- a/lib/Doctrine/ORM/Query/Expr/Func.php
+++ b/lib/Doctrine/ORM/Query/Expr/Func.php
@@ -39,7 +39,6 @@ class Func
      * Creates a function, with the given argument.
      *
      * @param string $name
-     *
      * @psalm-param list<mixed> $arguments
      */
     public function __construct($name, $arguments)

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -261,9 +261,9 @@ class Parser
     /**
      * Adds a custom tree walker for modifying the AST.
      *
-     * @return void
-     *
      * @psalm-param class-string $className
+     *
+     * @return void
      */
     public function addCustomTreeWalker($className)
     {
@@ -491,12 +491,11 @@ class Parser
      * Generates a new syntax error.
      *
      * @param string $expected Expected string.
+     * @psalm-param array<string, mixed>|null $token    Got token.
      *
      * @return void
      *
      * @throws QueryException
-     *
-     * @psalm-param array<string, mixed>|null $token    Got token.
      */
     public function syntaxError($expected = '', $token = null)
     {
@@ -517,12 +516,11 @@ class Parser
      * Generates a new semantical error.
      *
      * @param string $message Optional message.
+     * @psalm-param array<string, mixed>|null $token Optional token.
      *
      * @return void
      *
      * @throws QueryException
-     *
-     * @psalm-param array<string, mixed>|null $token Optional token.
      */
     public function semanticalError($message = '', $token = null)
     {
@@ -613,9 +611,9 @@ class Parser
     /**
      * Checks whether the given token type indicates an aggregate function.
      *
-     * @return bool TRUE if the token type is an aggregate function, FALSE otherwise.
-     *
      * @psalm-param Lexer::T_* $tokenType
+     *
+     * @return bool TRUE if the token type is an aggregate function, FALSE otherwise.
      */
     private function isAggregateFunction(int $tokenType): bool
     {

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -165,9 +165,9 @@ class QueryException extends ORMException
     }
 
     /**
-     * @return QueryException
-     *
      * @psalm-param array<string, string> $assoc
+     *
+     * @return QueryException
      */
     public static function iterateWithFetchJoinCollectionNotAllowed($assoc)
     {
@@ -190,9 +190,9 @@ class QueryException extends ORMException
     }
 
     /**
-     * @return QueryException
-     *
      * @psalm-param array<string, string> $assoc
+     *
+     * @return QueryException
      */
     public static function overwritingJoinConditionsNotYetSupported($assoc)
     {
@@ -215,9 +215,9 @@ class QueryException extends ORMException
     }
 
     /**
-     * @return QueryException
-     *
      * @psalm-param array<string, string> $assoc
+     *
+     * @return QueryException
      */
     public static function iterateWithFetchJoinNotAllowed($assoc)
     {

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -87,10 +87,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param string   $class      The class name of the root entity.
      * @param string   $alias      The unique alias to use for the root entity.
      * @param int|null $renameMode One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
+     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      *
      * @return void
-     *
-     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      */
     public function addRootEntityFromClassMetadata($class, $alias, $renamedColumns = [], $renameMode = null)
     {
@@ -110,10 +109,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param string   $relation    The association field that connects the parent entity result
      *                              with the joined entity result.
      * @param int|null $renameMode  One of the COLUMN_RENAMING_* constants or array for BC reasons (CUSTOM).
+     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      *
      * @return void
-     *
-     * @psalm-param array<string, string> $renamedColumns Columns that have been renamed (tableColumnName => queryColumnName).
      */
     public function addJoinedEntityFromClassMetadata($class, $alias, $parentAlias, $relation, $renamedColumns = [], $renameMode = null)
     {
@@ -129,12 +127,11 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @param string $class
      * @param string $alias
+     * @psalm-param array<string, string> $columnAliasMap
      *
      * @return void
      *
      * @throws InvalidArgumentException
-     *
-     * @psalm-param array<string, string> $columnAliasMap
      */
     protected function addAllClassFields($class, $alias, $columnAliasMap = [])
     {
@@ -199,10 +196,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @param string $columnName
      * @param int    $mode
+     * @psalm-param array<string, string>  $customRenameColumns
      *
      * @return string
-     *
-     * @psalm-param array<string, string>  $customRenameColumns
      */
     private function getColumnAlias($columnName, $mode, array $customRenameColumns)
     {
@@ -225,10 +221,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @param string $className
      * @param int    $mode
+     * @psalm-param array<string, string> $customRenameColumns
      *
      * @return string[]
-     *
-     * @psalm-param array<string, string> $customRenameColumns
      * @psalm-return array<array-key, string>
      */
     private function getColumnAliasMap($className, $mode, array $customRenameColumns)
@@ -430,9 +425,9 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * Works only for all the entity results. The select parts for scalar
      * expressions have to be written manually.
      *
-     * @return string
-     *
      * @psalm-param array<string, string> $tableAliases
+     *
+     * @return string
      */
     public function generateSelectClause($tableAliases = [])
     {

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -41,7 +41,6 @@ interface TreeWalker
      * Returns internal queryComponents array.
      *
      * @return array<string, array<string, mixed>>
-     *
      * @psalm-return array<string, array{
      *                   metadata: ClassMetadata,
      *                   parent: string,

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -56,7 +56,6 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
 
     /**
      * @return string|false
-     *
      * @psalm-return class-string<TreeWalker>|false
      */
     public function rewind()

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -455,7 +455,6 @@ class QueryBuilder
      * </code>
      *
      * @return mixed[]
-     *
      * @psalm-return list<mixed>
      */
     public function getRootAliases()
@@ -491,7 +490,6 @@ class QueryBuilder
      * </code>
      *
      * @return mixed[]
-     *
      * @psalm-return list<mixed>
      */
     public function getAllAliases()
@@ -512,7 +510,6 @@ class QueryBuilder
      * </code>
      *
      * @return mixed[]
-     *
      * @psalm-return list<mixed>
      */
     public function getRootEntities()
@@ -695,10 +692,9 @@ class QueryBuilder
      *
      * @param string $dqlPartName The DQL part name.
      * @param bool   $append      Whether to append (true) or replace (false).
+     * @psalm-param string|object|list<string>|array{join: array<int|string, object>} $dqlPart     An Expr object.
      *
      * @return self
-     *
-     * @psalm-param string|object|list<string>|array{join: array<int|string, object>} $dqlPart     An Expr object.
      */
     public function add($dqlPartName, $dqlPart, $append = false)
     {
@@ -1469,9 +1465,9 @@ class QueryBuilder
     /**
      * Resets DQL parts.
      *
-     * @return self
-     *
      * @psalm-param list<string>|null $parts
+     *
+     * @return self
      */
     public function resetDQLParts($parts = null)
     {

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -253,7 +253,6 @@ EOT
      * @param mixed  $value A Value to show
      *
      * @return string[]
-     *
      * @psalm-return array{0: string, 1: string}
      */
     private function formatField($label, $value): array
@@ -268,9 +267,9 @@ EOT
     /**
      * Format the association mappings
      *
-     * @return string[][]
-     *
      * @psalm-param array<string, array<string, mixed>> $propertyMappings
+     *
+     * @return string[][]
      * @psalm-return list<array{0: string, 1: string}>
      */
     private function formatMappings(array $propertyMappings): array
@@ -291,9 +290,9 @@ EOT
     /**
      * Format the entity listeners
      *
-     * @return string[]
-     *
      * @psalm-param list<object> $entityListeners
+     *
+     * @return string[]
      * @psalm-return array{0: string, 1: string}
      */
     private function formatEntityListeners(array $entityListeners): array

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -71,7 +71,6 @@ class ConvertDoctrine1Schema
      * Doctrine 1 schema.
      *
      * @return ClassMetadataInfo[] An array of ClassMetadataInfo instances
-     *
      * @psalm-return list<ClassMetadataInfo>
      */
     public function getMetadata()

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -384,10 +384,9 @@ public function __construct(<params>)
      * Generates and writes entity classes for the given array of ClassMetadataInfo instances.
      *
      * @param string $outputDirectory
+     * @psalm-param list<ClassMetadataInfo> $metadatas
      *
      * @return void
-     *
-     * @psalm-param list<ClassMetadataInfo> $metadatas
      */
     public function generate(array $metadatas, $outputDirectory)
     {
@@ -539,12 +538,11 @@ public function __construct(<params>)
      * Sets the class fields visibility for the entity (can either be private or protected).
      *
      * @param string $visibility
+     * @psalm-param self::FIELD_VISIBLE_*
      *
      * @return void
      *
      * @throws InvalidArgumentException
-     *
-     * @psalm-param self::FIELD_VISIBLE_*
      */
     public function setFieldVisibility($visibility)
     {
@@ -946,10 +944,9 @@ public function __construct(<params>)
 
     /**
      * @return ReflectionClass[]
+     * @psalm-return array<trait-string, ReflectionClass>
      *
      * @throws ReflectionException
-     *
-     * @psalm-return array<trait-string, ReflectionClass>
      */
     protected function getTraits(ClassMetadataInfo $metadata)
     {
@@ -1115,10 +1112,9 @@ public function __construct(<params>)
 
     /**
      * @param string $constraintName
+     * @psalm-param array<string, array<string, mixed>> $constraints
      *
      * @return string
-     *
-     * @psalm-param array<string, array<string, mixed>> $constraints
      */
     protected function generateTableConstraints($constraintName, array $constraints)
     {
@@ -1286,9 +1282,9 @@ public function __construct(<params>)
     }
 
     /**
-     * @return bool
-     *
      * @psalm-param array<string, mixed> $associationMapping
+     *
+     * @return bool
      */
     protected function isAssociationIsNullable(array $associationMapping)
     {
@@ -1490,9 +1486,9 @@ public function __construct(<params>)
     }
 
     /**
-     * @return string
-     *
      * @psalm-param array<string, mixed> $joinColumn
+     *
+     * @return string
      */
     protected function generateJoinColumnAnnotation(array $joinColumn)
     {
@@ -1812,9 +1808,9 @@ public function __construct(<params>)
     }
 
     /**
-     * @return string
-     *
      * @psalm-param array<string, mixed> $embeddedClass
+     *
+     * @return string
      */
     protected function generateEmbeddedPropertyDocBlock(array $embeddedClass)
     {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -88,9 +88,9 @@ abstract class AbstractExporter
     /**
      * Sets the array of ClassMetadata instances to export.
      *
-     * @return void
-     *
      * @psalm-param list<ClassMetadata> $metadata
+     *
+     * @return void
      */
     public function setMetadata(array $metadata)
     {
@@ -187,10 +187,9 @@ abstract class AbstractExporter
 
     /**
      * @param int $type
+     * @psalm-param ClassMetadataInfo::INHERITANCE_TYPE_* $type
      *
      * @return string
-     *
-     * @psalm-param ClassMetadataInfo::INHERITANCE_TYPE_* $type
      */
     protected function _getInheritanceTypeString($type)
     {
@@ -211,10 +210,9 @@ abstract class AbstractExporter
 
     /**
      * @param int $mode
+     * @psalm-param ClassMetadataInfo::FETCH_* $mode
      *
      * @return string
-     *
-     * @psalm-param ClassMetadataInfo::FETCH_* $mode
      */
     protected function _getFetchModeString($mode)
     {
@@ -232,10 +230,9 @@ abstract class AbstractExporter
 
     /**
      * @param int $policy
+     * @psalm-param ClassMetadataInfo::CHANGETRACKING_* $policy
      *
      * @return string
-     *
-     * @psalm-param ClassMetadataInfo::CHANGETRACKING_* $policy
      */
     protected function _getChangeTrackingPolicyString($policy)
     {
@@ -253,10 +250,9 @@ abstract class AbstractExporter
 
     /**
      * @param int $type
+     * @psalm-param ClassMetadataInfo::GENERATOR_TYPE_* $type
      *
      * @return string
-     *
-     * @psalm-param ClassMetadataInfo::GENERATOR_TYPE_* $type
      */
     protected function _getIdGeneratorTypeString($type)
     {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -197,7 +197,6 @@ class PhpExporter extends AbstractExporter
 
     /**
      * @return string[]
-     *
      * @psalm-return list<string>
      */
     private function processEntityListeners(ClassMetadataInfo $metadata): array

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -245,6 +245,7 @@ class YamlExporter extends AbstractExporter
 
     /**
      * @psalm-param array<string, mixed> $array
+     *
      * @psalm-return array<string, mixed>&array{entityListeners: array<class-string, array<string, array{string}>>}
      */
     private function processEntityListeners(ClassMetadataInfo $metadata, array $array): array
@@ -265,6 +266,7 @@ class YamlExporter extends AbstractExporter
     /**
      * @psalm-param array{entityListeners: array<class-string, array<string, array{string}>>} $array
      * @psalm-param list<array{class: class-string, method: string}> $entityListenerConfig
+     *
      * @psalm-return array{entityListeners: array<class-string, array<string, array{string}>>}
      */
     private function processEntityListenerConfig(

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -514,7 +514,6 @@ class LimitSubqueryOutputWalker extends SqlWalker
 
     /**
      * @return array-key[]
-     *
      * @psalm-return array<array-key, array-key>
      */
     private function getSQLIdentifier(SelectStatement $AST)

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -58,10 +58,9 @@ class ResolveTargetEntityListener implements EventSubscriber
      *
      * @param string $originalEntity
      * @param string $newEntity
+     * @psalm-param array<string, mixed> $mapping
      *
      * @return void
-     *
-     * @psalm-param array<string, mixed> $mapping
      */
     public function addResolveTargetEntity($originalEntity, $newEntity, array $mapping)
     {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -87,11 +87,11 @@ class SchemaTool
     /**
      * Creates the database schema for the given array of ClassMetadata instances.
      *
+     * @psalm-param list<ClassMetadata> $classes
+     *
      * @return void
      *
      * @throws ToolsException
-     *
-     * @psalm-param list<ClassMetadata> $classes
      */
     public function createSchema(array $classes)
     {
@@ -111,9 +111,9 @@ class SchemaTool
      * Gets the list of DDL statements that are required to create the database schema for
      * the given list of ClassMetadata instances.
      *
-     * @return string[] The SQL statements needed to create the schema for the classes.
-     *
      * @psalm-param list<ClassMetadata> $classes
+     *
+     * @return string[] The SQL statements needed to create the schema for the classes.
      */
     public function getCreateSchemaSql(array $classes)
     {
@@ -140,11 +140,11 @@ class SchemaTool
     /**
      * Creates a Schema instance from a given set of metadata classes.
      *
+     * @psalm-param list<ClassMetadata> $classes
+     *
      * @return Schema
      *
      * @throws ORMException
-     *
-     * @psalm-param list<ClassMetadata> $classes
      */
     public function getSchemaFromMetadata(array $classes)
     {
@@ -431,7 +431,6 @@ class SchemaTool
      * Creates a column definition as required by the DBAL from an ORM field mapping definition.
      *
      * @param ClassMetadata $class The class that owns the field mapping.
-     *
      * @psalm-param array<string, mixed> $mapping The field mapping.
      */
     private function gatherColumn(
@@ -500,13 +499,13 @@ class SchemaTool
      * Gathers the SQL for properly setting up the relations of the given class.
      * This includes the SQL for foreign key constraints and join tables.
      *
-     * @throws ORMException
-     *
      * @psalm-param array<string, array{
      *                  foreignTableName: string,
      *                  foreignColumns: list<string>
      *              }>                               $addedFks
      * @psalm-param array<string, bool>              $blacklistedFks
+     *
+     * @throws ORMException
      */
     private function gatherRelationsSql(
         ClassMetadata $class,
@@ -614,8 +613,6 @@ class SchemaTool
     /**
      * Gathers columns and fk constraints that are required for one part of relationship.
      *
-     * @throws ORMException
-     *
      * @psalm-param array<string, mixed>             $joinColumns
      * @psalm-param array<string, mixed>             $mapping
      * @psalm-param list<string>                     $primaryKeyColumns
@@ -624,6 +621,8 @@ class SchemaTool
      *                  foreignColumns: list<string>
      *              }>                               $addedFks
      * @psalm-param array<string,bool>               $blacklistedFks
+     *
+     * @throws ORMException
      */
     private function gatherRelationJoinColumns(
         array $joinColumns,
@@ -763,9 +762,9 @@ class SchemaTool
      * In any way when an exception is thrown it is suppressed since drop was
      * issued for all classes of the schema and some probably just don't exist.
      *
-     * @return void
-     *
      * @psalm-param list<ClassMetadata> $classes
+     *
+     * @return void
      */
     public function dropSchema(array $classes)
     {
@@ -815,9 +814,9 @@ class SchemaTool
     /**
      * Gets SQL to drop the tables defined by the passed classes.
      *
-     * @return string[]
-     *
      * @psalm-param list<ClassMetadata> $classes
+     *
+     * @return string[]
      */
     public function getDropSchemaSQL(array $classes)
     {

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -80,7 +80,6 @@ class SchemaValidator
      * Validates a single class of the current.
      *
      * @return string[]
-     *
      * @psalm-return list<string>
      */
     public function validateClass(ClassMetadataInfo $class)

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -883,11 +883,10 @@ class UnitOfWork implements PropertyChangedListener
      * Computes the changes of an association.
      *
      * @param mixed $value The value of the association.
+     * @psalm-param array<string, mixed> $assoc The association mapping.
      *
      * @throws ORMInvalidArgumentException
      * @throws ORMException
-     *
-     * @psalm-param array<string, mixed> $assoc The association mapping.
      */
     private function computeAssociationChanges(array $assoc, $value): void
     {
@@ -1412,10 +1411,10 @@ class UnitOfWork implements PropertyChangedListener
      * Extra updates for entities are stored as (entity, changeset) tuples.
      *
      * @param object $entity The entity for which to schedule an extra update.
+     * @psalm-param array<string, array{mixed, mixed}>  $changeset The changeset of the entity (what to update).
      *
      * @return void
      *
-     * @psalm-param array<string, array{mixed, mixed}>  $changeset The changeset of the entity (what to update).
      * @ignore
      */
     public function scheduleExtraUpdate($entity, array $changeset)
@@ -1772,11 +1771,10 @@ class UnitOfWork implements PropertyChangedListener
      * the already visited entities to prevent infinite recursions.
      *
      * @param object $entity The entity to persist.
+     * @psalm-param array<string, object> $visited The already visited entities.
      *
      * @throws ORMInvalidArgumentException
      * @throws UnexpectedValueException
-     *
-     * @psalm-param array<string, object> $visited The already visited entities.
      */
     private function doPersist(object $entity, array &$visited): void
     {
@@ -1858,11 +1856,10 @@ class UnitOfWork implements PropertyChangedListener
      * the already visited entities to prevent infinite recursions.
      *
      * @param object $entity The entity to delete.
+     * @psalm-param array<string, object> $visited The map of the already visited entities.
      *
      * @throws ORMInvalidArgumentException If the instance is a detached entity.
      * @throws UnexpectedValueException
-     *
-     * @psalm-param array<string, object> $visited The map of the already visited entities.
      */
     private function doRemove($entity, array &$visited): void
     {
@@ -1932,6 +1929,7 @@ class UnitOfWork implements PropertyChangedListener
      * Executes a merge operation on an entity.
      *
      * @param string[] $assoc
+     * @psalm-param array<string, object> $visited
      *
      * @return object The managed copy of the entity.
      *
@@ -1939,8 +1937,6 @@ class UnitOfWork implements PropertyChangedListener
      *         attribute and the version check against the managed copy fails.
      * @throws ORMInvalidArgumentException If the entity instance is NEW.
      * @throws EntityNotFoundException if an assigned identifier is used in the entity, but none is provided.
-     *
-     * @psalm-param array<string, object> $visited
      */
     private function doMerge(
         object $entity,
@@ -2186,10 +2182,9 @@ class UnitOfWork implements PropertyChangedListener
      * Executes a refresh operation on an entity.
      *
      * @param object $entity The entity to refresh.
+     * @psalm-param array<string, object>  $visited The already visited entities during cascades.
      *
      * @throws ORMInvalidArgumentException If the entity is not MANAGED.
-     *
-     * @psalm-param array<string, object>  $visited The already visited entities during cascades.
      */
     private function doRefresh(object $entity, array &$visited): void
     {
@@ -2637,10 +2632,10 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param string  $className The name of the entity class.
      * @param mixed[] $data      The data for the entity.
+     * @psalm-param array<string, mixed> $hints Any hints to account for during reconstitution/lookup of the entity.
      *
      * @return object The managed entity instance.
      *
-     * @psalm-param array<string, mixed> $hints Any hints to account for during reconstitution/lookup of the entity.
      * @ignore
      * @todo Rename: getOrCreateEntity
      */
@@ -3170,9 +3165,9 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * Gets a collection persister for a collection-valued association.
      *
-     * @return CollectionPersister
-     *
      * @psalm-param array<string, mixed> $association
+     *
+     * @return CollectionPersister
      */
     public function getCollectionPersister(array $association)
     {

--- a/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+++ b/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
@@ -19,7 +19,6 @@ final class HierarchyDiscriminatorResolver
      * it extracts all the discriminators from the child classes and returns them
      *
      * @return null[]
-     *
      * @psalm-return array<array-key, null>
      */
     public static function resolveDiscriminatorsForClass(

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -140,15 +140,7 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
-        <exclude-pattern>*/tests/*</exclude-pattern>
-    </rule>
-
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
-        <exclude-pattern>*/tests/*</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
@@ -193,13 +185,6 @@
 
     <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden">
         <exclude-pattern>tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php</exclude-pattern>
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
-        <!-- https://github.com/slevomat/coding-standard/issues/1094 -->
-        <exclude-pattern>lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php</exclude-pattern>
-        <exclude-pattern>lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php</exclude-pattern>
-        <exclude-pattern>lib/Doctrine/ORM/Tools/EntityGenerator.php</exclude-pattern>
     </rule>
 
     <rule ref="Squiz.Commenting.FunctionComment.WrongStyle">

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1884Test.php
@@ -55,8 +55,9 @@ class DDC1884Test extends OrmFunctionalTestCase
     }
 
     /**
-     * @psalm-var class-string<Car> $class
      * @psalm-return array{Car, Car, Car, Car}
+     *
+     * @psalm-var class-string<Car> $class
      */
     private function createCars(string $class): array
     {
@@ -85,8 +86,9 @@ class DDC1884Test extends OrmFunctionalTestCase
     }
 
     /**
-     * @psalm-var class-string<Driver> $class
      * @psalm-return array{Driver, Driver}
+     *
+     * @psalm-var class-string<Driver> $class
      */
     private function createDrivers(string $class): array
     {

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -509,6 +509,7 @@ class ClassMetadataFactoryTestSubject extends ClassMetadataFactory
 
     /**
      * @psalm-param class-string<object> $className
+     *
      * @override
      */
     protected function newClassMetadataInstance($className): ClassMetadata


### PR DESCRIPTION
Although this is no bugfix and touches `src`, I'm still targeting 2.8.x so that merges up are not too painful. The changes are about moving phpdoc comments around, so I don't think there is a risk of regression, even for static analysis.