### PR TITLE
Enable strict mode

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Countable;

--- a/lib/Doctrine/ORM/Cache.php
+++ b/lib/Doctrine/ORM/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Cache\QueryCache;

--- a/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/AssociationCacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/CacheConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/CacheConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache\Logging\CacheLogger;

--- a/lib/Doctrine/ORM/Cache/CacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/CacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/CacheException.php
+++ b/lib/Doctrine/ORM/Cache/CacheException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Cache/CacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/CacheFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache;

--- a/lib/Doctrine/ORM/Cache/CacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CacheKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/CollectionCacheKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function implode;

--- a/lib/Doctrine/ORM/Cache/CollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/CollectionHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\Common\Collections\Collection;

--- a/lib/Doctrine/ORM/Cache/ConcurrentRegion.php
+++ b/lib/Doctrine/ORM/Cache/ConcurrentRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/DefaultCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCacheFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\Common\Cache\Cache as CacheAdapter;

--- a/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultCollectionHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache\Persister\CachedPersister;

--- a/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/DefaultEntityHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
+++ b/lib/Doctrine/ORM/Cache/DefaultQueryCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Cache/EntityCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/EntityCacheKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function implode;

--- a/lib/Doctrine/ORM/Cache/EntityHydrator.php
+++ b/lib/Doctrine/ORM/Cache/EntityHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Cache/Exception/CacheException.php
+++ b/lib/Doctrine/ORM/Cache/Exception/CacheException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Exception;
 
 use Doctrine\ORM\Cache\CacheException as BaseCacheException;

--- a/lib/Doctrine/ORM/Cache/Lock.php
+++ b/lib/Doctrine/ORM/Cache/Lock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function time;

--- a/lib/Doctrine/ORM/Cache/LockException.php
+++ b/lib/Doctrine/ORM/Cache/LockException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache\Exception\CacheException;

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Logging;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;

--- a/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
+++ b/lib/Doctrine/ORM/Cache/Logging/CacheLoggerChain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Logging;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;

--- a/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
+++ b/lib/Doctrine/ORM/Cache/Logging/StatisticsCacheLogger.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Logging;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;

--- a/lib/Doctrine/ORM/Cache/MultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/MultiGetRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/Persister/CachedPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/CachedPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister;
 
 use Doctrine\ORM\Cache\Region;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/AbstractCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/CachedCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\Common\Collections\Collection;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/NonStrictReadWriteCachedCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadOnlyCachedCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Collection/ReadWriteCachedCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Collection;
 
 use Doctrine\ORM\Cache\CollectionCacheKey;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/AbstractEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/CachedEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\EntityCacheKey;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/NonStrictReadWriteCachedEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\EntityCacheKey;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadOnlyCachedEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
+++ b/lib/Doctrine/ORM/Cache/Persister/Entity/ReadWriteCachedEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Persister\Entity;
 
 use Doctrine\ORM\Cache\ConcurrentRegion;

--- a/lib/Doctrine/ORM/Cache/QueryCache.php
+++ b/lib/Doctrine/ORM/Cache/QueryCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Query\ResultSetMapping;

--- a/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function microtime;

--- a/lib/Doctrine/ORM/Cache/QueryCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache;

--- a/lib/Doctrine/ORM/Cache/QueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/QueryCacheValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/Region.php
+++ b/lib/Doctrine/ORM/Cache/Region.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use Doctrine\ORM\Cache\Exception\CacheException;

--- a/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultMultiGetRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Region;
 
 use Doctrine\Common\Cache\Cache;

--- a/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/DefaultRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Region;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
+++ b/lib/Doctrine/ORM/Cache/Region/FileLockRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Region;
 
 use Doctrine\ORM\Cache\CacheEntry;

--- a/lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php
+++ b/lib/Doctrine/ORM/Cache/Region/UpdateTimestampCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache\Region;
 
 use Doctrine\ORM\Cache\CacheKey;

--- a/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
+++ b/lib/Doctrine/ORM/Cache/RegionsConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function microtime;

--- a/lib/Doctrine/ORM/Cache/TimestampCacheKey.php
+++ b/lib/Doctrine/ORM/Cache/TimestampCacheKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
+++ b/lib/Doctrine/ORM/Cache/TimestampQueryCacheValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 use function microtime;

--- a/lib/Doctrine/ORM/Cache/TimestampRegion.php
+++ b/lib/Doctrine/ORM/Cache/TimestampRegion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Cache;
 
 /**

--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
+++ b/lib/Doctrine/ORM/Decorator/EntityManagerDecorator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Decorator;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -851,7 +851,7 @@ use function sprintf;
                 }
         }
 
-        throw InvalidHydrationMode::fromMode($hydrationMode);
+        throw InvalidHydrationMode::fromMode((string) $hydrationMode);
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/EntityNotFoundException.php
+++ b/lib/Doctrine/ORM/EntityNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/EntityRepository.php
+++ b/lib/Doctrine/ORM/EntityRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LifecycleEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Event/ListenersInvoker.php
+++ b/lib/Doctrine/ORM/Event/ListenersInvoker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
+++ b/lib/Doctrine/ORM/Event/LoadClassMetadataEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClassMetadataNotFoundEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Persistence\Event\ManagerEventArgs;

--- a/lib/Doctrine/ORM/Event/OnClearEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnClearEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/OnFlushEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PostFlushEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreFlushEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
+++ b/lib/Doctrine/ORM/Event/PreUpdateEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Event;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Events.php
+++ b/lib/Doctrine/ORM/Events.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 /**

--- a/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
+++ b/lib/Doctrine/ORM/Id/AbstractIdGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/AssignedGenerator.php
+++ b/lib/Doctrine/ORM/Id/AssignedGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/BigIntegerIdentityGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/IdentityGenerator.php
+++ b/lib/Doctrine/ORM/Id/IdentityGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/TableGenerator.php
+++ b/lib/Doctrine/ORM/Id/TableGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\ORM\EntityManager;

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Id;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
+++ b/lib/Doctrine/ORM/Internal/CommitOrderCalculator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal;
 
 use stdClass;

--- a/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\DBAL\Driver\ResultStatement;

--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/HydrationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Iterator;

--- a/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 /**

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Doctrine\ORM\NonUniqueResultException;

--- a/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
+++ b/lib/Doctrine/ORM/Internal/HydrationCompleteHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Internal;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/LazyCriteriaCollection.php
+++ b/lib/Doctrine/ORM/LazyCriteriaCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;

--- a/lib/Doctrine/ORM/Mapping/Annotation.php
+++ b/lib/Doctrine/ORM/Mapping/Annotation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 interface Annotation

--- a/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Mapping/AssociationOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverride.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AssociationOverrides.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/AttributeOverride.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverride.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
+++ b/lib/Doctrine/ORM/Mapping/AttributeOverrides.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EmbeddedBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/EntityListenerBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 use Doctrine\ORM\Events;

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 use function constant;

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Builder;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/Cache.php
+++ b/lib/Doctrine/ORM/Mapping/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
+++ b/lib/Doctrine/ORM/Mapping/ChangeTrackingPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadata.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\Common\EventManager;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php
@@ -33,6 +33,7 @@ use function array_map;
 use function array_merge;
 use function array_pop;
 use function array_values;
+use function assert;
 use function class_exists;
 use function count;
 use function explode;
@@ -973,12 +974,14 @@ class ClassMetadataInfo implements ClassMetadata
 
         foreach ($this->embeddedClasses as $property => $embeddedClass) {
             if (isset($embeddedClass['declaredField'])) {
+                $childProperty = $reflService->getAccessibleProperty(
+                    $this->embeddedClasses[$embeddedClass['declaredField']]['class'],
+                    $embeddedClass['originalField']
+                );
+                assert($childProperty !== null);
                 $parentReflFields[$property] = new ReflectionEmbeddedProperty(
                     $parentReflFields[$embeddedClass['declaredField']],
-                    $reflService->getAccessibleProperty(
-                        $this->embeddedClasses[$embeddedClass['declaredField']]['class'],
-                        $embeddedClass['originalField']
-                    ),
+                    $childProperty,
                     $this->embeddedClasses[$embeddedClass['declaredField']]['class']
                 );
 

--- a/lib/Doctrine/ORM/Mapping/Column.php
+++ b/lib/Doctrine/ORM/Mapping/Column.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/ColumnResult.php
+++ b/lib/Doctrine/ORM/Mapping/ColumnResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/CustomIdGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultEntityListenerResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use InvalidArgumentException;

--- a/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultNamingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use function strpos;

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorColumn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
+++ b/lib/Doctrine/ORM/Mapping/DiscriminatorMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DatabaseDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager;

--- a/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 require_once __DIR__ . '/../Annotation.php';
 require_once __DIR__ . '/../Entity.php';

--- a/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/DriverChain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;

--- a/lib/Doctrine/ORM/Mapping/Driver/PHPDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/PHPDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\PHPDriver as CommonPHPDriver;

--- a/lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/SimplifiedXmlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;

--- a/lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/SimplifiedYamlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\SymfonyFileLocator;

--- a/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/StaticPHPDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Persistence\Mapping\Driver\StaticPHPDriver as CommonStaticPHPDriver;

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/YamlDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Driver;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Mapping/Embeddable.php
+++ b/lib/Doctrine/ORM/Mapping/Embeddable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Embedded.php
+++ b/lib/Doctrine/ORM/Mapping/Embedded.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Entity.php
+++ b/lib/Doctrine/ORM/Mapping/Entity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListenerResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/EntityListeners.php
+++ b/lib/Doctrine/ORM/Mapping/EntityListeners.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/EntityResult.php
+++ b/lib/Doctrine/ORM/Mapping/EntityResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/FieldResult.php
+++ b/lib/Doctrine/ORM/Mapping/FieldResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/GeneratedValue.php
+++ b/lib/Doctrine/ORM/Mapping/GeneratedValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
+++ b/lib/Doctrine/ORM/Mapping/HasLifecycleCallbacks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Id.php
+++ b/lib/Doctrine/ORM/Mapping/Id.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Index.php
+++ b/lib/Doctrine/ORM/Mapping/Index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/InheritanceType.php
+++ b/lib/Doctrine/ORM/Mapping/InheritanceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/JoinColumn.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/JoinColumns.php
+++ b/lib/Doctrine/ORM/Mapping/JoinColumns.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/JoinTable.php
+++ b/lib/Doctrine/ORM/Mapping/JoinTable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/ManyToMany.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToMany.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
+++ b/lib/Doctrine/ORM/Mapping/MappedSuperclass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/MappingException.php
+++ b/lib/Doctrine/ORM/Mapping/MappingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQueries.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedNativeQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/NamedQueries.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQueries.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/NamedQuery.php
+++ b/lib/Doctrine/ORM/Mapping/NamedQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/NamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/NamingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/OneToMany.php
+++ b/lib/Doctrine/ORM/Mapping/OneToMany.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/OneToOne.php
+++ b/lib/Doctrine/ORM/Mapping/OneToOne.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/OrderBy.php
+++ b/lib/Doctrine/ORM/Mapping/OrderBy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PostLoad.php
+++ b/lib/Doctrine/ORM/Mapping/PostLoad.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PostPersist.php
+++ b/lib/Doctrine/ORM/Mapping/PostPersist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PostRemove.php
+++ b/lib/Doctrine/ORM/Mapping/PostRemove.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PostUpdate.php
+++ b/lib/Doctrine/ORM/Mapping/PostUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PreFlush.php
+++ b/lib/Doctrine/ORM/Mapping/PreFlush.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PrePersist.php
+++ b/lib/Doctrine/ORM/Mapping/PrePersist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PreRemove.php
+++ b/lib/Doctrine/ORM/Mapping/PreRemove.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/PreUpdate.php
+++ b/lib/Doctrine/ORM/Mapping/PreUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/QuoteStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
+++ b/lib/Doctrine/ORM/Mapping/Reflection/ReflectionPropertiesGetter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping\Reflection;
 
 use Doctrine\Persistence\Mapping\ReflectionService;

--- a/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
+++ b/lib/Doctrine/ORM/Mapping/ReflectionEmbeddedProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\Instantiator\Instantiator;

--- a/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Mapping/SequenceGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMapping.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
+++ b/lib/Doctrine/ORM/Mapping/SqlResultSetMappings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 /**

--- a/lib/Doctrine/ORM/Mapping/Table.php
+++ b/lib/Doctrine/ORM/Mapping/Table.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/UnderscoreNamingStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
+++ b/lib/Doctrine/ORM/Mapping/UniqueConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/Mapping/Version.php
+++ b/lib/Doctrine/ORM/Mapping/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use function array_values;

--- a/lib/Doctrine/ORM/NoResultException.php
+++ b/lib/Doctrine/ORM/NoResultException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 /**

--- a/lib/Doctrine/ORM/NonUniqueResultException.php
+++ b/lib/Doctrine/ORM/NonUniqueResultException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 /**

--- a/lib/Doctrine/ORM/ORMException.php
+++ b/lib/Doctrine/ORM/ORMException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache as CacheDriver;

--- a/lib/Doctrine/ORM/ORMInvalidArgumentException.php
+++ b/lib/Doctrine/ORM/ORMInvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/OptimisticLockException.php
+++ b/lib/Doctrine/ORM/OptimisticLockException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use DateTimeInterface;

--- a/lib/Doctrine/ORM/PersistentCollection.php
+++ b/lib/Doctrine/ORM/PersistentCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\AbstractLazyCollection;

--- a/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/AbstractCollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Persisters/Collection/CollectionPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/CollectionPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Collection;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Collection;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Collection;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/AbstractEntityInheritancePersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/CachedPersisterContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\ORM\Query\ResultSetMapping;

--- a/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/EntityPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;

--- a/lib/Doctrine/ORM/Persisters/MatchingAssociationFieldRequiresObject.php
+++ b/lib/Doctrine/ORM/Persisters/MatchingAssociationFieldRequiresObject.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters;
 
 use Doctrine\ORM\Exception\PersisterException;

--- a/lib/Doctrine/ORM/Persisters/PersisterException.php
+++ b/lib/Doctrine/ORM/Persisters/PersisterException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
+++ b/lib/Doctrine/ORM/Persisters/SqlValueVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Persisters;
 
 use Doctrine\Common\Collections\Expr\Comparison;

--- a/lib/Doctrine/ORM/PessimisticLockException.php
+++ b/lib/Doctrine/ORM/PessimisticLockException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Proxy/Autoloader.php
+++ b/lib/Doctrine/ORM/Proxy/Autoloader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Proxy;
 
 use Doctrine\Common\Proxy\Autoloader as BaseAutoloader;

--- a/lib/Doctrine/ORM/Proxy/Proxy.php
+++ b/lib/Doctrine/ORM/Proxy/Proxy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Proxy;
 
 use Doctrine\Common\Proxy\Proxy as BaseProxy;

--- a/lib/Doctrine/ORM/Proxy/ProxyFactory.php
+++ b/lib/Doctrine/ORM/Proxy/ProxyFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Proxy;
 
 use Closure;

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;

--- a/lib/Doctrine/ORM/Query/AST/ASTException.php
+++ b/lib/Doctrine/ORM/Query/AST/ASTException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;

--- a/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/AggregateExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/BetweenExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 class BetweenExpression extends Node

--- a/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CoalesceExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ComparisonExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalFactor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
+++ b/lib/Doctrine/ORM/Query/AST/ConditionalTerm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/DeleteClause.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/DeleteStatement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ExistsExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/FromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/FromClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/AvgFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\AggregateExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/BitAndFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/BitOrFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ConcatFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CountFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentDateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentDateFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\Lexer;

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimeFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\Lexer;

--- a/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimestampFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/CurrentTimestampFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\Lexer;

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateAddFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateDiffFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/DateSubFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\QueryException;

--- a/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\PathExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LengthFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LocateFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/LowerFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MaxFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\AggregateExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/MinFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\AggregateExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/ModFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SizeFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SqrtFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\SimpleArithmeticExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SubstringFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/SumFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\AggregateExpression;

--- a/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\DBAL\Platforms\TrimMode;

--- a/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
+++ b/lib/Doctrine/ORM/Query/AST/Functions/UpperFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST\Functions;
 
 use Doctrine\ORM\Query\AST\Node;

--- a/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/GroupByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/GroupByClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\Expr\GroupBy;

--- a/lib/Doctrine/ORM/Query/AST/HavingClause.php
+++ b/lib/Doctrine/ORM/Query/AST/HavingClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 class HavingClause extends Node

--- a/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/InExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/IndexBy.php
+++ b/lib/Doctrine/ORM/Query/AST/IndexBy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/InputParameter.php
+++ b/lib/Doctrine/ORM/Query/AST/InputParameter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\QueryException;

--- a/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/Join.php
+++ b/lib/Doctrine/ORM/Query/AST/Join.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/JoinVariableDeclaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/LikeExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/LikeExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/Literal.php
+++ b/lib/Doctrine/ORM/Query/AST/Literal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 class Literal extends Node

--- a/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NewObjectExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/Node.php
+++ b/lib/Doctrine/ORM/Query/AST/Node.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\ORM\Query\SqlWalker;

--- a/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/NullIfExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/OrderByClause.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/OrderByItem.php
+++ b/lib/Doctrine/ORM/Query/AST/OrderByItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use function strtoupper;

--- a/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/ParenthesisExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/PartialObjectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PartialObjectExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 class PartialObjectExpression extends Node

--- a/lib/Doctrine/ORM/Query/AST/PathExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/PathExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use function strtoupper;

--- a/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/RangeVariableDeclaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SelectStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/SelectStatement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/Subselect.php
+++ b/lib/Doctrine/ORM/Query/AST/Subselect.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectFromClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
+++ b/lib/Doctrine/ORM/Query/AST/SubselectIdentificationVariableDeclaration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/TypedExpression.php
+++ b/lib/Doctrine/ORM/Query/AST/TypedExpression.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Query/AST/UpdateClause.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/UpdateItem.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
+++ b/lib/Doctrine/ORM/Query/AST/UpdateStatement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/WhenClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhenClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/AST/WhereClause.php
+++ b/lib/Doctrine/ORM/Query/AST/WhereClause.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\AST;
 
 /**

--- a/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Cache\QueryCacheProfile;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableDeleteExecutor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/MultiTableUpdateExecutor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleSelectExecutor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
+++ b/lib/Doctrine/ORM/Query/Exec/SingleTableDeleteUpdateExecutor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Exec;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Query/Expr.php
+++ b/lib/Doctrine/ORM/Query/Expr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Traversable;

--- a/lib/Doctrine/ORM/Query/Expr/Andx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Andx.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 use InvalidArgumentException;

--- a/lib/Doctrine/ORM/Query/Expr/Comparison.php
+++ b/lib/Doctrine/ORM/Query/Expr/Comparison.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Composite.php
+++ b/lib/Doctrine/ORM/Query/Expr/Composite.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 use function implode;

--- a/lib/Doctrine/ORM/Query/Expr/From.php
+++ b/lib/Doctrine/ORM/Query/Expr/From.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Func.php
+++ b/lib/Doctrine/ORM/Query/Expr/Func.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 use function implode;

--- a/lib/Doctrine/ORM/Query/Expr/GroupBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/GroupBy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Join.php
+++ b/lib/Doctrine/ORM/Query/Expr/Join.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 use function strtoupper;

--- a/lib/Doctrine/ORM/Query/Expr/Literal.php
+++ b/lib/Doctrine/ORM/Query/Expr/Literal.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Math.php
+++ b/lib/Doctrine/ORM/Query/Expr/Math.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/OrderBy.php
+++ b/lib/Doctrine/ORM/Query/Expr/OrderBy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 use function count;

--- a/lib/Doctrine/ORM/Query/Expr/Orx.php
+++ b/lib/Doctrine/ORM/Query/Expr/Orx.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Expr/Select.php
+++ b/lib/Doctrine/ORM/Query/Expr/Select.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Expr;
 
 /**

--- a/lib/Doctrine/ORM/Query/Filter/FilterException.php
+++ b/lib/Doctrine/ORM/Query/Filter/FilterException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Filter;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query\Filter;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Query/FilterCollection.php
+++ b/lib/Doctrine/ORM/Query/FilterCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Configuration;

--- a/lib/Doctrine/ORM/Query/Lexer.php
+++ b/lib/Doctrine/ORM/Query/Lexer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Lexer\AbstractLexer;

--- a/lib/Doctrine/ORM/Query/Parameter.php
+++ b/lib/Doctrine/ORM/Query/Parameter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use function trim;

--- a/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
+++ b/lib/Doctrine/ORM/Query/ParameterTypeInferer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use DateInterval;

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Query/Parser.php
+++ b/lib/Doctrine/ORM/Query/Parser.php
@@ -2946,7 +2946,7 @@ class Parser
     /**
      * StringExpression ::= StringPrimary | ResultVariable | "(" Subselect ")"
      *
-     * @return Subselect|string
+     * @return Subselect|Node|string
      */
     public function StringExpression()
     {

--- a/lib/Doctrine/ORM/Query/ParserResult.php
+++ b/lib/Doctrine/ORM/Query/ParserResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;

--- a/lib/Doctrine/ORM/Query/Printer.php
+++ b/lib/Doctrine/ORM/Query/Printer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use function str_repeat;

--- a/lib/Doctrine/ORM/Query/QueryException.php
+++ b/lib/Doctrine/ORM/Query/QueryException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
+++ b/lib/Doctrine/ORM/Query/QueryExpressionVisitor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use function array_merge;

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use BadMethodCallException;

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -2117,7 +2117,7 @@ class SqlWalker implements TreeWalker
                 return $this->conn->quote($literal->value);
 
             case AST\Literal::BOOLEAN:
-                return $this->conn->getDatabasePlatform()->convertBooleans(strtolower($literal->value) === 'true');
+                return (string) $this->conn->getDatabasePlatform()->convertBooleans(strtolower($literal->value) === 'true');
 
             case AST\Literal::NUMERIC:
                 return (string) $literal->value;

--- a/lib/Doctrine/ORM/Query/TreeWalker.php
+++ b/lib/Doctrine/ORM/Query/TreeWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\AbstractQuery;

--- a/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerAdapter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\AbstractQuery;

--- a/lib/Doctrine/ORM/Query/TreeWalkerChain.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChain.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Query;
 
 use ArrayAccess;

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/DefaultRepositoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Repository/RepositoryFactory.php
+++ b/lib/Doctrine/ORM/Repository/RepositoryFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
+++ b/lib/Doctrine/ORM/Tools/AttachEntityListenersListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;

--- a/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/AbstractEntityManagerCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/CollectionRegionCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/EntityRegionCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/MetadataCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\Common\Cache\ApcCache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\Common\Cache\ApcCache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryRegionCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\ORM\Cache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\ClearCache;
 
 use Doctrine\Common\Cache\ApcCache;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\ConvertDoctrine1Schema;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;

--- a/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/EnsureProductionSettingsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Symfony\Component\Console\Input\InputInterface;

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateEntitiesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\Console\MetadataFilter;

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateProxiesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\Console\MetadataFilter;

--- a/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/GenerateRepositoriesCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\Console\MetadataFilter;

--- a/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/InfoCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Mapping\MappingException;

--- a/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/MappingDescribeCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/RunDqlCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\Common\Util\Debug;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/CreateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\SchemaTool;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\SchemaTool;

--- a/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/UpdateCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command\SchemaTool;
 
 use Doctrine\ORM\Tools\SchemaTool;

--- a/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ValidateSchemaCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Command;
 
 use Doctrine\ORM\Tools\SchemaValidator;

--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console;
 
 use Doctrine\DBAL\Tools\Console as DBALConsole;

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/ConnectionFromManagerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\EntityManagerProvider;
 
 use Doctrine\DBAL\Connection;

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/HelperSetManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/HelperSetManagerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\EntityManagerProvider;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/SingleManagerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\EntityManagerProvider;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/UnknownManagerException.php
+++ b/lib/Doctrine/ORM/Tools/Console/EntityManagerProvider/UnknownManagerException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\EntityManagerProvider;
 
 use OutOfBoundsException;

--- a/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
+++ b/lib/Doctrine/ORM/Tools/Console/Helper/EntityManagerHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console\Helper;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Console;
 
 use ArrayIterator;

--- a/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
+++ b/lib/Doctrine/ORM/Tools/ConvertDoctrine1Schema.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
+++ b/lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Tools/DisconnectedClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Tools/DisconnectedClassMetadataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Mapping\ClassMetadataFactory;

--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
+++ b/lib/Doctrine/ORM/Tools/Event/GenerateSchemaTableEventArgs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Event;
 
 use Doctrine\Common\EventArgs;

--- a/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/ClassMetadataExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AbstractExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\Deprecations\Deprecation;

--- a/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/AnnotationExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/PhpExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
@@ -154,7 +154,7 @@ class XmlExporter extends AbstractExporter
                 }
 
                 if (isset($field['length'])) {
-                    $idXml->addAttribute('length', $field['length']);
+                    $idXml->addAttribute('length', (string) $field['length']);
                 }
 
                 if (isset($field['associationKey']) && $field['associationKey']) {
@@ -186,11 +186,11 @@ class XmlExporter extends AbstractExporter
                 }
 
                 if (isset($field['precision'])) {
-                    $fieldXml->addAttribute('precision', $field['precision']);
+                    $fieldXml->addAttribute('precision', (string) $field['precision']);
                 }
 
                 if (isset($field['scale'])) {
-                    $fieldXml->addAttribute('scale', $field['scale']);
+                    $fieldXml->addAttribute('scale', (string) $field['scale']);
                 }
 
                 if (isset($field['unique']) && $field['unique']) {

--- a/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
+++ b/lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export\Driver;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;

--- a/lib/Doctrine/ORM/Tools/Export/ExportException.php
+++ b/lib/Doctrine/ORM/Tools/Export/ExportException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Export;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Query\AST\AggregateExpression;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use ArrayIterator;

--- a/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/RowNumberOverFunction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/WhereInWalker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
+++ b/lib/Doctrine/ORM/Tools/ResolveTargetEntityListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\EventSubscriber;

--- a/lib/Doctrine/ORM/Tools/SchemaTool.php
+++ b/lib/Doctrine/ORM/Tools/SchemaTool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\DBAL\Types\Type;

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\Cache\ApcuCache;

--- a/lib/Doctrine/ORM/Tools/ToolEvents.php
+++ b/lib/Doctrine/ORM/Tools/ToolEvents.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 class ToolEvents

--- a/lib/Doctrine/ORM/Tools/ToolsException.php
+++ b/lib/Doctrine/ORM/Tools/ToolsException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Tools;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/TransactionRequiredException.php
+++ b/lib/Doctrine/ORM/TransactionRequiredException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/UnexpectedResultException.php
+++ b/lib/Doctrine/ORM/UnexpectedResultException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use Doctrine\ORM\Exception\ORMException;

--- a/lib/Doctrine/ORM/UnitOfWork.php
+++ b/lib/Doctrine/ORM/UnitOfWork.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use DateTimeInterface;

--- a/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
+++ b/lib/Doctrine/ORM/Utility/HierarchyDiscriminatorResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Utility;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
+++ b/lib/Doctrine/ORM/Utility/IdentifierFlattener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Utility;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/lib/Doctrine/ORM/Utility/PersisterHelper.php
+++ b/lib/Doctrine/ORM/Utility/PersisterHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM\Utility;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/lib/Doctrine/ORM/Version.php
+++ b/lib/Doctrine/ORM/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\ORM;
 
 use function str_replace;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,7 +20,6 @@
     <exclude-pattern>*/tests/Doctrine/Tests/ORM/Tools/Export/export/*</exclude-pattern>
 
     <rule ref="Doctrine">
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2142,11 +2142,6 @@ parameters:
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method SimpleXMLElement\\:\\:addAttribute\\(\\) expects string, int given\\.$#"
-			count: 3
-			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 2
 			path: lib/Doctrine/ORM/Tools/Export/Driver/XmlExporter.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -490,7 +490,7 @@
       <code>getClassMetadata</code>
       <code>getReference</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="2">
+    <InvalidScalarArgument occurrences="1">
       <code>$hydrationMode</code>
       <code>$hydrationMode</code>
     </InvalidScalarArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1040,7 +1040,7 @@
       <code>$this-&gt;reflFields[$name]</code>
       <code>$this-&gt;reflFields[$this-&gt;identifier[0]]</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="10">
+    <PossiblyNullArgument occurrences="9">
       <code>$class</code>
       <code>$class</code>
       <code>$className</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2563,9 +2563,6 @@
       <code>call_user_func($functionClass, $functionName)</code>
       <code>call_user_func($functionClass, $functionName)</code>
     </DocblockTypeContradiction>
-    <ImplicitToStringCast occurrences="1">
-      <code>Subselect|string</code>
-    </ImplicitToStringCast>
     <InvalidArrayOffset occurrences="2">
       <code>$this-&gt;identVariableExpressions[$dqlAlias]</code>
       <code>$this-&gt;queryComponents[$dqlAlias]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -522,9 +522,8 @@
     <RedundantCondition occurrences="1">
       <code>is_object($connection)</code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>$this-&gt;filterCollection !== null</code>
-      <code>method_exists($this-&gt;metadataFactory, 'setCache')</code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType occurrences="2">
       <code>$connection instanceof Connection</code>
@@ -602,7 +601,7 @@
     </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/Id/AssignedGenerator.php">
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="1">
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
@@ -716,9 +715,6 @@
     <PossiblyNullArgument occurrences="1">
       <code>$objectClass</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$objectClass[key($objectClass)]</code>
-    </PossiblyNullArrayAccess>
     <PossiblyNullReference occurrences="6">
       <code>getValue</code>
       <code>getValue</code>
@@ -824,7 +820,7 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="1">
       <code>$class</code>
       <code>$class</code>
     </PossiblyNullArgument>
@@ -1044,7 +1040,7 @@
       <code>$this-&gt;reflFields[$name]</code>
       <code>$this-&gt;reflFields[$this-&gt;identifier[0]]</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="11">
+    <PossiblyNullArgument occurrences="10">
       <code>$class</code>
       <code>$class</code>
       <code>$className</code>
@@ -1782,7 +1778,7 @@
     <DeprecatedMethod occurrences="1">
       <code>fetchColumn</code>
     </DeprecatedMethod>
-    <PossiblyNullArgument occurrences="39">
+    <PossiblyNullArgument occurrences="38">
       <code>$association</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
@@ -2308,7 +2304,7 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/TrimFunction.php">
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="1">
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -2624,7 +2620,7 @@
       <code>$this-&gt;ConditionalExpression()</code>
       <code>$this-&gt;ConditionalExpression()</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArgument occurrences="27">
+    <PossiblyNullArgument occurrences="25">
       <code>$aliasIdentVariable</code>
       <code>$dql</code>
       <code>$dql</code>
@@ -3503,7 +3499,7 @@
     </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="2">
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
@@ -3621,7 +3617,7 @@
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;_outputDir</code>
       <code>$this-&gt;_outputDir</code>
     </PossiblyNullArgument>
@@ -3871,7 +3867,7 @@
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$this-&gt;identityMap[$rootClassName]</code>
     </PossiblyInvalidArrayOffset>
-    <PossiblyNullArgument occurrences="13">
+    <PossiblyNullArgument occurrences="11">
       <code>$assoc</code>
       <code>$assoc</code>
       <code>$assoc['targetEntity']</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3663,11 +3663,6 @@
     <DeprecatedClass occurrences="1">
       <code>AbstractExporter</code>
     </DeprecatedClass>
-    <InvalidScalarArgument occurrences="3">
-      <code>$field['length']</code>
-      <code>$field['precision']</code>
-      <code>$field['scale']</code>
-    </InvalidScalarArgument>
     <MissingClosureParamType occurrences="2">
       <code>$m1</code>
       <code>$m2</code>

--- a/tests/Doctrine/StaticAnalysis/Mapping/class-metadata-constructor.php
+++ b/tests/Doctrine/StaticAnalysis/Mapping/class-metadata-constructor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\StaticAnalysis\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\CMS;
 
 use Doctrine\ORM\Events;

--- a/tests/Doctrine/Tests/Models/Company/CompanyContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/Models/Company/CompanyContractListener.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyContractListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFixContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\Common\Collections\Collection;

--- a/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
+++ b/tests/Doctrine/Tests/Models/Company/CompanyFlexUltraContract.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\Company;
 
 use Doctrine\ORM\Events;

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869ChequePayment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869CreditCardPayment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
+++ b/tests/Doctrine/Tests/Models/DDC869/DDC869Payment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\DDC869;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889Entity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
+++ b/tests/Doctrine/Tests/Models/DDC889/DDC889SuperClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\Models\DDC889;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/FileLockRegionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Cache;
 
 use Doctrine\ORM\Cache\CacheKey;

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use DateTime;

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use DateTimeImmutable;

--- a/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryDqlFunctionTest.php
@@ -38,7 +38,7 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
         $salaryAvg = $this->_em->createQuery('SELECT AVG(m.salary) AS salary FROM Doctrine\Tests\Models\Company\CompanyManager m')
                                ->getSingleResult();
 
-        $this->assertEquals(375000, round($salaryAvg['salary'], 0));
+        $this->assertEquals(375000, round((float) $salaryAvg['salary'], 0));
     }
 
     public function testAggregateMin(): void
@@ -150,10 +150,10 @@ class QueryDqlFunctionTest extends OrmFunctionalTestCase
                          ->getArrayResult();
 
         $this->assertEquals(4, count($result));
-        $this->assertEquals(316, round($result[0]['sqrtsalary']));
-        $this->assertEquals(447, round($result[1]['sqrtsalary']));
-        $this->assertEquals(632, round($result[2]['sqrtsalary']));
-        $this->assertEquals(894, round($result[3]['sqrtsalary']));
+        $this->assertEquals(316, round((float) $result[0]['sqrtsalary']));
+        $this->assertEquals(447, round((float) $result[1]['sqrtsalary']));
+        $this->assertEquals(632, round((float) $result[2]['sqrtsalary']));
+        $this->assertEquals(894, round((float) $result[3]['sqrtsalary']));
     }
 
     public function testFunctionUpper(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Cache\ArrayCache;

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheAbstractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\ORM\Cache;

--- a/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SecondLevelCacheCompositePrimaryKeyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional;
 
 use DateTime;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5887Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6531Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6531Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/Symfony/AbstractDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Mapping\Symfony;
 
 use Doctrine\Persistence\Mapping\Driver\FileDriver;

--- a/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/YamlMappingDriverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests\ORM\Mapping;
 
 use Doctrine\ORM\Mapping\ClassMetadata;

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Doctrine\Tests;
 
 use Doctrine\Common\Cache\Cache;


### PR DESCRIPTION
#8836 was not enough to catch all the needed changes, I only fixed things I detected in my local setup, but there were more casts need with PHP 8. It also seems that Psalm and PHPStan detect more things in strict mode.

If you want me to split this into 2 PRs, let me know.

Closes #8819 

Note that I'm targeting 2.x here, let me explain why:
- I don't want too much divergence between both branches, especially when they touch that many files
- there is no BC break AFAIK: strict mode is about function we call, not about our public API (and yes, the AFAIK is important, but if there is one, we can fix it with a cast IMO)
- 3.x should be about removing deprecated stuff IMO: I think risky stuff that can be fixed quickly should be diluted in minors rather than piled up in 3.x, because having risky stuff always go to 3.x will make the migration to 3.0.0 very hard for everyone. In my vision, 3.0.0 should be very boring for somebody having addressed all deprecations, and not a big deal to upgrade to.