### PR TITLE
Throw exception NotSupported Exception for `UuidGenerator` with doctr…

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -51,6 +51,12 @@ jobs:
       - name: "Run a static analysis with phpstan/phpstan"
         continue-on-error: "${{ matrix.status == 'experimental' }}"
         run: "vendor/bin/phpstan analyse"
+        if: "${{ matrix.dbal-version == 'default' }}"
+
+      - name: "Run a static analysis with phpstan/phpstan"
+        continue-on-error: "${{ matrix.status == 'experimental' }}"
+        run: "vendor/bin/phpstan analyse -c phpstan-dbal3.neon"
+        if: "${{ matrix.dbal-version != 'default' }}"
 
   static-analysis-psalm:
     name: "Static Analysis with Psalm"

--- a/lib/Doctrine/ORM/Exception/NotSupported.php
+++ b/lib/Doctrine/ORM/Exception/NotSupported.php
@@ -10,4 +10,9 @@ final class NotSupported extends ORMException
     {
         return new self('This behaviour is (currently) not supported by Doctrine 2');
     }
+
+    public static function createForDbal3(): self
+    {
+        return new self('Feature was deprecated in doctrine/dbal 2.x and is not supported by installed doctrine/dbal:3.x, please see the doctrine/deprecations logs for new alternative approaches.');
+    }
 }

--- a/lib/Doctrine/ORM/Id/UuidGenerator.php
+++ b/lib/Doctrine/ORM/Id/UuidGenerator.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Id;
 
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Exception\NotSupported;
+
+use function method_exists;
 
 /**
  * Represents an ID generator that uses the database UUID expression
@@ -22,10 +26,16 @@ class UuidGenerator extends AbstractIdGenerator
             '%s is deprecated with no replacement, use an application-side generator instead',
             self::class
         );
+
+        if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+            throw NotSupported::createForDbal3();
+        }
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @throws NotSupported
      */
     public function generate(EntityManager $em, $entity)
     {

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -1,0 +1,8 @@
+includes:
+    - phpstan-baseline.neon
+    - phpstan-params.neon
+
+parameters:
+    ignoreErrors:
+        # deprecations from doctrine/dbal:3.x
+        - '/^Call to an undefined method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getGuidExpression\(\).$/'

--- a/phpstan-params.neon
+++ b/phpstan-params.neon
@@ -1,0 +1,14 @@
+parameters:
+    level: 5
+    paths:
+        - lib
+        - tests/Doctrine/StaticAnalysis
+    excludePaths:
+        - lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
+    earlyTerminatingMethodCalls:
+        Doctrine\ORM\Query\Parser:
+            - syntaxError
+    phpVersion: 70100
+    ignoreErrors:
+        # The class was added in PHP 8.1
+        - '/^Attribute class ReturnTypeWillChange does not exist.$/'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,21 +1,8 @@
 includes:
     - phpstan-baseline.neon
+    - phpstan-params.neon
 
 parameters:
-    level: 5
-    paths:
-        - lib
-        - tests/Doctrine/StaticAnalysis
-    excludePaths:
-        - lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php
-    earlyTerminatingMethodCalls:
-        Doctrine\ORM\Query\Parser:
-            - syntaxError
-    phpVersion: 70100
-
     ignoreErrors:
-        # The class was added in PHP 8.1
-        - '/^Attribute class ReturnTypeWillChange does not exist.$/'
-
         # https://github.com/doctrine/collections/pull/282
         - '/Variable \$offset in isset\(\) always exists and is not nullable\./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,5 +47,11 @@
                 <referencedClass name="Doctrine\Common\Cache\XcacheCache"/>
             </errorLevel>
         </UndefinedClass>
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/doctrine/orm/issues/8884 -->
+                <referencedMethod name="Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression"/>
+            </errorLevel>
+        </UndefinedMethod>
     </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
+use function method_exists;
 use function strlen;
 
 /**
@@ -22,6 +26,10 @@ class UUIDGeneratorTest extends OrmFunctionalTestCase
 
     public function testItIsDeprecated(): void
     {
+        if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+            self::markTestSkipped('Test valid for doctrine/dbal:2.x only.');
+        }
+
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/7312');
         $this->_em->getClassMetadata(UUIDEntity::class);
     }
@@ -32,6 +40,10 @@ class UUIDGeneratorTest extends OrmFunctionalTestCase
             self::markTestSkipped('Currently restricted to MySQL platform.');
         }
 
+        if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+            self::markTestSkipped('Test valid for doctrine/dbal:2.x only.');
+        }
+
         $this->_schemaTool->createSchema([
             $this->_em->getClassMetadata(UUIDEntity::class),
         ]);
@@ -40,6 +52,16 @@ class UUIDGeneratorTest extends OrmFunctionalTestCase
         $this->_em->persist($entity);
         self::assertNotNull($entity->getId());
         self::assertGreaterThan(0, strlen($entity->getId()));
+    }
+
+    public function testItCannotBeInitialised(): void
+    {
+        if (method_exists(AbstractPlatform::class, 'getGuidExpression')) {
+            self::markTestSkipped('Test valid for doctrine/dbal:3.x only.');
+        }
+
+        $this->expectException(NotSupported::class);
+        $this->_em->getClassMetadata(UUIDEntity::class);
     }
 }
 


### PR DESCRIPTION
Let's fix another issue:
```
[0;31mERROR[0m: UndefinedMethod - lib/Doctrine/ORM/Id/UuidGenerator.php:33:59 - Method Doctrine\DBAL\Platforms\AbstractPlatform::getGuidExpression does not exist (see https://psalm.dev/022)
        $sql  = 'SELECT ' . $conn->getDatabasePlatform()->[97;41mgetGuidExpression[0m();
```
Method has been removed with https://github.com/doctrine/dbal/pull/3211. 
Lets throw exception if method do not exists. Generator itself is already deprecated. 

Questions:
1. May it would be better to throw it in constructor?
2. What about unit tests? Should we cover also this case? 

It looks like there will be few similar issues, so let's start from this one to create a template for the next PRs :) 