### PR TITLE
Avoid unnecessary information in query hints to improve query cache hit ratio

### DIFF
--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -22,7 +22,6 @@ use function array_key_exists;
 use function array_map;
 use function array_sum;
 use function assert;
-use function count;
 use function is_string;
 
 /**
@@ -160,7 +159,7 @@ class Paginator implements Countable, IteratorAggregate
             $ids          = array_map('current', $foundIdRows);
 
             $this->appendTreeWalker($whereInQuery, WhereInWalker::class);
-            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, count($ids));
+            $whereInQuery->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
             $whereInQuery->setFirstResult(0)->setMaxResults(null);
             $whereInQuery->setCacheable($this->query->isCacheable());
 

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -28,15 +28,15 @@ use function reset;
  * The parameter namespace (dpid) is defined by
  * the PAGINATOR_ID_ALIAS
  *
- * The total number of parameters is retrieved from
- * the HINT_PAGINATOR_ID_COUNT query hint.
+ * The HINT_PAGINATOR_HAS_IDS query hint indicates whether there are
+ * any ids in the parameter at all.
  */
 class WhereInWalker extends TreeWalkerAdapter
 {
     /**
      * ID Count hint name.
      */
-    public const HINT_PAGINATOR_ID_COUNT = 'doctrine.id.count';
+    public const HINT_PAGINATOR_HAS_IDS = 'doctrine.paginator_has_ids';
 
     /**
      * Primary key alias for query.
@@ -65,9 +65,9 @@ class WhereInWalker extends TreeWalkerAdapter
         $pathExpression       = new PathExpression(PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION, $rootAlias, $identifierFieldName);
         $pathExpression->type = $pathType;
 
-        $count = $this->_getQuery()->getHint(self::HINT_PAGINATOR_ID_COUNT);
+        $hasIds = $this->_getQuery()->getHint(self::HINT_PAGINATOR_HAS_IDS);
 
-        if ($count > 0) {
+        if ($hasIds) {
             $arithmeticExpression                             = new ArithmeticExpression();
             $arithmeticExpression->simpleArithmeticExpression = new SimpleArithmeticExpression(
                 [$pathExpression]

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -667,6 +667,27 @@ SQL
         self::assertCount(9, $paginator->getIterator());
     }
 
+    public function testDifferentResultLengthsDoNotRequireExtraQueryCacheEntries(): void
+    {
+        $dql   = 'SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.id >= :id';
+        $query = $this->_em->createQuery($dql);
+        $query->setMaxResults(10);
+
+        $query->setParameter('id', 1);
+        $paginator = new Paginator($query);
+        $paginator->getIterator(); // exercise the Paginator
+
+        $initialCount = count(self::$queryCache->getValues());
+
+        $query->setParameter('id', 2);
+        $paginator = new Paginator($query);
+        $paginator->getIterator(); // exercise the Paginator again, with a smaller result set
+
+        $newCount = count(self::$queryCache->getValues());
+
+        self::assertSame($initialCount, $newCount);
+    }
+
     public function populate(): void
     {
         $groups = [];

--- a/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PaginationTest.php
@@ -674,18 +674,19 @@ SQL
         $query->setMaxResults(10);
 
         $query->setParameter('id', 1);
-        $paginator = new Paginator($query);
-        $paginator->getIterator(); // exercise the Paginator
+        $paginator     = new Paginator($query);
+        $initialResult = iterator_to_array($paginator->getIterator()); // exercise the Paginator
+        self::assertCount(9, $initialResult);
 
-        $initialCount = count(self::$queryCache->getValues());
+        $initialQueryCount = count(self::$queryCache->getValues());
 
-        $query->setParameter('id', 2);
+        $query->setParameter('id', $initialResult[1]->id); // skip the first result element
         $paginator = new Paginator($query);
-        $paginator->getIterator(); // exercise the Paginator again, with a smaller result set
+        self::assertCount(8, $paginator->getIterator()); // exercise the Paginator again, with a smaller result set
 
         $newCount = count(self::$queryCache->getValues());
 
-        self::assertSame($initialCount, $newCount);
+        self::assertSame($initialQueryCount, $newCount);
     }
 
     public function populate(): void

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/WhereInWalkerTest.php
@@ -19,7 +19,7 @@ class WhereInWalkerTest extends PaginationTestCase
     {
         $query = $this->entityManager->createQuery($dql);
         $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [WhereInWalker::class]);
-        $query->setHint(WhereInWalker::HINT_PAGINATOR_ID_COUNT, 10);
+        $query->setHint(WhereInWalker::HINT_PAGINATOR_HAS_IDS, true);
 
         $result = (new Parser($query))->parse();
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -74,7 +74,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
      *
      * @var CacheItemPoolInterface|null
      */
-    private static $queryCache = null;
+    protected static $queryCache = null;
 
     /**
      * Shared connection when a TestCase is run alone (outside of its functional suite).


### PR DESCRIPTION
I've noticed that over time my query caches fill up with redundant queries, i. e. different cache entries for the DQL -> SQL translation that are exactly the same. For me, it's an issue because the cache entries fill up precious OPcache memory.

Further investigation revealed that the queries themselves do not differ, but only the query hints – that are part of the computed cache key – do.

In particular, only the value for the `WhereInWalker::HINT_PAGINATOR_ID_COUNT` query hint are different. Since `WhereInWalker` only needs to know _if_ there are matching IDs but not _how many_, we could avoid such cache misses by using just a boolean value as cache hint.
