### PR TITLE
Referenced new support for PHP8 attributes

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -41,6 +41,7 @@ Mapping Objects onto a Database
 
 * **Drivers**:
   :doc:`Docblock Annotations <reference/annotations-reference>` |
+  :doc:`Attributes <reference/attributes-reference>` |
   :doc:`XML <reference/xml-mapping>` |
   :doc:`YAML <reference/yaml-mapping>` |
   :doc:`PHP <reference/php-mapping>`

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -51,6 +51,7 @@ Doctrine provides several different ways to specify object-relational
 mapping metadata:
 
 -  :doc:`Docblock Annotations <annotations-reference>`
+-  :doc:`Attributes <attributes-reference>`
 -  :doc:`XML <xml-mapping>`
 -  :doc:`YAML <yaml-mapping>`
 -  :doc:`PHP code <php-mapping>`

--- a/docs/en/sidebar.rst
+++ b/docs/en/sidebar.rst
@@ -41,9 +41,10 @@
       reference/native-sql
       reference/change-tracking-policies
       reference/partial-objects
+      reference/annotations-reference
+      reference/attributes-reference
       reference/xml-mapping
       reference/yaml-mapping
-      reference/annotations-reference
       reference/php-mapping
       reference/caching
       reference/improving-performance

--- a/docs/en/toc.rst
+++ b/docs/en/toc.rst
@@ -43,9 +43,10 @@ Reference Guide
    reference/native-sql
    reference/change-tracking-policies
    reference/partial-objects
+   reference/annotations-reference
+   reference/attributes-reference
    reference/xml-mapping
    reference/yaml-mapping
-   reference/annotations-reference
    reference/php-mapping
    reference/caching
    reference/improving-performance


### PR DESCRIPTION
In reference to [this issue](https://github.com/doctrine/orm/issues/8804).

Since 2.9 there is support for attributes as referenced by @beberlei 's [blog post](https://www.doctrine-project.org/2021/05/24/orm2.9.html).

[The docs for this new feature](https://github.com/doctrine/orm/blob/2.9.x/docs/en/reference/attributes-reference.rst?rgh-link-date=2021-06-30T06%3A50%3A00Z) are written, but not referenced anywhere.

This is a attempt to correct this. There is also a slight reordering taking place to keep consistency.

Fixes #8804 