### PR TITLE
fix: handle repeatable attributes

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -20,6 +20,8 @@ use function class_exists;
 use function constant;
 use function count;
 use function defined;
+use function get_class;
+use function is_array;
 
 class AttributeDriver extends AnnotationDriver
 {
@@ -36,6 +38,23 @@ class AttributeDriver extends AnnotationDriver
     public function __construct(array $paths)
     {
         parent::__construct(new AttributeReader(), $paths);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isTransient($className)
+    {
+        $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
+
+        foreach ($classAnnotations as $a) {
+            $annot = is_array($a) ? $a[0] : $a;
+            if (isset($this->entityAnnotationClasses[get_class($annot)])) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function loadMetadataForClass($className, ClassMetadata $metadata): void

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -21,7 +21,6 @@ use function constant;
 use function count;
 use function defined;
 use function get_class;
-use function is_array;
 
 class AttributeDriver extends AnnotationDriver
 {
@@ -48,7 +47,7 @@ class AttributeDriver extends AnnotationDriver
         $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
 
         foreach ($classAnnotations as $a) {
-            $annot = is_array($a) ? $a[0] : $a;
+            $annot = $a instanceof RepeatableAttributeCollection ? $a[0] : $a;
             if (isset($this->entityAnnotationClasses[get_class($annot)])) {
                 return false;
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -18,7 +18,6 @@ use ReflectionProperty;
 use function assert;
 use function class_exists;
 use function constant;
-use function count;
 use function defined;
 use function get_class;
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
@@ -12,7 +12,6 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 use function assert;
-use function count;
 use function is_string;
 use function is_subclass_of;
 

--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
@@ -24,44 +24,47 @@ final class AttributeReader
     /** @var array<string,bool> */
     private array $isRepeatableAttribute = [];
 
-    /** @return array<object> */
+    /** @return array<Annotation|RepeatableAttributeCollection> */
     public function getClassAnnotations(ReflectionClass $class): array
     {
         return $this->convertToAttributeInstances($class->getAttributes());
     }
 
-    /** @return array<object>|object|null */
+    /** @return Annotation|RepeatableAttributeCollection|null */
     public function getClassAnnotation(ReflectionClass $class, $annotationName)
     {
-        return $this->getClassAnnotations($class)[$annotationName] ?? ($this->isRepeatable($annotationName) ? [] : null);
+        return $this->getClassAnnotations($class)[$annotationName]
+            ?? ($this->isRepeatable($annotationName) ? new RepeatableAttributeCollection() : null);
     }
 
-    /** @return array<object> */
+    /** @return array<Annotation|RepeatableAttributeCollection> */
     public function getMethodAnnotations(ReflectionMethod $method): array
     {
         return $this->convertToAttributeInstances($method->getAttributes());
     }
 
-    /** @return array<object>|object|null */
+    /** @return Annotation|RepeatableAttributeCollection|null */
     public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
     {
-        return $this->getMethodAnnotations($method)[$annotationName] ?? ($this->isRepeatable($annotationName) ? [] : null);
+        return $this->getMethodAnnotations($method)[$annotationName]
+            ?? ($this->isRepeatable($annotationName) ? new RepeatableAttributeCollection() : null);
     }
 
-    /** @return array<object> */
+    /** @return array<Annotation|RepeatableAttributeCollection> */
     public function getPropertyAnnotations(ReflectionProperty $property): array
     {
         return $this->convertToAttributeInstances($property->getAttributes());
     }
 
-    /** @return array<object>|object|null */
+    /** @return Annotation|RepeatableAttributeCollection|null */
     public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
     {
-        return $this->getPropertyAnnotations($property)[$annotationName] ?? ($this->isRepeatable($annotationName) ? [] : null);
+        return $this->getPropertyAnnotations($property)[$annotationName]
+            ?? ($this->isRepeatable($annotationName) ? new RepeatableAttributeCollection() : null);
     }
 
     /**
-     * @param array<object> $attributes
+     * @param array<ReflectionAttribute> $attributes
      *
      * @return array<Annotation|RepeatableAttributeCollection>
      */

--- a/lib/Doctrine/ORM/Mapping/Driver/RepeatableAttributeCollection.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/RepeatableAttributeCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping\Driver;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping\Annotation;
+
+/**
+ * @template-extends ArrayObject<int,Annotation>
+ */
+final class RepeatableAttributeCollection extends ArrayObject
+{
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,8 @@ parameters:
     paths:
         - lib
         - tests/Doctrine/StaticAnalysis
+    excludePaths:
+        - lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
     earlyTerminatingMethodCalls:
         Doctrine\ORM\Query\Parser:
             - syntaxError

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1218,10 +1218,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$class</code>
     </DocblockTypeContradiction>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$mapping</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1"/>
     <NoInterfaceProperties occurrences="5">
       <code>$metadata-&gt;inheritanceType</code>
       <code>$metadata-&gt;isEmbeddedClass</code>
@@ -1289,10 +1285,6 @@
       <code>$value[1]</code>
     </InvalidArrayAccess>
     <InvalidScalarArgument occurrences="1"/>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$mapping</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$entityAnnotationClasses</code>
     </NonInvariantDocblockPropertyType>
@@ -1324,12 +1316,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$attributeClassName</code>
     </ArgumentTypeCoercion>
-    <InvalidReturnStatement occurrences="1">
-      <code>$instances</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array&lt;Annotation&gt;</code>
-    </InvalidReturnType>
     <MissingParamType occurrences="3">
       <code>$annotationName</code>
       <code>$annotationName</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,5 +21,11 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
             </errorLevel>
         </ParadoxicalCondition>
+        <NullArgument>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/5920 -->
+                <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php"/>
+            </errorLevel>
+        </NullArgument>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,7 @@
         <directory name="tests/Doctrine/StaticAnalysis" />
         <ignoreFiles>
             <directory name="vendor" />
+            <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php" />
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>

--- a/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Mapping;
 
+use Attribute;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Annotation;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use stdClass;
 
 use const PHP_VERSION_ID;
 
@@ -79,11 +82,17 @@ class AttributeDriverTest extends AbstractMappingDriverTest
         $this->assertEquals(['assoz_id', 'assoz_id'], $metadata->associationMappings['assoc']['joinTableColumns']);
     }
 
-    public function testIsTransientWithRepeatableAttributes(): void
+    public function testIsTransient(): void
     {
-        $driver      = $this->loadDriver();
-        $isTransient = $driver->isTransient(AttributeEntityStartingWithRepeatableAttributes::class);
-        $this->assertFalse($isTransient);
+        $driver = $this->loadDriver();
+
+        $this->assertTrue($driver->isTransient(stdClass::class));
+
+        $this->assertTrue($driver->isTransient(AttributeTransientClass::class));
+
+        $this->assertFalse($driver->isTransient(AttributeEntityWithoutOriginalParents::class));
+
+        $this->assertFalse($driver->isTransient(AttributeEntityStartingWithRepeatableAttributes::class));
     }
 }
 
@@ -107,5 +116,15 @@ class AttributeEntityWithoutOriginalParents
 #[ORM\Index(name: 'baz', columns: ['id'])]
 #[ORM\Entity]
 class AttributeEntityStartingWithRepeatableAttributes
+{
+}
+
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_ALL)]
+class AttributeTransientAnnotation implements Annotation
+{
+}
+
+#[AttributeTransientAnnotation]
+class AttributeTransientClass
 {
 }

--- a/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/AttributeDriverTest.php
@@ -16,7 +16,7 @@ class AttributeDriverTest extends AbstractMappingDriverTest
     public function requiresPhp8Assertion(): void
     {
         if (PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('requies PHP 8.0');
+            $this->markTestSkipped('requires PHP 8.0');
         }
     }
 
@@ -78,6 +78,13 @@ class AttributeDriverTest extends AbstractMappingDriverTest
         );
         $this->assertEquals(['assoz_id', 'assoz_id'], $metadata->associationMappings['assoc']['joinTableColumns']);
     }
+
+    public function testIsTransientWithRepeatableAttributes(): void
+    {
+        $driver      = $this->loadDriver();
+        $isTransient = $driver->isTransient(AttributeEntityStartingWithRepeatableAttributes::class);
+        $this->assertFalse($isTransient);
+    }
 }
 
 #[ORM\Entity]
@@ -94,4 +101,11 @@ class AttributeEntityWithoutOriginalParents
     #[ORM\InverseJoinColumn(name: 'assoz_id', referencedColumnName: 'assoz_id')]
     /** @var AttributeEntityWithoutOriginalParents[] */
     public $assoc;
+}
+
+#[ORM\Index(name: 'bar', columns: ['id'])]
+#[ORM\Index(name: 'baz', columns: ['id'])]
+#[ORM\Entity]
+class AttributeEntityStartingWithRepeatableAttributes
+{
 }


### PR DESCRIPTION
Introduces `isTransient` on `AttributeDriver` for better handling of repeatable attributes. Cleans up `AttributeReader` API a little.

Closes #8755 