### PR TITLE
Stop using Webmozart to fix error in Query/Parser

### DIFF
--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -78,7 +78,6 @@ use Doctrine\ORM\Query\AST\UpdateStatement;
 use Doctrine\ORM\Query\AST\WhenClause;
 use Doctrine\ORM\Query\AST\WhereClause;
 use ReflectionClass;
-use Webmozart\Assert\Assert;
 
 use function array_intersect;
 use function array_search;
@@ -3543,7 +3542,7 @@ class Parser
         $functionName  = strtolower($this->lexer->lookahead['value']);
         $functionClass = $this->em->getConfiguration()->getCustomNumericFunction($functionName);
 
-        Assert::notNull($functionClass);
+        assert($functionClass !== null);
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)
@@ -3584,7 +3583,7 @@ class Parser
         $functionName  = $this->lexer->lookahead['value'];
         $functionClass = $this->em->getConfiguration()->getCustomDatetimeFunction($functionName);
 
-        Assert::notNull($functionClass);
+        assert($functionClass !== null);
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)
@@ -3626,7 +3625,7 @@ class Parser
         $functionName  = $this->lexer->lookahead['value'];
         $functionClass = $this->em->getConfiguration()->getCustomStringFunction($functionName);
 
-        Assert::notNull($functionClass);
+        assert($functionClass !== null);
 
         $function = is_string($functionClass)
             ? new $functionClass($functionName)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1457,7 +1457,7 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$function of function call_user_func expects callable\\(\\)\\: mixed, null given\\.$#"
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 3
 			path: lib/Doctrine/ORM/Query/Parser.php
 


### PR DESCRIPTION
The `Doctrine\ORM\Query\Parser` uses [`Webmozart\Assert\Assert`](https://github.com/doctrine/orm/blob/2.9.x/lib/Doctrine/ORM/Query/Parser.php#L81) but it not required in [composer.json](https://github.com/doctrine/orm/blob/2.9.x/composer.json#L18-L35).

This results in error:

```
Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\ClassNotFoundError: "Attempted to load class "Assert" from namespace "Webmozart\Assert".
Did you forget a "use" statement for another namespace?" at /www/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Parser.php line 3629
```

This problem created by PR #8409