### PR TITLE
Restore functional cache tests

### DIFF
--- a/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/AbstractRegionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Cache;
 
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\Tests\Mocks\CacheEntryMock;
@@ -19,7 +20,7 @@ abstract class AbstractRegionTest extends OrmFunctionalTestCase
     /** @var Region */
     protected $region;
 
-    /** @var ArrayCache */
+    /** @var Cache */
     protected $cache;
 
     protected function setUp(): void

--- a/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
+++ b/tests/Doctrine/Tests/ORM/Cache/DefaultRegionTest.php
@@ -6,17 +6,17 @@ namespace Doctrine\Tests\ORM\Cache;
 
 use BadMethodCallException;
 use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Cache\CollectionCacheEntry;
 use Doctrine\ORM\Cache\Region;
 use Doctrine\ORM\Cache\Region\DefaultRegion;
 use Doctrine\Tests\Mocks\CacheEntryMock;
 use Doctrine\Tests\Mocks\CacheKeyMock;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function assert;
-use function class_exists;
 
 /**
  * @group DDC-2183
@@ -36,15 +36,11 @@ class DefaultRegionTest extends AbstractRegionTest
 
     public function testSharedRegion(): void
     {
-        if (! class_exists(ArrayCache::class)) {
-            $this->markTestSkipped('Test only applies with doctrine/cache 1.x');
-        }
-
         $cache   = new SharedArrayCache();
         $key     = new CacheKeyMock('key');
         $entry   = new CacheEntryMock(['value' => 'foo']);
-        $region1 = new DefaultRegion('region1', $cache->createChild());
-        $region2 = new DefaultRegion('region2', $cache->createChild());
+        $region1 = new DefaultRegion('region1', DoctrineProvider::wrap($cache->createChild()));
+        $region2 = new DefaultRegion('region2', DoctrineProvider::wrap($cache->createChild()));
 
         $this->assertFalse($region1->contains($key));
         $this->assertFalse($region2->contains($key));
@@ -135,76 +131,71 @@ class DefaultRegionTest extends AbstractRegionTest
     }
 }
 
-if (class_exists(ArrayCache::class)) {
-    /**
-     * Cache provider that offers child cache items (sharing the same array)
-     *
-     * Declared as a different class for readability purposes and kept in this file
-     * to keep its monstrosity contained.
-     *
-     * @internal
-     */
-    final class SharedArrayCache extends ArrayCache
+/**
+ * Cache provider that offers child cache items (sharing the same array)
+ *
+ * Declared as a different class for readability purposes and kept in this file
+ * to keep its monstrosity contained.
+ *
+ * @internal
+ */
+final class SharedArrayCache extends ArrayAdapter
+{
+    public function createChild(): CacheItemPoolInterface
     {
-        public function createChild(): Cache
-        {
-            return new class ($this) extends CacheProvider {
-                /** @var ArrayCache */
-                private $parent;
+        return new class ($this) implements CacheItemPoolInterface {
+            /** @var CacheItemPoolInterface */
+            private $parent;
 
-                public function __construct(ArrayCache $parent)
-                {
-                    $this->parent = $parent;
-                }
+            public function __construct(CacheItemPoolInterface $parent)
+            {
+                $this->parent = $parent;
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doFetch($id)
-                {
-                    return $this->parent->doFetch($id);
-                }
+            public function getItem($key): CacheItemInterface
+            {
+                return $this->parent->getItem($key);
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doContains($id)
-                {
-                    return $this->parent->doContains($id);
-                }
+            public function getItems(array $keys = []): iterable
+            {
+                return $this->parent->getItems($keys);
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doSave($id, $data, $lifeTime = 0)
-                {
-                    return $this->parent->doSave($id, $data, $lifeTime);
-                }
+            public function hasItem($key): bool
+            {
+                return $this->parent->hasItem($key);
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doDelete($id)
-                {
-                    return $this->parent->doDelete($id);
-                }
+            public function clear(): bool
+            {
+                return $this->parent->clear();
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doFlush()
-                {
-                    return $this->parent->doFlush();
-                }
+            public function deleteItem($key): bool
+            {
+                return $this->parent->deleteItem($key);
+            }
 
-                /**
-                 * {@inheritDoc}
-                 */
-                protected function doGetStats()
-                {
-                    return $this->parent->doGetStats();
-                }
-            };
-        }
+            public function deleteItems(array $keys): bool
+            {
+                return $this->parent->deleteItems($keys);
+            }
+
+            public function save(CacheItemInterface $item): bool
+            {
+                return $this->parent->save($item);
+            }
+
+            public function saveDeferred(CacheItemInterface $item): bool
+            {
+                return $this->parent->saveDeferred($item);
+            }
+
+            public function commit(): bool
+            {
+                return $this->parent->commit();
+            }
+        };
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -4,113 +4,98 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\Tests\OrmFunctionalTestCase;
-use ReflectionProperty;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-use function class_exists;
+use function assert;
 use function count;
 
-/**
- * QueryCacheTest
- */
 class QueryCacheTest extends OrmFunctionalTestCase
 {
-    /** @var ReflectionProperty */
-    private $cacheDataReflection;
-
     protected function setUp(): void
     {
-        if (! class_exists(ArrayCache::class)) {
-            $this->markTestSkipped('Test only applies with doctrine/cache 1.x');
-        }
-
-        $this->cacheDataReflection = new ReflectionProperty(ArrayCache::class, 'data');
-        $this->cacheDataReflection->setAccessible(true);
-
         $this->useModelSet('cms');
 
         parent::setUp();
     }
 
-    private function getCacheSize(ArrayCache $cache): int
-    {
-        return count($this->cacheDataReflection->getValue($cache));
-    }
-
-    public function testQueryCacheDependsOnHints(): Query
+    public function testQueryCacheDependsOnHints(): array
     {
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $cache = new ArrayCache();
-        $query->setQueryCacheDriver($cache);
+        $cache = new ArrayAdapter();
+        $query->setQueryCacheDriver(DoctrineProvider::wrap($cache));
 
         $query->getResult();
-        $this->assertEquals(1, $this->getCacheSize($cache));
+        self::assertCount(2, $cache->getValues());
 
         $query->setHint('foo', 'bar');
 
         $query->getResult();
-        $this->assertEquals(2, $this->getCacheSize($cache));
+        self::assertCount(3, $cache->getValues());
 
-        return $query;
+        return [$query, $cache];
     }
 
     /**
-     * @param <type> $query
-     *
      * @depends testQueryCacheDependsOnHints
      */
-    public function testQueryCacheDependsOnFirstResult($query): void
+    public function testQueryCacheDependsOnFirstResult(array $previous): void
     {
-        $cache      = $query->getQueryCacheDriver();
-        $cacheCount = $this->getCacheSize($cache);
+        [$query, $cache] = $previous;
+        assert($query instanceof Query);
+        assert($cache instanceof ArrayAdapter);
+
+        $cacheCount = count($cache->getValues());
 
         $query->setFirstResult(10);
         $query->setMaxResults(9999);
 
         $query->getResult();
-        $this->assertEquals($cacheCount + 1, $this->getCacheSize($cache));
+        self::assertCount($cacheCount + 1, $cache->getValues());
     }
 
     /**
-     * @param <type> $query
-     *
      * @depends testQueryCacheDependsOnHints
      */
-    public function testQueryCacheDependsOnMaxResults($query): void
+    public function testQueryCacheDependsOnMaxResults(array $previous): void
     {
-        $cache      = $query->getQueryCacheDriver();
-        $cacheCount = $this->getCacheSize($cache);
+        [$query, $cache] = $previous;
+        assert($query instanceof Query);
+        assert($cache instanceof ArrayAdapter);
+
+        $cacheCount = count($cache->getValues());
 
         $query->setMaxResults(10);
 
         $query->getResult();
-        $this->assertEquals($cacheCount + 1, $this->getCacheSize($cache));
+        self::assertCount($cacheCount + 1, $cache->getValues());
     }
 
     /**
-     * @param <type> $query
-     *
      * @depends testQueryCacheDependsOnHints
      */
-    public function testQueryCacheDependsOnHydrationMode($query): void
+    public function testQueryCacheDependsOnHydrationMode(array $previous): void
     {
-        $cache      = $query->getQueryCacheDriver();
-        $cacheCount = $this->getCacheSize($cache);
+        [$query, $cache] = $previous;
+        assert($query instanceof Query);
+        assert($cache instanceof ArrayAdapter);
+
+        $cacheCount = count($cache->getValues());
 
         $query->getArrayResult();
-        $this->assertEquals($cacheCount + 1, $this->getCacheSize($cache));
+        self::assertCount($cacheCount + 1, $cache->getValues());
     }
 
     public function testQueryCacheNoHitSaveParserResult(): void
     {
-        $this->_em->getConfiguration()->setQueryCacheImpl(new ArrayCache());
+        $this->_em->getConfiguration()->setQueryCacheImpl($this->createMock(Cache::class));
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
@@ -128,7 +113,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     public function testQueryCacheHitDoesNotSaveParserResult(): void
     {
-        $this->_em->getConfiguration()->setQueryCacheImpl(new ArrayCache());
+        $this->_em->getConfiguration()->setQueryCacheImpl($this->createMock(Cache::class));
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
@@ -167,6 +152,6 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
         $query->setQueryCacheDriver($cache);
 
-        $users = $query->getResult();
+        $query->getResult();
     }
 }

--- a/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/SQLFilterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Configuration;
@@ -30,9 +30,8 @@ use Doctrine\Tests\Models\Company\CompanyPerson;
 use Doctrine\Tests\OrmFunctionalTestCase;
 use InvalidArgumentException;
 use ReflectionMethod;
-use ReflectionProperty;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-use function class_exists;
 use function count;
 use function in_array;
 use function serialize;
@@ -397,31 +396,24 @@ class SQLFilterTest extends OrmFunctionalTestCase
 
     public function testQueryCacheDependsOnFilters(): void
     {
-        if (! class_exists(ArrayCache::class)) {
-            $this->markTestSkipped('Test only applies with doctrine/cache 1.x');
-        }
-
-        $cacheDataReflection = new ReflectionProperty(ArrayCache::class, 'data');
-        $cacheDataReflection->setAccessible(true);
-
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
-        $cache = new ArrayCache();
-        $query->setQueryCacheDriver($cache);
+        $cache = new ArrayAdapter();
+        $query->setQueryCacheDriver(DoctrineProvider::wrap($cache));
 
         $query->getResult();
-        $this->assertEquals(1, count($cacheDataReflection->getValue($cache)));
+        $this->assertCount(2, $cache->getValues());
 
         $conf = $this->_em->getConfiguration();
-        $conf->addFilter('locale', '\Doctrine\Tests\ORM\Functional\MyLocaleFilter');
+        $conf->addFilter('locale', MyLocaleFilter::class);
         $this->_em->getFilters()->enable('locale');
 
         $query->getResult();
-        $this->assertEquals(2, count($cacheDataReflection->getValue($cache)));
+        $this->assertCount(3, $cache->getValues());
 
         // Another time doesn't add another cache entry
         $query->getResult();
-        $this->assertEquals(2, count($cacheDataReflection->getValue($cache)));
+        $this->assertCount(3, $cache->getValues());
     }
 
     public function testQueryGenerationDependsOnFilters(): void

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -12,11 +12,9 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\ORM\Tools\Setup;
-use Doctrine\Tests\Common\Cache\ArrayCache;
 use Doctrine\Tests\OrmTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
-use function class_exists;
 use function count;
 use function get_include_path;
 use function method_exists;
@@ -93,11 +91,7 @@ class SetupTest extends OrmTestCase
      */
     public function testCacheNamespaceShouldBeGeneratedWhenCacheIsGivenButHasNoNamespace(): void
     {
-        if (! class_exists(ArrayCache::class)) {
-            $this->markTestSkipped('Only applies when using doctrine/cache directly');
-        }
-
-        $config = Setup::createConfiguration(false, '/foo', new ArrayCache());
+        $config = Setup::createConfiguration(false, '/foo', DoctrineProvider::wrap(new ArrayAdapter()));
         $cache  = $config->getMetadataCacheImpl();
 
         self::assertSame('dc2_1effb2475fcfba4f9e8b8a1dbc8f3caf_', $cache->getNamespace());
@@ -108,11 +102,7 @@ class SetupTest extends OrmTestCase
      */
     public function testConfiguredCacheNamespaceShouldBeUsedAsPrefixOfGeneratedNamespace(): void
     {
-        if (! class_exists(ArrayCache::class)) {
-            $this->markTestSkipped('Only applies when using doctrine/cache directly');
-        }
-
-        $originalCache = new ArrayCache();
+        $originalCache = DoctrineProvider::wrap(new ArrayAdapter());
         $originalCache->setNamespace('foo');
 
         $config = Setup::createConfiguration(false, '/foo', $originalCache);


### PR DESCRIPTION
When adding support for Doctrine cache 2, many functional tests that involve caching have been disabled. This PR enables them again, using a wrapped `ArrayAdapter` instead of `ArrayCache`.

I'm targeting 2.9.x here because I'm only changing tests and not touching any production code.