### PR TITLE
Undeprecate targetEntity omission for some types

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -22,7 +22,6 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * @Annotation
@@ -40,14 +39,6 @@ final class Embedded implements Annotation
 
     public function __construct(?string $class = null, $columnPrefix = null)
     {
-        if ($class === null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8753',
-                'Passing no class is deprecated.'
-            );
-        }
-
         $this->class        = $class;
         $this->columnPrefix = $columnPrefix;
     }

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -22,7 +22,6 @@ namespace Doctrine\ORM\Mapping;
 
 use Attribute;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
-use Doctrine\Deprecations\Deprecation;
 
 /**
  * @Annotation
@@ -58,14 +57,6 @@ final class ManyToOne implements Annotation
         string $fetch = 'LAZY',
         ?string $inversedBy = null
     ) {
-        if ($targetEntity === null) {
-            Deprecation::trigger(
-                'doctrine/orm',
-                'https://github.com/doctrine/orm/issues/8753',
-                'Passing no target entity is deprecated.'
-            );
-        }
-
         $this->targetEntity = $targetEntity;
         $this->cascade      = $cascade;
         $this->fetch        = $fetch;


### PR DESCRIPTION
Some relationship types are attached to properties that can be typed
since php 7.4.
To avoid repeating the property type in targetEntity, an autodetection
feature has been developed that allows building the mapping from that
type information and annotations.
Omitting the targetEntity stays deprecated for ManyToMany as there is no
auto-detection for that yet (although one could be built by analyzing
phpdoc annotations).