### PR TITLE
Check current class' discriminator map

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -285,7 +285,10 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
                 }
             } else {
                 assert($parent instanceof ClassMetadataInfo); // https://github.com/doctrine/orm/issues/8746
-                if ((! $class->reflClass || ! $class->reflClass->isAbstract()) && ! in_array($class->name, $parent->discriminatorMap)) {
+                if (
+                    (! $class->reflClass || ! $class->reflClass->isAbstract())
+                    && ! in_array($class->name, $class->discriminatorMap)
+                ) {
                     throw MappingException::mappedClassNotPartOfDiscriminatorMap($class->name, $class->rootEntityName);
                 }
             }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8914Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8914Test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional\Ticket;
+
+use Doctrine\Tests\OrmTestCase;
+
+use function assert;
+use function count;
+
+final class GH8914Test extends OrmTestCase
+{
+    /**
+     * @group GH-8914
+     * @doesNotPerformAssertions
+     */
+    public function testDiscriminatorMapWithSeveralLevelsIsSupported(): void
+    {
+        $entityManager = $this->getTestEntityManager();
+        $entityManager->getClassMetadata(GH8914Person::class);
+    }
+}
+
+/**
+ * @MappedSuperclass
+ */
+abstract class GH8914BaseEntity
+{
+}
+
+/**
+ * @Entity
+ * @InheritanceType("SINGLE_TABLE")
+ * @DiscriminatorColumn(name="discr", type="string")
+ * @DiscriminatorMap({"person" = "GH8914Person", "employee" = "GH8914Employee"})
+ */
+class GH8914Person extends GH8914BaseEntity
+{
+    /**
+     * @var int
+     * @Id
+     * @Column(type="integer")
+     * @GeneratedValue
+     */
+    public $id;
+}
+
+/**
+ * @Entity
+ */
+class GH8914Employee extends GH8914Person
+{
+}


### PR DESCRIPTION
A class can be in its own discriminator map, as described in documentation example at
https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/inheritance-mapping.html#single-table-

Fixes #8914

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/doctrine-orm
composer require doctrine/orm "dev-failing-test-8914 as 2.9.4"
```
