### PR TITLE
Stop swallowing exceptions

### DIFF
--- a/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/DefaultValuesTest.php
@@ -24,16 +24,19 @@ class DefaultValuesTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DefaultValueUser::class),
-                    $this->_em->getClassMetadata(DefaultValueAddress::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DefaultValueUser::class),
+            $this->_em->getClassMetadata(DefaultValueAddress::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(DefaultValueUser::class),
+            $this->_em->getClassMetadata(DefaultValueAddress::class),
+        ]);
+        parent::tearDown();
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/OptimisticTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use DateTime;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\DiscriminatorColumn;
@@ -24,28 +25,38 @@ use function strtotime;
 
 class OptimisticTest extends OrmFunctionalTestCase
 {
+    /** @var Connection */
+    private $_conn;
+
     protected function setUp(): void
     {
         parent::setUp();
-
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(OptimisticJoinedParent::class),
-                    $this->_em->getClassMetadata(OptimisticJoinedChild::class),
-                    $this->_em->getClassMetadata(OptimisticStandard::class),
-                    $this->_em->getClassMetadata(OptimisticTimestamp::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
-
         $this->_conn = $this->_em->getConnection();
+    }
+
+    private function createSchema(): void
+    {
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(OptimisticJoinedParent::class),
+            $this->_em->getClassMetadata(OptimisticJoinedChild::class),
+            $this->_em->getClassMetadata(OptimisticStandard::class),
+            $this->_em->getClassMetadata(OptimisticTimestamp::class),
+        ]);
+    }
+
+    private function dropSchema(): void
+    {
+        $this->_schemaTool->dropSchema([
+            $this->_em->getClassMetadata(OptimisticJoinedParent::class),
+            $this->_em->getClassMetadata(OptimisticJoinedChild::class),
+            $this->_em->getClassMetadata(OptimisticStandard::class),
+            $this->_em->getClassMetadata(OptimisticTimestamp::class),
+        ]);
     }
 
     public function testJoinedChildInsertSetsInitialVersionValue(): OptimisticJoinedChild
     {
+        $this->createSchema();
         $test = new OptimisticJoinedChild();
 
         $test->name     = 'child';
@@ -83,10 +94,13 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
+
+        $this->dropSchema();
     }
 
     public function testJoinedParentInsertSetsInitialVersionValue(): OptimisticJoinedParent
     {
+        $this->createSchema();
         $test = new OptimisticJoinedParent();
 
         $test->name = 'parent';
@@ -123,10 +137,14 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
+
+        $this->dropSchema();
     }
 
     public function testMultipleFlushesDoIncrementalUpdates(): void
     {
+        $this->createSchema();
+
         $test = new OptimisticStandard();
 
         for ($i = 0; $i < 5; $i++) {
@@ -138,10 +156,14 @@ class OptimisticTest extends OrmFunctionalTestCase
             self::assertIsInt($test->getVersion());
             self::assertEquals($i + 1, $test->getVersion());
         }
+
+        $this->dropSchema();
     }
 
     public function testStandardInsertSetsInitialVersionValue(): OptimisticStandard
     {
+        $this->createSchema();
+
         $test = new OptimisticStandard();
 
         $test->name = 'test';
@@ -179,10 +201,13 @@ class OptimisticTest extends OrmFunctionalTestCase
         } catch (OptimisticLockException $e) {
             self::assertSame($test, $e->getEntity());
         }
+
+        $this->dropSchema();
     }
 
     public function testLockWorksWithProxy(): void
     {
+        $this->createSchema();
         $test       = new OptimisticStandard();
         $test->name = 'test';
 
@@ -195,10 +220,12 @@ class OptimisticTest extends OrmFunctionalTestCase
         $this->_em->lock($proxy, LockMode::OPTIMISTIC, 1);
 
         $this->addToAssertionCount(1);
+        $this->dropSchema();
     }
 
     public function testOptimisticTimestampSetsDefaultValue(): OptimisticTimestamp
     {
+        $this->createSchema();
         $test = new OptimisticTimestamp();
 
         $test->name = 'Testing';
@@ -274,6 +301,8 @@ class OptimisticTest extends OrmFunctionalTestCase
 
         self::assertNotNull($caughtException, 'No OptimisticLockingException was thrown');
         self::assertSame($test, $caughtException->getEntity());
+
+        $this->dropSchema();
     }
 }
 

--- a/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/NotifyPolicyTest.php
@@ -33,16 +33,10 @@ class NotifyPolicyTest extends OrmFunctionalTestCase
 
         $this->expectDeprecationWithIdentifier('https://github.com/doctrine/orm/issues/8383');
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(NotifyUser::class),
-                    $this->_em->getClassMetadata(NotifyGroup::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(NotifyUser::class),
+            $this->_em->getClassMetadata(NotifyGroup::class),
+        ]);
     }
 
     public function testChangeTracking(): void

--- a/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OneToOneSelfReferentialAssociationTest.php
@@ -99,15 +99,9 @@ class OneToOneSelfReferentialAssociationTest extends OrmFunctionalTestCase
 
     public function testMultiSelfReference(): void
     {
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(MultiSelfReference::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(MultiSelfReference::class),
+        ]);
 
         $entity1 = new MultiSelfReference();
         $this->_em->persist($entity1);

--- a/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/OrderedJoinedTableInheritanceCollectionTest.php
@@ -30,17 +30,11 @@ class OrderedJoinedTableInheritanceCollectionTest extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(OJTICPet::class),
-                    $this->_em->getClassMetadata(OJTICCat::class),
-                    $this->_em->getClassMetadata(OJTICDog::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(OJTICPet::class),
+            $this->_em->getClassMetadata(OJTICCat::class),
+            $this->_em->getClassMetadata(OJTICDog::class),
+        ]);
 
         $dog       = new OJTICDog();
         $dog->name = 'Poofy';

--- a/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SequenceEmulatedIdentityStrategyTest.php
@@ -26,13 +26,9 @@ class SequenceEmulatedIdentityStrategyTest extends OrmFunctionalTestCase
                 'This test is special to platforms emulating IDENTITY key generation strategy through sequences.'
             );
         } else {
-            try {
-                $this->_schemaTool->createSchema(
-                    [$this->_em->getClassMetadata(SequenceEmulatedIdentityEntity::class)]
-                );
-            } catch (Exception $e) {
-                // Swallow all exceptions. We do not test the schema tool here.
-            }
+            $this->_schemaTool->createSchema(
+                [$this->_em->getClassMetadata(SequenceEmulatedIdentityEntity::class)]
+            );
         }
     }
 

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC1690Test.php
@@ -24,16 +24,10 @@ class DDC1690Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC1690Parent::class),
-                    $this->_em->getClassMetadata(DDC1690Child::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC1690Parent::class),
+            $this->_em->getClassMetadata(DDC1690Child::class),
+        ]);
     }
 
     public function testChangeTracking(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/DDC440Test.php
@@ -24,16 +24,10 @@ class DDC440Test extends OrmFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(DDC440Phone::class),
-                    $this->_em->getClassMetadata(DDC440Client::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(DDC440Phone::class),
+            $this->_em->getClassMetadata(DDC440Client::class),
+        ]);
     }
 
     /**

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/Ticket2481Test.php
@@ -18,15 +18,9 @@ class Ticket2481Test extends OrmFunctionalTestCase
     {
         parent::setUp();
 
-        try {
-            $this->_schemaTool->createSchema(
-                [
-                    $this->_em->getClassMetadata(Ticket2481Product::class),
-                ]
-            );
-        } catch (Exception $e) {
-            // Swallow all exceptions. We do not test the schema tool here.
-        }
+        $this->_schemaTool->createSchema([
+            $this->_em->getClassMetadata(Ticket2481Product::class),
+        ]);
 
         $this->_conn = $this->_em->getConnection();
     }


### PR DESCRIPTION
This was probably done in order to get rid of exceptions about tables
already existing, but may and does swallow other exceptions as well, for
instance exceptions about sequences failing to be created on Oracle
because the identifier is too long. This makes it unnecessarily hard to
understand what is going on.