### PR TITLE
Make templating Psalm-specific

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -321,11 +321,13 @@ interface EntityManagerInterface extends ObjectManager
      * {@inheritDoc}
      *
      * @psalm-param string|class-string<T> $className
+     * @phpstan-param string $className
      *
      * @return Mapping\ClassMetadata
      * @psalm-return Mapping\ClassMetadata<T>
+     * @phpstan-return Mapping\ClassMetadata<object>
      *
-     * @template T of object
+     * @psalm-template T of object
      */
     public function getClassMetadata($className);
 }

--- a/tests/Doctrine/StaticAnalysis/get-metadata.php
+++ b/tests/Doctrine/StaticAnalysis/get-metadata.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Doctrine\StaticAnalysis;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * EntityManagerInterface::getClassMetadata() is templated only for Psalm,
+ * because of limitations in PHPStan.
+ *
+ * @see https://github.com/phpstan/phpstan/issues/5175#issuecomment-861437050
+ */
+abstract class GetMetadata
+{
+    /**
+     * @param string|object $class
+     * @phpstan-param class-string|object $class
+     */
+    abstract public function getEntityManager($class): EntityManagerInterface;
+
+    /**
+     * @psalm-param class-string<TObject> $class
+     * @phpstan-param class-string $class
+     *
+     * @psalm-return ClassMetadata<TObject>
+     * @phpstan-return ClassMetadata<object>
+     *
+     * @psalm-template TObject of object
+     */
+    public function __invoke(string $class): ClassMetadata
+    {
+        return $this->getEntityManager($class)->getClassMetadata($class);
+    }
+}


### PR DESCRIPTION
If `$className` is a class-string, then we return an instance of that
class. However, if it's an alias, things get complicated, and it's hard
to tell. There does not seem to be a way to express that for now.

We should probably consider dropping namespace aliases entirely and add
support for `::class` inside DQL if it's not the case already.

Refs #8767 , https://github.com/phpstan/phpstan/issues/5175 , cc @VincentLanglet  