### PR TITLE
Redeclare `$_attributes` property in `Configuration` class.

### DIFF
--- a/lib/Doctrine/ORM/Configuration.php
+++ b/lib/Doctrine/ORM/Configuration.php
@@ -54,6 +54,9 @@ use function trim;
  */
 class Configuration extends \Doctrine\DBAL\Configuration
 {
+    /** @var mixed[] */
+    protected $_attributes = [];
+
     /**
      * Sets the directory where Doctrine generates any necessary proxy class files.
      *

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -232,6 +232,7 @@
 
     <rule ref="Squiz.NamingConventions.ValidVariableName.PublicHasUnderscore">
         <exclude-pattern>lib/Doctrine/ORM/AbstractQuery.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/ORM/Configuration.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/EntityRepository.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php</exclude-pattern>


### PR DESCRIPTION
Hello. 

doctrine/dbal:3.x removed `$_attributes` property in a `Configuration` class that we are extending in: https://github.com/doctrine/dbal/commit/5d03f6e443e8d444bf9917ca44b1b553ecaa4896

Lets redeclare it to keep backward compatibility and fix 65 of ot 110 following Psalm errors. 
```
[0;31mERROR[0m: UndefinedThisPropertyFetch - lib/Doctrine/ORM/Configuration.php:66:9 - Instance property Doctrine\ORM\Configuration::$_attributes is not defined (see https://psalm.dev/041)
        [97;41m$this->_attributes[0m['proxyDir'] = $dir;


[0;31mERROR[0m: UndefinedThisPropertyAssignment - lib/Doctrine/ORM/Configuration.php:66:9 - Instance property Doctrine\ORM\Configuration::$_attributes is not defined (see https://psalm.dev/040)
        [97;41m$this->_attributes[0m['proxyDir'] = $dir;
```
As a next step - I think we should deprecate usage of this property 2.10 and start using separate properties in 3.x similar to doctrine/dbal. 