### PR TITLE
Update UnitOfWork to be PHP 7.3 compatible in v2.5

### DIFF
--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -2633,7 +2633,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, $data[$field]);
                         $this->originalEntityData[$oid][$field] = $data[$field];
 
-                        continue;
+                        break;
                     }
 
                     $associatedId = array();
@@ -2662,7 +2662,7 @@ class UnitOfWork implements PropertyChangedListener
                         $class->reflFields[$field]->setValue($entity, null);
                         $this->originalEntityData[$oid][$field] = null;
 
-                        continue;
+                        break;
                     }
 
                     if ( ! isset($hints['fetchMode'][$class->name][$field])) {


### PR DESCRIPTION
Fix issue on PHP 7.3 where this error is triggered.
Fatal error: Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php:2636

Doctrine/orm 2.5 is the latest version usable on Symfony 2.8 and must be compatible with PHP 7.3
Solves update conflict for Symfony 2.x projects with PHP 7.3+