### PR TITLE
Support for DBAL 3's platform classes

### DIFF
--- a/lib/Doctrine/ORM/Internal/SQLResultCasing.php
+++ b/lib/Doctrine/ORM/Internal/SQLResultCasing.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Internal;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\DB2Platform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
 use function method_exists;
 use function strtolower;
@@ -17,13 +21,12 @@ trait SQLResultCasing
 {
     private function getSQLResultCasing(AbstractPlatform $platform, string $column): string
     {
-        switch ($platform->getName()) {
-            case 'db2':
-            case 'oracle':
-                return strtoupper($column);
+        if ($platform instanceof DB2Platform || $platform instanceof OraclePlatform) {
+            return strtoupper($column);
+        }
 
-            case 'postgresql':
-                return strtolower($column);
+        if ($platform instanceof PostgreSQL94Platform || $platform instanceof PostgreSQLPlatform) {
+            return strtolower($column);
         }
 
         if (method_exists(AbstractPlatform::class, 'getSQLResultCasing')) {

--- a/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
+++ b/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php
@@ -651,7 +651,11 @@ class ClassMetadataFactory extends AbstractClassMetadataFactory
 
     private function determineIdGeneratorStrategy(AbstractPlatform $platform): int
     {
-        if ($platform->getName() === 'oracle' || $platform->getName() === 'postgresql') {
+        if (
+            $platform instanceof Platforms\OraclePlatform
+            || $platform instanceof Platforms\PostgreSQL94Platform
+            || $platform instanceof Platforms\PostgreSQLPlatform
+        ) {
             return ClassMetadata::GENERATOR_TYPE_SEQUENCE;
         }
 

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
@@ -26,6 +25,7 @@ use function array_keys;
 use function array_values;
 use function assert;
 use function count;
+use function get_debug_type;
 use function in_array;
 use function ksort;
 use function md5;
@@ -739,14 +739,9 @@ final class Query extends AbstractQuery
     {
         ksort($this->_hints);
 
-        $platform = $this->getEntityManager()
-            ->getConnection()
-            ->getDatabasePlatform()
-            ->getName();
-
         return md5(
             $this->getDQL() . serialize($this->_hints) .
-            '&platform=' . $platform .
+            '&platform=' . get_debug_type($this->getEntityManager()->getConnection()->getDatabasePlatform()) .
             ($this->_em->hasFilters() ? $this->_em->getFilters()->getHash() : '') .
             '&firstResult=' . $this->firstResult . '&maxResult=' . $this->maxResults .
             '&hydrationMode=' . $this->_hydrationMode . '&types=' . serialize($this->parsedTypes) . 'DOCTRINE_QUERY_CACHE_SALT'

--- a/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/CountOutputWalker.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Tools\Pagination;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\AST\SelectStatement;
 use Doctrine\ORM\Query\ParserResult;
@@ -70,7 +72,7 @@ class CountOutputWalker extends SqlWalker
      */
     public function walkSelectStatement(SelectStatement $AST)
     {
-        if ($this->platform->getName() === 'mssql') {
+        if ($this->platform instanceof SQLServer2012Platform || $this->platform instanceof SQLServerPlatform) {
             $AST->orderByClause = null;
         }
 

--- a/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
+++ b/lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php
@@ -7,8 +7,10 @@ namespace Doctrine\ORM\Tools\Pagination;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\DB2Platform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SQLAnywherePlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\QuoteStrategy;
@@ -115,7 +117,9 @@ class LimitSubqueryOutputWalker extends SqlWalker
      */
     private function platformSupportsRowNumber(): bool
     {
-        return $this->platform instanceof PostgreSqlPlatform
+        return $this->platform instanceof PostgreSQL94Platform // DBAL 3.1 compatibility
+            || $this->platform instanceof PostgreSQLPlatform
+            || $this->platform instanceof SQLServer2012Platform // DBAL 3.1 compatibility
             || $this->platform instanceof SQLServerPlatform
             || $this->platform instanceof OraclePlatform
             || $this->platform instanceof SQLAnywherePlatform

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -14,3 +14,5 @@ parameters:
         -
             message: '/Application::add\(\) expects Symfony\\Component\\Console\\Command\\Command/'
             path: lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+
+        - '/^Class Doctrine\\DBAL\\Platforms\\(PostgreSQL|SQLServer|SQLAnywhere)Platform not found\.$/'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,5 @@ parameters:
         - '/Variable \$offset in isset\(\) always exists and is not nullable\./'
         # PHPStan doesn't understand our method_exists() safeguards.
         - '/Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\./'
+        # Class name will change in DBAL 3.
+        - '/Class Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform referenced with incorrect case: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform\./'

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -733,6 +733,11 @@
       <code>$class</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="lib/Doctrine/ORM/Internal/SQLResultCasing.php">
+    <MissingDependency occurrences="1">
+      <code>PostgreSQL94Platform</code>
+    </MissingDependency>
+  </file>
   <file src="lib/Doctrine/ORM/LazyCriteriaCollection.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$element</code>
@@ -869,6 +874,9 @@
       <code>$driver</code>
       <code>$evm</code>
     </MissingConstructor>
+    <MissingDependency occurrences="1">
+      <code>Platforms\PostgreSQL94Platform</code>
+    </MissingDependency>
     <NoInterfaceProperties occurrences="31">
       <code>$class-&gt;cache</code>
       <code>$class-&gt;changeTrackingPolicy</code>
@@ -3774,6 +3782,9 @@
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php">
+    <MissingDependency occurrences="1">
+      <code>PostgreSQL94Platform</code>
+    </MissingDependency>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$query</code>
     </MoreSpecificImplementedParamType>

--- a/psalm.xml
+++ b/psalm.xml
@@ -37,6 +37,12 @@
                 <file name="lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php"/>
             </errorLevel>
         </DocblockTypeContradiction>
+        <InvalidClass>
+            <errorLevel type="suppress">
+                <!-- Class name changes in DBAL 3. -->
+                <referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform" />
+            </errorLevel>
+        </InvalidClass>
         <ParadoxicalCondition>
             <errorLevel type="suppress">
                 <!-- See https://github.com/vimeo/psalm/issues/3381 -->

--- a/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
+++ b/tests/Doctrine/Tests/Mocks/DatabasePlatformMock.php
@@ -108,12 +108,9 @@ class DatabasePlatformMock extends AbstractPlatform
         $this->supportsSequences = $bool;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
-        return 'mock';
+        throw new BadMethodCallException('Call to deprecated method.');
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\ORM\Tools;
 use Doctrine\Tests\Models;
@@ -34,7 +35,7 @@ class DDC214Test extends OrmFunctionalTestCase
 
         $conn = $this->_em->getConnection();
 
-        if ($conn->getDriver()->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($conn->getDriver()->getDatabasePlatform() instanceof SqlitePlatform) {
             self::markTestSkipped('SQLite does not support ALTER TABLE statements.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/MySqlSchemaToolTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -13,7 +14,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Tests\Models;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
-use function count;
 use function method_exists;
 use function sprintf;
 
@@ -22,7 +22,7 @@ class MySqlSchemaToolTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
             self::markTestSkipped('The ' . self::class . ' requires the use of mysql.');
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/PostgreSqlSchemaToolTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\SchemaTool;
 
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -17,7 +19,6 @@ use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function array_filter;
 use function array_shift;
-use function count;
 use function implode;
 use function strpos;
 
@@ -27,7 +28,8 @@ class PostgreSqlSchemaToolTest extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'postgresql') {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('The ' . self::class . ' requires the use of postgresql.');
         }
     }

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1151Test.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -20,7 +22,8 @@ class DDC1151Test extends OrmFunctionalTestCase
 {
     public function testQuoteForeignKey(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'postgresql') {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('This test is useful for all databases, but designed only for postgresql.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1360Test.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -18,7 +20,8 @@ class DDC1360Test extends OrmFunctionalTestCase
 {
     public function testSchemaDoubleQuotedCreate(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'postgresql') {
+        $platform = $this->_em->getConnection()->getDatabasePlatform();
+        if (! $platform instanceof PostgreSQL94Platform && ! $platform instanceof PostgreSQLPlatform) {
             self::markTestSkipped('PostgreSQL only test.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1695Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -18,7 +19,7 @@ class DDC1695Test extends OrmFunctionalTestCase
 {
     public function testIssue(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'sqlite') {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
             self::markTestSkipped('Only with sqlite');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2182Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
@@ -19,7 +20,7 @@ class DDC2182Test extends OrmFunctionalTestCase
 {
     public function testPassColumnOptionsToJoinColumns(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
+        if (! $this->_em->getConnection()->getDatabasePlatform() instanceof MySQLPlatform) {
             self::markTestSkipped('This test is useful for all databases, but designed only for mysql.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
 use Doctrine\ORM\Mapping\DiscriminatorMap;
@@ -22,9 +23,7 @@ class DDC832Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        $platform = $this->_em->getConnection()->getDatabasePlatform();
-
-        if ($platform->getName() === 'oracle') {
+        if ($this->_em->getConnection()->getDatabasePlatform() instanceof OraclePlatform) {
             self::markTestSkipped('Doesnt run on Oracle.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC933Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\LockMode;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\TransactionRequiredException;
@@ -29,7 +30,7 @@ class DDC933Test extends OrmFunctionalTestCase
      */
     public function testLockCTIClass(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() === 'sqlite') {
+        if ($this->_em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform) {
             self::markTestSkipped('It should not run on in-memory databases');
         }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7875Test.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
 use Doctrine\DBAL\Configuration;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -31,7 +32,8 @@ final class GH7875Test extends OrmFunctionalTestCase
         $connection->executeStatement('DROP TABLE IF EXISTS gh7875_my_entity');
         $connection->executeStatement('DROP TABLE IF EXISTS gh7875_my_other_entity');
 
-        if ($connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+        $platform = $connection->getDatabasePlatform();
+        if ($platform instanceof PostgreSQL94Platform || $platform instanceof PostgreSQLPlatform) {
             $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_entity_id_seq');
             $connection->executeStatement('DROP SEQUENCE IF EXISTS gh7875_my_other_entity_id_seq');
         }

--- a/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/UUIDGeneratorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Exception\NotSupported;
@@ -36,12 +35,12 @@ class UUIDGeneratorTest extends OrmFunctionalTestCase
 
     public function testGenerateUUID(): void
     {
-        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
-            self::markTestSkipped('Currently restricted to MySQL platform.');
-        }
-
         if (! method_exists(AbstractPlatform::class, 'getGuidExpression')) {
             self::markTestSkipped('Test valid for doctrine/dbal:2.x only.');
+        }
+
+        if ($this->_em->getConnection()->getDatabasePlatform()->getName() !== 'mysql') {
+            self::markTestSkipped('Currently restricted to MySQL platform.');
         }
 
         $this->_schemaTool->createSchema([

--- a/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
+++ b/tests/Doctrine/Tests/ORM/Query/SelectSqlGenerationTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Query;
 
 use Doctrine\DBAL\LockMode;
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Column;
@@ -31,8 +31,12 @@ use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\OrmTestCase;
 use Exception;
 
+use function class_exists;
 use function get_class;
 use function sprintf;
+
+// DBAL 2 compatibility
+class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');
 
 class SelectSqlGenerationTest extends OrmTestCase
 {
@@ -341,7 +345,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         $connMock    = $this->entityManager->getConnection();
         $orgPlatform = $connMock->getDatabasePlatform();
 
-        $connMock->setDatabasePlatform(new MySqlPlatform());
+        $connMock->setDatabasePlatform(new MySQLPlatform());
 
         $this->assertSqlGeneration(
             'SELECT COUNT(CONCAT(u.id, u.name)) FROM Doctrine\Tests\Models\CMS\CmsUser u GROUP BY u.id',
@@ -644,7 +648,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         $connMock    = $this->entityManager->getConnection();
         $orgPlatform = $connMock->getDatabasePlatform();
 
-        $connMock->setDatabasePlatform(new MySqlPlatform());
+        $connMock->setDatabasePlatform(new MySQLPlatform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE CONCAT(c0_.name, 's') = ?"
@@ -654,7 +658,7 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT CONCAT(c0_.id, c0_.name) AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
         );
 
-        $connMock->setDatabasePlatform(new PostgreSqlPlatform());
+        $connMock->setDatabasePlatform(new PostgreSQL94Platform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE c0_.name || 's' = ?"
@@ -950,7 +954,7 @@ class SelectSqlGenerationTest extends OrmTestCase
     public function testBooleanLiteralInWhereOnPostgres(): void
     {
         $oldPlat = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $this->assertSqlGeneration(
             'SELECT b FROM Doctrine\Tests\Models\Generic\BooleanModel b WHERE b.booleanField = true',
@@ -1092,7 +1096,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function testPessimisticReadLockQueryHintPostgreSql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $this->assertSqlGeneration(
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
@@ -1133,7 +1137,7 @@ class SelectSqlGenerationTest extends OrmTestCase
      */
     public function testPessimisticReadLockQueryHintMySql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $this->assertSqlGeneration(
             "SELECT u FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE u.username = 'gblanco'",
@@ -2102,7 +2106,7 @@ class SelectSqlGenerationTest extends OrmTestCase
         $connMock    = $this->entityManager->getConnection();
         $orgPlatform = $connMock->getDatabasePlatform();
 
-        $connMock->setDatabasePlatform(new MySqlPlatform());
+        $connMock->setDatabasePlatform(new MySQLPlatform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, u.status, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE CONCAT(c0_.name, c0_.status, 's') = ?"
@@ -2112,7 +2116,7 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT CONCAT(c0_.id, c0_.name, c0_.status) AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
         );
 
-        $connMock->setDatabasePlatform(new PostgreSqlPlatform());
+        $connMock->setDatabasePlatform(new PostgreSQL94Platform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, u.status, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE c0_.name || c0_.status || 's' = ?"
@@ -2122,7 +2126,7 @@ class SelectSqlGenerationTest extends OrmTestCase
             'SELECT c0_.id || c0_.name || c0_.status AS sclr_0 FROM cms_users c0_ WHERE c0_.id = ?'
         );
 
-        $connMock->setDatabasePlatform(new SQLServerPlatform());
+        $connMock->setDatabasePlatform(new SQLServer2012Platform());
         $this->assertSqlGeneration(
             "SELECT u.id FROM Doctrine\Tests\Models\CMS\CmsUser u WHERE CONCAT(u.name, u.status, 's') = ?1",
             "SELECT c0_.id AS id_0 FROM cms_users c0_ WHERE (c0_.name + c0_.status + 's') = ?"

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/CountOutputWalkerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\CountOutputWalker;
 
@@ -67,7 +69,8 @@ class CountOutputWalkerTest extends PaginationTestCase
 
     public function testCountQueryOrderBySqlServer(): void
     {
-        if ($this->entityManager->getConnection()->getDatabasePlatform()->getName() !== 'mssql') {
+        $platform = $this->entityManager->getConnection()->getDatabasePlatform();
+        if (! $platform instanceof SQLServer2012Platform && ! $platform instanceof SQLServerPlatform) {
             self::markTestSkipped('SQLServer only test.');
         }
 

--- a/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Pagination/LimitSubqueryOutputWalkerTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools\Pagination;
 
-use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\LimitSubqueryOutputWalker;
+
+use function class_exists;
+
+// DBAL 2 compatibility
+class_exists('Doctrine\DBAL\Platforms\MySqlPlatform');
 
 final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
 {
@@ -30,7 +35,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT p, c, a FROM Doctrine\Tests\ORM\Tools\Pagination\MyBlogPost p JOIN p.category c JOIN p.author a ORDER BY p.title'
@@ -49,7 +54,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithScalarSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity'
@@ -68,7 +73,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithMixedSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity, u.id DESC'
@@ -87,7 +92,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryWithHiddenScalarSortPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $query      = $this->entityManager->createQuery(
             'SELECT u, g, COUNT(g.id) AS hidden g_quantity FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.groups g ORDER BY g_quantity, u.id DESC'
@@ -106,7 +111,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
     public function testLimitSubqueryPg(): void
     {
         $odp = $this->entityManager->getConnection()->getDatabasePlatform();
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $this->testLimitSubquery();
 
@@ -215,7 +220,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             'SELECT a FROM Doctrine\Tests\ORM\Tools\Pagination\Author a ORDER BY (1 - 1000) * 1 DESC'
         );
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
@@ -230,7 +235,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             'SELECT a FROM Doctrine\Tests\ORM\Tools\Pagination\Avatar a ORDER BY a.imageHeight * a.imageWidth DESC'
         );
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
@@ -245,7 +250,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             'SELECT u FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.avatar a ORDER BY a.imageHeight * a.imageWidth DESC'
         );
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
@@ -260,7 +265,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             'SELECT u, partial a.{id, imageAltDesc} FROM Doctrine\Tests\ORM\Tools\Pagination\User u JOIN u.avatar a ORDER BY a.imageHeight * a.imageWidth DESC'
         );
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
@@ -307,7 +312,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
         $query = $this->entityManager->createQuery(
             'SELECT a FROM Doctrine\Tests\ORM\Tools\Pagination\Avatar a ORDER BY a.imageAltDesc DESC'
         );
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, LimitSubqueryOutputWalker::class);
 
@@ -333,7 +338,7 @@ final class LimitSubqueryOutputWalkerTest extends PaginationTestCase
 
     public function testLimitSubqueryWithOrderByAndSubSelectInWhereClauseMySql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
         $query = $this->entityManager->createQuery(
             'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b
 WHERE  ((SELECT COUNT(simple.id) FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost simple) = 1)
@@ -349,7 +354,7 @@ ORDER BY b.id DESC'
 
     public function testLimitSubqueryWithOrderByAndSubSelectInWhereClausePgSql(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
         $query = $this->entityManager->createQuery(
             'SELECT b FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost b
 WHERE  ((SELECT COUNT(simple.id) FROM Doctrine\Tests\ORM\Tools\Pagination\BlogPost simple) = 1)
@@ -368,7 +373,7 @@ ORDER BY b.id DESC'
      */
     public function testLimitSubqueryOrderByFieldFromMappedSuperclass(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         // now use the third one in query
         $query = $this->entityManager->createQuery(
@@ -387,7 +392,7 @@ ORDER BY b.id DESC'
      */
     public function testLimitSubqueryOrderBySubSelectOrderByExpression(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new MySqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new MySQLPlatform());
 
         $query = $this->entityManager->createQuery(
             'SELECT a,
@@ -412,7 +417,7 @@ ORDER BY b.id DESC'
      */
     public function testLimitSubqueryOrderBySubSelectOrderByExpressionPg(): void
     {
-        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSqlPlatform());
+        $this->entityManager->getConnection()->setDatabasePlatform(new PostgreSQL94Platform());
 
         $query = $this->entityManager->createQuery(
             'SELECT a,

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -8,6 +8,10 @@ use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Cache\CacheConfiguration;
@@ -662,9 +666,14 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         if (isset($GLOBALS['DOCTRINE_MARK_SQL_LOGS'])) {
-            if (in_array(static::$sharedConn->getDatabasePlatform()->getName(), ['mysql', 'postgresql'], true)) {
+            $platform = static::$sharedConn->getDatabasePlatform();
+            if (
+                $platform instanceof MySQLPlatform
+                || $platform instanceof PostgreSQL94Platform
+                || $platform instanceof PostgreSQLPlatform
+            ) {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . static::class . '*/');
-            } elseif (static::$sharedConn->getDatabasePlatform()->getName() === 'oracle') {
+            } elseif ($platform instanceof OraclePlatform) {
                 static::$sharedConn->executeQuery('SELECT 1 /*' . static::class . '*/ FROM dual');
             }
         }


### PR DESCRIPTION
In DBAL 3, various platform classes have been removed or renamed. Furthermore, DBAL 3.2 will deprecate the `AbstractPlatform::getName()` method.

This PR makes the necessary adjustments in ORM.