### PR TITLE
Implement __serialize() and __unserialize()

### DIFF
--- a/lib/Doctrine/ORM/Id/SequenceGenerator.php
+++ b/lib/Doctrine/ORM/Id/SequenceGenerator.php
@@ -103,27 +103,43 @@ class SequenceGenerator extends AbstractIdGenerator implements Serializable
 
     /**
      * @return string
+     *
+     * @final
      */
     public function serialize()
     {
-        return serialize(
-            [
-                'allocationSize' => $this->_allocationSize,
-                'sequenceName'   => $this->_sequenceName,
-            ]
-        );
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            'allocationSize' => $this->_allocationSize,
+            'sequenceName' => $this->_sequenceName,
+        ];
     }
 
     /**
      * @param string $serialized
      *
      * @return void
+     *
+     * @final
      */
     public function unserialize($serialized)
     {
-        $array = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
 
-        $this->_sequenceName   = $array['sequenceName'];
-        $this->_allocationSize = $array['allocationSize'];
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->_sequenceName   = $data['sequenceName'];
+        $this->_allocationSize = $data['allocationSize'];
     }
 }


### PR DESCRIPTION
The `Serializable` interface is deprecated in favor of the magic methods `__serialize()` and `__unserialize()`. PHP 8.1 will trigger a deprecation warning if a class implements `Serializable` but not those two magic methods.

This PR addresses this issue by adding `__serialize()` and `__unserialize()` to the `SequenceGenerator` class.

This does however change the serialized string on PHP 7.4 and above. I don't know if that is a problem.