### PR TITLE
Document fluent interfaces

### DIFF
--- a/lib/Doctrine/ORM/AbstractQuery.php
+++ b/lib/Doctrine/ORM/AbstractQuery.php
@@ -181,7 +181,7 @@ abstract class AbstractQuery
      *
      * @param bool $cacheable
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setCacheable($cacheable)
     {
@@ -201,7 +201,7 @@ abstract class AbstractQuery
     /**
      * @param string $cacheRegion
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setCacheRegion($cacheRegion)
     {
@@ -241,7 +241,7 @@ abstract class AbstractQuery
      *
      * @param int $lifetime
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setLifetime($lifetime)
     {
@@ -261,7 +261,7 @@ abstract class AbstractQuery
     /**
      * @param int $cacheMode
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setCacheMode($cacheMode)
     {
@@ -342,7 +342,7 @@ abstract class AbstractQuery
      * @param ArrayCollection|mixed[] $parameters
      * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setParameters($parameters)
     {
@@ -372,7 +372,7 @@ abstract class AbstractQuery
      *                           the type conversion of this type. This is usually not needed for
      *                           strings and numeric types.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setParameter($key, $value, $type = null)
     {
@@ -479,7 +479,7 @@ abstract class AbstractQuery
     /**
      * Sets the ResultSetMapping that should be used for hydration.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setResultSetMapping(Query\ResultSetMapping $rsm)
     {
@@ -524,7 +524,7 @@ abstract class AbstractQuery
      * some form of caching with UnitOfWork registration you should use
      * {@see AbstractQuery::setResultCacheProfile()}.
      *
-     * @return static This query instance.
+     * @return $this
      *
      * @example
      * $lifetime = 100;
@@ -684,7 +684,7 @@ abstract class AbstractQuery
      * @param int    $lifetime      How long the cache entry is valid, in seconds.
      * @param string $resultCacheId ID to use for the cache entry.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function useResultCache($useCache, $lifetime = null, $resultCacheId = null)
     {
@@ -700,7 +700,7 @@ abstract class AbstractQuery
      * @param int|null    $lifetime      How long the cache entry is valid, in seconds.
      * @param string|null $resultCacheId ID to use for the cache entry.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function enableResultCache(?int $lifetime = null, ?string $resultCacheId = null): self
     {
@@ -713,7 +713,7 @@ abstract class AbstractQuery
     /**
      * Disables caching of the results of this query.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function disableResultCache(): self
     {
@@ -775,7 +775,7 @@ abstract class AbstractQuery
      *
      * @param bool $expire Whether or not to force resultset cache expiration.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function expireResultCache($expire = true)
     {
@@ -811,7 +811,7 @@ abstract class AbstractQuery
      * @param string $assocName
      * @param int    $fetchMode
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setFetchMode($class, $assocName, $fetchMode)
     {
@@ -830,7 +830,7 @@ abstract class AbstractQuery
      * @param string|int $hydrationMode Doctrine processing mode to be used during hydration process.
      *                                  One of the Query::HYDRATE_* constants.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setHydrationMode($hydrationMode)
     {
@@ -987,7 +987,7 @@ abstract class AbstractQuery
      * @param string $name  The name of the hint.
      * @param mixed  $value The value of the hint.
      *
-     * @return static This query instance.
+     * @return $this
      */
     public function setHint($name, $value)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/AssociationBuilder.php
@@ -35,7 +35,7 @@ class AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return static
+     * @return $this
      */
     public function mappedBy($fieldName)
     {
@@ -47,7 +47,7 @@ class AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return static
+     * @return $this
      */
     public function inversedBy($fieldName)
     {
@@ -57,7 +57,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadeAll()
     {
@@ -67,7 +67,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadePersist()
     {
@@ -77,7 +77,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadeRemove()
     {
@@ -87,7 +87,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadeMerge()
     {
@@ -97,7 +97,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadeDetach()
     {
@@ -107,7 +107,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function cascadeRefresh()
     {
@@ -117,7 +117,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function fetchExtraLazy()
     {
@@ -127,7 +127,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function fetchEager()
     {
@@ -137,7 +137,7 @@ class AssociationBuilder
     }
 
     /**
-     * @return static
+     * @return $this
      */
     public function fetchLazy()
     {
@@ -156,7 +156,7 @@ class AssociationBuilder
      * @param string|null $onDelete
      * @param string|null $columnDef
      *
-     * @return static
+     * @return $this
      */
     public function addJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {
@@ -175,7 +175,7 @@ class AssociationBuilder
     /**
      * Sets field as primary key.
      *
-     * @return static
+     * @return $this
      */
     public function makePrimaryKey()
     {
@@ -187,7 +187,7 @@ class AssociationBuilder
     /**
      * Removes orphan entities when detached from their parent.
      *
-     * @return static
+     * @return $this
      */
     public function orphanRemoval()
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ClassMetadataBuilder.php
@@ -33,7 +33,7 @@ class ClassMetadataBuilder
     /**
      * Marks the class as mapped superclass.
      *
-     * @return static
+     * @return $this
      */
     public function setMappedSuperClass()
     {
@@ -46,7 +46,7 @@ class ClassMetadataBuilder
     /**
      * Marks the class as embeddable.
      *
-     * @return static
+     * @return $this
      */
     public function setEmbeddable()
     {
@@ -83,7 +83,7 @@ class ClassMetadataBuilder
      *
      * @param string $repositoryClassName
      *
-     * @return static
+     * @return $this
      */
     public function setCustomRepositoryClass($repositoryClassName)
     {
@@ -95,7 +95,7 @@ class ClassMetadataBuilder
     /**
      * Marks class read only.
      *
-     * @return static
+     * @return $this
      */
     public function setReadOnly()
     {
@@ -109,7 +109,7 @@ class ClassMetadataBuilder
      *
      * @param string $name
      *
-     * @return static
+     * @return $this
      */
     public function setTable($name)
     {
@@ -124,7 +124,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @psalm-param list<string> $columns
      *
-     * @return static
+     * @return $this
      */
     public function addIndex(array $columns, $name)
     {
@@ -143,7 +143,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @psalm-param list<string> $columns
      *
-     * @return static
+     * @return $this
      */
     public function addUniqueConstraint(array $columns, $name)
     {
@@ -162,7 +162,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @param string $dqlQuery
      *
-     * @return static
+     * @return $this
      */
     public function addNamedQuery($name, $dqlQuery)
     {
@@ -179,7 +179,7 @@ class ClassMetadataBuilder
     /**
      * Sets class as root of a joined table inheritance hierarchy.
      *
-     * @return static
+     * @return $this
      */
     public function setJoinedTableInheritance()
     {
@@ -191,7 +191,7 @@ class ClassMetadataBuilder
     /**
      * Sets class as root of a single table inheritance hierarchy.
      *
-     * @return static
+     * @return $this
      */
     public function setSingleTableInheritance()
     {
@@ -207,7 +207,7 @@ class ClassMetadataBuilder
      * @param string $type
      * @param int    $length
      *
-     * @return static
+     * @return $this
      */
     public function setDiscriminatorColumn($name, $type = 'string', $length = 255)
     {
@@ -228,7 +228,7 @@ class ClassMetadataBuilder
      * @param string $name
      * @param string $class
      *
-     * @return static
+     * @return $this
      */
     public function addDiscriminatorMapClass($name, $class)
     {
@@ -240,7 +240,7 @@ class ClassMetadataBuilder
     /**
      * Sets deferred explicit change tracking policy.
      *
-     * @return static
+     * @return $this
      */
     public function setChangeTrackingPolicyDeferredExplicit()
     {
@@ -252,7 +252,7 @@ class ClassMetadataBuilder
     /**
      * Sets notify change tracking policy.
      *
-     * @return static
+     * @return $this
      */
     public function setChangeTrackingPolicyNotify()
     {
@@ -267,7 +267,7 @@ class ClassMetadataBuilder
      * @param string $methodName
      * @param string $event
      *
-     * @return static
+     * @return $this
      */
     public function addLifecycleEvent($methodName, $event)
     {
@@ -283,7 +283,7 @@ class ClassMetadataBuilder
      * @param string $type
      * @psalm-param array<string, mixed> $mapping
      *
-     * @return static
+     * @return $this
      */
     public function addField($name, $type, array $mapping = [])
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/FieldBuilder.php
@@ -45,7 +45,7 @@ class FieldBuilder
      *
      * @param int $length
      *
-     * @return static
+     * @return $this
      */
     public function length($length)
     {
@@ -59,7 +59,7 @@ class FieldBuilder
      *
      * @param bool $flag
      *
-     * @return static
+     * @return $this
      */
     public function nullable($flag = true)
     {
@@ -73,7 +73,7 @@ class FieldBuilder
      *
      * @param bool $flag
      *
-     * @return static
+     * @return $this
      */
     public function unique($flag = true)
     {
@@ -87,7 +87,7 @@ class FieldBuilder
      *
      * @param string $name
      *
-     * @return static
+     * @return $this
      */
     public function columnName($name)
     {
@@ -101,7 +101,7 @@ class FieldBuilder
      *
      * @param int $p
      *
-     * @return static
+     * @return $this
      */
     public function precision($p)
     {
@@ -115,7 +115,7 @@ class FieldBuilder
      *
      * @param int $s
      *
-     * @return static
+     * @return $this
      */
     public function scale($s)
     {
@@ -139,7 +139,7 @@ class FieldBuilder
     /**
      * Sets field as primary key.
      *
-     * @return static
+     * @return $this
      */
     public function makePrimaryKey()
     {
@@ -154,7 +154,7 @@ class FieldBuilder
      * @param string $name
      * @param mixed  $value
      *
-     * @return static
+     * @return $this
      */
     public function option($name, $value)
     {
@@ -166,7 +166,7 @@ class FieldBuilder
     /**
      * @param string $strategy
      *
-     * @return static
+     * @return $this
      */
     public function generatedValue($strategy = 'AUTO')
     {
@@ -178,7 +178,7 @@ class FieldBuilder
     /**
      * Sets field versioned.
      *
-     * @return static
+     * @return $this
      */
     public function isVersionField()
     {
@@ -194,7 +194,7 @@ class FieldBuilder
      * @param int    $allocationSize
      * @param int    $initialValue
      *
-     * @return static
+     * @return $this
      */
     public function setSequenceGenerator($sequenceName, $allocationSize = 1, $initialValue = 1)
     {
@@ -212,7 +212,7 @@ class FieldBuilder
      *
      * @param string $def
      *
-     * @return static
+     * @return $this
      */
     public function columnDefinition($def)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/ManyToManyAssociationBuilder.php
@@ -20,7 +20,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
     /**
      * @param string $name
      *
-     * @return static
+     * @return $this
      */
     public function setJoinTable($name)
     {
@@ -39,7 +39,7 @@ class ManyToManyAssociationBuilder extends OneToManyAssociationBuilder
      * @param string|null $onDelete
      * @param string|null $columnDef
      *
-     * @return static
+     * @return $this
      */
     public function addInverseJoinColumn($columnName, $referencedColumnName, $nullable = true, $unique = false, $onDelete = null, $columnDef = null)
     {

--- a/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
+++ b/lib/Doctrine/ORM/Mapping/Builder/OneToManyAssociationBuilder.php
@@ -14,7 +14,7 @@ class OneToManyAssociationBuilder extends AssociationBuilder
     /**
      * @psalm-param array<string, string> $fieldNames
      *
-     * @return static
+     * @return $this
      */
     public function setOrderBy(array $fieldNames)
     {
@@ -26,7 +26,7 @@ class OneToManyAssociationBuilder extends AssociationBuilder
     /**
      * @param string $fieldName
      *
-     * @return static
+     * @return $this
      */
     public function setIndexBy($fieldName)
     {

--- a/lib/Doctrine/ORM/NativeQuery.php
+++ b/lib/Doctrine/ORM/NativeQuery.php
@@ -22,7 +22,7 @@ final class NativeQuery extends AbstractQuery
      *
      * @param string $sql
      *
-     * @return self This query instance.
+     * @return $this
      */
     public function setSQL($sql): self
     {

--- a/lib/Doctrine/ORM/Query/Expr/Base.php
+++ b/lib/Doctrine/ORM/Query/Expr/Base.php
@@ -47,7 +47,7 @@ abstract class Base
      * @param string[]|object[]|string|object $args
      * @psalm-param list<string|object>|string|object $args
      *
-     * @return static
+     * @return $this
      */
     public function addMultiple($args = [])
     {
@@ -61,7 +61,7 @@ abstract class Base
     /**
      * @param mixed $arg
      *
-     * @return static
+     * @return $this
      *
      * @throws InvalidArgumentException
      */

--- a/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
+++ b/lib/Doctrine/ORM/Query/Filter/SQLFilter.php
@@ -58,7 +58,7 @@ abstract class SQLFilter
      * @param string       $type   The parameter type. If specified, the given value will be run through
      *                             the type conversion of this type.
      *
-     * @return self The current SQL filter.
+     * @return $this
      */
     final public function setParameterList(string $name, array $values, string $type = Types::STRING): self
     {
@@ -82,7 +82,7 @@ abstract class SQLFilter
      *                           the type conversion of this type. This is usually not needed for
      *                           strings and numeric types.
      *
-     * @return self The current SQL filter.
+     * @return $this
      */
     final public function setParameter($name, $value, $type = null): self
     {

--- a/lib/Doctrine/ORM/Query/ResultSetMapping.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMapping.php
@@ -170,7 +170,7 @@ class ResultSetMapping
      * @param string|null $resultAlias The result alias with which the entity result should be
      *                                 placed in the result structure.
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Rename: addRootEntity
      */
@@ -195,7 +195,7 @@ class ResultSetMapping
      *                            column should be used for.
      * @param string $discrColumn The name of the discriminator column in the SQL result set.
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Rename: addDiscriminatorColumn
      */
@@ -213,7 +213,7 @@ class ResultSetMapping
      * @param string $alias     The alias of an entity result or joined entity result.
      * @param string $fieldName The name of the field to use for indexing.
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      */
     public function addIndexBy($alias, $fieldName)
     {
@@ -250,7 +250,7 @@ class ResultSetMapping
      *
      * @param string $resultColumnName
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      */
     public function addIndexByScalar($resultColumnName)
     {
@@ -265,7 +265,7 @@ class ResultSetMapping
      * @param string $alias
      * @param string $resultColumnName
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      */
     public function addIndexByColumn($alias, $resultColumnName)
     {
@@ -316,7 +316,7 @@ class ResultSetMapping
      *                                    If not specified, the field is assumed to belong to the class
      *                                    designated by $alias.
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Rename: addField
      */
@@ -345,7 +345,7 @@ class ResultSetMapping
      * @param string $relation    The association field that connects the parent entity result
      *                            with the joined entity result.
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Rename: addJoinedEntity
      */
@@ -365,7 +365,7 @@ class ResultSetMapping
      * @param string $alias      The result alias with which the scalar result should be placed in the result structure.
      * @param string $type       The column type
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Rename: addScalar
      */
@@ -555,7 +555,7 @@ class ResultSetMapping
      * @param bool   $isIdentifierColumn
      * @param string $type               The column type
      *
-     * @return static This ResultSetMapping instance.
+     * @return $this
      *
      * @todo Make all methods of this class require all parameters and not infer anything
      */

--- a/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
+++ b/lib/Doctrine/ORM/Query/ResultSetMappingBuilder.php
@@ -267,7 +267,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @param string $resultClassName
      *
-     * @return static
+     * @return $this
      */
     public function addNamedNativeQueryResultClassMapping(ClassMetadataInfo $class, $resultClassName)
     {
@@ -311,7 +311,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      *
      * @param string $resultSetMappingName
      *
-     * @return static
+     * @return $this
      */
     public function addNamedNativeQueryResultSetMapping(ClassMetadataInfo $class, $resultSetMappingName)
     {
@@ -360,7 +360,7 @@ class ResultSetMappingBuilder extends ResultSetMapping
      * @param mixed[] $entityMapping
      * @param string  $alias
      *
-     * @return static
+     * @return $this
      *
      * @throws MappingException
      * @throws InvalidArgumentException

--- a/lib/Doctrine/ORM/QueryBuilder.php
+++ b/lib/Doctrine/ORM/QueryBuilder.php
@@ -182,7 +182,7 @@ class QueryBuilder
      *
      * @param bool $cacheable
      *
-     * @return static
+     * @return $this
      */
     public function setCacheable($cacheable)
     {
@@ -202,7 +202,7 @@ class QueryBuilder
     /**
      * @param string $cacheRegion
      *
-     * @return static
+     * @return $this
      */
     public function setCacheRegion($cacheRegion)
     {
@@ -234,7 +234,7 @@ class QueryBuilder
      *
      * @param int $lifetime
      *
-     * @return static
+     * @return $this
      */
     public function setLifetime($lifetime)
     {
@@ -254,7 +254,7 @@ class QueryBuilder
     /**
      * @param int $cacheMode
      *
-     * @return static
+     * @return $this
      */
     public function setCacheMode($cacheMode)
     {
@@ -530,7 +530,7 @@ class QueryBuilder
      * @param mixed           $value The parameter value.
      * @param string|int|null $type  ParameterType::* or \Doctrine\DBAL\Types\Type::* constant
      *
-     * @return static
+     * @return $this
      */
     public function setParameter($key, $value, $type = null)
     {
@@ -564,7 +564,7 @@ class QueryBuilder
      * @param ArrayCollection|mixed[] $parameters The query parameters to set.
      * @psalm-param ArrayCollection<int, Parameter>|mixed[] $parameters
      *
-     * @return static
+     * @return $this
      */
     public function setParameters($parameters)
     {
@@ -625,7 +625,7 @@ class QueryBuilder
      *
      * @param int|null $firstResult The first result to return.
      *
-     * @return static
+     * @return $this
      */
     public function setFirstResult($firstResult)
     {
@@ -650,7 +650,7 @@ class QueryBuilder
      *
      * @param int|null $maxResults The maximum number of results to retrieve.
      *
-     * @return static
+     * @return $this
      */
     public function setMaxResults($maxResults)
     {
@@ -681,7 +681,7 @@ class QueryBuilder
      * @param bool                $append      Whether to append (true) or replace (false).
      * @psalm-param string|object|list<string>|array{join: array<int|string, object>} $dqlPart
      *
-     * @return static
+     * @return $this
      */
     public function add($dqlPartName, $dqlPart, $append = false)
     {
@@ -744,7 +744,7 @@ class QueryBuilder
      *
      * @param mixed $select The selection expressions.
      *
-     * @return static
+     * @return $this
      */
     public function select($select = null)
     {
@@ -771,7 +771,7 @@ class QueryBuilder
      *
      * @param bool $flag
      *
-     * @return static
+     * @return $this
      */
     public function distinct($flag = true)
     {
@@ -793,7 +793,7 @@ class QueryBuilder
      *
      * @param mixed $select The selection expression.
      *
-     * @return static
+     * @return $this
      */
     public function addSelect($select = null)
     {
@@ -822,7 +822,7 @@ class QueryBuilder
      * @param string $delete The class/type whose instances are subject to the deletion.
      * @param string $alias  The class/type alias used in the constructed query.
      *
-     * @return static
+     * @return $this
      */
     public function delete($delete = null, $alias = null)
     {
@@ -849,7 +849,7 @@ class QueryBuilder
      * @param string $update The class/type whose instances are subject to the update.
      * @param string $alias  The class/type alias used in the constructed query.
      *
-     * @return static
+     * @return $this
      */
     public function update($update = null, $alias = null)
     {
@@ -876,7 +876,7 @@ class QueryBuilder
      * @param string $alias   The alias of the class.
      * @param string $indexBy The index for the from.
      *
-     * @return static
+     * @return $this
      */
     public function from($from, $alias, $indexBy = null)
     {
@@ -902,7 +902,7 @@ class QueryBuilder
      * @param string $alias   The root alias of the class.
      * @param string $indexBy The index for the from.
      *
-     * @return static
+     * @return $this
      *
      * @throws Query\QueryException
      */
@@ -948,7 +948,7 @@ class QueryBuilder
      * @param string|null $condition     The condition for the join.
      * @param string|null $indexBy       The index for the join.
      *
-     * @return self
+     * @return $this
      */
     public function join($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
     {
@@ -974,7 +974,7 @@ class QueryBuilder
      * @param string|null $condition     The condition for the join.
      * @param string|null $indexBy       The index for the join.
      *
-     * @return static
+     * @return $this
      */
     public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
     {
@@ -1014,7 +1014,7 @@ class QueryBuilder
      * @param string|null $condition     The condition for the join.
      * @param string|null $indexBy       The index for the join.
      *
-     * @return static
+     * @return $this
      */
     public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
     {
@@ -1047,7 +1047,7 @@ class QueryBuilder
      * @param string $key   The key/field to set.
      * @param mixed  $value The value, expression, placeholder, etc.
      *
-     * @return static
+     * @return $this
      */
     public function set($key, $value)
     {
@@ -1078,7 +1078,7 @@ class QueryBuilder
      *
      * @param mixed $predicates The restriction predicates.
      *
-     * @return static
+     * @return $this
      */
     public function where($predicates)
     {
@@ -1105,7 +1105,7 @@ class QueryBuilder
      *
      * @param mixed $where The query restrictions.
      *
-     * @return static
+     * @return $this
      */
     public function andWhere()
     {
@@ -1138,7 +1138,7 @@ class QueryBuilder
      *
      * @param mixed $where The WHERE statement.
      *
-     * @return static
+     * @return $this
      */
     public function orWhere()
     {
@@ -1168,7 +1168,7 @@ class QueryBuilder
      *
      * @param string $groupBy The grouping expression.
      *
-     * @return static
+     * @return $this
      */
     public function groupBy($groupBy)
     {
@@ -1188,7 +1188,7 @@ class QueryBuilder
      *
      * @param string $groupBy The grouping expression.
      *
-     * @return static
+     * @return $this
      */
     public function addGroupBy($groupBy)
     {
@@ -1201,7 +1201,7 @@ class QueryBuilder
      *
      * @param mixed $having The restriction over the groups.
      *
-     * @return static
+     * @return $this
      */
     public function having($having)
     {
@@ -1218,7 +1218,7 @@ class QueryBuilder
      *
      * @param mixed $having The restriction to append.
      *
-     * @return static
+     * @return $this
      */
     public function andHaving($having)
     {
@@ -1241,7 +1241,7 @@ class QueryBuilder
      *
      * @param mixed $having The restriction to add.
      *
-     * @return static
+     * @return $this
      */
     public function orHaving($having)
     {
@@ -1265,7 +1265,7 @@ class QueryBuilder
      * @param string|Expr\OrderBy $sort  The ordering expression.
      * @param string              $order The ordering direction.
      *
-     * @return static
+     * @return $this
      */
     public function orderBy($sort, $order = null)
     {
@@ -1280,7 +1280,7 @@ class QueryBuilder
      * @param string|Expr\OrderBy $sort  The ordering expression.
      * @param string              $order The ordering direction.
      *
-     * @return static
+     * @return $this
      */
     public function addOrderBy($sort, $order = null)
     {
@@ -1296,7 +1296,7 @@ class QueryBuilder
      * Adds orderings.
      * Overrides firstResult and maxResults if they're set.
      *
-     * @return static
+     * @return $this
      *
      * @throws Query\QueryException
      */
@@ -1446,7 +1446,7 @@ class QueryBuilder
      * @param string[]|null $parts
      * @psalm-param list<string>|null $parts
      *
-     * @return static
+     * @return $this
      */
     public function resetDQLParts($parts = null)
     {
@@ -1466,7 +1466,7 @@ class QueryBuilder
      *
      * @param string $part
      *
-     * @return static
+     * @return $this
      */
     public function resetDQLPart($part)
     {

--- a/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
+++ b/lib/Doctrine/ORM/Tools/EntityRepositoryGenerator.php
@@ -157,7 +157,7 @@ class <className> extends <repositoryName>
     /**
      * @param string $repositoryName
      *
-     * @return static
+     * @return $this
      */
     public function setDefaultRepositoryName($repositoryName)
     {


### PR DESCRIPTION
I'd like to streamline how fluent interfaces are documented in the doc blocks. The annotation `@return $this` should be understood by Psalm, PHPStan and PhpStorm and is imho the most accurate way to represent such an interface.