### PR TITLE
Avoid returning null from `EntityManager::getReference()` and `getPartialReference()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -746,6 +746,10 @@ following classes and methods:
 
 Use `toIterable()` instead.
 
+## BC BREAK: `Doctrine\ORM\EntityManagerInterface#getReference()` and `getPartialReference()` does not return `null` anymore
+
+Method `Doctrine\ORM\EntityManagerInterface#getReference()` and `getPartialReference()` throws `InstanceOfTheWrongTypeEncountered` in 3.0 when different entity type is found in inheritance hierachy.
+
 # Upgrade to 2.20
 
 ## Add `Doctrine\ORM\Query\OutputWalker` interface, deprecate `Doctrine\ORM\Query\SqlWalker::getExecutor()`

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -162,7 +162,7 @@
       <code><![CDATA[$entity]]></code>
       <code><![CDATA[$entity]]></code>
       <code><![CDATA[$entity]]></code>
-      <code><![CDATA[$entity instanceof $class->name ? $entity : null]]></code>
+      <code><![CDATA[$entity]]></code>
       <code><![CDATA[$persister->load($sortedId, null, null, [], $lockMode)]]></code>
       <code><![CDATA[$persister->loadById($sortedId)]]></code>
       <code><![CDATA[$this->metadataFactory]]></code>

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -10,6 +10,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Exception\EntityManagerClosed;
+use Doctrine\ORM\Exception\InstanceOfTheWrongTypeEncountered;
 use Doctrine\ORM\Exception\InvalidHydrationMode;
 use Doctrine\ORM\Exception\MissingIdentifierField;
 use Doctrine\ORM\Exception\MissingMappingDriverImplementation;
@@ -363,7 +364,7 @@ class EntityManager implements EntityManagerInterface
         }
     }
 
-    public function getReference(string $entityName, mixed $id): object|null
+    public function getReference(string $entityName, mixed $id): object
     {
         $class = $this->metadataFactory->getMetadataFor(ltrim($entityName, '\\'));
 
@@ -390,7 +391,11 @@ class EntityManager implements EntityManagerInterface
 
         // Check identity map first, if its already in there just return it.
         if ($entity !== false) {
-            return $entity instanceof $class->name ? $entity : null;
+            if (! $entity instanceof $class->name) {
+                throw InstanceOfTheWrongTypeEncountered::forInstance($entity);
+            }
+
+            return $entity;
         }
 
         if ($class->subClasses) {

--- a/src/EntityManagerInterface.php
+++ b/src/EntityManagerInterface.php
@@ -154,7 +154,7 @@ interface EntityManagerInterface extends ObjectManager
      * @param class-string<T> $entityName The name of the entity type.
      * @param mixed           $id         The entity identifier.
      *
-     * @return T|null The entity reference.
+     * @return T The entity reference.
      *
      * @throws ORMException
      *

--- a/tests/Tests/ORM/Functional/Ticket/DDC1041Test.php
+++ b/tests/Tests/ORM/Functional/Ticket/DDC1041Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\Exception\InstanceOfTheWrongTypeEncountered;
 use Doctrine\Tests\Models\Company\CompanyFixContract;
 use Doctrine\Tests\Models\Company\CompanyFlexContract;
 use Doctrine\Tests\OrmFunctionalTestCase;
@@ -19,7 +20,7 @@ class DDC1041Test extends OrmFunctionalTestCase
         parent::setUp();
     }
 
-    public function testGrabWrongSubtypeReturnsNull(): void
+    public function testGrabWrongSubtypeReturnsNullOrThrows(): void
     {
         $fix = new CompanyFixContract();
         $fix->setFixPrice(2000);
@@ -30,6 +31,10 @@ class DDC1041Test extends OrmFunctionalTestCase
         $id = $fix->getId();
 
         self::assertNull($this->_em->find(CompanyFlexContract::class, $id));
-        self::assertNull($this->_em->getReference(CompanyFlexContract::class, $id));
+
+        try {
+            $this->_em->getReference(CompanyFlexContract::class, $id);
+        } catch (InstanceOfTheWrongTypeEncountered) {
+        }
     }
 }


### PR DESCRIPTION
_This bothers me for a long time, though I'm not sure the solution is viable._

Though I'd rather not assert for `notNull` every time I use the reference.