### PR TITLE
Fixes #8857

### DIFF
--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -1207,6 +1207,13 @@ class SqlWalker implements TreeWalker
                     $conditions[] = '(' . $this->walkConditionalExpression($join->conditionalExpression) . ')';
                 }
 
+                // Apply the filters
+                $filterExpr = $this->generateFilterConditionSQL($class, $tableAlias);
+
+                if ($filterExpr) {
+                    $conditions[] = $filterExpr;
+                }
+
                 $isUnconditionalJoin = $conditions === [];
                 $condExprConjunction = $class->isInheritanceTypeJoined() && $joinType !== AST\Join::JOIN_TYPE_LEFT && $joinType !== AST\Join::JOIN_TYPE_LEFTOUTER && $isUnconditionalJoin
                     ? ' AND '
@@ -1219,13 +1226,6 @@ class SqlWalker implements TreeWalker
 
                 if ($discrSql) {
                     $conditions[] = $discrSql;
-                }
-
-                // Apply the filters
-                $filterExpr = $this->generateFilterConditionSQL($class, $tableAlias);
-
-                if ($filterExpr) {
-                    $conditions[] = $filterExpr;
                 }
 
                 if ($conditions) {


### PR DESCRIPTION
Now brackets are placed around the joined class hierarchy when using a filter without "with" condition on the join.
Fixes #8857