### PR TITLE
doctrine/dbal v3 - Make sure that values passed to are not null

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -762,7 +762,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $limit  = $criteria->getMaxResults();
         $offset = $criteria->getFirstResult();
         if ($limit !== null || $offset !== null) {
-            return $this->platform->modifyLimitQuery('', $limit, $offset);
+            return $this->platform->modifyLimitQuery('', $limit, $offset ?? 0);
         }
 
         return '';

--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1083,14 +1083,14 @@ class BasicEntityPersister implements EntityPersister
         $from   = ' FROM ' . $tableName . ' ' . $tableAlias;
         $join   = $this->currentPersisterContext->selectJoinSql . $joinSql;
         $where  = ($conditionSql ? ' WHERE ' . $conditionSql : '');
-        $lock   = $this->platform->appendLockHint($from, $lockMode);
+        $lock   = $this->platform->appendLockHint($from, $lockMode ?? LockMode::NONE);
         $query  = $select
             . $lock
             . $join
             . $where
             . $orderBySql;
 
-        return $this->platform->modifyLimitQuery($query, $limit, $offset) . $lockSql;
+        return $this->platform->modifyLimitQuery($query, $limit, $offset ?? 0) . $lockSql;
     }
 
     /**
@@ -1548,7 +1548,7 @@ class BasicEntityPersister implements EntityPersister
             'FROM '
             . $this->quoteStrategy->getTableName($this->class, $this->platform) . ' '
             . $this->getSQLTableAlias($this->class->name),
-            $lockMode
+            $lockMode ?? LockMode::NONE
         );
     }
 

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -332,7 +332,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
         $from       = ' FROM ' . $tableName . ' ' . $baseTableAlias;
         $where      = $conditionSql !== '' ? ' WHERE ' . $conditionSql : '';
-        $lock       = $this->platform->appendLockHint($from, $lockMode);
+        $lock       = $this->platform->appendLockHint($from, $lockMode ?? LockMode::NONE);
         $columnList = $this->getSelectColumnsSQL();
         $query      = 'SELECT ' . $columnList
                     . $lock
@@ -340,7 +340,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     . $where
                     . $orderBySql;
 
-        return $this->platform->modifyLimitQuery($query, $limit, $offset) . $lockSql;
+        return $this->platform->modifyLimitQuery($query, $limit, $offset ?? 0) . $lockSql;
     }
 
     /**

--- a/lib/Doctrine/ORM/Query/SqlWalker.php
+++ b/lib/Doctrine/ORM/Query/SqlWalker.php
@@ -551,7 +551,7 @@ class SqlWalker implements TreeWalker
         }
 
         if ($limit !== null || $offset !== null) {
-            $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset);
+            $sql = $this->platform->modifyLimitQuery($sql, $limit, $offset ?? 0);
         }
 
         if ($lockMode === null || $lockMode === false || $lockMode === LockMode::NONE) {


### PR DESCRIPTION
Hello! My first PR here. 
Partially fixes #8884 - 7 out of 117 issues. 

Let's start from fixing 2 types of issues:
```
[0;31mERROR[0m: PossiblyNullArgument - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:765:66 - Argument 3 of Doctrine\DBAL\Platforms\AbstractPlatform::modifyLimitQuery cannot be null, possibly null value provided (see https://psalm.dev/078)
            return $this->platform->modifyLimitQuery('', $limit, [97;41m$offset[0m);

[0;31mERROR[0m: PossiblyNullArgument - lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php:335:62 - Argument 2 of Doctrine\DBAL\Platforms\AbstractPlatform::appendLockHint cannot be null, possibly null value provided (see https://psalm.dev/078)
        $lock       = $this->platform->appendLockHint($from, [97;41m$lockMode[0m);
```
The first issue is simpler - `modifyLimitQuery` has default `$offset` value set to `0` - so let's pass it instead of `null`. 
For `AbstractPlatform::appendLockHint` there is no default value, so passing `LockMode::NONE` seems to be the best choice - it would not affect any known implementation. 

