### PR TITLE
Support for PSR-6 result caches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - php-version: "8.0"
             dbal-version: "2.13"
+          - php-version: "8.0"
+            dbal-version: "3.2@dev"
 
     steps:
       - name: "Checkout"

--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use Countable;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
@@ -20,10 +22,12 @@ use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Query\ResultSetMapping;
 use Doctrine\Persistence\Mapping\MappingException;
+use Psr\Cache\CacheItemPoolInterface;
 use Traversable;
 
 use function array_map;
 use function array_shift;
+use function assert;
 use function count;
 use function is_array;
 use function is_numeric;
@@ -32,6 +36,7 @@ use function is_scalar;
 use function iterator_count;
 use function iterator_to_array;
 use function ksort;
+use function method_exists;
 use function reset;
 use function serialize;
 use function sha1;
@@ -121,7 +126,7 @@ abstract class AbstractQuery
      */
     protected $_expireResultCache = false;
 
-    /** @var QueryCacheProfile */
+    /** @var QueryCacheProfile|null */
     protected $_hydrationCacheProfile;
 
     /**
@@ -529,9 +534,25 @@ abstract class AbstractQuery
      */
     public function setHydrationCacheProfile(?QueryCacheProfile $profile = null)
     {
-        if ($profile !== null && ! $profile->getResultCacheDriver()) {
-            $resultCacheDriver = $this->_em->getConfiguration()->getHydrationCacheImpl();
-            $profile           = $profile->setResultCacheDriver($resultCacheDriver);
+        if ($profile === null) {
+            $this->_hydrationCacheProfile = null;
+
+            return $this;
+        }
+
+        // DBAL < 3.2
+        if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            if (! $profile->getResultCacheDriver()) {
+                $defaultHydrationCacheImpl = $this->_em->getConfiguration()->getHydrationCacheImpl();
+                if ($defaultHydrationCacheImpl) {
+                    $profile = $profile->setResultCacheDriver($defaultHydrationCacheImpl);
+                }
+            }
+        } elseif (! $profile->getResultCache()) {
+            $defaultHydrationCacheImpl = $this->_em->getConfiguration()->getHydrationCacheImpl();
+            if ($defaultHydrationCacheImpl) {
+                $profile = $profile->setResultCache(CacheAdapter::wrap($defaultHydrationCacheImpl));
+            }
         }
 
         $this->_hydrationCacheProfile = $profile;
@@ -540,7 +561,7 @@ abstract class AbstractQuery
     }
 
     /**
-     * @return QueryCacheProfile
+     * @return QueryCacheProfile|null
      */
     public function getHydrationCacheProfile()
     {
@@ -553,13 +574,29 @@ abstract class AbstractQuery
      * If no result cache driver is set in the QueryCacheProfile, the default
      * result cache driver is used from the configuration.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setResultCacheProfile(?QueryCacheProfile $profile = null)
     {
-        if ($profile !== null && ! $profile->getResultCacheDriver()) {
-            $resultCacheDriver = $this->_em->getConfiguration()->getResultCacheImpl();
-            $profile           = $profile->setResultCacheDriver($resultCacheDriver);
+        if ($profile === null) {
+            $this->_queryCacheProfile = null;
+
+            return $this;
+        }
+
+        // DBAL < 3.2
+        if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            if (! $profile->getResultCacheDriver()) {
+                $defaultResultCacheDriver = $this->_em->getConfiguration()->getResultCacheImpl();
+                if ($defaultResultCacheDriver) {
+                    $profile = $profile->setResultCacheDriver($defaultResultCacheDriver);
+                }
+            }
+        } elseif (! $profile->getResultCache()) {
+            $defaultResultCache = $this->_em->getConfiguration()->getResultCache();
+            if ($defaultResultCache) {
+                $profile = $profile->setResultCache($defaultResultCache);
+            }
         }
 
         $this->_queryCacheProfile = $profile;
@@ -570,9 +607,11 @@ abstract class AbstractQuery
     /**
      * Defines a cache driver to be used for caching result sets and implicitly enables caching.
      *
+     * @deprecated Use {@see setResultCache()} instead.
+     *
      * @param \Doctrine\Common\Cache\Cache|null $resultCacheDriver Cache driver
      *
-     * @return static This query instance.
+     * @return $this
      *
      * @throws InvalidResultCacheDriver
      */
@@ -583,9 +622,38 @@ abstract class AbstractQuery
             throw InvalidResultCacheDriver::create();
         }
 
+        return $this->setResultCache($resultCacheDriver ? CacheAdapter::wrap($resultCacheDriver) : null);
+    }
+
+    /**
+     * Defines a cache driver to be used for caching result sets and implicitly enables caching.
+     *
+     * @return $this
+     */
+    public function setResultCache(?CacheItemPoolInterface $resultCache = null)
+    {
+        if ($resultCache === null) {
+            if ($this->_queryCacheProfile) {
+                $this->_queryCacheProfile = new QueryCacheProfile($this->_queryCacheProfile->getLifetime(), $this->_queryCacheProfile->getCacheKey());
+            }
+
+            return $this;
+        }
+
+        // DBAL < 3.2
+        if (! method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            $resultCacheDriver = DoctrineProvider::wrap($resultCache);
+
+            $this->_queryCacheProfile = $this->_queryCacheProfile
+                ? $this->_queryCacheProfile->setResultCacheDriver($resultCacheDriver)
+                : new QueryCacheProfile(0, null, $resultCacheDriver);
+
+            return $this;
+        }
+
         $this->_queryCacheProfile = $this->_queryCacheProfile
-            ? $this->_queryCacheProfile->setResultCacheDriver($resultCacheDriver)
-            : new QueryCacheProfile(0, null, $resultCacheDriver);
+            ? $this->_queryCacheProfile->setResultCache($resultCache)
+            : new QueryCacheProfile(0, null, $resultCache);
 
         return $this;
     }
@@ -1055,9 +1123,9 @@ abstract class AbstractQuery
         if ($this->_hydrationCacheProfile !== null) {
             [$cacheKey, $realCacheKey] = $this->getHydrationCacheId();
 
-            $queryCacheProfile = $this->getHydrationCacheProfile();
-            $cache             = $queryCacheProfile->getResultCacheDriver();
-            $result            = $cache->fetch($cacheKey);
+            $cache     = $this->getHydrationCache();
+            $cacheItem = $cache->getItem($cacheKey);
+            $result    = $cacheItem->isHit() ? $cacheItem->get() : [];
 
             if (isset($result[$realCacheKey])) {
                 return $result[$realCacheKey];
@@ -1067,10 +1135,8 @@ abstract class AbstractQuery
                 $result = [];
             }
 
-            $setCacheEntry = static function ($data) use ($cache, $result, $cacheKey, $realCacheKey, $queryCacheProfile): void {
-                $result[$realCacheKey] = $data;
-
-                $cache->save($cacheKey, $result, $queryCacheProfile->getLifetime());
+            $setCacheEntry = static function ($data) use ($cache, $result, $cacheItem, $realCacheKey): void {
+                $cache->save($cacheItem->set($result + [$realCacheKey => $data]));
             };
         }
 
@@ -1088,6 +1154,24 @@ abstract class AbstractQuery
         $setCacheEntry($data);
 
         return $data;
+    }
+
+    private function getHydrationCache(): CacheItemPoolInterface
+    {
+        assert($this->_hydrationCacheProfile !== null);
+
+        // Support for DBAL < 3.2
+        if (! method_exists($this->_hydrationCacheProfile, 'getResultCache')) {
+            $cacheDriver = $this->_hydrationCacheProfile->getResultCacheDriver();
+            assert($cacheDriver !== null);
+
+            return CacheAdapter::wrap($cacheDriver);
+        }
+
+        $cache = $this->_hydrationCacheProfile->getResultCache();
+        assert($cache !== null);
+
+        return $cache;
     }
 
     /**
@@ -1168,6 +1252,7 @@ abstract class AbstractQuery
         $hints['hydrationMode'] = $this->getHydrationMode();
 
         ksort($hints);
+        assert($queryCacheProfile !== null);
 
         return $queryCacheProfile->generateCacheKeys($sql, $parameters, $hints);
     }
@@ -1177,15 +1262,17 @@ abstract class AbstractQuery
      * If this is not explicitly set by the developer then a hash is automatically
      * generated for you.
      *
-     * @param string $id
+     * @param string|null $id
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setResultCacheId($id)
     {
-        $this->_queryCacheProfile = $this->_queryCacheProfile
-            ? $this->_queryCacheProfile->setCacheKey($id)
-            : new QueryCacheProfile(0, $id, $this->_em->getConfiguration()->getResultCacheImpl());
+        if (! $this->_queryCacheProfile) {
+            return $this->setResultCacheProfile(new QueryCacheProfile(0, $id));
+        }
+
+        $this->_queryCacheProfile = $this->_queryCacheProfile->setCacheKey($id);
 
         return $this;
     }
@@ -1195,7 +1282,7 @@ abstract class AbstractQuery
      *
      * @deprecated
      *
-     * @return string
+     * @return string|null
      */
     public function getResultCacheId()
     {

--- a/lib/Doctrine/ORM/Cache/Exception/InvalidResultCacheDriver.php
+++ b/lib/Doctrine/ORM/Cache/Exception/InvalidResultCacheDriver.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\ORM\Cache\Exception;
 
+/**
+ * @deprecated
+ */
 final class InvalidResultCacheDriver extends CacheException
 {
     public static function create(): self

--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -6,6 +6,7 @@ namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
@@ -20,6 +21,7 @@ use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\ORM\Query\QueryException;
 use Doctrine\ORM\Utility\HierarchyDiscriminatorResolver;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function array_keys;
 use function array_values;
@@ -29,6 +31,7 @@ use function get_debug_type;
 use function in_array;
 use function ksort;
 use function md5;
+use function method_exists;
 use function reset;
 use function serialize;
 use function sha1;
@@ -329,13 +332,20 @@ final class Query extends AbstractQuery
             return;
         }
 
-        $cacheDriver = $this->_queryCacheProfile->getResultCacheDriver();
-        $statements  = (array) $executor->getSqlStatements(); // Type casted since it can either be a string or an array
+        $cache = method_exists(QueryCacheProfile::class, 'getResultCache')
+            ? $this->_queryCacheProfile->getResultCache()
+            : $this->_queryCacheProfile->getResultCacheDriver();
+
+        assert($cache !== null);
+
+        $statements = (array) $executor->getSqlStatements(); // Type casted since it can either be a string or an array
 
         foreach ($statements as $statement) {
             $cacheKeys = $this->_queryCacheProfile->generateCacheKeys($statement, $sqlParams, $types, $connectionParams);
 
-            $cacheDriver->delete(reset($cacheKeys));
+            $cache instanceof CacheItemPoolInterface
+                ? $cache->deleteItem(reset($cacheKeys))
+                : $cache->delete(reset($cacheKeys));
         }
     }
 

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -10,3 +10,15 @@ parameters:
         - '/Call to an undefined method Doctrine\\DBAL\\Connection::createSchemaManager\(\)\./'
         # Class name will change in DBAL 3.
         - '/Class Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform referenced with incorrect case: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform\./'
+
+        # Forward compatibility for DBAL 3.2
+        - '/^Call to an undefined method Doctrine\\.*::[gs]etResultCache\(\)\.$/'
+        -
+        	message: '/^Parameter #3 \$resultCache of class Doctrine\\DBAL\\Cache\\QueryCacheProfile constructor/'
+        	path: lib/Doctrine/ORM/AbstractQuery.php
+
+        # False positive
+        -
+            message: '/^Call to an undefined method Doctrine\\Common\\Cache\\Cache::deleteAll\(\)\.$/'
+            count: 1
+            path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -30,7 +30,17 @@ parameters:
         	message: '/^Call to static method ensure\(\) on an unknown class Doctrine\\DBAL\\ForwardCompatibility\\Result\.$/'
         	path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
 
+        # Forward compatibility for DBAL 3.2
+        - '/^Call to an undefined method Doctrine\\.*::[gs]etResultCache\(\)\.$/'
+        -
+        	message: '/^Parameter #3 \$resultCache of class Doctrine\\DBAL\\Cache\\QueryCacheProfile constructor/'
+        	path: lib/Doctrine/ORM/AbstractQuery.php
+
         # False positive
         -
             message: '/^Variable \$offset in isset\(\) always exists and is not nullable\.$/'
             path: lib/Doctrine/ORM/PersistentCollection.php
+        -
+            message: '/^Call to an undefined method Doctrine\\Common\\Cache\\Cache::deleteAll\(\)\.$/'
+            count: 1
+            path: lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,10 +16,9 @@
     <InvalidFalsableReturnType occurrences="1">
       <code>Parameter|null</code>
     </InvalidFalsableReturnType>
-    <InvalidNullableReturnType occurrences="3">
+    <InvalidNullableReturnType occurrences="2">
       <code>\Doctrine\Common\Cache\Cache</code>
       <code>int</code>
-      <code>string</code>
     </InvalidNullableReturnType>
     <InvalidScalarArgument occurrences="1">
       <code>$key</code>
@@ -29,9 +28,8 @@
       <code>$data</code>
       <code>$data</code>
     </MissingClosureParamType>
-    <NullableReturnStatement occurrences="4">
+    <NullableReturnStatement occurrences="3">
       <code>$this-&gt;_em-&gt;getConfiguration()-&gt;getResultCacheImpl()</code>
-      <code>$this-&gt;_queryCacheProfile ? $this-&gt;_queryCacheProfile-&gt;getCacheKey() : null</code>
       <code>$this-&gt;_queryCacheProfile-&gt;getResultCacheDriver()</code>
       <code>$this-&gt;cacheMode</code>
     </NullableReturnStatement>
@@ -39,22 +37,11 @@
       <code>$stmt</code>
       <code>$stmt</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArgument occurrences="4">
-      <code>$resultCacheDriver</code>
-      <code>$resultCacheDriver</code>
-      <code>$resultCacheDriver</code>
-      <code>$resultCacheId</code>
-    </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$profile</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="3">
-      <code>fetch</code>
+    <PossiblyNullReference occurrences="2">
       <code>getCacheLogger</code>
       <code>getQueryCache</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
-      <code>$_hydrationCacheProfile</code>
+    <PropertyNotSetInConstructor occurrences="1">
       <code>$_resultSetMapping</code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="5">
@@ -64,9 +51,6 @@
       <code>(int) $lifetime</code>
       <code>(string) $cacheRegion</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;_hydrationCacheProfile !== null</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="lib/Doctrine/ORM/Cache.php">
     <MissingReturnType occurrences="1">
@@ -1647,7 +1631,7 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor occurrences="2">
       <code>$sql</code>
       <code>NativeQuery</code>
       <code>NativeQuery</code>
@@ -2046,11 +2030,10 @@
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>$timeToLive</code>
     </PossiblyNullPropertyAssignmentValue>
-    <PossiblyNullReference occurrences="2">
-      <code>delete</code>
+    <PossiblyNullReference occurrences="1">
       <code>evictEntityRegion</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="4">
+    <PropertyNotSetInConstructor occurrences="3">
       <code>$parserResult</code>
       <code>$queryCacheTTL</code>
       <code>Query</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,8 @@
                 <!-- DBAL 2 compatibility -->
                 <referencedClass name="Doctrine\DBAL\Tools\Console\Command\ImportCommand"/>
                 <referencedClass name="Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper"/>
+                <!-- The exception is thrown by a deprecated method. -->
+                <referencedClass name="Doctrine\ORM\Cache\Exception\InvalidResultCacheDriver"/>
             </errorLevel>
         </DeprecatedClass>
         <DeprecatedMethod>
@@ -42,6 +44,12 @@
                 <file name="lib/Doctrine/ORM/Tools/Pagination/LimitSubqueryOutputWalker.php"/>
             </errorLevel>
         </DocblockTypeContradiction>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- Argument type changes in DBAL 3.2 -->
+                <referencedFunction name="Doctrine\DBAL\Cache\QueryCacheProfile::__construct"/>
+            </errorLevel>
+        </InvalidArgument>
         <InvalidClass>
             <errorLevel type="suppress">
                 <!-- Class name changes in DBAL 3. -->

--- a/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\DBAL\Cache\QueryCacheProfile;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+
+use function method_exists;
+
+final class AbstractQueryTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testItMakesHydrationCacheProfilesAwareOfTheResultCacheDriver(): void
+    {
+        if (method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            self::markTestSkipped('this test is meant for DBAL < 3.2');
+        }
+
+        $configuration = new Configuration();
+        $configuration->setHydrationCacheImpl($this->createMock(Cache::class));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
+        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $cacheProfile = new QueryCacheProfile();
+
+        $query->setHydrationCacheProfile($cacheProfile);
+        self::assertNotNull($query->getHydrationCacheProfile()->getResultCacheDriver());
+    }
+
+    /**
+     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::setResultCache
+     */
+    public function testItMakesHydrationCacheProfilesAwareOfTheResultCache(): void
+    {
+        $configuration = new Configuration();
+        $configuration->setHydrationCacheImpl($this->createMock(Cache::class));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
+        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $cacheProfile = new QueryCacheProfile();
+
+        $query->setHydrationCacheProfile($cacheProfile);
+        self::assertNotNull($query->getHydrationCacheProfile()->getResultCache());
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
+    }
+
+    public function testItMakesResultCacheProfilesAwareOfTheResultCacheDriver(): void
+    {
+        if (method_exists(QueryCacheProfile::class, 'setResultCache')) {
+            self::markTestSkipped('this test is meant for DBAL < 3.2');
+        }
+
+        $configuration = new Configuration();
+        $configuration->setResultCacheImpl($this->createMock(Cache::class));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
+        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $cacheProfile = new QueryCacheProfile();
+
+        $query->setResultCacheProfile($cacheProfile);
+        self::assertNotNull($query->getResultCacheDriver());
+    }
+
+    /**
+     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::setResultCache
+     */
+    public function testItMakesResultCacheProfilesAwareOfTheResultCache(): void
+    {
+        $configuration = new Configuration();
+        $configuration->setResultCache($this->createMock(CacheItemPoolInterface::class));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn($configuration);
+        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+        $cacheProfile = new QueryCacheProfile();
+
+        $query->setResultCacheProfile($cacheProfile);
+        self::assertNotNull($query->getResultCacheDriver());
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
+    }
+
+    public function testSettingTheResultCacheIsPossibleWithoutCallingDeprecatedMethods(): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getConfiguration')->willReturn(new Configuration());
+        $query = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
+
+        $query->setResultCache($this->createMock(CacheItemPoolInterface::class));
+        self::assertNotNull($query->getResultCacheDriver());
+        $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
+    }
+}

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH2947Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH2947Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
@@ -21,7 +20,7 @@ class GH2947Test extends OrmFunctionalTestCase
 {
     protected function setUp(): void
     {
-        $this->resultCacheImpl = DoctrineProvider::wrap(new ArrayAdapter());
+        $this->resultCache = new ArrayAdapter();
 
         parent::setUp();
 

--- a/tests/Doctrine/Tests/OrmFunctionalTestCase.php
+++ b/tests/Doctrine/Tests/OrmFunctionalTestCase.php
@@ -41,7 +41,6 @@ use function explode;
 use function get_class;
 use function getenv;
 use function implode;
-use function in_array;
 use function is_object;
 use function method_exists;
 use function realpath;
@@ -97,9 +96,9 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
     /**
      * To be configured by the test that uses result set cache
      *
-     * @var Cache|null
+     * @var CacheItemPoolInterface|null
      */
-    protected $resultCacheImpl;
+    protected $resultCache;
 
     /**
      * Whether the database schema has already been created.
@@ -742,8 +741,12 @@ abstract class OrmFunctionalTestCase extends OrmTestCase
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
 
-        if ($this->resultCacheImpl !== null) {
-            $config->setResultCacheImpl($this->resultCacheImpl);
+        if ($this->resultCache !== null) {
+            if (method_exists($config, 'setResultCache')) {
+                $config->setResultCache($this->resultCache);
+            } else {
+                $config->setResultCacheImpl(DoctrineProvider::wrap($this->resultCache));
+            }
         }
 
         $enableSecondLevelCache = getenv('ENABLE_SECOND_LEVEL_CACHE');


### PR DESCRIPTION
Follows doctrine/dbal#4620

DBAL 3.2 will deprecate Doctrine Cache in favor of PSR-6 for result caches. This PR makes sure we call the non-deprecated methods.

I've also added a CI job that runs against a dev snapshot of DBAL, so we can actually test my changes.