### PR TITLE
Address Type deprecation messages

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM\Tools;
 
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Deprecations\Deprecation;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
@@ -189,24 +190,24 @@ class EntityGenerator
     /**
      * Hash-map for handle types.
      *
-     * @psalm-var array<Type::*, string>
+     * @psalm-var array<Types::*|Type::*, string>
      */
     protected $typeAlias = [
-        Type::DATETIMETZ    => '\DateTime',
-        Type::DATETIME      => '\DateTime',
-        Type::DATE          => '\DateTime',
-        Type::TIME          => '\DateTime',
-        Type::OBJECT        => '\stdClass',
-        Type::INTEGER       => 'int',
-        Type::BIGINT        => 'int',
-        Type::SMALLINT      => 'int',
-        Type::TEXT          => 'string',
-        Type::BLOB          => 'string',
-        Type::DECIMAL       => 'string',
-        Type::GUID          => 'string',
-        Type::JSON_ARRAY    => 'array',
-        Type::SIMPLE_ARRAY  => 'array',
-        Type::BOOLEAN       => 'bool',
+        Types::DATETIMETZ_MUTABLE => '\DateTime',
+        Types::DATETIME_MUTABLE   => '\DateTime',
+        Types::DATE_MUTABLE       => '\DateTime',
+        Types::TIME_MUTABLE       => '\DateTime',
+        Types::OBJECT             => '\stdClass',
+        Types::INTEGER            => 'int',
+        Types::BIGINT             => 'int',
+        Types::SMALLINT           => 'int',
+        Types::TEXT               => 'string',
+        Types::BLOB               => 'string',
+        Types::DECIMAL            => 'string',
+        Types::GUID               => 'string',
+        Type::JSON_ARRAY          => 'array',
+        Types::SIMPLE_ARRAY       => 'array',
+        Types::BOOLEAN            => 'bool',
     ];
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC425Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use DateTime;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -32,7 +32,7 @@ class DDC425Test extends OrmFunctionalTestCase
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(new \Doctrine\DBAL\Logging\EchoSQLLogger);
 
         $num = $this->_em->createQuery('DELETE ' . __NAMESPACE__ . '\DDC425Entity e WHERE e.someDatetimeField > ?1')
-                ->setParameter(1, new DateTime(), Type::DATETIME)
+                ->setParameter(1, new DateTime(), Types::DATETIME_MUTABLE)
                 ->getResult();
         self::assertEquals(0, $num);
     }

--- a/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/ParameterTypeInfererTest.php
@@ -9,7 +9,7 @@ use DateTime;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\Tests\OrmTestCase;
 
@@ -19,17 +19,17 @@ class ParameterTypeInfererTest extends OrmTestCase
     public function providerParameterTypeInferer(): array
     {
         return [
-            [1,                 Type::INTEGER],
+            [1,                 Types::INTEGER],
             ['bar',             ParameterType::STRING],
             ['1',               ParameterType::STRING],
-            [new DateTime(),     Type::DATETIME],
-            [new DateTimeImmutable(), Type::DATETIME_IMMUTABLE],
-            [new DateInterval('P1D'), Type::DATEINTERVAL],
+            [new DateTime(),     Types::DATETIME_MUTABLE],
+            [new DateTimeImmutable(), Types::DATETIME_IMMUTABLE],
+            [new DateInterval('P1D'), Types::DATEINTERVAL],
             [[2],          Connection::PARAM_INT_ARRAY],
             [['foo'],      Connection::PARAM_STR_ARRAY],
             [['1','2'],    Connection::PARAM_STR_ARRAY],
             [[],           Connection::PARAM_STR_ARRAY],
-            [true,              Type::BOOLEAN],
+            [true,              Types::BOOLEAN],
         ];
     }
 


### PR DESCRIPTION
This makes us more compatible with DBAL v3.
We didn't address `Type::JSON_ARRAY` because it has been removed

Refs #8884, #8885