### PR TITLE
Fix return types for PHP 8.1

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/IterableResult.php
@@ -21,6 +21,7 @@
 namespace Doctrine\ORM\Internal\Hydration;
 
 use Iterator;
+use ReturnTypeWillChange;
 
 /**
  * Represents a result structure that can be iterated over, hydrating row-by-row
@@ -55,6 +56,7 @@ class IterableResult implements Iterator
      *
      * @throws HydrationException
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->_rewinded === true) {
@@ -70,6 +72,7 @@ class IterableResult implements Iterator
      *
      * @return mixed[]|false
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         $this->_current = $this->_hydrator->hydrateRow();
@@ -81,6 +84,7 @@ class IterableResult implements Iterator
     /**
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->_current;
@@ -89,6 +93,7 @@ class IterableResult implements Iterator
     /**
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->_key;
@@ -97,6 +102,7 @@ class IterableResult implements Iterator
     /**
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return $this->_current !== false;

--- a/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
+++ b/lib/Doctrine/ORM/Query/TreeWalkerChainIterator.php
@@ -23,6 +23,7 @@ namespace Doctrine\ORM\Query;
 use ArrayAccess;
 use Doctrine\ORM\AbstractQuery;
 use Iterator;
+use ReturnTypeWillChange;
 
 use function key;
 use function next;
@@ -58,6 +59,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
      * @return string|false
      * @psalm-return class-string<TreeWalker>|false
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset($this->walkers);
@@ -66,6 +68,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * @return TreeWalker|null
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->offsetGet(key($this->walkers));
@@ -74,6 +77,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key($this->walkers);
@@ -82,6 +86,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * @return TreeWalker|null
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         next($this->walkers);
@@ -92,6 +97,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return key($this->walkers) !== null;
@@ -100,6 +106,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->walkers[$offset]);
@@ -111,6 +118,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
      *
      * @return TreeWalker|null
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -130,6 +138,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
      * @param string $value
      * @psalm-param array-key|null $offset
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
@@ -142,6 +151,7 @@ class TreeWalkerChainIterator implements Iterator, ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if ($this->offsetExists($offset)) {

--- a/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
+++ b/lib/Doctrine/ORM/Tools/Console/MetadataFilter.php
@@ -24,6 +24,7 @@ use ArrayIterator;
 use Countable;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use FilterIterator;
+use ReturnTypeWillChange;
 use RuntimeException;
 
 use function assert;
@@ -70,6 +71,7 @@ class MetadataFilter extends FilterIterator implements Countable
     /**
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function accept()
     {
         if (count($this->filter) === 0) {
@@ -99,6 +101,7 @@ class MetadataFilter extends FilterIterator implements Countable
     /**
      * @return ArrayIterator<int, ClassMetadata>
      */
+    #[ReturnTypeWillChange]
     public function getInnerIterator()
     {
         $innerIterator = parent::getInnerIterator();
@@ -111,6 +114,7 @@ class MetadataFilter extends FilterIterator implements Countable
     /**
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->getInnerIterator());

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -30,6 +30,7 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\ORM\QueryBuilder;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function array_map;
@@ -117,6 +118,7 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         if ($this->count === null) {
@@ -135,6 +137,7 @@ class Paginator implements Countable, IteratorAggregate
      *
      * @psalm-return ArrayIterator<array-key, T>
      */
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         $offset = $this->query->getFirstResult();

--- a/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
+++ b/tests/Doctrine/Tests/Mocks/HydratorMockStatement.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
+use ArrayIterator;
 use Doctrine\DBAL\Driver\Statement;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 use function array_shift;
 use function current;
@@ -127,12 +129,9 @@ class HydratorMockStatement implements IteratorAggregate, Statement
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
-        return $this->_resultSet;
+        return new ArrayIterator($this->_resultSet);
     }
 
     /**

--- a/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementArrayMock.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Mocks;
 
 use ArrayIterator;
 use PDO;
+use Traversable;
 
 use function count;
 use function current;
@@ -32,7 +33,7 @@ class StatementArrayMock extends StatementMock
     /**
      * @psalm-return ArrayIterator<int, mixed>
      */
-    public function getIterator(): ArrayIterator
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->_result);
     }

--- a/tests/Doctrine/Tests/Mocks/StatementMock.php
+++ b/tests/Doctrine/Tests/Mocks/StatementMock.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Mocks;
 
 use Doctrine\DBAL\Driver\Statement;
+use EmptyIterator;
 use IteratorAggregate;
 use PDO;
+use Traversable;
 
 /**
  * This class is a mock of the Statement interface.
@@ -97,10 +99,8 @@ class StatementMock implements IteratorAggregate, Statement
     {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
+        return new EmptyIterator();
     }
 }

--- a/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsGroup.php
@@ -66,9 +66,9 @@ class CmsGroup implements IteratorAggregate
     }
 
     /**
-     * @return ArrayCollection|Traversable
+     * @return Collection<int, CmsUser>
      */
-    public function getIterator()
+    public function getIterator(): Collection
     {
         return $this->getUsers();
     }


### PR DESCRIPTION
This PR adds a `ReturnTypeWillChange` to iplementations of various core interfaces to indicate that we intend to add a return type declaration one fine day. This way, we avoid a deprecation warning in PHP 8.1.