### PR TITLE
Add ReturnTypeWillChange to ReflectionEmbeddedProperty

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -22,6 +22,7 @@ namespace Doctrine\ORM\Mapping;
 
 use Doctrine\Instantiator\Instantiator;
 use ReflectionProperty;
+use ReturnTypeWillChange;
 
 /**
  * Acts as a proxy to a nested Property structure, making it look like
@@ -61,6 +62,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function getValue($object = null)
     {
         $embeddedObject = $this->parentProperty->getValue($object);
@@ -75,6 +77,7 @@ class ReflectionEmbeddedProperty extends ReflectionProperty
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function setValue($object, $value = null)
     {
         $embeddedObject = $this->parentProperty->getValue($object);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -136,6 +136,11 @@
         <exclude-pattern>lib/Doctrine/ORM/Cache/DefaultQueryCache.php</exclude-pattern>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment.UselessInheritDocComment">
+        <!-- Workaround for https://github.com/slevomat/coding-standard/issues/1233 -->
+        <exclude-pattern>lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php</exclude-pattern>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
         <exclude-pattern>lib/Doctrine/ORM/EntityManagerInterface.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
PHP 8.1 will introduce a process to add return types to internal methods, see https://wiki.php.net/rfc/internal_method_return_types

* Follows doctrine/dbal#4662
* Follows doctrine/persistence#189

This library extends `ReflectionProperty` and overrides public methods that are affected by this change. PHP 8.1 triggers deprecation warnings unless we declare that a future version of this library will add these return types as well. We can do so by adding the `ReturnTypeWillChange` attribute to those methods.

This PR suggests to do just that because adding the actual return types would break code that extends our classes. A future 3.0 release could add the actual return types.