### PR TITLE
upgrade static tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
-        "phpstan/phpstan": "^0.12.18",
+        "phpstan/phpstan": "^0.12.83",
         "phpunit/phpunit": "^8.5|^9.4",
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/yaml": "^3.4|^4.0|^5.0",
-        "vimeo/psalm": "4.1.1"
+        "vimeo/psalm": "4.7.0"
     },
     "suggest": {
         "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1476,6 +1476,26 @@ parameters:
 			path: lib/Doctrine/ORM/Query.php
 
 		-
+			message: "#^Call to function is_array\\(\\) with Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
+			message: "#^Method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManager but returns Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$where$#"
+			count: 2
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
+			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
+			count: 2
+			path: lib/Doctrine/ORM/QueryBuilder.php
+
+		-
 			message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node\\:\\:\\$value\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -2219,26 +2239,6 @@ parameters:
 			message: "#^Array \\(array\\<class\\-string\\<Doctrine\\\\ORM\\\\Query\\\\TreeWalker\\>\\>\\) does not accept Doctrine\\\\ORM\\\\Query\\\\TreeWalker\\.$#"
 			count: 2
 			path: lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
-
-		-
-			message: "#^Call to function is_array\\(\\) with Doctrine\\\\Common\\\\Collections\\\\ArrayCollection&iterable will always evaluate to false\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/QueryBuilder.php
-
-		-
-			message: "#^Method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:getEntityManager\\(\\) should return Doctrine\\\\ORM\\\\EntityManager but returns Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/QueryBuilder.php
-
-		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$where$#"
-			count: 2
-			path: lib/Doctrine/ORM/QueryBuilder.php
-
-		-
-			message: "#^Parameter \\#2 \\$dqlPart of method Doctrine\\\\ORM\\\\QueryBuilder\\:\\:add\\(\\) expects array\\<'join'\\|int, array\\<int\\|string, object\\>\\|string\\>\\|object\\|string, array\\<string, Doctrine\\\\ORM\\\\Query\\\\Expr\\\\Join\\> given\\.$#"
-			count: 2
-			path: lib/Doctrine/ORM/QueryBuilder.php
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,4 @@ parameters:
     earlyTerminatingMethodCalls:
         Doctrine\ORM\Query\Parser:
             - syntaxError
+    phpVersion: 70200

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.3.2@57b53ff26237074fdf5cbcb034f7da5172be4524">
+<files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
     <FalsableReturnStatement occurrences="1">
       <code>! $filteredParameters-&gt;isEmpty() ? $filteredParameters-&gt;first() : null</code>
@@ -326,6 +326,9 @@
     </FalsableReturnStatement>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
+    <InvalidArgument occurrences="1">
+      <code>$hints</code>
+    </InvalidArgument>
     <InvalidNullableReturnType occurrences="2">
       <code>loadById</code>
       <code>loadOneToOneEntity</code>
@@ -349,9 +352,6 @@
       <code>$paramMappings</code>
       <code>$sqlPositions</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
-      <code>$value[$i % $countValue]</code>
-    </InvalidArrayOffset>
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
@@ -555,13 +555,10 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
     </NullableReturnStatement>
-    <UndefinedInterfaceMethod occurrences="6">
+    <UndefinedInterfaceMethod occurrences="3">
       <code>getMapping</code>
       <code>getMapping</code>
       <code>takeSnapshot</code>
-      <code>unwrap</code>
-      <code>unwrap</code>
-      <code>unwrap</code>
     </UndefinedInterfaceMethod>
   </file>
 </files>


### PR DESCRIPTION
This PR upgrades static tools version and regenerate baseline with the last version following this comment: https://github.com/doctrine/orm/pull/8548#issuecomment-821783915

It also adds the version in phpstan config to ensure coherent baseline generation with different php versions.