### PR TITLE
Remove calls to `AbstractPlatform::getSQLResultCasing()`

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Internal\Hydration;
 
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Exception;
@@ -19,6 +20,8 @@ use function sprintf;
 
 class SimpleObjectHydrator extends AbstractHydrator
 {
+    use SQLResultCasing;
+
     /** @var ClassMetadata */
     private $class;
 
@@ -76,7 +79,7 @@ class SimpleObjectHydrator extends AbstractHydrator
 
         // We need to find the correct entity class name if we have inheritance in resultset
         if ($this->class->inheritanceType !== ClassMetadata::INHERITANCE_TYPE_NONE) {
-            $discrColumnName = $this->_platform->getSQLResultCasing($this->class->discriminatorColumn['name']);
+            $discrColumnName = $this->getSQLResultCasing($this->_platform, $this->class->discriminatorColumn['name']);
 
             // Find mapped discriminator column from the result set.
             $metaMappingDiscrColumnName = array_search($discrColumnName, $this->resultSetMapping()->metaMappings, true);

--- a/lib/Doctrine/ORM/Internal/SQLResultCasing.php
+++ b/lib/Doctrine/ORM/Internal/SQLResultCasing.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Internal;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+use function method_exists;
+use function strtolower;
+use function strtoupper;
+
+/**
+ * @internal
+ */
+trait SQLResultCasing
+{
+    private function getSQLResultCasing(AbstractPlatform $platform, string $column): string
+    {
+        switch ($platform->getName()) {
+            case 'db2':
+            case 'oracle':
+                return strtoupper($column);
+
+            case 'postgresql':
+                return strtolower($column);
+        }
+
+        if (method_exists(AbstractPlatform::class, 'getSQLResultCasing')) {
+            return $platform->getSQLResultCasing($column);
+        }
+
+        return $column;
+    }
+}

--- a/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Internal\SQLResultCasing;
 
 /**
  * ANSI compliant quote strategy, this strategy does not apply any quote.
@@ -12,6 +13,8 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
  */
 class AnsiQuoteStrategy implements QuoteStrategy
 {
+    use SQLResultCasing;
+
     /**
      * {@inheritdoc}
      */
@@ -73,6 +76,6 @@ class AnsiQuoteStrategy implements QuoteStrategy
      */
     public function getColumnAlias($columnName, $counter, AbstractPlatform $platform, ?ClassMetadata $class = null)
     {
-        return $platform->getSQLResultCasing($columnName . '_' . $counter);
+        return $this->getSQLResultCasing($platform, $columnName . '_' . $counter);
     }
 }

--- a/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
+++ b/lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\ORM\Internal\SQLResultCasing;
 
 use function array_map;
 use function array_merge;
@@ -17,6 +18,8 @@ use function substr;
  */
 class DefaultQuoteStrategy implements QuoteStrategy
 {
+    use SQLResultCasing;
+
     /**
      * {@inheritdoc}
      */
@@ -146,6 +149,6 @@ class DefaultQuoteStrategy implements QuoteStrategy
         $columnName  = preg_replace('/[^A-Za-z0-9_]/', '', $columnName);
         $columnName  = is_numeric($columnName) ? '_' . $columnName : $columnName;
 
-        return $platform->getSQLResultCasing($columnName);
+        return $this->getSQLResultCasing($platform, $columnName);
     }
 }

--- a/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Persisters\Entity;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
@@ -22,6 +23,8 @@ use function is_array;
  */
 class JoinedSubclassPersister extends AbstractEntityInheritancePersister
 {
+    use SQLResultCasing;
+
     /**
      * Map that maps column names to the table names that own them.
      * This is mainly a temporary cache, used during a single request.
@@ -412,7 +415,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         $discrColumn      = $this->class->discriminatorColumn['name'];
         $discrColumnType  = $this->class->discriminatorColumn['type'];
         $baseTableAlias   = $this->getSQLTableAlias($this->class->name);
-        $resultColumnName = $this->platform->getSQLResultCasing($discrColumn);
+        $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumn);
 
         $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r');
         $this->currentPersisterContext->rsm->setDiscriminatorColumn('r', $resultColumnName);

--- a/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Persisters\Entity;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Utility\PersisterHelper;
 
@@ -19,6 +20,8 @@ use function implode;
  */
 class SingleTablePersister extends AbstractEntityInheritancePersister
 {
+    use SQLResultCasing;
+
     /**
      * {@inheritdoc}
      */
@@ -47,7 +50,7 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
         $columnList[] = $tableAlias . '.' . $discrColumn;
 
-        $resultColumnName = $this->platform->getSQLResultCasing($discrColumn);
+        $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumn);
 
         $this->currentPersisterContext->rsm->setDiscriminatorColumn('r', $resultColumnName);
         $this->currentPersisterContext->rsm->addMetaResult('r', $resultColumnName, $discrColumn, false, $discrColumnType);

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Query;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Utility\PersisterHelper;
@@ -21,6 +22,8 @@ use function strtolower;
  */
 class ResultSetMappingBuilder extends ResultSetMapping
 {
+    use SQLResultCasing;
+
     /**
      * Picking this rename mode will register entity columns as is,
      * as they are in the database. This can cause clashes when multiple
@@ -131,7 +134,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
         foreach ($classMetadata->getColumnNames() as $columnName) {
             $propertyName = $classMetadata->getFieldName($columnName);
-            $columnAlias  = $platform->getSQLResultCasing($columnAliasMap[$columnName]);
+            $columnAlias  = $this->getSQLResultCasing($platform, $columnAliasMap[$columnName]);
 
             if (isset($this->fieldMappings[$columnAlias])) {
                 throw new InvalidArgumentException(sprintf(
@@ -150,7 +153,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
 
                 foreach ($associationMapping['joinColumns'] as $joinColumn) {
                     $columnName  = $joinColumn['name'];
-                    $columnAlias = $platform->getSQLResultCasing($columnAliasMap[$columnName]);
+                    $columnAlias = $this->getSQLResultCasing($platform, $columnAliasMap[$columnName]);
                     $columnType  = PersisterHelper::getTypeOfColumn($joinColumn['referencedColumnName'], $targetClass, $this->em);
 
                     if (isset($this->metaMappings[$columnAlias])) {

--- a/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/Paginator.php
@@ -7,6 +7,7 @@ namespace Doctrine\ORM\Tools\Pagination;
 use ArrayIterator;
 use Countable;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
@@ -28,6 +29,8 @@ use function count;
  */
 class Paginator implements Countable, IteratorAggregate
 {
+    use SQLResultCasing;
+
     /** @var Query */
     private $query;
 
@@ -229,7 +232,7 @@ class Paginator implements Countable, IteratorAggregate
             $platform = $countQuery->getEntityManager()->getConnection()->getDatabasePlatform(); // law of demeter win
 
             $rsm = new ResultSetMapping();
-            $rsm->addScalarResult($platform->getSQLResultCasing('dctrn_count'), 'count');
+            $rsm->addScalarResult($this->getSQLResultCasing($platform, 'dctrn_count'), 'count');
 
             $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, CountOutputWalker::class);
             $countQuery->setResultSetMapping($rsm);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -724,9 +724,6 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php">
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <InvalidScalarArgument occurrences="1">
       <code>array_keys($discrMap)</code>
     </InvalidScalarArgument>
@@ -749,9 +746,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/AnsiQuoteStrategy.php">
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$class-&gt;fieldMappings[$fieldName]['columnName']</code>
     </PossiblyUndefinedArrayOffset>
@@ -1129,9 +1123,6 @@
     </PossiblyFalseOperand>
   </file>
   <file src="lib/Doctrine/ORM/Mapping/DefaultQuoteStrategy.php">
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <MissingClosureParamType occurrences="1">
       <code>$joinColumn</code>
     </MissingClosureParamType>
@@ -1987,9 +1978,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$this-&gt;em</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <LessSpecificReturnStatement occurrences="1">
       <code>$postInsertIds</code>
     </LessSpecificReturnStatement>
@@ -2002,9 +1990,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Entity/SingleTablePersister.php">
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$columnList</code>
     </PossiblyUndefinedVariable>
@@ -2969,10 +2954,6 @@
       <code>$renameMode</code>
       <code>$renameMode</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="2">
-      <code>getSQLResultCasing</code>
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$class-&gt;fieldMappings[$this-&gt;fieldMappings[$columnName]]['columnName']</code>
     </PossiblyUndefinedArrayOffset>
@@ -3829,9 +3810,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$parameters</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
-      <code>getSQLResultCasing</code>
-    </DeprecatedMethod>
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;count === null</code>
     </DocblockTypeContradiction>

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,12 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <!-- We're calling the deprecated method for BC here. -->
+                <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
+            </errorLevel>
+        </DeprecatedMethod>
         <DocblockTypeContradiction>
             <errorLevel type="suppress">
                 <!-- We're catching invalid input here. -->

--- a/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NativeQueryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Internal\Hydration\HydrationException;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\PersistentCollection;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -25,15 +27,9 @@ use Doctrine\Tests\Models\DDC3899\DDC3899User;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
 
-use function count;
-use function is_array;
-use function is_numeric;
-
-/**
- * NativeQueryTest
- */
 class NativeQueryTest extends OrmFunctionalTestCase
 {
+    use SQLResultCasing;
     use VerifyDeprecations;
 
     /** @var AbstractPlatform */
@@ -61,8 +57,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsUser::class, 'u');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('id'), 'id');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('name'), 'name');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'id'), 'id');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'name'), 'name');
 
         $query = $this->_em->createNativeQuery('SELECT id, name FROM cms_users WHERE username = ?', $rsm);
         $query->setParameter(1, 'romanb');
@@ -95,11 +91,11 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsAddress::class, 'a');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('id'), 'id');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('country'), 'country');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('zip'), 'zip');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('city'), 'city');
-        $rsm->addMetaResult('a', $this->platform->getSQLResultCasing('user_id'), 'user_id', false, 'integer');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'id'), 'id');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'country'), 'country');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'zip'), 'zip');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'city'), 'city');
+        $rsm->addMetaResult('a', $this->getSQLResultCasing($this->platform, 'user_id'), 'user_id', false, 'integer');
 
         $query = $this->_em->createNativeQuery('SELECT a.id, a.country, a.zip, a.city, a.user_id FROM cms_addresses a WHERE a.id = ?', $rsm);
         $query->setParameter(1, $addr->id);
@@ -134,11 +130,11 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsUser::class, 'u');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('id'), 'id');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('name'), 'name');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('status'), 'status');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'id'), 'id');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'name'), 'name');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'status'), 'status');
         $rsm->addJoinedEntityResult(CmsPhonenumber::class, 'p', 'u', 'phonenumbers');
-        $rsm->addFieldResult('p', $this->platform->getSQLResultCasing('phonenumber'), 'phonenumber');
+        $rsm->addFieldResult('p', $this->getSQLResultCasing($this->platform, 'phonenumber'), 'phonenumber');
 
         $query = $this->_em->createNativeQuery('SELECT id, name, status, phonenumber FROM cms_users INNER JOIN cms_phonenumbers ON id = user_id WHERE username = ?', $rsm);
         $query->setParameter(1, 'romanb');
@@ -176,14 +172,14 @@ class NativeQueryTest extends OrmFunctionalTestCase
 
         $rsm = new ResultSetMapping();
         $rsm->addEntityResult(CmsUser::class, 'u');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('id'), 'id');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('name'), 'name');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('status'), 'status');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'id'), 'id');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'name'), 'name');
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'status'), 'status');
         $rsm->addJoinedEntityResult(CmsAddress::class, 'a', 'u', 'address');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('a_id'), 'id');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('country'), 'country');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('zip'), 'zip');
-        $rsm->addFieldResult('a', $this->platform->getSQLResultCasing('city'), 'city');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'a_id'), 'id');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'country'), 'country');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'zip'), 'zip');
+        $rsm->addFieldResult('a', $this->getSQLResultCasing($this->platform, 'city'), 'city');
 
         $query = $this->_em->createNativeQuery('SELECT u.id, u.name, u.status, a.id AS a_id, a.country, a.zip, a.city FROM cms_users u INNER JOIN cms_addresses a ON u.id = a.user_id WHERE u.username = ?', $rsm);
         $query->setParameter(1, 'romanb');
@@ -793,8 +789,8 @@ class NativeQueryTest extends OrmFunctionalTestCase
         $rsm = new ResultSetMappingBuilder($this->_em, ResultSetMappingBuilder::COLUMN_RENAMING_INCREMENT);
         $rsm->addEntityResult(DDC3899User::class, 'u');
         $rsm->addJoinedEntityResult(DDC3899FixContract::class, 'c', 'u', 'contracts');
-        $rsm->addFieldResult('u', $this->platform->getSQLResultCasing('id'), 'id');
-        $rsm->setDiscriminatorColumn('c', $this->platform->getSQLResultCasing('discr'));
+        $rsm->addFieldResult('u', $this->getSQLResultCasing($this->platform, 'id'), 'id');
+        $rsm->setDiscriminatorColumn('c', $this->getSQLResultCasing($this->platform, 'discr'));
 
         $selectClause = $rsm->generateSelectClause(['u' => 'u1', 'c' => 'c1']);
 


### PR DESCRIPTION
`AbstractPlatform::getSQLResultCasing()` has been removed in DBAL 3. This PR is a pragmatic approach to move that logic into the ORM.

DBAL should be able to enforce a certain result casing for us. While the proposed change further unblocks the DBAL 3 migration, I think that in the long run we should try to leverage that feature instead.