### PR TITLE
Make tests independent

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ExtraLazyCollectionTest.php
@@ -67,9 +67,13 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $class->associationMappings['phonenumbers']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
         $class->associationMappings['phonenumbers']['indexBy'] = 'phonenumber';
 
-        unset($class->associationMappings['phonenumbers']['cache']);
-        unset($class->associationMappings['articles']['cache']);
-        unset($class->associationMappings['users']['cache']);
+        foreach (['phonenumbers', 'articles', 'users'] as $field) {
+            if (isset($class->associationMappings[$field]['cache'])) {
+                $this->previousCacheConfig[$field] = $class->associationMappings[$field]['cache'];
+            }
+
+            unset($class->associationMappings[$field]['cache']);
+        }
 
         $class                                          = $this->_em->getClassMetadata(CmsGroup::class);
         $class->associationMappings['users']['fetch']   = ClassMetadataInfo::FETCH_EXTRA_LAZY;
@@ -86,6 +90,13 @@ class ExtraLazyCollectionTest extends OrmFunctionalTestCase
         $class->associationMappings['groups']['fetch']       = ClassMetadataInfo::FETCH_LAZY;
         $class->associationMappings['articles']['fetch']     = ClassMetadataInfo::FETCH_LAZY;
         $class->associationMappings['phonenumbers']['fetch'] = ClassMetadataInfo::FETCH_LAZY;
+
+        foreach (['phonenumbers', 'articles', 'users'] as $field) {
+            if (isset($this->previousCacheConfig[$field])) {
+                $class->associationMappings[$field]['cache'] = $this->previousCacheConfig[$field];
+                unset($this->previousCacheConfig[$field]);
+            }
+        }
 
         unset($class->associationMappings['groups']['indexBy']);
         unset($class->associationMappings['articles']['indexBy']);

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
@@ -208,6 +208,9 @@ class IdentityMapTest extends OrmFunctionalTestCase
         $this->assertEquals(4, count($user3->getPhonenumbers()));
     }
 
+    /**
+     * @group non-cacheable
+     */
     public function testCollectionValuedAssociationIdentityMapBehaviorWithRefresh(): void
     {
         $user           = new CmsUser();


### PR DESCRIPTION
It seems like IdentityMapTest cannot be run on its own when the second
level cache is enabled (with ENABLE_SECOND_LEVEL_CACHE=1).
It does work when running the whole test suite because
ExtraLazyCollectionTest disables part of that cache in its setUp()
method.
In this patch, we restore the class metadata as it was before running
setUp() and put the test in IdentityMapTest inside the group that is
excluded when running with ENABLE_SECOND_LEVEL_CACHE=1 on the CI.

I am unsure if this is legitimate of if I should rather mark the test as skipped with a message saying this might be a bug.

Blocks https://github.com/doctrine/orm/pull/8651