### PR TITLE
Fix loading metadata for cold reflection class

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -60,7 +60,11 @@ class AttributeDriver extends AnnotationDriver
         assert($metadata instanceof ClassMetadataInfo);
 
         $reflectionClass = $metadata->getReflectionClass();
-
+        
+        if ($reflectionClass === null) {
+            $reflectionClass = new ReflectionClass($className);
+        }
+        
         $classAttributes = $this->reader->getClassAnnotations($reflectionClass);
 
         // Evaluate Entity annotation


### PR DESCRIPTION
When using discriminator map attributes the reflection class can be null