### PR TITLE
Fix getting-started example by including cache

### DIFF
--- a/docs/en/tutorials/getting-started.rst
+++ b/docs/en/tutorials/getting-started.rst
@@ -82,7 +82,8 @@ that directory with the following contents:
     {
         "require": {
             "doctrine/orm": "^2.6.2",
-            "symfony/yaml": "2.*"
+            "symfony/yaml": "2.*",
+            "symfony/cache": "^5.3"
         },
         "autoload": {
             "psr-0": {"": "src/"}


### PR DESCRIPTION
As per the discussion going on in #8809 , a cache is necessary for the example code to work.

Closes #8809