### PR TITLE
Replace spl_object_hash() with spl_object_id()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/persistence": "^2.2",
         "psr/cache": "^1 || ^2 || ^3",
         "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/polyfill-php72": "^1.23",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -5,7 +5,7 @@ namespace Doctrine\ORM\Cache\Persister\Collection;
 use Doctrine\ORM\Cache\CollectionCacheKey;
 use Doctrine\ORM\PersistentCollection;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {
@@ -47,7 +47,7 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
 
         $this->persister->delete($collection);
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = $key;
+        $this->queuedCache['delete'][spl_object_id($collection)] = $key;
     }
 
     /**
@@ -69,14 +69,14 @@ class NonStrictReadWriteCachedCollectionPersister extends AbstractCollectionPers
         if ($isDirty && ! $isInitialized || isset($this->association['orderBy'])) {
             $this->persister->update($collection);
 
-            $this->queuedCache['delete'][spl_object_hash($collection)] = $key;
+            $this->queuedCache['delete'][spl_object_id($collection)] = $key;
 
             return;
         }
 
         $this->persister->update($collection);
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = [
+        $this->queuedCache['update'][spl_object_id($collection)] = [
             'key'   => $key,
             'list'  => $collection,
         ];

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\Collection\CollectionPersister;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
 {
@@ -78,7 +78,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['delete'][spl_object_hash($collection)] = [
+        $this->queuedCache['delete'][spl_object_id($collection)] = [
             'key'   => $key,
             'lock'  => $lock,
         ];
@@ -106,7 +106,7 @@ class ReadWriteCachedCollectionPersister extends AbstractCollectionPersister
             return;
         }
 
-        $this->queuedCache['update'][spl_object_hash($collection)] = [
+        $this->queuedCache['update'][spl_object_id($collection)] = [
             'key'   => $key,
             'lock'  => $lock,
         ];

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -15,7 +15,7 @@ use function count;
 use function is_array;
 use function key;
 use function ltrim;
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * The ObjectHydrator constructs an object graph out of an SQL result set.
@@ -162,7 +162,7 @@ class ObjectHydrator extends AbstractHydrator
         string $fieldName,
         string $parentDqlAlias
     ): PersistentCollection {
-        $oid      = spl_object_hash($entity);
+        $oid      = spl_object_id($entity);
         $relation = $class->associationMappings[$fieldName];
         $value    = $class->reflFields[$fieldName]->getValue($entity);
 
@@ -356,7 +356,7 @@ class ObjectHydrator extends AbstractHydrator
                     continue;
                 }
 
-                $oid = spl_object_hash($parentObject);
+                $oid = spl_object_id($parentObject);
 
                 // Check the type of the relation (many or single-valued)
                 if (! ($relation['type'] & ClassMetadata::TO_ONE)) {
@@ -429,7 +429,7 @@ class ObjectHydrator extends AbstractHydrator
                                     $inverseAssoc = $targetClass->associationMappings[$relation['inversedBy']];
                                     if ($inverseAssoc['type'] & ClassMetadata::TO_ONE) {
                                         $targetClass->reflFields[$inverseAssoc['fieldName']]->setValue($element, $parentObject);
-                                        $this->_uow->setOriginalEntityProperty(spl_object_hash($element), $inverseAssoc['fieldName'], $parentObject);
+                                        $this->_uow->setOriginalEntityProperty(spl_object_id($element), $inverseAssoc['fieldName'], $parentObject);
                                     }
                                 } elseif ($parentClass === $targetClass && $relation['mappedBy']) {
                                     // Special case: bi-directional self-referencing one-one on the same class
@@ -438,7 +438,7 @@ class ObjectHydrator extends AbstractHydrator
                             } else {
                                 // For sure bidirectional, as there is no inverse side in unidirectional mappings
                                 $targetClass->reflFields[$relation['mappedBy']]->setValue($element, $parentObject);
-                                $this->_uow->setOriginalEntityProperty(spl_object_hash($element), $relation['mappedBy'], $parentObject);
+                                $this->_uow->setOriginalEntityProperty(spl_object_id($element), $relation['mappedBy'], $parentObject);
                             }
 
                             // Update result pointer

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -41,7 +41,7 @@ use function is_array;
 use function is_subclass_of;
 use function ltrim;
 use function method_exists;
-use function spl_object_hash;
+use function spl_object_id;
 use function str_replace;
 use function strpos;
 use function strtolower;
@@ -833,7 +833,7 @@ class ClassMetadataInfo implements ClassMetadata
      */
     public function __toString()
     {
-        return self::class . '@' . spl_object_hash($this);
+        return self::class . '@' . spl_object_id($this);
     }
 
     /**

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -13,7 +13,7 @@ use function implode;
 use function is_object;
 use function method_exists;
 use function reset;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 
 /**
@@ -239,7 +239,7 @@ class ORMInvalidArgumentException extends InvalidArgumentException
      */
     private static function objToStr($obj): string
     {
-        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_hash($obj);
+        return method_exists($obj, '__toString') ? (string) $obj : get_class($obj) . '@' . spl_object_id($obj);
     }
 
     /**

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -17,7 +17,7 @@ use function array_udiff_assoc;
 use function array_walk;
 use function get_class;
 use function is_object;
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * A PersistentCollection represents a collection of elements that have persistent state.
@@ -158,7 +158,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
             );
 
             $this->em->getUnitOfWork()->setOriginalEntityProperty(
-                spl_object_hash($element),
+                spl_object_id($element),
                 $this->backRefFieldName,
                 $this->owner
             );
@@ -687,7 +687,7 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     /**
      * @param object[] $newObjects
      *
-     * Note: the only reason why this entire looping/complexity is performed via `spl_object_hash`
+     * Note: the only reason why this entire looping/complexity is performed via `spl_object_id`
      *       is because we want to prevent using `array_udiff()`, which is likely to cause very
      *       high overhead (complexity of O(n^2)). `array_diff_key()` performs the operation in
      *       core, which is faster than using a callback for comparisons
@@ -695,8 +695,8 @@ final class PersistentCollection extends AbstractLazyCollection implements Selec
     private function restoreNewObjectsInDirtyCollection(array $newObjects): void
     {
         $loadedObjects               = $this->collection->toArray();
-        $newObjectsByOid             = array_combine(array_map('spl_object_hash', $newObjects), $newObjects);
-        $loadedObjectsByOid          = array_combine(array_map('spl_object_hash', $loadedObjects), $loadedObjects);
+        $newObjectsByOid             = array_combine(array_map('spl_object_id', $newObjects), $newObjects);
+        $loadedObjectsByOid          = array_combine(array_map('spl_object_id', $loadedObjects), $loadedObjects);
         $newObjectsThatWereNotLoaded = array_diff_key($newObjectsByOid, $loadedObjectsByOid);
 
         if ($newObjectsThatWereNotLoaded) {

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -43,7 +43,7 @@ use function implode;
 use function is_array;
 use function is_object;
 use function reset;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 use function strpos;
 use function strtoupper;
@@ -132,7 +132,7 @@ class BasicEntityPersister implements EntityPersister
     /**
      * Queued inserts.
      *
-     * @psalm-var array<string, object>
+     * @psalm-var array<int, object>
      */
     protected $queuedInserts = [];
 
@@ -233,7 +233,7 @@ class BasicEntityPersister implements EntityPersister
      */
     public function addInsert($entity)
     {
-        $this->queuedInserts[spl_object_hash($entity)] = $entity;
+        $this->queuedInserts[spl_object_id($entity)] = $entity;
     }
 
     /**
@@ -640,7 +640,7 @@ class BasicEntityPersister implements EntityPersister
             }
 
             if ($newVal !== null) {
-                $oid = spl_object_hash($newVal);
+                $oid = spl_object_id($newVal);
 
                 if (isset($this->queuedInserts[$oid]) || $uow->isScheduledForInsert($newVal)) {
                     // The associated entity $newVal is not yet persisted, so we must

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -29,7 +29,7 @@ interface EntityPersister
     /**
      * Get all queued inserts.
      *
-     * @psalm-return array<string, object>
+     * @psalm-return array<string|int, object>
      */
     public function getInserts();
 

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -5,7 +5,7 @@ namespace Doctrine\ORM\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * This factory is used to create default repository objects for entities at runtime.
@@ -24,7 +24,7 @@ final class DefaultRepositoryFactory implements RepositoryFactory
      */
     public function getRepository(EntityManagerInterface $entityManager, $entityName): ObjectRepository
     {
-        $repositoryHash = $entityManager->getClassMetadata($entityName)->getName() . spl_object_hash($entityManager);
+        $repositoryHash = $entityManager->getClassMetadata($entityName)->getName() . spl_object_id($entityManager);
 
         if (isset($this->repositoryList[$repositoryHash])) {
             return $this->repositoryList[$repositoryHash];

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -16,7 +16,7 @@ use function fopen;
 use function fwrite;
 use function gettype;
 use function is_object;
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * Use this logger to dump the identity map during the onFlush event. This is useful for debugging
@@ -74,7 +74,7 @@ class DebugUnitOfWorkListener
             fwrite($fh, 'Class: ' . $className . "\n");
 
             foreach ($map as $entity) {
-                fwrite($fh, ' Entity: ' . $this->getIdString($entity, $uow) . ' ' . spl_object_hash($entity) . "\n");
+                fwrite($fh, ' Entity: ' . $this->getIdString($entity, $uow) . ' ' . spl_object_id($entity) . "\n");
                 fwrite($fh, "  Associations:\n");
 
                 $cm = $em->getClassMetadata($className);
@@ -91,7 +91,7 @@ class DebugUnitOfWorkListener
                                 fwrite($fh, '[PROXY] ');
                             }
 
-                            fwrite($fh, $this->getIdString($value, $uow) . ' ' . spl_object_hash($value) . "\n");
+                            fwrite($fh, $this->getIdString($value, $uow) . ' ' . spl_object_id($value) . "\n");
                         }
                     } else {
                         $initialized = ! ($value instanceof PersistentCollection) || $value->isInitialized();
@@ -101,12 +101,12 @@ class DebugUnitOfWorkListener
                             fwrite($fh, '[INITIALIZED] ' . $this->getType($value) . ' ' . count($value) . " elements\n");
 
                             foreach ($value as $obj) {
-                                fwrite($fh, '    ' . $this->getIdString($obj, $uow) . ' ' . spl_object_hash($obj) . "\n");
+                                fwrite($fh, '    ' . $this->getIdString($obj, $uow) . ' ' . spl_object_id($obj) . "\n");
                             }
                         } else {
                             fwrite($fh, '[PROXY] ' . $this->getType($value) . " unknown element size\n");
                             foreach ($value->unwrap() as $obj) {
-                                fwrite($fh, '    ' . $this->getIdString($obj, $uow) . ' ' . spl_object_hash($obj) . "\n");
+                                fwrite($fh, '    ' . $this->getIdString($obj, $uow) . ' ' . spl_object_id($obj) . "\n");
                             }
                         }
                     }

--- a/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
+++ b/tests/Doctrine/Tests/Mocks/UnitOfWorkMock.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\Mocks;
 use Doctrine\ORM\Persisters\Entity\BasicEntityPersister;
 use Doctrine\ORM\UnitOfWork;
 
-use function spl_object_hash;
+use function spl_object_id;
 
 /**
  * Mock class for UnitOfWork.
@@ -33,7 +33,7 @@ class UnitOfWorkMock extends UnitOfWork
      */
     public function & getEntityChangeSet($entity)
     {
-        $oid = spl_object_hash($entity);
+        $oid = spl_object_id($entity);
 
         if (isset($this->_mockDataChangeSets[$oid])) {
             return $this->_mockDataChangeSets[$oid];
@@ -60,6 +60,6 @@ class UnitOfWorkMock extends UnitOfWork
      */
     public function setOriginalEntityData($entity, array $originalData)
     {
-        $this->_originalEntityData[spl_object_hash($entity)] = $originalData;
+        $this->_originalEntityData[spl_object_id($entity)] = $originalData;
     }
 }

--- a/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
+++ b/tests/Doctrine/Tests/ORM/ORMInvalidArgumentExceptionTest.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\ORMInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function spl_object_hash;
+use function spl_object_id;
 use function uniqid;
 
 /**
@@ -87,7 +87,7 @@ class ORMInvalidArgumentExceptionTest extends TestCase
                     ],
                 ],
                 'A new entity was found through the relationship \'foo1#bar1\' that was not configured to cascade '
-                . 'persist operations for entity: stdClass@' . spl_object_hash($entity1)
+                . 'persist operations for entity: stdClass@' . spl_object_id($entity1)
                 . '. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity '
                 . 'or configure cascade persist this association in the mapping for example '
                 . '@ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem '
@@ -106,13 +106,13 @@ class ORMInvalidArgumentExceptionTest extends TestCase
                 ],
                 'Multiple non-persisted new entities were found through the given association graph:' . "\n\n"
                 . ' * A new entity was found through the relationship \'foo1#bar1\' that was not configured to '
-                . 'cascade persist operations for entity: stdClass@' . spl_object_hash($entity1) . '. '
+                . 'cascade persist operations for entity: stdClass@' . spl_object_id($entity1) . '. '
                 . 'To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity '
                 . 'or configure cascade persist this association in the mapping for example '
                 . '@ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem '
                 . 'implement \'baz1#__toString()\' to get a clue.' . "\n"
                 . ' * A new entity was found through the relationship \'foo2#bar2\' that was not configured to '
-                . 'cascade persist operations for entity: stdClass@' . spl_object_hash($entity2) . '. To solve '
+                . 'cascade persist operations for entity: stdClass@' . spl_object_id($entity2) . '. To solve '
                 . 'this issue: Either explicitly call EntityManager#persist() on this unknown entity or '
                 . 'configure cascade persist this association in the mapping for example '
                 . '@ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem '


### PR DESCRIPTION
It is more efficient, and can be provided to 7.1 users thanks to
`symfony/polyfill-php72`.

Backports #6878 

@beberlei I know we wanted to target Doctrine 3 with this, but I found a way to target v2. WDYT?