### PR TITLE
Remove Proxy from EntityManagerInterface contract

### DIFF
--- a/lib/Doctrine/ORM/EntityManagerInterface.php
+++ b/lib/Doctrine/ORM/EntityManagerInterface.php
@@ -23,7 +23,6 @@ namespace Doctrine\ORM;
 use BadMethodCallException;
 use DateTimeInterface;
 use Doctrine\Common\EventManager;
-use Doctrine\Common\Proxy\Proxy;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 use Doctrine\ORM\Proxy\ProxyFactory;
@@ -170,7 +169,7 @@ interface EntityManagerInterface extends ObjectManager
      * @psalm-param class-string<T> $entityName
      *
      * @return object|null The entity reference.
-     * @psalm-return (T&Proxy)|null
+     * @psalm-return T|null
      *
      * @throws ORMException
      *
@@ -198,7 +197,7 @@ interface EntityManagerInterface extends ObjectManager
      * @psalm-param class-string<T> $entityName
      *
      * @return object|null The (partial) entity reference
-     * @psalm-return (T&Proxy)|null
+     * @psalm-return T|null
      *
      * @template T
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,22 +161,22 @@ parameters:
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getPartialReference\\(\\) should return \\(Doctrine\\\\Common\\\\Proxy\\\\Proxy&T\\)\\|null but returns object\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getPartialReference\\(\\) should return T\\|null but returns object\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getPartialReference\\(\\) should return \\(Doctrine\\\\Common\\\\Proxy\\\\Proxy&T\\)\\|null but returns object\\|null\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getPartialReference\\(\\) should return T\\|null but returns object\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getReference\\(\\) should return \\(Doctrine\\\\Common\\\\Proxy\\\\Proxy&T\\)\\|null but returns Doctrine\\\\Common\\\\Proxy\\\\Proxy\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getReference\\(\\) should return T\\|null but returns Doctrine\\\\Common\\\\Proxy\\\\Proxy\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityManager.php
 
 		-
-			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getReference\\(\\) should return \\(Doctrine\\\\Common\\\\Proxy\\\\Proxy&T\\)\\|null but returns object\\|null\\.$#"
+			message: "#^Method Doctrine\\\\ORM\\\\EntityManager\\:\\:getReference\\(\\) should return T\\|null but returns object\\|null\\.$#"
 			count: 1
 			path: lib/Doctrine/ORM/EntityManager.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -487,7 +487,7 @@
       <code>is_object($entity)</code>
       <code>is_object($entity)</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="10">
+    <InvalidReturnStatement occurrences="9">
       <code>$entity</code>
       <code>$entity</code>
       <code>$entity</code>
@@ -496,7 +496,6 @@
       <code>$entity instanceof $class-&gt;name ? $entity : null</code>
       <code>$persister-&gt;load($sortedId, null, null, [], $lockMode)</code>
       <code>$persister-&gt;loadById($sortedId)</code>
-      <code>$this-&gt;find($entityName, $sortedId)</code>
       <code>$this-&gt;metadataFactory-&gt;getMetadataFor($className)</code>
     </InvalidReturnStatement>
     <InvalidReturnType occurrences="4">


### PR DESCRIPTION
After merging #8922 by @simPod, I had a deeper look that the implementation to see if we can fix some of the newly baselined errors. I'd like to partially revert the change now. Sorry for the confusion.

#8922 added an intersection with the `Proxy` interface to the return type of `EntityManagerInterface::getReference()` and `getPartialReference()`. Here's why I now think that this is problematic:

1. While our implementation `EntityManager` _might_ return such an object, we cannot guarantee that it will. If you look at the following code snippet, you can see that the actual entity is returned instead of a reference, if the entity has already been registered with the UoW. In that case, the returned entity might not be a proxy object.

   https://github.com/doctrine/orm/blob/04d28a93628157e7174f4322a1b1cbdbf60afe12/lib/Doctrine/ORM/EntityManager.php#L515-L520

   If we kept the `Proxy` interface in the return type, the correct type would be `(T&Proxy)|T|null`.

2. The `Proxy` interface is somewhat an implementation detail of our `EntityManager` implementation that should not be leaked to the interface. I believe, the ORM _should_ be able to move to a different proxy library without violating the contract of `EntityManagerInterface`.