### PR TITLE
Adapt tests to new way of wrapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-pdo": "*",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.13",
-        "doctrine/cache": "^1.11.3 || ^2.0.3",
+        "doctrine/cache": "^1.12.1 || ^2.1.1",
         "doctrine/collections": "^1.5",
         "doctrine/common": "^3.0.3",
         "doctrine/dbal": "^2.13.0",

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -143,7 +143,7 @@ class SetupTest extends OrmTestCase
         $this->assertSame($cache, $config->getQueryCacheImpl());
 
         if (method_exists(Configuration::class, 'getMetadataCache')) {
-            $this->assertSame($adapter, $config->getMetadataCache());
+            $this->assertSame($adapter, $config->getMetadataCache()->getCache()->getPool());
         } else {
             $this->assertSame($cache, $config->getMetadataCacheImpl());
         }


### PR DESCRIPTION
Namespacing is configured here, which means since recent doctrine/cache releases
instead of just one layer, we have a PSR cache wrapped in a doctrine cache
with namespacing, itself wrapped again with a PSR cache.