### PR TITLE
Check for use of deprecated API with Psalm

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,20 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
+    <DeprecatedClass occurrences="1">
+      <code>IterableResult</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>iterate</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$resultCacheDriver !== null &amp;&amp; ! ($resultCacheDriver instanceof \Doctrine\Common\Cache\Cache)</code>
+    </DocblockTypeContradiction>
     <FalsableReturnStatement occurrences="1">
       <code>! $filteredParameters-&gt;isEmpty() ? $filteredParameters-&gt;first() : null</code>
     </FalsableReturnStatement>
+    <InvalidFalsableReturnType occurrences="1">
+      <code>Parameter|null</code>
+    </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="3">
       <code>\Doctrine\Common\Cache\Cache</code>
       <code>int</code>
       <code>string</code>
     </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$key</code>
+    </InvalidScalarArgument>
+    <MissingClosureParamType occurrences="3">
+      <code>$alias</code>
+      <code>$data</code>
+      <code>$data</code>
+    </MissingClosureParamType>
     <NullableReturnStatement occurrences="4">
       <code>$this-&gt;_em-&gt;getConfiguration()-&gt;getResultCacheImpl()</code>
       <code>$this-&gt;_queryCacheProfile ? $this-&gt;_queryCacheProfile-&gt;getCacheKey() : null</code>
       <code>$this-&gt;_queryCacheProfile-&gt;getResultCacheDriver()</code>
       <code>$this-&gt;cacheMode</code>
     </NullableReturnStatement>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$stmt</code>
+      <code>$stmt</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="4">
+      <code>$resultCacheDriver</code>
+      <code>$resultCacheDriver</code>
+      <code>$resultCacheDriver</code>
+      <code>$resultCacheId</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$profile</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="3">
+      <code>fetch</code>
+      <code>getCacheLogger</code>
+      <code>getQueryCache</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$_hydrationCacheProfile</code>
+      <code>$_resultSetMapping</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="2">
+      <code>array_map($translate, $rsm-&gt;aliasMap)</code>
+      <code>array_map($translate, $rsm-&gt;declaringClasses)</code>
+    </PropertyTypeCoercion>
+    <RedundantCastGivenDocblockType occurrences="5">
+      <code>(bool) $cacheable</code>
+      <code>(int) $cacheMode</code>
+      <code>(int) $lifetime</code>
+      <code>(int) $lifetime</code>
+      <code>(string) $cacheRegion</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;_hydrationCacheProfile !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache.php">
+    <MissingReturnType occurrences="1">
+      <code>evictQueryRegion</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/CacheConfiguration.php">
+    <PossiblyNullReference occurrences="1">
+      <code>getTimestampRegion</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/CollectionCacheKey.php">
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(string) $association</code>
+      <code>(string) $entityClass</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/DefaultCache.php">
+    <InvalidOperand occurrences="1">
+      <code>! $association['type']</code>
+    </InvalidOperand>
+    <MissingReturnType occurrences="1">
+      <code>evictQueryRegion</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1"/>
+    <PossiblyNullReference occurrences="1">
+      <code>getCacheFactory</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCacheFactory.php">
     <InvalidNullableReturnType occurrences="1">
@@ -23,21 +107,60 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;fileLockRegionDirectory</code>
     </NullableReturnStatement>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $fileLockRegionDirectory</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php">
     <InvalidNullableReturnType occurrences="1">
       <code>loadCacheEntry</code>
     </InvalidNullableReturnType>
+    <MissingClosureParamType occurrences="2">
+      <code>$entity</code>
+      <code>$index</code>
+    </MissingClosureParamType>
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php">
+    <MissingReturnType occurrences="1">
+      <code>loadCacheEntry</code>
+    </MissingReturnType>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$fieldMapping['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getCacheRegion</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Cache/DefaultQueryCache.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$assocKeys-&gt;identifiers[$assocIndex]</code>
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$cacheKeys-&gt;identifiers[$index]</code>
+      <code>$unCachedAssociationData-&gt;class</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$assocValue === null</code>
+    </DocblockTypeContradiction>
+    <MissingClosureParamType occurrences="1">
+      <code>$id</code>
+    </MissingClosureParamType>
+    <NoInterfaceProperties occurrences="2">
+      <code>$assocEntry-&gt;class</code>
+      <code>$assocEntry-&gt;class</code>
+    </NoInterfaceProperties>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$cacheConfig-&gt;getCacheLogger()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="1">
+      <code>getCacheLogger</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>assert($cm instanceof ClassMetadata)</code>
+    </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="5">
       <code>getCacheRegion</code>
       <code>resolveAssociationEntries</code>
@@ -46,13 +169,141 @@
       <code>storeEntityCache</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Cache/EntityCacheEntry.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$value-&gt;class</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/EntityHydrator.php">
+    <MissingReturnType occurrences="1">
+      <code>loadCacheEntry</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Lock.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>time()</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Logging/CacheLogger.php">
+    <MissingReturnType occurrences="9">
+      <code>collectionCacheHit</code>
+      <code>collectionCacheMiss</code>
+      <code>collectionCachePut</code>
+      <code>entityCacheHit</code>
+      <code>entityCacheMiss</code>
+      <code>entityCachePut</code>
+      <code>queryCacheHit</code>
+      <code>queryCacheMiss</code>
+      <code>queryCachePut</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php">
+    <MissingReturnType occurrences="9">
+      <code>collectionCacheHit</code>
+      <code>collectionCacheMiss</code>
+      <code>collectionCachePut</code>
+      <code>entityCacheHit</code>
+      <code>entityCacheMiss</code>
+      <code>entityCachePut</code>
+      <code>queryCacheHit</code>
+      <code>queryCacheMiss</code>
+      <code>queryCachePut</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php">
+    <MissingReturnType occurrences="9">
+      <code>collectionCacheHit</code>
+      <code>collectionCacheMiss</code>
+      <code>collectionCachePut</code>
+      <code>entityCacheHit</code>
+      <code>entityCacheMiss</code>
+      <code>entityCachePut</code>
+      <code>queryCacheHit</code>
+      <code>queryCacheMiss</code>
+      <code>queryCachePut</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/CachedPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$cache</code>
+      <code>$entityKey</code>
+      <code>$targetEntity</code>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>object[]|null</code>
+    </ImplementedReturnTypeMismatch>
+    <NoInterfaceProperties occurrences="1">
+      <code>$entry-&gt;identifiers</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="2">
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>buildCollectionHydrator</code>
+      <code>getCacheFactory</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$collection-&gt;getOwner()</code>
+    </PossiblyNullArgument>
+  </file>
   <file src="lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+    </PossiblyNullArgument>
     <UndefinedInterfaceMethod occurrences="2">
       <code>lock</code>
       <code>lock</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$cacheEntry</code>
+    </ArgumentTypeCoercion>
+    <MissingReturnType occurrences="1">
+      <code>loadAll</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$cacheEntry-&gt;class</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="2">
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$em-&gt;getCache()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>getCacheFactory</code>
+      <code>getTimestampRegion</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$result</code>
+      <code>assert($metadata instanceof ClassMetadata)</code>
+    </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="9">
       <code>getCacheRegion</code>
       <code>getCacheRegion</code>
@@ -65,22 +316,176 @@
       <code>storeEntityCache</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php">
+    <MissingReturnType occurrences="2">
+      <code>afterTransactionComplete</code>
+      <code>afterTransactionRolledBack</code>
+    </MissingReturnType>
+    <RedundantCondition occurrences="1">
+      <code>$isChanged</code>
+    </RedundantCondition>
     <UndefinedInterfaceMethod occurrences="2">
       <code>lock</code>
       <code>lock</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Cache/Region.php">
+    <MissingReturnType occurrences="3">
+      <code>evict</code>
+      <code>evictAll</code>
+      <code>put</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php">
+    <DeprecatedClass occurrences="2">
+      <code>MultiGetCache</code>
+      <code>MultiGetCache|Cache</code>
+    </DeprecatedClass>
+    <MissingParamType occurrences="2">
+      <code>$lifetime</code>
+      <code>$name</code>
+    </MissingParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$cache</code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>fetchMultiple</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/DefaultRegion.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;cache</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>CacheProvider</code>
+    </MoreSpecificReturnType>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(int) $lifetime</code>
+      <code>(string) $name</code>
+    </RedundantCastGivenDocblockType>
+  </file>
   <file src="lib/Doctrine/ORM/Cache/Region/FileLockRegion.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>bool</code>
+    </ImplementedReturnTypeMismatch>
     <InvalidNullableReturnType occurrences="1">
       <code>lock</code>
     </InvalidNullableReturnType>
+    <MissingReturnType occurrences="3">
+      <code>evict</code>
+      <code>evictAll</code>
+      <code>put</code>
+    </MissingReturnType>
     <NullableReturnStatement occurrences="2">
       <code>null</code>
       <code>null</code>
     </NullableReturnStatement>
   </file>
+  <file src="lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php">
+    <MissingReturnType occurrences="1">
+      <code>update</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/RegionsConfiguration.php">
+    <RedundantCastGivenDocblockType occurrences="6">
+      <code>(int) $defaultLifetime</code>
+      <code>(int) $defaultLifetime</code>
+      <code>(int) $defaultLockLifetime</code>
+      <code>(int) $defaultLockLifetime</code>
+      <code>(int) $lifetime</code>
+      <code>(int) $lifetime</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/TimestampCacheEntry.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(float) $time</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/TimestampCacheKey.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $space</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php">
+    <NoInterfaceProperties occurrences="1">
+      <code>$timestamp-&gt;time</code>
+    </NoInterfaceProperties>
+  </file>
+  <file src="lib/Doctrine/ORM/Cache/TimestampRegion.php">
+    <MissingReturnType occurrences="1">
+      <code>update</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Configuration.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$className</code>
+      <code>$className</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="4">
+      <code>ArrayCache::class</code>
+      <code>new ArrayCache()</code>
+      <code>new CachedReader($reader, new ArrayCache())</code>
+      <code>new SimpleAnnotationReader()</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="3">
+      <code>AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php')</code>
+      <code>getAutoGenerateProxyClasses</code>
+      <code>getMetadataCacheImpl</code>
+    </DeprecatedMethod>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $flag</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php">
+    <DeprecatedMethod occurrences="2">
+      <code>copy</code>
+      <code>getHydrator</code>
+    </DeprecatedMethod>
+    <MissingParamType occurrences="3">
+      <code>$entity</code>
+      <code>$lockMode</code>
+      <code>$lockVersion</code>
+    </MissingParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$wrapped</code>
+    </NonInvariantDocblockPropertyType>
+    <TooManyArguments occurrences="2">
+      <code>find</code>
+      <code>flush</code>
+    </TooManyArguments>
+  </file>
   <file src="lib/Doctrine/ORM/EntityManager.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$connection</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="2">
+      <code>ProxyFactory</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="5">
+      <code>getAutoGenerateProxyClasses</code>
+      <code>getMetadataCacheImpl</code>
+      <code>getProxyDir</code>
+      <code>getProxyNamespace</code>
+      <code>merge</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="10">
+      <code>$connection instanceof Connection</code>
+      <code>$entityName !== null &amp;&amp; ! is_string($entityName)</code>
+      <code>$this-&gt;expressionBuilder === null</code>
+      <code>$this-&gt;filterCollection === null</code>
+      <code>$this-&gt;filterCollection === null</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+      <code>is_object($entity)</code>
+    </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="6">
       <code>$entity</code>
       <code>$entity</code>
@@ -93,8 +498,61 @@
       <code>?T</code>
       <code>getReference</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="2">
+      <code>$hydrationMode</code>
+      <code>$hydrationMode</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$this-&gt;repositoryFactory-&gt;getRepository($this, $entityName)</code>
+      <code>new $class($this)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="2">
+      <code>EntityRepository&lt;T&gt;</code>
+      <code>newHydrator</code>
+    </MoreSpecificReturnType>
+    <PossiblyNullArgument occurrences="3">
+      <code>$config-&gt;getProxyDir()</code>
+      <code>$config-&gt;getProxyNamespace()</code>
+      <code>$entity</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>createCache</code>
+      <code>getCacheFactory</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$cache</code>
+      <code>$expressionBuilder</code>
+      <code>$filterCollection</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>new $metadataFactoryClassName()</code>
+    </PropertyTypeCoercion>
+    <RedundantCondition occurrences="1">
+      <code>is_object($connection)</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;filterCollection !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>': "' . $connection . '"'</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="lib/Doctrine/ORM/EntityManagerInterface.php">
+    <DeprecatedClass occurrences="1">
+      <code>ProxyFactory</code>
+    </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/EntityRepository.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$this-&gt;_entityName</code>
+      <code>$this-&gt;_entityName</code>
+      <code>$this-&gt;_entityName</code>
+      <code>$this-&gt;_entityName</code>
+      <code>$this-&gt;_entityName</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>self::$inflector === null</code>
+    </DocblockTypeContradiction>
     <InvalidReturnStatement occurrences="3">
       <code>$persister-&gt;load($criteria, null, null, [], null, 1, $orderBy)</code>
       <code>$this-&gt;_em-&gt;find($this-&gt;_entityName, $id, $lockMode, $lockVersion)</code>
@@ -110,25 +568,441 @@
       <code>$criteria</code>
       <code>$orderBy</code>
     </MoreSpecificImplementedParamType>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$em</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/LifecycleEventArgs.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;getObjectManager()</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>EntityManager</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;getObjectManager()</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>EntityManager</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $className</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/PostFlushEventArgs.php">
+    <PropertyTypeCoercion occurrences="1">
+      <code>$em</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Event/PreFlushEventArgs.php">
+    <PropertyTypeCoercion occurrences="1">
+      <code>$em</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Id/AssignedGenerator.php">
+    <PossiblyNullArgument occurrences="3">
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$sequenceName</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $em-&gt;getConnection()-&gt;lastInsertId($this-&gt;sequenceName)</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Id/IdentityGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$sequenceName</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Id/SequenceGenerator.php">
+    <DeprecatedMethod occurrences="2">
+      <code>fetchColumn</code>
+      <code>query</code>
+    </DeprecatedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Id/TableGenerator.php">
+    <DeprecatedMethod occurrences="2">
+      <code>executeUpdate</code>
+      <code>fetchColumn</code>
+    </DeprecatedMethod>
+    <PossiblyFalseOperand occurrences="3">
+      <code>$currentLevel</code>
+      <code>$this-&gt;_nextValue</code>
+      <code>$this-&gt;_nextValue</code>
+    </PossiblyFalseOperand>
     <UndefinedMethod occurrences="2">
       <code>getTableHiLoCurrentValSql</code>
       <code>getTableHiLoUpdateNextValSql</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Id/UuidGenerator.php">
+    <DeprecatedMethod occurrences="3">
+      <code>fetchColumn</code>
+      <code>getGuidExpression</code>
+      <code>query</code>
+    </DeprecatedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/CommitOrderCalculator.php">
+    <RedundantCondition occurrences="2">
+      <code>$vertex-&gt;state !== self::VISITED</code>
+      <code>$vertex-&gt;state !== self::VISITED</code>
+    </RedundantCondition>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php">
+    <DeprecatedClass occurrences="3">
+      <code>FetchMode::ASSOCIATIVE</code>
+      <code>IterableResult</code>
+      <code>new IterableResult($this)</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="3">
+      <code>closeCursor</code>
+      <code>fetch</code>
+      <code>fetch</code>
+    </DeprecatedMethod>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$_hints</code>
+      <code>$_rsm</code>
+      <code>$_stmt</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="4">
+      <code>$resultSetMapping</code>
+      <code>$resultSetMapping</code>
+      <code>$stmt</code>
+      <code>$stmt</code>
+    </PropertyTypeCoercion>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>return $rowData;</code>
+    </ReferenceConstraintViolation>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>fetch</code>
+    </DeprecatedMethod>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$index</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArrayAssignment occurrences="2">
+      <code>$result[$resultKey]</code>
+      <code>$result[$resultKey]</code>
+    </PossiblyNullArrayAssignment>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$newObject['args']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>ArrayHydrator</code>
+      <code>ArrayHydrator</code>
+      <code>ArrayHydrator</code>
+    </PropertyNotSetInConstructor>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>$result</code>
+    </ReferenceConstraintViolation>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/IterableResult.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>mixed[]|false</code>
+    </ImplementedReturnTypeMismatch>
+    <PossiblyFalsePropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;_hydrator-&gt;hydrateRow()</code>
+      <code>$this-&gt;next()</code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;_current !== false</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>fetch</code>
+    </DeprecatedMethod>
+    <InvalidScalarArgument occurrences="1">
+      <code>array_keys($discrMap)</code>
+    </InvalidScalarArgument>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$index</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+      <code>$parentObject</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$objectClass</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="1">
+      <code>$objectClass[key($objectClass)]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="6">
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$newObject['args']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>ObjectHydrator</code>
+      <code>ObjectHydrator</code>
+      <code>ObjectHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>fetch</code>
+    </DeprecatedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>ScalarHydrator</code>
+      <code>ScalarHydrator</code>
+      <code>ScalarHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php">
+    <DeprecatedMethod occurrences="2">
+      <code>fetch</code>
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <InvalidScalarArgument occurrences="1">
+      <code>array_keys($discrMap)</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="1">
+      <code>$this-&gt;class-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$class</code>
+      <code>SimpleObjectHydrator</code>
+      <code>SimpleObjectHydrator</code>
+      <code>SimpleObjectHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php">
+    <DeprecatedMethod occurrences="1">
+      <code>fetchAll</code>
+    </DeprecatedMethod>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>SingleScalarHydrator</code>
+      <code>SingleScalarHydrator</code>
+      <code>SingleScalarHydrator</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="lib/Doctrine/ORM/LazyCriteriaCollection.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$element</code>
     </MoreSpecificImplementedParamType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>LazyCriteriaCollection</code>
+    </PropertyNotSetInConstructor>
     <UndefinedInterfaceMethod occurrences="1">
       <code>matching</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php">
+    <DeprecatedMethod occurrences="1">
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$class-&gt;fieldMappings[$fieldName]['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AssociationOverride.php">
+    <MissingConstructor occurrences="5">
+      <code>$fetch</code>
+      <code>$inversedBy</code>
+      <code>$joinColumns</code>
+      <code>$joinTable</code>
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AssociationOverrides.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AttributeOverride.php">
+    <MissingConstructor occurrences="2">
+      <code>$column</code>
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/AttributeOverrides.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$class</code>
+      <code>$repositoryClassName</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="1">
+      <code>addNamedQuery</code>
+    </DeprecatedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </ArgumentTypeCoercion>
+    <PossiblyNullArgument occurrences="2">
+      <code>$class</code>
+      <code>$class</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php">
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$generatedValue</code>
+      <code>$sequenceDef</code>
+      <code>$version</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="3">
+      <code>(bool) $flag</code>
+      <code>(bool) $flag</code>
+      <code>(string) $customIdGenerator</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Cache.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$region</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ClassMetadata.php">
+    <PropertyNotSetInConstructor occurrences="8">
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+      <code>ClassMetadata</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php">
+    <ArgumentTypeCoercion occurrences="26">
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$map</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$parent</code>
+      <code>$subClassCandidate</code>
+      <code>new $definition['class']()</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="5">
+      <code>addNamedNativeQuery</code>
+      <code>addNamedQuery</code>
+      <code>fixSchemaElementName</code>
+      <code>fixSchemaElementName</code>
+      <code>prefersSequences</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="4">
+      <code>! $metadata-&gt;reflClass</code>
+      <code>$class-&gt;reflClass</code>
+      <code>$definition</code>
+    </DocblockTypeContradiction>
     <InvalidArrayOffset occurrences="1">
       <code>$subClass-&gt;table[$indexType][$indexName]</code>
     </InvalidArrayOffset>
+    <InvalidScalarArgument occurrences="2">
+      <code>$definition</code>
+      <code>$parent-&gt;sequenceGeneratorDefinition</code>
+    </InvalidScalarArgument>
+    <MissingConstructor occurrences="2">
+      <code>$driver</code>
+      <code>$evm</code>
+    </MissingConstructor>
+    <NoInterfaceProperties occurrences="31">
+      <code>$class-&gt;cache</code>
+      <code>$class-&gt;changeTrackingPolicy</code>
+      <code>$class-&gt;containsForeignIdentifier</code>
+      <code>$class-&gt;discriminatorMap</code>
+      <code>$class-&gt;embeddedClasses</code>
+      <code>$class-&gt;entityListeners</code>
+      <code>$class-&gt;entityListeners</code>
+      <code>$class-&gt;isMappedSuperclass</code>
+      <code>$class-&gt;isMappedSuperclass</code>
+      <code>$class-&gt;name</code>
+      <code>$class-&gt;name</code>
+      <code>$class-&gt;name</code>
+      <code>$parent-&gt;cache</code>
+      <code>$parent-&gt;changeTrackingPolicy</code>
+      <code>$parent-&gt;containsForeignIdentifier</code>
+      <code>$parent-&gt;customGeneratorDefinition</code>
+      <code>$parent-&gt;customRepositoryClassName</code>
+      <code>$parent-&gt;discriminatorColumn</code>
+      <code>$parent-&gt;discriminatorMap</code>
+      <code>$parent-&gt;entityListeners</code>
+      <code>$parent-&gt;generatorType</code>
+      <code>$parent-&gt;identifier</code>
+      <code>$parent-&gt;inheritanceType</code>
+      <code>$parent-&gt;isMappedSuperclass</code>
+      <code>$parent-&gt;isVersioned</code>
+      <code>$parent-&gt;lifecycleCallbacks</code>
+      <code>$parent-&gt;namedNativeQueries</code>
+      <code>$parent-&gt;namedQueries</code>
+      <code>$parent-&gt;sqlResultSetMappings</code>
+      <code>$parent-&gt;table</code>
+      <code>$parent-&gt;versionField</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidIterator occurrences="1">
+      <code>$parentClass-&gt;table[$indexType]</code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;em</code>
+      <code>$this-&gt;em</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;em-&gt;getConfiguration()-&gt;getMetadataDriverImpl()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="6">
+      <code>getConfiguration</code>
+      <code>getConfiguration</code>
+      <code>getConfiguration</code>
+      <code>getConfiguration</code>
+      <code>getConfiguration</code>
+      <code>getConnection</code>
+    </PossiblyNullReference>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$subClass-&gt;table</code>
+    </PropertyTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$parent</code>
+      <code>$parent-&gt;idGenerator</code>
+    </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="17">
       <code>inlineEmbeddable</code>
       <code>isInheritanceTypeNone</code>
@@ -150,6 +1024,26 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$class</code>
+      <code>$subclass</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;columnNames</code>
+      <code>$this-&gt;columnNames</code>
+    </DeprecatedProperty>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;table</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>string|null</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidDocblock occurrences="4">
+      <code>protected function _validateAndCompleteAssociationMapping(array $mapping)</code>
+      <code>protected function _validateAndCompleteManyToManyMapping(array $mapping)</code>
+      <code>protected function _validateAndCompleteOneToOneMapping(array $mapping)</code>
+      <code>public $inheritanceType = self::INHERITANCE_TYPE_NONE;</code>
+    </InvalidDocblock>
     <InvalidNullableReturnType occurrences="2">
       <code>ReflectionProperty</code>
       <code>ReflectionProperty</code>
@@ -157,12 +1051,199 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$definition</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="1">
+      <code>$type</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$cache</code>
+    </LessSpecificReturnStatement>
+    <MissingClosureParamType occurrences="2">
+      <code>$joinColumn</code>
+      <code>$joinColumn</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>static function ($joinColumn) {</code>
+    </MissingClosureReturnType>
+    <MissingPropertyType occurrences="1">
+      <code>$inheritanceType</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>_validateAndCompleteAssociationMapping</code>
+      <code>_validateAndCompleteManyToManyMapping</code>
+      <code>_validateAndCompleteOneToOneMapping</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array{usage: int, region: string|null}</code>
+    </MoreSpecificReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$this-&gt;reflFields[$name]</code>
       <code>$this-&gt;reflFields[$this-&gt;identifier[0]]</code>
     </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="11">
+      <code>$class</code>
+      <code>$class</code>
+      <code>$className</code>
+      <code>$entityResult['entityClass']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$parentReflFields[$embeddedClass['declaredField']]</code>
+      <code>$parentReflFields[$mapping['declaredField']]</code>
+      <code>$queryMapping['resultClass']</code>
+      <code>$reflService-&gt;getAccessibleProperty($mapping['originalClass'], $mapping['originalField'])</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$reflService-&gt;getClass($this-&gt;name)</code>
+      <code>$reflService-&gt;getClass($this-&gt;name)</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="6">
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>instantiate</code>
+      <code>setValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="11">
+      <code>$fieldMapping['columnName']</code>
+      <code>$fieldMapping['columnName']</code>
+      <code>$mapping['columnName']</code>
+      <code>$mapping['originalClass']</code>
+      <code>$mapping['originalField']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$this-&gt;fieldMappings[$field]['columnName']</code>
+      <code>$this-&gt;fieldMappings[$field]['columnName']</code>
+      <code>$this-&gt;fieldMappings[$idProperty]['columnName']</code>
+      <code>$this-&gt;fieldMappings[$idProperty]['columnName']</code>
+      <code>$this-&gt;fieldMappings[$idProperty]['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyNotSetInConstructor occurrences="8">
+      <code>$discriminatorColumn</code>
+      <code>$idGenerator</code>
+      <code>$isVersioned</code>
+      <code>$namespace</code>
+      <code>$reflClass</code>
+      <code>$sequenceGeneratorDefinition</code>
+      <code>$table</code>
+      <code>$tableGeneratorDefinition</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="13">
+      <code>$entityName</code>
+      <code>$entityName</code>
+      <code>$this-&gt;entityListeners</code>
+      <code>$this-&gt;fieldMappings</code>
+      <code>$this-&gt;fullyQualifiedClassName($repositoryClassName)</code>
+      <code>$this-&gt;sqlResultSetMappings</code>
+      <code>$this-&gt;subClasses</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;table</code>
+    </PropertyTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$className !== null</code>
+      <code>$columnDef !== null</code>
+      <code>$mapping !== false</code>
+      <code>$mapping !== false</code>
+    </RedundantConditionGivenDocblockType>
+    <RedundantPropertyInitializationCheck occurrences="1"/>
+    <TooManyArguments occurrences="2">
+      <code>joinColumnName</code>
+      <code>joinColumnName</code>
+    </TooManyArguments>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Column.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="5">
+      <code>$columnDefinition</code>
+      <code>$length</code>
+      <code>$name</code>
+      <code>$precision</code>
+      <code>$scale</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ColumnResult.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/CustomIdGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$class</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_object($object)</code>
+    </DocblockTypeContradiction>
+    <InvalidStringClass occurrences="1">
+      <code>new $className()</code>
+    </InvalidStringClass>
+    <MissingReturnType occurrences="1">
+      <code>register</code>
+    </MissingReturnType>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;instances</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php">
+    <MissingParamType occurrences="1">
+      <code>$className</code>
+    </MissingParamType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($className, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php">
+    <DeprecatedMethod occurrences="1">
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <MissingClosureParamType occurrences="1">
+      <code>$joinColumn</code>
+    </MissingClosureParamType>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$class-&gt;fieldMappings[$fieldName]['columnName']</code>
+      <code>$class-&gt;fieldMappings[$fieldName]['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$columnDefinition</code>
+      <code>$length</code>
+      <code>$name</code>
+      <code>$type</code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$class</code>
+    </DocblockTypeContradiction>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$mapping</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1"/>
+    <NoInterfaceProperties occurrences="5">
+      <code>$metadata-&gt;inheritanceType</code>
+      <code>$metadata-&gt;isEmbeddedClass</code>
+      <code>$metadata-&gt;isMappedSuperclass</code>
+      <code>$metadata-&gt;isMappedSuperclass</code>
+      <code>$metadata-&gt;name</code>
+    </NoInterfaceProperties>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$entityAnnotationClasses</code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$primaryTable['indexes']</code>
+      <code>$primaryTable['uniqueConstraints']</code>
+    </PossiblyUndefinedArrayOffset>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>isset($column-&gt;columnDefinition)</code>
+      <code>isset($column-&gt;name)</code>
+    </RedundantConditionGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="32">
       <code>addEntityListener</code>
       <code>addLifecycleCallback</code>
@@ -199,6 +1280,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>new AttributeReader()</code>
     </InvalidArgument>
@@ -208,14 +1292,53 @@
       <code>$value[1]</code>
       <code>$value[1]</code>
     </InvalidArrayAccess>
+    <InvalidScalarArgument occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$mapping</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1"/>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$entityAnnotationClasses</code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$listenerClassName</code>
+    </PossiblyNullArgument>
+    <PossiblyNullIterator occurrences="3">
+      <code>$joinColumnAttributes</code>
+      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\InverseJoinColumn::class)</code>
+      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\JoinColumn::class)</code>
+    </PossiblyNullIterator>
+    <RawObjectIteration occurrences="3">
+      <code>$joinColumnAttributes</code>
+      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\InverseJoinColumn::class)</code>
+      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\JoinColumn::class)</code>
+    </RawObjectIteration>
+    <RedundantCondition occurrences="3">
+      <code>assert($method instanceof ReflectionMethod)</code>
+      <code>assert($method instanceof ReflectionMethod)</code>
+      <code>assert($property instanceof ReflectionProperty)</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>assert($cacheAttribute instanceof Mapping\Cache)</code>
+      <code>isset($column-&gt;columnDefinition)</code>
+      <code>isset($column-&gt;name)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$attributeClassName</code>
+    </ArgumentTypeCoercion>
     <InvalidReturnStatement occurrences="1">
       <code>$instances</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="1">
       <code>array&lt;Annotation&gt;</code>
     </InvalidReturnType>
+    <MissingParamType occurrences="3">
+      <code>$annotationName</code>
+      <code>$annotationName</code>
+      <code>$annotationName</code>
+    </MissingParamType>
     <UndefinedMethod occurrences="4">
       <code>getAttributes</code>
       <code>getAttributes</code>
@@ -224,11 +1347,138 @@
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$metadata</code>
+      <code>$metadata</code>
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="13">
+      <code>Type::BIGINT</code>
+      <code>Type::BLOB</code>
+      <code>Type::DECIMAL</code>
+      <code>Type::FLOAT</code>
+      <code>Type::GUID</code>
+      <code>Type::INTEGER</code>
+      <code>Type::JSON_ARRAY</code>
+      <code>Type::OBJECT</code>
+      <code>Type::SIMPLE_ARRAY</code>
+      <code>Type::SMALLINT</code>
+      <code>Type::STRING</code>
+      <code>Type::TARRAY</code>
+      <code>Type::TEXT</code>
+    </DeprecatedConstant>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$this-&gt;namespace . $this-&gt;classNamesForTables[$tableName]</code>
+      <code>$this-&gt;namespace . $this-&gt;inflector-&gt;classify(strtolower($tableName))</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>class-string</code>
+    </MoreSpecificReturnType>
+    <NoInterfaceProperties occurrences="2">
+      <code>$metadata-&gt;name</code>
+      <code>$metadata-&gt;table</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="3">
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+      <code>$this-&gt;tables[$tableName]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="4">
+      <code>getColumns</code>
+      <code>getColumns</code>
+      <code>getColumns</code>
+      <code>getIndexes</code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod occurrences="1">
       <code>mapManyToMany</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/PHPDriver.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>PHPDriver</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php">
+    <MissingParamType occurrences="2">
+      <code>$fileExtension</code>
+      <code>$prefixes</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php">
+    <DeprecatedClass occurrences="2">
+      <code>YamlDriver</code>
+      <code>parent::__construct($locator, $fileExtension)</code>
+    </DeprecatedClass>
+    <MissingParamType occurrences="2">
+      <code>$fileExtension</code>
+      <code>$prefixes</code>
+    </MissingParamType>
+  </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <ImplicitToStringCast occurrences="1">
+      <code>$cacheMapping['usage']</code>
+    </ImplicitToStringCast>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingParamType occurrences="2">
+      <code>$fileExtension</code>
+      <code>$locator</code>
+    </MissingParamType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array{usage: int|null, region?: string}</code>
+    </MoreSpecificReturnType>
+    <NoInterfaceProperties occurrences="12">
+      <code>$indexXml-&gt;options</code>
+      <code>$metadata-&gt;inheritanceType</code>
+      <code>$metadata-&gt;isEmbeddedClass</code>
+      <code>$metadata-&gt;isMappedSuperclass</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$uniqueXml-&gt;options</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidPropertyFetch occurrences="2">
+      <code>$indexXml-&gt;options</code>
+      <code>$uniqueXml-&gt;options</code>
+    </PossiblyInvalidPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
+    <RedundantCast occurrences="1">
+      <code>(string) $attributes-&gt;name</code>
+    </RedundantCast>
+    <RedundantCondition occurrences="20">
+      <code>isset($attributes-&gt;name)</code>
+      <code>isset($xmlRoot-&gt;cache)</code>
+      <code>isset($xmlRoot-&gt;embedded)</code>
+      <code>isset($xmlRoot-&gt;field)</code>
+      <code>isset($xmlRoot-&gt;indexes)</code>
+      <code>isset($xmlRoot-&gt;options)</code>
+      <code>isset($xmlRoot-&gt;{'association-overrides'})</code>
+      <code>isset($xmlRoot-&gt;{'attribute-overrides'})</code>
+      <code>isset($xmlRoot-&gt;{'discriminator-column'})</code>
+      <code>isset($xmlRoot-&gt;{'discriminator-map'})</code>
+      <code>isset($xmlRoot-&gt;{'entity-listeners'})</code>
+      <code>isset($xmlRoot-&gt;{'lifecycle-callbacks'})</code>
+      <code>isset($xmlRoot-&gt;{'many-to-many'})</code>
+      <code>isset($xmlRoot-&gt;{'many-to-one'})</code>
+      <code>isset($xmlRoot-&gt;{'named-native-queries'})</code>
+      <code>isset($xmlRoot-&gt;{'named-queries'})</code>
+      <code>isset($xmlRoot-&gt;{'one-to-many'})</code>
+      <code>isset($xmlRoot-&gt;{'one-to-one'})</code>
+      <code>isset($xmlRoot-&gt;{'sql-result-set-mappings'})</code>
+      <code>isset($xmlRoot-&gt;{'unique-constraints'})</code>
+    </RedundantCondition>
     <UndefinedInterfaceMethod occurrences="34">
       <code>addEntityListener</code>
       <code>addLifecycleCallback</code>
@@ -267,6 +1517,44 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <InvalidDocblock occurrences="1">
+      <code>private function cacheToArray(array $cacheMapping): array</code>
+    </InvalidDocblock>
+    <MissingParamType occurrences="2">
+      <code>$fileExtension</code>
+      <code>$locator</code>
+    </MissingParamType>
+    <NoInterfaceProperties occurrences="6">
+      <code>$metadata-&gt;inheritanceType</code>
+      <code>$metadata-&gt;isEmbeddedClass</code>
+      <code>$metadata-&gt;isMappedSuperclass</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+      <code>$metadata-&gt;table</code>
+    </NoInterfaceProperties>
+    <PossiblyUndefinedMethod occurrences="18">
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+      <code>$element</code>
+    </PossiblyUndefinedMethod>
     <UndefinedInterfaceMethod occurrences="43">
       <code>$element</code>
       <code>$element</code>
@@ -313,12 +1601,213 @@
       <code>setVersionMapping</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Mapping/Embedded.php">
+    <MissingParamType occurrences="1">
+      <code>$columnPrefix</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Entity.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$repositoryClass</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/EntityListenerResolver.php">
+    <MissingReturnType occurrences="1">
+      <code>register</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/EntityResult.php">
+    <MissingConstructor occurrences="2">
+      <code>$discriminatorColumn</code>
+      <code>$entityClass</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/FieldResult.php">
+    <MissingConstructor occurrences="2">
+      <code>$column</code>
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Index.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$columns</code>
+      <code>$fields</code>
+      <code>$flags</code>
+      <code>$name</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/InverseJoinColumn.php">
+    <MissingParamType occurrences="1">
+      <code>$onDelete</code>
+    </MissingParamType>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$columnDefinition</code>
+      <code>$fieldName</code>
+      <code>$name</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/JoinColumn.php">
+    <MissingParamType occurrences="1">
+      <code>$onDelete</code>
+    </MissingParamType>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$columnDefinition</code>
+      <code>$fieldName</code>
+      <code>$name</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/JoinColumns.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/JoinTable.php">
+    <MissingParamType occurrences="2">
+      <code>$inverseJoinColumns</code>
+      <code>$joinColumns</code>
+    </MissingParamType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$name</code>
+      <code>$schema</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ManyToMany.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$cascade</code>
+      <code>$indexBy</code>
+      <code>$inversedBy</code>
+      <code>$mappedBy</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ManyToOne.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$cascade</code>
+      <code>$inversedBy</code>
+      <code>$targetEntity</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/MappedSuperclass.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$repositoryClass</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/MappingException.php">
+    <MissingParamType occurrences="6">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
+      <code>$indexName</code>
+      <code>$indexName</code>
+      <code>$propertyName</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/NamedNativeQuery.php">
+    <MissingConstructor occurrences="4">
+      <code>$name</code>
+      <code>$query</code>
+      <code>$resultClass</code>
+      <code>$resultSetMapping</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/NamedQueries.php">
+    <MissingConstructor occurrences="1">
+      <code>$value</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/NamedQuery.php">
+    <MissingConstructor occurrences="2">
+      <code>$name</code>
+      <code>$query</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/OneToMany.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$cascade</code>
+      <code>$indexBy</code>
+      <code>$mappedBy</code>
+      <code>$targetEntity</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/OneToOne.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$cascade</code>
+      <code>$inversedBy</code>
+      <code>$mappedBy</code>
+      <code>$targetEntity</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;embeddedClass</code>
+    </ArgumentTypeCoercion>
+    <MissingParamType occurrences="3">
+      <code>$object</code>
+      <code>$object</code>
+      <code>$value</code>
+    </MissingParamType>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $embeddedClass</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/SequenceGenerator.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$sequenceName</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/Table.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$indexes</code>
+      <code>$name</code>
+      <code>$schema</code>
+      <code>$uniqueConstraints</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php">
+    <MissingParamType occurrences="1">
+      <code>$className</code>
+    </MissingParamType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($className, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="lib/Doctrine/ORM/Mapping/UniqueConstraint.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$columns</code>
+      <code>$fields</code>
+      <code>$name</code>
+      <code>$options</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
   <file src="lib/Doctrine/ORM/NativeQuery.php">
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$sql</code>
+      <code>NativeQuery</code>
+      <code>NativeQuery</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/ORMInvalidArgumentException.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$entity</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/PersistentCollection.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>isset($offset)</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>object|null</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidDocblock occurrences="1">
+      <code>final class PersistentCollection extends AbstractLazyCollection implements Selectable</code>
+    </InvalidDocblock>
     <InvalidReturnStatement occurrences="5">
       <code>$persister-&gt;slice($this, $offset, $length)</code>
       <code>$this-&gt;collection</code>
@@ -329,36 +1818,390 @@
       <code>Collection&lt;TKey, T&gt;</code>
       <code>array&lt;TKey,T&gt;</code>
     </InvalidReturnType>
+    <MissingClosureParamType occurrences="4">
+      <code>$a</code>
+      <code>$a</code>
+      <code>$b</code>
+      <code>$b</code>
+    </MissingClosureParamType>
+    <MissingParamType occurrences="2">
+      <code>$key</code>
+      <code>$offset</code>
+    </MissingParamType>
+    <PossiblyNullArgument occurrences="4">
+      <code>$this-&gt;association</code>
+      <code>$this-&gt;association</code>
+      <code>$this-&gt;association</code>
+      <code>$this-&gt;association['targetEntity']</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="12">
+      <code>$this-&gt;association['fetch']</code>
+      <code>$this-&gt;association['fetch']</code>
+      <code>$this-&gt;association['fetch']</code>
+      <code>$this-&gt;association['fetch']</code>
+      <code>$this-&gt;association['fetch']</code>
+      <code>$this-&gt;association['isOwningSide']</code>
+      <code>$this-&gt;association['orphanRemoval']</code>
+      <code>$this-&gt;association['targetEntity']</code>
+      <code>$this-&gt;association['type']</code>
+      <code>$this-&gt;association['type']</code>
+      <code>$this-&gt;association['type']</code>
+      <code>$this-&gt;association['type']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="2">
+      <code>setValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$backRefFieldName</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>is_object($this-&gt;collection)</code>
+      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
+      <code>is_object($value) &amp;&amp; $this-&gt;em</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="1">
+      <code>andX</code>
+    </TooManyArguments>
     <UndefinedInterfaceMethod occurrences="1">
       <code>matching</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
+    <DeprecatedMethod occurrences="5">
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>fetchColumn</code>
+      <code>fetchColumn</code>
+      <code>fetchColumn</code>
+    </DeprecatedMethod>
     <FalsableReturnStatement occurrences="1">
       <code>$this-&gt;conn-&gt;fetchColumn($sql, $params, 0, $types)</code>
     </FalsableReturnStatement>
+    <PossiblyNullArgument occurrences="39">
+      <code>$association</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$filterMapping</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$owner</code>
+      <code>$owner</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="35">
+      <code>$mapping[$sourceRelationMode]</code>
+      <code>$mapping['indexBy']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['isOwningSide']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullArrayOffset occurrences="4">
+      <code>$associationSourceClass-&gt;associationMappings</code>
+      <code>$sourceClass-&gt;associationMappings</code>
+      <code>$targetClass-&gt;associationMappings</code>
+      <code>$targetClass-&gt;associationMappings</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullIterator occurrences="7">
+      <code>$joinColumns</code>
+      <code>$mapping[$sourceRelationMode]</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTable']['joinColumns']</code>
+      <code>$mapping['joinTableColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+    </PossiblyNullIterator>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
+    <DeprecatedMethod occurrences="5">
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+    </DeprecatedMethod>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>int|null</code>
+    </ImplementedReturnTypeMismatch>
+    <PossiblyNullArgument occurrences="14">
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$mapping</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="13">
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['mappedBy']</code>
+      <code>$mapping['orphanRemoval']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['targetEntity']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$targetClass-&gt;associationMappings</code>
+    </PossiblyNullArrayOffset>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php">
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$fieldMapping['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="4">
+      <code>Type::BIGINT</code>
+      <code>Type::DATETIME</code>
+      <code>Type::INTEGER</code>
+      <code>Type::SMALLINT</code>
+    </DeprecatedConstant>
+    <DeprecatedMethod occurrences="6">
+      <code>closeCursor</code>
+      <code>execute</code>
+      <code>executeUpdate</code>
+      <code>fetchColumn</code>
+      <code>fetchColumn</code>
+      <code>fetchColumn</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$value === null</code>
+    </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
       <code>$hints</code>
     </InvalidArgument>
     <InvalidNullableReturnType occurrences="1">
       <code>loadOneToOneEntity</code>
     </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="4">
+      <code>$hints</code>
+      <code>[Query::HINT_REFRESH =&gt; true]</code>
+      <code>[UnitOfWork::HINT_DEFEREAGERLOAD =&gt; true]</code>
+      <code>[UnitOfWork::HINT_DEFEREAGERLOAD =&gt; true]</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="3">
+      <code>$postInsertIds</code>
+      <code>[$params, $types]</code>
+      <code>[$sqlParams, $sqlTypes]</code>
+    </LessSpecificReturnStatement>
+    <MissingPropertyType occurrences="1">
+      <code>$eagerEntity-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>loadAll</code>
+    </MissingReturnType>
+    <MoreSpecificReturnType occurrences="3">
+      <code>executeInserts</code>
+      <code>expandCriteriaParameters</code>
+      <code>expandParameters</code>
+    </MoreSpecificReturnType>
     <NullableReturnStatement occurrences="2">
       <code>$targetEntity</code>
       <code>$targetEntity</code>
     </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="2">
+      <code>$association</code>
+      <code>$type</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="1">
+      <code>$assoc['isOwningSide']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="7">
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$fieldMapping['columnName']</code>
+      <code>$fieldMapping['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$insertSql</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;currentPersisterContext-&gt;sqlTableAliases</code>
+    </PropertyTypeCoercion>
+    <RedundantCondition occurrences="1">
+      <code>($comparison === Comparison::EQ || $comparison === Comparison::IS) &amp;&amp; $value === null</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;insertSql !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$selectJoinSql</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$class</code>
+    </PropertyTypeCoercion>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $handlesLimits</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php">
+    <MissingReturnType occurrences="1">
+      <code>loadAll</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;em</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="1">
+      <code>Type::STRING</code>
+    </DeprecatedConstant>
+    <DeprecatedMethod occurrences="5">
+      <code>closeCursor</code>
+      <code>closeCursor</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$postInsertIds</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>executeInserts</code>
+    </MoreSpecificReturnType>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$isVersioned</code>
+      <code>$isVersioned</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php">
+    <DeprecatedMethod occurrences="1">
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$columnList</code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="lib/Doctrine/ORM/Persisters/SqlValueVisitor.php">
+    <RedundantCondition occurrences="1">
+      <code>($operator === Comparison::EQ || $operator === Comparison::IS) &amp;&amp; $value === null</code>
+    </RedundantCondition>
   </file>
   <file src="lib/Doctrine/ORM/Proxy/ProxyFactory.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$classMetadata</code>
+      <code>$classMetadata</code>
+    </ArgumentTypeCoercion>
     <InvalidArgument occurrences="1">
       <code>$classMetadata-&gt;getReflectionProperties()</code>
     </InvalidArgument>
+    <NoInterfaceProperties occurrences="2">
+      <code>$metadata-&gt;isEmbeddedClass</code>
+      <code>$metadata-&gt;isMappedSuperclass</code>
+    </NoInterfaceProperties>
+    <PossiblyNullArgument occurrences="1">
+      <code>$property-&gt;name</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$property-&gt;name</code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference occurrences="1">
+      <code>setAccessible</code>
+    </PossiblyNullReference>
     <UndefinedInterfaceMethod occurrences="1">
       <code>__wakeup</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query.php">
+    <DeprecatedClass occurrences="1">
+      <code>IterableResult</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>parent::iterate($parameters, $hydrationMode)</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="2">
+      <code>$this-&gt;_resultSetMapping === null</code>
+      <code>$this-&gt;_resultSetMapping === null</code>
+    </DocblockTypeContradiction>
+    <InvalidScalarArgument occurrences="1">
+      <code>$sqlParams</code>
+    </InvalidScalarArgument>
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
@@ -366,24 +2209,295 @@
       <code>$hydrationMode</code>
       <code>$parameters</code>
     </MoreSpecificImplementedParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;getDQL()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$timeToLive</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="2">
+      <code>delete</code>
+      <code>evictEntityRegion</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$parserResult</code>
+      <code>$queryCacheTTL</code>
+      <code>Query</code>
+      <code>Query</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(int) $timeToLive</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$dqlQuery !== null</code>
+      <code>$rsm !== null</code>
+      <code>$timeToLive !== null</code>
+      <code>assert($rsm !== null)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/BetweenExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/DeleteClause.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aliasIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ExistsExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$simpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstArithmetic</code>
+      <code>$secondArithmetic</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstArithmetic</code>
+      <code>$secondArithmetic</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstStringPrimary</code>
+      <code>$secondStringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php">
+    <DeprecatedConstant occurrences="1">
+      <code>Type::INTEGER</code>
+    </DeprecatedConstant>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php">
+    <InvalidScalarArgument occurrences="7">
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+    </InvalidScalarArgument>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;unit-&gt;value</code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php">
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+      <code>$parser-&gt;ArithmeticPrimary()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$date1</code>
+      <code>$date2</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php">
+    <InvalidScalarArgument occurrences="7">
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+      <code>$this-&gt;intervalExpression-&gt;dispatch($sqlWalker)</code>
+    </InvalidScalarArgument>
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;unit-&gt;value</code>
     </UndefinedPropertyFetch>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php">
+    <PossiblyNullArrayAccess occurrences="1">
+      <code>$parser-&gt;getLexer()-&gt;token['value']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$class-&gt;associationMappings</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$field['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$fieldMapping</code>
+      <code>$pathExpression</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;fieldMapping !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="1">
+      <code>Type::INTEGER</code>
+    </DeprecatedConstant>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php">
+    <InvalidScalarArgument occurrences="1"/>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;simpleArithmeticExpression</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstStringPrimary</code>
+      <code>$secondStringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstSimpleArithmeticExpression</code>
+      <code>$secondSimpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php">
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$class-&gt;associationMappings</code>
+    </PossiblyNullArrayOffset>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$collectionPathExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$simpleArithmeticExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$optionalSecondSimpleArithmeticExpression</code>
+      <code>$sqlWalker-&gt;walkSimpleArithmeticExpression($this-&gt;firstSimpleArithmeticExpression)</code>
+    </InvalidScalarArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$firstSimpleArithmeticExpression</code>
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aggregateExpression</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php">
+    <DeprecatedConstant occurrences="4">
+      <code>AbstractPlatform::TRIM_BOTH</code>
+      <code>AbstractPlatform::TRIM_LEADING</code>
+      <code>AbstractPlatform::TRIM_TRAILING</code>
+      <code>AbstractPlatform::TRIM_UNSPECIFIED</code>
+    </DeprecatedConstant>
+    <PossiblyNullArgument occurrences="3">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$lexer-&gt;lookahead['value']</code>
+      <code>$lexer-&gt;token['value']</code>
+    </PossiblyNullArrayAccess>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$both</code>
+      <code>$leading</code>
+      <code>$stringPrimary</code>
+      <code>$trailing</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;stringPrimary</code>
+    </ArgumentTypeCoercion>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$stringPrimary</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/InExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/IndexBy.php">
+    <DeprecatedProperty occurrences="1">
+      <code>$this-&gt;simpleStateFieldPathExpression</code>
+    </DeprecatedProperty>
     <InvalidNullableReturnType occurrences="1">
       <code>dispatch</code>
     </InvalidNullableReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$sqlWalker-&gt;walkIndexBy($this)</code>
     </NullableReturnStatement>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$not</code>
+      <code>$value</code>
+    </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod occurrences="1">
@@ -395,17 +2509,238 @@
       <code>walkJoinVariableDeclaration</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/LikeExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Node.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_array($obj)</code>
+    </DocblockTypeContradiction>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($obj)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$not</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/OrderByItem.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/PathExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$fieldIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php">
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateClause.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$aliasIdentificationVariable</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/WhenClause.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php">
+    <DeprecatedMethod occurrences="5">
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+    </DeprecatedMethod>
+    <PossiblyInvalidIterator occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </PossiblyInvalidIterator>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>MultiTableDeleteExecutor</code>
+      <code>MultiTableDeleteExecutor</code>
+    </PropertyNotSetInConstructor>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </UninitializedProperty>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php">
+    <DeprecatedMethod occurrences="5">
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+      <code>executeUpdate</code>
+    </DeprecatedMethod>
+    <PossiblyInvalidIterator occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </PossiblyInvalidIterator>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>MultiTableUpdateExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>SingleSelectExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php">
+    <DeprecatedMethod occurrences="1">
+      <code>executeUpdate</code>
+    </DeprecatedMethod>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$this-&gt;_sqlStatements</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>SingleTableDeleteUpdateExecutor</code>
+      <code>SingleTableDeleteUpdateExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr.php">
+    <MissingParamType occurrences="1">
+      <code>$y</code>
+    </MissingParamType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Andx.php">
+    <NonInvariantDocblockPropertyType occurrences="2">
+      <code>$allowedClasses</code>
+      <code>$parts</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Base.php">
+    <PossiblyInvalidCast occurrences="1">
+      <code>$this-&gt;parts[0]</code>
+    </PossiblyInvalidCast>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array) $args</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Composite.php">
+    <PossiblyInvalidCast occurrences="2">
+      <code>$part</code>
+      <code>$this-&gt;parts[0]</code>
+    </PossiblyInvalidCast>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/From.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>$indexBy</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Func.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array) $arguments</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/GroupBy.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$parts</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Join.php">
+    <PossiblyNullPropertyAssignmentValue occurrences="4">
+      <code>$alias</code>
+      <code>$condition</code>
+      <code>$conditionType</code>
+      <code>$indexBy</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Literal.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$parts</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Orx.php">
+    <NonInvariantDocblockPropertyType occurrences="2">
+      <code>$allowedClasses</code>
+      <code>$parts</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Expr/Select.php">
+    <NonInvariantDocblockPropertyType occurrences="2">
+      <code>$allowedClasses</code>
+      <code>$parts</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/Filter/SQLFilter.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>static function ($value) use ($connection, $param) {</code>
+    </MissingClosureReturnType>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;parameters</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/FilterCollection.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;enabledFilters[$name]</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>SQLFilter</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$filterHash</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="2">
+      <code>$em</code>
+      <code>$this-&gt;enabledFilters</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ParameterTypeInferer.php">
+    <DeprecatedConstant occurrences="5">
+      <code>Type::BOOLEAN</code>
+      <code>Type::DATEINTERVAL</code>
+      <code>Type::DATETIME</code>
+      <code>Type::DATETIME_IMMUTABLE</code>
+      <code>Type::INTEGER</code>
+    </DeprecatedConstant>
+  </file>
   <file src="lib/Doctrine/ORM/Query/Parser.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$stringPattern</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="3">
+      <code>call_user_func($functionClass, $functionName)</code>
+      <code>call_user_func($functionClass, $functionName)</code>
+      <code>call_user_func($functionClass, $functionName)</code>
+    </DocblockTypeContradiction>
+    <ImplicitToStringCast occurrences="1">
+      <code>Subselect|string</code>
+    </ImplicitToStringCast>
     <InvalidArrayOffset occurrences="2">
       <code>$this-&gt;identVariableExpressions[$dqlAlias]</code>
       <code>$this-&gt;queryComponents[$dqlAlias]</code>
@@ -431,6 +2766,16 @@
       <code>AST\BetweenExpression|</code>
       <code>ArithmeticFactor</code>
     </InvalidReturnType>
+    <InvalidScalarArgument occurrences="3">
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
+      <code>$this-&gt;lexer-&gt;getLiteral($token)</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="3">
+      <code>$function</code>
+      <code>$function</code>
+      <code>$function</code>
+    </LessSpecificReturnStatement>
     <NullableReturnStatement occurrences="9">
       <code>$aliasIdentVariable</code>
       <code>$factors[0]</code>
@@ -442,8 +2787,205 @@
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
     </NullableReturnStatement>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($fromClassName, '\\')</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="6">
+      <code>$AST</code>
+      <code>$conditionalExpression</code>
+      <code>$expr</code>
+      <code>$stringExpr</code>
+      <code>$this-&gt;ConditionalExpression()</code>
+      <code>$this-&gt;ConditionalExpression()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;ConditionalExpression()</code>
+      <code>$this-&gt;ConditionalExpression()</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullArgument occurrences="30">
+      <code>$aliasIdentVariable</code>
+      <code>$dql</code>
+      <code>$dql</code>
+      <code>$dql</code>
+      <code>$field</code>
+      <code>$fromClassName</code>
+      <code>$fromClassName</code>
+      <code>$fromClassName</code>
+      <code>$functionName</code>
+      <code>$functionName</code>
+      <code>$functionName</code>
+      <code>$lookaheadType</code>
+      <code>$lookaheadType</code>
+      <code>$lookaheadType</code>
+      <code>$resultVariable</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;query-&gt;getDQL()</code>
+      <code>$this-&gt;query-&gt;getDQL()</code>
+      <code>$token['value']</code>
+      <code>$token['value']</code>
+      <code>$token['value']</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="75">
+      <code>$glimpse['type']</code>
+      <code>$glimpse['value']</code>
+      <code>$lookahead['type']</code>
+      <code>$lookahead['type']</code>
+      <code>$next['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['type']</code>
+      <code>$peek['value']</code>
+      <code>$peek['value']</code>
+      <code>$this-&gt;lexer-&gt;glimpse()['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['type']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;lookahead['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$this-&gt;lexer-&gt;token['value']</code>
+      <code>$token['type']</code>
+      <code>$token['type']</code>
+      <code>$token['type']</code>
+      <code>$token['type']</code>
+      <code>$token['type']</code>
+      <code>$token['type']</code>
+      <code>$token['value']</code>
+      <code>$token['value']</code>
+      <code>$token['value']</code>
+      <code>$token['value']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="1">
+      <code>getNumberOfRequiredParameters</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$args</code>
+    </PossiblyUndefinedVariable>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$customOutputWalker</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="2">
+      <code>$className</code>
+      <code>$this-&gt;customTreeWalkers</code>
+    </PropertyTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>$AST instanceof AST\SelectStatement</code>
+      <code>is_string($functionClass)</code>
+      <code>is_string($functionClass)</code>
+      <code>is_string($functionClass)</code>
+    </RedundantConditionGivenDocblockType>
+    <UnsafeInstantiation occurrences="4">
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $funcClass($funcNameLower)</code>
+      <code>new $outputWalkerClass($this-&gt;query, $this-&gt;parserResult, $this-&gt;queryComponents)</code>
+    </UnsafeInstantiation>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ParserResult.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$_sqlExecutor</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/QueryExpressionVisitor.php">
+    <RedundantCondition occurrences="1">
+      <code>Comparison::EQ</code>
+    </RedundantCondition>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ResultSetMapping.php">
+    <PropertyTypeCoercion occurrences="3">
+      <code>$this-&gt;aliasMap</code>
+      <code>$this-&gt;aliasMap</code>
+      <code>$this-&gt;declaringClasses</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$class</code>
+      <code>$class</code>
+      <code>$class</code>
+      <code>$renameMode</code>
+      <code>$renameMode</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="2">
+      <code>getSQLResultCasing</code>
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$class-&gt;fieldMappings[$this-&gt;fieldMappings[$columnName]]['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Query/SqlWalker.php">
+    <DocblockTypeContradiction occurrences="10">
+      <code>! ($factor instanceof AST\ConditionalFactor)</code>
+      <code>$condExpr instanceof AST\ConditionalExpression</code>
+      <code>$condTerm instanceof AST\ConditionalTerm</code>
+      <code>$simpleArithmeticExpr instanceof AST\SimpleArithmeticExpression</code>
+      <code>$this-&gt;queryComponents[$dqlAlias]['relation'] === null</code>
+      <code>''</code>
+      <code>is_numeric($leftExpr) ? $leftExpr : $this-&gt;conn-&gt;quote($leftExpr)</code>
+      <code>is_numeric($rightExpr) ? $rightExpr : $this-&gt;conn-&gt;quote($rightExpr)</code>
+      <code>is_string($expression)</code>
+      <code>is_string($stringExpr)</code>
+    </DocblockTypeContradiction>
+    <ImplicitToStringCast occurrences="1">
+      <code>$expr</code>
+    </ImplicitToStringCast>
     <InvalidArgument occurrences="1">
       <code>$selectedClass['class']-&gt;name</code>
     </InvalidArgument>
@@ -464,27 +3006,637 @@
       <code>$this-&gt;scalarResultAliasMap</code>
       <code>$this-&gt;scalarResultAliasMap</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidScalarArgument occurrences="4">
+      <code>$resultAlias</code>
+      <code>$resultAlias</code>
+      <code>$resultAlias</code>
+      <code>$resultAlias</code>
+    </InvalidScalarArgument>
+    <MissingPropertyType occurrences="1">
+      <code>$targetEntity-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$aggExpression-&gt;pathExpression</code>
+      <code>$whereClause-&gt;conditionalExpression</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="12">
+      <code>$AST-&gt;whereClause</code>
+      <code>$AST-&gt;whereClause</code>
+      <code>$AST-&gt;whereClause</code>
+      <code>$arithmeticExpr-&gt;simpleArithmeticExpression</code>
+      <code>$arithmeticExpr-&gt;subselect</code>
+      <code>$condExpr</code>
+      <code>$field</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+      <code>$identificationVariableDecl-&gt;rangeVariableDeclaration</code>
+      <code>$resultAlias</code>
+      <code>$subselect-&gt;whereClause</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="9">
+      <code>$class-&gt;associationMappings</code>
+      <code>$class-&gt;associationMappings</code>
+      <code>$class-&gt;fieldMappings</code>
+      <code>$class-&gt;fieldMappings</code>
+      <code>$class-&gt;fieldMappings</code>
+      <code>$this-&gt;scalarFields[$dqlAlias]</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+      <code>$this-&gt;scalarResultAliasMap</code>
+    </PossiblyNullArrayOffset>
+    <PossiblyNullReference occurrences="1">
+      <code>dispatch</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="3">
+      <code>$fieldMapping['columnName']</code>
+      <code>$mapping['columnName']</code>
+      <code>$mapping['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+    <PropertyTypeCoercion occurrences="3">
+      <code>$query</code>
+      <code>$this-&gt;queryComponents</code>
+      <code>$this-&gt;selectedClasses</code>
+    </PropertyTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="5">
+      <code>$leftExpr instanceof AST\Node</code>
+      <code>$likeExpr-&gt;stringPattern instanceof AST\InputParameter</code>
+      <code>$rightExpr instanceof AST\Node</code>
+      <code>$whereClause !== null</code>
+      <code>($factor-&gt;not ? 'NOT ' : '') . $this-&gt;walkConditionalPrimary($factor-&gt;conditionalPrimary)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerAdapter.php">
+    <ImplementedReturnTypeMismatch occurrences="47">
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingParamType occurrences="43">
+      <code>$AST</code>
+      <code>$aggExpression</code>
+      <code>$arithmeticExpr</code>
+      <code>$betweenExpr</code>
+      <code>$collMemberExpr</code>
+      <code>$compExpr</code>
+      <code>$condExpr</code>
+      <code>$condTerm</code>
+      <code>$emptyCollCompExpr</code>
+      <code>$existsExpr</code>
+      <code>$factor</code>
+      <code>$factor</code>
+      <code>$fromClause</code>
+      <code>$function</code>
+      <code>$groupByClause</code>
+      <code>$groupByItem</code>
+      <code>$havingClause</code>
+      <code>$inExpr</code>
+      <code>$inputParam</code>
+      <code>$instanceOfExpr</code>
+      <code>$join</code>
+      <code>$likeExpr</code>
+      <code>$literal</code>
+      <code>$nullCompExpr</code>
+      <code>$orderByClause</code>
+      <code>$orderByItem</code>
+      <code>$pathExpr</code>
+      <code>$primary</code>
+      <code>$qExpr</code>
+      <code>$resultVariable</code>
+      <code>$selectClause</code>
+      <code>$selectExpression</code>
+      <code>$simpleArithmeticExpr</code>
+      <code>$simpleSelectClause</code>
+      <code>$simpleSelectExpression</code>
+      <code>$stateFieldPathExpression</code>
+      <code>$stringPrimary</code>
+      <code>$subselect</code>
+      <code>$subselectFromClause</code>
+      <code>$term</code>
+      <code>$updateClause</code>
+      <code>$updateItem</code>
+      <code>$whereClause</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>_getQueryComponents</code>
+    </MissingReturnType>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$this-&gt;_queryComponents</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerChain.php">
+    <ImplementedReturnTypeMismatch occurrences="47">
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingParamType occurrences="44">
+      <code>$AST</code>
+      <code>$aggExpression</code>
+      <code>$arithmeticExpr</code>
+      <code>$betweenExpr</code>
+      <code>$collMemberExpr</code>
+      <code>$compExpr</code>
+      <code>$condExpr</code>
+      <code>$condPrimary</code>
+      <code>$condTerm</code>
+      <code>$dqlAlias</code>
+      <code>$emptyCollCompExpr</code>
+      <code>$existsExpr</code>
+      <code>$factor</code>
+      <code>$factor</code>
+      <code>$fromClause</code>
+      <code>$function</code>
+      <code>$groupByClause</code>
+      <code>$groupByItem</code>
+      <code>$havingClause</code>
+      <code>$inExpr</code>
+      <code>$inputParam</code>
+      <code>$instanceOfExpr</code>
+      <code>$join</code>
+      <code>$likeExpr</code>
+      <code>$literal</code>
+      <code>$nullCompExpr</code>
+      <code>$orderByClause</code>
+      <code>$orderByItem</code>
+      <code>$pathExpr</code>
+      <code>$qExpr</code>
+      <code>$resultVariable</code>
+      <code>$selectClause</code>
+      <code>$selectExpression</code>
+      <code>$simpleArithmeticExpr</code>
+      <code>$simpleSelectClause</code>
+      <code>$simpleSelectExpression</code>
+      <code>$stateFieldPathExpression</code>
+      <code>$stringPrimary</code>
+      <code>$subselect</code>
+      <code>$subselectFromClause</code>
+      <code>$term</code>
+      <code>$updateClause</code>
+      <code>$updateItem</code>
+      <code>$whereClause</code>
+    </MissingParamType>
+    <PossiblyNullReference occurrences="46">
+      <code>walkAggregateExpression</code>
+      <code>walkArithmeticExpression</code>
+      <code>walkArithmeticFactor</code>
+      <code>walkArithmeticTerm</code>
+      <code>walkBetweenExpression</code>
+      <code>walkCollectionMemberExpression</code>
+      <code>walkComparisonExpression</code>
+      <code>walkConditionalExpression</code>
+      <code>walkConditionalFactor</code>
+      <code>walkConditionalPrimary</code>
+      <code>walkConditionalTerm</code>
+      <code>walkDeleteClause</code>
+      <code>walkDeleteStatement</code>
+      <code>walkEmptyCollectionComparisonExpression</code>
+      <code>walkExistsExpression</code>
+      <code>walkFromClause</code>
+      <code>walkFunction</code>
+      <code>walkGroupByClause</code>
+      <code>walkGroupByItem</code>
+      <code>walkHavingClause</code>
+      <code>walkInExpression</code>
+      <code>walkInputParameter</code>
+      <code>walkInstanceOfExpression</code>
+      <code>walkJoin</code>
+      <code>walkLikeExpression</code>
+      <code>walkLiteral</code>
+      <code>walkNullComparisonExpression</code>
+      <code>walkOrderByClause</code>
+      <code>walkOrderByItem</code>
+      <code>walkPathExpression</code>
+      <code>walkQuantifiedExpression</code>
+      <code>walkResultVariable</code>
+      <code>walkSelectClause</code>
+      <code>walkSelectExpression</code>
+      <code>walkSelectStatement</code>
+      <code>walkSimpleArithmeticExpression</code>
+      <code>walkSimpleSelectClause</code>
+      <code>walkSimpleSelectExpression</code>
+      <code>walkStateFieldPathExpression</code>
+      <code>walkStringPrimary</code>
+      <code>walkSubselect</code>
+      <code>walkSubselectFromClause</code>
+      <code>walkUpdateClause</code>
+      <code>walkUpdateItem</code>
+      <code>walkUpdateStatement</code>
+      <code>walkWhereClause</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php">
+    <ImplementedParamTypeMismatch occurrences="1">
+      <code>$value</code>
+    </ImplementedParamTypeMismatch>
+    <ImplementedReturnTypeMismatch occurrences="2">
+      <code>TreeWalker|null</code>
+      <code>class-string&lt;TreeWalker&gt;|false</code>
+    </ImplementedReturnTypeMismatch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$offset</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayOffset occurrences="1">
+      <code>$this-&gt;walkers</code>
+    </PossiblyNullArrayOffset>
+    <PropertyTypeCoercion occurrences="2">
+      <code>$this-&gt;walkers</code>
+      <code>$this-&gt;walkers</code>
+    </PropertyTypeCoercion>
   </file>
   <file src="lib/Doctrine/ORM/QueryBuilder.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>[$rootAlias =&gt; $join]</code>
+      <code>[$rootAlias =&gt; $join]</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="2">
+      <code>getRootAlias</code>
+      <code>getRootAlias</code>
+    </DeprecatedMethod>
     <FalsableReturnStatement occurrences="1">
       <code>! $filteredParameters-&gt;isEmpty() ? $filteredParameters-&gt;first() : null</code>
     </FalsableReturnStatement>
+    <InvalidFalsableReturnType occurrences="1">
+      <code>Parameter|null</code>
+    </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="1">
       <code>int</code>
     </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="1">
+      <code>$key</code>
+    </InvalidScalarArgument>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;cacheMode</code>
     </NullableReturnStatement>
+    <PossiblyFalseArgument occurrences="4">
+      <code>$spacePos</code>
+      <code>$spacePos</code>
+      <code>strpos($join, '.')</code>
+      <code>strpos($join, '.')</code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand occurrences="2">
+      <code>$spacePos</code>
+      <code>$spacePos</code>
+    </PossiblyFalseOperand>
+    <PossiblyInvalidIterator occurrences="1">
+      <code>$dqlPart</code>
+    </PossiblyInvalidIterator>
+    <PossiblyNullArgument occurrences="2">
+      <code>$alias</code>
+      <code>$alias</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$_dql</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="5">
+      <code>(bool) $cacheable</code>
+      <code>(bool) $flag</code>
+      <code>(int) $cacheMode</code>
+      <code>(int) $lifetime</code>
+      <code>(string) $cacheRegion</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;_dql !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>new $repositoryClassName($entityManager, $metadata)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>ObjectRepository</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$input-&gt;getOption('em')</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="13">
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$ownerClass</code>
+      <code>$ownerClass</code>
+      <code>$ownerClass</code>
+      <code>$ownerClass</code>
+      <code>$ownerClass</code>
+      <code>$ownerClass</code>
+      <code>$ownerId</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityClass</code>
+      <code>$entityId</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($queryRegion)</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+      <code>$name</code>
+    </PossiblyInvalidArgument>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($queryRegion)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="10">
+      <code>ClassMetadataExporter</code>
+      <code>ClassMetadataExporter</code>
+      <code>ClassMetadataExporter|null</code>
+      <code>EntityGenerator</code>
+      <code>EntityGenerator</code>
+      <code>EntityGenerator|null</code>
+      <code>new ClassMetadataExporter()</code>
+      <code>new EntityGenerator()</code>
+      <code>private $entityGenerator = null;</code>
+      <code>private $metadataExporter = null;</code>
+    </DeprecatedClass>
+    <InvalidScalarArgument occurrences="1">
+      <code>4</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="4">
+      <code>$extend</code>
+      <code>$input-&gt;getArgument('dest-path')</code>
+      <code>$input-&gt;getOption('from')</code>
+      <code>$toType</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadata</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="3">
+      <code>AbstractExporter</code>
+      <code>new ClassMetadataExporter()</code>
+      <code>new EntityGenerator()</code>
+    </DeprecatedClass>
     <InvalidNullableReturnType occurrences="1">
       <code>execute</code>
     </InvalidNullableReturnType>
+    <InvalidScalarArgument occurrences="2">
+      <code>$input-&gt;getOption('filter')</code>
+      <code>4</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$class-&gt;name</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidArgument occurrences="8">
+      <code>$destPath</code>
+      <code>$destPath</code>
+      <code>$destPath</code>
+      <code>$extend</code>
+      <code>$input-&gt;getArgument('dest-path')</code>
+      <code>$input-&gt;getArgument('to-type')</code>
+      <code>$input-&gt;getOption('force')</code>
+      <code>$namespace</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$metadatas</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="1">
+      <code>new EntityGenerator()</code>
+    </DeprecatedClass>
+    <InvalidScalarArgument occurrences="2">
+      <code>$input-&gt;getOption('filter')</code>
+      <code>4</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$metadata-&gt;name</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$extend</code>
+      <code>$input-&gt;getArgument('dest-path')</code>
+      <code>$input-&gt;getArgument('dest-path')</code>
+      <code>$input-&gt;getOption('generate-annotations')</code>
+      <code>$input-&gt;getOption('generate-methods')</code>
+      <code>$input-&gt;getOption('regenerate-entities')</code>
+      <code>$input-&gt;getOption('update-entities')</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php">
+    <DeprecatedMethod occurrences="2">
+      <code>getProxyDir</code>
+      <code>getProxyDir</code>
+    </DeprecatedMethod>
+    <InvalidScalarArgument occurrences="1">
+      <code>$input-&gt;getOption('filter')</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$metadata-&gt;name</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidArgument occurrences="3">
+      <code>$destPath</code>
+      <code>$destPath</code>
+      <code>$destPath</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$em-&gt;getConfiguration()-&gt;getProxyDir()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php">
+    <DeprecatedClass occurrences="1">
+      <code>new EntityRepositoryGenerator()</code>
+    </DeprecatedClass>
+    <InvalidScalarArgument occurrences="1">
+      <code>$input-&gt;getOption('filter')</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <NoInterfaceProperties occurrences="1">
+      <code>$metadata-&gt;customRepositoryClassName</code>
+    </NoInterfaceProperties>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$input-&gt;getArgument('dest-path')</code>
+      <code>$input-&gt;getArgument('dest-path')</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getAllClassNames</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php">
     <InvalidArgument occurrences="1">
       <code>$metadata-&gt;entityListeners</code>
     </InvalidArgument>
+    <MissingPropertyType occurrences="1">
+      <code>$metadata-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$input-&gt;getArgument('entityName')</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getAllClassNames</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php">
+    <DeprecatedClass occurrences="1">
+      <code>Debug::dump($resultSet, (int) $input-&gt;getOption('depth'), true, false)</code>
+    </DeprecatedClass>
+    <InvalidScalarArgument occurrences="2">
+      <code>$hydrationModeName</code>
+      <code>7</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$dql</code>
+      <code>$hydrationModeName</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php">
     <InvalidNullableReturnType occurrences="1">
@@ -494,36 +3646,520 @@
       <code>$this-&gt;executeSchemaCommand($input, $output, new SchemaTool($em), $metadatas, $ui)</code>
     </NullableReturnStatement>
   </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;getName()</code>
+      <code>$this-&gt;getName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;getName()</code>
+      <code>$this-&gt;getName()</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php">
+    <MissingReturnType occurrences="1">
+      <code>configure</code>
+    </MissingReturnType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php">
+    <DeprecatedClass occurrences="6">
+      <code>Versions::getVersion('doctrine/orm')</code>
+      <code>new Command\ConvertDoctrine1SchemaCommand()</code>
+      <code>new Command\GenerateEntitiesCommand($entityManagerProvider)</code>
+      <code>new Command\GenerateRepositoriesCommand($entityManagerProvider)</code>
+      <code>new DBALConsole\Command\ImportCommand()</code>
+      <code>new DBALConsole\Helper\ConnectionHelper($entityManager-&gt;getConnection())</code>
+    </DeprecatedClass>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">
+    <PossiblyNullArgument occurrences="3">
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/EntityGenerator.php">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$this-&gt;getClassToExtend()</code>
+      <code>$this-&gt;getClassToExtend() ?: $metadata-&gt;name</code>
+      <code>$this-&gt;getClassToExtend() ?: $metadata-&gt;name</code>
+      <code>array_map('strlen', $paramTypes)</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="15">
+      <code>Type::BIGINT</code>
+      <code>Type::BLOB</code>
+      <code>Type::BOOLEAN</code>
+      <code>Type::DATE</code>
+      <code>Type::DATETIME</code>
+      <code>Type::DATETIMETZ</code>
+      <code>Type::DECIMAL</code>
+      <code>Type::GUID</code>
+      <code>Type::INTEGER</code>
+      <code>Type::JSON_ARRAY</code>
+      <code>Type::OBJECT</code>
+      <code>Type::SIMPLE_ARRAY</code>
+      <code>Type::SMALLINT</code>
+      <code>Type::TEXT</code>
+      <code>Type::TIME</code>
+    </DeprecatedConstant>
+    <DocblockTypeContradiction occurrences="4">
+      <code>$metadata-&gt;reflClass !== null</code>
+      <code>$metadata-&gt;reflClass !== null || class_exists($metadata-&gt;name)</code>
+      <code>class_exists($metadata-&gt;name)</code>
+      <code>new ReflectionClass($metadata-&gt;name)</code>
+    </DocblockTypeContradiction>
+    <InvalidDocblock occurrences="1">
+      <code>public function setFieldVisibility($visibility)</code>
+    </InvalidDocblock>
+    <MissingParamType occurrences="1">
+      <code>$visibility</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="3">
+      <code>$metadata-&gt;inheritanceType</code>
+      <code>$metadata-&gt;inheritanceType</code>
+      <code>$metadata-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>setFieldVisibility</code>
+    </MissingReturnType>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$last</code>
+      <code>strrpos($metadata-&gt;name, '\\')</code>
+    </PossiblyFalseArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$variableType</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$classToExtend</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $embeddablesImmutable</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="5">
+      <code>! $this-&gt;isNew &amp;&amp; class_exists($metadata-&gt;name)</code>
+      <code>! $this-&gt;isNew &amp;&amp; class_exists($metadata-&gt;name)</code>
+      <code>$metadata-&gt;reflClass</code>
+      <code>$metadata-&gt;reflClass !== null</code>
+      <code>isset($metadata-&gt;lifecycleCallbacks)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$fullClassName</code>
+      <code>$fullClassName</code>
+      <code>$fullClassName</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>EntityRepository::class</code>
+    </DocblockTypeContradiction>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($fullClassName, '\\')</code>
+    </PossiblyFalseArgument>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($fullClassName, '\\')</code>
+    </PossiblyFalseOperand>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$repositoryName</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$repositoryName</code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php">
+    <DeprecatedClass occurrences="7">
+      <code>Driver\AbstractExporter</code>
+      <code>Driver\AnnotationExporter::class</code>
+      <code>Driver\PhpExporter::class</code>
+      <code>Driver\XmlExporter::class</code>
+      <code>Driver\YamlExporter::class</code>
+      <code>Driver\YamlExporter::class</code>
+      <code>ExportException::invalidExporterDriverType($type)</code>
+    </DeprecatedClass>
+    <InvalidStringClass occurrences="1">
+      <code>new $class($dest)</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>new $class($dest)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>Driver\AbstractExporter</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php">
+    <DeprecatedClass occurrences="1">
+      <code>ExportException::attemptOverwriteExistingFile($path)</code>
+    </DeprecatedClass>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$this-&gt;_outputDir</code>
+      <code>$this-&gt;_outputDir</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php">
+    <DeprecatedClass occurrences="3">
+      <code>AbstractExporter</code>
+      <code>EntityGenerator</code>
+      <code>EntityGenerator|null</code>
+    </DeprecatedClass>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$_extension</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$metadata-&gt;changeTrackingPolicy</code>
+      <code>$metadata-&gt;generatorType</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="1">
+      <code>AbstractExporter</code>
+    </DeprecatedClass>
+    <MissingPropertyType occurrences="1">
+      <code>$metadata-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$_extension</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$metadata-&gt;changeTrackingPolicy</code>
+      <code>$metadata-&gt;generatorType</code>
+      <code>$metadata-&gt;generatorType</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="1">
+      <code>AbstractExporter</code>
+    </DeprecatedClass>
+    <InvalidScalarArgument occurrences="6">
+      <code>$field['length']</code>
+      <code>$field['length']</code>
+      <code>$field['precision']</code>
+      <code>$field['scale']</code>
+      <code>$sequenceDefinition['allocationSize']</code>
+      <code>$sequenceDefinition['initialValue']</code>
+    </InvalidScalarArgument>
+    <MissingClosureParamType occurrences="2">
+      <code>$m1</code>
+      <code>$m2</code>
+    </MissingClosureParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$metadata-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$_extension</code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$simpleXml-&gt;asXML()</code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>addAttribute</code>
+    </PossiblyNullReference>
+    <RedundantCondition occurrences="1">
+      <code>isset($field['associationKey']) &amp;&amp; $field['associationKey']</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>isset($metadata-&gt;lifecycleCallbacks)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$metadata-&gt;changeTrackingPolicy</code>
+      <code>$metadata-&gt;generatorType</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="1">
+      <code>AbstractExporter</code>
+    </DeprecatedClass>
+    <DocblockTypeContradiction occurrences="1">
+      <code>['name' =&gt; null]</code>
+    </DocblockTypeContradiction>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$array</code>
+    </LessSpecificReturnStatement>
+    <MissingPropertyType occurrences="1">
+      <code>$metadata-&gt;inheritanceType</code>
+    </MissingPropertyType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;string, mixed&gt;&amp;array{entityListeners: array&lt;class-string, array&lt;string, array{string}&gt;&gt;}</code>
+    </MoreSpecificReturnType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$_extension</code>
+    </NonInvariantDocblockPropertyType>
+    <PossiblyUndefinedArrayOffset occurrences="1">
+      <code>$fieldMapping['columnName']</code>
+    </PossiblyUndefinedArrayOffset>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$metadata-&gt;table</code>
+      <code>isset($metadata-&gt;lifecycleCallbacks)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$query</code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/CountWalker.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$query</code>
     </MoreSpecificImplementedParamType>
+    <PossiblyFalseArgument occurrences="1">
+      <code>strrpos($orderByItemString, ' ')</code>
+    </PossiblyFalseArgument>
+    <PossiblyNullIterator occurrences="1">
+      <code>$orderByClause-&gt;orderByItems</code>
+    </PossiblyNullIterator>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$query-&gt;getFirstResult()</code>
+      <code>$query-&gt;getMaxResults()</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullPropertyFetch occurrences="1">
+      <code>$orderByClause-&gt;orderByItems</code>
+    </PossiblyNullPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/Paginator.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$parameters</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="1">
+      <code>getSQLResultCasing</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;count === null</code>
+    </DocblockTypeContradiction>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$count</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $fetchJoinCollection</code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php">
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$orderByClause</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression instanceof ConditionalPrimary</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>void</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingClosureReturnType occurrences="1">
+      <code>static function ($id) use ($connection, $type) {</code>
+    </MissingClosureReturnType>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$AST-&gt;whereClause-&gt;conditionalExpression instanceof ConditionalExpression</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/SchemaTool.php">
+    <DeprecatedMethod occurrences="1">
+      <code>addUnnamedForeignKeyConstraint</code>
+    </DeprecatedMethod>
+    <DocblockTypeContradiction occurrences="1">
+      <code>$definingClass</code>
+    </DocblockTypeContradiction>
+    <MissingClosureParamType occurrences="1">
+      <code>$asset</code>
+    </MissingClosureParamType>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$definingClass</code>
+      <code>$referencedFieldName</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="1">
+      <code>getColumns</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$fieldMapping['precision']</code>
+      <code>$fieldMapping['scale']</code>
+    </PossiblyUndefinedArrayOffset>
+    <RedundantCondition occurrences="1">
+      <code>is_numeric($indexName)</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>assert(is_array($assoc))</code>
+      <code>is_array($assoc)</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>$indexName</code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/Setup.php">
+    <DeprecatedClass occurrences="14">
+      <code>ApcuCache::class</code>
+      <code>ArrayCache::class</code>
+      <code>ArrayCache::class</code>
+      <code>ArrayCache::class</code>
+      <code>MemcachedCache::class</code>
+      <code>RedisCache::class</code>
+      <code>new ApcuCache()</code>
+      <code>new ArrayCache()</code>
+      <code>new ArrayCache()</code>
+      <code>new ClassLoader('Doctrine', $directory)</code>
+      <code>new ClassLoader('Symfony\Component', $directory . '/Doctrine')</code>
+      <code>new MemcachedCache()</code>
+      <code>new RedisCache()</code>
+      <code>new YamlDriver($paths)</code>
+    </DeprecatedClass>
+    <DeprecatedMethod occurrences="1">
+      <code>setMetadataCacheImpl</code>
+    </DeprecatedMethod>
+    <UnresolvableInclude occurrences="1">
+      <code>require_once $directory . '/Doctrine/Common/ClassLoader.php'</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="lib/Doctrine/ORM/Tools/ToolsException.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>'0'</code>
+    </InvalidScalarArgument>
   </file>
   <file src="lib/Doctrine/ORM/UnitOfWork.php">
+    <ArgumentTypeCoercion occurrences="7">
+      <code>$class</code>
+      <code>$class</code>
+      <code>$collectionToDelete</code>
+      <code>$collectionToUpdate</code>
+      <code>$commitOrder[$i]</code>
+      <code>$entityName</code>
+      <code>$this-&gt;em</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="4">
+      <code>! is_object($object)</code>
+      <code>$association['type'] === ClassMetadata::ONE_TO_MANY</code>
+      <code>$association['type'] === ClassMetadata::ONE_TO_MANY</code>
+      <code>is_object($object)</code>
+    </DocblockTypeContradiction>
     <InvalidNullableReturnType occurrences="1">
       <code>object</code>
     </InvalidNullableReturnType>
+    <InvalidOperand occurrences="1">
+      <code>$association['type']</code>
+    </InvalidOperand>
     <InvalidPropertyAssignmentValue occurrences="2">
       <code>$this-&gt;entityChangeSets</code>
       <code>$this-&gt;entityChangeSets</code>
     </InvalidPropertyAssignmentValue>
+    <MissingClosureReturnType occurrences="5">
+      <code>static function ($assoc) {</code>
+      <code>static function ($assoc) {</code>
+      <code>static function ($assoc) {</code>
+      <code>static function ($assoc) {</code>
+      <code>static function ($assoc) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="3">
+      <code>$managedCopy</code>
+      <code>$prevManagedCopy</code>
+      <code>$previousManagedCopy</code>
+    </MissingParamType>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;identityMap[$rootClassName][$idHash]</code>
     </NullableReturnStatement>
+    <PossiblyInvalidArrayOffset occurrences="1">
+      <code>$this-&gt;identityMap[$rootClassName]</code>
+    </PossiblyInvalidArrayOffset>
+    <PossiblyNullArgument occurrences="13">
+      <code>$assoc</code>
+      <code>$assoc</code>
+      <code>$assoc['targetEntity']</code>
+      <code>$class-&gt;getTypeOfField($class-&gt;getSingleIdentifierFieldName())</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collection-&gt;getOwner()</code>
+      <code>$collectionToDelete-&gt;getMapping()</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$newValue</code>
+      <code>$owner</code>
+      <code>$owner</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$assoc['targetEntity']</code>
+      <code>$assoc['type']</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullReference occurrences="33">
+      <code>buildCachedCollectionPersister</code>
+      <code>buildCachedEntityPersister</code>
+      <code>getCacheFactory</code>
+      <code>getCacheFactory</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>getValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>unwrap</code>
+      <code>unwrap</code>
+      <code>unwrap</code>
+    </PossiblyUndefinedMethod>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$class-&gt;cache !== null</code>
+      <code>$this-&gt;hasCache &amp;&amp; $class-&gt;cache !== null</code>
+      <code>is_array($entity)</code>
+    </RedundantConditionGivenDocblockType>
+    <ReferenceConstraintViolation occurrences="1">
+      <code>$visited</code>
+    </ReferenceConstraintViolation>
     <UndefinedInterfaceMethod occurrences="3">
       <code>getMapping</code>
       <code>getMapping</code>
       <code>takeSnapshot</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php">
+    <NoInterfaceProperties occurrences="2">
+      <code>$rootClassMetadata-&gt;name</code>
+      <code>$rootClassMetadata-&gt;subClasses</code>
+    </NoInterfaceProperties>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="5"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
Follow-up to #8689.

This enables checks for usage of deprecated API in the psalm configuration and also updates the baseline to not report any errors. Deprecations will be fixed gradually.