### PR TITLE
Allow Symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,14 +29,14 @@
         "doctrine/instantiator": "^1.3",
         "doctrine/lexer": "^1.0",
         "doctrine/persistence": "^2.2",
-        "symfony/console": "^3.0|^4.0|^5.0"
+        "symfony/console": "^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
         "phpstan/phpstan": "^0.12.83",
         "phpunit/phpunit": "^8.5|^9.4",
         "squizlabs/php_codesniffer": "3.6.0",
-        "symfony/yaml": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0|^6.0",
         "vimeo/psalm": "4.7.0"
     },
     "suggest": {


### PR DESCRIPTION
Same as #7723: this is required to unlock our CI and will help ensure Doctrine is compatible from day 1.