### PR TITLE
Fix Psalm/PHPStan errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,6 +126,16 @@ parameters:
 			path: lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
 
 		-
+			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\ArrayCache not found\\.$#"
+			count: 2
+			path: lib/Doctrine/ORM/Configuration.php
+
+		-
+			message: "#^Parameter \\#2 \\$cache of class Doctrine\\\\Common\\\\Annotations\\\\CachedReader constructor expects Doctrine\\\\Common\\\\Cache\\\\Cache, Doctrine\\\\Common\\\\Cache\\\\ArrayCache given\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Configuration.php
+
+		-
 			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:find\\(\\) invoked with 4 parameters, 2 required\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -1416,6 +1426,11 @@ parameters:
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 3
+			path: lib/Doctrine/ORM/Query/Parser.php
+
+		-
 			message: "#^Method Doctrine\\\\ORM\\\\Query\\\\Parser\\:\\:ArithmeticFactor\\(\\) should return Doctrine\\\\ORM\\\\Query\\\\AST\\\\ArithmeticFactor but returns Doctrine\\\\ORM\\\\Query\\\\AST\\\\Node\\|string\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Query/Parser.php
@@ -1434,11 +1449,6 @@ parameters:
 					        AST\\\\NullComparisonExpression\\)\\: Unexpected token "\\\\n     \\* ", expected type at offset 344$#
 				"""
 			count: 1
-			path: lib/Doctrine/ORM/Query/Parser.php
-
-		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 3
 			path: lib/Doctrine/ORM/Query/Parser.php
 
 		-
@@ -2017,9 +2027,29 @@ parameters:
 			path: lib/Doctrine/ORM/QueryBuilder.php
 
 		-
+			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\ApcCache not found\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+
+		-
+			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\XcacheCache not found\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+
+		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+
+		-
+			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\ApcCache not found\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+
+		-
+			message: "#^Class Doctrine\\\\Common\\\\Cache\\\\XcacheCache not found\\.$#"
+			count: 1
+			path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
 
 		-
 			message: "#^Parameter \\#1 \\$metadata of method Doctrine\\\\ORM\\\\Tools\\\\Export\\\\Driver\\\\AbstractExporter\\:\\:setMetadata\\(\\) expects array\\<int, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata\\>, array\\<int, Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\> given\\.$#"

--- a/psalm.xml
+++ b/psalm.xml
@@ -28,5 +28,12 @@
                 <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php"/>
             </errorLevel>
         </NullArgument>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Doctrine\Common\Cache\ApcCache"/>
+                <referencedClass name="Doctrine\Common\Cache\ArrayCache"/>
+                <referencedClass name="Doctrine\Common\Cache\XcacheCache"/>
+            </errorLevel>
+        </UndefinedClass>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Now that a DBAL release was tagged that is compatible with Doctrine Cache 2, PHPStan and Psalm complain about undefined legacy classes from the cache namespace. All occurrences look safe which is why I propose to ignore those errors.