### PR TITLE
Make implicit type casts explicit

### DIFF
--- a/lib/Doctrine/ORM/Cache/Lock.php
+++ b/lib/Doctrine/ORM/Cache/Lock.php
@@ -24,6 +24,6 @@ class Lock
      */
     public static function createLockRead()
     {
-        return new self(uniqid(time(), true));
+        return new self(uniqid((string) time(), true));
     }
 }

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -614,7 +614,7 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
                 $sequenceGenerator = new SequenceGenerator(
                     $this->em->getConfiguration()->getQuoteStrategy()->getSequenceName($definition, $class, $this->getTargetPlatform()),
-                    $definition['allocationSize']
+                    (int) $definition['allocationSize']
                 );
                 $class->setIdGenerator($sequenceGenerator);
                 break;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -610,13 +610,13 @@ class ClassMetadataInfo implements ClassMetadata
      * <code>
      * array(
      *     'sequenceName' => 'name',
-     *     'allocationSize' => 20,
-     *     'initialValue' => 1
+     *     'allocationSize' => '20',
+     *     'initialValue' => '1'
      * )
      * </code>
      *
      * @var mixed[]
-     * @psalm-var array{sequenceName: string, allocationSize: int, initialValue: int}
+     * @psalm-var array{sequenceName: string, allocationSize: string, initialValue: string, quoted?: mixed}
      * @todo Merge with tableGeneratorDefinition into generic generatorDefinition
      */
     public $sequenceGeneratorDefinition;
@@ -3289,7 +3289,7 @@ class ClassMetadataInfo implements ClassMetadata
      * )
      * </code>
      *
-     * @psalm-param array<string, string> $definition
+     * @psalm-param array{sequenceName?: string, allocationSize?: int|string, initialValue?: int|string, quoted?: mixed} $definition
      *
      * @return void
      *
@@ -3306,13 +3306,16 @@ class ClassMetadataInfo implements ClassMetadata
             $definition['quoted']       = true;
         }
 
-        if (! isset($definition['allocationSize']) || trim($definition['allocationSize']) === '') {
+        if (! isset($definition['allocationSize']) || trim((string) $definition['allocationSize']) === '') {
             $definition['allocationSize'] = '1';
         }
 
-        if (! isset($definition['initialValue']) || trim($definition['initialValue']) === '') {
+        if (! isset($definition['initialValue']) || trim((string) $definition['initialValue']) === '') {
             $definition['initialValue'] = '1';
         }
+
+        $definition['allocationSize'] = (string) $definition['allocationSize'];
+        $definition['initialValue']   = (string) $definition['initialValue'];
 
         $this->sequenceGeneratorDefinition = $definition;
     }

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -863,7 +863,7 @@ class XmlDriver extends FileDriver
     private function cacheToArray(SimpleXMLElement $cacheMapping): array
     {
         $region = isset($cacheMapping['region']) ? (string) $cacheMapping['region'] : null;
-        $usage  = isset($cacheMapping['usage']) ? strtoupper($cacheMapping['usage']) : null;
+        $usage  = isset($cacheMapping['usage']) ? strtoupper((string) $cacheMapping['usage']) : null;
 
         if ($usage && ! defined('Doctrine\ORM\Mapping\ClassMetadata::CACHE_USAGE_' . $usage)) {
             throw new InvalidArgumentException(sprintf('Invalid cache usage "%s"', $usage));

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -179,7 +179,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         [$quotedJoinTable, $whereClauses, $params, $types] = $this->getJoinTableRestrictionsWithKey(
             $collection,
-            $key,
+            (string) $key,
             true
         );
 

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -493,7 +493,7 @@ class Parser
         $message .= $expected !== '' ? sprintf('Expected %s, got ', $expected) : 'Unexpected ';
         $message .= $this->lexer->lookahead === null ? 'end of string.' : sprintf("'%s'", $token['value']);
 
-        throw QueryException::syntaxError($message, QueryException::dqlError($this->query->getDQL()));
+        throw QueryException::syntaxError($message, QueryException::dqlError($this->query->getDQL() ?? ''));
     }
 
     /**
@@ -524,7 +524,7 @@ class Parser
         $length = $pos !== false ? $pos - $token['position'] : $distance;
 
         $tokenPos = isset($token['position']) && $token['position'] > 0 ? $token['position'] : '-1';
-        $tokenStr = substr($dql, $token['position'], $length);
+        $tokenStr = substr($dql, (int) $token['position'], $length);
 
         // Building informative message
         $message = 'line 0, col ' . $tokenPos . " near '" . $tokenStr . "': Error: " . $message;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2120,7 +2120,7 @@ class SqlWalker implements TreeWalker
                 return $this->conn->getDatabasePlatform()->convertBooleans(strtolower($literal->value) === 'true');
 
             case AST\Literal::NUMERIC:
-                return $literal->value;
+                return (string) $literal->value;
 
             default:
                 throw QueryException::invalidLiteral($literal);

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -976,7 +976,7 @@ class QueryBuilder
      */
     public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
     {
-        $parentAlias = substr($join, 0, strpos($join, '.'));
+        $parentAlias = substr($join, 0, (int) strpos($join, '.'));
 
         $rootAlias = $this->findRootAlias($alias, $parentAlias);
 

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -230,15 +230,15 @@ class ConvertDoctrine1Schema
             $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_SEQUENCE);
 
             $definition = [
-                'sequenceName' => is_array($column['sequence']) ? $column['sequence']['name'] : $column['sequence'],
+                'sequenceName' => (string) (is_array($column['sequence']) ? $column['sequence']['name'] : $column['sequence']),
             ];
 
             if (isset($column['sequence']['size'])) {
-                $definition['allocationSize'] = $column['sequence']['size'];
+                $definition['allocationSize'] = (int) $column['sequence']['size'];
             }
 
             if (isset($column['sequence']['value'])) {
-                $definition['initialValue'] = $column['sequence']['value'];
+                $definition['initialValue'] = (int) $column['sequence']['value'];
             }
 
             $metadata->setSequenceGeneratorDefinition($definition);

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -82,7 +82,7 @@ class <className> extends <repositoryName>
      */
     private function getClassNamespace(string $fullClassName): string
     {
-        return substr($fullClassName, 0, strrpos($fullClassName, '\\'));
+        return substr($fullClassName, 0, (int) strrpos($fullClassName, '\\'));
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -182,7 +182,7 @@ class XmlExporter extends AbstractExporter
                 }
 
                 if (isset($field['length'])) {
-                    $fieldXml->addAttribute('length', $field['length']);
+                    $fieldXml->addAttribute('length', (string) $field['length']);
                 }
 
                 if (isset($field['precision'])) {
@@ -200,7 +200,7 @@ class XmlExporter extends AbstractExporter
                 if (isset($field['options'])) {
                     $optionsXml = $fieldXml->addChild('options');
                     foreach ($field['options'] as $key => $value) {
-                        $optionXml = $optionsXml->addChild('option', $value);
+                        $optionXml = $optionsXml->addChild('option', (string) $value);
                         $optionXml->addAttribute('name', $key);
                     }
                 }
@@ -230,7 +230,7 @@ class XmlExporter extends AbstractExporter
             $a1 = array_search($m1['type'], $orderMap);
             $a2 = array_search($m2['type'], $orderMap);
 
-            return strcmp($a1, $a2);
+            return strcmp((string) $a1, (string) $a2);
         });
 
         foreach ($metadata->associationMappings as $associationMapping) {

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -378,8 +378,8 @@ class SchemaTool
                 if (! $schema->hasSequence($quotedName)) {
                     $schema->createSequence(
                         $quotedName,
-                        $seqDef['allocationSize'],
-                        $seqDef['initialValue']
+                        (int) $seqDef['allocationSize'],
+                        (int) $seqDef['initialValue']
                     );
                 }
             }

--- a/lib/Doctrine/ORM/Tools/ToolsException.php
+++ b/lib/Doctrine/ORM/Tools/ToolsException.php
@@ -15,7 +15,11 @@ class ToolsException extends ORMException
 {
     public static function schemaToolFailure(string $sql, Throwable $e): self
     {
-        return new self("Schema-Tool failed with Error '" . $e->getMessage() . "' while executing DDL: " . $sql, '0', $e);
+        return new self(
+            "Schema-Tool failed with Error '" . $e->getMessage() . "' while executing DDL: " . $sql,
+            0,
+            $e
+        );
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,11 +46,6 @@ parameters:
 			path: lib/Doctrine/ORM/Cache/DefaultQueryCache.php
 
 		-
-			message: "#^Parameter \\#1 \\$prefix of function uniqid expects string, int given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Cache/Lock.php
-
-		-
 			message: "#^Access to an undefined property Doctrine\\\\ORM\\\\Cache\\\\CacheEntry\\:\\:\\$identifiers\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -451,16 +446,6 @@ parameters:
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$definition of method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\<object\\>\\:\\:setSequenceGeneratorDefinition\\(\\) expects array\\<string, string\\>, array\\<string, int\\|string\\> given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
-
-		-
-			message: "#^Parameter \\#1 \\$definition of method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\<object\\>\\:\\:setSequenceGeneratorDefinition\\(\\) expects array\\<string, string\\>, array\\<string, int\\|string\\|true\\> given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
-
-		-
 			message: "#^Parameter \\#1 \\$subClass of method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataFactory\\:\\:addInheritedEmbeddedClasses\\(\\) expects Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadata, Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -587,11 +572,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$type of static method Doctrine\\\\ORM\\\\Mapping\\\\MappingException\\:\\:invalidInheritanceType\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\<T of object\\>\\:\\:\\$sequenceGeneratorDefinition \\(array\\('sequenceName' \\=\\> string, 'allocationSize' \\=\\> int, 'initialValue' \\=\\> int\\)\\) does not accept array\\<string, string\\|true\\>\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
 
@@ -793,11 +773,6 @@ parameters:
 		-
 			message: "#^Argument of an invalid type Doctrine\\\\ORM\\\\Mapping\\\\JoinColumn supplied for foreach, only iterables are supported\\.$#"
 			count: 2
-			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
-
-		-
-			message: "#^Parameter \\#1 \\$definition of method Doctrine\\\\ORM\\\\Mapping\\\\ClassMetadataInfo\\<object\\>\\:\\:setSequenceGeneratorDefinition\\(\\) expects array\\<string, string\\>, array\\<string, int\\|string\\> given\\.$#"
-			count: 1
 			path: lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
 
 		-
@@ -2162,23 +2137,13 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Parameter \\#1 \\$str1 of function strcmp expects string, int\\|false given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
-
-		-
 			message: "#^Parameter \\#1 \\$type of method Doctrine\\\\ORM\\\\Tools\\\\Export\\\\Driver\\\\AbstractExporter\\:\\:_getIdGeneratorTypeString\\(\\) expects 1\\|2\\|3\\|4\\|5\\|6\\|7, int given\\.$#"
 			count: 2
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Parameter \\#2 \\$str2 of function strcmp expects string, int\\|false given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
-
-		-
 			message: "#^Parameter \\#2 \\$value of method SimpleXMLElement\\:\\:addAttribute\\(\\) expects string, int given\\.$#"
-			count: 6
+			count: 3
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
@@ -2235,11 +2200,6 @@ parameters:
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Tools/SchemaTool.php
-
-		-
-			message: "#^Parameter \\#2 \\$code of class Doctrine\\\\ORM\\\\Tools\\\\ToolsException constructor expects int, string given\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Tools/ToolsException.php
 
 		-
 			message: "#^Binary operation \"&\" between string and 3 results in an error\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -175,11 +175,6 @@
       <code>loadCacheEntry</code>
     </MissingReturnType>
   </file>
-  <file src="lib/Doctrine/ORM/Cache/Lock.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>time()</code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/Doctrine/ORM/Cache/Logging/CacheLogger.php">
     <MissingReturnType occurrences="9">
       <code>collectionCacheHit</code>
@@ -911,10 +906,6 @@
     <InvalidArrayOffset occurrences="1">
       <code>$subClass-&gt;table[$indexType][$indexName]</code>
     </InvalidArrayOffset>
-    <InvalidScalarArgument occurrences="2">
-      <code>$definition</code>
-      <code>$parent-&gt;sequenceGeneratorDefinition</code>
-    </InvalidScalarArgument>
     <MissingConstructor occurrences="2">
       <code>$driver</code>
       <code>$evm</code>
@@ -1025,9 +1016,6 @@
       <code>ReflectionProperty</code>
       <code>ReflectionProperty</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$definition</code>
-    </InvalidPropertyAssignmentValue>
     <InvalidScalarArgument occurrences="1">
       <code>$type</code>
     </InvalidScalarArgument>
@@ -1262,7 +1250,6 @@
       <code>$value[1]</code>
       <code>$value[1]</code>
     </InvalidArrayAccess>
-    <InvalidScalarArgument occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$entityAnnotationClasses</code>
     </NonInvariantDocblockPropertyType>
@@ -1351,9 +1338,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$metadata</code>
     </ArgumentTypeCoercion>
-    <ImplicitToStringCast occurrences="1">
-      <code>$cacheMapping['usage']</code>
-    </ImplicitToStringCast>
     <LessSpecificReturnStatement occurrences="1"/>
     <MissingParamType occurrences="2">
       <code>$fileExtension</code>
@@ -2643,7 +2627,7 @@
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArgument occurrences="30">
+    <PossiblyNullArgument occurrences="29">
       <code>$aliasIdentVariable</code>
       <code>$dql</code>
       <code>$dql</code>
@@ -3196,7 +3180,7 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;cacheMode</code>
     </NullableReturnStatement>
-    <PossiblyFalseArgument occurrences="4">
+    <PossiblyFalseArgument occurrences="3">
       <code>$spacePos</code>
       <code>$spacePos</code>
       <code>strpos($join, '.')</code>
@@ -3604,9 +3588,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>EntityRepository::class</code>
     </DocblockTypeContradiction>
-    <PossiblyFalseArgument occurrences="1">
-      <code>strrpos($fullClassName, '\\')</code>
-    </PossiblyFalseArgument>
     <PossiblyFalseOperand occurrences="1">
       <code>strrpos($fullClassName, '\\')</code>
     </PossiblyFalseOperand>
@@ -3686,13 +3667,11 @@
     <DeprecatedClass occurrences="1">
       <code>AbstractExporter</code>
     </DeprecatedClass>
-    <InvalidScalarArgument occurrences="6">
+    <InvalidScalarArgument occurrences="3">
       <code>$field['length']</code>
       <code>$field['length']</code>
       <code>$field['precision']</code>
       <code>$field['scale']</code>
-      <code>$sequenceDefinition['allocationSize']</code>
-      <code>$sequenceDefinition['initialValue']</code>
     </InvalidScalarArgument>
     <MissingClosureParamType occurrences="2">
       <code>$m1</code>
@@ -3861,11 +3840,6 @@
     <UnresolvableInclude occurrences="1">
       <code>require_once $directory . '/Doctrine/Common/ClassLoader.php'</code>
     </UnresolvableInclude>
-  </file>
-  <file src="lib/Doctrine/ORM/Tools/ToolsException.php">
-    <InvalidScalarArgument occurrences="1">
-      <code>'0'</code>
-    </InvalidScalarArgument>
   </file>
   <file src="lib/Doctrine/ORM/UnitOfWork.php">
     <ArgumentTypeCoercion occurrences="6">

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -282,9 +282,9 @@ class FileLockRegionTest extends AbstractRegionTest
 
         foreach ($directoryIterator as $file) {
             if ($file->isFile()) {
-                @unlink($file->getRealPath());
+                @unlink((string) $file->getRealPath());
             } else {
-                @rmdir($file->getRealPath());
+                @rmdir((string) $file->getRealPath());
             }
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -251,7 +251,10 @@ class OptimisticTest extends OrmFunctionalTestCase
         $caughtException = null;
 
         try {
-            $expectedVersionExpired = DateTime::createFromFormat('U', $test->version->getTimestamp() - 3600);
+            $expectedVersionExpired = DateTime::createFromFormat(
+                'U',
+                (string) ($test->version->getTimestamp() - 3600)
+            );
 
             $this->_em->lock($test, LockMode::OPTIMISTIC, $expectedVersionExpired);
         } catch (OptimisticLockException $e) {

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
@@ -187,7 +187,7 @@ class GH5887CustomIdObjectType extends StringType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return new GH5887CustomIdObject($value);
+        return new GH5887CustomIdObject((int) $value);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -84,9 +84,9 @@ abstract class AbstractDriverTest extends TestCase
 
         foreach ($iterator as $path) {
             if ($path->isDir()) {
-                @rmdir($path);
+                @rmdir((string) $path);
             } else {
-                @unlink($path);
+                @unlink((string) $path);
             }
         }
 

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -516,7 +516,7 @@ class QueryTest extends OrmTestCase
         $this->expectException(QueryException::class);
         $this->expectExceptionMessage('[Syntax Error] line 0, col -1: Error: Expected SELECT, UPDATE or DELETE, got end of string.');
 
-        $query = $this->entityManager->createQuery('0')->execute();
+        $this->entityManager->createQuery('0')->execute();
     }
 
     /**


### PR DESCRIPTION
Before we discuss what target branch the `strict_types` PR should use, here is a PR that makes 2.10.x compatible with strict types.
Everything was pretty straightforward except the sequence generator which is full of casts from int to string and _vice versa_. After reading https://github.com/doctrine/orm/pull/6683 , it seems to me that we want to be compatible with sequences greater than PHP_INT_MAX, but I doubt we are in practice.
Note how this reduces the baseline.