### PR TITLE
Make code php 7.3 lint-compatible

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2637,7 +2637,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        break;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
Current latest 2.4 release v2.4.8 raised a warning when ran on php 7.3:
```shell
$ php7.3 -v; find . -name '*.php' -exec php7.3 -l {} \;| grep -v '^No syntax errors'
PHP 7.3.27-9+ubuntu20.04.1+deb.sury.org+1 (cli) (built: Feb 23 2021 15:10:30) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.27, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.3.27-9+ubuntu20.04.1+deb.sury.org+1, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v3.0.3, Copyright (c) 2002-2021, by Derick Rethans
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in ./lib/Doctrine/ORM/UnitOfWork.php on line 2640
```

I changed the `continue` into the `break` ([meaning of `continue;` inside a switch](https://secure.php.net/continue)), although continue 2 seems to be equivalent as there is no code after the switch statement.