### PR TITLE
Assert action is not null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "squizlabs/php_codesniffer": "3.6.0",
         "symfony/cache": "^4.4 || ^5.2",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "vimeo/psalm": "4.7.0"
+        "vimeo/psalm": "4.9.2"
     },
     "suggest": {
         "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0",

--- a/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/XmlDriver.php
@@ -909,6 +909,7 @@ class XmlDriver extends FileDriver
     {
         $cascades = [];
         foreach ($cascadeElement->children() as $action) {
+            assert($action !== null);
             // According to the JPA specifications, XML uses "cascade-persist"
             // instead of "persist". Here, both variations
             // are supported because both YAML and Annotation use "persist"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
+<files psalm-version="4.9.2@00c062267d6e3229d91a1939992987e2d46f2393">
   <file src="lib/Doctrine/ORM/AbstractQuery.php">
     <DeprecatedClass occurrences="1">
       <code>IterableResult</code>
@@ -103,6 +103,9 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;fileLockRegionDirectory</code>
     </NullableReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$em</code>
+    </ParamNameMismatch>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(string) $fileLockRegionDirectory</code>
     </RedundantCastGivenDocblockType>
@@ -507,6 +510,16 @@
       <code>EntityRepository&lt;T&gt;</code>
       <code>newHydrator</code>
     </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="8">
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entity</code>
+      <code>$entityName</code>
+      <code>$entityName</code>
+    </ParamNameMismatch>
     <PossiblyNullArgument occurrences="3">
       <code>$config-&gt;getProxyDir()</code>
       <code>$config-&gt;getProxyNamespace()</code>
@@ -562,10 +575,6 @@
       <code>?T</code>
       <code>Collection&lt;int, T&gt;</code>
     </InvalidReturnType>
-    <MoreSpecificImplementedParamType occurrences="2">
-      <code>$criteria</code>
-      <code>$criteria</code>
-    </MoreSpecificImplementedParamType>
     <PropertyTypeCoercion occurrences="1">
       <code>$em</code>
     </PropertyTypeCoercion>
@@ -1024,16 +1033,15 @@
       <code>$class</code>
       <code>$subclass</code>
     </ArgumentTypeCoercion>
-    <DeprecatedProperty occurrences="2">
+    <DeprecatedProperty occurrences="4">
+      <code>$this-&gt;columnNames</code>
+      <code>$this-&gt;columnNames</code>
       <code>$this-&gt;columnNames</code>
       <code>$this-&gt;columnNames</code>
     </DeprecatedProperty>
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;table</code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>string|null</code>
-    </ImplementedReturnTypeMismatch>
     <InvalidDocblock occurrences="4">
       <code>protected function _validateAndCompleteAssociationMapping(array $mapping)</code>
       <code>protected function _validateAndCompleteManyToManyMapping(array $mapping)</code>
@@ -1075,6 +1083,11 @@
       <code>$this-&gt;reflFields[$name]</code>
       <code>$this-&gt;reflFields[$this-&gt;identifier[0]]</code>
     </NullableReturnStatement>
+    <ParamNameMismatch occurrences="3">
+      <code>$entity</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+    </ParamNameMismatch>
     <PossiblyNullArgument occurrences="11">
       <code>$class</code>
       <code>$class</code>
@@ -1293,11 +1306,6 @@
       <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\InverseJoinColumn::class)</code>
       <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\JoinColumn::class)</code>
     </PossiblyNullIterator>
-    <RawObjectIteration occurrences="3">
-      <code>$joinColumnAttributes</code>
-      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\InverseJoinColumn::class)</code>
-      <code>$this-&gt;reader-&gt;getPropertyAnnotation($property, Mapping\JoinColumn::class)</code>
-    </RawObjectIteration>
     <RedundantCondition occurrences="3">
       <code>assert($method instanceof ReflectionMethod)</code>
       <code>assert($method instanceof ReflectionMethod)</code>
@@ -1385,6 +1393,11 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$metadata</code>
     </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="3">
+      <code>$xmlRoot-&gt;getName() === 'embeddable'</code>
+      <code>$xmlRoot-&gt;getName() === 'entity'</code>
+      <code>$xmlRoot-&gt;getName() === 'mapped-superclass'</code>
+    </DocblockTypeContradiction>
     <ImplicitToStringCast occurrences="1">
       <code>$cacheMapping['usage']</code>
     </ImplicitToStringCast>
@@ -1786,6 +1799,9 @@
       <code>$key</code>
       <code>$offset</code>
     </MissingParamType>
+    <ParamNameMismatch occurrences="1">
+      <code>$value</code>
+    </ParamNameMismatch>
     <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;association</code>
       <code>$this-&gt;association</code>
@@ -1826,7 +1842,8 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
-    <DeprecatedMethod occurrences="5">
+    <DeprecatedMethod occurrences="6">
+      <code>executeUpdate</code>
       <code>executeUpdate</code>
       <code>executeUpdate</code>
       <code>fetchColumn</code>
@@ -1836,7 +1853,7 @@
     <FalsableReturnStatement occurrences="1">
       <code>$this-&gt;conn-&gt;fetchColumn($sql, $params, 0, $types)</code>
     </FalsableReturnStatement>
-    <PossiblyNullArgument occurrences="39">
+    <PossiblyNullArgument occurrences="45">
       <code>$association</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
@@ -1848,6 +1865,10 @@
       <code>$collection-&gt;getOwner()</code>
       <code>$collection-&gt;getOwner()</code>
       <code>$filterMapping</code>
+      <code>$filterMapping</code>
+      <code>$indexBy</code>
+      <code>$mapping</code>
+      <code>$mapping</code>
       <code>$mapping</code>
       <code>$mapping</code>
       <code>$mapping</code>
@@ -1856,6 +1877,8 @@
       <code>$mapping</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns'][$joinTableColumn]</code>
+      <code>$mapping['relationToTargetKeyColumns'][$joinTableColumn]</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
@@ -1877,7 +1900,7 @@
       <code>$owner</code>
       <code>$owner</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="32">
+    <PossiblyNullArrayAccess occurrences="36">
       <code>$mapping['indexBy']</code>
       <code>$mapping['isOwningSide']</code>
       <code>$mapping['isOwningSide']</code>
@@ -1888,12 +1911,16 @@
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
       <code>$mapping['joinTable']</code>
+      <code>$mapping['joinTable']['inverseJoinColumns']</code>
+      <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['mappedBy']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToSourceKeyColumns']</code>
+      <code>$mapping['relationToTargetKeyColumns']</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
       <code>$mapping['sourceEntity']</code>
@@ -1916,14 +1943,20 @@
       <code>$sourceClass-&gt;associationMappings</code>
       <code>$targetClass-&gt;associationMappings</code>
     </PossiblyNullArrayOffset>
-    <PossiblyNullIterator occurrences="6">
+    <PossiblyNullIterator occurrences="8">
       <code>$joinColumns</code>
+      <code>$mapping['joinTable']['inverseJoinColumns']</code>
+      <code>$mapping['joinTable']['inverseJoinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTable']['joinColumns']</code>
       <code>$mapping['joinTableColumns']</code>
       <code>$mapping['relationToSourceKeyColumns']</code>
     </PossiblyNullIterator>
+    <PossiblyNullReference occurrences="2">
+      <code>getFieldForColumn</code>
+      <code>getFieldForColumn</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/OneToManyPersister.php">
     <DeprecatedMethod occurrences="5">
@@ -2158,10 +2191,18 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>parent::setHint($name, $value)</code>
+      <code>parent::setHydrationMode($hydrationMode)</code>
+    </LessSpecificReturnStatement>
     <MoreSpecificImplementedParamType occurrences="2">
       <code>$hydrationMode</code>
       <code>$parameters</code>
     </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>self</code>
+      <code>self</code>
+    </MoreSpecificReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;getDQL()</code>
     </PossiblyNullArgument>
@@ -2188,30 +2229,92 @@
       <code>assert($rsm !== null)</code>
     </RedundantConditionGivenDocblockType>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticFactor.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ArithmeticTerm.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/BetweenExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/CoalesceExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/CollectionMemberExpression.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ComparisonExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalFactor.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalPrimary.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/ConditionalTerm.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/DeleteClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$aliasIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/DeleteStatement.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/EmptyCollectionComparisonExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/ExistsExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/FromClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/AbsFunction.php">
     <PropertyNotSetInConstructor occurrences="1">
@@ -2303,6 +2406,11 @@
     <UndefinedPropertyFetch occurrences="1">
       <code>$this-&gt;unit-&gt;value</code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Functions/FunctionNode.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Functions/IdentityFunction.php">
     <PossiblyNullArrayAccess occurrences="1">
@@ -2426,7 +2534,30 @@
       <code>$stringPrimary</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/GeneralCaseExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/GroupByClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/HavingClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/IdentificationVariableDeclaration.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/InExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
@@ -2441,16 +2572,37 @@
     <NullableReturnStatement occurrences="1">
       <code>$sqlWalker-&gt;walkIndexBy($this)</code>
     </NullableReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/InstanceOfExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$not</code>
       <code>$value</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Join.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationDeclaration.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/JoinAssociationPathExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/JoinClassPathExpression.php">
     <UndefinedMethod occurrences="1">
@@ -2463,9 +2615,17 @@
     </UndefinedMethod>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/LikeExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NewObjectExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/Node.php">
     <DocblockTypeContradiction occurrences="1">
@@ -2476,11 +2636,27 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/NullComparisonExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$not</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/NullIfExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/OrderByClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/OrderByItem.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
@@ -2491,37 +2667,105 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/QuantifiedExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SelectStatement.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleArithmeticExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleCaseExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleSelectExpression.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$fieldIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Query/AST/SimpleWhenClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/Subselect.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/SubselectFromClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/UpdateClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$aliasIdentificationVariable</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateItem.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/UpdateStatement.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
+  </file>
   <file src="lib/Doctrine/ORM/Query/AST/WhenClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
     <UndefinedMethod occurrences="1">
       <code>walkWhenClauseExpression</code>
     </UndefinedMethod>
+  </file>
+  <file src="lib/Doctrine/ORM/Query/AST/WhereClause.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$sqlWalker</code>
+    </ParamNameMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Query/Exec/AbstractSqlExecutor.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">
@@ -2594,6 +2838,9 @@
     </NonInvariantDocblockPropertyType>
   </file>
   <file src="lib/Doctrine/ORM/Query/Expr/Base.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;parts</code>
+    </ArgumentTypeCoercion>
     <PossiblyInvalidCast occurrences="1">
       <code>$this-&gt;parts[0]</code>
     </PossiblyInvalidCast>
@@ -2773,7 +3020,6 @@
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
       <code>$this-&gt;lexer-&gt;token['value']</code>
-      <code>$this-&gt;query-&gt;getDQL()</code>
       <code>$this-&gt;query-&gt;getDQL()</code>
       <code>$token['value']</code>
       <code>$token['value']</code>
@@ -3208,6 +3454,9 @@
       <code>$updateItem</code>
       <code>$whereClause</code>
     </MissingParamType>
+    <ParamNameMismatch occurrences="1">
+      <code>$condPrimary</code>
+    </ParamNameMismatch>
     <PossiblyNullReference occurrences="46">
       <code>walkAggregateExpression</code>
       <code>walkArithmeticExpression</code>
@@ -3401,7 +3650,9 @@
       <code>new ClassMetadataExporter()</code>
       <code>new EntityGenerator()</code>
     </DeprecatedClass>
-    <InvalidNullableReturnType occurrences="1"/>
+    <InvalidNullableReturnType occurrences="1">
+      <code>int</code>
+    </InvalidNullableReturnType>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
@@ -3482,7 +3733,9 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/AbstractCommand.php">
-    <InvalidNullableReturnType occurrences="1"/>
+    <InvalidNullableReturnType occurrences="1">
+      <code>int</code>
+    </InvalidNullableReturnType>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;executeSchemaCommand($input, $output, new SchemaTool($em), $metadatas, $ui)</code>
     </NullableReturnStatement>
@@ -3714,7 +3967,8 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Export/Driver/YamlExporter.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$array</code>
       <code>$metadata-&gt;changeTrackingPolicy</code>
       <code>$metadata-&gt;generatorType</code>
     </ArgumentTypeCoercion>
@@ -3764,7 +4018,8 @@
     <PossiblyNullIterator occurrences="1">
       <code>$orderByClause-&gt;orderByItems</code>
     </PossiblyNullIterator>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
+    <PossiblyNullPropertyAssignmentValue occurrences="3">
+      <code>$AST-&gt;orderByClause</code>
       <code>$query-&gt;getFirstResult()</code>
       <code>$query-&gt;getMaxResults()</code>
     </PossiblyNullPropertyAssignmentValue>


### PR DESCRIPTION
It is used later on as an object. This does not happen in the CI,
presumably because the CI uses PHP 8. Some contributors including me
still use PHP 7.4 in some setups though.