### PR TITLE
Fix ignoring custom types for PersistentCollection matching()

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Collection/ManyToManyPersister.php
@@ -238,6 +238,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
         $targetClass   = $this->em->getClassMetadata($mapping['targetEntity']);
         $onConditions  = $this->getOnConditionSQL($mapping);
         $whereClauses  = $params = [];
+        $paramTypes    = [];
 
         if (! $mapping['isOwningSide']) {
             $associationSourceClass = $targetClass;
@@ -253,6 +254,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $params[]       = $ownerMetadata->containsForeignIdentifier
                 ? $id[$ownerMetadata->getFieldForColumn($value)]
                 : $id[$ownerMetadata->fieldNames[$value]];
+            $paramTypes[]   = PersisterHelper::getTypeOfColumn($value, $ownerMetadata, $this->em);
         }
 
         $parameters = $this->expandCriteriaParameters($criteria);
@@ -263,6 +265,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
             $field          = $this->quoteStrategy->getColumnName($name, $targetClass, $this->platform);
             $whereClauses[] = sprintf('te.%s %s ?', $field, $operator);
             $params[]       = $value;
+            $paramTypes[]   = PersisterHelper::getTypeOfColumn($field, $targetClass, $this->em);
         }
 
         $tableName = $this->quoteStrategy->getTableName($targetClass, $this->platform);
@@ -281,7 +284,7 @@ class ManyToManyPersister extends AbstractCollectionPersister
 
         $sql .= $this->getLimitSql($criteria);
 
-        $stmt = $this->conn->executeQuery($sql, $params);
+        $stmt = $this->conn->executeQuery($sql, $params, $paramTypes);
 
         return $this
             ->em

--- a/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
+++ b/tests/Doctrine/Tests/ORM/Functional/PersistentCollectionCriteriaTest.php
@@ -11,6 +11,8 @@ use Doctrine\Tests\Models\Quote\User as QuoteUser;
 use Doctrine\Tests\Models\Tweet\Tweet;
 use Doctrine\Tests\Models\Tweet\User;
 use Doctrine\Tests\Models\Tweet\User as TweetUser;
+use Doctrine\Tests\Models\ValueConversionType\InversedManyToManyExtraLazyEntity;
+use Doctrine\Tests\Models\ValueConversionType\OwningManyToManyExtraLazyEntity;
 use Doctrine\Tests\OrmFunctionalTestCase;
 
 class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
@@ -19,6 +21,7 @@ class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
     {
         $this->useModelSet('tweet');
         $this->useModelSet('quote');
+        $this->useModelSet('vct_manytomany_extralazy');
         parent::setUp();
     }
 
@@ -94,5 +97,32 @@ class PersistentCollectionCriteriaTest extends OrmFunctionalTestCase
         $this->assertFalse($tweets->isInitialized());
         $this->assertCount(1, $tweets);
         $this->assertFalse($tweets->isInitialized());
+    }
+
+    public function testCanHandleComplexTypesOnAssociation(): void
+    {
+        $parent      = new OwningManyToManyExtraLazyEntity();
+        $parent->id2 = 'Alice';
+
+        $this->_em->persist($parent);
+
+        $child      = new InversedManyToManyExtraLazyEntity();
+        $child->id1 = 'Bob';
+
+        $this->_em->persist($child);
+
+        $parent->associatedEntities->add($child);
+
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $parent = $this->_em->find(OwningManyToManyExtraLazyEntity::class, $parent->id2);
+
+        $criteria = Criteria::create()->where(Criteria::expr()->eq('id1', 'Bob'));
+
+        $result = $parent->associatedEntities->matching($criteria);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('Bob', $result[0]->id1);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/doctrine/orm/issues/8995, https://github.com/doctrine/orm/issues/8406, https://github.com/doctrine/orm/issues/7822