### PR TITLE
Move `JoinColumn` nullability check to drivers

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1527,14 +1527,6 @@ class ClassMetadataInfo implements ClassMetadata
             $mapping['targetEntity'] = $type->getName();
         }
 
-        if (isset($mapping['joinColumns'])) {
-            foreach ($mapping['joinColumns'] as &$joinColumn) {
-                if ($type->allowsNull() === false) {
-                    $joinColumn['nullable'] = false;
-                }
-            }
-        }
-
         return $mapping;
     }
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -33,12 +33,14 @@ use ReflectionMethod;
 use ReflectionProperty;
 use UnexpectedValueException;
 
+use function assert;
 use function class_exists;
 use function constant;
 use function count;
 use function defined;
 use function get_class;
 use function is_array;
+use function is_bool;
 use function is_numeric;
 
 use const PHP_VERSION_ID;
@@ -436,7 +438,7 @@ class AnnotationDriver extends AbstractAnnotationDriver
                     $joinColumns = [];
 
                     foreach ($associationOverride->joinColumns as $joinColumn) {
-                        $joinColumns[] = $this->joinColumnToArray($joinColumn, $property);
+                        $joinColumns[] = $this->joinColumnToArray($joinColumn);
                     }
 
                     $override['joinColumns'] = $joinColumns;
@@ -717,12 +719,14 @@ class AnnotationDriver extends AbstractAnnotationDriver
         $nullable = $joinColumn->nullable;
         if (
             PHP_VERSION_ID >= 70400
-            && null !== $property
+            && $property !== null
             && $property->hasType()
             && ! $joinColumn->isNullableSet()
         ) {
             $nullable = $property->getType()->allowsNull();
         }
+
+        assert(is_bool($nullable));
 
         return [
             'name' => $joinColumn->name,

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -19,6 +19,7 @@ use function assert;
 use function class_exists;
 use function constant;
 use function defined;
+use function is_bool;
 
 use const PHP_VERSION_ID;
 
@@ -503,7 +504,6 @@ class AttributeDriver extends AnnotationDriver
      * Parse the given JoinColumn as array
      *
      * @param Mapping\JoinColumn|Mapping\InverseJoinColumn $joinColumn
-     * @param ReflectionProperty|null                      $property
      *
      * @return mixed[]
      * @psalm-return array{
@@ -520,12 +520,14 @@ class AttributeDriver extends AnnotationDriver
         $nullable = $joinColumn->nullable;
         if (
             PHP_VERSION_ID >= 70400
-            && null !== $property
+            && $property !== null
             && $property->hasType()
             && ! $joinColumn->isNullableSet()
         ) {
             $nullable = $property->getType()->allowsNull();
         }
+
+        assert(is_bool($nullable));
 
         return [
             'name' => $joinColumn->name,

--- a/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/InverseJoinColumn.php
@@ -69,4 +69,8 @@ final class InverseJoinColumn implements Annotation
         $this->columnDefinition     = $columnDefinition;
         $this->fieldName            = $fieldName;
     }
+
+    public function isNullableSet(): bool {
+        return true;
+    }
 }

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -72,7 +72,7 @@ final class JoinColumn implements Annotation
         $this->referencedColumnName = $referencedColumnName;
         $this->unique               = $unique;
         $this->nullable             = $nullable ?? true;
-        $this->nullableSet          = null !== $nullable;
+        $this->nullableSet          = $nullable !== null;
         $this->onDelete             = $onDelete;
         $this->columnDefinition     = $columnDefinition;
         $this->fieldName            = $fieldName;

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -43,6 +43,9 @@ final class JoinColumn implements Annotation
     /** @var bool */
     public $nullable = true;
 
+    /** @var bool */
+    private $nullableSet;
+
     /** @var mixed */
     public $onDelete;
 
@@ -60,7 +63,7 @@ final class JoinColumn implements Annotation
         ?string $name = null,
         string $referencedColumnName = 'id',
         bool $unique = false,
-        bool $nullable = true,
+        ?bool $nullable = null,
         $onDelete = null,
         ?string $columnDefinition = null,
         ?string $fieldName = null
@@ -68,9 +71,18 @@ final class JoinColumn implements Annotation
         $this->name                 = $name;
         $this->referencedColumnName = $referencedColumnName;
         $this->unique               = $unique;
-        $this->nullable             = $nullable;
+        $this->nullable             = $nullable ?? true;
+        $this->nullableSet          = null !== $nullable;
         $this->onDelete             = $onDelete;
         $this->columnDefinition     = $columnDefinition;
         $this->fieldName            = $fieldName;
+    }
+
+    /**
+     * @return bool True if nullable was set on annotation, false otherwise
+     */
+    public function isNullableSet(): bool
+    {
+        return $this->nullableSet;
     }
 }


### PR DESCRIPTION
This is a draft solution for #8723. This PR moves `nullable` logic on `JoinColumn` from `ClassMetadataInfo` to drivers and implements reflection fallback for Annotation and Attribute drivers.

Logic here is to use property nullability if and only if there are `JoinColumn` annotation/attributes that doesn't have `nullable` set, thus limiting possible BC to situation when `JoinColumn` is set without `nullable` and the property is not nullable.

This logic can be extended to other drivers if desired. Also I didn't add any tests (yet!) to get the approach reviewed first.