### PR TITLE
Document possibly-null member variables

### DIFF
--- a/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ArrayHydrator.php
@@ -41,9 +41,9 @@ class ArrayHydrator extends AbstractHydrator
      */
     protected function prepare()
     {
-        $this->_isSimpleQuery = count($this->_rsm->aliasMap) <= 1;
+        $this->_isSimpleQuery = count($this->resultSetMapping()->aliasMap) <= 1;
 
-        foreach ($this->_rsm->aliasMap as $dqlAlias => $className) {
+        foreach ($this->resultSetMapping()->aliasMap as $dqlAlias => $className) {
             $this->_identifierMap[$dqlAlias]  = [];
             $this->_resultPointers[$dqlAlias] = [];
             $this->_idTemplate[$dqlAlias]     = '';
@@ -57,7 +57,7 @@ class ArrayHydrator extends AbstractHydrator
     {
         $result = [];
 
-        while ($data = $this->_stmt->fetchAssociative()) {
+        while ($data = $this->statement()->fetchAssociative()) {
             $this->hydrateRowData($data, $result);
         }
 
@@ -78,10 +78,10 @@ class ArrayHydrator extends AbstractHydrator
         foreach ($rowData['data'] as $dqlAlias => $data) {
             $index = false;
 
-            if (isset($this->_rsm->parentAliasMap[$dqlAlias])) {
+            if (isset($this->resultSetMapping()->parentAliasMap[$dqlAlias])) {
                 // It's a joined result
 
-                $parent = $this->_rsm->parentAliasMap[$dqlAlias];
+                $parent = $this->resultSetMapping()->parentAliasMap[$dqlAlias];
                 $path   = $parent . '.' . $dqlAlias;
 
                 // missing parent data, skipping as RIGHT JOIN hydration is not supported.
@@ -91,7 +91,7 @@ class ArrayHydrator extends AbstractHydrator
 
                 // Get a reference to the right element in the result tree.
                 // This element will get the associated element attached.
-                if ($this->_rsm->isMixed && isset($this->_rootAliases[$parent])) {
+                if ($this->resultSetMapping()->isMixed && isset($this->_rootAliases[$parent])) {
                     $first = reset($this->_resultPointers);
                     // TODO: Exception if $key === null ?
                     $baseElement =& $this->_resultPointers[$parent][key($first)];
@@ -103,8 +103,8 @@ class ArrayHydrator extends AbstractHydrator
                     continue;
                 }
 
-                $relationAlias = $this->_rsm->relationMap[$dqlAlias];
-                $parentClass   = $this->_metadataCache[$this->_rsm->aliasMap[$parent]];
+                $relationAlias = $this->resultSetMapping()->relationMap[$dqlAlias];
+                $parentClass   = $this->_metadataCache[$this->resultSetMapping()->aliasMap[$parent]];
                 $relation      = $parentClass->associationMappings[$relationAlias];
 
                 // Check the type of the relation (many or single-valued)
@@ -123,8 +123,8 @@ class ArrayHydrator extends AbstractHydrator
                         if (! $indexExists || ! $indexIsValid) {
                             $element = $data;
 
-                            if (isset($this->_rsm->indexByMap[$dqlAlias])) {
-                                $baseElement[$relationAlias][$row[$this->_rsm->indexByMap[$dqlAlias]]] = $element;
+                            if (isset($this->resultSetMapping()->indexByMap[$dqlAlias])) {
+                                $baseElement[$relationAlias][$row[$this->resultSetMapping()->indexByMap[$dqlAlias]]] = $element;
                             } else {
                                 $baseElement[$relationAlias][] = $element;
                             }
@@ -156,11 +156,11 @@ class ArrayHydrator extends AbstractHydrator
                 // It's a root result element
 
                 $this->_rootAliases[$dqlAlias] = true; // Mark as root
-                $entityKey                     = $this->_rsm->entityMappings[$dqlAlias] ?: 0;
+                $entityKey                     = $this->resultSetMapping()->entityMappings[$dqlAlias] ?: 0;
 
                 // if this row has a NULL value for the root result id then make it a null result.
                 if (! isset($nonemptyComponents[$dqlAlias])) {
-                    $result[] = $this->_rsm->isMixed
+                    $result[] = $this->resultSetMapping()->isMixed
                         ? [$entityKey => null]
                         : null;
 
@@ -172,12 +172,12 @@ class ArrayHydrator extends AbstractHydrator
 
                 // Check for an existing element
                 if ($this->_isSimpleQuery || ! isset($this->_identifierMap[$dqlAlias][$id[$dqlAlias]])) {
-                    $element = $this->_rsm->isMixed
+                    $element = $this->resultSetMapping()->isMixed
                         ? [$entityKey => $data]
                         : $data;
 
-                    if (isset($this->_rsm->indexByMap[$dqlAlias])) {
-                        $resultKey          = $row[$this->_rsm->indexByMap[$dqlAlias]];
+                    if (isset($this->resultSetMapping()->indexByMap[$dqlAlias])) {
+                        $resultKey          = $row[$this->resultSetMapping()->indexByMap[$dqlAlias]];
                         $result[$resultKey] = $element;
                     } else {
                         $resultKey = $this->_resultCounter;
@@ -204,8 +204,8 @@ class ArrayHydrator extends AbstractHydrator
         if (isset($rowData['scalars'])) {
             if (! isset($resultKey)) {
                 // this only ever happens when no object is fetched (scalar result only)
-                $resultKey = isset($this->_rsm->indexByMap['scalars'])
-                    ? $row[$this->_rsm->indexByMap['scalars']]
+                $resultKey = isset($this->resultSetMapping()->indexByMap['scalars'])
+                    ? $row[$this->resultSetMapping()->indexByMap['scalars']]
                     : $this->_resultCounter - 1;
             }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php
@@ -18,7 +18,7 @@ class ScalarHydrator extends AbstractHydrator
     {
         $result = [];
 
-        while ($data = $this->_stmt->fetchAssociative()) {
+        while ($data = $this->statement()->fetchAssociative()) {
             $this->hydrateRowData($data, $result);
         }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php
@@ -27,15 +27,15 @@ class SimpleObjectHydrator extends AbstractHydrator
      */
     protected function prepare()
     {
-        if (count($this->_rsm->aliasMap) !== 1) {
+        if (count($this->resultSetMapping()->aliasMap) !== 1) {
             throw new RuntimeException('Cannot use SimpleObjectHydrator with a ResultSetMapping that contains more than one object result.');
         }
 
-        if ($this->_rsm->scalarMappings) {
+        if ($this->resultSetMapping()->scalarMappings) {
             throw new RuntimeException('Cannot use SimpleObjectHydrator with a ResultSetMapping that contains scalar mappings.');
         }
 
-        $this->class = $this->getClassMetadata(reset($this->_rsm->aliasMap));
+        $this->class = $this->getClassMetadata(reset($this->resultSetMapping()->aliasMap));
     }
 
     /**
@@ -56,7 +56,7 @@ class SimpleObjectHydrator extends AbstractHydrator
     {
         $result = [];
 
-        while ($row = $this->_stmt->fetchAssociative()) {
+        while ($row = $this->statement()->fetchAssociative()) {
             $this->hydrateRowData($row, $result);
         }
 
@@ -79,17 +79,23 @@ class SimpleObjectHydrator extends AbstractHydrator
             $discrColumnName = $this->_platform->getSQLResultCasing($this->class->discriminatorColumn['name']);
 
             // Find mapped discriminator column from the result set.
-            $metaMappingDiscrColumnName = array_search($discrColumnName, $this->_rsm->metaMappings, true);
+            $metaMappingDiscrColumnName = array_search($discrColumnName, $this->resultSetMapping()->metaMappings, true);
             if ($metaMappingDiscrColumnName) {
                 $discrColumnName = $metaMappingDiscrColumnName;
             }
 
             if (! isset($row[$discrColumnName])) {
-                throw HydrationException::missingDiscriminatorColumn($entityName, $discrColumnName, key($this->_rsm->aliasMap));
+                throw HydrationException::missingDiscriminatorColumn(
+                    $entityName,
+                    $discrColumnName,
+                    key($this->resultSetMapping()->aliasMap)
+                );
             }
 
             if ($row[$discrColumnName] === '') {
-                throw HydrationException::emptyDiscriminatorValue(key($this->_rsm->aliasMap));
+                throw HydrationException::emptyDiscriminatorValue(key(
+                    $this->resultSetMapping()->aliasMap
+                ));
             }
 
             $discrMap = $this->class->discriminatorMap;
@@ -106,7 +112,7 @@ class SimpleObjectHydrator extends AbstractHydrator
 
         foreach ($row as $column => $value) {
             // An ObjectHydrator should be used instead of SimpleObjectHydrator
-            if (isset($this->_rsm->relationMap[$column])) {
+            if (isset($this->resultSetMapping()->relationMap[$column])) {
                 throw new Exception(sprintf('Unable to retrieve association information for column "%s"', $column));
             }
 

--- a/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
+++ b/lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php
@@ -21,7 +21,7 @@ class SingleScalarHydrator extends AbstractHydrator
      */
     protected function hydrateAllData()
     {
-        $data    = $this->_stmt->fetchAllAssociative();
+        $data    = $this->statement()->fetchAllAssociative();
         $numRows = count($data);
 
         if ($numRows === 0) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,16 +216,6 @@ parameters:
 			path: lib/Doctrine/ORM/Id/TableGenerator.php
 
 		-
-			message: "#^Property Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\AbstractHydrator\\:\\:\\$_rsm \\(Doctrine\\\\ORM\\\\Query\\\\ResultSetMapping\\) does not accept null\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
-
-		-
-			message: "#^Property Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\AbstractHydrator\\:\\:\\$_stmt \\(Doctrine\\\\DBAL\\\\Result\\) does not accept null\\.$#"
-			count: 1
-			path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
-
-		-
 			message: "#^Parameter \\#2 \\$discrMap of static method Doctrine\\\\ORM\\\\Internal\\\\Hydration\\\\HydrationException\\:\\:invalidDiscriminatorValue\\(\\) expects array\\<string, string\\>, array\\<int, int\\|string\\> given\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/Internal/Hydration/ObjectHydrator.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -657,16 +657,7 @@
       <code>IterableResult</code>
       <code>new IterableResult($this)</code>
     </DeprecatedClass>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>$_hints</code>
-      <code>$_rsm</code>
-      <code>$_stmt</code>
-    </PropertyNotSetInConstructor>
-    <PropertyTypeCoercion occurrences="2">
+    <PropertyTypeCoercion occurrences="1">
       <code>$resultSetMapping</code>
       <code>$resultSetMapping</code>
     </PropertyTypeCoercion>
@@ -685,11 +676,6 @@
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$newObject['args']</code>
     </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>ArrayHydrator</code>
-      <code>ArrayHydrator</code>
-      <code>ArrayHydrator</code>
-    </PropertyNotSetInConstructor>
     <ReferenceConstraintViolation occurrences="1">
       <code>$result</code>
     </ReferenceConstraintViolation>
@@ -736,18 +722,6 @@
     <PossiblyUndefinedArrayOffset occurrences="1">
       <code>$newObject['args']</code>
     </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>ObjectHydrator</code>
-      <code>ObjectHydrator</code>
-      <code>ObjectHydrator</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Internal/Hydration/ScalarHydrator.php">
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>ScalarHydrator</code>
-      <code>ScalarHydrator</code>
-      <code>ScalarHydrator</code>
-    </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/Internal/Hydration/SimpleObjectHydrator.php">
     <DeprecatedMethod occurrences="1">
@@ -759,18 +733,8 @@
     <MissingPropertyType occurrences="1">
       <code>$this-&gt;class-&gt;inheritanceType</code>
     </MissingPropertyType>
-    <PropertyNotSetInConstructor occurrences="4">
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$class</code>
-      <code>SimpleObjectHydrator</code>
-      <code>SimpleObjectHydrator</code>
-      <code>SimpleObjectHydrator</code>
-    </PropertyNotSetInConstructor>
-  </file>
-  <file src="lib/Doctrine/ORM/Internal/Hydration/SingleScalarHydrator.php">
-    <PropertyNotSetInConstructor occurrences="3">
-      <code>SingleScalarHydrator</code>
-      <code>SingleScalarHydrator</code>
-      <code>SingleScalarHydrator</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/LazyCriteriaCollection.php">


### PR DESCRIPTION
Many of the variables in `AbstractHydrator` are not initialized in the
constructor, and should be documented as possibly null because of that.
Introducing accessors that perform null checks allows to to have to do
these null checks when using the accessors.
Making the member variables private would be a backwards-compatibility
break and could be considered for the next major version.

This makes Psalm's and PHPStan's baselines smaller, and should make
implementing new hydrators easier.

This should help with #8919 