### PR TITLE
Update ignore rules to reflect current situation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,9 @@
 /tools export-ignore
 /docs export-ignore
 /.github export-ignore
+.doctrine-project.json export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-.gitmodules export-ignore
-.travis.yml export-ignore
 build.properties export-ignore
 build.properties.dev export-ignore
 build.xml export-ignore
@@ -15,4 +14,6 @@ run-all.sh export-ignore
 phpcs.xml.dist export-ignore
 phpbench.json export-ignore
 phpstan.neon export-ignore
+phpstan-baseline.neon export-ignore
 psalm.xml export-ignore
+psalm-baseline.xml export-ignore


### PR DESCRIPTION
We no longer use Travis, we do not use git submodules as far as I know,
and we now use baseline files.