### PR TITLE
Deprecate all things related to DB-generated UUIDs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade to 2.10
 
+## Deprecated: database-side UUID generation
+
+[DB-generated UUIDs are deprecated as of `doctrine/dbal` 2.8][DBAL deprecation].
+As a consequence, `Doctrine\ORM\Id\UuidGenerator` is deprecated, and using the
+`UUID` strategy for generating identifiers is deprecated as well.
+
+[DBAL deprecation]: https://github.com/doctrine/dbal/pull/3212
+
 ## Minor BC BREAK: Custom hydrators and `toIterable()`
 
 The type declaration of the `$stmt` parameter of `AbstractHydrator::toIterable()` has been removed. This change might

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -463,7 +463,7 @@ Optional attributes:
 
 
 -  **strategy**: Set the name of the identifier generation strategy.
-   Valid values are ``AUTO``, ``SEQUENCE``, ``TABLE``, ``IDENTITY``, ``UUID``, ``CUSTOM`` and ``NONE``, explained
+   Valid values are ``AUTO``, ``SEQUENCE``, ``TABLE``, ``IDENTITY``, ``UUID`` (deprecated), ``CUSTOM`` and ``NONE``, explained
    in the :ref:`Identifier Generation Strategies <identifier-generation-strategies>` section.
    If not specified, default value is AUTO.
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -372,7 +372,7 @@ Optional attributes:
 
 -  **strategy**: Set the name of the identifier generation strategy.
    Valid values are ``AUTO``, ``SEQUENCE``, ``TABLE``, ``IDENTITY``,
-   ``UUID``, ``CUSTOM`` and ``NONE``.
+   ``UUID`` (deprecated), ``CUSTOM`` and ``NONE``.
    If not specified, the default value is ``AUTO``.
 
 Example:

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -376,8 +376,8 @@ Here is the list of possible generation strategies:
    strategy does currently not provide full portability and is
    supported by the following platforms: MySQL/SQLite/SQL Anywhere
    (AUTO\_INCREMENT), MSSQL (IDENTITY) and PostgreSQL (SERIAL).
--  ``UUID``: Tells Doctrine to use the built-in Universally Unique Identifier
-   generator. This strategy provides full portability.
+-  ``UUID`` (deprecated): Tells Doctrine to use the built-in Universally
+   Unique Identifier generator. This strategy provides full portability.
 -  ``TABLE``: Tells Doctrine to use a separate table for ID
    generation. This strategy provides full portability.
    ***This strategy is not yet implemented!***

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -20,13 +20,26 @@
 
 namespace Doctrine\ORM\Id;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
 
 /**
  * Represents an ID generator that uses the database UUID expression
+ *
+ * @deprecated use an application-side generator instead
  */
 class UuidGenerator extends AbstractIdGenerator
 {
+    public function __construct()
+    {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/7312',
+            '%s is deprecated with no replacement, use an application-side generator instead',
+            self::class
+        );
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -642,6 +642,12 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 break;
 
             case ClassMetadata::GENERATOR_TYPE_UUID:
+                Deprecation::trigger(
+                    'doctrine/orm',
+                    'https://github.com/doctrine/orm/issues/7312',
+                    'Mapping for %s: the "UUID" id generator strategy is deprecated with no replacement',
+                    $class->name
+                );
                 $class->setIdGenerator(new UuidGenerator());
                 break;
 

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -149,6 +149,8 @@ class ClassMetadataInfo implements ClassMetadata
     /**
      * UUID means that a UUID/GUID expression is used for id generation. Full
      * portability is currently not guaranteed.
+     *
+     * @deprecated use an application-side generator instead
      */
     public const GENERATOR_TYPE_UUID = 6;
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -890,6 +890,12 @@
       <code>$parent</code>
       <code>new $definition['class']()</code>
     </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="1">
+      <code>new UuidGenerator()</code>
+    </DeprecatedClass>
+    <DeprecatedConstant occurrences="1">
+      <code>ClassMetadata::GENERATOR_TYPE_UUID</code>
+    </DeprecatedConstant>
     <DeprecatedMethod occurrences="5">
       <code>addNamedNativeQuery</code>
       <code>addNamedQuery</code>
@@ -996,6 +1002,9 @@
       <code>$class</code>
       <code>$subclass</code>
     </ArgumentTypeCoercion>
+    <DeprecatedConstant occurrences="1">
+      <code>self::GENERATOR_TYPE_UUID</code>
+    </DeprecatedConstant>
     <DeprecatedProperty occurrences="2">
       <code>$this-&gt;columnNames</code>
       <code>$this-&gt;columnNames</code>
@@ -3530,7 +3539,8 @@
       <code>$this-&gt;getClassToExtend() ?: $metadata-&gt;name</code>
       <code>array_map('strlen', $paramTypes)</code>
     </ArgumentTypeCoercion>
-    <DeprecatedConstant occurrences="15">
+    <DeprecatedConstant occurrences="16">
+      <code>ClassMetadataInfo::GENERATOR_TYPE_UUID</code>
       <code>Type::BIGINT</code>
       <code>Type::BLOB</code>
       <code>Type::BOOLEAN</code>
@@ -3631,6 +3641,9 @@
     <DeprecatedClass occurrences="1">
       <code>ExportException::attemptOverwriteExistingFile($path)</code>
     </DeprecatedClass>
+    <DeprecatedConstant occurrences="1">
+      <code>ClassMetadataInfo::GENERATOR_TYPE_UUID</code>
+    </DeprecatedConstant>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function strlen;
@@ -13,23 +14,23 @@ use function strlen;
  */
 class UUIDGeneratorTest extends OrmFunctionalTestCase
 {
-    protected function setUp(): void
+    use VerifyDeprecations;
+
+    public function testItIsDeprecated(): void
     {
-        parent::setUp();
-
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
-            $this->markTestSkipped('Currently restricted to MySQL platform.');
-        }
-
-        $this->_schemaTool->createSchema(
-            [
-                $this->_em->getClassMetadata(UUIDEntity::class),
-            ]
-        );
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/7312');
+        $this->_em->getClassMetadata(UUIDEntity::class);
     }
 
     public function testGenerateUUID(): void
     {
+        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
+            $this->markTestSkipped('Currently restricted to MySQL platform.');
+        }
+
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(UUIDEntity::class),
+        ]);
         $entity = new UUIDEntity();
 
         $this->_em->persist($entity);


### PR DESCRIPTION
DB-generated UUIDs have been deprecated in the DBAL.

Related to #7330