### PR TITLE
Fix annotation for phpstan

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -304,7 +304,7 @@ interface EntityManagerInterface extends ObjectManager
     /**
      * {@inheritDoc}
      *
-     * @psalm-param string|class-string<T> $className
+     * @psalm-param class-string<T> $className
      *
      * @return Mapping\ClassMetadata
      * @psalm-return Mapping\ClassMetadata<T>

--- a/tests/Doctrine/StaticAnalysis/entity-manager-interface.php
+++ b/tests/Doctrine/StaticAnalysis/entity-manager-interface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\StaticAnalysis\Mapping;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+class EntityManagerInterfaceTest
+{
+    /**
+     * @return ClassMetadata<\DateTime>
+     */
+    public function testGetClassMetadata(EntityManagerInterface $entityManager): ClassMetadata
+    {
+        return $entityManager->getClassMetadata(\DateTime::class);
+    }
+}


### PR DESCRIPTION
Phpstan doesn't support string|class-string<T>
Since the string part will be deprecated, it's
better to keep the part with the template. There
is a test for this, but it only works when phpstan
will reach level 7.