### PR TITLE
Remove calls to prefersSequences()

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
+use BadMethodCallException;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
@@ -11,29 +13,30 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class DatabasePlatformMock extends AbstractPlatform
 {
-    /** @var string */
-    private $_sequenceNextValSql = '';
+    /** @var bool */
+    private $supportsIdentityColumns = true;
 
     /** @var bool */
-    private $_prefersIdentityColumns = true;
+    private $supportsSequences = false;
 
-    /** @var bool */
-    private $_prefersSequences = false;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function prefersIdentityColumns()
+    public function prefersIdentityColumns(): bool
     {
-        return $this->_prefersIdentityColumns;
+        throw new BadMethodCallException('Call to deprecated method.');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function prefersSequences()
+    public function supportsIdentityColumns(): bool
     {
-        return $this->_prefersSequences;
+        return $this->supportsIdentityColumns;
+    }
+
+    public function prefersSequences(): bool
+    {
+        throw new BadMethodCallException('Call to deprecated method.');
+    }
+
+    public function supportsSequences(): bool
+    {
+        return $this->supportsSequences;
     }
 
     /**
@@ -41,7 +44,7 @@ class DatabasePlatformMock extends AbstractPlatform
      */
     public function getSequenceNextValSQL($sequenceName)
     {
-        return $this->_sequenceNextValSql;
+        return '';
     }
 
     /**
@@ -95,19 +98,14 @@ class DatabasePlatformMock extends AbstractPlatform
 
     /* MOCK API */
 
-    public function setPrefersIdentityColumns(bool $bool): void
+    public function setSupportsIdentityColumns(bool $bool): void
     {
-        $this->_prefersIdentityColumns = $bool;
+        $this->supportsIdentityColumns = $bool;
     }
 
-    public function setPrefersSequences(bool $bool): void
+    public function setSupportsSequences(bool $bool): void
     {
-        $this->_prefersSequences = $bool;
-    }
-
-    public function setSequenceNextValSql(string $sql): void
-    {
-        $this->_sequenceNextValSql = $sql;
+        $this->supportsSequences = $bool;
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/ClassMetadataFactoryTest.php
@@ -59,8 +59,8 @@ class ClassMetadataFactoryTest extends OrmTestCase
 
         $conn         = $entityManager->getConnection();
         $mockPlatform = $conn->getDatabasePlatform();
-        $mockPlatform->setPrefersSequences(true);
-        $mockPlatform->setPrefersIdentityColumns(false);
+        $mockPlatform->setSupportsSequences(true);
+        $mockPlatform->setSupportsIdentityColumns(false);
 
         $cm1 = $this->createValidClassMetadata();
 


### PR DESCRIPTION
`AbstractPlatform::prefersSequences()` is deprecated and does not exist in DBAL 3. Let's not call it if it's not there.