### PR TITLE
[Gh-8589] A new approach to non-nullable typed associations for BC

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1515,18 +1515,18 @@ class ClassMetadataInfo implements ClassMetadata
     {
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
-        if (
-            ! isset($mapping['targetEntity'])
-            && ($mapping['type'] & self::TO_ONE) > 0
-            && $type instanceof ReflectionNamedType
-        ) {
+        if ($type === null || ($mapping['type'] & self::TO_ONE) === 0) {
+            return $mapping;
+        }
+
+        if (! isset($mapping['targetEntity']) && $type instanceof ReflectionNamedType) {
             $mapping['targetEntity'] = $type->getName();
         }
 
-        if ($type !== null && isset($mapping['joinColumns'])) {
+        if (isset($mapping['joinColumns'])) {
             foreach ($mapping['joinColumns'] as &$joinColumn) {
-                if (! isset($joinColumn['nullable'])) {
-                    $joinColumn['nullable'] = $type->allowsNull();
+                if ($type->allowsNull() === false) {
+                    $joinColumn['nullable'] = false;
                 }
             }
         }
@@ -1801,7 +1801,6 @@ class ClassMetadataInfo implements ClassMetadata
                     [
                         'name' => $this->namingStrategy->joinColumnName($mapping['fieldName'], $this->name),
                         'referencedColumnName' => $this->namingStrategy->referenceColumnName(),
-                        'nullable' => true,
                     ],
                 ];
             }
@@ -1817,10 +1816,6 @@ class ClassMetadataInfo implements ClassMetadata
                     } else {
                         $uniqueConstraintColumns[] = $joinColumn['name'];
                     }
-                }
-
-                if (! isset($joinColumn['nullable'])) {
-                    $joinColumn['nullable'] = true;
                 }
 
                 if (empty($joinColumn['name'])) {

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -40,8 +40,8 @@ final class JoinColumn implements Annotation
     /** @var bool */
     public $unique = false;
 
-    /** @var bool|null */
-    public $nullable;
+    /** @var bool */
+    public $nullable = true;
 
     /** @var mixed */
     public $onDelete;
@@ -60,7 +60,7 @@ final class JoinColumn implements Annotation
         ?string $name = null,
         string $referencedColumnName = 'id',
         bool $unique = false,
-        ?bool $nullable = null,
+        bool $nullable = true,
         $onDelete = null,
         ?string $columnDefinition = null,
         ?string $fieldName = null

--- a/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/CascadeRemoveOrderTest.php
@@ -158,7 +158,6 @@ class CascadeRemoveOrderEntityG
      *     targetEntity="Doctrine\Tests\ORM\Functional\CascadeRemoveOrderEntityO",
      *     inversedBy="oneToMany"
      * )
-     * @JoinColumn(nullable=true, onDelete="SET NULL")
      */
     private $ownerO;
 

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -278,13 +278,6 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         // Explicit Not Nullable
         $this->assertFalse($class->isNullable('username'));
-
-        // Join table Nullable
-        $this->assertFalse($class->getAssociationMapping('email')['joinColumns'][0]['nullable']);
-        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
-
-        $this->assertTrue($class->getAssociationMapping('mainEmail')['joinColumns'][0]['nullable']);
-        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -278,6 +278,9 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
 
         // Explicit Not Nullable
         $this->assertFalse($class->isNullable('username'));
+
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -127,6 +127,12 @@ class ClassMetadataTest extends OrmTestCase
         // Explicit Not Nullable
         $cm->mapField(['fieldName' => 'username', 'length' => 50]);
         $this->assertFalse($cm->isNullable('username'));
+
+        $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
+        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
+
+        $cm->mapManyToOne(['fieldName' => 'mainEmail']);
+        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -127,15 +127,6 @@ class ClassMetadataTest extends OrmTestCase
         // Explicit Not Nullable
         $cm->mapField(['fieldName' => 'username', 'length' => 50]);
         $this->assertFalse($cm->isNullable('username'));
-
-        // Join table Nullable
-        $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
-        $this->assertFalse($cm->getAssociationMapping('email')['joinColumns'][0]['nullable']);
-        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
-
-        $cm->mapManyToOne(['fieldName' => 'mainEmail']);
-        $this->assertTrue($cm->getAssociationMapping('mainEmail')['joinColumns'][0]['nullable']);
-        $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     public function testFieldTypeFromReflection(): void


### PR DESCRIPTION
This partially reverts #8589 because it was overzealously working on non typed properties as well, defining 'nullable' => true on all join columns. This made `CascadeRemoveOrderTest` fail on databases with foreign keys.

With this approach the code about join columns stays untouched, unless the typed property is defined as non-nullable *and* join columns are used. 

Fixes #8638 