### PR TITLE
Change persistence ordering for OneToOne to allow making JoinColumns non-nullable

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499OneToManyRelationshipTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499OneToManyRelationshipTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6499
+ */
+class DDC6499OneToManyRelationshipTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(Application::class),
+                $this->_em->getClassMetadata(Person::class),
+                $this->_em->getClassMetadata(ApplicationPerson::class),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->_schemaTool->dropSchema(
+            [
+                $this->_em->getClassMetadata(Application::class),
+                $this->_em->getClassMetadata(Person::class),
+                $this->_em->getClassMetadata(ApplicationPerson::class),
+            ]
+        );
+    }
+
+    /**
+     * Test for the bug described in issue #6499.
+     */
+    public function testIssue(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $person = new Person();
+        $this->_em->persist($person);
+
+        $application = new Application();
+        $this->_em->persist($application);
+
+        $applicationPerson = new ApplicationPerson($person, $application);
+
+        $this->_em->persist($applicationPerson);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $personFromDatabase      = $this->_em->find(Person::class, $person->id);
+        $applicationFromDatabase = $this->_em->find(Application::class, $application->id);
+
+        self::assertEquals($personFromDatabase->id, $person->id, 'Issue #6499 will result in a Integrity constraint violation before reaching this point.');
+        self::assertFalse($personFromDatabase->getApplicationPeople()->isEmpty());
+
+        self::assertEquals($applicationFromDatabase->id, $application->id, 'Issue #6499 will result in a Integrity constraint violation before reaching this point.');
+        self::assertFalse($applicationFromDatabase->getApplicationPeople()->isEmpty());
+    }
+}
+
+/**
+ * @Entity()
+ * @Table("ddc6499_application")
+ */
+class Application
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity=ApplicationPerson::class, mappedBy="application", orphanRemoval=true, cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     * @var Collection
+     */
+    private $applicationPeople;
+
+    public function __construct()
+    {
+        $this->applicationPeople = new ArrayCollection();
+    }
+
+    public function getApplicationPeople(): Collection
+    {
+        return $this->applicationPeople;
+    }
+}
+/**
+ * @Entity()
+ * @Table("ddc6499_person")
+ */
+class Person
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @OneToMany(targetEntity=ApplicationPerson::class, mappedBy="person", orphanRemoval=true, cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     * @var Collection
+     */
+    private $applicationPeople;
+
+    public function __construct()
+    {
+        $this->applicationPeople = new ArrayCollection();
+    }
+
+    public function getApplicationPeople(): Collection
+    {
+        return $this->applicationPeople;
+    }
+}
+
+/**
+ * @Entity()
+ * @Table("ddc6499_application_person")
+ */
+class ApplicationPerson
+{
+    /**
+     * @Id
+     * @GeneratedValue
+     * @Column(type="integer")
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @ManyToOne(targetEntity=Application::class, inversedBy="applicationPeople", cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     * @var Application
+     */
+    public $application;
+
+    /**
+     * @ManyToOne(targetEntity=Person::class, inversedBy="applicationPeople", cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     * @var Person
+     */
+    public $person;
+
+    public function __construct(Person $person, Application $application)
+    {
+        $this->person      = $person;
+        $this->application = $application;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499OneToOneRelationshipTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499OneToOneRelationshipTest.php
@@ -7,7 +7,7 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 /**
  * @group DDC-6499
  */
-class DDC6499Test extends OrmFunctionalTestCase
+class DDC6499OneToOneRelationshipTest extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
@@ -59,7 +59,6 @@ class DDC6499A
      * @Id
      * @Column(type="integer")
      * @GeneratedValue
-     *
      * @var int
      */
     public $id;
@@ -67,7 +66,6 @@ class DDC6499A
     /**
      * @OneToOne(targetEntity="DDC6499B", cascade={"persist"})
      * @JoinColumn(nullable=false)
-     *
      * @var DDC6499B
      */
     public $b;
@@ -85,7 +83,6 @@ class DDC6499B
      * @Id
      * @Column(type="integer")
      * @GeneratedValue
-     *
      * @var int
      */
     public $id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC6499Test.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+/**
+ * @group DDC-6499
+ */
+class DDC6499Test extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->_schemaTool->createSchema(
+            [
+                $this->_em->getClassMetadata(DDC6499A::class),
+                $this->_em->getClassMetadata(DDC6499B::class),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->_schemaTool->dropSchema(
+            [
+                $this->_em->getClassMetadata(DDC6499A::class),
+                $this->_em->getClassMetadata(DDC6499B::class),
+            ]
+        );
+    }
+
+    /**
+     * Test for the bug described in issue #6499.
+     */
+    public function testIssue(): void
+    {
+        if (! $this->_em->getConnection()->getDatabasePlatform()->supportsForeignKeyConstraints()) {
+            self::markTestSkipped('Platform does not support foreign keys.');
+        }
+
+        $a = new DDC6499A();
+
+        $this->_em->persist($a);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        self::assertEquals($this->_em->find(DDC6499A::class, $a->id)->b->id, $a->b->id, 'Issue #6499 will result in a Integrity constraint violation before reaching this point.');
+    }
+}
+
+/** @Entity */
+class DDC6499A
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @OneToOne(targetEntity="DDC6499B", cascade={"persist"})
+     * @JoinColumn(nullable=false)
+     *
+     * @var DDC6499B
+     */
+    public $b;
+
+    public function __construct()
+    {
+        $this->b = new DDC6499B();
+    }
+}
+
+/** @Entity */
+class DDC6499B
+{
+    /**
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     *
+     * @var int
+     */
+    public $id;
+}


### PR DESCRIPTION
closes #7006
closes #6499
closes #5538
closes #4230

The issue as discussed earlier in #7006, #6499, #5538 and #4230 makes it harder to encapsulate behavior inside domain objects, when following some basic principles of DDD aggregate roots. In other words, the aggregate should not leak it's child nor have a dependency on a em/repo for the child to get persisted.

To be clear on the workaround, setting the `@JoinColumn` to nullable solves this, as Doctrine does take care of setting the `id` on the object at a later moment.

In response to discussing a fix for #6499 we borrowed the test as @Frikkle proposed in #6533 and slightly adjusted it to demonstrate the issue on persisting cascading relationships.

## Expected

The exception we should get on running the test, that would confirm that the persistence ordering is wrong:

> Exception : [Doctrine\ORM\ORMException] The identifier id is missing for a query of Doctrine\Tests\ORM\Functional\Ticket\DDC6499A

## Actual

There is pending discussion in https://github.com/doctrine/orm/pull/6533 on a proposed fix.

As the tests in this PR pass, that proves that the commit ordering works correctly.
