### PR TITLE
Add hint for ->iterate() deprecation

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -948,7 +948,7 @@ abstract class AbstractQuery
      * Executes the query and returns an IterableResult that can be used to incrementally
      * iterate over the result.
      *
-     * @deprecated
+     * @deprecated 2.8 Use {@see toIterable} instead. See https://github.com/doctrine/orm/issues/8463
      *
      * @param ArrayCollection|mixed[]|null $parameters    The query parameters.
      * @param string|int|null              $hydrationMode The hydration mode to use.


### PR DESCRIPTION
Just going over deprecations and noticed this one just tells me it's deprecated without saying what to use instead.. Also pointed to https://github.com/doctrine/orm/issues/8463 as it clearly shows the usage change which is great to have 👍🏻 