### PR TITLE
Remove UUID generator strategy from fixtures

### DIFF
--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293User.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293User.dcm.xml
@@ -6,7 +6,7 @@
                             https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Doctrine\Tests\Models\DDC3293\DDC3293User" table="user">
         <id name="id" column="id">
-            <generator strategy="UUID" />
+            <generator strategy="AUTO" />
         </id>
         <embedded
             name="address"

--- a/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293UserPrefixed.dcm.xml
+++ b/tests/Doctrine/Tests/ORM/Mapping/xml/Doctrine.Tests.Models.DDC3293.DDC3293UserPrefixed.dcm.xml
@@ -6,7 +6,7 @@
                             https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Doctrine\Tests\Models\DDC3293\DDC3293UserPrefixed" table="user">
         <id name="id" column="id">
-            <generator strategy="UUID" />
+            <generator strategy="AUTO" />
         </id>
         <embedded
             name="address"


### PR DESCRIPTION
The `UUID` generator strategy won't work with DBAL 3 anymore. This PR proposes to switch to test fixtures from `UUID` to `AUTO` in order to make these tests run on DBAL 3 as well. The test fixtures reference issue #4085. Unless I'm missing something, the generator strategy should be irrelevant for that issue.