### PR TITLE
FileLockRegion::__construct 3rd param is meant to be an int

### DIFF
--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -64,7 +64,7 @@ class FileLockRegion implements ConcurrentRegion
 
     /**
      * @param string $directory
-     * @param int $lockLifetime
+     * @param int    $lockLifetime
      *
      * @throws InvalidArgumentException
      */

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -59,12 +59,12 @@ class FileLockRegion implements ConcurrentRegion
     /** @var string */
     private $directory;
 
-    /** @psalm-var numeric-string */
+    /** @psalm-var int */
     private $lockLifetime;
 
     /**
      * @param string $directory
-     * @param string $lockLifetime
+     * @param int $lockLifetime
      *
      * @throws InvalidArgumentException
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,11 +56,6 @@ parameters:
 			path: lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
 
 		-
-			message: "#^Parameter \\#3 \\$lockLifetime of class Doctrine\\\\ORM\\\\Cache\\\\Region\\\\FileLockRegion constructor expects string, int given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
-
-		-
 			message: "#^Method Doctrine\\\\ORM\\\\Cache\\\\DefaultCollectionHydrator\\:\\:loadCacheEntry\\(\\) should return array but returns null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -258,11 +253,6 @@ parameters:
 		-
 			message: "#^Method Doctrine\\\\ORM\\\\Cache\\\\Region\\\\FileLockRegion\\:\\:lock\\(\\) should return Doctrine\\\\ORM\\\\Cache\\\\Lock but returns null\\.$#"
 			count: 2
-			path: lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Cache\\\\Region\\\\FileLockRegion\\:\\:\\$lockLifetime \\(string&numeric\\) does not accept string\\.$#"
-			count: 1
 			path: lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
 
 		-


### PR DESCRIPTION
Following https://github.com/doctrine/orm/pull/8630#discussion_r615421792, this is a proper PR that propose changing the type of the param to an int.

This is kinda a BC break because while the code and behaviour doesn't change, it technically modify the expected type.

Note that before #8630, every value given internally was effectively an int.