### PR TITLE
Validate all fields in schema validator

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -103,7 +103,7 @@ class SchemaValidator
             if (! class_exists($assoc['targetEntity']) || $cmf->isTransient($assoc['targetEntity'])) {
                 $ce[] = "The target entity '" . $assoc['targetEntity'] . "' specified on " . $class->name . '#' . $fieldName . ' is unknown or not an entity.';
 
-                return $ce;
+                continue;
             }
 
             if ($assoc['mappedBy'] && $assoc['inversedBy']) {


### PR DESCRIPTION
I'm currently debugging some thing with resolve target entities and did saw that the validator only output the first error instead of all associations. The following changes should now return all errors on the target entity.