### PR TITLE
Clarified type hint nullability being the first default

### DIFF
--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -113,9 +113,9 @@ Optional attributes:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column. 
-    If not specified and a type hint is given (e.g. ?int or int), the nullability
-    of the type hint is used. Defaults to false.
+-  **nullable**: Determines if NULL values are allowed for this column. 
+   If not specified and a type hint is given (e.g. ?int or int), the nullability
+   of the type hint is used. Defaults to false.
 
 -  **options**: Array of additional options:
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -113,7 +113,9 @@ Optional attributes:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column. If not specified, default value is false.
+-  **nullable**: Determines if NULL values allowed for this column. 
+    If not specified and a type hint is given (e.g. ?int or int), the nullability
+    of the type hint is used. Defaults to false.
 
 -  **options**: Array of additional options:
 

--- a/docs/en/reference/annotations-reference.rst
+++ b/docs/en/reference/annotations-reference.rst
@@ -89,7 +89,7 @@ as part of the lifecycle of the instance variables entity-class.
 Required attributes:
 
 -  **type**: Name of the Doctrine Type which is converted between PHP
-   and Database representation. Default to ``string`` or :ref:`Type from PHP property type <reference-php-mapping-types>`
+   and Database representation. Defaults to ``string`` or :ref:`type from PHP property type <reference-php-mapping-types>`.
 
 Optional attributes:
 

--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -62,7 +62,8 @@ as part of the lifecycle of the instance variables entity-class.
 Required attributes:
 
 -  **type**: Name of the DBAL Type which does the conversion between PHP
-   and Database representation.
+   and Database representation. Defaults to ``string`` or 
+   :ref:`type from PHP property type <reference-php-mapping-types>`.
 
 Optional attributes:
 
@@ -86,8 +87,9 @@ Optional attributes:
 -  **unique**: Boolean value to determine if the value of the column
    should be unique across all rows of the underlying entities table.
 
--  **nullable**: Determines if NULL values allowed for this column.
-    If not specified, default value is ``false``.
+-  **nullable**: Determines if NULL values are allowed for this column. 
+   If not specified and a type hint is given (e.g. ?int or int), the nullability
+   of the type hint is used. Defaults to false.
 
 -  **options**: Array of additional options:
 


### PR DESCRIPTION
This adds the reference to the new mapping that uses explicit type hints and their nullability to the attribute reference doc.

It also clarifies that a property being typed as nullable will be mapped to a nullable column, in both attribute- as annotation-reference-doc. 