### PR TITLE
Fix metadata cache compatibility layer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-pdo": "*",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.13",
-        "doctrine/cache": "^1.11|^2.0",
+        "doctrine/cache": "^1.11.3|^2.0.3",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.0",

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -133,6 +133,7 @@ class ConfigurationTest extends DoctrineTestCase
         $queryCacheImpl = $this->createMock(Cache::class);
         $this->configuration->setMetadataCacheImpl($queryCacheImpl);
         $this->assertSame($queryCacheImpl, $this->configuration->getMetadataCacheImpl());
+        $this->assertNotNull($this->configuration->getMetadataCache());
     }
 
     public function testSetGetMetadataCache(): void
@@ -141,6 +142,7 @@ class ConfigurationTest extends DoctrineTestCase
         $cache = $this->createStub(CacheItemPoolInterface::class);
         $this->configuration->setMetadataCache($cache);
         $this->assertSame($cache, $this->configuration->getMetadataCache());
+        $this->assertNotNull($this->configuration->getMetadataCacheImpl());
     }
 
     public function testAddGetNamedQuery(): void


### PR DESCRIPTION
Fixes #8721.

This updates the BC layer to always return a legacy cache when a PSR-6 cache is configured and vice-versa.