### PR TITLE
Make ClassMetadata covariant

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -24,7 +24,7 @@ namespace Doctrine\ORM\Mapping;
  * {@inheritDoc}
  *
  * @todo remove or rename ClassMetadataInfo to ClassMetadata
- * @template T of object
+ * @template-covariant T of object
  * @template-extends ClassMetadataInfo<T>
  */
 class ClassMetadata extends ClassMetadataInfo

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -81,7 +81,7 @@ use const PHP_VERSION_ID;
  *    get the whole class name, namespace inclusive, prepended to every property in
  *    the serialized representation).
  *
- * @template T of object
+ * @template-covariant T of object
  * @template-implements ClassMetadata<T>
  */
 class ClassMetadataInfo implements ClassMetadata


### PR DESCRIPTION
The interface ClassMetada use `template-covariant`.
But the both implementations `ClassMetadaInfo` and `ClassMetada` doesn't.
I think it should. @greg0ire 

This would solve this kind of issue https://psalm.dev/r/d704dea38a
We're having this issue on SonataDoctrineORMAdminBundle for instance https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1454
