### PR TITLE
Build with DBAL 3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,56 @@ env:
   fail-fast: true
 
 jobs:
+  phpunit-smoke-check-dbal-3:
+    name: "Experimental: PHPUnit with SQLite and DBAL 3"
+    runs-on: "ubuntu-20.04"
+    continue-on-error: true
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.0"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          extensions: "pdo, pdo_sqlite"
+          coverage: "pcov"
+          ini-values: "zend.assertions=1"
+
+      - name: "Require DBAL 3"
+        run: "composer require doctrine/dbal ^3.0 --no-update"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+
+      - name: "Run PHPUnit"
+        continue-on-error: true
+        run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml --coverage-clover=coverage-no-cache.xml"
+        env:
+            ENABLE_SECOND_LEVEL_CACHE: 0
+
+      - name: "Run PHPUnit with Second Level Cache"
+        id: "phpunit-run-slc"
+        continue-on-error: true
+        run: "vendor/bin/phpunit -c ci/github/phpunit/sqlite.xml --exclude-group performance,non-cacheable,locking_functional --coverage-clover=coverage-cache.xml"
+        env:
+            ENABLE_SECOND_LEVEL_CACHE: 1
+
+      - name: "Upload coverage file"
+        uses: "actions/upload-artifact@v2"
+        if: "steps.phpunit-run-slc.outcome == 'success' && steps.phpunit-run-slc.conclusion == 'success'"
+        with:
+          name: "phpunit-sqlite-${{ matrix.php-version }}-dbal3-coverage"
+          path: "coverage*.xml"
+
   phpunit-smoke-check:
     name: "PHPUnit with SQLite"
     runs-on: "ubuntu-20.04"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,11 +13,21 @@ jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
     runs-on: "ubuntu-20.04"
+    continue-on-error: "${{ matrix.status == 'experimental' }}"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "8.0"
+        dbal-version:
+          - "default"
+        status:
+          - "stable"
+        include:
+          - dbal-version: "^3.0"
+            php-version: "8.0"
+            status: "experimental"
 
     steps:
       - name: "Checkout code"
@@ -28,6 +38,10 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+
+      - name: "Require DBAL 3"
+        run: "composer require doctrine/dbal ${{ matrix.dbal-version }} --no-update"
+        if: "${{ matrix.dbal-version != 'default' }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
@@ -35,16 +49,27 @@ jobs:
           dependency-versions: "highest"
 
       - name: "Run a static analysis with phpstan/phpstan"
+        continue-on-error: "${{ matrix.status == 'experimental' }}"
         run: "vendor/bin/phpstan analyse"
 
   static-analysis-psalm:
     name: "Static Analysis with Psalm"
     runs-on: "ubuntu-20.04"
+    continue-on-error: "${{ matrix.status == 'experimental' }}"
 
     strategy:
+      fail-fast: false
       matrix:
         php-version:
           - "8.0"
+        dbal-version:
+          - "default"
+        status:
+          - "stable"
+        include:
+          - dbal-version: "^3.0"
+            php-version: "8.0"
+            status: "experimental"
 
     steps:
       - name: "Checkout code"
@@ -56,10 +81,15 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
+      - name: "Require DBAL 3"
+        run: "composer require doctrine/dbal ${{ matrix.dbal-version }} --no-update"
+        if: "${{ matrix.dbal-version != 'default' }}"
+
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "highest"
 
       - name: "Run a static analysis with vimeo/psalm"
+        continue-on-error: "${{ matrix.status == 'experimental' }}"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"


### PR DESCRIPTION
Please consider reviewing and merging https://github.com/doctrine/orm/pull/8872 first.

This is a work in progress, the plan as of now is to have 3 additional build jobs:
- 1 for phpstan
- 1 for Psalm
- 1 for Phpunit with SQLite

When those 3 are green, the next steps should be to run the PHPUnit jobs on more PHP versions (it only runs on 8.0 currently), and then to add more jobs depending on that job.

For static analysis, I used a variable, but for continuous integration, I don't think it's possible since it would make dependent jobs (about postgres, mysql, etc.) not run.

While I'm confident we will be able to fix the phpunit job, it might be more challenging to fix the Phpstan job without making the Phpstan job with DBAL 2 fail because it does not have the exact same baseline. We should not hesitate to remove it if that turns out to be the case IMO, but until then, it's good to have that information in the pipeline and ask the community for help in getting that DBAL 3 support :slightly_smiling_face: 