### PR TITLE
SchemaValidator: Fix mapped superclass missing in discriminator map

### DIFF
--- a/lib/Doctrine/ORM/Tools/SchemaValidator.php
+++ b/lib/Doctrine/ORM/Tools/SchemaValidator.php
@@ -255,7 +255,7 @@ class SchemaValidator
             }
         }
 
-        if (! $class->isInheritanceTypeNone() && ! $class->isRootEntity() && array_search($class->name, $class->discriminatorMap) === false) {
+        if (! $class->isInheritanceTypeNone() && ! $class->isRootEntity() && ! $class->isMappedSuperclass && array_search($class->name, $class->discriminatorMap) === false) {
             $ce[] = "Entity class '" . $class->name . "' is part of inheritance hierarchy, but is " .
                 "not mapped in the root entity '" . $class->rootEntityName . "' discriminator map. " .
                 'All subclasses must be listed in the discriminator map.';

--- a/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SchemaValidatorTest.php
@@ -199,6 +199,46 @@ class SchemaValidatorTest extends OrmTestCase
             $ce
         );
     }
+
+    /**
+     * @group 8771
+     */
+    public function testMappedSuperclassNotPresentInDiscriminator(): void
+    {
+        $class1 = $this->em->getClassMetadata(MappedSuperclass::class);
+        $ce     = $this->validator->validateClass($class1);
+
+        $this->assertEquals([], $ce);
+    }
+}
+
+/**
+ * @MappedSuperClass
+ */
+abstract class MappedSuperclass extends ParentEntity
+{
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorMap({"child" = ChildEntity::class})
+ */
+abstract class ParentEntity
+{
+    /**
+     * @var mixed
+     * @Id
+     * @Column
+     */
+    protected $key;
+}
+
+/**
+ * @Entity
+ */
+class ChildEntity extends MappedSuperclass
+{
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/doctrine/orm/issues/8771

I'm not sure if it's actually valid case for a MappedSuperclass to be a part of the DiscriminatorMap. 

It looks like the discussion continues in https://github.com/doctrine/orm/pull/8415, https://github.com/doctrine/orm/pull/7825.

This is a fix for the current behaviour so that it does not block people from upgrading to ORM 2.9