### PR TITLE
Mute psalm Undefined Class errors for classes that has been removed i…

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Collection;
 use BadMethodCallException;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Persisters\SqlValueVisitor;
@@ -756,6 +757,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
     /**
      * @throws DBALException
+     * @throws Exception
      */
     private function getLimitSql(Criteria $criteria): string
     {

--- a/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Collection;
 use BadMethodCallException;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Utility\PersisterHelper;
@@ -165,6 +166,7 @@ class OneToManyPersister extends AbstractCollectionPersister
 
     /**
      * @throws DBALException
+     * @throws Exception
      */
     private function deleteEntityCollection(PersistentCollection $collection): int
     {
@@ -193,6 +195,7 @@ class OneToManyPersister extends AbstractCollectionPersister
      * Thanks Steve Ebersole (Hibernate) for idea on how to tackle reliably this scenario, we owe him a beer! =)
      *
      * @throws DBALException
+     * @throws Exception
      */
     private function deleteJoinedEntityCollection(PersistentCollection $collection): int
     {

--- a/psalm.xml
+++ b/psalm.xml
@@ -45,7 +45,17 @@
                 <referencedClass name="Doctrine\Common\Cache\ApcCache"/>
                 <referencedClass name="Doctrine\Common\Cache\ArrayCache"/>
                 <referencedClass name="Doctrine\Common\Cache\XcacheCache"/>
+                <referencedClass name="Doctrine\DBAL\Driver\ResultStatement"/>
+                <referencedClass name="Doctrine\DBAL\ForwardCompatibility\Result"/>
+                <referencedClass name="Doctrine\DBAL\Exception"/>
+                <referencedClass name="Doctrine\DBAL\DBALException"/>
+                <referencedClass name="Doctrine\DBAL\Platforms\PostgreSqlPlatform"/>
             </errorLevel>
         </UndefinedClass>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="Doctrine\DBAL\Connection::getSchemaManager"/>
+            </errorLevel>
+        </DeprecatedMethod>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Mute following psalm errors:
```
ERROR: UndefinedDocblockClass - lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php:110:15 - Docblock-defined class or interface Doctrine\DBAL\Driver\ResultStatement does not exist (see https://psalm.dev/200)
     * @param Result|ResultStatement $stmt

ERROR: UndefinedDocblockClass - lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php:758:16 - Docblock-defined class or interface Doctrine\DBAL\DBALException does not exist (see https://psalm.dev/200)
     * @throws DBALException

ERROR: DeprecatedMethod - lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php:90:39 - The method Doctrine\DBAL\Connection::getSchemaManager has been marked as deprecated (see https://psalm.dev/001)
                $em->getConnection()->getSchemaManager()

ERROR: UndefinedClass - lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php:118:43 - Class or interface Doctrine\DBAL\Platforms\PostgreSqlPlatform does not exist (see https://psalm.dev/019)
        return $this->platform instanceof PostgreSqlPlatform
```

Added @throws annotation with exception class that replaced DBALException. 