### PR TITLE
Bug/#8667 segmentation fault when column is nullable

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -682,10 +682,10 @@ class BasicEntityPersister implements EntityPersister
                 $quotedColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
                 $value = $newValId ? $newValId[$targetClass->getFieldForColumn($targetColumn)] : null;
 
-                $this->quotedColumns[$sourceColumn]  = $quotedColumn;
                 $result[$owningTable][$sourceColumn] = $value;
-                $this->columnTypes[$sourceColumn] = $joinColumn['nullable'] && $value !== null ?
-                    PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em):
+                $this->quotedColumns[$sourceColumn]  = $quotedColumn;
+                $this->columnTypes[$sourceColumn]    = ! ( $joinColumn['nullable'] && $value === null ) ?
+                    PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em) :
                     null;
             }
         }

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -680,12 +680,13 @@ class BasicEntityPersister implements EntityPersister
                 $sourceColumn = $joinColumn['name'];
                 $targetColumn = $joinColumn['referencedColumnName'];
                 $quotedColumn = $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform);
+                $value = $newValId ? $newValId[$targetClass->getFieldForColumn($targetColumn)] : null;
 
                 $this->quotedColumns[$sourceColumn]  = $quotedColumn;
-                $this->columnTypes[$sourceColumn]    = PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em);
-                $result[$owningTable][$sourceColumn] = $newValId
-                    ? $newValId[$targetClass->getFieldForColumn($targetColumn)]
-                    : null;
+                $result[$owningTable][$sourceColumn] = $value;
+                $this->columnTypes[$sourceColumn] = $joinColumn['nullable'] && $value !== null ?
+                    PersisterHelper::getTypeOfColumn($targetColumn, $targetClass, $this->em):
+                    null;
             }
         }
 


### PR DESCRIPTION
When property in Entity is defined as column with ManyToOne relation and have possibility to provide nullable values, during insertion to database original `\PDO` object returns PHP Core error `Segmentation fault`, because we trying to bind nullable parameter as integer. But this PullRequest is just proposition. Maybe someone have better idea how we can manage nullable relation and binding of parameters.

Tested with `doctrine\orm` 2.9.x and PHP 8.0.5

