### PR TITLE
Remove ImportCommand from console

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 
+use function class_exists;
+
 /**
  * Handles running the Console Tools inside Symfony Console context.
  */
@@ -79,10 +81,13 @@ final class ConsoleRunner
 
         $connectionProvider = new ConnectionFromManagerProvider($entityManagerProvider);
 
+        if (class_exists(DBALConsole\Command\ImportCommand::class)) {
+            $cli->add(new DBALConsole\Command\ImportCommand());
+        }
+
         $cli->addCommands(
             [
                 // DBAL Commands
-                new DBALConsole\Command\ImportCommand(),
                 new DBALConsole\Command\ReservedWordsCommand($connectionProvider),
                 new DBALConsole\Command\RunSqlCommand($connectionProvider),
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3620,7 +3620,8 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php">
-    <DeprecatedClass occurrences="6">
+    <DeprecatedClass occurrences="7">
+      <code>DBALConsole\Command\ImportCommand::class</code>
       <code>Versions::getVersion('doctrine/orm')</code>
       <code>new Command\ConvertDoctrine1SchemaCommand()</code>
       <code>new Command\GenerateEntitiesCommand($entityManagerProvider)</code>

--- a/tests/Doctrine/Tests/ORM/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/Console/ConsoleRunnerTest.php
@@ -30,7 +30,6 @@ final class ConsoleRunnerTest extends DoctrineTestCase
         self::assertSame($helperSet, $app->getHelperSet());
         self::assertSame(Versions::getVersion('doctrine/orm'), $app->getVersion());
 
-        self::assertTrue($app->has('dbal:import'));
         self::assertTrue($app->has('dbal:reserved-words'));
         self::assertTrue($app->has('dbal:run-sql'));
         self::assertTrue($app->has('orm:clear-cache:region:collection'));


### PR DESCRIPTION
`ImportCommand` has been removed from DBAL.

This PR patches `ConsoleRunner` to only include `ImportCommand` if it's available.