### PR TITLE
Add extension point for the "embedded" XML node

### DIFF
--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -308,6 +308,9 @@
   </xs:complexType>
 
   <xs:complexType name="embedded">
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" namespace="##other"/>
+    </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="class" type="orm:fqcn" use="optional" />
     <xs:attribute name="column-prefix" type="xs:string" use="optional" />


### PR DESCRIPTION
This adds support for subnodes under the `<embedded>` element.

See doctrine-extensions/DoctrineExtensions#2246 ([ref](https://github.com/doctrine-extensions/DoctrineExtensions/blob/d1fc884a8cd14785e80ca1363dac745e37bd2359/tests/Gedmo/Mapping/Driver/Xml/Mapping.Fixture.Xml.LoggableWithEmbedded.dcm.xml#L7-L9)).

Related to #64.