### PR TITLE
Platform param in the connection params results in not evicting cache entries

### DIFF
--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -132,6 +132,7 @@ abstract class OrmTestCase extends DoctrineTestCase
                 'wrapperClass' => Mocks\ConnectionMock::class,
                 'user'         => 'john',
                 'password'     => 'wayne',
+                'platform'     => new Mocks\DatabasePlatformMock(),
             ];
         }
 


### PR DESCRIPTION
The Query code tries to repeat the logic of the creation of query result cache keys, therefore it depends on that logic.
This leads to the bug presented in the PR, namely:

Doctrine\DBAL\Connection::executeCacheQuery() unsets the platform param before it creates the query result cache key:
```php
$connectionParams = $this->params;
unset($connectionParams['platform']);

[$cacheKey, $realKey] = $qcp->generateCacheKeys($sql, $params, $types, $connectionParams);
```
However, Doctrine\ORM\Query::evictResultSetCache() doesn't unset the platform param when creating the query result cache key.
Therefore, when the platform param is present, the cached results are not being evicted from the cache and the Doctrine\Test\ORM\Query\QueryTest::testResultCacheEviction() test fails as the old result is still retrieved from the cache. 

As an ad hoc solution we could unset the platform param as in Doctrine\DBAL\Connection::executeCacheQuery(), but it doesn't solve the architectural issue which results from breaking the Single Responsibility Principle and coupling the two modules. 
Should the query result cache in that form exist at all? Shouldn't it be like in Hibernate where the query result cache is connected with the second level cache? Actually, what is called "query result caching" in Hibernated is already implemented in Doctrine (it is query caching in second level caching).    