### PR TITLE
[GH-8818] Deprecate entity namespace short aliases.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -29,6 +29,16 @@ Overriding this method is not recommended, which is why the method is documented
 + public function toIterable($stmt, ResultSetMapping $resultSetMapping, array $hints = []): iterable
 ```
 
+## Deprecated: Entity Namespace Aliases
+
+Entity namespace aliases are deprecated, use the magic ::class constant to abbreviate full class names
+in EntityManager, EntityRepository and DQL.
+
+```diff
+-  $entityManager->find('MyBundle:User', $id);
++  $entityManager->find(User::class, $id);
+```
+
 # Upgrade to 2.9
 
 ## Minor BC BREAK: Setup tool needs cache implementation

--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1527,7 +1527,6 @@ Terminals
 
 -  identifier (name, email, ...) must match ``[a-z_][a-z0-9_]*``
 -  fully_qualified_name (Doctrine\Tests\Models\CMS\CmsUser) matches PHP's fully qualified class names
--  aliased_name (CMS:CmsUser) uses two identifiers, one for the namespace alias and one for the class inside it
 -  string ('foo', 'bar''s house', '%ninja%', ...)
 -  char ('/', '\\', ' ', ...)
 -  integer (-1, 0, 1, 34, ...)

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -202,6 +202,13 @@ class Configuration extends \Doctrine\DBAL\Configuration
      */
     public function getEntityNamespace($entityNamespaceAlias)
     {
+        Deprecation::trigger(
+            'doctrine/orm',
+            'https://github.com/doctrine/orm/issues/8818',
+            'Entity short namespace aliases such as "%s" are deprecated, use ::class constant instead.',
+            $entityNamespaceAlias
+        );
+
         if (! isset($this->_attributes['entityNamespaces'][$entityNamespaceAlias])) {
             throw UnknownEntityNamespace::fromNamespaceAlias($entityNamespaceAlias);
         }

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\ORM;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\Exception\MetadataCacheNotConfigured;
 use Doctrine\ORM\Cache\Exception\MetadataCacheUsesNonPersistentCache;
@@ -39,6 +40,8 @@ use function class_exists;
  */
 class ConfigurationTest extends DoctrineTestCase
 {
+    use VerifyDeprecations;
+
     /** @var Configuration */
     private $configuration;
 
@@ -111,6 +114,8 @@ class ConfigurationTest extends DoctrineTestCase
 
     public function testSetGetEntityNamespace(): void
     {
+        $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8818');
+
         $this->configuration->addEntityNamespace('TestNamespace', __NAMESPACE__);
         $this->assertSame(__NAMESPACE__, $this->configuration->getEntityNamespace('TestNamespace'));
         $namespaces = ['OtherNamespace' => __NAMESPACE__];


### PR DESCRIPTION
This PR deprecates entity namespace short aliases as advertised in issue.

Fixes #8818 