### PR TITLE
Remove unnecessary `method_exists()` checks

### DIFF
--- a/lib/Doctrine/ORM/EntityManager.php
+++ b/lib/Doctrine/ORM/EntityManager.php
@@ -6,7 +6,6 @@ namespace Doctrine\ORM;
 
 use BadMethodCallException;
 use Doctrine\Common\Cache\Psr6\CacheAdapter;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\DBAL\Connection;
@@ -40,7 +39,6 @@ use function is_callable;
 use function is_object;
 use function is_string;
 use function ltrim;
-use function method_exists;
 use function sprintf;
 
 /**
@@ -1012,28 +1010,13 @@ use function sprintf;
             return;
         }
 
-        // We have a PSR-6 compatible metadata factory. Use cache directly
-        if (method_exists($this->metadataFactory, 'setCache')) {
-            $this->metadataFactory->setCache($metadataCache);
-
-            return;
-        }
-
-        // Wrap PSR-6 cache to provide doctrine/cache interface
-        $this->metadataFactory->setCacheDriver(DoctrineProvider::wrap($metadataCache));
+        $this->metadataFactory->setCache($metadataCache);
     }
 
     private function configureLegacyMetadataCache(): void
     {
         $metadataCache = $this->config->getMetadataCacheImpl();
         if (! $metadataCache) {
-            return;
-        }
-
-        // Metadata factory is not PSR-6 compatible. Use cache directly
-        if (! method_exists($this->metadataFactory, 'setCache')) {
-            $this->metadataFactory->setCacheDriver($metadataCache);
-
             return;
         }
 

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -27,7 +27,6 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 use function class_exists;
 use function extension_loaded;
 use function md5;
-use function method_exists;
 use function sys_get_temp_dir;
 
 /**
@@ -124,12 +123,7 @@ class Setup
 
         $config = new Configuration();
 
-        if (method_exists(Configuration::class, 'setMetadataCache')) {
-            $config->setMetadataCache(CacheAdapter::wrap($cache));
-        } else {
-            $config->setMetadataCacheImpl($cache);
-        }
-
+        $config->setMetadataCache(CacheAdapter::wrap($cache));
         $config->setQueryCacheImpl($cache);
         $config->setResultCacheImpl($cache);
         $config->setProxyDir($proxyDir);

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function class_exists;
 use function count;
 use function get_include_path;
-use function method_exists;
 use function set_include_path;
 use function spl_autoload_functions;
 use function spl_autoload_unregister;
@@ -142,11 +141,7 @@ class SetupTest extends OrmTestCase
         self::assertSame($cache, $config->getResultCacheImpl());
         self::assertSame($cache, $config->getQueryCacheImpl());
 
-        if (method_exists(Configuration::class, 'getMetadataCache')) {
-            self::assertSame($adapter, $config->getMetadataCache()->getCache()->getPool());
-        } else {
-            self::assertSame($cache, $config->getMetadataCacheImpl());
-        }
+        self::assertSame($adapter, $config->getMetadataCache()->getCache()->getPool());
     }
 
     /**
@@ -160,11 +155,7 @@ class SetupTest extends OrmTestCase
         self::assertSame($cache, $config->getResultCacheImpl());
         self::assertSame($cache, $config->getQueryCacheImpl());
 
-        if (method_exists(Configuration::class, 'getMetadataCache')) {
-            self::assertInstanceOf(CacheAdapter::class, $config->getMetadataCache());
-            self::assertSame($cache, $config->getMetadataCache()->getCache());
-        } else {
-            self::assertSame($cache, $config->getMetadataCacheImpl());
-        }
+        self::assertInstanceOf(CacheAdapter::class, $config->getMetadataCache());
+        self::assertSame($cache, $config->getMetadataCache()->getCache());
     }
 }


### PR DESCRIPTION
This PR removed a couple of `method_exsists()` checks that will always evaluate to `true`.