### PR TITLE
Drop more usages of SimpleAnnotationReader

### DIFF
--- a/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
+++ b/tests/Doctrine/Tests/Mocks/EntityManagerMock.php
@@ -60,7 +60,7 @@ class EntityManagerMock extends EntityManager
             $config = new Configuration();
             $config->setProxyDir(__DIR__ . '/../Proxies');
             $config->setProxyNamespace('Doctrine\Tests\Proxies');
-            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], true));
+            $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], false));
         }
 
         if ($eventManager === null) {

--- a/tests/Doctrine/Tests/Models/CMS/CmsArticle.php
+++ b/tests/Doctrine/Tests/Models/CMS/CmsArticle.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
+++ b/tests/Doctrine/Tests/Models/DDC1590/DDC1590Entity.php
@@ -9,10 +9,11 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\MappedSuperclass;
 
 /**
  * @Entity
- * @MappedSuperClass
+ * @MappedSuperclass
  */
 abstract class DDC1590Entity
 {

--- a/tests/Doctrine/Tests/Models/NonPublicSchemaJoins/User.php
+++ b/tests/Doctrine/Tests/Models/NonPublicSchemaJoins/User.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Models\NonPublicSchemaJoins;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/Models/Pagination/Logo.php
+++ b/tests/Doctrine/Tests/Models/Pagination/Logo.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\Mapping\Table;
 /**
  * Logo
  *
- * @Author Bill Schaller
  * @Entity
  * @Table(name="pagination_logo")
  */

--- a/tests/Doctrine/Tests/Models/Routing/RoutingRoute.php
+++ b/tests/Doctrine/Tests/Models/Routing/RoutingRoute.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OneToMany;

--- a/tests/Doctrine/Tests/Models/StockExchange/Bond.php
+++ b/tests/Doctrine/Tests/Models/StockExchange/Bond.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Models\StockExchange;
 
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;

--- a/tests/Doctrine/Tests/Models/VersionedManyToOne/Article.php
+++ b/tests/Doctrine/Tests/Models/VersionedManyToOne/Article.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/Models/VersionedManyToOne/Category.php
+++ b/tests/Doctrine/Tests/Models/VersionedManyToOne/Category.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/Models/VersionedOneToOne/FirstRelatedEntity.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToOne/FirstRelatedEntity.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/Models/VersionedOneToOne/SecondRelatedEntity.php
+++ b/tests/Doctrine/Tests/Models/VersionedOneToOne/SecondRelatedEntity.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -120,7 +120,7 @@ class LockAgentWorker
         $config->setProxyNamespace('MyProject\Proxies');
         $config->setAutoGenerateProxyClasses(true);
 
-        $annotDriver = $config->newDefaultAnnotationDriver([__DIR__ . '/../../../Models/'], true);
+        $annotDriver = $config->newDefaultAnnotationDriver([__DIR__ . '/../../../Models/'], false);
         $config->setMetadataDriverImpl($annotDriver);
         $config->setMetadataCache(new ArrayAdapter());
 

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
@@ -305,6 +306,7 @@ class OptimisticJoinedParent
      */
     public $version;
 }
+
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/MergeProxiesTest.php
@@ -241,7 +241,7 @@ class MergeProxiesTest extends OrmFunctionalTestCase
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
             [realpath(__DIR__ . '/../../Models/Cache')],
-            true
+            false
         ));
         $config->setSQLLogger($logger);
 

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\ManyToOne;

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceGeneratorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
+use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1181Test.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinColumns;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class DDC1181Test extends OrmFunctionalTestCase
@@ -75,7 +76,7 @@ class DDC1181Hotel
     public $id;
 
     /**
-     * @oneToMany(targetEntity="DDC1181Booking", mappedBy="hotel", cascade={"remove"})
+     * @OneToMany(targetEntity="DDC1181Booking", mappedBy="hotel", cascade={"remove"})
      * @var Booking[]
      */
     public $bookings;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1595Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1787Test.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1925Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2084Test.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\ORM\Mapping\Column;
-use Doctrine\ORM\Mapping\Entity;
-use Doctrine\ORM\Mapping\GeneratedValue;
-use Doctrine\ORM\Mapping\Id;
-use Doctrine\ORM\Mapping\JoinColumn;
-use Doctrine\ORM\Mapping\OneToOne;
-use Doctrine\ORM\Mapping\Table;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
 
@@ -70,6 +63,14 @@ class DDC2084Test extends OrmFunctionalTestCase
 }
 
 namespace Doctrine\Tests\ORM\Functional\Ticket\DDC2084;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
 
 /**
  * @Entity

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC211Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC2175Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC3785Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\Embeddable;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC422Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC698Test.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC719Test.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\MappedSuperclass;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC742Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC960Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use Exception;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC992Test.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\ManyToOne;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH5804Test.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\CustomIdGenerator;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH6394Test.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class GH6394Test extends OrmFunctionalTestCase

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7067Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7067Test.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function assert;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7366Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7366Test.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\ORM\TransactionRequiredException;
 use Doctrine\Tests\OrmFunctionalTestCase;
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7761Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7761Test.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\JoinTable;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Doctrine\ORM\Mapping\OrderBy;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8443Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8443Test.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\Table;
 use Doctrine\ORM\Query;
 use Doctrine\Tests\Models\Company\CompanyManager;
 use Doctrine\Tests\Models\Company\CompanyPerson;

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8914Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH8914Test.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\DiscriminatorColumn;
+use Doctrine\ORM\Mapping\DiscriminatorMap;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\InheritanceType;
+use Doctrine\ORM\Mapping\MappedSuperclass;
 use Doctrine\Tests\OrmTestCase;
 
 use function assert;

--- a/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
+++ b/tests/Doctrine/Tests/ORM/Mapping/BasicInheritanceMappingTest.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\SequenceGenerator;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Doctrine\Tests\Models\DDC869\DDC869ChequePayment;
 use Doctrine\Tests\Models\DDC869\DDC869CreditCardPayment;

--- a/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/EntityRepositoryGeneratorTest.php
@@ -50,7 +50,6 @@ class EntityRepositoryGeneratorTest extends OrmTestCase
         mkdir($this->tmpDir);
 
         $this->generator = new EntityGenerator();
-        $this->generator->setAnnotationPrefix('');
         $this->generator->setGenerateAnnotations(true);
         $this->generator->setGenerateStubMethods(true);
         $this->generator->setRegenerateEntityIfExists(false);

--- a/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
+++ b/tests/Doctrine/Tests/ORM/UnitOfWorkTest.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\Version;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMInvalidArgumentException;
 use Doctrine\ORM\UnitOfWork;

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -764,7 +764,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
                     realpath(__DIR__ . '/Models/Cache'),
                     realpath(__DIR__ . '/Models/GeoNames'),
                 ],
-                true
+                false
             )
         );
 

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -101,7 +101,7 @@ abstract class OrmTestCase extends DoctrineTestCase
         $config = new Configuration();
 
         $config->setMetadataCache($metadataCache);
-        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], true));
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], false));
         $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
@@ -109,7 +109,7 @@ abstract class OrmTestCase extends DoctrineTestCase
             [
                 realpath(__DIR__ . '/Models/Cache'),
             ],
-            true
+            false
         ));
 
         if ($this->isSecondLevelCacheEnabled) {


### PR DESCRIPTION
Follow-up of #8844 

When merging up 2.9.5, I was expecting phpunit failures because of new test classes that were not using use statements. The failures did not happen, because #8844 only removed some usages of the `SimpleAnnotationReader`, not all.