### PR TITLE
Remove calls to `EchoSQLLogger`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional\Locking;
 use Closure;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -126,7 +125,6 @@ class LockAgentWorker
 
         $cache = DoctrineProvider::wrap(new ArrayAdapter());
         $config->setQueryCacheImpl($cache);
-        $config->setSQLLogger(new EchoSQLLogger());
 
         return EntityManager::create($conn, $config);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -27,8 +26,6 @@ class DDC832Test extends OrmFunctionalTestCase
         if ($platform->getName() === 'oracle') {
             self::markTestSkipped('Doesnt run on Oracle.');
         }
-
-        $this->_em->getConfiguration()->setSQLLogger(new EchoSQLLogger());
 
         try {
             $this->_schemaTool->createSchema(


### PR DESCRIPTION
`EchoSQLLogger` is gone in DBAL 3. Do we actually need it?