### PR TITLE
Don't call deprecated `getSchemaManager()`

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ConvertMappingCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Tools\Console\Command;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Mapping\Driver\DatabaseDriver;
 use Doctrine\ORM\Tools\Console\MetadataFilter;
 use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
@@ -21,6 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use function file_exists;
 use function is_dir;
 use function is_writable;
+use function method_exists;
 use function mkdir;
 use function realpath;
 use function sprintf;
@@ -89,7 +91,9 @@ EOT
 
         if ($input->getOption('from-database') === true) {
             $databaseDriver = new DatabaseDriver(
-                $em->getConnection()->getSchemaManager()
+                method_exists(Connection::class, 'createSchemaManager')
+                    ? $em->getConnection()->createSchemaManager()
+                    : $em->getConnection()->getSchemaManager()
             );
 
             $em->getConfiguration()->setMetadataDriverImpl(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,5 @@ parameters:
     ignoreErrors:
         # https://github.com/doctrine/collections/pull/282
         - '/Variable \$offset in isset\(\) always exists and is not nullable\./'
+        # PHPStan doesn't understand our method_exists() safeguards.
+        - '/Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -20,6 +20,8 @@
             <errorLevel type="suppress">
                 <!-- We're calling the deprecated method for BC here. -->
                 <file name="lib/Doctrine/ORM/Internal/SQLResultCasing.php"/>
+                <!-- We need to keep the calls for DBAL 2.13 compatibility. -->
+                <referencedMethod name="Doctrine\DBAL\Connection::getSchemaManager"/>
             </errorLevel>
         </DeprecatedMethod>
         <DocblockTypeContradiction>

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTest.php
@@ -26,7 +26,7 @@ class DatabaseDriverTest extends DatabaseDriverTestCase
         $this->useModelSet('cms');
         parent::setUp();
 
-        $this->schemaManager = $this->_em->getConnection()->getSchemaManager();
+        $this->schemaManager = $this->createSchemaManager();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DatabaseDriverTestCase.php
@@ -25,7 +25,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
      */
     protected function convertToClassMetadata(array $entityTables, array $manyTables = []): array
     {
-        $sm     = $this->_em->getConnection()->getSchemaManager();
+        $sm     = $this->createSchemaManager();
         $driver = new DatabaseDriver($sm);
         $driver->setTables($entityTables, $manyTables);
 
@@ -49,7 +49,7 @@ abstract class DatabaseDriverTestCase extends OrmFunctionalTestCase
         $classNames = array_map('strtolower', $classNames);
         $metadatas  = [];
 
-        $sm     = $this->_em->getConnection()->getSchemaManager();
+        $sm     = $this->createSchemaManager();
         $driver = new DatabaseDriver($sm);
 
         foreach ($driver->getAllClassNames() as $className) {

--- a/tests/Doctrine/Tests/ORM/Functional/ManyToOneOrphanRemovalTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ManyToOneOrphanRemovalTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/CompanySchemaTest.php
@@ -26,7 +26,7 @@ class CompanySchemaTest extends OrmFunctionalTestCase
      */
     public function testGeneratedSchema(): Schema
     {
-        $schema = $this->_em->getConnection()->getSchemaManager()->createSchema();
+        $schema = $this->createSchemaManager()->createSchema();
 
         self::assertTrue($schema->hasTable('company_contracts'));
 

--- a/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SchemaTool/DDC214Test.php
@@ -90,7 +90,7 @@ class DDC214Test extends OrmFunctionalTestCase
             // was already created
         }
 
-        $sm = $this->_em->getConnection()->getSchemaManager();
+        $sm = $this->createSchemaManager();
 
         $fromSchema = $sm->createSchema();
         $toSchema   = $this->schemaTool->getSchemaFromMetadata($classMetadata);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC192Test.php
@@ -30,9 +30,7 @@ class DDC192Test extends OrmFunctionalTestCase
 
         $this->_schemaTool->createSchema($classes);
 
-        $tables = $this->_em->getConnection()
-                            ->getSchemaManager()
-                            ->listTableNames();
+        $tables = $this->createSchemaManager()->listTableNames();
 
         foreach ($classes as $class) {
             assert($class instanceof ClassMetadata);

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC832Test.php
@@ -44,7 +44,7 @@ class DDC832Test extends OrmFunctionalTestCase
     {
         $platform = $this->_em->getConnection()->getDatabasePlatform();
 
-        $sm = $this->_em->getConnection()->getSchemaManager();
+        $sm = $this->createSchemaManager();
         $sm->dropTable($platform->quoteIdentifier('TREE_INDEX'));
         $sm->dropTable($platform->quoteIdentifier('INDEX'));
         $sm->dropTable($platform->quoteIdentifier('LIKE'));

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -6,17 +6,16 @@ namespace Doctrine\Tests;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\Logging\StatisticsCacheLogger;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
-use Doctrine\ORM\Proxy\Factory\ProxyFactory;
 use Doctrine\ORM\Tools\DebugUnitOfWorkListener;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
@@ -40,6 +39,7 @@ use function getenv;
 use function implode;
 use function in_array;
 use function is_object;
+use function method_exists;
 use function realpath;
 use function sprintf;
 use function strpos;
@@ -70,7 +70,7 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     /**
      * Shared connection when a TestCase is run alone (outside of its functional suite).
      *
-     * @var \Doctrine\DBAL\Connection|null
+     * @var Connection|null
      */
     protected static $sharedConn;
 
@@ -795,6 +795,13 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         }
 
         return EntityManager::create($conn, $config);
+    }
+
+    final protected function createSchemaManager(): AbstractSchemaManager
+    {
+        return method_exists(Connection::class, 'createSchemaManager')
+            ? $this->_em->getConnection()->createSchemaManager()
+            : $this->_em->getConnection()->getSchemaManager();
     }
 
     /**

--- a/tests/Doctrine/Tests/TestUtil.php
+++ b/tests/Doctrine/Tests/TestUtil.php
@@ -7,11 +7,13 @@ namespace Doctrine\Tests;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use UnexpectedValueException;
 
 use function explode;
 use function fwrite;
 use function get_class;
+use function method_exists;
 use function sprintf;
 use function strlen;
 use function strpos;
@@ -87,19 +89,24 @@ class TestUtil
             $dbname = $testConn->getDatabase();
             $testConn->close();
 
-            $privConn->getSchemaManager()->dropAndCreateDatabase($dbname);
+            self::createSchemaManager($privConn)->dropAndCreateDatabase($dbname);
 
             $privConn->close();
         } else {
-            $sm = $testConn->getSchemaManager();
-
-            $schema = $sm->createSchema();
+            $schema = self::createSchemaManager($testConn)->createSchema();
             $stmts  = $schema->toDropSql($testConn->getDatabasePlatform());
 
             foreach ($stmts as $stmt) {
                 $testConn->executeStatement($stmt);
             }
         }
+    }
+
+    private static function createSchemaManager(Connection $connection): AbstractSchemaManager
+    {
+        return method_exists(Connection::class, 'createSchemaManager')
+            ? $connection->createSchemaManager()
+            : $connection->getSchemaManager();
     }
 
     private static function addDbEventSubscribers(Connection $conn): void


### PR DESCRIPTION
`Connection::getSchemaManager()` will be replaced by `Connection::createSchemaManager()`. We should call the new method if it's available.

Part of #8884