### PR TITLE
feat(ScalarColumnHydrator): added ScalarColumnHydrator to get flat array results from query for single column

### DIFF
--- a/docs/en/reference/dql-doctrine-query-language.rst
+++ b/docs/en/reference/dql-doctrine-query-language.rst
@@ -1184,6 +1184,7 @@ The constants for the different hydration modes are:
 -  ``Query::HYDRATE_ARRAY``
 -  ``Query::HYDRATE_SCALAR``
 -  ``Query::HYDRATE_SINGLE_SCALAR``
+-  ``Query::HYDRATE_SCALAR_COLUMN``
 
 Object Hydration
 ^^^^^^^^^^^^^^^^
@@ -1271,6 +1272,25 @@ You can use the ``getSingleScalarResult()`` shortcut as well:
 
     <?php
     $numArticles = $query->getSingleScalarResult();
+
+Scalar Column Hydration
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have a query which returns a one-dimensional array of scalar values
+you can use scalar column hydration:
+
+.. code-block:: php
+
+    <?php
+    $query = $em->createQuery('SELECT a.id FROM CmsUser u');
+    $ids = $query->getResult(Query::HYDRATE_SCALAR_COLUMN);
+
+You can use the ``getSingleColumnResult()`` shortcut as well:
+
+.. code-block:: php
+
+    <?php
+    $ids = $query->getSingleColumnResult();
 
 Custom Hydration Modes
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -71,6 +71,11 @@ abstract class AbstractQuery
     public const HYDRATE_SIMPLEOBJECT = 5;
 
     /**
+     * Hydrates scalar column value.
+     */
+    public const HYDRATE_SCALAR_COLUMN = 6;
+
+    /**
      * The parameter map of this query.
      *
      * @var ArrayCollection|Parameter[]
@@ -782,6 +787,18 @@ abstract class AbstractQuery
     public function getArrayResult()
     {
         return $this->execute(null, self::HYDRATE_ARRAY);
+    }
+
+    /**
+     * Gets one-dimensional array of results for the query.
+     *
+     * Alias for execute(null, HYDRATE_SCALAR_COLUMN).
+     *
+     * @return mixed[]
+     */
+    public function getSingleColumnResult()
+    {
+        return $this->execute(null, self::HYDRATE_SCALAR_COLUMN);
     }
 
     /**

--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -865,6 +865,9 @@ use function sprintf;
             case Query::HYDRATE_SIMPLEOBJECT:
                 return new Internal\Hydration\SimpleObjectHydrator($this);
 
+            case Query::HYDRATE_SCALAR_COLUMN:
+                return new Internal\Hydration\ScalarColumnHydrator($this);
+
             default:
                 $class = $this->config->getCustomHydrationMode($hydrationMode);
 

--- a/lib/Doctrine/ORM/Exception/MultipleSelectorsFoundException.php
+++ b/lib/Doctrine/ORM/Exception/MultipleSelectorsFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Exception;
+
+use function implode;
+use function sprintf;
+
+final class MultipleSelectorsFoundException extends ORMException
+{
+    public const MULTIPLE_SELECTORS_FOUND_EXCEPTION = 'Multiple selectors found: %s. Please select only one.';
+
+    /**
+     * @param string[] $selectors
+     */
+    public static function create(array $selectors): self
+    {
+        return new self(
+            sprintf(
+                self::MULTIPLE_SELECTORS_FOUND_EXCEPTION,
+                implode(', ', $selectors)
+            )
+        );
+    }
+}

--- a/lib/Doctrine/ORM/Exception/NamedNativeQueryNotFound.php
+++ b/lib/Doctrine/ORM/Exception/NamedNativeQueryNotFound.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Exception;
 
-use LogicException;
-
 use function sprintf;
 
 final class NamedNativeQueryNotFound extends ORMException implements ConfigurationException

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarColumnHydrator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal\Hydration;
+
+use Doctrine\DBAL\Driver\Exception;
+use Doctrine\ORM\Exception\MultipleSelectorsFoundException;
+
+use function count;
+
+/**
+ * Hydrator that produces one-dimensional array.
+ */
+final class ScalarColumnHydrator extends AbstractHydrator
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws MultipleSelectorsFoundException
+     * @throws Exception
+     */
+    protected function hydrateAllData(): array
+    {
+        if (count($this->resultSetMapping()->fieldMappings) > 1) {
+            throw MultipleSelectorsFoundException::create($this->resultSetMapping()->fieldMappings);
+        }
+
+        $result = [];
+
+        while ($row = $this->statement()->fetchOne()) {
+            $result[] = $row;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -21,10 +21,8 @@ use Doctrine\Tests\Models\CMS\CmsUser;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
 
-use function count;
 use function get_class;
-use function is_array;
-use function is_numeric;
+use function in_array;
 
 class BasicFunctionalTest extends OrmFunctionalTestCase
 {
@@ -256,6 +254,35 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         self::assertEquals('Guilherme', $usersScalar[0]['u_name']);
         self::assertEquals('gblanco', $usersScalar[0]['u_username']);
         self::assertEquals('developer', $usersScalar[0]['u_status']);
+    }
+
+    public function testSingleColumnQuery(): void
+    {
+        $gregoire           = new CmsUser();
+        $gregoire->name     = 'Gregoire';
+        $gregoire->username = 'greg0ire';
+        $gregoire->status   = 'developer';
+        $this->_em->persist($gregoire);
+
+        $bhushan           = new CmsUser();
+        $bhushan->name     = 'Bhushan';
+        $bhushan->username = 'bhushan';
+        $bhushan->status   = 'developer';
+        $this->_em->persist($bhushan);
+
+        $this->_em->flush();
+
+        $query = $this->_em->createQuery('select u.username from Doctrine\Tests\Models\CMS\CmsUser u order by u.username DESC');
+
+        $users = $query->getSingleColumnResult();
+
+        $expected = [
+            'greg0ire',
+            'bhushan',
+        ];
+
+        self::assertCount(2, $users);
+        self::assertSame($expected, $users);
     }
 
     public function testBasicOneToManyInnerJoin(): void

--- a/tests/Doctrine/Tests/ORM/Hydration/ScalarColumnHydratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Hydration/ScalarColumnHydratorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Hydration;
+
+use Doctrine\ORM\Exception\MultipleSelectorsFoundException;
+use Doctrine\ORM\Internal\Hydration\ScalarColumnHydrator;
+use Doctrine\ORM\Query\ResultSetMapping;
+use Doctrine\Tests\Mocks\ArrayResultFactory;
+use Doctrine\Tests\Models\CMS\CmsUser;
+
+use function sprintf;
+
+class ScalarColumnHydratorTest extends HydrationTestCase
+{
+    /**
+     * Select u.id from CmsUser u
+     */
+    public function testEmptyResultTest(): void
+    {
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult(CmsUser::class, 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+
+        $stmt     = ArrayResultFactory::createFromArray($emptyResultSet = []);
+        $hydrator = new ScalarColumnHydrator($this->entityManager);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Select u.id from CmsUser u
+     */
+    public function testSingleColumnEntityQueryWithoutScalarMap(): void
+    {
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult(CmsUser::class, 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+
+        $resultSet = [
+            ['u__id' => '1'],
+            ['u__id' => '2'],
+        ];
+
+        $stmt     = ArrayResultFactory::createFromArray($resultSet);
+        $hydrator = new ScalarColumnHydrator($this->entityManager);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+
+        $this->assertEquals(1, $result[0]);
+        $this->assertEquals(2, $result[1]);
+    }
+
+    /**
+     * Select u.id from CmsUser u
+     */
+    public function testSingleColumnEntityQueryWithScalarMap(): void
+    {
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult(CmsUser::class, 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addScalarResult('sclr0', 'id');
+        $rsm->addIndexByScalar('sclr0');
+
+        $resultSet = [
+            ['u__id' => '1'],
+            ['u__id' => '2'],
+        ];
+
+        $stmt     = ArrayResultFactory::createFromArray($resultSet);
+        $hydrator = new ScalarColumnHydrator($this->entityManager);
+        $result   = $hydrator->hydrateAll($stmt, $rsm);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+
+        $this->assertEquals(1, $result[0]);
+        $this->assertEquals(2, $result[1]);
+    }
+
+    /**
+     * Select u.id, u.name from CmsUser u
+     */
+    public function testMultipleColumnEntityQueryThrowsException(): void
+    {
+        $rsm = new ResultSetMapping();
+
+        $rsm->addEntityResult(CmsUser::class, 'u');
+        $rsm->addFieldResult('u', 'u__id', 'id');
+        $rsm->addFieldResult('u', 'u__name', 'name');
+
+        $resultSet = [
+            [
+                'u__id'   => '1',
+                'u__name' => 'Gregoire',
+            ],
+            [
+                'u__id'   => '2',
+                'u__name' => 'Bhushan',
+            ],
+        ];
+
+        $stmt     = ArrayResultFactory::createFromArray($resultSet);
+        $hydrator = new ScalarColumnHydrator($this->entityManager);
+
+        $this->expectException(MultipleSelectorsFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            MultipleSelectorsFoundException::MULTIPLE_SELECTORS_FOUND_EXCEPTION,
+            'id, name'
+        ));
+
+        $hydrator->hydrateAll($stmt, $rsm);
+    }
+}


### PR DESCRIPTION
Description: 

- feat(AbstractQuery): added getFlatArrayResultByKey method to Abstract Query to get flat array results from query


### How it helps ?

- Imagine if We just want list of ids from database then we need to implement something like this in repository


```php
$transform = function($item) {
    return $item['id'];
};

$result = array_map($transform, $em->createQuery("SELECT a.id FROM Auction a")->getArrayResult());
```

With `getFlatArrayResultByKey`

```php
$em->createQuery("SELECT a.id FROM Auction a")->getFlatArrayResultByKey('id');
```

and if we don't pass any key then it works same as `getArrayResult`