### PR TITLE
Introduce PSR-6 for metadata caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-pdo": "*",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.12",
-        "doctrine/cache": "^1.9.1",
+        "doctrine/cache": "^1.11.0",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.0",
@@ -30,6 +30,7 @@
         "doctrine/instantiator": "^1.3",
         "doctrine/lexer": "^1.0",
         "doctrine/persistence": "^2.0",
+        "psr/cache": "^1 || ^2 || ^3",
         "symfony/console": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
@@ -37,6 +38,7 @@
         "phpstan/phpstan": "^0.12.83",
         "phpunit/phpunit": "^7.5|^8.5|^9.4",
         "squizlabs/php_codesniffer": "3.6.0",
+        "symfony/cache": "^5.2",
         "symfony/yaml": "^3.4|^4.0|^5.0",
         "vimeo/psalm": "4.7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpstan/phpstan": "^0.12.83",
         "phpunit/phpunit": "^7.5|^8.5|^9.4",
         "squizlabs/php_codesniffer": "3.6.0",
-        "symfony/cache": "^5.2",
+        "symfony/cache": "^4.4|^5.2",
         "symfony/yaml": "^3.4|^4.0|^5.0",
         "vimeo/psalm": "4.7.0"
     },

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -21,6 +21,8 @@
 namespace Doctrine\ORM;
 
 use BadMethodCallException;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Connection;
@@ -48,6 +50,7 @@ use function is_callable;
 use function is_object;
 use function is_string;
 use function ltrim;
+use function method_exists;
 use function sprintf;
 
 /**
@@ -164,7 +167,8 @@ use function sprintf;
 
         $this->metadataFactory = new $metadataFactoryClassName();
         $this->metadataFactory->setEntityManager($this);
-        $this->metadataFactory->setCacheDriver($this->config->getMetadataCacheImpl());
+
+        $this->configureMetadataCache();
 
         $this->repositoryFactory = $config->getRepositoryFactory();
         $this->unitOfWork        = new UnitOfWork($this);
@@ -985,5 +989,43 @@ use function sprintf;
                     throw TransactionRequiredException::transactionRequired();
                 }
         }
+    }
+
+    private function configureMetadataCache(): void
+    {
+        $metadataCache = $this->config->getMetadataCache();
+        if (! $metadataCache) {
+            $this->configureLegacyMetadataCache();
+
+            return;
+        }
+
+        // We have a PSR-6 compatible metadata factory. Use cache directly
+        if (method_exists($this->metadataFactory, 'setCache')) {
+            $this->metadataFactory->setCache($metadataCache);
+
+            return;
+        }
+
+        // Wrap PSR-6 cache to provide doctrine/cache interface
+        $this->metadataFactory->setCacheDriver(DoctrineProvider::wrap($metadataCache));
+    }
+
+    private function configureLegacyMetadataCache(): void
+    {
+        $metadataCache = $this->config->getMetadataCacheImpl();
+        if (! $metadataCache) {
+            return;
+        }
+
+        // Metadata factory is not PSR-6 compatible. Use cache directly
+        if (! method_exists($this->metadataFactory, 'setCache')) {
+            $this->metadataFactory->setCacheDriver($metadataCache);
+
+            return;
+        }
+
+        // Wrap doctrine/cache to provide PSR-6 interface
+        $this->metadataFactory->setCache(CacheAdapter::wrap($metadataCache));
     }
 }

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -17,8 +17,8 @@ use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Tests\DoctrineTestCase;
 use Doctrine\Tests\Models\DDC753\DDC753CustomRepository;
-use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use ReflectionClass;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -26,7 +26,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 /**
  * Tests for the Configuration object
  */
-class ConfigurationTest extends TestCase
+class ConfigurationTest extends DoctrineTestCase
 {
     /** @var Configuration */
     private $configuration;

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -136,7 +136,7 @@ class ConfigurationTest extends TestCase
     public function testSetGetMetadataCache(): void
     {
         $this->assertNull($this->configuration->getMetadataCache());
-        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache = $this->createStub(CacheItemPoolInterface::class);
         $this->configuration->setMetadataCache($cache);
         $this->assertSame($cache, $this->configuration->getMetadataCache());
     }
@@ -233,7 +233,7 @@ class ConfigurationTest extends TestCase
         $this->configuration->ensureProductionSettings();
     }
 
-    public function testEnsureProductionSettingsLegacyLegacyMetadataArrayCache(): void
+    public function testEnsureProductionSettingsLegacyMetadataArrayCache(): void
     {
         $this->setProductionSettings();
         $this->configuration->setMetadataCacheImpl(new ArrayCache());

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use GearmanWorker;
 use InvalidArgumentException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function assert;
 use function is_array;
@@ -121,9 +122,9 @@ class LockAgentWorker
 
         $annotDriver = $config->newDefaultAnnotationDriver([__DIR__ . '/../../../Models/'], true);
         $config->setMetadataDriverImpl($annotDriver);
+        $config->setMetadataCache(new ArrayAdapter());
 
         $cache = new ArrayCache();
-        $config->setMetadataCacheImpl($cache);
         $config->setQueryCacheImpl($cache);
         $config->setSQLLogger(new EchoSQLLogger());
 

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -17,6 +17,8 @@ use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\Tests\Mocks\EntityManagerMock;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function is_array;
 use function realpath;
@@ -29,9 +31,9 @@ abstract class OrmTestCase extends DoctrineTestCase
     /**
      * The metadata cache that is shared between all ORM tests (except functional tests).
      *
-     * @var Cache|null
+     * @var CacheItemPoolInterface|null
      */
-    private static $_metadataCacheImpl = null;
+    private static $_metadataCache = null;
 
     /**
      * The query cache that is shared between all ORM tests (except functional tests).
@@ -92,11 +94,11 @@ abstract class OrmTestCase extends DoctrineTestCase
     ): EntityManagerMock {
         $metadataCache = $withSharedMetadata
             ? self::getSharedMetadataCacheImpl()
-            : new ArrayCache();
+            : new ArrayAdapter();
 
         $config = new Configuration();
 
-        $config->setMetadataCacheImpl($metadataCache);
+        $config->setMetadataCache($metadataCache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], true));
         $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
         $config->setProxyDir(__DIR__ . '/Proxies');
@@ -142,13 +144,13 @@ abstract class OrmTestCase extends DoctrineTestCase
         $this->isSecondLevelCacheLogEnabled = $log;
     }
 
-    private static function getSharedMetadataCacheImpl(): Cache
+    private static function getSharedMetadataCacheImpl(): ?CacheItemPoolInterface
     {
-        if (self::$_metadataCacheImpl === null) {
-            self::$_metadataCacheImpl = new ArrayCache();
+        if (self::$_metadataCache === null) {
+            self::$_metadataCache = new ArrayAdapter();
         }
 
-        return self::$_metadataCacheImpl;
+        return self::$_metadataCache;
     }
 
     private static function getSharedQueryCacheImpl(): Cache


### PR DESCRIPTION
Closes #8650.

This bumps the doctrine/cache dependency to the just-released 1.11 version that includes the PSR-6 adapters needed for compatibility code. The dependency to doctrine/persistence does not to be bumped; instead we check if doctrine/persistence supports PSR-6 caching. I can update this if requested.