### PR TITLE
[CS] Clean elses

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -41,10 +41,10 @@ class IterableResult implements Iterator
     {
         if ($this->_rewinded === true) {
             throw new HydrationException('Can only iterate a Result once.');
-        } else {
-            $this->_current  = $this->next();
-            $this->_rewinded = true;
         }
+
+        $this->_current  = $this->next();
+        $this->_rewinded = true;
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -42,9 +42,9 @@ class StatementArrayMock extends StatementMock
         $row = reset($this->_result);
         if ($row) {
             return count($row);
-        } else {
-            return 0;
         }
+
+        return 0;
     }
 
     /**

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -809,11 +809,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
             $last25queries = array_slice(array_reverse($this->_sqlLoggerStack->queries, true), 0, 25, true);
             foreach ($last25queries as $i => $query) {
                 $params   = array_map(static function ($p) {
-                    if (is_object($p)) {
-                        return get_class($p);
-                    } else {
-                        return var_export($p, true);
-                    }
+                    return is_object($p) ? get_class($p) : var_export($p, true);
                 }, $query['params'] ?: []);
                 $queries .= $i . ". SQL: '" . $query['sql'] . "' Params: " . implode(', ', $params) . PHP_EOL;
             }


### PR DESCRIPTION
Backport of #6929

I checked with `php-cs-fixer fix tests --rules='no_useless_else'` that there was no additional useless `else`.