### PR TITLE
Add PHP 8.1 to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,6 +19,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout"
@@ -33,6 +34,11 @@ jobs:
           extensions: "pdo, pdo_sqlite"
           coverage: "pcov"
           ini-values: "zend.assertions=1"
+
+      # To be removed as soon as https://github.com/doctrine/dbal/pull/4818 is released.
+      - name: "Switch to dev dependencies"
+        if: "${{ matrix.php-version == '8.1' }}"
+        run: "composer config minimum-stability dev"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
+++ b/tests/Doctrine/Tests/ORM/Functional/Ticket/GH7941Test.php
@@ -50,7 +50,9 @@ final class GH7941Test extends OrmFunctionalTestCase
         $result = $query->getSingleResult();
 
         self::assertSame(6, $result['count']);
-        self::assertSame('325', $result['sales']);
+
+        // While other drivers will return a string, pdo_sqlite returns an integer as of PHP 8.1
+        self::assertEquals(325, $result['sales']);
 
         // Driver return type and precision is determined by the underlying php extension, most seem to return a string.
         // pdo_mysql and mysqli both currently return '54.1667' so this is the maximum precision we can assert.
@@ -68,7 +70,7 @@ final class GH7941Test extends OrmFunctionalTestCase
         foreach ($query->getResult() as $i => $item) {
             $product = self::PRODUCTS[$i];
 
-            self::assertSame(ltrim($product['price'], '-'), $item['absolute']);
+            self::assertEquals(ltrim($product['price'], '-'), $item['absolute']);
             self::assertSame(strlen($product['name']), $item['length']);
 
             // Driver return types for the `square_root` column are inconsistent depending on the underlying


### PR DESCRIPTION
TODO:

- [x] #8963
- [x] `Doctrine\Tests\ORM\Functional\Ticket\GH7941Test::typesShouldBeConvertedForDQLFunctions`