### PR TITLE
Remove remaining call to `prefersSequences()`

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC117Test.php
@@ -287,10 +287,6 @@ class DDC117Test extends OrmFunctionalTestCase
      */
     public function testOneToOneCascadePersist(): void
     {
-        if (! $this->_em->getConnection()->getDatabasePlatform()->prefersSequences()) {
-            self::markTestSkipped('Test only works with databases that prefer sequences as ID strategy.');
-        }
-
         $this->article1       = new DDC117Article('Foo');
         $this->articleDetails = new DDC117ArticleDetails($this->article1, 'Very long text');
 


### PR DESCRIPTION
This PR removes one call to `prefersSequences()` that slipped my eye. Here it is used to skip a test for platforms that don't "prefer" sequences.

While that test certainly was meant to reproduce a bug that occurred with sequences, I'm unsure if we really need to skip it in other environments.