### PR TITLE
Fix exception not thrown by "getEntityIdentifier"

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -192,14 +192,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $paramIndex = 1;
                 $data       = $insertData[$tableName] ?? [];
 
-                foreach ((array) $id as $idName => $idVal) {
+                foreach ($id as $idName => $idVal) {
                     $type = $this->columnTypes[$idName] ?? Type::STRING;
 
                     $stmt->bindValue($paramIndex++, $idVal, $type);
                 }
 
                 foreach ($data as $columnName => $value) {
-                    if (! is_array($id) || ! isset($id[$columnName])) {
+                    if (! isset($id[$columnName])) {
                         $stmt->bindValue($paramIndex++, $value, $this->columnTypes[$columnName]);
                     }
                 }

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -3034,12 +3034,15 @@ class UnitOfWork implements PropertyChangedListener
      *
      * @param object $entity
      *
-     * @return mixed The identifier values.
+     * @return mixed[] The identifier values.
      */
     public function getEntityIdentifier($entity)
     {
-        return $this->entityIdentifiers[spl_object_hash($entity)]
-            ?? EntityNotFoundException::noIdentifierFound(get_class($entity));
+        if (! isset($this->entityIdentifiers[spl_object_hash($entity)])) {
+            throw EntityNotFoundException::noIdentifierFound(get_class($entity));
+        }
+
+        return $this->entityIdentifiers[spl_object_hash($entity)];
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\EventManager;
+use Doctrine\ORM\EntityNotFoundException;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\OptimisticLockException;
@@ -814,6 +815,12 @@ class UnitOfWorkTest extends OrmTestCase
 
         $this->expectException(OptimisticLockException::class);
         $this->_unitOfWork->commit();
+    }
+
+    public function testItThrowsWhenLookingUpIdentifierForUnknownEntity(): void
+    {
+        $this->expectException(EntityNotFoundException::class);
+        $this->_unitOfWork->getEntityIdentifier(new stdClass());
     }
 }
 


### PR DESCRIPTION
In #8201, the behavior of `getEntityIdentifier` changed to return either an `array` **OR** an instance of `EntityNotFoundException`.

But everywhere else in the project, we assume the function to return an array (here is one of the 40 occurrences I found https://github.com/doctrine/orm/blob/233d9b027692cad87c970eb660958855daeb8043/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php#L1014-L1015)

This PR change the method to throws the exception instead of returning it, and change the docblock to match the description saying ` The returned value is always an array of identifier values` (https://github.com/doctrine/orm/blob/233d9b027692cad87c970eb660958855daeb8043/lib/Doctrine/ORM/UnitOfWork.php#L3053)