### PR TITLE
Fix ClassMetadaInfo template inference

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -710,6 +710,7 @@ class ClassMetadataInfo implements ClassMetadata
      * metadata of the class with the given name.
      *
      * @param string $entityName The name of the entity class the new instance is used for.
+     * @psalm-param class-string<T> $entityName
      */
     public function __construct($entityName, ?NamingStrategy $namingStrategy = null)
     {

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -105,6 +105,7 @@ class ConvertDoctrine1Schema
 
     /**
      * @param mixed[] $mappingInformation
+     * @psalm-param class-string $className
      */
     private function convertToClassMetadataInfo(
         string $className,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1125,9 +1125,7 @@
       <code>$table</code>
       <code>$tableGeneratorDefinition</code>
     </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="13">
-      <code>$entityName</code>
-      <code>$entityName</code>
+    <PropertyTypeCoercion occurrences="11">
       <code>$this-&gt;entityListeners</code>
       <code>$this-&gt;fieldMappings</code>
       <code>$this-&gt;fullyQualifiedClassName($repositoryClassName)</code>


### PR DESCRIPTION
Hi @greg0ire, I saw you fixed some psalm issue recently
https://github.com/doctrine/orm/commit/6de321cb09d7208ff3930db50b0bedaf7ca39d92

Currently the following code
```
    /**
     * @phpstan-template T of object
     * @phpstan-param class-string<T> $class
     * @phpstan-return ClassMetadata<T>
     */
    private function getMetadata(string $class): ClassMetadata
    {
        return new ClassMetadata($class);
    }
```
is not working, since `new ClassMetadata($class)` is inferred as `ClassMetadata<object>`.

Which lead to weird static analysis issue in 2.8.5 release.

I fix this in this PR.