### PR TITLE
Only wire ConnectionHelper if it's available

### DIFF
--- a/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
@@ -27,12 +27,13 @@ final class ConsoleRunner
      */
     public static function createHelperSet(EntityManagerInterface $entityManager): HelperSet
     {
-        return new HelperSet(
-            [
-                'db' => new DBALConsole\Helper\ConnectionHelper($entityManager->getConnection()),
-                'em' => new EntityManagerHelper($entityManager),
-            ]
-        );
+        $helpers = ['em' => new EntityManagerHelper($entityManager)];
+
+        if (class_exists(DBALConsole\Helper\ConnectionHelper::class)) {
+            $helpers['db'] = new DBALConsole\Helper\ConnectionHelper($entityManager->getConnection());
+        }
+
+        return new HelperSet($helpers);
     }
 
     /**

--- a/phpstan-dbal3.neon
+++ b/phpstan-dbal3.neon
@@ -6,3 +6,11 @@ parameters:
     ignoreErrors:
         # deprecations from doctrine/dbal:3.x
         - '/^Call to an undefined method Doctrine\\DBAL\\Platforms\\AbstractPlatform::getGuidExpression\(\).$/'
+
+        # Fallback logic for DBAL 2
+        -
+            message: '/HelperSet constructor expects/'
+            path: lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php
+        -
+            message: '/Application::add\(\) expects Symfony\\Component\\Console\\Command\\Command/'
+            path: lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -659,7 +659,6 @@
     </DeprecatedClass>
     <PropertyTypeCoercion occurrences="1">
       <code>$resultSetMapping</code>
-      <code>$resultSetMapping</code>
     </PropertyTypeCoercion>
     <ReferenceConstraintViolation occurrences="1">
       <code>return $rowData;</code>
@@ -3562,14 +3561,11 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/ConsoleRunner.php">
-    <DeprecatedClass occurrences="7">
-      <code>DBALConsole\Command\ImportCommand::class</code>
+    <DeprecatedClass occurrences="4">
       <code>Versions::getVersion('doctrine/orm')</code>
       <code>new Command\ConvertDoctrine1SchemaCommand()</code>
       <code>new Command\GenerateEntitiesCommand($entityManagerProvider)</code>
       <code>new Command\GenerateRepositoriesCommand($entityManagerProvider)</code>
-      <code>new DBALConsole\Command\ImportCommand()</code>
-      <code>new DBALConsole\Helper\ConnectionHelper($entityManager-&gt;getConnection())</code>
     </DeprecatedClass>
   </file>
   <file src="lib/Doctrine/ORM/Tools/DebugUnitOfWorkListener.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,13 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <!-- DBAL 2 compatibility -->
+                <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ImportCommand"/>
+                <referencedClass name="Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper"/>
+            </errorLevel>
+        </DeprecatedClass>
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <!-- We're calling the deprecated method for BC here. -->


### PR DESCRIPTION
DBAL deprecated its `ConnectionHelper` class, a helper for Symfony console applications. I propose to not use that class if it's not there.

Part of #8884, #8885.

I haven't found any tests nor usage of the `createHelperSet()` method I've changed here. The other helper that is wired here simply exposes a `getEntityManager()` method that… well… returns an entity manager. In modern Symfony applications, we would probably use DI to make the EM available to commands. I feel like we should follow the example of DBAL here and deprecate `createHelperSet()`, `EntityManagerHelper` and related classes and change our own commands to use DI instead. That could be done in a follow-up PR. WDYT?