### PR TITLE
Update inheritance-mapping.rst

### DIFF
--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -274,6 +274,9 @@ be a leaf entity in the inheritance hierarchy, (ie. have no subclasses).
 Otherwise Doctrine *CANNOT* create proxy instances
 of this entity and will *ALWAYS* load the entity eagerly.
 
+Also, there is another important performance consideration: It is *NOT POSSIBLE* 
+to query for the base entity avoiding all the LEFT JOINs with the sub-types.
+
 SQL Schema considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/en/reference/inheritance-mapping.rst
+++ b/docs/en/reference/inheritance-mapping.rst
@@ -274,8 +274,8 @@ be a leaf entity in the inheritance hierarchy, (ie. have no subclasses).
 Otherwise Doctrine *CANNOT* create proxy instances
 of this entity and will *ALWAYS* load the entity eagerly.
 
-Also, there is another important performance consideration: It is *NOT POSSIBLE* 
-to query for the base entity avoiding all the LEFT JOINs with the sub-types.
+There is also another important performance consideration that it is *NOT POSSIBLE* 
+to query for the base entity without any LEFT JOINs to the sub-types.
 
 SQL Schema considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I updated **Inheritance Mapping** documentation based on what we discussed in #5961. 
I added what I think is an important comment about how it is not possible to query directly the base class in a CTI schema without getting all the LEFT JOINs with the leaf entities tables.