### PR TITLE
Remove calls to deprecated Connection methods

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -187,7 +187,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         $sql = 'SELECT 1 FROM ' . $quotedJoinTable . ' WHERE ' . implode(' AND ', $whereClauses);
 
-        return (bool) $this->conn->fetchColumn($sql, $params, 0, $types);
+        return (bool) $this->conn->fetchOne($sql, $params, $types);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1744,9 +1744,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php">
-    <DeprecatedMethod occurrences="1">
-      <code>fetchColumn</code>
-    </DeprecatedMethod>
     <PossiblyNullArgument occurrences="44">
       <code>$association</code>
       <code>$collection-&gt;getOwner()</code>

--- a/tests/Doctrine/Tests/Mocks/ConnectionMock.php
+++ b/tests/Doctrine/Tests/Mocks/ConnectionMock.php
@@ -114,13 +114,21 @@ class ConnectionMock extends Connection
     /**
      * {@inheritdoc}
      */
-    public function fetchColumn($statement, array $params = [], $colunm = 0, array $types = [])
+    public function fetchOne(string $sql, array $params = [], array $types = [])
     {
         if ($this->_fetchOneException !== null) {
             throw $this->_fetchOneException;
         }
 
         return $this->_fetchOneResult;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchColumn($statement, array $params = [], $colunm = 0, array $types = [])
+    {
+        throw new BadMethodCallException('Call to deprecated method.');
     }
 
     public function query(?string $sql = null): Result

--- a/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/BasicFunctionalTest.php
@@ -137,7 +137,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $userId = $this->_em->getConnection()->executeQuery(
             'SELECT user_id FROM cms_addresses WHERE id=?',
             [$address->id]
-        )->fetchColumn();
+        )->fetchOne();
         self::assertIsNumeric($userId);
 
         $this->_em->clear();
@@ -208,13 +208,13 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->flush();
 
         // Check that there are just 2 phonenumbers left
-        $count = $this->_em->getConnection()->fetchColumn('SELECT COUNT(*) FROM cms_phonenumbers');
+        $count = $this->_em->getConnection()->fetchOne('SELECT COUNT(*) FROM cms_phonenumbers');
         self::assertEquals(2, $count); // only 2 remaining
 
         // check that clear() removes the others via orphan removal
         $user->getPhonenumbers()->clear();
         $this->_em->flush();
-        self::assertEquals(0, $this->_em->getConnection()->fetchColumn('select count(*) from cms_phonenumbers'));
+        self::assertEquals(0, $this->_em->getConnection()->fetchOne('select count(*) from cms_phonenumbers'));
     }
 
     public function testBasicQuery(): void
@@ -671,7 +671,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->flush();
         $this->_em->clear();
 
-        self::assertEquals(0, $this->_em->getConnection()->fetchColumn('select count(*) from cms_users'));
+        self::assertEquals(0, $this->_em->getConnection()->fetchOne('select count(*) from cms_users'));
 
         //$this->_em->getConnection()->getConfiguration()->setSQLLogger(null);
     }
@@ -728,12 +728,12 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $this->_em->persist($user);
         $this->_em->flush();
 
-        self::assertEquals(1, $this->_em->getConnection()->fetchColumn('select 1 from cms_addresses where user_id = ' . $user->id));
+        self::assertEquals(1, $this->_em->getConnection()->fetchOne('select 1 from cms_addresses where user_id = ' . $user->id));
 
         $address->user = null;
         $this->_em->flush();
 
-        self::assertNotEquals(1, $this->_em->getConnection()->fetchColumn('select 1 from cms_addresses where user_id = ' . $user->id));
+        self::assertNotEquals(1, $this->_em->getConnection()->fetchOne('select 1 from cms_addresses where user_id = ' . $user->id));
     }
 
     /**
@@ -840,14 +840,14 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
 
         $this->_em->flush();
 
-        self::assertEquals(0, $this->_em->getConnection()->fetchColumn('select count(*) from cms_addresses'));
+        self::assertEquals(0, $this->_em->getConnection()->fetchOne('select count(*) from cms_addresses'));
 
         // check orphan removal through replacement
         $user->address = $address;
         $address->user = $user;
 
         $this->_em->flush();
-        self::assertEquals(1, $this->_em->getConnection()->fetchColumn('select count(*) from cms_addresses'));
+        self::assertEquals(1, $this->_em->getConnection()->fetchOne('select count(*) from cms_addresses'));
 
         // remove $address to free up unique key id
         $this->_em->remove($address);
@@ -862,7 +862,7 @@ class BasicFunctionalTest extends OrmFunctionalTestCase
         $user->address       = $newAddress;
 
         $this->_em->flush();
-        self::assertEquals(1, $this->_em->getConnection()->fetchColumn('select count(*) from cms_addresses'));
+        self::assertEquals(1, $this->_em->getConnection()->fetchOne('select count(*) from cms_addresses'));
     }
 
     public function testGetPartialReferenceToUpdateObjectWithoutLoadingIt(): void

--- a/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DetachedEntityTest.php
@@ -222,7 +222,7 @@ class DetachedEntityTest extends OrmFunctionalTestCase
         $this->_em->detach($article);
 
         $sql = 'UPDATE cms_articles SET version = version + 1 WHERE id = ' . $article->id;
-        $this->_em->getConnection()->executeUpdate($sql);
+        $this->_em->getConnection()->executeStatement($sql);
 
         $this->expectException(OptimisticLockException::class);
         $this->expectExceptionMessage('The optimistic lock failed, version 1 was expected, but is actually 2');

--- a/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/IdentityMapTest.php
@@ -85,7 +85,7 @@ class IdentityMapTest extends OrmFunctionalTestCase
         self::assertSame($user1, $address->user);
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', [$user2->getId()]);
+        $this->_em->getConnection()->executeStatement('update cms_addresses set user_id = ?', [$user2->getId()]);
 
         // But we want to have this external change!
         // Solution 1: refresh(), broken atm!
@@ -127,7 +127,7 @@ class IdentityMapTest extends OrmFunctionalTestCase
         self::assertSame($user1, $address->user);
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('update cms_addresses set user_id = ?', [$user2->getId()]);
+        $this->_em->getConnection()->executeStatement('update cms_addresses set user_id = ?', [$user2->getId()]);
 
         //select
         $q        = $this->_em->createQuery('select a, u from Doctrine\Tests\Models\CMS\CmsAddress a join a.user u');
@@ -183,7 +183,7 @@ class IdentityMapTest extends OrmFunctionalTestCase
         self::assertFalse($user->getPhonenumbers()->isDirty());
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
+        $this->_em->getConnection()->executeStatement('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
 
         //select
         $q     = $this->_em->createQuery('select u, p from Doctrine\Tests\Models\CMS\CmsUser u join u.phonenumbers p');
@@ -237,7 +237,7 @@ class IdentityMapTest extends OrmFunctionalTestCase
         self::assertCount(3, $user->getPhonenumbers());
 
         //external update to CmsAddress
-        $this->_em->getConnection()->executeUpdate('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
+        $this->_em->getConnection()->executeStatement('insert into cms_phonenumbers (phonenumber, user_id) VALUES (?,?)', [999, $user->getId()]);
 
         //select
         $q     = $this->_em->createQuery('select u, p from Doctrine\Tests\Models\CMS\CmsUser u join u.phonenumbers p');

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManyBidirectionalAssociationTest.php
@@ -247,7 +247,7 @@ class OneToManyBidirectionalAssociationTest extends OrmFunctionalTestCase
         $foreignKey = $this->_em->getConnection()->executeQuery(
             'SELECT product_id FROM ecommerce_features WHERE id=?',
             [$feature->getId()]
-        )->fetchColumn();
+        )->fetchOne();
         self::assertEquals($value, $foreignKey);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToManySelfReferentialAssociationTest.php
@@ -128,7 +128,7 @@ class OneToManySelfReferentialAssociationTest extends OrmFunctionalTestCase
 
     public function assertForeignKeyIs($value, ECommerceCategory $child): void
     {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT parent_id FROM ecommerce_categories WHERE id=?', [$child->getId()])->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT parent_id FROM ecommerce_categories WHERE id=?', [$child->getId()])->fetchOne();
         self::assertEquals($value, $foreignKey);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneBidirectionalAssociationTest.php
@@ -153,7 +153,7 @@ class OneToOneBidirectionalAssociationTest extends OrmFunctionalTestCase
 
     public function assertCartForeignKeyIs($value): void
     {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT customer_id FROM ecommerce_carts WHERE id=?', [$this->cart->getId()])->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT customer_id FROM ecommerce_carts WHERE id=?', [$this->cart->getId()])->fetchOne();
         self::assertEquals($value, $foreignKey);
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneEagerLoadingTest.php
@@ -234,7 +234,7 @@ class OneToOneEagerLoadingTest extends OrmFunctionalTestCase
         $this->_em->persist($order);
         $this->_em->flush();
 
-        $this->_em->getConnection()->exec('UPDATE TrainOrder SET train_id = NULL');
+        $this->_em->getConnection()->executeStatement('UPDATE TrainOrder SET train_id = NULL');
 
         self::assertSame($train, $order->train);
         $this->_em->refresh($order);

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -135,7 +135,7 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
 
     public function assertForeignKeyIs($value): void
     {
-        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT mentor_id FROM ecommerce_customers WHERE id=?', [$this->customer->getId()])->fetchColumn();
+        $foreignKey = $this->_em->getConnection()->executeQuery('SELECT mentor_id FROM ecommerce_customers WHERE id=?', [$this->customer->getId()])->fetchOne();
         self::assertEquals($value, $foreignKey);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneUnidirectionalAssociationTest.php
@@ -112,7 +112,7 @@ class OneToOneUnidirectionalAssociationTest extends OrmFunctionalTestCase
         $foreignKey = $this->_em->getConnection()->executeQuery(
             'SELECT shipping_id FROM ecommerce_products WHERE id=?',
             [$this->product->getId()]
-        )->fetchColumn();
+        )->fetchOne();
         self::assertEquals($value, $foreignKey);
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -44,7 +44,7 @@ class SequenceEmulatedIdentityStrategyTest extends OrmFunctionalTestCase
         $platform   = $connection->getDatabasePlatform();
 
         // drop sequence manually due to dependency
-        $connection->exec(
+        $connection->executeStatement(
             $platform->getDropSequenceSQL(
                 new Sequence($platform->getIdentitySequenceName('seq_identity', 'id'))
             )

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1654Test.php
@@ -33,9 +33,9 @@ class DDC1654Test extends OrmFunctionalTestCase
     public function tearDown(): void
     {
         $conn = static::$sharedConn;
-        $conn->executeUpdate('DELETE FROM ddc1654post_ddc1654comment');
-        $conn->executeUpdate('DELETE FROM DDC1654Comment');
-        $conn->executeUpdate('DELETE FROM DDC1654Post');
+        $conn->executeStatement('DELETE FROM ddc1654post_ddc1654comment');
+        $conn->executeStatement('DELETE FROM DDC1654Comment');
+        $conn->executeStatement('DELETE FROM DDC1654Post');
     }
 
     public function testManyToManyRemoveFromCollectionOrphanRemoval(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3634Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use BadMethodCallException;
 use Closure;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\Connection;
@@ -357,6 +358,12 @@ class DDC3634LastInsertIdMockingConnection extends Connection
 
     /** {@inheritDoc} */
     public function executeUpdate($query, array $params = [], array $types = []): int
+    {
+        throw new BadMethodCallException('Call to deprecated method.');
+    }
+
+    /** {@inheritDoc} */
+    public function executeStatement($query, array $params = [], array $types = []): int
     {
         return $this->forwardCall();
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -57,7 +57,7 @@ class DDC422Test extends OrmFunctionalTestCase
         self::assertFalse($customer->contacts->isInitialized());
         $this->_em->flush();
 
-        self::assertEquals(1, $this->_em->getConnection()->fetchColumn('select count(*) from ddc422_customers_contacts'));
+        self::assertEquals(1, $this->_em->getConnection()->fetchOne('select count(*) from ddc422_customers_contacts'));
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
@@ -28,12 +28,12 @@ final class GH7875Test extends OrmFunctionalTestCase
     {
         $connection = $this->_em->getConnection();
 
-        $connection->exec('DROP TABLE IF EXISTS gh7875_my_entity');
-        $connection->exec('DROP TABLE IF EXISTS gh7875_my_other_entity');
+        $connection->executeStatement('DROP TABLE IF EXISTS gh7875_my_entity');
+        $connection->executeStatement('DROP TABLE IF EXISTS gh7875_my_other_entity');
 
         if ($connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
-            $connection->exec('DROP SEQUENCE IF EXISTS gh7875_my_entity_id_seq');
-            $connection->exec('DROP SEQUENCE IF EXISTS gh7875_my_other_entity_id_seq');
+            $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_entity_id_seq');
+            $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_other_entity_id_seq');
         }
     }
 
@@ -58,7 +58,7 @@ final class GH7875Test extends OrmFunctionalTestCase
 
         self::assertCount(1, $sqls);
 
-        $this->_em->getConnection()->exec(current($sqls));
+        $this->_em->getConnection()->executeStatement(current($sqls));
 
         $sqls = array_filter($tool->getUpdateSchemaSql($classes), static function (string $sql): bool {
             return strpos($sql, ' gh7875_my_entity ') !== false;

--- a/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeValueSqlTest.php
@@ -49,7 +49,7 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
         $entity = $this->_em->find('\Doctrine\Tests\Models\CustomType\CustomTypeUpperCase', $id);
 
         self::assertEquals('foo', $entity->lowerCaseString, 'Entity holds lowercase string');
-        self::assertEquals('FOO', $this->_em->getConnection()->fetchColumn('select lowerCaseString from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
+        self::assertEquals('FOO', $this->_em->getConnection()->fetchOne('select lowerCaseString from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
     }
 
     /**
@@ -70,7 +70,7 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
 
         $entity = $this->_em->find('\Doctrine\Tests\Models\CustomType\CustomTypeUpperCase', $id);
         self::assertEquals('foo', $entity->namedLowerCaseString, 'Entity holds lowercase string');
-        self::assertEquals('FOO', $this->_em->getConnection()->fetchColumn('select named_lower_case_string from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
+        self::assertEquals('FOO', $this->_em->getConnection()->fetchOne('select named_lower_case_string from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
 
         $entity->namedLowerCaseString = 'bar';
 
@@ -83,7 +83,7 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
 
         $entity = $this->_em->find('\Doctrine\Tests\Models\CustomType\CustomTypeUpperCase', $id);
         self::assertEquals('bar', $entity->namedLowerCaseString, 'Entity holds lowercase string');
-        self::assertEquals('BAR', $this->_em->getConnection()->fetchColumn('select named_lower_case_string from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
+        self::assertEquals('BAR', $this->_em->getConnection()->fetchOne('select named_lower_case_string from customtype_uppercases where id=' . $entity->id . ''), 'Database holds uppercase string');
     }
 
     public function testTypeValueSqlWithAssociations(): void
@@ -110,7 +110,7 @@ class TypeValueSqlTest extends OrmFunctionalTestCase
         $entity = $this->_em->find(CustomTypeParent::class, $parentId);
 
         self::assertTrue($entity->customInteger < 0, 'Fetched customInteger negative');
-        self::assertEquals(1, $this->_em->getConnection()->fetchColumn('select customInteger from customtype_parents where id=' . $entity->id . ''), 'Database has stored customInteger positive');
+        self::assertEquals(1, $this->_em->getConnection()->fetchOne('select customInteger from customtype_parents where id=' . $entity->id . ''), 'Database has stored customInteger positive');
 
         self::assertNotNull($parent->child, 'Child attached');
         self::assertCount(2, $entity->getMyFriends(), '2 friends attached');

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdForeignKeyTest.php
@@ -50,26 +50,26 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+        $conn->executeStatement('DROP TABLE vct_xref_manytomany_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_owning_manytomany_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_inversed_manytomany_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_auxiliary');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id4 FROM vct_auxiliary LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id1 FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT foreign_id FROM vct_inversed_manytomany_compositeid_foreignkey LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id2 FROM vct_owning_manytomany_compositeid_foreignkey LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT associated_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_foreign_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT owning_id FROM vct_xref_manytomany_compositeid_foreignkey LIMIT 1'));
     }
 
     /**
@@ -192,6 +192,6 @@ class ManyToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
 
         // test association is removed
 
-        self::assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid_foreignkey'));
+        self::assertEquals(0, $conn->fetchOne('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid_foreignkey'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyCompositeIdTest.php
@@ -45,23 +45,23 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_compositeid');
+        $conn->executeStatement('DROP TABLE vct_xref_manytomany_compositeid');
+        $conn->executeStatement('DROP TABLE vct_owning_manytomany_compositeid');
+        $conn->executeStatement('DROP TABLE vct_inversed_manytomany_compositeid');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_inversed_manytomany_compositeid LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id3 FROM vct_owning_manytomany_compositeid LIMIT 1'));
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT inversed_id1 FROM vct_xref_manytomany_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT inversed_id2 FROM vct_xref_manytomany_compositeid LIMIT 1'));
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT inversed_id1 FROM vct_xref_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT inversed_id2 FROM vct_xref_manytomany_compositeid LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT owning_id FROM vct_xref_manytomany_compositeid LIMIT 1'));
     }
 
     /**
@@ -154,6 +154,6 @@ class ManyToManyCompositeIdTest extends OrmFunctionalTestCase
 
         // test association is removed
 
-        self::assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid'));
+        self::assertEquals(0, $conn->fetchOne('SELECT COUNT(*) FROM vct_xref_manytomany_compositeid'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyExtraLazyTest.php
@@ -59,9 +59,9 @@ class ManyToManyExtraLazyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany_extralazy');
+        $conn->executeStatement('DROP TABLE vct_xref_manytomany_extralazy');
+        $conn->executeStatement('DROP TABLE vct_owning_manytomany_extralazy');
+        $conn->executeStatement('DROP TABLE vct_inversed_manytomany_extralazy');
     }
 
     public function testThatTheExtraLazyCollectionFromOwningToInversedIsCounted(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/ManyToManyTest.php
@@ -44,21 +44,21 @@ class ManyToManyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_xref_manytomany');
-        $conn->executeUpdate('DROP TABLE vct_owning_manytomany');
-        $conn->executeUpdate('DROP TABLE vct_inversed_manytomany');
+        $conn->executeStatement('DROP TABLE vct_xref_manytomany');
+        $conn->executeStatement('DROP TABLE vct_owning_manytomany');
+        $conn->executeStatement('DROP TABLE vct_inversed_manytomany');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_manytomany LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_manytomany LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytomany LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_owning_manytomany LIMIT 1'));
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT inversed_id FROM vct_xref_manytomany LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT owning_id FROM vct_xref_manytomany LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT inversed_id FROM vct_xref_manytomany LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT owning_id FROM vct_xref_manytomany LIMIT 1'));
     }
 
     /**
@@ -150,6 +150,6 @@ class ManyToManyTest extends OrmFunctionalTestCase
 
         // test association is removed
 
-        self::assertEquals(0, $conn->fetchColumn('SELECT COUNT(*) FROM vct_xref_manytomany'));
+        self::assertEquals(0, $conn->fetchOne('SELECT COUNT(*) FROM vct_xref_manytomany'));
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdForeignKeyTest.php
@@ -51,23 +51,23 @@ class OneToManyCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+        $conn->executeStatement('DROP TABLE vct_owning_manytoone_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetomany_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_auxiliary');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id4 FROM vct_auxiliary LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT foreign_id FROM vct_inversed_onetomany_compositeid_foreignkey LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id2 FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT associated_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_foreign_id FROM vct_owning_manytoone_compositeid_foreignkey LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyCompositeIdTest.php
@@ -46,20 +46,20 @@ class OneToManyCompositeIdTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_compositeid');
+        $conn->executeStatement('DROP TABLE vct_owning_manytoone_compositeid');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetomany_compositeid');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_inversed_onetomany_compositeid LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_manytoone_compositeid LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_manytoone_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id3 FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_id1 FROM vct_owning_manytoone_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT associated_id2 FROM vct_owning_manytoone_compositeid LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyExtraLazyTest.php
@@ -57,8 +57,8 @@ class OneToManyExtraLazyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone_extralazy');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany_extralazy');
+        $conn->executeStatement('DROP TABLE vct_owning_manytoone_extralazy');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetomany_extralazy');
     }
 
     public function testThatExtraLazyCollectionIsCounted(): void

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToManyTest.php
@@ -45,18 +45,18 @@ class OneToManyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_manytoone');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetomany');
+        $conn->executeStatement('DROP TABLE vct_owning_manytoone');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetomany');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetomany LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetomany LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_manytoone LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_manytoone LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_owning_manytoone LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_id FROM vct_owning_manytoone LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdForeignKeyTest.php
@@ -50,23 +50,23 @@ class OneToOneCompositeIdForeignKeyTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid_foreignkey');
-        $conn->executeUpdate('DROP TABLE vct_auxiliary');
+        $conn->executeStatement('DROP TABLE vct_owning_onetoone_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetoone_compositeid_foreignkey');
+        $conn->executeStatement('DROP TABLE vct_auxiliary');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id4 FROM vct_auxiliary LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id4 FROM vct_auxiliary LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT foreign_id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT foreign_id FROM vct_inversed_onetoone_compositeid_foreignkey LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id2 FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_foreign_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id2 FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT associated_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_foreign_id FROM vct_owning_onetoone_compositeid_foreignkey LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneCompositeIdTest.php
@@ -45,20 +45,20 @@ class OneToOneCompositeIdTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone_compositeid');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone_compositeid');
+        $conn->executeStatement('DROP TABLE vct_owning_onetoone_compositeid');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetoone_compositeid');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_inversed_onetoone_compositeid LIMIT 1'));
 
-        self::assertEquals('tuv', $conn->fetchColumn('SELECT id3 FROM vct_owning_onetoone_compositeid LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_id1 FROM vct_owning_onetoone_compositeid LIMIT 1'));
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT associated_id2 FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        self::assertEquals('tuv', $conn->fetchOne('SELECT id3 FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_id1 FROM vct_owning_onetoone_compositeid LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT associated_id2 FROM vct_owning_onetoone_compositeid LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ValueConversionType/OneToOneTest.php
@@ -45,18 +45,18 @@ class OneToOneTest extends OrmFunctionalTestCase
     {
         $conn = static::$sharedConn;
 
-        $conn->executeUpdate('DROP TABLE vct_owning_onetoone');
-        $conn->executeUpdate('DROP TABLE vct_inversed_onetoone');
+        $conn->executeStatement('DROP TABLE vct_owning_onetoone');
+        $conn->executeStatement('DROP TABLE vct_inversed_onetoone');
     }
 
     public function testThatTheValueOfIdentifiersAreConvertedInTheDatabase(): void
     {
         $conn = $this->_em->getConnection();
 
-        self::assertEquals('nop', $conn->fetchColumn('SELECT id1 FROM vct_inversed_onetoone LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT id1 FROM vct_inversed_onetoone LIMIT 1'));
 
-        self::assertEquals('qrs', $conn->fetchColumn('SELECT id2 FROM vct_owning_onetoone LIMIT 1'));
-        self::assertEquals('nop', $conn->fetchColumn('SELECT associated_id FROM vct_owning_onetoone LIMIT 1'));
+        self::assertEquals('qrs', $conn->fetchOne('SELECT id2 FROM vct_owning_onetoone LIMIT 1'));
+        self::assertEquals('nop', $conn->fetchOne('SELECT associated_id FROM vct_owning_onetoone LIMIT 1'));
     }
 
     /**

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -359,162 +359,162 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($this->_usedModelSets['cms'])) {
-            $conn->executeUpdate('DELETE FROM cms_users_groups');
-            $conn->executeUpdate('DELETE FROM cms_groups');
-            $conn->executeUpdate('DELETE FROM cms_users_tags');
-            $conn->executeUpdate('DELETE FROM cms_tags');
-            $conn->executeUpdate('DELETE FROM cms_addresses');
-            $conn->executeUpdate('DELETE FROM cms_phonenumbers');
-            $conn->executeUpdate('DELETE FROM cms_comments');
-            $conn->executeUpdate('DELETE FROM cms_articles');
-            $conn->executeUpdate('DELETE FROM cms_users');
-            $conn->executeUpdate('DELETE FROM cms_emails');
+            $conn->executeStatement('DELETE FROM cms_users_groups');
+            $conn->executeStatement('DELETE FROM cms_groups');
+            $conn->executeStatement('DELETE FROM cms_users_tags');
+            $conn->executeStatement('DELETE FROM cms_tags');
+            $conn->executeStatement('DELETE FROM cms_addresses');
+            $conn->executeStatement('DELETE FROM cms_phonenumbers');
+            $conn->executeStatement('DELETE FROM cms_comments');
+            $conn->executeStatement('DELETE FROM cms_articles');
+            $conn->executeStatement('DELETE FROM cms_users');
+            $conn->executeStatement('DELETE FROM cms_emails');
         }
 
         if (isset($this->_usedModelSets['ecommerce'])) {
-            $conn->executeUpdate('DELETE FROM ecommerce_carts_products');
-            $conn->executeUpdate('DELETE FROM ecommerce_products_categories');
-            $conn->executeUpdate('DELETE FROM ecommerce_products_related');
-            $conn->executeUpdate('DELETE FROM ecommerce_carts');
-            $conn->executeUpdate('DELETE FROM ecommerce_customers');
-            $conn->executeUpdate('DELETE FROM ecommerce_features');
-            $conn->executeUpdate('DELETE FROM ecommerce_products');
-            $conn->executeUpdate('DELETE FROM ecommerce_shippings');
-            $conn->executeUpdate('UPDATE ecommerce_categories SET parent_id = NULL');
-            $conn->executeUpdate('DELETE FROM ecommerce_categories');
+            $conn->executeStatement('DELETE FROM ecommerce_carts_products');
+            $conn->executeStatement('DELETE FROM ecommerce_products_categories');
+            $conn->executeStatement('DELETE FROM ecommerce_products_related');
+            $conn->executeStatement('DELETE FROM ecommerce_carts');
+            $conn->executeStatement('DELETE FROM ecommerce_customers');
+            $conn->executeStatement('DELETE FROM ecommerce_features');
+            $conn->executeStatement('DELETE FROM ecommerce_products');
+            $conn->executeStatement('DELETE FROM ecommerce_shippings');
+            $conn->executeStatement('UPDATE ecommerce_categories SET parent_id = NULL');
+            $conn->executeStatement('DELETE FROM ecommerce_categories');
         }
 
         if (isset($this->_usedModelSets['company'])) {
-            $conn->executeUpdate('DELETE FROM company_contract_employees');
-            $conn->executeUpdate('DELETE FROM company_contract_managers');
-            $conn->executeUpdate('DELETE FROM company_contracts');
-            $conn->executeUpdate('DELETE FROM company_persons_friends');
-            $conn->executeUpdate('DELETE FROM company_managers');
-            $conn->executeUpdate('DELETE FROM company_employees');
-            $conn->executeUpdate('UPDATE company_persons SET spouse_id = NULL');
-            $conn->executeUpdate('DELETE FROM company_persons');
-            $conn->executeUpdate('DELETE FROM company_raffles');
-            $conn->executeUpdate('DELETE FROM company_auctions');
-            $conn->executeUpdate('UPDATE company_organizations SET main_event_id = NULL');
-            $conn->executeUpdate('DELETE FROM company_events');
-            $conn->executeUpdate('DELETE FROM company_organizations');
+            $conn->executeStatement('DELETE FROM company_contract_employees');
+            $conn->executeStatement('DELETE FROM company_contract_managers');
+            $conn->executeStatement('DELETE FROM company_contracts');
+            $conn->executeStatement('DELETE FROM company_persons_friends');
+            $conn->executeStatement('DELETE FROM company_managers');
+            $conn->executeStatement('DELETE FROM company_employees');
+            $conn->executeStatement('UPDATE company_persons SET spouse_id = NULL');
+            $conn->executeStatement('DELETE FROM company_persons');
+            $conn->executeStatement('DELETE FROM company_raffles');
+            $conn->executeStatement('DELETE FROM company_auctions');
+            $conn->executeStatement('UPDATE company_organizations SET main_event_id = NULL');
+            $conn->executeStatement('DELETE FROM company_events');
+            $conn->executeStatement('DELETE FROM company_organizations');
         }
 
         if (isset($this->_usedModelSets['generic'])) {
-            $conn->executeUpdate('DELETE FROM boolean_model');
-            $conn->executeUpdate('DELETE FROM date_time_model');
-            $conn->executeUpdate('DELETE FROM decimal_model');
-            $conn->executeUpdate('DELETE FROM serialize_model');
+            $conn->executeStatement('DELETE FROM boolean_model');
+            $conn->executeStatement('DELETE FROM date_time_model');
+            $conn->executeStatement('DELETE FROM decimal_model');
+            $conn->executeStatement('DELETE FROM serialize_model');
         }
 
         if (isset($this->_usedModelSets['routing'])) {
-            $conn->executeUpdate('DELETE FROM RoutingRouteLegs');
-            $conn->executeUpdate('DELETE FROM RoutingRouteBooking');
-            $conn->executeUpdate('DELETE FROM RoutingRoute');
-            $conn->executeUpdate('DELETE FROM RoutingLeg');
-            $conn->executeUpdate('DELETE FROM RoutingLocation');
+            $conn->executeStatement('DELETE FROM RoutingRouteLegs');
+            $conn->executeStatement('DELETE FROM RoutingRouteBooking');
+            $conn->executeStatement('DELETE FROM RoutingRoute');
+            $conn->executeStatement('DELETE FROM RoutingLeg');
+            $conn->executeStatement('DELETE FROM RoutingLocation');
         }
 
         if (isset($this->_usedModelSets['navigation'])) {
-            $conn->executeUpdate('DELETE FROM navigation_tour_pois');
-            $conn->executeUpdate('DELETE FROM navigation_photos');
-            $conn->executeUpdate('DELETE FROM navigation_pois');
-            $conn->executeUpdate('DELETE FROM navigation_tours');
-            $conn->executeUpdate('DELETE FROM navigation_countries');
+            $conn->executeStatement('DELETE FROM navigation_tour_pois');
+            $conn->executeStatement('DELETE FROM navigation_photos');
+            $conn->executeStatement('DELETE FROM navigation_pois');
+            $conn->executeStatement('DELETE FROM navigation_tours');
+            $conn->executeStatement('DELETE FROM navigation_countries');
         }
 
         if (isset($this->_usedModelSets['directorytree'])) {
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('file'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('file'));
             // MySQL doesn't know deferred deletions therefore only executing the second query gives errors.
-            $conn->executeUpdate('DELETE FROM Directory WHERE parentDirectory_id IS NOT NULL');
-            $conn->executeUpdate('DELETE FROM Directory');
+            $conn->executeStatement('DELETE FROM Directory WHERE parentDirectory_id IS NOT NULL');
+            $conn->executeStatement('DELETE FROM Directory');
         }
 
         if (isset($this->_usedModelSets['ddc117'])) {
-            $conn->executeUpdate('DELETE FROM ddc117editor_ddc117translation');
-            $conn->executeUpdate('DELETE FROM DDC117Editor');
-            $conn->executeUpdate('DELETE FROM DDC117ApproveChanges');
-            $conn->executeUpdate('DELETE FROM DDC117Link');
-            $conn->executeUpdate('DELETE FROM DDC117Reference');
-            $conn->executeUpdate('DELETE FROM DDC117ArticleDetails');
-            $conn->executeUpdate('DELETE FROM DDC117Translation');
-            $conn->executeUpdate('DELETE FROM DDC117Article');
+            $conn->executeStatement('DELETE FROM ddc117editor_ddc117translation');
+            $conn->executeStatement('DELETE FROM DDC117Editor');
+            $conn->executeStatement('DELETE FROM DDC117ApproveChanges');
+            $conn->executeStatement('DELETE FROM DDC117Link');
+            $conn->executeStatement('DELETE FROM DDC117Reference');
+            $conn->executeStatement('DELETE FROM DDC117ArticleDetails');
+            $conn->executeStatement('DELETE FROM DDC117Translation');
+            $conn->executeStatement('DELETE FROM DDC117Article');
         }
 
         if (isset($this->_usedModelSets['stockexchange'])) {
-            $conn->executeUpdate('DELETE FROM exchange_bonds_stocks');
-            $conn->executeUpdate('DELETE FROM exchange_bonds');
-            $conn->executeUpdate('DELETE FROM exchange_stocks');
-            $conn->executeUpdate('DELETE FROM exchange_markets');
+            $conn->executeStatement('DELETE FROM exchange_bonds_stocks');
+            $conn->executeStatement('DELETE FROM exchange_bonds');
+            $conn->executeStatement('DELETE FROM exchange_stocks');
+            $conn->executeStatement('DELETE FROM exchange_markets');
         }
 
         if (isset($this->_usedModelSets['legacy'])) {
-            $conn->executeUpdate('DELETE FROM legacy_users_cars');
-            $conn->executeUpdate('DELETE FROM legacy_users_reference');
-            $conn->executeUpdate('DELETE FROM legacy_articles');
-            $conn->executeUpdate('DELETE FROM legacy_cars');
-            $conn->executeUpdate('DELETE FROM legacy_users');
+            $conn->executeStatement('DELETE FROM legacy_users_cars');
+            $conn->executeStatement('DELETE FROM legacy_users_reference');
+            $conn->executeStatement('DELETE FROM legacy_articles');
+            $conn->executeStatement('DELETE FROM legacy_cars');
+            $conn->executeStatement('DELETE FROM legacy_users');
         }
 
         if (isset($this->_usedModelSets['customtype'])) {
-            $conn->executeUpdate('DELETE FROM customtype_parent_friends');
-            $conn->executeUpdate('DELETE FROM customtype_parents');
-            $conn->executeUpdate('DELETE FROM customtype_children');
-            $conn->executeUpdate('DELETE FROM customtype_uppercases');
+            $conn->executeStatement('DELETE FROM customtype_parent_friends');
+            $conn->executeStatement('DELETE FROM customtype_parents');
+            $conn->executeStatement('DELETE FROM customtype_children');
+            $conn->executeStatement('DELETE FROM customtype_uppercases');
         }
 
         if (isset($this->_usedModelSets['compositekeyinheritance'])) {
-            $conn->executeUpdate('DELETE FROM JoinedChildClass');
-            $conn->executeUpdate('DELETE FROM JoinedRootClass');
-            $conn->executeUpdate('DELETE FROM SingleRootClass');
+            $conn->executeStatement('DELETE FROM JoinedChildClass');
+            $conn->executeStatement('DELETE FROM JoinedRootClass');
+            $conn->executeStatement('DELETE FROM SingleRootClass');
         }
 
         if (isset($this->_usedModelSets['taxi'])) {
-            $conn->executeUpdate('DELETE FROM taxi_paid_ride');
-            $conn->executeUpdate('DELETE FROM taxi_ride');
-            $conn->executeUpdate('DELETE FROM taxi_car');
-            $conn->executeUpdate('DELETE FROM taxi_driver');
+            $conn->executeStatement('DELETE FROM taxi_paid_ride');
+            $conn->executeStatement('DELETE FROM taxi_ride');
+            $conn->executeStatement('DELETE FROM taxi_car');
+            $conn->executeStatement('DELETE FROM taxi_driver');
         }
 
         if (isset($this->_usedModelSets['tweet'])) {
-            $conn->executeUpdate('DELETE FROM tweet_tweet');
-            $conn->executeUpdate('DELETE FROM tweet_user_list');
-            $conn->executeUpdate('DELETE FROM tweet_user');
+            $conn->executeStatement('DELETE FROM tweet_tweet');
+            $conn->executeStatement('DELETE FROM tweet_user_list');
+            $conn->executeStatement('DELETE FROM tweet_user');
         }
 
         if (isset($this->_usedModelSets['cache'])) {
-            $conn->executeUpdate('DELETE FROM cache_attraction_location_info');
-            $conn->executeUpdate('DELETE FROM cache_attraction_contact_info');
-            $conn->executeUpdate('DELETE FROM cache_attraction_info');
-            $conn->executeUpdate('DELETE FROM cache_visited_cities');
-            $conn->executeUpdate('DELETE FROM cache_flight');
-            $conn->executeUpdate('DELETE FROM cache_attraction');
-            $conn->executeUpdate('DELETE FROM cache_travel');
-            $conn->executeUpdate('DELETE FROM cache_traveler');
-            $conn->executeUpdate('DELETE FROM cache_traveler_profile_info');
-            $conn->executeUpdate('DELETE FROM cache_traveler_profile');
-            $conn->executeUpdate('DELETE FROM cache_city');
-            $conn->executeUpdate('DELETE FROM cache_state');
-            $conn->executeUpdate('DELETE FROM cache_country');
-            $conn->executeUpdate('DELETE FROM cache_login');
-            $conn->executeUpdate('DELETE FROM cache_token');
-            $conn->executeUpdate('DELETE FROM cache_complex_action');
-            $conn->executeUpdate('DELETE FROM cache_action');
-            $conn->executeUpdate('DELETE FROM cache_client');
+            $conn->executeStatement('DELETE FROM cache_attraction_location_info');
+            $conn->executeStatement('DELETE FROM cache_attraction_contact_info');
+            $conn->executeStatement('DELETE FROM cache_attraction_info');
+            $conn->executeStatement('DELETE FROM cache_visited_cities');
+            $conn->executeStatement('DELETE FROM cache_flight');
+            $conn->executeStatement('DELETE FROM cache_attraction');
+            $conn->executeStatement('DELETE FROM cache_travel');
+            $conn->executeStatement('DELETE FROM cache_traveler');
+            $conn->executeStatement('DELETE FROM cache_traveler_profile_info');
+            $conn->executeStatement('DELETE FROM cache_traveler_profile');
+            $conn->executeStatement('DELETE FROM cache_city');
+            $conn->executeStatement('DELETE FROM cache_state');
+            $conn->executeStatement('DELETE FROM cache_country');
+            $conn->executeStatement('DELETE FROM cache_login');
+            $conn->executeStatement('DELETE FROM cache_token');
+            $conn->executeStatement('DELETE FROM cache_complex_action');
+            $conn->executeStatement('DELETE FROM cache_action');
+            $conn->executeStatement('DELETE FROM cache_client');
         }
 
         if (isset($this->_usedModelSets['ddc3346'])) {
-            $conn->executeUpdate('DELETE FROM ddc3346_articles');
-            $conn->executeUpdate('DELETE FROM ddc3346_users');
+            $conn->executeStatement('DELETE FROM ddc3346_articles');
+            $conn->executeStatement('DELETE FROM ddc3346_users');
         }
 
         if (isset($this->_usedModelSets['ornemental_orphan_removal'])) {
-            $conn->executeUpdate('DELETE FROM ornemental_orphan_removal_person');
-            $conn->executeUpdate('DELETE FROM ornemental_orphan_removal_phone_number');
+            $conn->executeStatement('DELETE FROM ornemental_orphan_removal_person');
+            $conn->executeStatement('DELETE FROM ornemental_orphan_removal_phone_number');
         }
 
         if (isset($this->_usedModelSets['quote'])) {
-            $conn->executeUpdate(
+            $conn->executeStatement(
                 sprintf(
                     'UPDATE %s SET %s = NULL',
                     $platform->quoteIdentifier('quote-address'),
@@ -522,104 +522,104 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
                 )
             );
 
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-users-groups'));
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-group'));
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-phone'));
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-user'));
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-address'));
-            $conn->executeUpdate('DELETE FROM ' . $platform->quoteIdentifier('quote-city'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-users-groups'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-group'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-phone'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-user'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-address'));
+            $conn->executeStatement('DELETE FROM ' . $platform->quoteIdentifier('quote-city'));
         }
 
         if (isset($this->_usedModelSets['vct_onetoone'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_onetoone');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone');
+            $conn->executeStatement('DELETE FROM vct_owning_onetoone');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetoone');
         }
 
         if (isset($this->_usedModelSets['vct_onetoone_compositeid'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_onetoone_compositeid');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone_compositeid');
+            $conn->executeStatement('DELETE FROM vct_owning_onetoone_compositeid');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetoone_compositeid');
         }
 
         if (isset($this->_usedModelSets['vct_onetoone_compositeid_foreignkey'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_onetoone_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetoone_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_auxiliary');
+            $conn->executeStatement('DELETE FROM vct_owning_onetoone_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetoone_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_auxiliary');
         }
 
         if (isset($this->_usedModelSets['vct_onetomany'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_manytoone');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany');
+            $conn->executeStatement('DELETE FROM vct_owning_manytoone');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetomany');
         }
 
         if (isset($this->_usedModelSets['vct_onetomany_compositeid'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_compositeid');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_compositeid');
+            $conn->executeStatement('DELETE FROM vct_owning_manytoone_compositeid');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetomany_compositeid');
         }
 
         if (isset($this->_usedModelSets['vct_onetomany_compositeid_foreignkey'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_auxiliary');
+            $conn->executeStatement('DELETE FROM vct_owning_manytoone_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetomany_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_auxiliary');
         }
 
         if (isset($this->_usedModelSets['vct_onetomany_extralazy'])) {
-            $conn->executeUpdate('DELETE FROM vct_owning_manytoone_extralazy');
-            $conn->executeUpdate('DELETE FROM vct_inversed_onetomany_extralazy');
+            $conn->executeStatement('DELETE FROM vct_owning_manytoone_extralazy');
+            $conn->executeStatement('DELETE FROM vct_inversed_onetomany_extralazy');
         }
 
         if (isset($this->_usedModelSets['vct_manytomany'])) {
-            $conn->executeUpdate('DELETE FROM vct_xref_manytomany');
-            $conn->executeUpdate('DELETE FROM vct_owning_manytomany');
-            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany');
+            $conn->executeStatement('DELETE FROM vct_xref_manytomany');
+            $conn->executeStatement('DELETE FROM vct_owning_manytomany');
+            $conn->executeStatement('DELETE FROM vct_inversed_manytomany');
         }
 
         if (isset($this->_usedModelSets['vct_manytomany_compositeid'])) {
-            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_compositeid');
-            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_compositeid');
-            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_compositeid');
+            $conn->executeStatement('DELETE FROM vct_xref_manytomany_compositeid');
+            $conn->executeStatement('DELETE FROM vct_owning_manytomany_compositeid');
+            $conn->executeStatement('DELETE FROM vct_inversed_manytomany_compositeid');
         }
 
         if (isset($this->_usedModelSets['vct_manytomany_compositeid_foreignkey'])) {
-            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_compositeid_foreignkey');
-            $conn->executeUpdate('DELETE FROM vct_auxiliary');
+            $conn->executeStatement('DELETE FROM vct_xref_manytomany_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_owning_manytomany_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_inversed_manytomany_compositeid_foreignkey');
+            $conn->executeStatement('DELETE FROM vct_auxiliary');
         }
 
         if (isset($this->_usedModelSets['vct_manytomany_extralazy'])) {
-            $conn->executeUpdate('DELETE FROM vct_xref_manytomany_extralazy');
-            $conn->executeUpdate('DELETE FROM vct_owning_manytomany_extralazy');
-            $conn->executeUpdate('DELETE FROM vct_inversed_manytomany_extralazy');
+            $conn->executeStatement('DELETE FROM vct_xref_manytomany_extralazy');
+            $conn->executeStatement('DELETE FROM vct_owning_manytomany_extralazy');
+            $conn->executeStatement('DELETE FROM vct_inversed_manytomany_extralazy');
         }
 
         if (isset($this->_usedModelSets['geonames'])) {
-            $conn->executeUpdate('DELETE FROM geonames_admin1_alternate_name');
-            $conn->executeUpdate('DELETE FROM geonames_admin1');
-            $conn->executeUpdate('DELETE FROM geonames_city');
-            $conn->executeUpdate('DELETE FROM geonames_country');
+            $conn->executeStatement('DELETE FROM geonames_admin1_alternate_name');
+            $conn->executeStatement('DELETE FROM geonames_admin1');
+            $conn->executeStatement('DELETE FROM geonames_city');
+            $conn->executeStatement('DELETE FROM geonames_country');
         }
 
         if (isset($this->_usedModelSets['custom_id_object_type'])) {
-            $conn->executeUpdate('DELETE FROM custom_id_type_child');
-            $conn->executeUpdate('DELETE FROM custom_id_type_parent');
+            $conn->executeStatement('DELETE FROM custom_id_type_child');
+            $conn->executeStatement('DELETE FROM custom_id_type_parent');
         }
 
         if (isset($this->_usedModelSets['pagination'])) {
-            $conn->executeUpdate('DELETE FROM pagination_logo');
-            $conn->executeUpdate('DELETE FROM pagination_department');
-            $conn->executeUpdate('DELETE FROM pagination_company');
-            $conn->executeUpdate('DELETE FROM pagination_user');
+            $conn->executeStatement('DELETE FROM pagination_logo');
+            $conn->executeStatement('DELETE FROM pagination_department');
+            $conn->executeStatement('DELETE FROM pagination_company');
+            $conn->executeStatement('DELETE FROM pagination_user');
         }
 
         if (isset($this->_usedModelSets['versioned_many_to_one'])) {
-            $conn->executeUpdate('DELETE FROM versioned_many_to_one_article');
-            $conn->executeUpdate('DELETE FROM versioned_many_to_one_category');
+            $conn->executeStatement('DELETE FROM versioned_many_to_one_article');
+            $conn->executeStatement('DELETE FROM versioned_many_to_one_category');
         }
 
         if (isset($this->_usedModelSets['issue5989'])) {
-            $conn->executeUpdate('DELETE FROM issue5989_persons');
-            $conn->executeUpdate('DELETE FROM issue5989_employees');
-            $conn->executeUpdate('DELETE FROM issue5989_managers');
+            $conn->executeStatement('DELETE FROM issue5989_persons');
+            $conn->executeStatement('DELETE FROM issue5989_employees');
+            $conn->executeStatement('DELETE FROM issue5989_managers');
         }
 
         $this->_em->clear();

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -97,7 +97,7 @@ class TestUtil
             $stmts  = $schema->toDropSql($testConn->getDatabasePlatform());
 
             foreach ($stmts as $stmt) {
-                $testConn->exec($stmt);
+                $testConn->executeStatement($stmt);
             }
         }
     }


### PR DESCRIPTION
This PR removes more calls to deprecated methods of the `Connection` class, mainly `fetchColumn()`, `exec()` and `executeUpdate()`.