### PR TITLE
Switch cache configuration to PSR-6

### DIFF
--- a/lib/Doctrine/ORM/Query.php
+++ b/lib/Doctrine/ORM/Query.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\DBAL\LockMode;
@@ -497,7 +498,9 @@ final class Query extends AbstractQuery
             return $this->queryCache;
         }
 
-        return $this->_em->getConfiguration()->getQueryCacheImpl();
+        $queryCache = $this->_em->getConfiguration()->getQueryCache();
+
+        return $queryCache ? DoctrineProvider::wrap($queryCache) : null;
     }
 
     /**

--- a/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
+++ b/lib/Doctrine/ORM/Tools/Console/Command/ClearCache/ResultCommand.php
@@ -68,7 +68,7 @@ EOT
         $ui = new SymfonyStyle($input, $output);
 
         $em          = $this->getEntityManager($input);
-        $cache       = method_exists(Configuration::class, 'getResultCache') ? $em->getConfiguration()->getResultCache() : null;
+        $cache       = $em->getConfiguration()->getResultCache();
         $cacheDriver = method_exists(Configuration::class, 'getResultCacheImpl') ? $em->getConfiguration()->getResultCacheImpl() : null;
 
         if (! $cacheDriver && ! $cache) {

--- a/lib/Doctrine/ORM/Tools/Setup.php
+++ b/lib/Doctrine/ORM/Tools/Setup.php
@@ -124,8 +124,8 @@ class Setup
         $config = new Configuration();
 
         $config->setMetadataCache(CacheAdapter::wrap($cache));
-        $config->setQueryCacheImpl($cache);
-        $config->setResultCacheImpl($cache);
+        $config->setQueryCache(CacheAdapter::wrap($cache));
+        $config->setResultCache(CacheAdapter::wrap($cache));
         $config->setProxyDir($proxyDir);
         $config->setProxyNamespace('DoctrineProxies');
         $config->setAutoGenerateProxyClasses($isDevMode);

--- a/phpstan-dbal2.neon
+++ b/phpstan-dbal2.neon
@@ -12,7 +12,10 @@ parameters:
         - '/Class Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform referenced with incorrect case: Doctrine\\DBAL\\Platforms\\PostgreSQLPlatform\./'
 
         # Forward compatibility for DBAL 3.2
-        - '/^Call to an undefined method Doctrine\\.*::[gs]etResultCache\(\)\.$/'
+        - '/^Call to an undefined method Doctrine\\DBAL\\Cache\\QueryCacheProfile::[gs]etResultCache\(\)\.$/'
+        -
+        	message: '/^Call to an undefined static method Doctrine\\DBAL\\Configuration::[gs]etResultCache\(\)\.$/'
+        	path: lib/Doctrine/ORM/Configuration.php
         -
         	message: '/^Parameter #3 \$resultCache of class Doctrine\\DBAL\\Cache\\QueryCacheProfile constructor/'
         	path: lib/Doctrine/ORM/AbstractQuery.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,7 +31,10 @@ parameters:
         	path: lib/Doctrine/ORM/Internal/Hydration/AbstractHydrator.php
 
         # Forward compatibility for DBAL 3.2
-        - '/^Call to an undefined method Doctrine\\.*::[gs]etResultCache\(\)\.$/'
+        - '/^Call to an undefined method Doctrine\\DBAL\\Cache\\QueryCacheProfile::[gs]etResultCache\(\)\.$/'
+        -
+        	message: '/^Call to an undefined static method Doctrine\\DBAL\\Configuration::[gs]etResultCache\(\)\.$/'
+        	path: lib/Doctrine/ORM/Configuration.php
         -
         	message: '/^Parameter #3 \$resultCache of class Doctrine\\DBAL\\Cache\\QueryCacheProfile constructor/'
         	path: lib/Doctrine/ORM/AbstractQuery.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -44,10 +44,9 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$_resultSetMapping</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="5">
+    <RedundantCastGivenDocblockType occurrences="4">
       <code>(bool) $cacheable</code>
       <code>(int) $cacheMode</code>
-      <code>(int) $lifetime</code>
       <code>(int) $lifetime</code>
       <code>(string) $cacheRegion</code>
     </RedundantCastGivenDocblockType>
@@ -405,10 +404,11 @@
       <code>new CachedReader($reader, new ArrayCache())</code>
       <code>new SimpleAnnotationReader()</code>
     </DeprecatedClass>
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod occurrences="4">
       <code>AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php')</code>
       <code>getAutoGenerateProxyClasses</code>
       <code>getMetadataCacheImpl</code>
+      <code>getQueryCacheImpl</code>
     </DeprecatedMethod>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $flag</code>
@@ -1634,7 +1634,6 @@
     <PropertyNotSetInConstructor occurrences="2">
       <code>$sql</code>
       <code>NativeQuery</code>
-      <code>NativeQuery</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="lib/Doctrine/ORM/ORMInvalidArgumentException.php">
@@ -2036,7 +2035,6 @@
     <PropertyNotSetInConstructor occurrences="3">
       <code>$parserResult</code>
       <code>$queryCacheTTL</code>
-      <code>Query</code>
       <code>Query</code>
     </PropertyNotSetInConstructor>
     <RedundantCastGivenDocblockType occurrences="1">
@@ -3367,6 +3365,9 @@
     </MissingReturnType>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ClearCache/QueryCommand.php">
+    <DeprecatedMethod occurrences="1">
+      <code>getQueryCacheImpl</code>
+    </DeprecatedMethod>
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
@@ -3386,6 +3387,13 @@
     <MissingReturnType occurrences="1">
       <code>configure</code>
     </MissingReturnType>
+    <PossiblyNullArgument occurrences="2">
+      <code>$cacheDriver</code>
+      <code>$cacheDriver</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>deleteAll</code>
+    </PossiblyNullReference>
   </file>
   <file src="lib/Doctrine/ORM/Tools/Console/Command/ConvertDoctrine1SchemaCommand.php">
     <ArgumentTypeCoercion occurrences="1">

--- a/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
+++ b/tests/Doctrine/Tests/ORM/AbstractQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM;
 
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\AbstractQuery;
@@ -13,88 +13,73 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 
-use function method_exists;
-
 final class AbstractQueryTest extends TestCase
 {
     use VerifyDeprecations;
 
+    /**
+     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::getResultCacheDriver
+     */
     public function testItMakesHydrationCacheProfilesAwareOfTheResultCacheDriver(): void
     {
-        if (method_exists(QueryCacheProfile::class, 'setResultCache')) {
-            self::markTestSkipped('this test is meant for DBAL < 3.2');
-        }
+        $cache = $this->createMock(CacheItemPoolInterface::class);
 
         $configuration = new Configuration();
-        $configuration->setHydrationCacheImpl($this->createMock(Cache::class));
+        $configuration->setHydrationCache($cache);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->method('getConfiguration')->willReturn($configuration);
         $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setHydrationCacheProfile($cacheProfile);
-        self::assertNotNull($query->getHydrationCacheProfile()->getResultCacheDriver());
+        self::assertSame($cache, CacheAdapter::wrap($query->getHydrationCacheProfile()->getResultCacheDriver()));
     }
 
     /**
-     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::setResultCache
+     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::getResultCache
      */
     public function testItMakesHydrationCacheProfilesAwareOfTheResultCache(): void
     {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+
         $configuration = new Configuration();
-        $configuration->setHydrationCacheImpl($this->createMock(Cache::class));
+        $configuration->setHydrationCache($cache);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->method('getConfiguration')->willReturn($configuration);
         $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setHydrationCacheProfile($cacheProfile);
-        self::assertNotNull($query->getHydrationCacheProfile()->getResultCache());
+        self::assertSame($cache, $query->getHydrationCacheProfile()->getResultCache());
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
     }
 
-    public function testItMakesResultCacheProfilesAwareOfTheResultCacheDriver(): void
-    {
-        if (method_exists(QueryCacheProfile::class, 'setResultCache')) {
-            self::markTestSkipped('this test is meant for DBAL < 3.2');
-        }
-
-        $configuration = new Configuration();
-        $configuration->setResultCacheImpl($this->createMock(Cache::class));
-        $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->method('getConfiguration')->willReturn($configuration);
-        $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
-        $cacheProfile = new QueryCacheProfile();
-
-        $query->setResultCacheProfile($cacheProfile);
-        self::assertNotNull($query->getResultCacheDriver());
-    }
-
-    /**
-     * @requires function Doctrine\DBAL\Cache\QueryCacheProfile::setResultCache
-     */
     public function testItMakesResultCacheProfilesAwareOfTheResultCache(): void
     {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+
         $configuration = new Configuration();
-        $configuration->setResultCache($this->createMock(CacheItemPoolInterface::class));
+        $configuration->setResultCache($cache);
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->method('getConfiguration')->willReturn($configuration);
         $query        = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
         $cacheProfile = new QueryCacheProfile();
 
         $query->setResultCacheProfile($cacheProfile);
-        self::assertNotNull($query->getResultCacheDriver());
+        self::assertSame($cache, CacheAdapter::wrap($query->getResultCacheDriver()));
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
     }
 
     public function testSettingTheResultCacheIsPossibleWithoutCallingDeprecatedMethods(): void
     {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->method('getConfiguration')->willReturn(new Configuration());
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [$entityManager]);
 
-        $query->setResultCache($this->createMock(CacheItemPoolInterface::class));
-        self::assertNotNull($query->getResultCacheDriver());
+        $query->setResultCache($cache);
+        self::assertSame($cache, CacheAdapter::wrap($query->getResultCacheDriver()));
         $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/dbal/pull/4620');
     }
 }

--- a/tests/Doctrine/Tests/ORM/ConfigurationTest.php
+++ b/tests/Doctrine/Tests/ORM/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\ORM;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Proxy\AbstractProxyFactory;
 use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
 use Doctrine\ORM\Cache\CacheConfiguration;
@@ -128,17 +129,38 @@ class ConfigurationTest extends DoctrineTestCase
     public function testSetGetQueryCacheImpl(): void
     {
         self::assertNull($this->configuration->getQueryCacheImpl()); // defaults
+        self::assertNull($this->configuration->getQueryCache()); // defaults
         $queryCacheImpl = $this->createMock(Cache::class);
         $this->configuration->setQueryCacheImpl($queryCacheImpl);
         self::assertSame($queryCacheImpl, $this->configuration->getQueryCacheImpl());
+        self::assertNotNull($this->configuration->getQueryCache());
+    }
+
+    public function testSetGetQueryCache(): void
+    {
+        self::assertNull($this->configuration->getQueryCache()); // defaults
+        $queryCache = $this->createMock(CacheItemPoolInterface::class);
+        $this->configuration->setQueryCache($queryCache);
+        self::assertSame($queryCache, $this->configuration->getQueryCache());
+        self::assertSame($queryCache, CacheAdapter::wrap($this->configuration->getQueryCacheImpl()));
     }
 
     public function testSetGetHydrationCacheImpl(): void
     {
         self::assertNull($this->configuration->getHydrationCacheImpl()); // defaults
-        $queryCacheImpl = $this->createMock(Cache::class);
-        $this->configuration->setHydrationCacheImpl($queryCacheImpl);
-        self::assertSame($queryCacheImpl, $this->configuration->getHydrationCacheImpl());
+        $hydrationCacheImpl = $this->createMock(Cache::class);
+        $this->configuration->setHydrationCacheImpl($hydrationCacheImpl);
+        self::assertSame($hydrationCacheImpl, $this->configuration->getHydrationCacheImpl());
+        self::assertNotNull($this->configuration->getHydrationCache());
+    }
+
+    public function testSetGetHydrationCache(): void
+    {
+        self::assertNull($this->configuration->getHydrationCache()); // defaults
+        $hydrationCache = $this->createStub(CacheItemPoolInterface::class);
+        $this->configuration->setHydrationCache($hydrationCache);
+        self::assertSame($hydrationCache, $this->configuration->getHydrationCache());
+        self::assertSame($hydrationCache, CacheAdapter::wrap($this->configuration->getHydrationCacheImpl()));
     }
 
     public function testSetGetMetadataCacheImpl(): void
@@ -156,7 +178,7 @@ class ConfigurationTest extends DoctrineTestCase
         $cache = $this->createStub(CacheItemPoolInterface::class);
         $this->configuration->setMetadataCache($cache);
         self::assertSame($cache, $this->configuration->getMetadataCache());
-        self::assertNotNull($this->configuration->getMetadataCacheImpl());
+        self::assertSame($cache, CacheAdapter::wrap($this->configuration->getMetadataCacheImpl()));
     }
 
     public function testAddGetNamedQuery(): void

--- a/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Locking/LockAgentWorker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\ORM\Functional\Locking;
 
 use Closure;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
@@ -123,8 +122,7 @@ class LockAgentWorker
         $config->setMetadataDriverImpl($annotDriver);
         $config->setMetadataCache(new ArrayAdapter());
 
-        $cache = DoctrineProvider::wrap(new ArrayAdapter());
-        $config->setQueryCacheImpl($cache);
+        $config->setQueryCache(new ArrayAdapter());
 
         return EntityManager::create($conn, $config);
     }

--- a/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/QueryCacheTest.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Exec\AbstractSqlExecutor;
 use Doctrine\ORM\Query\ParserResult;
 use Doctrine\Tests\OrmFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 use function assert;
@@ -95,7 +96,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     public function testQueryCacheNoHitSaveParserResult(): void
     {
-        $this->_em->getConfiguration()->setQueryCacheImpl($this->createMock(Cache::class));
+        $this->_em->getConfiguration()->setQueryCache($this->createMock(CacheItemPoolInterface::class));
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 
@@ -113,7 +114,7 @@ class QueryCacheTest extends OrmFunctionalTestCase
 
     public function testQueryCacheHitDoesNotSaveParserResult(): void
     {
-        $this->_em->getConfiguration()->setQueryCacheImpl($this->createMock(Cache::class));
+        $this->_em->getConfiguration()->setQueryCache($this->createMock(CacheItemPoolInterface::class));
 
         $query = $this->_em->createQuery('select ux from Doctrine\Tests\Models\CMS\CmsUser ux');
 

--- a/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/ResultCacheTest.php
@@ -7,7 +7,6 @@ namespace Doctrine\Tests\ORM\Functional;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\DBAL\Cache\QueryCacheProfile;
 use Doctrine\ORM\AbstractQuery;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\NativeQuery;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\ResultSetMapping;
@@ -412,11 +411,7 @@ class ResultCacheTest extends OrmFunctionalTestCase
 
     private function resetCache(): void
     {
-        if (method_exists(Configuration::class, 'setResultCache')) {
-            $this->_em->getConfiguration()->setResultCache(new ArrayAdapter());
-        } else {
-            $this->_em->getConfiguration()->setResultCacheImpl(DoctrineProvider::wrap(new ArrayAdapter()));
-        }
+        $this->_em->getConfiguration()->setResultCache(new ArrayAdapter());
     }
 
     private static function assertCacheDoesNotHaveItem(string $key, CacheItemPoolInterface $cache): void

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7820Test.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Functional\Ticket;
 
-use Doctrine\Common\Cache\ClearableCache;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
@@ -16,7 +15,6 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 use function array_map;
-use function assert;
 use function is_string;
 use function iterator_to_array;
 
@@ -86,12 +84,9 @@ class GH7820Test extends OrmFunctionalTestCase
     /** @group GH7837 */
     public function testWillFindSongsInPaginatorEvenWithCachedQueryParsing(): void
     {
-        $cache = $this->_em->getConfiguration()
-            ->getQueryCacheImpl();
-
-        assert($cache instanceof ClearableCache);
-
-        $cache->deleteAll();
+        $this->_em->getConfiguration()
+            ->getQueryCache()
+            ->clear();
 
         $query = $this->_em->getRepository(GH7820Line::class)
             ->createQueryBuilder('l')

--- a/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
+++ b/tests/Doctrine/Tests/ORM/Tools/SetupTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\ORM\Tools;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
@@ -128,7 +126,9 @@ class SetupTest extends OrmTestCase
         $cache   = DoctrineProvider::wrap($adapter);
         $config  = Setup::createAnnotationMetadataConfiguration([], true, null, $cache);
 
+        self::assertSame($adapter, $config->getResultCache()->getCache()->getPool());
         self::assertSame($cache, $config->getResultCacheImpl());
+        self::assertSame($adapter, $config->getQueryCache()->getCache()->getPool());
         self::assertSame($cache, $config->getQueryCacheImpl());
 
         self::assertSame($adapter, $config->getMetadataCache()->getCache()->getPool());
@@ -139,13 +139,15 @@ class SetupTest extends OrmTestCase
      */
     public function testConfigureCacheCustomInstance(): void
     {
-        $cache  = $this->createMock(Cache::class);
-        $config = Setup::createConfiguration(true, null, $cache);
+        $adapter = new ArrayAdapter();
+        $cache   = DoctrineProvider::wrap($adapter);
+        $config  = Setup::createConfiguration(true, null, $cache);
 
+        self::assertSame($adapter, $config->getResultCache()->getCache()->getPool());
         self::assertSame($cache, $config->getResultCacheImpl());
+        self::assertSame($adapter, $config->getQueryCache()->getCache()->getPool());
         self::assertSame($cache, $config->getQueryCacheImpl());
 
-        self::assertInstanceOf(CacheAdapter::class, $config->getMetadataCache());
-        self::assertSame($cache, $config->getMetadataCache()->getCache());
+        self::assertSame($adapter, $config->getMetadataCache()->getCache()->getPool());
     }
 }

--- a/tests/Doctrine/Tests/OrmTestCase.php
+++ b/tests/Doctrine/Tests/OrmTestCase.php
@@ -39,9 +39,9 @@ abstract class OrmTestCase extends DoctrineTestCase
     /**
      * The query cache that is shared between all ORM tests (except functional tests).
      *
-     * @var Cache|null
+     * @var CacheItemPoolInterface|null
      */
-    private static $_queryCacheImpl = null;
+    private static $queryCache = null;
 
     /** @var bool */
     protected $isSecondLevelCacheEnabled = false;
@@ -102,7 +102,7 @@ abstract class OrmTestCase extends DoctrineTestCase
 
         $config->setMetadataCache($metadataCache);
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver([], false));
-        $config->setQueryCacheImpl(self::getSharedQueryCacheImpl());
+        $config->setQueryCache(self::getSharedQueryCache());
         $config->setProxyDir(__DIR__ . '/Proxies');
         $config->setProxyNamespace('Doctrine\Tests\Proxies');
         $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver(
@@ -155,13 +155,13 @@ abstract class OrmTestCase extends DoctrineTestCase
         return self::$_metadataCache;
     }
 
-    private static function getSharedQueryCacheImpl(): Cache
+    private static function getSharedQueryCache(): CacheItemPoolInterface
     {
-        if (self::$_queryCacheImpl === null) {
-            self::$_queryCacheImpl = DoctrineProvider::wrap(new ArrayAdapter());
+        if (self::$queryCache === null) {
+            self::$queryCache = new ArrayAdapter();
         }
 
-        return self::$_queryCacheImpl;
+        return self::$queryCache;
     }
 
     protected function getSharedSecondLevelCacheDriverImpl(): Cache


### PR DESCRIPTION
This PR enables applications to configure all caches as PSR-6 caches.

This way, we internalize the Doctrine Cache interfaces. We still use the Doctrine Cache interfaces to access the caches, but this is an implementation detail we can change in a follow-up.