### PR TITLE
Remove calls to `Driver::getName()`

### DIFF
--- a/tests/Doctrine/Tests/Mocks/DriverMock.php
+++ b/tests/Doctrine/Tests/Mocks/DriverMock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Mocks;
 
+use BadMethodCallException;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
@@ -70,7 +71,7 @@ class DriverMock implements Driver
      */
     public function getName()
     {
-        return 'mock';
+        throw new BadMethodCallException('Call to deprecated method.');
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -34,7 +34,7 @@ class DDC214Test extends OrmFunctionalTestCase
 
         $conn = $this->_em->getConnection();
 
-        if (strpos($conn->getDriver()->getName(), 'sqlite') !== false) {
+        if ($conn->getDriver()->getDatabasePlatform()->getName() === 'sqlite') {
             self::markTestSkipped('SQLite does not support ALTER TABLE statements.');
         }
 


### PR DESCRIPTION
`Driver::getName()` is gone in DBAL 3. Let's not call it.