### PR TITLE
Drop support for generating json array fields

### DIFF
--- a/lib/Doctrine/ORM/Tools/EntityGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityGenerator.php
@@ -190,7 +190,7 @@ class EntityGenerator
     /**
      * Hash-map for handle types.
      *
-     * @psalm-var array<Types::*|Type::*, string>
+     * @psalm-var array<Types::*|'json_array', string>
      */
     protected $typeAlias = [
         Types::DATETIMETZ_MUTABLE => '\DateTime',
@@ -205,7 +205,8 @@ class EntityGenerator
         Types::BLOB               => 'string',
         Types::DECIMAL            => 'string',
         Types::GUID               => 'string',
-        Type::JSON_ARRAY          => 'array',
+        'json_array'              => 'array',
+        Types::JSON               => 'array',
         Types::SIMPLE_ARRAY       => 'array',
         Types::BOOLEAN            => 'bool',
     ];

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3579,9 +3579,8 @@
       <code>$this-&gt;getClassToExtend() ?: $metadata-&gt;name</code>
       <code>array_map('strlen', $paramTypes)</code>
     </ArgumentTypeCoercion>
-    <DeprecatedConstant occurrences="2">
+    <DeprecatedConstant occurrences="1">
       <code>ClassMetadataInfo::GENERATOR_TYPE_UUID</code>
-      <code>Type::JSON_ARRAY</code>
     </DeprecatedConstant>
     <DocblockTypeContradiction occurrences="3">
       <code>$metadata-&gt;reflClass !== null</code>


### PR DESCRIPTION
`JSON_ARRAY` has been deprecated for a while, we should not encourage
people to generate new entities with it, since it will introduce
technical debt for them.