### PR TITLE
Fix getClassMetadata phpdoc

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -320,7 +320,8 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param string|class-string<T> $className
+     * @param string $className
+     * @psalm-param class-string<T> $className
      *
      * @return Mapping\ClassMetadata
      * @psalm-return Mapping\ClassMetadata<T>


### PR DESCRIPTION
Hi @greg0ire, 2.9.3 fixed multiples issues but I also discovered another issue with the generics ^^'

```
@psalm-param string|class-string<T>
```
is reduce to `string` by phpstan. 

Which lead to this issue: https://phpstan.org/r/aaf083de-4264-424d-a40e-55aa6af4256c
It works fine with https://phpstan.org/r/91eed37e-b9ca-45b3-9145-fa237922d9f5