### PR TITLE
[GH-8723] Remove use of nullability to automatically detect nullable status

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -113,7 +113,7 @@ Optional attributes:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column. If not specified, default value is false. When using typed properties on entity class defaults to true when property is nullable.
+-  **nullable**: Determines if NULL values allowed for this column. If not specified, default value is false.
 
 -  **options**: Array of additional options:
 
@@ -649,8 +649,6 @@ Optional attributes:
    constraint level. Defaults to false.
 -  **nullable**: Determine whether the related entity is required, or if
    null is an allowed state for the relation. Defaults to true.
-   When using typed properties on entity class defaults to false when
-   property is not nullable.
 -  **onDelete**: Cascade Action (Database-level)
 -  **columnDefinition**: DDL SQL snippet that starts after the column
    name and specifies the complete (non-portable!) column definition.

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1468,10 +1468,6 @@ class ClassMetadataInfo implements ClassMetadata
         $type = $this->reflClass->getProperty($mapping['fieldName'])->getType();
 
         if ($type) {
-            if (! isset($mapping['nullable'])) {
-                $mapping['nullable'] = $type->allowsNull();
-            }
-
             if (
                 ! isset($mapping['type'])
                 && ($type instanceof ReflectionNamedType)
@@ -1525,14 +1521,6 @@ class ClassMetadataInfo implements ClassMetadata
 
         if (! isset($mapping['targetEntity']) && $type instanceof ReflectionNamedType) {
             $mapping['targetEntity'] = $type->getName();
-        }
-
-        if (isset($mapping['joinColumns'])) {
-            foreach ($mapping['joinColumns'] as &$joinColumn) {
-                if ($type->allowsNull() === false) {
-                    $joinColumn['nullable'] = false;
-                }
-            }
         }
 
         return $mapping;

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -57,8 +57,8 @@ final class Column implements Annotation
     /** @var bool */
     public $unique = false;
 
-    /** @var bool|null */
-    public $nullable;
+    /** @var bool */
+    public $nullable = false;
 
     /** @var array<string,mixed> */
     public $options = [];
@@ -76,7 +76,7 @@ final class Column implements Annotation
         ?int $precision = null,
         ?int $scale = null,
         bool $unique = false,
-        ?bool $nullable = null,
+        bool $nullable = false,
         array $options = [],
         ?string $columnDefinition = null
     ) {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -265,24 +265,6 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         return $class;
     }
 
-    public function testFieldIsNullableByType(): void
-    {
-        if (PHP_VERSION_ID < 70400) {
-            $this->markTestSkipped('requies PHP 7.4');
-        }
-
-        $class = $this->createClassMetadata(UserTyped::class);
-
-        // Explicit Nullable
-        $this->assertTrue($class->isNullable('status'));
-
-        // Explicit Not Nullable
-        $this->assertFalse($class->isNullable('username'));
-
-        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
-        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('mainEmail')['targetEntity']);
-    }
-
     public function testFieldTypeFromReflection(): void
     {
         if (PHP_VERSION_ID < 70400) {

--- a/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AbstractMappingDriverTest.php
@@ -281,6 +281,9 @@ abstract class AbstractMappingDriverTest extends OrmTestCase
         $this->assertEquals('json', $class->getTypeOfField('array'));
         $this->assertEquals('boolean', $class->getTypeOfField('boolean'));
         $this->assertEquals('float', $class->getTypeOfField('float'));
+
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('email')['targetEntity']);
+        $this->assertEquals(CmsEmail::class, $class->getAssociationMapping('mainEmail')['targetEntity']);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataTest.php
@@ -120,14 +120,6 @@ class ClassMetadataTest extends OrmTestCase
         $cm = new ClassMetadata(TypedProperties\UserTyped::class);
         $cm->initializeReflection(new RuntimeReflectionService());
 
-        // Explicit Nullable
-        $cm->mapField(['fieldName' => 'status', 'length' => 50]);
-        $this->assertTrue($cm->isNullable('status'));
-
-        // Explicit Not Nullable
-        $cm->mapField(['fieldName' => 'username', 'length' => 50]);
-        $this->assertFalse($cm->isNullable('username'));
-
         $cm->mapOneToOne(['fieldName' => 'email', 'joinColumns' => [[]]]);
         $this->assertEquals(CmsEmail::class, $cm->getAssociationMapping('email')['targetEntity']);
 


### PR DESCRIPTION
The new typed properties support has a flaw around the the concept of nullable. Setting a type in the entity to be or not be nullable does not necessarily mean the databsae column has to be the same. They can differ from each other.

As such it is better to remove the the use of `allowsNull()` as the default value for a column's or joincolumn's nullable flag.

This supersedes #8726 

Fixes #8723