### PR TITLE
[GH-8327] Make EntityManagerProvider compatible with expected DoctrineBundle usage

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
@@ -34,6 +34,8 @@ abstract class AbstractEntityManagerCommand extends Command
             return $this->getHelper('em')->getEntityManager();
         }
 
-        return $this->entityManagerProvider->getManager($input->getOption('em'));
+        return $input->getOption('em') === null
+            ? $this->entityManagerProvider->getDefaultManager()
+            : $this->entityManagerProvider->getManager($input->getOption('em'));
     }
 }

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -50,7 +50,7 @@ class CollectionRegionCommand extends AbstractEntityManagerCommand
              ->addArgument('owner-class', InputArgument::OPTIONAL, 'The owner entity name.')
              ->addArgument('association', InputArgument::OPTIONAL, 'The association collection name.')
              ->addArgument('owner-id', InputArgument::OPTIONAL, 'The owner identifier.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('all', null, InputOption::VALUE_NONE, 'If defined, all entity regions will be deleted/invalidated.')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.')
              ->setHelp(<<<EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -49,7 +49,7 @@ class EntityRegionCommand extends AbstractEntityManagerCommand
              ->setDescription('Clear a second-level cache entity region')
              ->addArgument('entity-class', InputArgument::OPTIONAL, 'The entity name.')
              ->addArgument('entity-id', InputArgument::OPTIONAL, 'The entity identifier.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('all', null, InputOption::VALUE_NONE, 'If defined, all entity regions will be deleted/invalidated.')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.')
              ->setHelp(<<<EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -49,7 +49,7 @@ class MetadataCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:clear-cache:metadata')
              ->setDescription('Clear all metadata cache of the various cache drivers')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, cache entries will be flushed instead of deleted/invalidated.')
              ->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the metadata cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -49,7 +49,7 @@ class QueryCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:clear-cache:query')
              ->setDescription('Clear all query cache of the various cache drivers')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, cache entries will be flushed instead of deleted/invalidated.')
              ->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the query cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -48,7 +48,7 @@ class QueryRegionCommand extends AbstractEntityManagerCommand
         $this->setName('orm:clear-cache:region:query')
              ->setDescription('Clear a second-level cache query region')
              ->addArgument('region-name', InputArgument::OPTIONAL, 'The query region to clear.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('all', null, InputOption::VALUE_NONE, 'If defined, all query regions will be deleted/invalidated.')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, all cache entries will be flushed.')
              ->setHelp(<<<EOT

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -49,7 +49,7 @@ class ResultCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:clear-cache:result')
              ->setDescription('Clear all result cache of the various cache drivers')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('flush', null, InputOption::VALUE_NONE, 'If defined, cache entries will be flushed instead of deleted/invalidated.')
              ->setHelp(<<<EOT
 The <info>%command.name%</info> command is meant to clear the result cache of associated Entity Manager.

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -59,7 +59,7 @@ class ConvertMappingCommand extends AbstractEntityManagerCommand
              ->setDescription('Convert mapping information between supported formats')
              ->addArgument('to-type', InputArgument::REQUIRED, 'The mapping type to be converted.')
              ->addArgument('dest-path', InputArgument::REQUIRED, 'The path to generate your entities classes.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be processed.')
              ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force to overwrite existing mapping files.')
              ->addOption('from-database', null, null, 'Whether or not to convert mapping information from existing database.')

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -40,7 +40,7 @@ class EnsureProductionSettingsCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:ensure-production-settings')
              ->setDescription('Verify that Doctrine is properly configured for a production environment')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('complete', null, InputOption::VALUE_NONE, 'Flag to also inspect database connection existence.')
              ->setHelp('Verify that Doctrine is properly configured for a production environment.');
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -53,7 +53,7 @@ class GenerateEntitiesCommand extends AbstractEntityManagerCommand
              ->setAliases(['orm:generate:entities'])
              ->setDescription('Generate entity classes and method stubs from your mapping information')
              ->addArgument('dest-path', InputArgument::REQUIRED, 'The path to generate your entity classes.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be processed.')
              ->addOption('generate-annotations', null, InputOption::VALUE_OPTIONAL, 'Flag to define if generator should generate annotation metadata on entities.', false)
              ->addOption('generate-methods', null, InputOption::VALUE_OPTIONAL, 'Flag to define if generator should generate stub methods on entities.', true)

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -51,7 +51,7 @@ class GenerateProxiesCommand extends AbstractEntityManagerCommand
              ->setAliases(['orm:generate:proxies'])
              ->setDescription('Generates proxy classes for entity classes')
              ->addArgument('dest-path', InputArgument::OPTIONAL, 'The path to generate your proxy classes. If none is provided, it will attempt to grab from configuration.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be processed.')
              ->setHelp('Generates proxy classes for entity classes.');
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -52,7 +52,7 @@ class GenerateRepositoriesCommand extends AbstractEntityManagerCommand
              ->setAliases(['orm:generate:repositories'])
              ->setDescription('Generate repository classes from your mapping information')
              ->addArgument('dest-path', InputArgument::REQUIRED, 'The path to generate your repository classes.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('filter', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'A string pattern used to match entities that should be processed.')
              ->setHelp('Generate repository classes from your mapping information.');
     }

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -43,7 +43,7 @@ class InfoCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:info')
              ->setDescription('Show basic information about all mapped entities')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->setHelp(<<<EOT
 The <info>%command.name%</info> shows basic information about which
 entities exist and possibly if their mapping information contains errors or

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -63,7 +63,7 @@ final class MappingDescribeCommand extends AbstractEntityManagerCommand
         $this->setName('orm:mapping:describe')
              ->addArgument('entityName', InputArgument::REQUIRED, 'Full or partial name of entity')
              ->setDescription('Display information about mapped objects')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->setHelp(<<<EOT
 The %command.full_name% command describes the metadata for the given full or partial entity class name.
 

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -51,7 +51,7 @@ class RunDqlCommand extends AbstractEntityManagerCommand
         $this->setName('orm:run-dql')
              ->setDescription('Executes arbitrary DQL directly from the command line')
              ->addArgument('dql', InputArgument::REQUIRED, 'The DQL to execute.')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('hydrate', null, InputOption::VALUE_REQUIRED, 'Hydration mode of result set. Should be either: object, array, scalar or single-scalar.', 'object')
              ->addOption('first-result', null, InputOption::VALUE_REQUIRED, 'The first result in the result set.')
              ->addOption('max-result', null, InputOption::VALUE_REQUIRED, 'The maximum number of results in the result set.')

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -42,7 +42,7 @@ class ValidateSchemaCommand extends AbstractEntityManagerCommand
     {
         $this->setName('orm:validate-schema')
              ->setDescription('Validate the mapping files')
-             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on', 'default')
+             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'Name of the entity manager to operate on')
              ->addOption('skip-mapping', null, InputOption::VALUE_NONE, 'Skip the mapping validation check')
              ->addOption('skip-sync', null, InputOption::VALUE_NONE, 'Skip checking if the mapping is in sync with the database')
              ->setHelp('Validate that the mapping files are correct and in sync with the database.');

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
@@ -7,5 +7,6 @@ use Doctrine\ORM\EntityManagerInterface;
 interface EntityManagerProvider
 {
     public function getDefaultManager(): EntityManagerInterface;
+
     public function getManager(string $name): EntityManagerInterface;
 }

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
@@ -6,5 +6,6 @@ use Doctrine\ORM\EntityManagerInterface;
 
 interface EntityManagerProvider
 {
-    public function getManager(string $name = 'default'): EntityManagerInterface;
+    public function getDefaultManager(): EntityManagerInterface;
+    public function getManager(string $name): EntityManagerInterface;
 }

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
@@ -17,7 +17,7 @@ final class ConnectionFromManagerProvider implements ConnectionProvider
     public function __construct(EntityManagerProvider $entityManagerProvider, $defaultManagerName = 'default')
     {
         $this->entityManagerProvider = $entityManagerProvider;
-        $this->defaultManagerName = $defaultManagerName;
+        $this->defaultManagerName    = $defaultManagerName;
     }
 
     public function getDefaultConnection(): Connection

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
@@ -11,18 +11,14 @@ final class ConnectionFromManagerProvider implements ConnectionProvider
     /** @var EntityManagerProvider */
     private $entityManagerProvider;
 
-    /** @var string */
-    private $defaultManagerName;
-
-    public function __construct(EntityManagerProvider $entityManagerProvider, $defaultManagerName = 'default')
+    public function __construct(EntityManagerProvider $entityManagerProvider)
     {
         $this->entityManagerProvider = $entityManagerProvider;
-        $this->defaultManagerName    = $defaultManagerName;
     }
 
     public function getDefaultConnection(): Connection
     {
-        return $this->entityManagerProvider->getManager($this->defaultManagerName)->getConnection();
+        return $this->entityManagerProvider->getDefaultManager()->getConnection();
     }
 
     public function getConnection(string $name): Connection

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
@@ -11,14 +11,18 @@ final class ConnectionFromManagerProvider implements ConnectionProvider
     /** @var EntityManagerProvider */
     private $entityManagerProvider;
 
-    public function __construct(EntityManagerProvider $entityManagerProvider)
+    /** @var string */
+    private $defaultManagerName;
+
+    public function __construct(EntityManagerProvider $entityManagerProvider, $defaultManagerName = 'default')
     {
         $this->entityManagerProvider = $entityManagerProvider;
+        $this->defaultManagerName = $defaultManagerName;
     }
 
     public function getDefaultConnection(): Connection
     {
-        return $this->entityManagerProvider->getManager('default')->getConnection();
+        return $this->entityManagerProvider->getManager($this->defaultManagerName)->getConnection();
     }
 
     public function getConnection(string $name): Connection

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/HelperSetManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/HelperSetManagerProvider.php
@@ -26,12 +26,17 @@ final class HelperSetManagerProvider implements EntityManagerProvider
         );
     }
 
-    public function getManager(string $name = 'default'): EntityManagerInterface
+    public function getManager(string $name): EntityManagerInterface
     {
         if ($name !== 'default') {
             throw UnknownManagerException::unknownManager($name, ['default']);
         }
 
+        return $this->getDefaultManager();
+    }
+
+    public function getDefaultManager(): EntityManagerInterface
+    {
         $helper = $this->helperSet->get('entityManager');
 
         assert($helper instanceof EntityManagerHelper);

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
@@ -15,7 +15,7 @@ final class SingleManagerProvider implements EntityManagerProvider
 
     public function __construct(EntityManagerInterface $entityManager, string $defaultManagerName = 'default')
     {
-        $this->entityManager = $entityManager;
+        $this->entityManager      = $entityManager;
         $this->defaultManagerName = $defaultManagerName;
     }
 

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
@@ -10,15 +10,24 @@ final class SingleManagerProvider implements EntityManagerProvider
     /** @var EntityManagerInterface */
     private $entityManager;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    /** @var string */
+    private $defaultManagerName;
+
+    public function __construct(EntityManagerInterface $entityManager, string $defaultManagerName = 'default')
     {
         $this->entityManager = $entityManager;
+        $this->defaultManagerName = $defaultManagerName;
     }
 
-    public function getManager(string $name = 'default'): EntityManagerInterface
+    public function getDefaultManager(): EntityManagerInterface
     {
-        if ($name !== 'default') {
-            throw UnknownManagerException::unknownManager($name, ['default']);
+        return $this->entityManager;
+    }
+
+    public function getManager(string $name): EntityManagerInterface
+    {
+        if ($name !== $this->defaultManagerName) {
+            throw UnknownManagerException::unknownManager($name, [$this->defaultManagerName]);
         }
 
         return $this->entityManager;


### PR DESCRIPTION
This complication of the `EntityManagerProvider` API with a new method is necessary, because during integration in DoctrineBundle https://github.com/doctrine/DoctrineBundle/pull/1327 it showed that their `em` option defaults to `NULL`, which isn't compatible with ORM using `default` as the default value.

Related #8327 #8524

Fixes #8643  