### PR TITLE
EntityManager@transactional - Use return value or null

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -249,7 +249,7 @@ use function sprintf;
             $this->flush();
             $this->conn->commit();
 
-            return $return ?: true;
+            return $return;
         } catch (Throwable $e) {
             $this->close();
             $this->conn->rollBack();


### PR DESCRIPTION
Use expected return values or null instead of "falsey" values becoming true (empty arrays, strings)