### PR TITLE
Remove references to `Type::DATETIME`

### DIFF
--- a/tests/Doctrine/Performance/Query/QueryBoundParameterProcessingBench.php
+++ b/tests/Doctrine/Performance/Query/QueryBoundParameterProcessingBench.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Performance\Query;
 
 use DateTime;
-use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Query;
 use Doctrine\Performance\EntityManagerFactory;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
@@ -59,7 +59,7 @@ DQL;
 
         foreach (range(1, 10) as $index) {
             $this->parsedQueryWithInferredParameterType->setParameter('parameter' . $index, new DateTime());
-            $this->parsedQueryWithDeclaredParameterType->setParameter('parameter' . $index, new DateTime(), DateTimeType::DATETIME);
+            $this->parsedQueryWithDeclaredParameterType->setParameter('parameter' . $index, new DateTime(), Types::DATETIME_MUTABLE);
         }
 
         // Force parsing upfront - we don't benchmark that bit in this scenario

--- a/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/TypeTest.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\ORM\Functional;
 
 use DateTime;
 use DateTimeZone;
-use Doctrine\DBAL\Types\Type as DBALType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Tests\Models\Generic\BooleanModel;
 use Doctrine\Tests\Models\Generic\DateTimeModel;
 use Doctrine\Tests\Models\Generic\DecimalModel;
@@ -146,7 +146,7 @@ class TypeTest extends OrmFunctionalTestCase
         $this->_em->clear();
 
         $dateTimeDb = $this->_em->createQuery('SELECT d FROM Doctrine\Tests\Models\Generic\DateTimeModel d WHERE d.datetime = ?1')
-                                ->setParameter(1, $date, DBALType::DATETIME)
+                                ->setParameter(1, $date, Types::DATETIME_MUTABLE)
                                 ->getSingleResult();
 
         self::assertInstanceOf(DateTime::class, $dateTimeDb->datetime);
@@ -168,7 +168,7 @@ class TypeTest extends OrmFunctionalTestCase
                                  ->select('d')
                                  ->from(DateTimeModel::class, 'd')
                                  ->where('d.datetime = ?1')
-                                 ->setParameter(1, $date, DBALType::DATETIME)
+                                 ->setParameter(1, $date, Types::DATETIME_MUTABLE)
                                  ->getQuery()->getSingleResult();
 
         self::assertInstanceOf(DateTime::class, $dateTimeDb->datetime);

--- a/tests/Doctrine/Tests/ORM/Query/QueryTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/QueryTest.php
@@ -9,7 +9,7 @@ use DateTimeImmutable;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\ParameterType;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
@@ -505,7 +505,7 @@ class QueryTest extends OrmTestCase
 
         $query = $this->entityManager->createQuery('SELECT d FROM ' . DateTimeModel::class . ' d WHERE d.datetime = :value');
 
-        $query->setParameter('value', new DateTime(), Type::DATETIME);
+        $query->setParameter('value', new DateTime(), Types::DATETIME_MUTABLE);
 
         self::assertEmpty($query->getResult());
     }


### PR DESCRIPTION
`Type::DATETIME` is gone in DBAL 3.