### PR TITLE
Handle generic parameters in UnitOfWork

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -630,8 +630,12 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param ClassMetadata $class  The class descriptor of the entity.
      * @param object        $entity The entity for which to compute the changes.
+     * @psalm-param ClassMetadata<T> $class
+     * @psalm-param T $entity
      *
      * @return void
+     *
+     * @template T of object
      *
      * @ignore
      */
@@ -959,6 +963,10 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * @param object $entity
+     * @psalm-param ClassMetadata<T> $class
+     * @psalm-param T $entity
+     *
+     * @template T of object
      */
     private function persistNew(ClassMetadata $class, $entity): void
     {
@@ -1017,11 +1025,14 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param ClassMetadata $class  The class descriptor of the entity.
      * @param object        $entity The entity for which to (re)calculate the change set.
+     * @psalm-param ClassMetadata<T> $class
+     * @psalm-param T $entity
      *
      * @return void
      *
      * @throws ORMInvalidArgumentException If the passed entity is not MANAGED.
      *
+     * @template T of object
      * @ignore
      */
     public function recomputeSingleEntityChangeSet(ClassMetadata $class, $entity)
@@ -1144,6 +1155,10 @@ class UnitOfWork implements PropertyChangedListener
 
     /**
      * @param object $entity
+     * @psalm-param ClassMetadata<T> $class
+     * @psalm-param T $entity
+     *
+     * @template T of object
      */
     private function addToEntityIdentifiersAndEntityMap(
         ClassMetadata $class,
@@ -2020,8 +2035,13 @@ class UnitOfWork implements PropertyChangedListener
     /**
      * @param object $entity
      * @param object $managedCopy
+     * @psalm-param ClassMetadata<T> $class
+     * @psalm-param T $entity
+     * @psalm-param T $managedCopy
      *
      * @throws OptimisticLockException
+     *
+     * @template T of object
      */
     private function ensureVersionMatch(
         ClassMetadata $class,


### PR DESCRIPTION
The following code:

```php
$classMetadata = $this->entityManager->getClassMetadata(User::class);
$this->entityManager->getUnitOfWork()->recomputeSingleEntityChangeSet($classMetadata, $user);
```

Triggers this error in psalm:

```
Argument 1 of Doctrine\ORM\UnitOfWork::recomputeSingleEntityChangeSet expects Doctrine\ORM\Mapping\ClassMetadata<object>, Doctrine\ORM\Mapping\ClassMetadata<App\Entity\User> provided (see https://psalm.dev/004)
        $this->entityManager->getUnitOfWork()->recomputeSingleEntityChangeSet($classMetadata, $user);
```

**Update**: I've also changed some other methods.